### PR TITLE
[codex] Fix DEM heightmap chunk seams

### DIFF
--- a/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.cs
@@ -3069,6 +3069,9 @@ public static class LocalCityGmlResonitePlanBuilder
         PlateauImportRequest request)
     {
         ParsedCityObject terrainAlignedCityObject = ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler);
+        List<ResoniteConstructionCityObject> materializedCityObjects = [];
+        List<ResoniteConstructionCityObject> generatedRoadMarkings = [];
+
         foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject in SplitParsedCityObject(
                      terrainAlignedCityObject,
                      demTerrainTextureOverlays))
@@ -3091,7 +3094,7 @@ public static class LocalCityGmlResonitePlanBuilder
 
             if (HasRenderableGeometry(cityObject))
             {
-                yield return cityObject;
+                materializedCityObjects.Add(cityObject);
             }
 
             GeodeticPoint markingOrigin = GetCityObjectOrigin(splitCityObject.CityObject);
@@ -3121,9 +3124,204 @@ public static class LocalCityGmlResonitePlanBuilder
             };
             if (HasRenderableGeometry(markingObject))
             {
-                yield return markingObject;
+                generatedRoadMarkings.Add(markingObject);
             }
         }
+
+        ResoniteConstructionCityObject[] alignedCityObjects =
+            request.DemTerrainMode == DemTerrainMode.HeightMap
+            && string.Equals(parsedCityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
+                ? AlignAdjacentDemHeightMapChunkBoundaries(materializedCityObjects)
+                : [.. materializedCityObjects];
+
+        foreach (ResoniteConstructionCityObject cityObject in alignedCityObjects)
+        {
+            yield return cityObject;
+        }
+
+        foreach (ResoniteConstructionCityObject markingObject in generatedRoadMarkings)
+        {
+            yield return markingObject;
+        }
+    }
+
+    private static ResoniteConstructionCityObject[] AlignAdjacentDemHeightMapChunkBoundaries(
+        IReadOnlyList<ResoniteConstructionCityObject> cityObjects)
+    {
+        ResoniteConstructionCityObject[] aligned = cityObjects.ToArray();
+
+        for (int leftIndex = 0; leftIndex < aligned.Length; leftIndex++)
+        {
+            for (int rightIndex = leftIndex + 1; rightIndex < aligned.Length; rightIndex++)
+            {
+                if (aligned[leftIndex].Geometry is not ResoniteHeightMapGridGeometry leftGeometry
+                    || aligned[rightIndex].Geometry is not ResoniteHeightMapGridGeometry rightGeometry)
+                {
+                    continue;
+                }
+
+                bool alignedBoundary =
+                    TryAlignVerticalHeightMapBoundary(
+                        aligned[leftIndex],
+                        leftGeometry,
+                        aligned[rightIndex],
+                        rightGeometry,
+                        out ResoniteConstructionCityObject updatedLeft,
+                        out ResoniteConstructionCityObject updatedRight)
+                    || TryAlignVerticalHeightMapBoundary(
+                        aligned[rightIndex],
+                        rightGeometry,
+                        aligned[leftIndex],
+                        leftGeometry,
+                        out updatedRight,
+                        out updatedLeft)
+                    || TryAlignHorizontalHeightMapBoundary(
+                        aligned[leftIndex],
+                        leftGeometry,
+                        aligned[rightIndex],
+                        rightGeometry,
+                        out updatedLeft,
+                        out updatedRight)
+                    || TryAlignHorizontalHeightMapBoundary(
+                        aligned[rightIndex],
+                        rightGeometry,
+                        aligned[leftIndex],
+                        leftGeometry,
+                        out updatedRight,
+                        out updatedLeft);
+                if (!alignedBoundary)
+                {
+                    continue;
+                }
+
+                aligned[leftIndex] = updatedLeft;
+                aligned[rightIndex] = updatedRight;
+            }
+        }
+
+        return aligned;
+    }
+
+    private static bool TryAlignVerticalHeightMapBoundary(
+        ResoniteConstructionCityObject leftObject,
+        ResoniteHeightMapGridGeometry leftGeometry,
+        ResoniteConstructionCityObject rightObject,
+        ResoniteHeightMapGridGeometry rightGeometry,
+        out ResoniteConstructionCityObject updatedLeftObject,
+        out ResoniteConstructionCityObject updatedRightObject)
+    {
+        updatedLeftObject = leftObject;
+        updatedRightObject = rightObject;
+
+        if (leftGeometry.Height != rightGeometry.Height)
+        {
+            return false;
+        }
+
+        const double boundaryTolerance = 1e-3;
+        double leftMaxX = leftObject.Transform.Position.X + (leftGeometry.Size.X / 2.0);
+        double rightMinX = rightObject.Transform.Position.X - (rightGeometry.Size.X / 2.0);
+        if (Math.Abs(leftMaxX - rightMinX) > boundaryTolerance)
+        {
+            return false;
+        }
+
+        double leftMinZ = leftObject.Transform.Position.Z - (leftGeometry.Size.Y / 2.0);
+        double leftMaxZ = leftObject.Transform.Position.Z + (leftGeometry.Size.Y / 2.0);
+        double rightMinZ = rightObject.Transform.Position.Z - (rightGeometry.Size.Y / 2.0);
+        double rightMaxZ = rightObject.Transform.Position.Z + (rightGeometry.Size.Y / 2.0);
+        if (Math.Abs(leftMinZ - rightMinZ) > boundaryTolerance
+            || Math.Abs(leftMaxZ - rightMaxZ) > boundaryTolerance)
+        {
+            return false;
+        }
+
+        double[] leftSamples = leftGeometry.HeightSamples.ToArray();
+        double[] rightSamples = rightGeometry.HeightSamples.ToArray();
+        double leftBaseHeight = leftObject.Transform.Position.Y - leftGeometry.MaxHeight;
+        double rightBaseHeight = rightObject.Transform.Position.Y - rightGeometry.MaxHeight;
+
+        for (int row = 0; row < leftGeometry.Height; row++)
+        {
+            int leftSampleIndex = (row * leftGeometry.Width) + (leftGeometry.Width - 1);
+            int rightSampleIndex = row * rightGeometry.Width;
+            double averageWorldHeight = ((leftBaseHeight + leftSamples[leftSampleIndex]) + (rightBaseHeight + rightSamples[rightSampleIndex])) / 2.0;
+            leftSamples[leftSampleIndex] = averageWorldHeight - leftBaseHeight;
+            rightSamples[rightSampleIndex] = averageWorldHeight - rightBaseHeight;
+        }
+
+        updatedLeftObject = leftObject with { Geometry = CreateUpdatedHeightMapGeometry(leftGeometry, leftSamples) };
+        updatedRightObject = rightObject with { Geometry = CreateUpdatedHeightMapGeometry(rightGeometry, rightSamples) };
+        return true;
+    }
+
+    private static bool TryAlignHorizontalHeightMapBoundary(
+        ResoniteConstructionCityObject southObject,
+        ResoniteHeightMapGridGeometry southGeometry,
+        ResoniteConstructionCityObject northObject,
+        ResoniteHeightMapGridGeometry northGeometry,
+        out ResoniteConstructionCityObject updatedSouthObject,
+        out ResoniteConstructionCityObject updatedNorthObject)
+    {
+        updatedSouthObject = southObject;
+        updatedNorthObject = northObject;
+
+        if (southGeometry.Width != northGeometry.Width)
+        {
+            return false;
+        }
+
+        const double boundaryTolerance = 1e-3;
+        double southMaxZ = southObject.Transform.Position.Z + (southGeometry.Size.Y / 2.0);
+        double northMinZ = northObject.Transform.Position.Z - (northGeometry.Size.Y / 2.0);
+        if (Math.Abs(southMaxZ - northMinZ) > boundaryTolerance)
+        {
+            return false;
+        }
+
+        double southMinX = southObject.Transform.Position.X - (southGeometry.Size.X / 2.0);
+        double southMaxX = southObject.Transform.Position.X + (southGeometry.Size.X / 2.0);
+        double northMinX = northObject.Transform.Position.X - (northGeometry.Size.X / 2.0);
+        double northMaxX = northObject.Transform.Position.X + (northGeometry.Size.X / 2.0);
+        if (Math.Abs(southMinX - northMinX) > boundaryTolerance
+            || Math.Abs(southMaxX - northMaxX) > boundaryTolerance)
+        {
+            return false;
+        }
+
+        double[] southSamples = southGeometry.HeightSamples.ToArray();
+        double[] northSamples = northGeometry.HeightSamples.ToArray();
+        double southBaseHeight = southObject.Transform.Position.Y - southGeometry.MaxHeight;
+        double northBaseHeight = northObject.Transform.Position.Y - northGeometry.MaxHeight;
+        int southRowStart = (southGeometry.Height - 1) * southGeometry.Width;
+
+        for (int column = 0; column < southGeometry.Width; column++)
+        {
+            int southSampleIndex = southRowStart + column;
+            int northSampleIndex = column;
+            double averageWorldHeight = ((southBaseHeight + southSamples[southSampleIndex]) + (northBaseHeight + northSamples[northSampleIndex])) / 2.0;
+            southSamples[southSampleIndex] = averageWorldHeight - southBaseHeight;
+            northSamples[northSampleIndex] = averageWorldHeight - northBaseHeight;
+        }
+
+        updatedSouthObject = southObject with { Geometry = CreateUpdatedHeightMapGeometry(southGeometry, southSamples) };
+        updatedNorthObject = northObject with { Geometry = CreateUpdatedHeightMapGeometry(northGeometry, northSamples) };
+        return true;
+    }
+
+    private static ResoniteHeightMapGridGeometry CreateUpdatedHeightMapGeometry(
+        ResoniteHeightMapGridGeometry geometry,
+        IReadOnlyList<double> heightSamples)
+    {
+        double minHeight = heightSamples.Min();
+        double maxHeight = heightSamples.Max();
+
+        return geometry with
+        {
+            MinHeight = minHeight,
+            MaxHeight = maxHeight,
+            HeightSamples = heightSamples,
+        };
     }
 
     private static bool TryMaterializeDemHeightMapCityObject(
@@ -3197,10 +3395,9 @@ public static class LocalCityGmlResonitePlanBuilder
             (int)Math.Ceiling(extentZ / request.DemHeightmapMetersPerVertex) + 1,
             2,
             request.DemHeightmapMaxResolution);
