### PR TITLE
[codex] Open ResoniteLink before CityGML bootstrap

### DIFF
--- a/src/Plateau.ResoniteLink.Application/Importing/IResoniteSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/IResoniteSceneBuilder.cs
@@ -4,6 +4,10 @@ namespace Plateau.ResoniteLink.Application.Importing;
 
 public interface IResoniteSceneBuilder : IAsyncDisposable
 {
+    Task EnsureConnectedAsync(
+        PlateauImportRequest request,
+        CancellationToken cancellationToken = default);
+
     Task BeginAsync(
         ResoniteConstructionMetadata metadata,
         string workRoot,

--- a/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
@@ -38,17 +38,23 @@ public sealed class PlateauImportService(
         ReportProgress(
             $"[import] Resolved dataset source for '{resolvedRequest.Dataset}' mesh '{resolvedRequest.MeshCode}'.");
 
-        Stopwatch sourceStopwatch = Stopwatch.StartNew();
-        IResoniteConstructionSource source = await constructionSourceFactory.CreateAsync(
-            resolvedRequest,
-            progressReporter,
-            cancellationToken);
-        sourceStopwatch.Stop();
-        ReportProgress(
-            $"[import] Prepared construction source in {sourceStopwatch.Elapsed.TotalSeconds:F3}s.");
-
         try
         {
+            Stopwatch connectStopwatch = Stopwatch.StartNew();
+            await sceneBuilder.EnsureConnectedAsync(resolvedRequest, cancellationToken);
+            connectStopwatch.Stop();
+            ReportProgress(
+                $"[import] Scene builder connection check completed in {connectStopwatch.Elapsed.TotalSeconds:F3}s.");
+
+            Stopwatch sourceStopwatch = Stopwatch.StartNew();
+            IResoniteConstructionSource source = await constructionSourceFactory.CreateAsync(
+                resolvedRequest,
+                progressReporter,
+                cancellationToken);
+            sourceStopwatch.Stop();
+            ReportProgress(
+                $"[import] Prepared construction source in {sourceStopwatch.Elapsed.TotalSeconds:F3}s.");
+
             Stopwatch beginStopwatch = Stopwatch.StartNew();
             await sceneBuilder.BeginAsync(source.Metadata, workRoot, cancellationToken);
             beginStopwatch.Stop();

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -27,6 +27,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
     private readonly ResoniteLinkSendDiagnostics diagnostics;
     private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator;
     private readonly ResoniteLiveAssetStateStore liveAssetStateStore;
+    private readonly SemaphoreSlim clientInitializationGate = new(1, 1);
     private readonly Action<string>? progressReporter;
     private List<IResoniteLinkClient>? clients;
     private ResoniteConstructionMetadata? metadata;
@@ -88,6 +89,15 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         this.progressReporter = progressReporter;
     }
 
+    public async Task EnsureConnectedAsync(
+        PlateauImportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        await EnsureClientsConnectedAsync(request, cancellationToken);
+    }
+
     public async Task BeginAsync(
         ResoniteConstructionMetadata metadata,
         string workRoot,
@@ -119,13 +129,8 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             "assetgroup",
             "common");
 
-        clients = Enumerable.Range(0, connectionCount)
-            .Select(_ =>
-            {
-                IResoniteLinkClient client = clientFactory();
-                return diagnostics.Enabled ? new MetricsResoniteLinkClient(client, diagnostics) : client;
-            })
-            .ToList();
+        await EnsureClientsConnectedAsync(metadata.Request, cancellationToken);
+        ObjectDisposedException.ThrowIf(clients is null, this);
         IResoniteLinkClient setupClient = clients[0];
         licenseManager = new ResoniteLicenseManager(metadata.Attribution);
         slotEnsureTasks = new ConcurrentDictionary<string, Lazy<Task>>(StringComparer.Ordinal);
@@ -175,12 +180,9 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         firstPreparedCityObjectLogged = 0;
         firstBuiltCityObjectLogged = 0;
         diagnostics.StartSendWindow(connectionCount);
-        await Task.WhenAll(clients.Select(client => client.ConnectAsync(endpoint, cancellationToken)));
         processingTasks = clients
             .Select(client => ProcessQueuedCityObjectsAsync(cityObjectChannel.Reader, client, cancellationToken))
             .ToArray();
-        ReportProgress(
-            $"[live] Connected {connectionCount} ResoniteLink sessions to {endpoint} for dataset '{metadata.Request.Dataset}' mesh '{metadata.Request.MeshCode}'.");
 
         await EnsureSlotKnownAsync(
             setupClient,
@@ -215,6 +217,49 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         await EnsureSlotKnownAsync(setupClient, datasetAssetsSlotId, datasetSlotId, "Assets", null, null, cancellationToken);
         await EnsureSlotKnownAsync(setupClient, commonAssetsSlotId, datasetAssetsSlotId, CommonAssetsSlotName, null, null, cancellationToken);
         ReportProgress("[live] Dataset slots and asset groups are ready.");
+    }
+
+    private async Task EnsureClientsConnectedAsync(
+        PlateauImportRequest request,
+        CancellationToken cancellationToken)
+    {
+        await clientInitializationGate.WaitAsync(cancellationToken);
+        try
+        {
+            if (clients is not null)
+            {
+                return;
+            }
+
+            List<IResoniteLinkClient> createdClients = Enumerable.Range(0, connectionCount)
+                .Select(_ =>
+                {
+                    IResoniteLinkClient client = clientFactory();
+                    return diagnostics.Enabled ? new MetricsResoniteLinkClient(client, diagnostics) : client;
+                })
+                .ToList();
+
+            try
+            {
+                await Task.WhenAll(createdClients.Select(client => client.ConnectAsync(endpoint, cancellationToken)));
+                clients = createdClients;
+                ReportProgress(
+                    $"[live] Connected {connectionCount} ResoniteLink sessions to {endpoint} for dataset '{request.Dataset}' mesh '{request.MeshCode}'.");
+            }
+            catch
+            {
+                foreach (IResoniteLinkClient client in createdClients)
+                {
+                    client.Dispose();
+                }
+
+                throw;
+            }
+        }
+        finally
+        {
+            clientInitializationGate.Release();
+        }
     }
 
     public async Task ProcessCityObjectAsync(

--- a/tests/Plateau.ResoniteLink.Tests/Application/LocalCityGmlResonitePlanBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/LocalCityGmlResonitePlanBuilderTests.cs
@@ -130,6 +130,13 @@ public sealed class LocalCityGmlResonitePlanBuilderTests
     {
         public List<ResoniteConstructionCityObject> CityObjects { get; } = [];
 
+        public Task EnsureConnectedAsync(
+            PlateauImportRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
         public Task BeginAsync(
             ResoniteConstructionMetadata metadata,
             string workRoot,

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -1762,6 +1762,7 @@ public sealed class PlateauImportServiceTests
             workRoot: "runtime/resonite");
 
         Assert.Contains(progressMessages, static message => message.StartsWith("[import] Resolved dataset source", StringComparison.Ordinal));
+        Assert.Contains(progressMessages, static message => message.StartsWith("[import] Scene builder connection check completed", StringComparison.Ordinal));
         Assert.Contains(progressMessages, static message => message.StartsWith("[import] Scanned ", StringComparison.Ordinal));
         Assert.Contains(progressMessages, static message => message.StartsWith("[import] Parsed ", StringComparison.Ordinal));
         Assert.Contains(progressMessages, static message => message.StartsWith("[import] Prepared construction source", StringComparison.Ordinal));
@@ -1803,9 +1804,141 @@ public sealed class PlateauImportServiceTests
         Assert.Single(sceneBuilder.CityObjects);
     }
 
+    [Fact]
+    public async Task ExecuteAsyncEnsuresSceneBuilderConnectionBeforeConstructionSourceBootstrap()
+    {
+        List<string> callOrder = [];
+        StubResoniteSceneBuilder sceneBuilder = new()
+        {
+            OnEnsureConnected = () => callOrder.Add("connect"),
+            OnBegin = () => callOrder.Add("begin"),
+        };
+
+        RecordingConstructionSourceFactory constructionSourceFactory = new(
+            CreateStubConstructionSource(),
+            onCreate: () => callOrder.Add("create-source"));
+        RecordingDatasetSourceResolver datasetSourceResolver = new(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: "/resolved/source",
+                ServerUri: null));
+        PlateauImportService service = new(
+            sceneBuilder,
+            datasetSourceResolver,
+            constructionSourceFactory: constructionSourceFactory);
+
+        await service.ExecuteAsync(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Remote,
+                LocalSourcePath: null,
+                ServerUri: new Uri("https://example.invalid/source.zip", UriKind.Absolute)),
+            workRoot: "runtime/resonite");
+
+        Assert.Equal(["connect", "create-source", "begin"], callOrder);
+        Assert.Equal(1, sceneBuilder.EnsureConnectedCallCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncDisposesSceneBuilderWhenConstructionSourceBootstrapFailsAfterConnect()
+    {
+        StubResoniteSceneBuilder sceneBuilder = new();
+        RecordingDatasetSourceResolver datasetSourceResolver = new(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: "/resolved/source",
+                ServerUri: null));
+        FailingConstructionSourceFactory constructionSourceFactory = new(new InvalidOperationException("bootstrap failed"));
+        PlateauImportService service = new(
+            sceneBuilder,
+            datasetSourceResolver,
+            constructionSourceFactory: constructionSourceFactory);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ExecuteAsync(
+                new PlateauImportRequest(
+                    Dataset: "tokyo23ku",
+                    MeshCode: "53394525",
+                    SourceKind: DatasetSourceKind.Remote,
+                    LocalSourcePath: null,
+                    ServerUri: new Uri("https://example.invalid/source.zip", UriKind.Absolute)),
+                workRoot: "runtime/resonite"));
+
+        Assert.Equal("bootstrap failed", exception.Message);
+        Assert.Equal(1, sceneBuilder.EnsureConnectedCallCount);
+        Assert.Equal(1, sceneBuilder.DisposeCallCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncStopsBeforeConstructionSourceBootstrapWhenConnectionCheckFails()
+    {
+        List<string> callOrder = [];
+        StubResoniteSceneBuilder sceneBuilder = new()
+        {
+            OnEnsureConnected = () => callOrder.Add("connect"),
+            OnBegin = () => callOrder.Add("begin"),
+            EnsureConnectedException = new InvalidOperationException("connect failed"),
+        };
+        RecordingDatasetSourceResolver datasetSourceResolver = new(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: "/resolved/source",
+                ServerUri: null));
+        RecordingConstructionSourceFactory constructionSourceFactory = new(
+            CreateStubConstructionSource(),
+            onCreate: () => callOrder.Add("create-source"));
+        PlateauImportService service = new(
+            sceneBuilder,
+            datasetSourceResolver,
+            constructionSourceFactory: constructionSourceFactory);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ExecuteAsync(
+                new PlateauImportRequest(
+                    Dataset: "tokyo23ku",
+                    MeshCode: "53394525",
+                    SourceKind: DatasetSourceKind.Remote,
+                    LocalSourcePath: null,
+                    ServerUri: new Uri("https://example.invalid/source.zip", UriKind.Absolute)),
+                workRoot: "runtime/resonite"));
+
+        Assert.Equal("connect failed", exception.Message);
+        Assert.Equal(["connect"], callOrder);
+        Assert.Empty(constructionSourceFactory.Requests);
+        Assert.Equal(1, sceneBuilder.EnsureConnectedCallCount);
+        Assert.Equal(1, sceneBuilder.DisposeCallCount);
+    }
+
     private sealed class StubResoniteSceneBuilder : IResoniteSceneBuilder
     {
         public List<ResoniteConstructionCityObject> CityObjects { get; } = [];
+        public int EnsureConnectedCallCount { get; private set; }
+        public int DisposeCallCount { get; private set; }
+        public Action? OnEnsureConnected { get; set; }
+        public Action? OnBegin { get; set; }
+        public Exception? EnsureConnectedException { get; set; }
+
+        public Task EnsureConnectedAsync(
+            PlateauImportRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            EnsureConnectedCallCount++;
+            OnEnsureConnected?.Invoke();
+            if (EnsureConnectedException is not null)
+            {
+                throw EnsureConnectedException;
+            }
+
+            return Task.CompletedTask;
+        }
 
         public Task BeginAsync(
             ResoniteConstructionMetadata metadata,
@@ -1814,6 +1947,7 @@ public sealed class PlateauImportServiceTests
         {
             ArgumentNullException.ThrowIfNull(metadata);
             ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
+            OnBegin?.Invoke();
             return Task.CompletedTask;
         }
 
@@ -1833,6 +1967,7 @@ public sealed class PlateauImportServiceTests
 
         public ValueTask DisposeAsync()
         {
+            DisposeCallCount++;
             return ValueTask.CompletedTask;
         }
     }
@@ -1851,7 +1986,9 @@ public sealed class PlateauImportServiceTests
         }
     }
 
-    private sealed class RecordingConstructionSourceFactory(IResoniteConstructionSource source)
+    private sealed class RecordingConstructionSourceFactory(
+        IResoniteConstructionSource source,
+        Action? onCreate = null)
         : IResoniteConstructionSourceFactory
     {
         public List<PlateauImportRequest> Requests { get; } = [];
@@ -1862,8 +1999,21 @@ public sealed class PlateauImportServiceTests
             CancellationToken cancellationToken = default)
         {
             Requests.Add(request);
+            onCreate?.Invoke();
             progressReporter?.Invoke("[import] Parsed 1 city object from stub source in 0.000s.");
             return Task.FromResult(source);
+        }
+    }
+
+    private sealed class FailingConstructionSourceFactory(Exception exception)
+        : IResoniteConstructionSourceFactory
+    {
+        public Task<IResoniteConstructionSource> CreateAsync(
+            PlateauImportRequest request,
+            Action<string>? progressReporter = null,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromException<IResoniteConstructionSource>(exception);
         }
     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliApplicationTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliApplicationTests.cs
@@ -124,6 +124,13 @@ public sealed class CliApplicationTests
     {
         public List<ResoniteConstructionCityObject> CityObjects { get; } = [];
 
+        public Task EnsureConnectedAsync(
+            PlateauImportRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
         public Task BeginAsync(
             ResoniteConstructionMetadata metadata,
             string workRoot,


### PR DESCRIPTION
## What changed
- moved the ResoniteLink connection check ahead of CityGML construction-source bootstrap so connection failures surface before long parsing work
- added a dedicated early-connect phase on the scene builder and reused the connected clients during `BeginAsync`
- hardened client initialization against concurrent callers and added failure-path tests for connect/bootstrap disposal behavior

## Why
The live import path previously waited until after construction-source preparation and parsing work to open ResoniteLink. When the listener was unavailable, the command could spend a long time parsing and then fail on connect. This change fails earlier and cleans up correctly on bootstrap or connect errors.

## Impact
- users get ResoniteLink connection failures before the expensive CityGML bootstrap finishes
- successful imports still reuse the same connected sessions for the later live-build phase
- the new behavior is covered by ordering, disposal, and connection-failure tests

## Validation
- `bash scripts/verify-ci.sh`
- second-pass review by 6 reviewer subagents: no findings
