### PR TITLE
[codex] Clarify dataset-specific PLATEAU license notes in README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -118,13 +118,15 @@ dotnet test Plateau.ResoniteLink.sln --configuration Release -m:1 -p:UseSharedCo
 ## License Notes
 
 - ルートのソースコードは [MIT](LICENSE) で提供する。
-- import 対象の PLATEAU dataset 自体を、この repository が再 license するわけではない。利用条件は元の [PLATEAU Site Policy](https://www.mlit.go.jp/plateau/site-policy/) に従い、現行ポリシーでは、公開コンテンツは概ね PDL 1.0 互換の条件で利用できる一方、出典記載と、加工・編集した場合の明示が必要とされている。
+- import 対象の PLATEAU dataset 自体を、この repository が再 license することはない。この repository の MIT license はコードベースのみに適用され、PLATEAU data には適用されない。各 dataset はそれぞれ固有の著作権者、attribution 要件、license 条件を保持する。
+- import、再配布、派生コンテンツの公開を行う前に、その dataset に同梱された README / metadata、配布ページ、個別の権利表記を、ライセンス、出典表記、加工・編集時の明示義務、再配布条件、その他の利用条件の正本として確認すること。
+- [PLATEAU Site Policy](https://www.mlit.go.jp/plateau/site-policy/) は、PLATEAU website 上で別個の権利表記がないコンテンツに対する portal-level の既定条件であり、個別の 3D都市モデル package に付属する dataset-specific な条件を上書きするものではない。
 - PLATEAU SDK for Unity は別 upstream の MIT project であり、ライセンス控えを `THIRD_PARTY_LICENSES/PLATEAU-SDK-for-Unity-LICENSE.txt` に置いている。
 - `src/Plateau.ResoniteLink.Cli/Assets/DefaultMaterials/` 配下の同梱 default material texture は AmbientCG 由来で、`THIRD_PARTY_LICENSES/ambientCG-CC0-1.0.txt` に CC0 1.0 と出所を記録している。
 - 既定の DEM terrain imagery overlay は同梱 asset ではない。Geospatial Information Authority of Japan (GSI, 国土地理院) の seamless photo tile endpoint `https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/{z}/{x}/{y}.jpg` から生成しており、出所と利用上の注意は `THIRD_PARTY_LICENSES/gsi-seamlessphoto.txt` に記録している。
 - NuGet を含む主要依存は、それぞれ upstream のライセンスに従う。binary や同梱 asset を再配布する前に、実際に出荷する version の package metadata と upstream ライセンス条件を確認する。
 
-PLATEAU guidance:
+PLATEAU dataset guidance:
 
-- [PLATEAU Start Guide](https://www.mlit.go.jp/plateau/start-guide/) では、3D都市モデルの著作権は各地方公共団体に帰属し、dataset ごとに PDL 1.0、CC BY 4.0、ODC BY、ODbL などの open license で提供されると案内されている。
-- 派生コンテンツや再配布を行う場合は、元 dataset の attribution を保持し、dataset 個別条件や測量法由来の制約がないかも確認する。
+- [PLATEAU Start Guide](https://www.mlit.go.jp/plateau/start-guide/) では、3D都市モデルの著作権は各地方公共団体に帰属し、PLATEAU dataset は source dataset に応じて PDL 1.0、CC BY 4.0、ODC BY、ODbL などの条件で公開されうると案内している。
+- dataset page、同梱 README、source metadata により、より具体的な条件が示されている場合は、attribution、改変表示、再配布条件、追加制約、測量法その他の法令由来の制約確認を含め、その dataset 個別条件を正とする。

--- a/README.md
+++ b/README.md
@@ -121,13 +121,15 @@ dotnet test Plateau.ResoniteLink.sln --configuration Release -m:1 -p:UseSharedCo
 ## License Notes
 
 - The repository root is licensed under [MIT](LICENSE).
-- Imported PLATEAU datasets are not re-licensed by this repository. Their use remains subject to the original PLATEAU terms in the [PLATEAU Site Policy](https://www.mlit.go.jp/plateau/site-policy/), which currently states that published PLATEAU content is generally available under PDL 1.0-compatible terms, requires source attribution, and requires marking edits/derivative use where applicable.
+- Imported PLATEAU datasets are not re-licensed by this repository. The MIT license for this repository applies to this codebase only, not to PLATEAU data, and each dataset keeps its own copyright holder, attribution requirements, and license terms.
+- Before importing, redistributing, or publishing derived content, treat the dataset's own README, metadata, download page, and attached rights notices as the authoritative source for its license, attribution text, edit-marking obligations, redistribution rules, and any other use conditions.
+- The [PLATEAU Site Policy](https://www.mlit.go.jp/plateau/site-policy/) is only the portal-level default for PLATEAU website content when no separate rights statement is shown there; it does not override dataset-specific terms attached to a particular 3D city model package.
 - PLATEAU SDK for Unity is a separate upstream MIT-licensed project; a local copy of that license is tracked in `THIRD_PARTY_LICENSES/PLATEAU-SDK-for-Unity-LICENSE.txt`.
 - Bundled default material textures under `src/Plateau.ResoniteLink.Cli/Assets/DefaultMaterials/` are sourced from AmbientCG and tracked as CC0 1.0 in `THIRD_PARTY_LICENSES/ambientCG-CC0-1.0.txt`.
 - The default DEM terrain imagery overlay is not a bundled asset. It is generated from the Geospatial Information Authority of Japan (GSI) seamless photo tile endpoint `https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/{z}/{x}/{y}.jpg`; provenance and usage notes are tracked in `THIRD_PARTY_LICENSES/gsi-seamlessphoto.txt`.
 - NuGet and other runtime dependencies keep their own upstream licenses. Before redistributing binaries or vendored assets, review the package metadata and upstream license terms for the exact versions you ship.
 
-PLATEAU guidance:
+PLATEAU dataset guidance:
 
-- The [PLATEAU Start Guide](https://www.mlit.go.jp/plateau/start-guide/) states that PLATEAU 3D city model copyrights belong to the respective local governments and that the datasets are provided as open data under licenses such as PDL 1.0, CC BY 4.0, ODC BY, or ODbL depending on the source dataset.
-- When publishing derived content or redistributed data, keep the original dataset-level attribution and check whether any dataset-specific restrictions or measurement-law constraints apply.
+- The [PLATEAU Start Guide](https://www.mlit.go.jp/plateau/start-guide/) states that 3D city model copyrights belong to the respective local governments, and PLATEAU datasets may be published under terms such as PDL 1.0, CC BY 4.0, ODC BY, or ODbL depending on the source dataset.
+- If a dataset page, bundled README, or source metadata states more specific conditions, treat those dataset-specific conditions as authoritative for attribution, edit-marking, redistribution, and any additional restrictions, including possible measurement-law or other statutory constraints.


### PR DESCRIPTION
- Tightens the README license section so the repository MIT license is clearly scoped to this codebase only.
- States that imported PLATEAU datasets keep their own dataset-level licenses and terms, rather than implying one repository-wide PLATEAU data license.
- Directs readers to treat each dataset's published README/metadata/license notice as the authoritative source for attribution, modification marking, redistribution, and any additional restrictions.
- Keeps the third-party asset notes for PLATEAU SDK for Unity, AmbientCG, and GSI imagery intact while making their boundaries easier to distinguish from dataset licensing.
- Updates the Japanese README alongside the English README to keep the documentation aligned.
- Validation: `dotnet format whitespace . --folder --verify-no-changes`