-        ushort[] heightSamples = new ushort[width * height];
         double minHeight = double.PositiveInfinity;
         double maxHeight = double.NegativeInfinity;
-        double[] localHeights = new double[heightSamples.Length];
+        double[] localHeights = new double[width * height];
 
         for (int zIndex = 0; zIndex < height; zIndex++)
         {
@@ -3220,15 +3417,6 @@ public static class LocalCityGmlResonitePlanBuilder
                 minHeight = Math.Min(minHeight, localHeight);
                 maxHeight = Math.Max(maxHeight, localHeight);
             }
-        }
-
-        double heightRange = Math.Max(maxHeight - minHeight, 0.0);
-        for (int index = 0; index < localHeights.Length; index++)
-        {
-            double normalized = heightRange <= 1e-9
-                ? 0.0
-                : Math.Clamp((localHeights[index] - minHeight) / heightRange, 0.0, 1.0);
-            heightSamples[index] = (ushort)Math.Round(normalized * ushort.MaxValue, MidpointRounding.AwayFromZero);
         }
 
         ResoniteMaterialBinding[] materials = CreateDemHeightMapMaterials(
@@ -3263,9 +3451,9 @@ public static class LocalCityGmlResonitePlanBuilder
                 Width: width,
                 Height: height,
                 Size: new ResoniteFloat2(extentX, extentZ),
-                MinHeight: 0.0,
-                MaxHeight: heightRange,
-                HeightSamples: heightSamples),
+                MinHeight: minHeight,
+                MaxHeight: maxHeight,
+                HeightSamples: localHeights),
             Materials: materials,
             SourceObjectKey: cityObject.SourceIdentity);
         return true;
