### PR TITLE
Harden import validation and CLI parsing

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -95,6 +95,7 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   --dataset tokyo23ku \
   --mesh-code 533944 \
   --source remote \
+  --server-url https://example.invalid/plateau_tokyo23ku_citygml.zip \
   --resonitelink-port <port>
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -71,6 +71,7 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   --dataset tokyo23ku \
   --mesh-code 533944 \
   --source remote \
+  --server-url https://example.invalid/plateau_tokyo23ku_citygml.zip \
   --resonitelink-port <port>
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -61,21 +61,21 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   --send-metrics
 ```
 
-`--resonitelink-port` または `--resonitelink-url` は必須です。`--work-root` の既定値は `runtime/<os>/resonite/` で、live 用の生成 asset と remote download cache の保存先としてだけ使います。`--packages` には公式 PLATEAU の `udx/<package>/` 名をカンマ区切りで指定でき、省略時の CLI 既定値は `dem,bldg,brid,frn,tran,rwy,trk,tun,ubld,unf,veg` です。`--resonitelink-connections` の既定値は `1` です。`--send-metrics` を付けると、`System.Diagnostics.Metrics` による opt-in の計測を有効化し、低カーディナリティの counter / histogram と CLI summary を出します。DEM の既定出力は従来どおり mesh 経路で、`--dem-terrain-mode heightmap` を指定すると `dem` を `GridMesh` + 高さテクスチャ経路へ切り替えます。`--dem-heightmap-meters-per-vertex` と `--dem-heightmap-max-resolution` はサンプル密度と安全上限の制御に使います。オプション名は可能な範囲で PLATEAU SDK for Unity に寄せており、`--local-source-path` は `DatasetSourceConfigLocal.LocalSourcePath`、`--server-url` は `DatasetSourceConfigRemote.ServerUrl` に対応します。
+`--resonitelink-port` または `--resonitelink-url` は必須です。`--work-root` の既定値は `runtime/<os>/resonite/` で、live 用の生成 asset、remote download cache、そして live asset 再利用状態を保持する `resonite-live-asset-state.json` の保存先になります。この directory を削除すると、download cache と asset の dedupe / reuse 状態が両方とも失われます。`--packages` には公式 PLATEAU の `udx/<package>/` 名をカンマ区切りで指定でき、省略時の CLI 既定値は `dem,bldg,brid,frn,tran,rwy,trk,tun,ubld,unf,veg` です。`--resonitelink-connections` の既定値は `1` です。`--send-metrics` を付けると、`System.Diagnostics.Metrics` による opt-in の計測を有効化し、低カーディナリティの counter / histogram と CLI summary を出します。さらに、global / package ごとの LOD 除外、marking の扱い、package ごとの object pattern を制御する filter option もあります。`--exclude-lod-for-package` を省略した場合の既定 fallback は現在 `tran:1` で、`--exclude-lod-for-package tran:none` を使うと明示的に解除できます。DEM の既定出力は従来どおり mesh 経路で、`--dem-terrain-mode heightmap` を指定すると `dem` を `GridMesh` + 高さテクスチャ経路へ切り替えます。`--dem-heightmap-meters-per-vertex` と `--dem-heightmap-max-resolution` はサンプル密度と安全上限の制御に使います。オプション名は可能な範囲で PLATEAU SDK for Unity に寄せており、`--local-source-path` は `DatasetSourceConfigLocal.LocalSourcePath`、`--server-url` は `DatasetSourceConfigRemote.ServerUrl` に対応します。
 
 公式 PLATEAU の CityGML ZIP/7z archive URL を明示指定してオンライン取得しつつ Resonite に取り込む例:
 
 ```bash
 dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   build \
-  --dataset tokyo23ku \
+  --dataset plateau-20202-matsumoto-shi-2020 \
   --mesh-code 533944 \
   --source remote \
-  --server-url https://example.invalid/plateau_tokyo23ku_citygml.zip \
+  --server-url https://example.invalid/plateau-20202-matsumoto-shi-2020_citygml.zip \
   --resonitelink-port <port>
 ```
 
-`--source remote` は組み込みの dataset search を行いません。`--server-url` に direct な CityGML ZIP/7z archive URL を渡すと、その archive を `runtime/<os>/resonite/cache/remote/<dataset>/<archive-hash>/` に download し、その cached archive を透過的に読んで同じ local importer に渡します。cache key は要求した mesh code ではなく archive URL に基づくため、詳細 mesh code が変わっても同じ archive を再利用できます。
+`--source remote` は組み込みの dataset search を行いません。`--dataset` には `www.geospatial.jp` の公式 dataset page slug を使い、`--server-url` には direct な CityGML ZIP/7z archive URL を渡します。CLI はその archive を `runtime/<os>/resonite/cache/remote/<dataset>/<archive-hash>/` に download し、その cached archive を透過的に読んで同じ local importer に渡します。cache key は要求した mesh code ではなく archive URL に基づくため、詳細 mesh code が変わっても、canonical な dataset namespace を保ったまま同じ archive を再利用できます。
 
 正規の identifier と archive URL を調べる手順:
 
@@ -92,10 +92,10 @@ Windows から ResoniteLink 経由で Resonite にライブ構築する例:
 ```bash
 dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   build \
-  --dataset tokyo23ku \
+  --dataset plateau-20202-matsumoto-shi-2020 \
   --mesh-code 533944 \
   --source remote \
-  --server-url https://example.invalid/plateau_tokyo23ku_citygml.zip \
+  --server-url https://example.invalid/plateau-20202-matsumoto-shi-2020_citygml.zip \
   --resonitelink-port <port>
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,21 +64,21 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   --send-metrics
 ```
 
-`--resonitelink-port` or `--resonitelink-url` is required. `--work-root` defaults to `runtime/<os>/resonite/` and is used only for generated live assets and the remote download cache. `--packages` accepts a comma-separated list of official PLATEAU `udx/<package>/` names; when omitted, the CLI defaults to `dem,bldg,brid,frn,tran,rwy,trk,tun,ubld,unf,veg`. `--resonitelink-connections` defaults to `1`. `--send-metrics` enables opt-in `System.Diagnostics.Metrics` instrumentation with low-cardinality counters, histograms, and a CLI summary. DEM output stays on the existing mesh path by default; `--dem-terrain-mode heightmap` switches `dem` to a `GridMesh` + height texture path, with `--dem-heightmap-meters-per-vertex` and `--dem-heightmap-max-resolution` controlling sampling density and the safety cap. Option names follow PLATEAU SDK for Unity where practical: `--local-source-path` matches `DatasetSourceConfigLocal.LocalSourcePath`, and `--server-url` matches `DatasetSourceConfigRemote.ServerUrl`.
+`--resonitelink-port` or `--resonitelink-url` is required. `--work-root` defaults to `runtime/<os>/resonite/` and stores generated live assets, the remote download cache, and the live asset reuse state file `resonite-live-asset-state.json`; deleting that directory resets cached downloads and asset dedupe/reuse state. `--packages` accepts a comma-separated list of official PLATEAU `udx/<package>/` names; when omitted, the CLI defaults to `dem,bldg,brid,frn,tran,rwy,trk,tun,ubld,unf,veg`. `--resonitelink-connections` defaults to `1`. `--send-metrics` enables opt-in `System.Diagnostics.Metrics` instrumentation with low-cardinality counters, histograms, and a CLI summary. Filtering options are also available for global or package-specific LOD exclusion, marking inclusion, and package-specific object patterns; when `--exclude-lod-for-package` is omitted, the CLI applies the current default fallback `tran:1`, and `--exclude-lod-for-package tran:none` clears it explicitly. DEM output stays on the existing mesh path by default; `--dem-terrain-mode heightmap` switches `dem` to a `GridMesh` + height texture path, with `--dem-heightmap-meters-per-vertex` and `--dem-heightmap-max-resolution` controlling sampling density and the safety cap. Option names follow PLATEAU SDK for Unity where practical: `--local-source-path` matches `DatasetSourceConfigLocal.LocalSourcePath`, and `--server-url` matches `DatasetSourceConfigRemote.ServerUrl`.
 
 Import an official PLATEAU CityGML ZIP/7z archive online from an explicit archive URL:
 
 ```bash
 dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   build \
