### PR TITLE
[codex] fix common material reuse

### DIFF
--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -557,6 +557,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         ObjectDisposedException.ThrowIf(datasetSlotId is null, this);
         ObjectDisposedException.ThrowIf(meshCodeSlotId is null, this);
         ObjectDisposedException.ThrowIf(datasetAssetsSlotId is null, this);
+        ObjectDisposedException.ThrowIf(commonAssetsSlotId is null, this);
         ObjectDisposedException.ThrowIf(materialAssetManager is null, this);
 
         ResoniteConstructionCityObject cityObject = preparedCityObject.CityObject;
@@ -664,17 +665,12 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             ReportBuildStep(
                 cityObject,
                 $"Ensuring material {materialIndex + 1}/{cityObject.Materials.Count} ({material.MaterialKey}).");
-            string materialInstanceKey = ResoniteLinkEntityIdFactory.CreateStableEntityId(
-                metadata.Request.Dataset,
-                rootMeshCode,
-                objectIdentity,
-                "material",
-                material.MaterialKey);
+            string materialInstanceKey = CreateSharedMaterialInstanceKey(material);
             string materialId = await materialAssetManager.EnsureMaterialComponentAsync(
                 client,
                 material,
                 preparedTextureDataByKey,
-                meshAssetSlotId,
+                commonAssetsSlotId,
                 materialInstanceKey,
                 cancellationToken);
             materialIds.Add(materialId);
@@ -752,6 +748,60 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         }
 
         return cityObject.SourceObjectKey ?? cityObject.SlotKey;
+    }
+
+    private static string CreateSharedMaterialInstanceKey(ResoniteMaterialBinding material)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+
+        using IncrementalHash incrementalHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        AppendString(incrementalHash, material.MaterialType.ToString());
+        AppendString(incrementalHash, material.Projection.ToString());
+        AppendString(incrementalHash, material.TextureSourceKind.ToString());
+        AppendString(incrementalHash, material.TexturePath ?? string.Empty);
+        AppendString(incrementalHash, material.Family ?? string.Empty);
+        AppendDouble(incrementalHash, material.BaseColor.R);
+        AppendDouble(incrementalHash, material.BaseColor.G);
+        AppendDouble(incrementalHash, material.BaseColor.B);
+        AppendDouble(incrementalHash, material.BaseColor.A);
+
+        if (material.TextureScale is not null)
+        {
+            AppendBoolean(incrementalHash, true);
+            AppendDouble(incrementalHash, material.TextureScale.X);
+            AppendDouble(incrementalHash, material.TextureScale.Y);
+        }
+        else
+        {
+            AppendBoolean(incrementalHash, false);
+        }
+
+        if (material.TextureOffset is not null)
+        {
+            AppendBoolean(incrementalHash, true);
+            AppendDouble(incrementalHash, material.TextureOffset.X);
+            AppendDouble(incrementalHash, material.TextureOffset.Y);
+        }
+        else
+        {
+            AppendBoolean(incrementalHash, false);
+        }
+
+        if (material.DepthOffset is not null)
+        {
+            AppendBoolean(incrementalHash, true);
+            AppendDouble(incrementalHash, material.DepthOffset.Factor);
+            AppendDouble(incrementalHash, material.DepthOffset.Units);
+        }
+        else
+        {
+            AppendBoolean(incrementalHash, false);
+        }
+
+        string materialFingerprint = Convert.ToHexString(incrementalHash.GetHashAndReset());
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{material.MaterialKey}_{materialFingerprint[..16]}");
     }
 
     private static bool IsDemPackage(string packageName)

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
@@ -178,6 +178,36 @@ public sealed class ResoniteLinkSceneBuilderAssetReuseTests
         }
     }
 
+    [Fact]
+    public async Task BuildAsyncSharesCommonMaterialAssetsAcrossCityObjectsInSameSession()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path, packageNames: ["bldg"]);
+        using ReuseSessionSharedClient sharedClient = new();
+
+        string bundledTexturePath = BundledDefaultMaterialFamilies.FacadeVariants[0];
+        CapturedScene scene = new(
+            metadata,
+            [
+                CreateBundledTriangleCityObject(
+                    objectIdentity: "shared-material-one",
+                    texturePath: bundledTexturePath,
+                    mesh: CreateTriangleMesh(0.0, 1.0, 2.0, "triangle-textured-material")),
+                CreateBundledTriangleCityObject(
+                    objectIdentity: "shared-material-two",
+                    texturePath: bundledTexturePath,
+                    mesh: CreateTriangleMesh(3.0, 4.0, 5.0, "triangle-textured-material")),
+            ]);
+
+        await BuildSceneOnceAsync(scene, sharedClient, Path.Combine(datasetDirectory.Path, "work"));
+
+        Assert.Equal(
+            1,
+            sharedClient.AddedComponents.Count(static request =>
+                string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal)));
+        Assert.Equal(5, sharedClient.ImportedTexturePaths.Count);
+    }
+
     private static async Task BuildSceneOnceAsync(
         CapturedScene scene,
         ReuseSessionSharedClient client,

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -39,7 +39,7 @@ public sealed class ResoniteLinkSceneBuilderTests
         IReadOnlyList<string> destinations = await RunBuilderAsync(builder, scene);
 
         Assert.Single(destinations);
-        Assert.Equal(7, fakeClient.ImportedTexturePaths.Count);
+        Assert.Equal(6, fakeClient.ImportedTexturePaths.Count);
         Assert.Equal(scene.CityObjects.Count, fakeClient.ImportedMeshes.Count);
         Assert.Contains(fakeClient.AddedComponents, static request =>
             string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticMesh", StringComparison.Ordinal));
@@ -82,7 +82,7 @@ public sealed class ResoniteLinkSceneBuilderTests
         AddComponent[] staticTextureRequests = fakeClient.AddedComponents
             .Where(request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal))
             .ToArray();
-        Assert.Equal(7, staticTextureRequests.Length);
+        Assert.Equal(6, staticTextureRequests.Length);
 
         Assert.Contains(
             fakeClient.ImportedTexturePaths,
@@ -146,11 +146,11 @@ public sealed class ResoniteLinkSceneBuilderTests
                 string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal)
                 && request.ContainerSlotId != fakeClient.BuildingSlotIds["Building One"])
             .ToArray();
-        Assert.Equal(3, materialRequests.Length);
+        Assert.Equal(2, materialRequests.Length);
         Assert.All(materialRequests, request =>
         {
             Assert.StartsWith(
-                "PLATEAU tokyo23ku/Assets/",
+                "PLATEAU tokyo23ku/Assets/Common",
                 fakeClient.SlotPaths[request.ContainerSlotId],
                 StringComparison.Ordinal);
         });


### PR DESCRIPTION
## Summary
- move shared live material assets into `Assets/Common` instead of creating them per city object
- derive common material instance keys from material content so identical materials reuse the same live components
- add and update tests to cover shared material reuse and the lower duplicate texture/material import counts

## Root Cause
The live send path created a `Common` assets slot but still generated material IDs from each city object's identity and attached those material assets under object-specific mesh asset slots. That prevented material reuse across city objects and caused duplicate material and companion texture imports during large sends.

## Impact
This reduces redundant live material uploads for repeated fallback materials and should avoid long sends appearing to stall while repeatedly reimporting the same common assets.

## Validation
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet test Plateau.ResoniteLink.sln --configuration Release -m:1 -p:UseSharedCompilation=false`