@@ -3395,25 +3583,25 @@ public static class LocalCityGmlResonitePlanBuilder
         GeographicRectangle clippedBounds = IntersectGeographicBounds(
             GetCityObjectGeographicBounds(cityObject),
             demTerrainTextureOverlay.GeographicBounds);
-        double centerLatitude = (clippedBounds.MinLatitude + clippedBounds.MaxLatitude) / 2.0;
-        double centerLongitude = (clippedBounds.MinLongitude + clippedBounds.MaxLongitude) / 2.0;
+        double referenceLatitude = cityObjectOrigin.Latitude;
+        double referenceLongitude = cityObjectOrigin.Longitude;
         ResoniteFloat3 westPosition = CreateGlobalHeightMapLocalPosition(
-            new GeodeticPoint(centerLatitude, clippedBounds.MinLongitude, cityObjectOrigin.Altitude),
+            new GeodeticPoint(referenceLatitude, clippedBounds.MinLongitude, cityObjectOrigin.Altitude),
             slotPosition,
             globalOriginPoint,
             globalCartesian);
         ResoniteFloat3 eastPosition = CreateGlobalHeightMapLocalPosition(
-            new GeodeticPoint(centerLatitude, clippedBounds.MaxLongitude, cityObjectOrigin.Altitude),
+            new GeodeticPoint(referenceLatitude, clippedBounds.MaxLongitude, cityObjectOrigin.Altitude),
             slotPosition,
             globalOriginPoint,
             globalCartesian);
         ResoniteFloat3 southPosition = CreateGlobalHeightMapLocalPosition(
-            new GeodeticPoint(clippedBounds.MinLatitude, centerLongitude, cityObjectOrigin.Altitude),
+            new GeodeticPoint(clippedBounds.MinLatitude, referenceLongitude, cityObjectOrigin.Altitude),
             slotPosition,
             globalOriginPoint,
             globalCartesian);
         ResoniteFloat3 northPosition = CreateGlobalHeightMapLocalPosition(
-            new GeodeticPoint(clippedBounds.MaxLatitude, centerLongitude, cityObjectOrigin.Altitude),
+            new GeodeticPoint(clippedBounds.MaxLatitude, referenceLongitude, cityObjectOrigin.Altitude),
             slotPosition,
             globalOriginPoint,
             globalCartesian);

--- a/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.cs
@@ -3148,180 +3148,235 @@ public static class LocalCityGmlResonitePlanBuilder
     private static ResoniteConstructionCityObject[] AlignAdjacentDemHeightMapChunkBoundaries(
         IReadOnlyList<ResoniteConstructionCityObject> cityObjects)
     {
-        ResoniteConstructionCityObject[] aligned = cityObjects.ToArray();
-
-        for (int leftIndex = 0; leftIndex < aligned.Length; leftIndex++)
+        HeightMapChunkAlignmentState?[] states = cityObjects
+            .Select(static cityObject => HeightMapChunkAlignmentState.TryCreate(cityObject))
+            .ToArray();
+        if (states.Any(static state => state is null))
         {
-            for (int rightIndex = leftIndex + 1; rightIndex < aligned.Length; rightIndex++)
+            return cityObjects.ToArray();
+        }
+
+        HeightMapChunkAlignmentState[] chunkStates = states
+            .Select(static state => state!)
+            .ToArray();
+        int sampleOffset = 0;
+        foreach (HeightMapChunkAlignmentState state in chunkStates)
+        {
+            state.SampleOffset = sampleOffset;
+            sampleOffset += state.HeightSamples.Length;
+        }
+
+        HeightMapSampleUnionFind unionFind = new(sampleOffset);
+        bool foundSharedBoundary = false;
+
+        for (int leftIndex = 0; leftIndex < chunkStates.Length; leftIndex++)
+        {
+            for (int rightIndex = leftIndex + 1; rightIndex < chunkStates.Length; rightIndex++)
             {
-                if (aligned[leftIndex].Geometry is not ResoniteHeightMapGridGeometry leftGeometry
-                    || aligned[rightIndex].Geometry is not ResoniteHeightMapGridGeometry rightGeometry)
-                {
-                    continue;
-                }
-
-                bool alignedBoundary =
-                    TryAlignVerticalHeightMapBoundary(
-                        aligned[leftIndex],
-                        leftGeometry,
-                        aligned[rightIndex],
-                        rightGeometry,
-                        out ResoniteConstructionCityObject updatedLeft,
-                        out ResoniteConstructionCityObject updatedRight)
-                    || TryAlignVerticalHeightMapBoundary(
-                        aligned[rightIndex],
-                        rightGeometry,
-                        aligned[leftIndex],
-                        leftGeometry,
-                        out updatedRight,
-                        out updatedLeft)
-                    || TryAlignHorizontalHeightMapBoundary(
-                        aligned[leftIndex],
-                        leftGeometry,
-                        aligned[rightIndex],
-                        rightGeometry,
-                        out updatedLeft,
-                        out updatedRight)
-                    || TryAlignHorizontalHeightMapBoundary(
-                        aligned[rightIndex],
-                        rightGeometry,
-                        aligned[leftIndex],
-                        leftGeometry,
-                        out updatedRight,
-                        out updatedLeft);
-                if (!alignedBoundary)
-                {
-                    continue;
-                }
-
-                aligned[leftIndex] = updatedLeft;
-                aligned[rightIndex] = updatedRight;
+                foundSharedBoundary |=
+                    TryUnionVerticalHeightMapBoundary(chunkStates[leftIndex], chunkStates[rightIndex], unionFind)
+                    || TryUnionVerticalHeightMapBoundary(chunkStates[rightIndex], chunkStates[leftIndex], unionFind)
+                    || TryUnionHorizontalHeightMapBoundary(chunkStates[leftIndex], chunkStates[rightIndex], unionFind)
+                    || TryUnionHorizontalHeightMapBoundary(chunkStates[rightIndex], chunkStates[leftIndex], unionFind);
             }
         }
 
-        return aligned;
+        if (!foundSharedBoundary)
+        {
+            return cityObjects.ToArray();
+        }
+
+        Dictionary<int, (double WorldHeightSum, int Count)> groupedWorldHeights = [];
+        foreach (HeightMapChunkAlignmentState state in chunkStates)
+        {
+            for (int localSampleIndex = 0; localSampleIndex < state.HeightSamples.Length; localSampleIndex++)
+            {
+                int root = unionFind.Find(state.SampleOffset + localSampleIndex);
+                double worldHeight = state.BaseHeight + state.HeightSamples[localSampleIndex];
+                if (groupedWorldHeights.TryGetValue(root, out (double WorldHeightSum, int Count) current))
+                {
+                    groupedWorldHeights[root] = (current.WorldHeightSum + worldHeight, current.Count + 1);
+                }
+                else
+                {
+                    groupedWorldHeights[root] = (worldHeight, 1);
+                }
+            }
+        }
+
+        foreach (HeightMapChunkAlignmentState state in chunkStates)
+        {
+            for (int localSampleIndex = 0; localSampleIndex < state.HeightSamples.Length; localSampleIndex++)
+            {
+                int root = unionFind.Find(state.SampleOffset + localSampleIndex);
+                (double worldHeightSum, int count) = groupedWorldHeights[root];
+                state.HeightSamples[localSampleIndex] = (worldHeightSum / count) - state.BaseHeight;
+            }
+        }
+
+        return chunkStates
+            .Select(static state => state.ToCityObject())
+            .ToArray();
     }
 