-  --dataset tokyo23ku \
+  --dataset plateau-20202-matsumoto-shi-2020 \
   --mesh-code 533944 \
   --source remote \
-  --server-url https://example.invalid/plateau_tokyo23ku_citygml.zip \
+  --server-url https://example.invalid/plateau-20202-matsumoto-shi-2020_citygml.zip \
   --resonitelink-port <port>
 ```
 
-`--source remote` does not perform any built-in dataset search. Pass `--server-url` as a direct CityGML ZIP/7z archive URL, and the CLI downloads it into `runtime/<os>/resonite/cache/remote/<dataset>/<archive-hash>/` before running the same local importer against the cached archive. The cache key is based on the archive URL rather than the requested mesh code, so repeated imports can reuse the same archive even when the detailed mesh code changes.
+`--source remote` does not perform any built-in dataset search. Use the official `www.geospatial.jp` dataset page slug as `--dataset`, pass `--server-url` as a direct CityGML ZIP/7z archive URL, and the CLI downloads it into `runtime/<os>/resonite/cache/remote/<dataset>/<archive-hash>/` before running the same local importer against the cached archive. The cache key is based on the archive URL rather than the requested mesh code, so repeated imports can reuse the same archive even when the detailed mesh code changes while keeping the same canonical dataset namespace.
 
 To find the official identifier and archive URL:
 
@@ -95,10 +95,10 @@ Build live into Resonite through ResoniteLink from Windows:
 ```bash
 dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   build \
-  --dataset tokyo23ku \
+  --dataset plateau-20202-matsumoto-shi-2020 \
   --mesh-code 533944 \
   --source remote \
-  --server-url https://example.invalid/plateau_tokyo23ku_citygml.zip \
+  --server-url https://example.invalid/plateau-20202-matsumoto-shi-2020_citygml.zip \
   --resonitelink-port <port>
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   --dataset tokyo23ku \
   --mesh-code 533944 \
   --source remote \
+  --server-url https://example.invalid/plateau_tokyo23ku_citygml.zip \
   --resonitelink-port <port>
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   --dataset tokyo23ku \
   --mesh-code 533944 \
   --source remote \
