### PR TITLE
docs: switch agent dataset fixtures to matsumoto

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -39,8 +39,8 @@ Codex Cloud のような一時環境では次を使います。
 ```bash
 dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   build \
-  --dataset tokyo23ku \
-  --mesh-code 53394525 \
+  --dataset plateau-20202-matsumoto-shi-2020 \
+  --mesh-code 54372778 \
   --source local \
   --local-source-path /path/to/plateau \
   --resonitelink-port <port>
@@ -52,7 +52,7 @@ remote archive import 例:
 dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   build \
   --dataset plateau-20202-matsumoto-shi-2020 \
-  --mesh-code 533944 \
+  --mesh-code 54372788 \
   --source remote \
   --server-url https://example.invalid/plateau-20202-matsumoto-shi-2020_citygml.zip \
   --resonitelink-port <port>

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Local import example:
 ```bash
 dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   build \
-  --dataset tokyo23ku \
-  --mesh-code 53394525 \
+  --dataset plateau-20202-matsumoto-shi-2020 \
+  --mesh-code 54372778 \
   --source local \
   --local-source-path /path/to/plateau \
   --resonitelink-port <port>
@@ -52,7 +52,7 @@ Remote archive example:
 dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   build \
   --dataset plateau-20202-matsumoto-shi-2020 \
-  --mesh-code 533944 \
+  --mesh-code 54372788 \
   --source remote \
   --server-url https://example.invalid/plateau-20202-matsumoto-shi-2020_citygml.zip \
   --resonitelink-port <port>

--- a/skills/resonite-live-send-debug/SKILL.md
+++ b/skills/resonite-live-send-debug/SKILL.md
@@ -13,9 +13,11 @@ Do not use this skill for code-only review or static log reading. Use it only wh
 
 ## Dataset Defaults
 
-Unless the user asks for a different target, use the Matsumoto dataset `plateau-20202-matsumoto-shi-2020` with adjacent detailed-building meshes `54372778` and `54372788` for document-backed reproductions and comparisons. The local cache under `runtime/windows/resonite/cache/remote/20202_matsumoto-shi_city_2020_citygml_7_op/udx/bldg/` contains both files, with `54372778_bldg_6697_op.gml` and `54372788_bldg_6697_op.gml` plus matching appearance directories.
+Unless the user asks for a different target, use the Matsumoto dataset `plateau-20202-matsumoto-shi-2020` with adjacent detailed-building meshes `54372778` and `54372788` for document-backed reproductions and comparisons. Those two meshes are the default fixtures because this repo already contains successful live-send evidence for `54372778`, and the current workspace dataset sample includes detailed-building source files for both meshes.
 
-When the task specifically needs `frn` or city-furniture content, use Yokohama mesh `53391530` instead. The local cache contains `udx/frn/53391530_frn_6697_*` under `runtime/windows/resonite/cache/remote/14100-yokohama-shi/53391530/14100_yokohama-shi_city_2023_citygml_1_op/`, while the Matsumoto default pair above does not provide the same `frn` fixture.
+When the task specifically needs `frn` or city-furniture content, use Yokohama mesh `53391530` instead. This repo already contains successful Yokohama live-send logs for that mesh, and the current workspace dataset sample includes the needed `frn` source there, while the Matsumoto default pair above is for building-focused checks.
+
+Do not assume a fixed on-disk cache layout for these fixtures. Resolve the actual local source path from the current dataset resolver behavior, and use the matching `--dry-run` import or live-send logs to confirm that the requested dataset and mesh resolve before running destructive steps.
 
 ## Quick Start
 

--- a/skills/resonite-live-send-debug/SKILL.md
+++ b/skills/resonite-live-send-debug/SKILL.md
@@ -11,6 +11,12 @@ Warning: cleanup in this workflow can destroy live world results in the current 
 
 Do not use this skill for code-only review or static log reading. Use it only when the user wants a real Windows send, a real Resonite world inspection, or a comparison that is invalid without machine-level execution.
 
+## Dataset Defaults
+
+Unless the user asks for a different target, use the Matsumoto dataset `plateau-20202-matsumoto-shi-2020` with adjacent detailed-building meshes `54372778` and `54372788` for document-backed reproductions and comparisons. The local cache under `runtime/windows/resonite/cache/remote/20202_matsumoto-shi_city_2020_citygml_7_op/udx/bldg/` contains both files, with `54372778_bldg_6697_op.gml` and `54372788_bldg_6697_op.gml` plus matching appearance directories.
+
+When the task specifically needs `frn` or city-furniture content, use Yokohama mesh `53391530` instead. The local cache contains `udx/frn/53391530_frn_6697_*` under `runtime/windows/resonite/cache/remote/14100-yokohama-shi/53391530/14100_yokohama-shi_city_2023_citygml_1_op/`, while the Matsumoto default pair above does not provide the same `frn` fixture.
+
 ## Quick Start
 
 Before any destructive live run, clear the local gate first:

--- a/skills/resonite-live-send-debug/references/workflow.md
+++ b/skills/resonite-live-send-debug/references/workflow.md
@@ -5,7 +5,8 @@ Use this reference after `SKILL.md` triggers.
 Default document fixtures:
 
 - Use `plateau-20202-matsumoto-shi-2020` with adjacent detailed-building meshes `54372778` and `54372788` unless the task requires a different dataset.
-- Switch to Yokohama mesh `53391530` only when the task needs `frn` validation, because the local cache provides `udx/frn/53391530_frn_6697_*` there.
+- Switch to Yokohama mesh `53391530` only when the task needs `frn` validation.
+- Treat those fixture choices as dataset and mesh selectors, not as a promise about cache paths. Confirm the actual local source path with the current resolver or a matching `--dry-run` import before you inspect files or launch cleanup.
 
 ## Required Repo Artifacts
 

--- a/skills/resonite-live-send-debug/references/workflow.md
+++ b/skills/resonite-live-send-debug/references/workflow.md
@@ -2,6 +2,11 @@
 
 Use this reference after `SKILL.md` triggers.
 
+Default document fixtures:
+
+- Use `plateau-20202-matsumoto-shi-2020` with adjacent detailed-building meshes `54372778` and `54372788` unless the task requires a different dataset.
+- Switch to Yokohama mesh `53391530` only when the task needs `frn` validation, because the local cache provides `udx/frn/53391530_frn_6697_*` there.
+
 ## Required Repo Artifacts
 
 Expect these files under the workspace root:


### PR DESCRIPTION
## Summary
- switch documented local and remote examples to Matsumoto meshes 54372778 and 54372788
- document Matsumoto as the default live-send dataset fixture for agents
- keep Yokohama 53391530 as the exception when frn validation is required

## Verification
- dotnet restore Plateau.ResoniteLink.sln --locked-mode
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false
- dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 -p:UseSharedCompilation=false
- bash scripts/verify-ci.sh