-    private static bool TryAlignVerticalHeightMapBoundary(
-        ResoniteConstructionCityObject leftObject,
-        ResoniteHeightMapGridGeometry leftGeometry,
-        ResoniteConstructionCityObject rightObject,
-        ResoniteHeightMapGridGeometry rightGeometry,
-        out ResoniteConstructionCityObject updatedLeftObject,
-        out ResoniteConstructionCityObject updatedRightObject)
+    private static bool TryUnionVerticalHeightMapBoundary(
+        HeightMapChunkAlignmentState leftState,
+        HeightMapChunkAlignmentState rightState,
+        HeightMapSampleUnionFind unionFind)
     {
-        updatedLeftObject = leftObject;
-        updatedRightObject = rightObject;
-
-        if (leftGeometry.Height != rightGeometry.Height)
+        if (leftState.Geometry.Height != rightState.Geometry.Height)
         {
             return false;
         }
 
         const double boundaryTolerance = 1e-3;
-        double leftMaxX = leftObject.Transform.Position.X + (leftGeometry.Size.X / 2.0);
-        double rightMinX = rightObject.Transform.Position.X - (rightGeometry.Size.X / 2.0);
+        double leftMaxX = leftState.CityObject.Transform.Position.X + (leftState.Geometry.Size.X / 2.0);
+        double rightMinX = rightState.CityObject.Transform.Position.X - (rightState.Geometry.Size.X / 2.0);
         if (Math.Abs(leftMaxX - rightMinX) > boundaryTolerance)
         {
             return false;
         }
 
-        double leftMinZ = leftObject.Transform.Position.Z - (leftGeometry.Size.Y / 2.0);
-        double leftMaxZ = leftObject.Transform.Position.Z + (leftGeometry.Size.Y / 2.0);
-        double rightMinZ = rightObject.Transform.Position.Z - (rightGeometry.Size.Y / 2.0);
-        double rightMaxZ = rightObject.Transform.Position.Z + (rightGeometry.Size.Y / 2.0);
+        double leftMinZ = leftState.CityObject.Transform.Position.Z - (leftState.Geometry.Size.Y / 2.0);
+        double leftMaxZ = leftState.CityObject.Transform.Position.Z + (leftState.Geometry.Size.Y / 2.0);
+        double rightMinZ = rightState.CityObject.Transform.Position.Z - (rightState.Geometry.Size.Y / 2.0);
+        double rightMaxZ = rightState.CityObject.Transform.Position.Z + (rightState.Geometry.Size.Y / 2.0);
         if (Math.Abs(leftMinZ - rightMinZ) > boundaryTolerance
             || Math.Abs(leftMaxZ - rightMaxZ) > boundaryTolerance)
         {
             return false;
         }
 
-        double[] leftSamples = leftGeometry.HeightSamples.ToArray();
-        double[] rightSamples = rightGeometry.HeightSamples.ToArray();
-        double leftBaseHeight = leftObject.Transform.Position.Y - leftGeometry.MaxHeight;
-        double rightBaseHeight = rightObject.Transform.Position.Y - rightGeometry.MaxHeight;
-
-        for (int row = 0; row < leftGeometry.Height; row++)
+        for (int row = 0; row < leftState.Geometry.Height; row++)
         {
-            int leftSampleIndex = (row * leftGeometry.Width) + (leftGeometry.Width - 1);
-            int rightSampleIndex = row * rightGeometry.Width;
-            double averageWorldHeight = ((leftBaseHeight + leftSamples[leftSampleIndex]) + (rightBaseHeight + rightSamples[rightSampleIndex])) / 2.0;
-            leftSamples[leftSampleIndex] = averageWorldHeight - leftBaseHeight;
-            rightSamples[rightSampleIndex] = averageWorldHeight - rightBaseHeight;
+            int leftSampleIndex = (row * leftState.Geometry.Width) + (leftState.Geometry.Width - 1);
+            int rightSampleIndex = row * rightState.Geometry.Width;
+            unionFind.Union(leftState.SampleOffset + leftSampleIndex, rightState.SampleOffset + rightSampleIndex);
         }
 
-        updatedLeftObject = leftObject with { Geometry = CreateUpdatedHeightMapGeometry(leftGeometry, leftSamples) };
-        updatedRightObject = rightObject with { Geometry = CreateUpdatedHeightMapGeometry(rightGeometry, rightSamples) };
         return true;
     }
 