+  --server-url https://example.invalid/plateau_tokyo23ku_citygml.zip \
   --resonitelink-port <port>
 ```
 

--- a/docs/live-testing.ja.md
+++ b/docs/live-testing.ja.md
@@ -91,12 +91,25 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- `
   build `
   --dataset <dataset> `
   --mesh-code <mesh-code> `
-  --source <local-or-remote> `
+  --source local `
+  --local-source-path <dataset-root> `
   --resonitelink-port <port>
 ```
 
-`--source local` を使う場合は、`--local-source-path <dataset-root>` も指定する。値は Unity SDK の `LocalSourcePath` 命名に合わせており、dataset directory、ZIP/7z archive、または `udx/` を含む nested dataset root を配下に持つ ancestor directory を指せる。
-`--source remote` を使う場合は、`--server-url` に official PLATEAU の direct な CityGML ZIP/7z archive URL を指定する必要がある。CLI は dataset search を行わない。download した archive は `runtime/<os>/resonite/cache/remote/<dataset>/<archive-hash>/` に cache され、archive URL が同じである限り mesh code が変わっても再利用される。あとから `--source local --local-source-path ...` で再利用することもできる。
+remote を使う場合は、source 固有の引数を次の形に切り替える。
+
+```powershell
+dotnet run --project src/Plateau.ResoniteLink.Cli -- `
+  build `
+  --dataset <dataset> `
+  --mesh-code <mesh-code> `
+  --source remote `
+  --server-url <direct-citygml-zip-or-7z-url> `
+  --resonitelink-port <port>
+```
+
+`--local-source-path <dataset-root>` は Unity SDK の `LocalSourcePath` 命名に合わせており、dataset directory、ZIP/7z archive、または `udx/` を含む nested dataset root を配下に持つ ancestor directory を指せる。
+`--server-url` には official PLATEAU の direct な CityGML ZIP/7z archive URL を指定する必要がある。CLI は dataset search を行わない。download した archive は `runtime/<os>/resonite/cache/remote/<dataset>/<archive-hash>/` に cache され、archive URL が同じである限り mesh code が変わっても再利用される。あとから `--source local --local-source-path ...` で再利用することもできる。
 
 長時間の送信では、インラインの `cmd.exe /c dotnet ...` よりも、小さな Windows PowerShell ラッパーを使う方が安定する。この環境では、`Start-Process -Wait -PassThru` と stdout/stderr の redirect を使う形の方が、WSL interop 由来の詰まりを切り分けやすい。
 

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -91,12 +91,25 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- `
   build `
   --dataset <dataset> `
   --mesh-code <mesh-code> `
-  --source <local-or-remote> `
+  --source local `
+  --local-source-path <dataset-root> `
   --resonitelink-port <port>
 ```
 
-If `--source local` is used, also pass `--local-source-path <dataset-root>`. The value follows the Unity SDK `LocalSourcePath` naming and may point at a dataset directory, a ZIP/7z archive, or an ancestor directory that contains one nested dataset root with `udx/`.
-If `--source remote` is used, `--server-url` must point directly to an official PLATEAU CityGML ZIP/7z archive. The CLI does not perform dataset search. The downloaded archive is cached under `runtime/<os>/resonite/cache/remote/<dataset>/<archive-hash>/`, and the cache is reused across mesh-code changes as long as the archive URL stays the same. The cached data can later be reused through `--source local --local-source-path ...`.
+For remote mode, swap the source-specific arguments:
+
+```powershell
+dotnet run --project src/Plateau.ResoniteLink.Cli -- `
+  build `
+  --dataset <dataset> `
+  --mesh-code <mesh-code> `
+  --source remote `
+  --server-url <direct-citygml-zip-or-7z-url> `
+  --resonitelink-port <port>
+```
+
+`--local-source-path <dataset-root>` follows the Unity SDK `LocalSourcePath` naming and may point at a dataset directory, a ZIP/7z archive, or an ancestor directory that contains one nested dataset root with `udx/`.
+`--server-url` must point directly to an official PLATEAU CityGML ZIP/7z archive. The CLI does not perform dataset search. The downloaded archive is cached under `runtime/<os>/resonite/cache/remote/<dataset>/<archive-hash>/`, and the cache is reused across mesh-code changes as long as the archive URL stays the same. The cached data can later be reused through `--source local --local-source-path ...`.
 
 For long-running sends, prefer a small Windows PowerShell wrapper over an inline `cmd.exe /c dotnet ...` command. In this environment, a wrapper that uses `Start-Process -Wait -PassThru` plus redirected stdout/stderr is easier to observe and less likely to get stuck on WSL interop details.
 

--- a/src/Plateau.ResoniteLink.Application/Importing/PlateauImportRequestValidator.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/PlateauImportRequestValidator.cs
@@ -31,7 +31,8 @@ public static class PlateauImportRequestValidator
             else
             {
                 string[] unsupportedPackageNames = request.PackageNames
-                    .Where(packageName => !PlateauPackageCatalog.TryNormalizePackageName(packageName, out _))
+                    .Select(static packageName => NormalizePackageNameInput(packageName))
+                    .Where(static packageName => !PlateauPackageCatalog.TryNormalizePackageName(packageName, out _))
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .OrderBy(packageName => packageName, StringComparer.OrdinalIgnoreCase)
                     .ToArray();
@@ -46,8 +47,14 @@ public static class PlateauImportRequestValidator
 
         if (request.ExcludeLodLevelsByPackage is not null)
         {
+            AddDuplicatePackageMapKeyError(
+                request.ExcludeLodLevelsByPackage.Keys,
+                "ExcludeLodLevelsByPackage",
+                errors);
+
             string[] unsupportedPackageNames = request.ExcludeLodLevelsByPackage.Keys
-                .Where(packageName => !PlateauPackageCatalog.TryNormalizePackageName(packageName, out _))
+                .Select(static packageName => NormalizePackageNameInput(packageName))
+                .Where(static packageName => !PlateauPackageCatalog.TryNormalizePackageName(packageName, out _))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(packageName => packageName, StringComparer.OrdinalIgnoreCase)
                 .ToArray();
@@ -61,8 +68,14 @@ public static class PlateauImportRequestValidator
 
         if (request.PackagePatterns is not null)
         {
+            AddDuplicatePackageMapKeyError(
+                request.PackagePatterns.Keys,
+                "PackagePatterns",
+                errors);
+
             string[] unsupportedPackageNames = request.PackagePatterns.Keys
-                .Where(packageName => !PlateauPackageCatalog.TryNormalizePackageName(packageName, out _))
+                .Select(static packageName => NormalizePackageNameInput(packageName))
+                .Where(static packageName => !PlateauPackageCatalog.TryNormalizePackageName(packageName, out _))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(packageName => packageName, StringComparer.OrdinalIgnoreCase)
                 .ToArray();
@@ -137,5 +150,42 @@ public static class PlateauImportRequestValidator
         string extension = Path.GetExtension(serverUri.AbsolutePath);
         return SupportedRemoteArchiveExtensions.Any(
             supportedExtension => string.Equals(extension, supportedExtension, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static void AddDuplicatePackageMapKeyError(
+        IEnumerable<string> packageKeys,
+        string fieldName,
+        List<string> errors)
+    {
+        string[] duplicateNormalizedPackageNames = packageKeys
+            .Select(TryNormalizePackageNameInput)
+            .Where(static packageName => packageName is not null)
+            .Select(static packageName => packageName!)
+            .GroupBy(static packageName => packageName, StringComparer.OrdinalIgnoreCase)
+            .Where(static group => group.Count() > 1)
+            .Select(static group => group.Key)
+            .OrderBy(static packageName => packageName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (duplicateNormalizedPackageNames.Length == 0)
+        {
+            return;
+        }
+
+        errors.Add(
+            $"The {fieldName} value contains duplicate package keys after normalization: {string.Join(", ", duplicateNormalizedPackageNames)}.");
+    }
+
+    private static string NormalizePackageNameInput(string? packageName)
+    {
+        return packageName?.Trim() ?? string.Empty;
+    }
+
+    private static string? TryNormalizePackageNameInput(string? packageName)
+    {
+        string trimmedPackageName = NormalizePackageNameInput(packageName);
+        return PlateauPackageCatalog.TryNormalizePackageName(trimmedPackageName, out string normalizedPackageName)
+            ? normalizedPackageName
+            : null;
     }
 }

--- a/src/Plateau.ResoniteLink.Application/Importing/PlateauImportRequestValidator.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/PlateauImportRequestValidator.cs
@@ -4,6 +4,8 @@ namespace Plateau.ResoniteLink.Application.Importing;
 
 public static class PlateauImportRequestValidator
 {
+    private static readonly string[] SupportedRemoteArchiveExtensions = [".zip", ".7z"];
+
     public static IReadOnlyList<string> Validate(PlateauImportRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -42,6 +44,36 @@ public static class PlateauImportRequestValidator
             }
         }
 
+        if (request.ExcludeLodLevelsByPackage is not null)
+        {
+            string[] unsupportedPackageNames = request.ExcludeLodLevelsByPackage.Keys
+                .Where(packageName => !PlateauPackageCatalog.TryNormalizePackageName(packageName, out _))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(packageName => packageName, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (unsupportedPackageNames.Length > 0)
+            {
+                errors.Add(
+                    $"Unsupported package name(s): {string.Join(", ", unsupportedPackageNames)}. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.");
+            }
+        }
+
+        if (request.PackagePatterns is not null)
+        {
+            string[] unsupportedPackageNames = request.PackagePatterns.Keys
+                .Where(packageName => !PlateauPackageCatalog.TryNormalizePackageName(packageName, out _))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(packageName => packageName, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (unsupportedPackageNames.Length > 0)
+            {
+                errors.Add(
+                    $"Unsupported package name(s): {string.Join(", ", unsupportedPackageNames)}. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.");
+            }
+        }
+
         switch (request.SourceKind)
         {
             case DatasetSourceKind.Local:
@@ -68,6 +100,12 @@ public static class PlateauImportRequestValidator
                 if (!request.ServerUri.IsAbsoluteUri)
                 {
                     errors.Add("The --server-url value must be an absolute URI.");
+                    break;
+                }
+
+                if (!LooksLikeSupportedArchiveUri(request.ServerUri))
+                {
+                    errors.Add("The --server-url value must point directly to a .zip or .7z CityGML archive over http or https.");
                 }
 
                 break;
@@ -84,5 +122,20 @@ public static class PlateauImportRequestValidator
         }
 
         return errors;
+    }
+
+    internal static bool LooksLikeSupportedArchiveUri(Uri serverUri)
+    {
+        ArgumentNullException.ThrowIfNull(serverUri);
+
+        if (!string.Equals(serverUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(serverUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string extension = Path.GetExtension(serverUri.AbsolutePath);
+        return SupportedRemoteArchiveExtensions.Any(
+            supportedExtension => string.Equals(extension, supportedExtension, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
@@ -99,25 +99,18 @@ public sealed class PlateauImportService(
 
         return request with
         {
-            Dataset = request.Dataset.Trim(),
-            MeshCode = request.MeshCode.Trim(),
+            Dataset = TrimToEmpty(request.Dataset),
+            MeshCode = TrimToEmpty(request.MeshCode),
             LocalSourcePath = string.IsNullOrWhiteSpace(request.LocalSourcePath) ? null : request.LocalSourcePath.Trim(),
             PackageNames = request.PackageNames is null
                 ? null
-                : request.PackageNames.Select(static packageName => packageName.Trim()).ToArray(),
-            ExcludeLodLevelsByPackage = request.ExcludeLodLevelsByPackage is null
-                ? null
-                : request.ExcludeLodLevelsByPackage.ToDictionary(
-                    static pair => pair.Key.Trim(),
-                    static pair => pair.Value,
-                    StringComparer.OrdinalIgnoreCase),
-            PackagePatterns = request.PackagePatterns is null
-                ? null
-                : request.PackagePatterns.ToDictionary(
-                    static pair => pair.Key.Trim(),
-                    static pair => pair.Value,
-                    StringComparer.OrdinalIgnoreCase),
+                : request.PackageNames.Select(static packageName => TrimToEmpty(packageName)).ToArray(),
         };
+    }
+
+    private static string TrimToEmpty(string? value)
+    {
+        return value?.Trim() ?? string.Empty;
     }
 
     private static PlateauImportRequest NormalizeRequest(PlateauImportRequest request)

--- a/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
@@ -24,12 +24,14 @@ public sealed class PlateauImportService(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
 
-        PlateauImportRequest normalizedRequest = NormalizeRequest(request);
-        IReadOnlyList<string> validationErrors = PlateauImportRequestValidator.Validate(normalizedRequest);
+        PlateauImportRequest validationRequest = NormalizeRequestForValidation(request);
+        IReadOnlyList<string> validationErrors = PlateauImportRequestValidator.Validate(validationRequest);
         if (validationErrors.Count > 0)
         {
             throw new PlateauImportValidationException(validationErrors);
         }
+
+        PlateauImportRequest normalizedRequest = NormalizeRequest(validationRequest);
 
         PlateauImportRequest resolvedRequest =
             await datasetSourceResolver.ResolveAsync(normalizedRequest, workRoot, cancellationToken);
@@ -91,7 +93,7 @@ public sealed class PlateauImportService(
         progressReporter?.Invoke(message);
     }
 
-    private static PlateauImportRequest NormalizeRequest(PlateauImportRequest request)
+    private static PlateauImportRequest NormalizeRequestForValidation(PlateauImportRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -100,6 +102,30 @@ public sealed class PlateauImportService(
             Dataset = request.Dataset.Trim(),
             MeshCode = request.MeshCode.Trim(),
             LocalSourcePath = string.IsNullOrWhiteSpace(request.LocalSourcePath) ? null : request.LocalSourcePath.Trim(),
+            PackageNames = request.PackageNames is null
+                ? null
+                : request.PackageNames.Select(static packageName => packageName.Trim()).ToArray(),
+            ExcludeLodLevelsByPackage = request.ExcludeLodLevelsByPackage is null
+                ? null
+                : request.ExcludeLodLevelsByPackage.ToDictionary(
+                    static pair => pair.Key.Trim(),
+                    static pair => pair.Value,
+                    StringComparer.OrdinalIgnoreCase),
+            PackagePatterns = request.PackagePatterns is null
+                ? null
+                : request.PackagePatterns.ToDictionary(
+                    static pair => pair.Key.Trim(),
+                    static pair => pair.Value,
+                    StringComparer.OrdinalIgnoreCase),
+        };
+    }
+
+    private static PlateauImportRequest NormalizeRequest(PlateauImportRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return request with
+        {
             PackageNames = request.PackageNames is null
                 ? null
                 : PlateauPackageCatalog.NormalizeRequestedPackageNames(request.PackageNames),

--- a/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
@@ -24,21 +24,12 @@ public sealed class PlateauImportService(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
 
-        IReadOnlyList<string> validationErrors = PlateauImportRequestValidator.Validate(request);
+        PlateauImportRequest normalizedRequest = NormalizeRequest(request);
+        IReadOnlyList<string> validationErrors = PlateauImportRequestValidator.Validate(normalizedRequest);
         if (validationErrors.Count > 0)
         {
             throw new PlateauImportValidationException(validationErrors);
         }
-
-        PlateauImportRequest normalizedRequest = request with
-        {
-            Dataset = request.Dataset.Trim(),
-            MeshCode = request.MeshCode.Trim(),
-            LocalSourcePath = string.IsNullOrWhiteSpace(request.LocalSourcePath) ? null : request.LocalSourcePath.Trim(),
-            PackageNames = request.PackageNames is null
-                ? null
-                : PlateauPackageCatalog.NormalizeRequestedPackageNames(request.PackageNames),
-        };
 
         PlateauImportRequest resolvedRequest =
             await datasetSourceResolver.ResolveAsync(normalizedRequest, workRoot, cancellationToken);
@@ -98,5 +89,64 @@ public sealed class PlateauImportService(
     private void ReportProgress(string message)
     {
         progressReporter?.Invoke(message);
+    }
+
+    private static PlateauImportRequest NormalizeRequest(PlateauImportRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return request with
+        {
+            Dataset = request.Dataset.Trim(),
+            MeshCode = request.MeshCode.Trim(),
+            LocalSourcePath = string.IsNullOrWhiteSpace(request.LocalSourcePath) ? null : request.LocalSourcePath.Trim(),
+            PackageNames = request.PackageNames is null
+                ? null
+                : PlateauPackageCatalog.NormalizeRequestedPackageNames(request.PackageNames),
+            ExcludeLodLevelsByPackage = request.ExcludeLodLevelsByPackage is null
+                ? null
+                : NormalizePackageExclusionMap(request.ExcludeLodLevelsByPackage),
+            PackagePatterns = request.PackagePatterns is null
+                ? null
+                : NormalizePackagePatternMap(request.PackagePatterns),
+        };
+    }
+
+    private static Dictionary<string, IReadOnlySet<int>> NormalizePackageExclusionMap(
+        IReadOnlyDictionary<string, IReadOnlySet<int>> exclusionsByPackage)
+    {
+        Dictionary<string, IReadOnlySet<int>> normalized = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach ((string packageName, IReadOnlySet<int> excludedLods) in exclusionsByPackage)
+        {
+            if (!PlateauPackageCatalog.TryNormalizePackageName(packageName, out string normalizedPackageName))
+            {
+                throw new ArgumentException(
+                    $"Unsupported package '{packageName}'. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.");
+            }
+
+            normalized[normalizedPackageName] = excludedLods;
+        }
+
+        return normalized;
+    }
+
+    private static Dictionary<string, string> NormalizePackagePatternMap(
+        IReadOnlyDictionary<string, string> patternsByPackage)
+    {
+        Dictionary<string, string> normalized = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach ((string packageName, string pattern) in patternsByPackage)
+        {
+            if (!PlateauPackageCatalog.TryNormalizePackageName(packageName, out string normalizedPackageName))
+            {
+                throw new ArgumentException(
+                    $"Unsupported package '{packageName}'. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.");
+            }
+
+            normalized[normalizedPackageName] = pattern;
+        }
+
+        return normalized;
     }
 }

--- a/src/Plateau.ResoniteLink.Cli/BundledDefaultMaterialAssetStore.cs
+++ b/src/Plateau.ResoniteLink.Cli/BundledDefaultMaterialAssetStore.cs
@@ -9,7 +9,8 @@ internal static class BundledDefaultMaterialAssetStore
     private static readonly HashSet<string> ResourceNames = Assembly
         .GetManifestResourceNames()
         .ToHashSet(StringComparer.Ordinal);
-    private static readonly string ExtractionRoot = Path.Combine(
+    private static readonly AsyncLocal<string?> ExtractionRootOverride = new();
+    private static readonly string DefaultExtractionRoot = Path.Combine(
         Path.GetTempPath(),
         "Plateau.ResoniteLink",
         "default-materials");
@@ -25,7 +26,7 @@ internal static class BundledDefaultMaterialAssetStore
         string resourceName = GetResourceName(logicalPath);
 
         string absolutePath = Path.Combine(
-            ExtractionRoot,
+            GetExtractionRoot(),
             logicalPath.Replace('/', Path.DirectorySeparatorChar));
         string? directory = Path.GetDirectoryName(absolutePath);
         if (directory is null)
@@ -64,6 +65,15 @@ internal static class BundledDefaultMaterialAssetStore
 
         absolutePath = GetAbsolutePath(logicalPath);
         return true;
+    }
+
+    internal static IDisposable PushExtractionRootOverride(string extractionRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extractionRoot);
+
+        string? previousRoot = ExtractionRootOverride.Value;
+        ExtractionRootOverride.Value = extractionRoot;
+        return new ExtractionRootOverrideScope(previousRoot);
     }
 
     private static string GetResourceName(string logicalPath)
@@ -123,5 +133,27 @@ internal static class BundledDefaultMaterialAssetStore
         }
 
         return string.Join('.', segments);
+    }
+
+    private static string GetExtractionRoot()
+    {
+        return ExtractionRootOverride.Value ?? DefaultExtractionRoot;
+    }
+
+    private sealed class ExtractionRootOverrideScope(string? previousRoot) : IDisposable
+    {
+        private readonly string? previousRoot = previousRoot;
+        private bool disposed;
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            ExtractionRootOverride.Value = previousRoot;
+            disposed = true;
+        }
     }
 }

--- a/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
@@ -34,7 +34,7 @@ public static class CliArgumentsParser
           --local-source-path <path>
                                Required when --source local is used. Mirrors the Unity SDK LocalSourcePath naming.
           --server-url <url>     Required when --source remote is used. Absolute direct .zip/.7z CityGML archive URL. Mirrors the Unity SDK ServerUrl naming.
-          --work-root <path>     Optional. Working directory for live-generated assets and remote download cache. Default: runtime/<os>/resonite.
+          --work-root <path>     Optional. Working directory for live-generated assets, remote download cache, and asset reuse state. Default: runtime/<os>/resonite.
           --resonitelink-port    Required unless --resonitelink-url is used. Connect to ws://localhost:<port>/ and build live in Resonite.
           --resonitelink-url     Required unless --resonitelink-port is used. Absolute ws:// or wss:// endpoint for live ResoniteLink builds.
           --resonitelink-connections <count>

--- a/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
@@ -240,6 +240,12 @@ public static class CliArgumentsParser
                                     $"The value '{serverUrl}' is not a valid absolute URL.");
                             }
 
+                            if (!LooksLikeSupportedArchiveUri(serverUri))
+                            {
+                                return CliParseResult.Failure(
+                                    "The --server-url value must point directly to a .zip or .7z CityGML archive over http or https.");
+                            }
+
                             break;
                         }
                     case "--exclude-lod":
@@ -276,27 +282,14 @@ public static class CliArgumentsParser
                         }
                     default:
                         {
-                            // Check for package-specific pattern options like --tran-pattern
-                            bool foundPatternOption = false;
-                            foreach (string pkg in PlateauPackageCatalog.SupportedPackageNames)
+                            if (TryParsePackagePatternOption(token, args, ref index, out string? normalizedPackageName, out string? patternValue))
                             {
-                                string optionPrefix = $"--{pkg}-pattern";
-                                if (token.Equals(optionPrefix, StringComparison.OrdinalIgnoreCase))
-                                {
-                                    string patternValue = ReadValue(args, ref index, token);
-                                    packagePatterns ??= new();
-                                    packagePatterns[pkg] = patternValue;
-                                    foundPatternOption = true;
-                                    break;
-                                }
+                                packagePatterns ??= new(StringComparer.OrdinalIgnoreCase);
+                                packagePatterns[normalizedPackageName!] = patternValue!;
+                                break;
                             }
 
-                            if (!foundPatternOption)
-                            {
-                                return CliParseResult.Failure($"Unknown option '{token}'.");
-                            }
-
-                            break;
+                            return CliParseResult.Failure($"Unknown option '{token}'.");
                         }
                 }
             }
@@ -516,6 +509,47 @@ public static class CliArgumentsParser
 
         exclusionMap = normalizedMap.Count > 0 ? normalizedMap : null;
         return true;
+    }
+
+    private static bool TryParsePackagePatternOption(
+        string token,
+        string[] args,
+        ref int index,
+        out string? normalizedPackageName,
+        out string? patternValue)
+    {
+        normalizedPackageName = null;
+        patternValue = null;
+
+        const string suffix = "-pattern";
+        if (!token.StartsWith("--", StringComparison.Ordinal)
+            || !token.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string packageName = token[2..^suffix.Length];
+        if (!PlateauPackageCatalog.TryNormalizePackageName(packageName, out string? normalized))
+        {
+            return false;
+        }
+
+        normalizedPackageName = normalized;
+        patternValue = ReadValue(args, ref index, token);
+        return true;
+    }
+
+    private static bool LooksLikeSupportedArchiveUri(Uri serverUri)
+    {
+        if (!string.Equals(serverUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(serverUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string extension = Path.GetExtension(serverUri.AbsolutePath);
+        return string.Equals(extension, ".zip", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(extension, ".7z", StringComparison.OrdinalIgnoreCase);
     }
 
     internal static string GetCurrentOsDirectoryName()

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -100,6 +100,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
 
         this.metadata = metadata;
         string resolvedWorkRoot = Path.GetFullPath(workRoot);
+        Directory.CreateDirectory(resolvedWorkRoot);
         generatedAssetsRoot = Path.Combine(resolvedWorkRoot, ".generated-assets");
         liveAssetStatePath = Path.Combine(resolvedWorkRoot, LiveAssetStateFileName);
         datasetSlotId = ResoniteLinkEntityIdFactory.CreateDatasetScopedEntityId(
@@ -1716,7 +1717,9 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         {
             string directory = Path.GetDirectoryName(liveAssetStatePath) ?? ".";
             Directory.CreateDirectory(directory);
-            string temporaryPath = $"{liveAssetStatePath}.tmp";
+            string temporaryPath = Path.Combine(
+                directory,
+                $"{Path.GetFileName(liveAssetStatePath)}.{Guid.NewGuid():N}.tmp");
             LiveAssetState state = new(
                 assetSourceFingerprints.OrderBy(static pair => pair.Key, StringComparer.Ordinal)
                     .ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal));

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -1720,16 +1720,40 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             string temporaryPath = Path.Combine(
                 directory,
                 $"{Path.GetFileName(liveAssetStatePath)}.{Guid.NewGuid():N}.tmp");
-            LiveAssetState state = new(
-                assetSourceFingerprints.OrderBy(static pair => pair.Key, StringComparer.Ordinal)
-                    .ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal));
-            string json = JsonSerializer.Serialize(state, LiveAssetStateJsonContext.Default.LiveAssetState);
-            await File.WriteAllTextAsync(temporaryPath, json, cancellationToken);
-            File.Move(temporaryPath, liveAssetStatePath, overwrite: true);
+            try
+            {
+                LiveAssetState state = new(
+                    assetSourceFingerprints.OrderBy(static pair => pair.Key, StringComparer.Ordinal)
+                        .ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal));
+                string json = JsonSerializer.Serialize(state, LiveAssetStateJsonContext.Default.LiveAssetState);
+                await File.WriteAllTextAsync(temporaryPath, json, cancellationToken);
+                File.Move(temporaryPath, liveAssetStatePath, overwrite: true);
+            }
+            finally
+            {
+                TryDeleteTemporaryAssetStateFile(temporaryPath);
+            }
         }
         finally
         {
             assetStateWriteLock.Release();
+        }
+    }
+
+    private static void TryDeleteTemporaryAssetStateFile(string temporaryPath)
+    {
+        try
+        {
+            if (File.Exists(temporaryPath))
+            {
+                File.Delete(temporaryPath);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
         }
     }
 

--- a/src/Plateau.ResoniteLink.Domain/Importing/PlateauMeshCode.cs
+++ b/src/Plateau.ResoniteLink.Domain/Importing/PlateauMeshCode.cs
@@ -45,6 +45,11 @@ public static class PlateauMeshCode
         {
             int secondLatitudeIndex = int.Parse(meshCode[4].ToString(), CultureInfo.InvariantCulture);
             int secondLongitudeIndex = int.Parse(meshCode[5].ToString(), CultureInfo.InvariantCulture);
+            if (secondLatitudeIndex > 7 || secondLongitudeIndex > 7)
+            {
+                return false;
+            }
+
             latitudeSpan /= 8.0;
             longitudeSpan /= 8.0;
             southLatitude += secondLatitudeIndex * latitudeSpan;
@@ -55,6 +60,11 @@ public static class PlateauMeshCode
         {
             int thirdLatitudeIndex = int.Parse(meshCode[6].ToString(), CultureInfo.InvariantCulture);
             int thirdLongitudeIndex = int.Parse(meshCode[7].ToString(), CultureInfo.InvariantCulture);
+            if (thirdLatitudeIndex > 9 || thirdLongitudeIndex > 9)
+            {
+                return false;
+            }
+
             latitudeSpan /= 10.0;
             longitudeSpan /= 10.0;
             southLatitude += thirdLatitudeIndex * latitudeSpan;

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -25,6 +25,54 @@ public sealed class PlateauImportRequestValidatorTests
                 StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void ValidateRejectsRemoteServerUrlThatIsNotDirectArchive()
+    {
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            SourceKind: DatasetSourceKind.Remote,
+            LocalSourcePath: null,
+            ServerUri: new Uri("https://example.invalid/dataset"));
+
+        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
+
+        Assert.Contains(
+            errors,
+            error => string.Equals(
+                error,
+                "The --server-url value must point directly to a .zip or .7z CityGML archive over http or https.",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRejectsUnsupportedPackageKeysInPackageMaps()
+    {
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "C:/dataset",
+            ServerUri: null,
+            ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
+            {
+                ["unknown"] = new HashSet<int> { 1 },
+            },
+            PackagePatterns: new Dictionary<string, string>
+            {
+                ["another-unknown"] = "*Road*",
+            });
+
+        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
+
+        Assert.Contains(
+            errors,
+            error => error.Contains("Unsupported package name(s): unknown.", StringComparison.Ordinal));
+        Assert.Contains(
+            errors,
+            error => error.Contains("Unsupported package name(s): another-unknown.", StringComparison.Ordinal));
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-0.01)]

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -73,6 +73,40 @@ public sealed class PlateauImportRequestValidatorTests
             error => error.Contains("Unsupported package name(s): another-unknown.", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void ValidateRejectsDuplicateNormalizedPackageKeysInPackageMaps()
+    {
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "C:/dataset",
+            ServerUri: null,
+            ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
+            {
+                ["tran"] = new HashSet<int> { 1 },
+                [" TRAN "] = new HashSet<int> { 2 },
+            },
+            PackagePatterns: new Dictionary<string, string>
+            {
+                ["waterbody"] = "*Water*",
+                ["wtr"] = "*River*",
+            });
+
+        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
+
+        Assert.Contains(
+            errors,
+            error => error.Contains(
+                "The ExcludeLodLevelsByPackage value contains duplicate package keys after normalization: tran.",
+                StringComparison.Ordinal));
+        Assert.Contains(
+            errors,
+            error => error.Contains(
+                "The PackagePatterns value contains duplicate package keys after normalization: wtr.",
+                StringComparison.Ordinal));
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-0.01)]

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -201,6 +201,38 @@ public sealed class PlateauImportServiceTests
     }
 
     [Fact]
+    public async Task ExecuteAsyncNormalizesWhitespacePaddedLocalPathAndPackageMaps()
+    {
+        StubResoniteSceneBuilder sceneBuilder = new();
+        PlateauImportService service = new(sceneBuilder);
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDatasetMixedObjects");
+
+        ImportExecutionResult result = await service.ExecuteAsync(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: $"  {fixturePath}  ",
+                ServerUri: null,
+                PackageNames: [" waterbody ", " tran "],
+                ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
+                {
+                    ["waterbody"] = new HashSet<int> { 1 },
+                },
+                PackagePatterns: new Dictionary<string, string>
+                {
+                    ["waterbody"] = "*Water*",
+                }),
+            workRoot: "runtime/resonite");
+
+        Assert.Equal(["wtr", "tran"], result.Metadata.Request.PackageNames);
+        Assert.NotNull(result.Metadata.Request.ExcludeLodLevelsByPackage);
+        Assert.True(result.Metadata.Request.ExcludeLodLevelsByPackage.ContainsKey("wtr"));
+        Assert.NotNull(result.Metadata.Request.PackagePatterns);
+        Assert.Equal("*Water*", result.Metadata.Request.PackagePatterns["wtr"]);
+    }
+
+    [Fact]
     public async Task ExecuteAsyncFiltersRequestedPackages()
     {
         StubResoniteSceneBuilder sceneBuilder = new();
@@ -1674,7 +1706,7 @@ public sealed class PlateauImportServiceTests
                 MeshCode: " 53394525 ",
                 SourceKind: DatasetSourceKind.Remote,
                 LocalSourcePath: null,
-                ServerUri: new Uri("https://example.invalid/source", UriKind.Absolute)),
+                ServerUri: new Uri("https://example.invalid/source.zip", UriKind.Absolute)),
             workRoot: "runtime/resonite");
 
         PlateauImportRequest factoryRequest = Assert.Single(constructionSourceFactory.Requests);

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -1353,6 +1353,66 @@ public sealed class PlateauImportServiceTests
     }
 
     [Fact]
+    public async Task ExecuteAsyncRejectsNullStringFieldsWithValidationException()
+    {
+        StubResoniteSceneBuilder sceneBuilder = new();
+        PlateauImportService service = new(sceneBuilder);
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
+
+        PlateauImportValidationException exception = await Assert.ThrowsAsync<PlateauImportValidationException>(() =>
+            service.ExecuteAsync(
+                new PlateauImportRequest(
+                    Dataset: null!,
+                    MeshCode: null!,
+                    SourceKind: DatasetSourceKind.Local,
+                    LocalSourcePath: fixturePath,
+                    ServerUri: null),
+                workRoot: "runtime/resonite"));
+
+        Assert.Contains("The dataset value is required.", exception.Errors);
+        Assert.Contains("The mesh code value is required.", exception.Errors);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncRejectsDuplicateNormalizedPackageMapKeysWithValidationException()
+    {
+        StubResoniteSceneBuilder sceneBuilder = new();
+        PlateauImportService service = new(sceneBuilder);
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
+
+        PlateauImportValidationException exception = await Assert.ThrowsAsync<PlateauImportValidationException>(() =>
+            service.ExecuteAsync(
+                new PlateauImportRequest(
+                    Dataset: "tokyo23ku",
+                    MeshCode: "53394525",
+                    SourceKind: DatasetSourceKind.Local,
+                    LocalSourcePath: fixturePath,
+                    ServerUri: null,
+                    ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
+                    {
+                        ["tran"] = new HashSet<int> { 1 },
+                        [" TRAN "] = new HashSet<int> { 2 },
+                    },
+                    PackagePatterns: new Dictionary<string, string>
+                    {
+                        ["waterbody"] = "*Water*",
+                        ["wtr"] = "*River*",
+                    }),
+                workRoot: "runtime/resonite"));
+
+        Assert.Contains(
+            exception.Errors,
+            error => error.Contains(
+                "The ExcludeLodLevelsByPackage value contains duplicate package keys after normalization: tran.",
+                StringComparison.Ordinal));
+        Assert.Contains(
+            exception.Errors,
+            error => error.Contains(
+                "The PackagePatterns value contains duplicate package keys after normalization: wtr.",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task ExecuteAsyncFallsBackToBundledDefaultTextureWhenTextureFileIsMissing()
     {
         StubResoniteSceneBuilder sceneBuilder = new();

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -1327,6 +1327,32 @@ public sealed class PlateauImportServiceTests
     }
 
     [Fact]
+    public async Task ExecuteAsyncRejectsUnsupportedPackagePatternWithValidationException()
+    {
+        StubResoniteSceneBuilder sceneBuilder = new();
+        PlateauImportService service = new(sceneBuilder);
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
+
+        PlateauImportValidationException exception = await Assert.ThrowsAsync<PlateauImportValidationException>(() =>
+            service.ExecuteAsync(
+                new PlateauImportRequest(
+                    Dataset: "tokyo23ku",
+                    MeshCode: "53394525",
+                    SourceKind: DatasetSourceKind.Local,
+                    LocalSourcePath: fixturePath,
+                    ServerUri: null,
+                    PackagePatterns: new Dictionary<string, string>
+                    {
+                        ["unknown"] = "*Road*",
+                    }),
+                workRoot: "runtime/resonite"));
+
+        Assert.Contains(
+            exception.Errors,
+            error => error.Contains("Unsupported package name(s): unknown.", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task ExecuteAsyncFallsBackToBundledDefaultTextureWhenTextureFileIsMissing()
     {
         StubResoniteSceneBuilder sceneBuilder = new();

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -149,7 +149,7 @@ public sealed class CliArgumentsParserTests
                 "--source",
                 "remote",
                 "--server-url",
-                "https://example.invalid/plateau",
+                "https://example.invalid/plateau.zip",
                 "--resonitelink-port",
                 "-1",
             ]);
@@ -170,7 +170,7 @@ public sealed class CliArgumentsParserTests
                 "--source",
                 "remote",
                 "--server-url",
-                "https://example.invalid/plateau",
+                "https://example.invalid/plateau.zip",
                 "--resonitelink-url",
                 "ws://localhost:12345/",
             ]);
@@ -178,9 +178,56 @@ public sealed class CliArgumentsParserTests
         Assert.Null(result.Error);
         Assert.Equal(DatasetSourceKind.Remote, result.Options!.Request.SourceKind);
         Assert.Equal(
-            new Uri("https://example.invalid/plateau"),
+            new Uri("https://example.invalid/plateau.zip"),
             result.Options.Request.ServerUri);
         Assert.Equal(new Uri("ws://localhost:12345/"), result.Options.ResoniteLinkUri);
+    }
+
+    [Fact]
+    public void ParseRejectsRemoteCommandWhenServerUrlIsNotDirectArchive()
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "build",
+                "--dataset",
+                "tokyo23ku",
+                "--mesh-code",
+                "53394525",
+                "--source",
+                "remote",
+                "--server-url",
+                "https://example.invalid/plateau",
+                "--resonitelink-url",
+                "ws://localhost:12345/",
+            ]);
+
+        Assert.Equal(
+            "The --server-url value must point directly to a .zip or .7z CityGML archive over http or https.",
+            result.Error);
+    }
+
+    [Fact]
+    public void ParseAcceptsPackagePatternOptionForAliasPackageName()
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "build",
+                "--dataset",
+                "tokyo23ku",
+                "--mesh-code",
+                "53394525",
+                "--local-source-path",
+                "/data/plateau",
+                "--waterbody-pattern",
+                "*Water*",
+                "--resonitelink-port",
+                "12345",
+            ]);
+
+        Assert.Null(result.Error);
+        Assert.NotNull(result.Options);
+        Assert.NotNull(result.Options.Request.PackagePatterns);
+        Assert.Equal("*Water*", result.Options.Request.PackagePatterns["wtr"]);
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
@@ -208,6 +208,34 @@ public sealed class ResoniteLinkSceneBuilderAssetReuseTests
         Assert.Equal(5, sharedClient.ImportedTexturePaths.Count);
     }
 
+    [Fact]
+    public async Task BuildAsyncAllowsConcurrentBuildersToPersistLiveAssetStateInSameWorkRoot()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        CapturedScene firstScene = new(
+            metadata,
+            [CreateTriangleCityObject(
+                objectIdentity: "shared-work-root-one",
+                mesh: CreateTriangleMesh(0.0, 1.0, 2.0, "triangle-textured-material"))]);
+        CapturedScene secondScene = new(
+            metadata,
+            [CreateTriangleCityObject(
+                objectIdentity: "shared-work-root-two",
+                mesh: CreateTriangleMesh(3.0, 4.0, 5.0, "triangle-textured-material"))]);
+        string workRoot = Path.Combine(datasetDirectory.Path, "work");
+
+        using ReuseSessionSharedClient firstClient = new();
+        using ReuseSessionSharedClient secondClient = new();
+
+        await Task.WhenAll(
+            BuildSceneOnceAsync(firstScene, firstClient, workRoot),
+            BuildSceneOnceAsync(secondScene, secondClient, workRoot));
+
+        string statePath = Path.Combine(workRoot, "resonite-live-asset-state.json");
+        Assert.True(File.Exists(statePath));
+    }
+
     private static async Task BuildSceneOnceAsync(
         CapturedScene scene,
         ReuseSessionSharedClient client,

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
@@ -124,6 +124,8 @@ public sealed class ResoniteLinkSceneBuilderAssetReuseTests
 
         try
         {
+            using IDisposable extractionRootScope = BundledDefaultMaterialAssetStore.PushExtractionRootOverride(
+                Path.Combine(datasetDirectory.Path, "bundled-assets"));
             string bundledTexturePath = BundledDefaultMaterialFamilies.FacadeVariants[0];
             ResoniteMaterialBinding sampleMaterial = new(
                 MaterialKey: "bundle-companion-test",
@@ -234,6 +236,37 @@ public sealed class ResoniteLinkSceneBuilderAssetReuseTests
 
         string statePath = Path.Combine(workRoot, "resonite-live-asset-state.json");
         Assert.True(File.Exists(statePath));
+    }
+
+    [Fact]
+    public async Task BuildAsyncReusesPersistedLiveAssetStateAcrossBuilderRuns()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path, packageNames: ["bldg"]);
+        string workRoot = Path.Combine(datasetDirectory.Path, "work");
+        string bundledTexturePath = BundledDefaultMaterialFamilies.FacadeVariants[0];
+        CapturedScene scene = new(
+            metadata,
+            [CreateBundledTriangleCityObject(
+                objectIdentity: "persisted-live-state",
+                texturePath: bundledTexturePath,
+                mesh: CreateTriangleMesh(0.0, 1.0, 2.0, "triangle-textured-material"))]);
+
+        ReuseFakeSession session = new();
+        using ReuseSessionSharedClient firstClient = new(session);
+        using ReuseSessionSharedClient secondClient = new(session);
+
+        await BuildSceneOnceAsync(scene, firstClient, workRoot);
+        string statePath = Path.Combine(workRoot, "resonite-live-asset-state.json");
+        Assert.True(File.Exists(statePath));
+
+        int importedTextureCountAfterFirstRun = firstClient.ImportedTexturePaths.Count;
+        int importedMeshCountAfterFirstRun = firstClient.ImportedMeshes.Count;
+
+        await BuildSceneOnceAsync(scene, secondClient, workRoot);
+
+        Assert.Equal(importedTextureCountAfterFirstRun, secondClient.ImportedTexturePaths.Count);
+        Assert.Equal(importedMeshCountAfterFirstRun, secondClient.ImportedMeshes.Count);
     }
 
     private static async Task BuildSceneOnceAsync(
@@ -445,7 +478,17 @@ public sealed class ResoniteLinkSceneBuilderAssetReuseTests
 
     private sealed class ReuseSessionSharedClient : IResoniteLinkClient
     {
-        private readonly ReuseFakeSession session = new();
+        private readonly ReuseFakeSession session;
+
+        public ReuseSessionSharedClient()
+            : this(new ReuseFakeSession())
+        {
+        }
+
+        public ReuseSessionSharedClient(ReuseFakeSession session)
+        {
+            this.session = session;
+        }
 
         public int ConnectCallCount { get; private set; }
         public List<AddComponent> AddedComponents => session.AddedComponents;

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
@@ -269,6 +269,27 @@ public sealed class ResoniteLinkSceneBuilderAssetReuseTests
         Assert.Equal(importedMeshCountAfterFirstRun, secondClient.ImportedMeshes.Count);
     }
 
+    [Fact]
+    public async Task BuildAsyncCleansTemporaryLiveAssetStateFileWhenPersistMoveFails()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        CapturedScene scene = new(
+            metadata,
+            [CreateTriangleCityObject(
+                objectIdentity: "persist-failure-cleanup",
+                mesh: CreateTriangleMesh(0.0, 1.0, 2.0, "triangle-textured-material"))]);
+        string workRoot = Path.Combine(datasetDirectory.Path, "work");
+        string statePath = Path.Combine(workRoot, "resonite-live-asset-state.json");
+        Directory.CreateDirectory(statePath);
+        using ReuseSessionSharedClient client = new();
+
+        await Assert.ThrowsAnyAsync<IOException>(() => BuildSceneOnceAsync(scene, client, workRoot));
+        Assert.DoesNotContain(
+            Directory.EnumerateFiles(workRoot, "resonite-live-asset-state.json.*.tmp"),
+            static path => File.Exists(path));
+    }
+
     private static async Task BuildSceneOnceAsync(
         CapturedScene scene,
         ReuseSessionSharedClient client,

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -1098,7 +1098,8 @@ public sealed class ResoniteLinkSceneBuilderTests
             ResoniteLinkSendDiagnostics.Disabled,
             () => blockingClient);
 
-        await builder.BeginAsync(scene.Metadata, "runtime/resonite");
+        using TemporaryDirectory workDirectory = new();
+        await builder.BeginAsync(scene.Metadata, workDirectory.Path);
         await builder.ProcessCityObjectAsync(scene.CityObjects[0]);
 
         Task<IReadOnlyList<string>> completionTask = builder.CompleteAsync();

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -11,6 +11,7 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace Plateau.ResoniteLink.Tests.Cli;
 
+[Collection(BundledCompanionTextureIsolationGroup.Name)]
 [SuppressMessage(
     "Reliability",
     "CA2000:Dispose objects before losing scope",

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderYOffsetTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderYOffsetTests.cs
@@ -25,7 +25,8 @@ public sealed class ResoniteLinkSceneBuilderYOffsetTests
             ResoniteLinkSendDiagnostics.Disabled,
             () => fakeClient);
 
-        await builder.BeginAsync(scene.Metadata, "runtime/resonite");
+        using TemporaryDirectory workDirectory = new();
+        await builder.BeginAsync(scene.Metadata, workDirectory.Path);
         foreach (ResoniteConstructionCityObject cityObject in scene.CityObjects)
         {
             await builder.ProcessCityObjectAsync(cityObject);
@@ -82,7 +83,8 @@ public sealed class ResoniteLinkSceneBuilderYOffsetTests
             ResoniteLinkSendDiagnostics.Disabled,
             () => fakeClient);
 
-        await builder.BeginAsync(scene.Metadata, "runtime/resonite");
+        using TemporaryDirectory workDirectory = new();
+        await builder.BeginAsync(scene.Metadata, workDirectory.Path);
 
         Slot datasetSlot = Assert.IsType<Slot>(fakeClient.SlotsById[datasetSlotId]);
         Field_float3 datasetPosition = Assert.IsType<Field_float3>(datasetSlot.Position);

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteMaterialComponentBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteMaterialComponentBuilderTests.cs
@@ -5,6 +5,7 @@ using ResoniteLink;
 
 namespace Plateau.ResoniteLink.Tests.Cli;
 
+[Collection(BundledCompanionTextureIsolationGroup.Name)]
 public sealed class ResoniteMaterialComponentBuilderTests
 {
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Domain/PlateauMeshCodeTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Domain/PlateauMeshCodeTests.cs
@@ -1,0 +1,45 @@
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Tests.Domain;
+
+public sealed class PlateauMeshCodeTests
+{
+    [Fact]
+    public void TryGetBoundsReturnsExpectedBoundsForValidThirdLevelMesh()
+    {
+        bool parsed = PlateauMeshCode.TryGetBounds(
+            "53394525",
+            out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds);
+
+        Assert.True(parsed);
+        Assert.Equal(35.683333333333337, bounds.SouthLatitude, 9);
+        Assert.Equal(35.69166666666667, bounds.NorthLatitude, 9);
+        Assert.Equal(139.6875, bounds.WestLongitude, 9);
+        Assert.Equal(139.7, bounds.EastLongitude, 9);
+    }
+
+    [Fact]
+    public void TryGetCenterReturnsExpectedCenterForValidThirdLevelMesh()
+    {
+        bool parsed = PlateauMeshCode.TryGetCenter("53394525", out ResoniteLocalOrigin center);
+
+        Assert.True(parsed);
+        Assert.Equal(35.6875, center.Latitude, 9);
+        Assert.Equal(139.69375, center.Longitude, 9);
+        Assert.Equal(0.0, center.Altitude, 9);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("5339452A")]
+    [InlineData("5339452")]
+    [InlineData("533948")]
+    public void TryGetBoundsRejectsInvalidMeshCodes(string meshCode)
+    {
+        bool parsed = PlateauMeshCode.TryGetBounds(
+            meshCode,
+            out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) _);
+
+        Assert.False(parsed);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize import requests before validation and validate remote archive URLs plus package-keyed maps consistently
- accept package alias pattern flags, tighten CLI remote URL parsing, and add PlateauMeshCode coverage for invalid subdivisions
- make live asset state writes safe for shared work roots and fix the remote README examples in English and Japanese

## Verification
- `dotnet test Plateau.ResoniteLink.sln --configuration Release -m:1 -p:UseSharedCompilation=false`
- `dotnet test tests/Plateau.ResoniteLink.Tests/Plateau.ResoniteLink.Tests.csproj --configuration Release --filter "FullyQualifiedName~PlateauImportRequestValidatorTests|FullyQualifiedName~PlateauImportServiceTests|FullyQualifiedName~CliArgumentsParserTests|FullyQualifiedName~PlateauMeshCodeTests|FullyQualifiedName~ResoniteLinkSceneBuilderAssetReuseTests" -m:1 -p:UseSharedCompilation=false`

## Notes
- `dotnet format whitespace . --folder --verify-no-changes` timed out after 60s in this WSL environment, so whitespace verification could not be completed with that command.