-    private static bool TryAlignHorizontalHeightMapBoundary(
-        ResoniteConstructionCityObject southObject,
-        ResoniteHeightMapGridGeometry southGeometry,
-        ResoniteConstructionCityObject northObject,
-        ResoniteHeightMapGridGeometry northGeometry,
-        out ResoniteConstructionCityObject updatedSouthObject,
-        out ResoniteConstructionCityObject updatedNorthObject)
+    private static bool TryUnionHorizontalHeightMapBoundary(
+        HeightMapChunkAlignmentState southState,
+        HeightMapChunkAlignmentState northState,
+        HeightMapSampleUnionFind unionFind)
     {
-        updatedSouthObject = southObject;
-        updatedNorthObject = northObject;
-
-        if (southGeometry.Width != northGeometry.Width)
+        if (southState.Geometry.Width != northState.Geometry.Width)
         {
             return false;
         }
 
         const double boundaryTolerance = 1e-3;
-        double southMaxZ = southObject.Transform.Position.Z + (southGeometry.Size.Y / 2.0);
-        double northMinZ = northObject.Transform.Position.Z - (northGeometry.Size.Y / 2.0);
+        double southMaxZ = southState.CityObject.Transform.Position.Z + (southState.Geometry.Size.Y / 2.0);
+        double northMinZ = northState.CityObject.Transform.Position.Z - (northState.Geometry.Size.Y / 2.0);
         if (Math.Abs(southMaxZ - northMinZ) > boundaryTolerance)
         {
             return false;
         }
 
-        double southMinX = southObject.Transform.Position.X - (southGeometry.Size.X / 2.0);
-        double southMaxX = southObject.Transform.Position.X + (southGeometry.Size.X / 2.0);
-        double northMinX = northObject.Transform.Position.X - (northGeometry.Size.X / 2.0);
-        double northMaxX = northObject.Transform.Position.X + (northGeometry.Size.X / 2.0);
+        double southMinX = southState.CityObject.Transform.Position.X - (southState.Geometry.Size.X / 2.0);
+        double southMaxX = southState.CityObject.Transform.Position.X + (southState.Geometry.Size.X / 2.0);
+        double northMinX = northState.CityObject.Transform.Position.X - (northState.Geometry.Size.X / 2.0);
+        double northMaxX = northState.CityObject.Transform.Position.X + (northState.Geometry.Size.X / 2.0);
         if (Math.Abs(southMinX - northMinX) > boundaryTolerance
             || Math.Abs(southMaxX - northMaxX) > boundaryTolerance)
         {
             return false;
         }
 
-        double[] southSamples = southGeometry.HeightSamples.ToArray();
-        double[] northSamples = northGeometry.HeightSamples.ToArray();
-        double southBaseHeight = southObject.Transform.Position.Y - southGeometry.MaxHeight;
-        double northBaseHeight = northObject.Transform.Position.Y - northGeometry.MaxHeight;
-        int southRowStart = (southGeometry.Height - 1) * southGeometry.Width;
-
-        for (int column = 0; column < southGeometry.Width; column++)
+        int southRowStart = (southState.Geometry.Height - 1) * southState.Geometry.Width;
+        for (int column = 0; column < southState.Geometry.Width; column++)
         {
             int southSampleIndex = southRowStart + column;
-            int northSampleIndex = column;
-            double averageWorldHeight = ((southBaseHeight + southSamples[southSampleIndex]) + (northBaseHeight + northSamples[northSampleIndex])) / 2.0;
-            southSamples[southSampleIndex] = averageWorldHeight - southBaseHeight;
-            northSamples[northSampleIndex] = averageWorldHeight - northBaseHeight;
+            unionFind.Union(southState.SampleOffset + southSampleIndex, northState.SampleOffset + column);
         }
 
-        updatedSouthObject = southObject with { Geometry = CreateUpdatedHeightMapGeometry(southGeometry, southSamples) };
-        updatedNorthObject = northObject with { Geometry = CreateUpdatedHeightMapGeometry(northGeometry, northSamples) };
         return true;
     }
 
-    private static ResoniteHeightMapGridGeometry CreateUpdatedHeightMapGeometry(
-        ResoniteHeightMapGridGeometry geometry,
-        IReadOnlyList<double> heightSamples)
+    private sealed class HeightMapChunkAlignmentState
     {
-        double minHeight = heightSamples.Min();
-        double maxHeight = heightSamples.Max();
-
-        return geometry with
+        public HeightMapChunkAlignmentState(
+            ResoniteConstructionCityObject cityObject,
+            ResoniteHeightMapGridGeometry geometry,
+            double[] heightSamples)
         {
-            MinHeight = minHeight,
-            MaxHeight = maxHeight,
-            HeightSamples = heightSamples,
-        };
+            CityObject = cityObject;
+            Geometry = geometry;
+            HeightSamples = heightSamples;
+            BaseHeight = cityObject.Transform.Position.Y - geometry.MaxHeight;
+        }
+
+        public ResoniteConstructionCityObject CityObject { get; }
+
+        public ResoniteHeightMapGridGeometry Geometry { get; }
+
+        public double[] HeightSamples { get; }
+
+        public double BaseHeight { get; }
+
+        public int SampleOffset { get; set; }
+
+        public static HeightMapChunkAlignmentState? TryCreate(ResoniteConstructionCityObject cityObject)
+        {
+            return cityObject.Geometry is ResoniteHeightMapGridGeometry geometry
+                ? new HeightMapChunkAlignmentState(cityObject, geometry, geometry.HeightSamples.ToArray())
+                : null;
+        }
+
+        public ResoniteConstructionCityObject ToCityObject()
+        {
+            double minHeight = HeightSamples.Min();
+            double maxHeight = HeightSamples.Max();
+
+            return CityObject with
+            {
+                Transform = CityObject.Transform with
+                {
+                    Position = CityObject.Transform.Position with
+                    {
+                        Y = BaseHeight + maxHeight,
+                    },
+                },
+                Geometry = Geometry with
+                {
+                    MinHeight = minHeight,
+                    MaxHeight = maxHeight,
+                    HeightSamples = HeightSamples,
+                },
+            };
+        }
+    }
+
+    private sealed class HeightMapSampleUnionFind
+    {
+        private readonly int[] _parents;
+
+        public HeightMapSampleUnionFind(int sampleCount)
+        {
+            _parents = Enumerable.Range(0, sampleCount).ToArray();
+        }
+
+        public int Find(int index)
+        {
+            if (_parents[index] != index)
+            {
+                _parents[index] = Find(_parents[index]);
+            }
+
+            return _parents[index];
+        }
+
+        public void Union(int left, int right)
+        {
+            int leftRoot = Find(left);
+            int rightRoot = Find(right);
+            if (leftRoot != rightRoot)
+            {
+                _parents[rightRoot] = leftRoot;
+            }
+        }
     }
 
     private static bool TryMaterializeDemHeightMapCityObject(

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -937,9 +937,9 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             .Append(',')
             .Append(heightMap.MaxHeight.ToString("R", CultureInfo.InvariantCulture));
 
-        foreach (ushort sample in heightMap.HeightSamples)
+        foreach (double sample in heightMap.HeightSamples)
         {
-            identityBuilder.Append(',').Append(sample.ToString(CultureInfo.InvariantCulture));
+            identityBuilder.Append(',').Append(sample.ToString("R", CultureInfo.InvariantCulture));
         }
     }
 
@@ -1163,6 +1163,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
     private static PreparedHeightMapTexture PrepareHeightMapTexture(ResoniteHeightMapGridGeometry geometry)
     {
         float[] rawPixels = new float[geometry.Width * geometry.Height * 4];
+        double heightRange = Math.Max(geometry.MaxHeight - geometry.MinHeight, 0.0);
 
         for (int y = 0; y < geometry.Height; y++)
         {
@@ -1170,7 +1171,11 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             {
                 // FrooxEngine.GridMesh uses `color.r + color.g + color.b / 3` for displacement.
                 // Encode the inverted height into blue only (scaled by 3) so the effective sampled height stays 1x.
-                float heightValue = (ushort.MaxValue - geometry.HeightSamples[(y * geometry.Width) + x]) / (float)ushort.MaxValue;
+                double heightSample = geometry.HeightSamples[(y * geometry.Width) + x];
+                double normalizedHeight = heightRange <= 1e-9
+                    ? 0.0
+                    : Math.Clamp((heightSample - geometry.MinHeight) / heightRange, 0.0, 1.0);
+                float heightValue = (float)(1.0 - normalizedHeight);
                 int pixelIndex = (y * geometry.Width * 4) + (x * 4);
                 rawPixels[pixelIndex] = 0.0f;
                 rawPixels[pixelIndex + 1] = 0.0f;

--- a/src/Plateau.ResoniteLink.Domain/Importing/ResoniteConstructionGeometry.cs
+++ b/src/Plateau.ResoniteLink.Domain/Importing/ResoniteConstructionGeometry.cs
@@ -12,5 +12,5 @@ public sealed record ResoniteHeightMapGridGeometry(
     ResoniteFloat2 Size,
     double MinHeight,
     double MaxHeight,
-    IReadOnlyList<ushort> HeightSamples)
+    IReadOnlyList<double> HeightSamples)
     : ResoniteConstructionGeometry;

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Compression;
+using System.Reflection;
 
 using Plateau.ResoniteLink.Application.Importing;
 using Plateau.ResoniteLink.Domain.Importing;
@@ -1009,6 +1010,118 @@ public sealed class PlateauImportServiceTests
 
             Assert.InRange(Math.Abs(westWorldHeight - eastWorldHeight), 0.0, tolerance);
         }
+    }
+
+    [Fact]
+    public void AlignAdjacentDemHeightMapChunkBoundariesPreservesChunkWorldHeightsWhenBoundaryAveragingRaisesMaximum()
+    {
+        ResoniteConstructionCityObject leftChunk = CreateHeightMapChunk(
+            "left",
+            positionX: 0.0,
+            positionY: 25.0,
+            positionZ: 0.0,
+            width: 2,
+            height: 2,
+            sizeX: 10.0,
+            sizeY: 10.0,
+            minHeight: 10.0,
+            maxHeight: 25.0,
+            heightSamples: [10.0, 20.0, 10.0, 25.0]);
+        ResoniteConstructionCityObject rightChunk = CreateHeightMapChunk(
+            "right",
+            positionX: 10.0,
+            positionY: 45.0,
+            positionZ: 0.0,
+            width: 2,
+            height: 2,
+            sizeX: 10.0,
+            sizeY: 10.0,
+            minHeight: 30.0,
+            maxHeight: 45.0,
+            heightSamples: [45.0, 30.0, 35.0, 30.0]);
+
+        ResoniteConstructionCityObject[] alignedChunks = AlignAdjacentDemHeightMapChunkBoundaries(leftChunk, rightChunk);
+
+        ResoniteConstructionCityObject alignedLeftChunk = alignedChunks
+            .OrderBy(static chunk => chunk.Transform.Position.X)
+            .First();
+        ResoniteHeightMapGridGeometry alignedLeftGeometry = Assert.IsType<ResoniteHeightMapGridGeometry>(alignedLeftChunk.Geometry);
+
+        Assert.Equal(32.5, alignedLeftChunk.Transform.Position.Y, 6);
+        Assert.Equal(10.0, GetHeightMapWorldHeight(alignedLeftChunk, alignedLeftGeometry, row: 0, column: 0), 6);
+        Assert.Equal(32.5, GetHeightMapWorldHeight(alignedLeftChunk, alignedLeftGeometry, row: 0, column: 1), 6);
+        Assert.Equal(30.0, GetHeightMapWorldHeight(alignedLeftChunk, alignedLeftGeometry, row: 1, column: 1), 6);
+    }
+
+    [Fact]
+    public void AlignAdjacentDemHeightMapChunkBoundariesReconcilesSharedCornerAcrossTwoByTwoChunks()
+    {
+        ResoniteConstructionCityObject northWestChunk = CreateHeightMapChunk(
+            "north-west",
+            positionX: 0.0,
+            positionY: 10.0,
+            positionZ: -10.0,
+            width: 2,
+            height: 2,
+            sizeX: 10.0,
+            sizeY: 10.0,
+            minHeight: 0.0,
+            maxHeight: 10.0,
+            heightSamples: [1.0, 2.0, 3.0, 10.0]);
+        ResoniteConstructionCityObject northEastChunk = CreateHeightMapChunk(
+            "north-east",
+            positionX: 10.0,
+            positionY: 20.0,
+            positionZ: -10.0,
+            width: 2,
+            height: 2,
+            sizeX: 10.0,
+            sizeY: 10.0,
+            minHeight: 4.0,
+            maxHeight: 20.0,
+            heightSamples: [20.0, 5.0, 6.0, 7.0]);
+        ResoniteConstructionCityObject southWestChunk = CreateHeightMapChunk(
+            "south-west",
+            positionX: 0.0,
+            positionY: 30.0,
+            positionZ: 0.0,
+            width: 2,
+            height: 2,
+            sizeX: 10.0,
+            sizeY: 10.0,
+            minHeight: 8.0,
+            maxHeight: 30.0,
+            heightSamples: [8.0, 9.0, 10.0, 30.0]);
+        ResoniteConstructionCityObject southEastChunk = CreateHeightMapChunk(
+            "south-east",
+            positionX: 10.0,
+            positionY: 40.0,
+            positionZ: 0.0,
+            width: 2,
+            height: 2,
+            sizeX: 10.0,
+            sizeY: 10.0,
+            minHeight: 11.0,
+            maxHeight: 40.0,
+            heightSamples: [40.0, 11.0, 12.0, 13.0]);
+
+        ResoniteConstructionCityObject[] alignedChunks = AlignAdjacentDemHeightMapChunkBoundaries(
+            northWestChunk,
+            northEastChunk,
+            southWestChunk,
+            southEastChunk);
+
+        double sharedCenterX = 5.0;
+        double sharedCenterZ = -5.0;
+        double[] sharedCornerHeights = alignedChunks
+            .Select(chunk =>
+            {
+                ResoniteHeightMapGridGeometry geometry = Assert.IsType<ResoniteHeightMapGridGeometry>(chunk.Geometry);
+                return GetCornerHeightNearestPoint(chunk, geometry, sharedCenterX, sharedCenterZ);
+            })
+            .ToArray();
+
+        Assert.All(sharedCornerHeights, height => Assert.Equal(sharedCornerHeights[0], height, 6));
     }
 
     [Fact]
@@ -2283,6 +2396,85 @@ public sealed class PlateauImportServiceTests
         File.WriteAllText(
             Path.Combine(packageDirectory, "plateau_tokyo23ku_dem_53394525_split_boundary.gml"),
             xml);
+    }
+
+    private static ResoniteConstructionCityObject[] AlignAdjacentDemHeightMapChunkBoundaries(
+        params ResoniteConstructionCityObject[] cityObjects)
+    {
+        MethodInfo method = typeof(LocalCityGmlResonitePlanBuilder).GetMethod(
+            "AlignAdjacentDemHeightMapChunkBoundaries",
+            BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("Expected private heightmap boundary alignment helper.");
+
+        return (ResoniteConstructionCityObject[])method.Invoke(null, [cityObjects])!;
+    }
+
+    private static ResoniteConstructionCityObject CreateHeightMapChunk(
+        string displayName,
+        double positionX,
+        double positionY,
+        double positionZ,
+        int width,
+        int height,
+        double sizeX,
+        double sizeY,
+        double minHeight,
+        double maxHeight,
+        IReadOnlyList<double> heightSamples)
+    {
+        return new ResoniteConstructionCityObject(
+            SlotKey: displayName,
+            DisplayName: displayName,
+            PackageName: "dem",
+            ActualMeshCode: "53394525",
+            LodLevel: 1,
+            Transform: new ResoniteTransform(new ResoniteFloat3(positionX, positionY, positionZ)),
+            Geometry: new ResoniteHeightMapGridGeometry(
+                Width: width,
+                Height: height,
+                Size: new ResoniteFloat2(sizeX, sizeY),
+                MinHeight: minHeight,
+                MaxHeight: maxHeight,
+                HeightSamples: heightSamples),
+            Materials: []);
+    }
+
+    private static double GetHeightMapWorldHeight(
+        ResoniteConstructionCityObject chunk,
+        ResoniteHeightMapGridGeometry geometry,
+        int row,
+        int column)
+    {
+        return chunk.Transform.Position.Y
+            - geometry.MaxHeight
+            + geometry.HeightSamples[(row * geometry.Width) + column];
+    }
+
+    private static double GetCornerHeightNearestPoint(
+        ResoniteConstructionCityObject chunk,
+        ResoniteHeightMapGridGeometry geometry,
+        double targetX,
+        double targetZ)
+    {
+        int[] rows = [0, geometry.Height - 1];
+        int[] columns = [0, geometry.Width - 1];
+        double minX = chunk.Transform.Position.X - (geometry.Size.X / 2.0);
+        double minZ = chunk.Transform.Position.Z - (geometry.Size.Y / 2.0);
+        double stepX = geometry.Width <= 1 ? 0.0 : geometry.Size.X / (geometry.Width - 1);
+        double stepZ = geometry.Height <= 1 ? 0.0 : geometry.Size.Y / (geometry.Height - 1);
+
+        return rows
+            .SelectMany(row => columns.Select(column =>
+            {
+                double x = minX + (column * stepX);
+                double z = minZ + (row * stepZ);
+                double distanceSquared = Math.Pow(x - targetX, 2.0) + Math.Pow(z - targetZ, 2.0);
+                double height = GetHeightMapWorldHeight(chunk, geometry, row, column);
+                return (distanceSquared, height);
+            }))
+            .OrderBy(static candidate => candidate.distanceSquared)
+            .First()
+            .height;
     }
 
     private static void CreateRuntimeStraddledSplitBoundaryDemFixture(string datasetRoot)

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -966,6 +966,52 @@ public sealed class PlateauImportServiceTests
     }
 
     [Fact]
+    public async Task ExecuteAsyncKeepsSplitDemHeightMapBoundaryHeightsAlignedAcrossChunks()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        CreateRuntimeSplitBoundaryDemFixture(datasetRoot.Path);
+        StubResoniteSceneBuilder sceneBuilder = new();
+        PlateauImportService service = new(sceneBuilder);
+
+        ImportExecutionResult heightMapResult = await service.ExecuteAsync(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: datasetRoot.Path,
+                ServerUri: null,
+                PackageNames: ["dem"],
+                DemTerrainMode: DemTerrainMode.HeightMap,
+                DemHeightmapMetersPerVertex: 10.0,
+                DemHeightmapMaxResolution: 64),
+            workRoot: "runtime/resonite-heightmap");
+        CapturedResoniteScene heightMapScene = heightMapResult.Metadata.ToScene(sceneBuilder.CityObjects.ToArray());
+
+        ResoniteConstructionCityObject[] demChunks = heightMapScene.CityObjects
+            .Where(static cityObject => string.Equals(cityObject.PackageName, "dem", StringComparison.Ordinal))
+            .OrderBy(static cityObject => cityObject.DisplayName, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(2, demChunks.Length);
+        ResoniteHeightMapGridGeometry westGeometry = Assert.IsType<ResoniteHeightMapGridGeometry>(demChunks[0].Geometry);
+        ResoniteHeightMapGridGeometry eastGeometry = Assert.IsType<ResoniteHeightMapGridGeometry>(demChunks[1].Geometry);
+        Assert.Equal(westGeometry.Height, eastGeometry.Height);
+
+        const double tolerance = 1e-9;
+        for (int row = 0; row < westGeometry.Height; row++)
+        {
+            double westWorldHeight = demChunks[0].Transform.Position.Y
+                - westGeometry.MaxHeight
+                + westGeometry.HeightSamples[(row * westGeometry.Width) + (westGeometry.Width - 1)];
+            double eastWorldHeight = demChunks[1].Transform.Position.Y
+                - eastGeometry.MaxHeight
+                + eastGeometry.HeightSamples[row * eastGeometry.Width];
+
+            Assert.InRange(Math.Abs(westWorldHeight - eastWorldHeight), 0.0, tolerance);
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsyncKeepsSplitDemBoundaryVerticesAlignedAcrossChunks()
     {
         using TemporaryDirectory datasetRoot = new();

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
@@ -442,7 +442,7 @@ public sealed class ResoniteLinkSceneBuilderAssetReuseTests
 
     private static ResoniteConstructionCityObject CreateHeightMapCityObject(
         string objectIdentity,
-        IReadOnlyList<ushort> heightSamples)
+        IReadOnlyList<double> heightSamples)
     {
         return new ResoniteConstructionCityObject(
             SlotKey: $"slot-{objectIdentity}",

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -419,7 +419,7 @@ public sealed class ResoniteLinkSceneBuilderTests
                         Size: new ResoniteFloat2(10.0, 10.0),
                         MinHeight: 0.0,
                         MaxHeight: 10.0,
-                        HeightSamples: [0, ushort.MaxValue, 0, ushort.MaxValue]),
+                        HeightSamples: [0.0, 10.0, 0.0, 10.0]),
                     Materials:
                     [
                         new ResoniteMaterialBinding(

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderYOffsetTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderYOffsetTests.cs
@@ -113,7 +113,7 @@ public sealed class ResoniteLinkSceneBuilderYOffsetTests
                 Size: new ResoniteFloat2(10.0, 10.0),
                 MinHeight: 0.0,
                 MaxHeight: 3.0,
-                HeightSamples: [0, 1, 2, 3]),
+                HeightSamples: [0.0, 1.0, 2.0, 3.0]),
             Materials: [CreateWireframeMaterial()],
             SourceObjectKey: sourceObjectKey);
 


### PR DESCRIPTION
## Summary
- fix DEM `heightmap` seam artifacts at GridMesh boundaries
- preserve actual sampled heights across split DEM chunks instead of per-chunk quantized values
- align shared chunk edges after split heightmap generation so adjacent tiles resolve to identical border heights
- keep HDR height texture generation consistent with geometry `MinHeight` / `MaxHeight` ranges

## Root cause
Split DEM heightmap chunks were effectively carrying chunk-local height representations, so shared borders could resolve to slightly different vertex heights after normalization and texture generation. The issue was in this importer pipeline, not in FrooxEngine sampler settings.

## Changes
- store DEM height samples as real heights (`double`) rather than pre-quantized `ushort` samples
- normalize height textures from `MinHeight` / `MaxHeight` at texture build time
- compute split chunk bounds against a shared origin
- post-process adjacent split heightmap chunks to force shared-edge height agreement
- update CLI/domain tests to match the new height sample representation
- add a regression test for split DEM heightmap boundary alignment

## Validation
- `dotnet restore Plateau.ResoniteLink.sln --locked-mode`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 -p:UseSharedCompilation=false`

## Live verification
- sent Yokohama DEM in `heightmap` mode to the Windows-side `localhost` listener and confirmed successful live send
- sent Matsumoto building-rich district `54372767` in `dem,bldg` mode and confirmed live streaming of terrain plus building objects
