### PR TITLE
[codex] Redesign local data directory defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .env
 .codex
 .tmp/
+local/
 runtime/
 nul
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,6 +15,7 @@ Plateau.ResoniteLink は、[PLATEAU](https://www.mlit.go.jp/plateau/) の CityGM
 - 対象 runtime は .NET SDK 10。release asset の実行にも .NET 10 が必要。
 - `--resonitelink-port` または `--resonitelink-url` で到達できる ResoniteLink listener が必要。
 - live adapter の asset import は現在、mesh に `ImportMesh(ImportMeshRawData)`、texture に `ImportTexture(ImportTexture2DFile)` を使います。
+- ResoniteLink の entity ID は session-scoped な opaque value として扱います。create が成功した場合、その session 内で正規 ID として扱うのは resolve 済み `Response` の ID です。要求 ID は request-local なヒントにすぎず、別 session へ永続化・再利用してはいけません。既存 entity の reuse 探索は、新規 create の確認とは別の仕組みとして扱います。
 
 ## Quick Start
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -65,6 +65,8 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
 bash scripts/verify-ci.sh
 ```
 
+`--work-root` を省略した場合、CLI は dataset ごとの archive と live temporary file を `local/<dataset>/` 配下に置きます。
+
 ## Further Reading
 
 - Product requirements: [docs/requirements.ja.md](docs/requirements.ja.md)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ By default, the CLI prints milestone-level progress and keeps detailed per-file 
 bash scripts/verify-ci.sh
 ```
 
+When `--work-root` is omitted, the CLI stores dataset-local archives and live temporary files under `local/<dataset>/`.
+
 ## Further Reading
 
 - Product requirements: [docs/requirements.md](docs/requirements.md)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Plateau.ResoniteLink is a .NET 10 CLI for streaming [PLATEAU](https://www.mlit.g
 - Target runtime: .NET SDK 10. Release assets also require .NET 10.
 - A running ResoniteLink listener reachable by `--resonitelink-port` or `--resonitelink-url` is required.
 - Live adapter asset import currently uses `ImportMesh(ImportMeshRawData)` for meshes and `ImportTexture(ImportTexture2DFile)` for textures.
+- ResoniteLink entity IDs are treated as session-scoped opaque values. For successful create operations, the resolved `Response` ID is authoritative within the session; requested IDs are only request-local hints, must not be persisted across sessions, and reuse discovery is handled separately from create confirmation.
 
 ## Quick Start
 

--- a/src/Plateau.ResoniteLink.Application/Importing/CkanPlateauDatasetSourceResolver.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/CkanPlateauDatasetSourceResolver.cs
@@ -1,8 +1,5 @@
 using System.Net;
 using System.Net.Http.Headers;
-using System.Globalization;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 
 using Plateau.ResoniteLink.Domain.Importing;
@@ -55,29 +52,20 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
                 [$"The direct archive URL '{remoteSource.ServerUri}' is not a supported archive. Supported extensions: .zip, .7z."]);
         }
 
+        _ = WorkRootLayout.CreateSafePathSegment(request.Dataset);
+        _ = TryCreateSafePathSegment(request.MeshCode, out _);
+
         Uri archiveUri = remoteSource.ServerUri;
 
-        string safeDataset = CreateSafePathSegment(request.Dataset);
-        string archiveCacheKey = CreateArchiveCacheKey(archiveUri);
-        string cacheRoot = GetArchiveCacheRoot(workRoot, safeDataset, archiveCacheKey);
-        if (TryCreateSafePathSegment(request.MeshCode, out string? safeMeshCode))
-        {
-            TryMigrateLegacyArchiveCache(workRoot, safeDataset, safeMeshCode!, archiveCacheKey, cacheRoot);
-        }
-        else
-        {
-            TryMigrateLegacyArchiveCacheForRegex(workRoot, safeDataset, archiveCacheKey, cacheRoot);
-        }
-
-        Directory.CreateDirectory(cacheRoot);
-
         string archiveFileName = GetArchiveFileName(archiveUri);
-        string archivePath = Path.Combine(cacheRoot, archiveFileName);
-        string archiveMetadataPath = $"{archivePath}.{CreateArchiveMetadataFileName()}";
+        string archivePath = WorkRootLayout.GetSourceArchivePath(workRoot, archiveFileName);
+        string archiveMetadataPath = WorkRootLayout.GetSourceArchiveMetadataPath(archivePath);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(archivePath)!);
 
         if (File.Exists(archivePath))
         {
-            if (await TryReuseCachedArchiveAsync(archiveUri, archivePath, archiveMetadataPath, cancellationToken))
+            if (await TryReuseCachedArchiveAsync(workRoot, archiveUri, archivePath, archiveMetadataPath, cancellationToken))
             {
                 return request with
                 {
@@ -86,7 +74,7 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
             }
         }
 
-        await DownloadArchiveAsync(archiveUri, archivePath, archiveMetadataPath, cancellationToken);
+        await DownloadArchiveAsync(workRoot, archiveUri, archivePath, archiveMetadataPath, cancellationToken);
 
         return request with
         {
@@ -95,6 +83,7 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
     }
 
     private async Task<bool> TryReuseCachedArchiveAsync(
+        string datasetRoot,
         Uri archiveUri,
         string archivePath,
         string metadataPath,
@@ -104,6 +93,7 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
         if (metadata is null || (metadata.ETag is null && metadata.LastModifiedUtc is null))
         {
             return await TryRefreshCachedArchiveWithoutMetadataAsync(
+                datasetRoot,
                 archiveUri,
                 archivePath,
                 metadataPath,
@@ -138,7 +128,7 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
 
             response.EnsureSuccessStatusCode();
             await WriteCachedArchiveResponseAsync(response, archivePath, metadataPath, cancellationToken);
-            InvalidateMaterializedCache(archivePath);
+            InvalidateTemporaryMaterializedFiles(datasetRoot, archivePath);
             return true;
         }
         catch (HttpRequestException) when (File.Exists(archivePath))
@@ -148,6 +138,7 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
     }
 
     private async Task<bool> TryRefreshCachedArchiveWithoutMetadataAsync(
+        string datasetRoot,
         Uri archiveUri,
         string archivePath,
         string metadataPath,
@@ -161,7 +152,7 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
                 cancellationToken);
             response.EnsureSuccessStatusCode();
             await WriteCachedArchiveResponseAsync(response, archivePath, metadataPath, cancellationToken);
-            InvalidateMaterializedCache(archivePath);
+            InvalidateTemporaryMaterializedFiles(datasetRoot, archivePath);
             return true;
         }
         catch (HttpRequestException) when (File.Exists(archivePath))
@@ -171,6 +162,7 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
     }
 
     private async Task DownloadArchiveAsync(
+        string datasetRoot,
         Uri archiveUri,
         string archivePath,
         string metadataPath,
@@ -183,53 +175,33 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
         response.EnsureSuccessStatusCode();
 
         await WriteCachedArchiveResponseAsync(response, archivePath, metadataPath, cancellationToken);
-        InvalidateMaterializedCache(archivePath);
+        InvalidateTemporaryMaterializedFiles(datasetRoot, archivePath);
     }
 
-    private static void InvalidateMaterializedCache(string archivePath)
+    private static void InvalidateTemporaryMaterializedFiles(string datasetRoot, string archivePath)
     {
-        string? cacheDirectory = Path.GetDirectoryName(archivePath);
-        while (!string.IsNullOrWhiteSpace(cacheDirectory))
+        string runRoot = Path.Combine(Path.GetFullPath(datasetRoot), "run");
+        if (!Directory.Exists(runRoot))
         {
-            if (string.Equals(Path.GetFileName(cacheDirectory), "cache", StringComparison.Ordinal))
-            {
-                string? workRoot = Path.GetDirectoryName(cacheDirectory);
-                if (string.IsNullOrWhiteSpace(workRoot))
-                {
-                    return;
-                }
-
-                InvalidateMaterializedCacheUnder(workRoot, archivePath);
-                return;
-            }
-
-            cacheDirectory = Path.GetDirectoryName(cacheDirectory);
+            return;
         }
-    }
 
-    private static void InvalidateMaterializedCacheUnder(string workRoot, string archivePath)
-    {
-        foreach (string archiveCacheName in PlateauDatasetContentSourceFactory.GetMaterializedArchiveCacheKeys(archivePath))
+        string archiveCacheName = WorkRootLayout.GetMaterializedArchiveCacheKey(archivePath);
+        try
         {
-            TryDeleteDirectory(Path.Combine(workRoot, ".dataset-cache", archiveCacheName));
-            TryDeleteDirectory(Path.Combine(workRoot, ".generated-assets", ".dataset-cache", archiveCacheName));
-
-            try
+            foreach (string materializedRoot in Directory.EnumerateDirectories(
+                         runRoot,
+                         "materialized",
+                         SearchOption.AllDirectories))
             {
-                foreach (string materializedCacheRoot in Directory.EnumerateDirectories(
-                             workRoot,
-                             ".dataset-cache",
-                             SearchOption.AllDirectories))
-                {
-                    TryDeleteDirectory(Path.Combine(materializedCacheRoot, archiveCacheName));
-                }
+                TryDeleteDirectory(Path.Combine(materializedRoot, archiveCacheName));
             }
-            catch (IOException)
-            {
-            }
-            catch (UnauthorizedAccessException)
-            {
-            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
         }
     }
 
@@ -367,8 +339,6 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
         }
     }
 
-    private static string CreateArchiveMetadataFileName() => "meta.json";
-
     private static bool LooksLikeSupportedArchiveUri(Uri uri)
     {
         return TryGetArchiveKind(uri.AbsolutePath, out _);
@@ -386,35 +356,11 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
         return fileName;
     }
 
-    private static string CreateSafePathSegment(string value)
-    {
-        string normalized = value.Trim();
-        if (string.IsNullOrWhiteSpace(normalized))
-        {
-            throw new PlateauImportValidationException([$"Invalid path segment '{value}'."]);
-        }
-
-        char[] invalidCharacters = Path.GetInvalidFileNameChars();
-        invalidCharacters = invalidCharacters
-            .Concat(new[] { '/', '\\', Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar })
-            .Distinct()
-            .ToArray();
-
-        if (normalized.IndexOfAny(invalidCharacters) >= 0
-            || normalized.Equals("..", StringComparison.Ordinal)
-            || normalized.Equals(".", StringComparison.Ordinal))
-        {
-            throw new PlateauImportValidationException([$"Invalid path segment '{value}'."]);
-        }
-
-        return normalized;
-    }
-
     private static bool TryCreateSafePathSegment(string value, out string? safePathSegment)
     {
         try
         {
-            safePathSegment = CreateSafePathSegment(value);
+            safePathSegment = WorkRootLayout.CreateSafePathSegment(value);
             return true;
         }
         catch (PlateauImportValidationException)
@@ -441,117 +387,6 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
             || normalized.Contains("..\\", StringComparison.Ordinal)
             || normalized.StartsWith("./", StringComparison.Ordinal)
             || normalized.StartsWith(".\\", StringComparison.Ordinal);
-    }
-
-    private static string CreateArchiveCacheKey(Uri archiveUri)
-    {
-        byte[] digest = SHA256.HashData(Encoding.UTF8.GetBytes(archiveUri.ToString()));
-
-        StringBuilder builder = new(capacity: digest.Length * 2);
-        for (int index = 0; index < digest.Length; index++)
-        {
-            _ = builder.Append(digest[index].ToString("x2", CultureInfo.InvariantCulture));
-        }
-
-        return builder.ToString();
-    }
-
-    private static string GetArchiveCacheRoot(string workRoot, string safeDataset, string archiveCacheKey)
-    {
-        return Path.GetFullPath(Path.Combine(
-            workRoot,
-            "cache",
-            "remote",
-            safeDataset,
-            archiveCacheKey));
-    }
-
-    private static string GetLegacyArchiveCacheRoot(
-        string workRoot,
-        string safeDataset,
-        string safeMeshCode,
-        string archiveCacheKey)
-    {
-        return Path.GetFullPath(Path.Combine(
-            workRoot,
-            "cache",
-            "remote",
-            safeDataset,
-            safeMeshCode,
-            archiveCacheKey));
-    }
-
-    private static void TryMigrateLegacyArchiveCache(
-        string workRoot,
-        string safeDataset,
-        string safeMeshCode,
-        string archiveCacheKey,
-        string cacheRoot)
-    {
-        if (Directory.Exists(cacheRoot))
-        {
-            return;
-        }
-
-        string legacyCacheRoot = GetLegacyArchiveCacheRoot(workRoot, safeDataset, safeMeshCode, archiveCacheKey);
-        if (!Directory.Exists(legacyCacheRoot))
-        {
-            return;
-        }
-
-        Directory.CreateDirectory(Path.GetDirectoryName(cacheRoot)!);
-        Directory.Move(legacyCacheRoot, cacheRoot);
-        TryDeleteEmptyDirectory(Path.GetDirectoryName(legacyCacheRoot));
-    }
-
-    private static void TryMigrateLegacyArchiveCacheForRegex(
-        string workRoot,
-        string safeDataset,
-        string archiveCacheKey,
-        string cacheRoot)
-    {
-        if (Directory.Exists(cacheRoot))
-        {
-            return;
-        }
-
-        string datasetCacheRoot = Path.GetFullPath(Path.Combine(workRoot, "cache", "remote", safeDataset));
-        if (!Directory.Exists(datasetCacheRoot))
-        {
-            return;
-        }
-
-        string? legacyCacheRoot = Directory
-            .EnumerateDirectories(datasetCacheRoot)
-            .Select(directory => Path.Combine(directory, archiveCacheKey))
-            .FirstOrDefault(Directory.Exists);
-        if (legacyCacheRoot is null)
-        {
-            return;
-        }
-
-        Directory.CreateDirectory(Path.GetDirectoryName(cacheRoot)!);
-        Directory.Move(legacyCacheRoot, cacheRoot);
-        TryDeleteEmptyDirectory(Path.GetDirectoryName(legacyCacheRoot));
-    }
-
-    private static void TryDeleteEmptyDirectory(string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
-        {
-            return;
-        }
-
-        try
-        {
-            Directory.Delete(path, recursive: false);
-        }
-        catch (IOException)
-        {
-        }
-        catch (UnauthorizedAccessException)
-        {
-        }
     }
 
     private static bool TryGetArchiveKind(string path, out SupportedArchiveKind archiveKind)

--- a/src/Plateau.ResoniteLink.Application/Importing/PlateauDatasetContentSourceFactory.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/PlateauDatasetContentSourceFactory.cs
@@ -1,6 +1,3 @@
-using System.Security.Cryptography;
-using System.Text;
-
 using SharpCompress.Archives;
 using SharpCompress.Readers;
 
@@ -72,32 +69,9 @@ public static class PlateauDatasetContentSourceFactory
                 .Where(static segment => segment.Length > 0));
     }
 
-    internal static IReadOnlyList<string> GetMaterializedArchiveCacheKeys(string archivePath)
-    {
-        string fullArchivePath = Path.GetFullPath(archivePath);
-        string fileStem = Path.GetFileNameWithoutExtension(fullArchivePath);
-        List<string> keys = [];
-
-        if (!string.IsNullOrWhiteSpace(fileStem))
-        {
-            string digest = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(fullArchivePath))).ToLowerInvariant();
-            keys.Add($"{fileStem}-{digest[..12]}");
-            keys.Add(fileStem);
-        }
-
-        return keys;
-    }
-
     internal static string GetMaterializedArchiveCacheKey(string archivePath)
     {
-        IReadOnlyList<string> keys = GetMaterializedArchiveCacheKeys(archivePath);
-        if (keys.Count == 0)
-        {
-            throw new PlateauImportValidationException(
-                [$"The archive path '{archivePath}' must have a non-empty file name before the extension to create a materialized archive cache key."]);
-        }
-
-        return keys[0];
+        return WorkRootLayout.GetMaterializedArchiveCacheKey(archivePath);
     }
 
     internal static string GetDirectoryPath(string relativePath)
@@ -256,10 +230,7 @@ public static class PlateauDatasetContentSourceFactory
             cancellationToken.ThrowIfCancellationRequested();
 
             string normalizedPath = NormalizeSafeRelativePath(relativePath);
-            string archiveCacheRoot = Path.Combine(
-                outputRoot,
-                ".dataset-cache",
-                GetMaterializedArchiveCacheKey(ArchivePath));
+            string archiveCacheRoot = WorkRootLayout.GetMaterializedArchiveRoot(outputRoot, ArchivePath);
             string destinationPath = ResolveMaterializedPath(archiveCacheRoot, normalizedPath);
 
             Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);

--- a/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
@@ -33,9 +33,10 @@ public sealed class PlateauImportService(
         }
 
         PlateauImportRequest normalizedRequest = NormalizeRequest(validationRequest);
+        string datasetWorkRoot = WorkRootLayout.ResolveDatasetRoot(workRoot, normalizedRequest.Dataset);
 
         PlateauImportRequest resolvedRequest =
-            await datasetSourceResolver.ResolveAsync(normalizedRequest, workRoot, cancellationToken);
+            await datasetSourceResolver.ResolveAsync(normalizedRequest, datasetWorkRoot, cancellationToken);
         ReportProgress(
             PlateauLog.Debug("import", $"Resolved dataset source for '{resolvedRequest.Dataset}' mesh '{resolvedRequest.MeshCode}'."));
 
@@ -58,7 +59,7 @@ public sealed class PlateauImportService(
 
             Stopwatch beginStopwatch = Stopwatch.StartNew();
             ReportProgress(PlateauLog.Info("import", "Starting live scene initialization."));
-            await sceneBuilder.BeginAsync(source.Metadata, workRoot, cancellationToken);
+            await sceneBuilder.BeginAsync(source.Metadata, datasetWorkRoot, cancellationToken);
             beginStopwatch.Stop();
             ReportProgress(PlateauLog.Debug("import", $"Scene builder initialization completed in {beginStopwatch.Elapsed.TotalSeconds:F3}s."));
 

--- a/src/Plateau.ResoniteLink.Application/Importing/WorkRootLayout.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/WorkRootLayout.cs
@@ -1,0 +1,93 @@
+namespace Plateau.ResoniteLink.Application.Importing;
+
+internal static class WorkRootLayout
+{
+    public static string ResolveDatasetRoot(string workRoot, string dataset)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
+
+        string safeDataset = CreateSafePathSegment(dataset);
+        return Path.GetFullPath(Path.Combine(workRoot, safeDataset));
+    }
+
+    public static string GetSourceArchivePath(string datasetRoot, string archiveFileName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(datasetRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(archiveFileName);
+
+        string extension = Path.GetExtension(archiveFileName);
+        if (!string.Equals(extension, ".zip", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(extension, ".7z", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new PlateauImportValidationException(
+                [$"The archive file '{archiveFileName}' is not a supported CityGML archive."]);
+        }
+
+        return Path.Combine(
+            Path.GetFullPath(datasetRoot),
+            $"source-archive{extension.ToLowerInvariant()}");
+    }
+
+    public static string GetSourceArchiveMetadataPath(string archivePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(archivePath);
+        return $"{archivePath}.meta.json";
+    }
+
+    public static string CreateRunRoot(string datasetRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(datasetRoot);
+        return Path.Combine(Path.GetFullPath(datasetRoot), "run", Guid.NewGuid().ToString("N"));
+    }
+
+    public static string GetMaterializedArchiveRoot(string outputRoot, string archivePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(archivePath);
+
+        return Path.Combine(
+            Path.GetFullPath(outputRoot),
+            "materialized",
+            GetMaterializedArchiveCacheKey(archivePath));
+    }
+
+    public static string GetMaterializedArchiveCacheKey(string archivePath)
+    {
+        string fullArchivePath = Path.GetFullPath(archivePath);
+        string fileStem = Path.GetFileNameWithoutExtension(fullArchivePath);
+        if (string.IsNullOrWhiteSpace(fileStem))
+        {
+            throw new PlateauImportValidationException(
+                [$"The archive path '{archivePath}' must have a non-empty file name before the extension to create a materialized archive cache key."]);
+        }
+
+        string digest = Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(fullArchivePath)))
+            .ToLowerInvariant();
+        return $"{fileStem}-{digest[..12]}";
+    }
+
+    public static string CreateSafePathSegment(string value)
+    {
+        string normalized = value.Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            throw new PlateauImportValidationException([$"Invalid path segment '{value}'."]);
+        }
+
+        char[] invalidCharacters = Path.GetInvalidFileNameChars();
+        invalidCharacters = invalidCharacters
+            .Concat(new[] { '/', '\\', Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar })
+            .Distinct()
+            .ToArray();
+
+        if (normalized.IndexOfAny(invalidCharacters) >= 0
+            || normalized.Equals("..", StringComparison.Ordinal)
+            || normalized.Equals(".", StringComparison.Ordinal))
+        {
+            throw new PlateauImportValidationException([$"Invalid path segment '{value}'."]);
+        }
+
+        return normalized;
+    }
+}

--- a/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
@@ -36,7 +36,7 @@ public static class CliArgumentsParser
           --local-source-path <path>
                                Required when --source local is used. Mirrors the Unity SDK LocalSourcePath naming.
           --server-url <url>     Required when --source remote is used. Absolute direct .zip/.7z CityGML archive URL. Mirrors the Unity SDK ServerUrl naming.
-          --work-root <path>     Optional. Working directory for live-generated assets, remote download cache, and asset reuse state. Default: runtime/<os>/resonite.
+          --work-root <path>     Optional. Parent directory for dataset-local archive storage and live temporary files. Default: local.
           --resonitelink-port    Required unless --resonitelink-url is used. Connect to ws://localhost:<port>/ and build live in Resonite.
           --resonitelink-url     Required unless --resonitelink-port is used. Absolute ws:// or wss:// endpoint for live ResoniteLink builds.
           --resonitelink-connections <count>
@@ -63,7 +63,7 @@ public static class CliArgumentsParser
         string? dataset = null;
         string? meshCode = null;
         string? localSourcePath = null;
-        string workRoot = Path.Combine("runtime", GetCurrentOsDirectoryName(), "resonite");
+        string workRoot = "local";
         Uri? resoniteLinkUri = null;
         int resoniteLinkConnectionCount = CliDefaultOptions.ResoniteLinkConnectionCount;
         bool enableSendMetrics = false;
@@ -565,23 +565,4 @@ public static class CliArgumentsParser
             || string.Equals(extension, ".7z", StringComparison.OrdinalIgnoreCase);
     }
 
-    internal static string GetCurrentOsDirectoryName()
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            return "windows";
-        }
-
-        if (OperatingSystem.IsLinux())
-        {
-            return "linux";
-        }
-
-        if (OperatingSystem.IsMacOS())
-        {
-            return "macos";
-        }
-
-        return "unknown";
-    }
 }

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -1023,7 +1023,6 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
                 mutationClient,
                 importClient,
                 objectSlots.AssetLodSlot.SlotId,
-                objectSlots.LodSlot.SlotId,
                 CreateMeshAssetSlotName(cityObject),
                 CreateHeightMapAssetSlotName(cityObject),
                 cityObject.DisplayName,

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -40,7 +40,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
     private CreatedSlot? datasetAssetsRootSlot;
     private CreatedSlot? commonAssetsRootSlot;
     private ResoniteMaterialAssetManager? materialAssetManager;
-    private string? generatedAssetsRoot;
+    private string? runRoot;
     private AsyncCompletedResultCache<TextureImportCacheKey, Uri>? importedTextureUriCache;
     private DispatchLaneAllocator? dispatchLaneAllocator;
     private ResoniteTextureImportResolver? textureImportResolver;
@@ -120,7 +120,8 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         this.metadata = metadata;
         string resolvedWorkRoot = Path.GetFullPath(workRoot);
         Directory.CreateDirectory(resolvedWorkRoot);
-        generatedAssetsRoot = Path.Combine(resolvedWorkRoot, ".generated-assets");
+        runRoot = CreateRunRoot(resolvedWorkRoot);
+        Directory.CreateDirectory(runRoot);
         string completionMeshCode = ResolveCompletionMeshCode(metadata);
 
         ReportProgress(
@@ -149,7 +150,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         datasetContentSource = await PlateauDatasetContentSourceFactory.CreateAsync(localSource.LocalSourcePath!, cancellationToken);
         textureImportResolver = new ResoniteTextureImportResolver(
             datasetContentSource,
-            generatedAssetsRoot,
+            runRoot,
             metadata.SourceDataset.TerrainTextureOverlays,
             terrainTextureAssetGenerator);
         ReportProgress("[live] Creating dataset root, asset groups, and anchor slots.");
@@ -547,7 +548,9 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             datasetAssetsRootSlot = null;
             commonAssetsRootSlot = null;
             materialAssetManager = null;
-            generatedAssetsRoot = null;
+            string? priorRunRoot = runRoot;
+            runRoot = null;
+            TryDeleteDirectory(priorRunRoot);
             sharedSlotCache.Clear();
             importedTextureUriCache = null;
             dispatchLaneAllocator = null;
@@ -560,6 +563,31 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             sceneBuildStopwatch = null;
             sceneAnchor = null;
         }
+    }
+
+    private static void TryDeleteDirectory(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static string CreateRunRoot(string datasetRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(datasetRoot);
+        return Path.Combine(Path.GetFullPath(datasetRoot), "run", Guid.NewGuid().ToString("N"));
     }
 
     private async Task ProcessQueuedCityObjectAsync(
@@ -995,6 +1023,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
                 mutationClient,
                 importClient,
                 objectSlots.AssetLodSlot.SlotId,
+                objectSlots.LodSlot.SlotId,
                 CreateMeshAssetSlotName(cityObject),
                 CreateHeightMapAssetSlotName(cityObject),
                 cityObject.DisplayName,

--- a/src/Plateau.ResoniteLink.Cli/ResoniteTextureImportResolver.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteTextureImportResolver.cs
@@ -6,24 +6,24 @@ namespace Plateau.ResoniteLink.Cli;
 internal sealed class ResoniteTextureImportResolver
 {
     private readonly IPlateauDatasetContentSource datasetContentSource;
-    private readonly string generatedAssetsRoot;
+    private readonly string runRoot;
     private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator;
     private readonly TerrainTextureOverlayLookup terrainTextureOverlayLookup;
     private readonly AsyncCompletedResultCache<TextureReferenceKey, ResoniteTextureImport> resolvedTextureCache = new();
 
     public ResoniteTextureImportResolver(
         IPlateauDatasetContentSource datasetContentSource,
-        string generatedAssetsRoot,
+        string runRoot,
         IEnumerable<TerrainTextureOverlay> terrainTextureOverlays,
         ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
     {
         ArgumentNullException.ThrowIfNull(datasetContentSource);
-        ArgumentException.ThrowIfNullOrWhiteSpace(generatedAssetsRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(runRoot);
         ArgumentNullException.ThrowIfNull(terrainTextureOverlays);
         ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
 
         this.datasetContentSource = datasetContentSource;
-        this.generatedAssetsRoot = generatedAssetsRoot;
+        this.runRoot = runRoot;
         this.terrainTextureAssetGenerator = terrainTextureAssetGenerator;
         terrainTextureOverlayLookup = new TerrainTextureOverlayLookup(terrainTextureOverlays);
     }
@@ -58,7 +58,7 @@ internal sealed class ResoniteTextureImportResolver
         {
             ResoniteTextureSourceKind.Dataset => await datasetContentSource.MaterializeFileAsync(
                 texturePath,
-                generatedAssetsRoot,
+                runRoot,
                 cancellationToken),
             ResoniteTextureSourceKind.Bundled => BundledDefaultMaterialAssetStore.GetAbsolutePath(texturePath),
             _ => throw new InvalidOperationException($"Unsupported texture source kind '{textureSourceKind}'."),

--- a/tests/Plateau.ResoniteLink.Tests/Application/ArchivePlateauDatasetContentSourceFactoryTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/ArchivePlateauDatasetContentSourceFactoryTests.cs
@@ -26,7 +26,7 @@ public sealed class ArchivePlateauDatasetContentSourceFactoryTests
         string expectedSafePath = Path.GetFullPath(
             Path.Combine(
                 outputRoot,
-                ".dataset-cache",
+                "materialized",
                 GetMaterializedArchiveCacheKey(archivePath),
                 safePath.Replace('/', Path.DirectorySeparatorChar)));
 
@@ -54,7 +54,7 @@ public sealed class ArchivePlateauDatasetContentSourceFactoryTests
         string expectedUnsafePath = Path.GetFullPath(
             Path.Combine(
                 outputRoot,
-                ".dataset-cache",
+                "materialized",
                 GetMaterializedArchiveCacheKey(archivePath),
                 traversalPath.Replace('/', Path.DirectorySeparatorChar)));
 

--- a/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverCacheTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverCacheTests.cs
@@ -85,7 +85,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
     }
 
     [Fact]
-    public async Task ResolveAsyncUsesUriHashInCachePathToAvoidFilenameCollisions()
+    public async Task ResolveAsyncUsesDatasetScopedFixedArchivePath()
     {
         byte[] zipBytes = CreateZipArchive(("udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml", "<CityModel />"));
         using TemporaryDirectory workRoot = new();
@@ -134,18 +134,15 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
 
         Assert.NotNull(firstRequest.LocalSourcePath);
         Assert.NotNull(secondRequest.LocalSourcePath);
-        Assert.NotEqual(firstRequest.LocalSourcePath, secondRequest.LocalSourcePath);
-        Assert.Equal("533944.zip", Path.GetFileName(firstRequest.LocalSourcePath));
-        Assert.Equal("533944.zip", Path.GetFileName(secondRequest.LocalSourcePath));
+        string expectedArchivePath = Path.Combine(workRoot.Path, "source-archive.zip");
+        Assert.Equal(expectedArchivePath, firstRequest.LocalSourcePath);
+        Assert.Equal(expectedArchivePath, secondRequest.LocalSourcePath);
         Assert.True(File.Exists(firstRequest.LocalSourcePath));
         Assert.True(File.Exists(secondRequest.LocalSourcePath));
-        Assert.NotEqual(
-            Path.GetDirectoryName(firstRequest.LocalSourcePath),
-            Path.GetDirectoryName(secondRequest.LocalSourcePath));
     }
 
     [Fact]
-    public async Task ResolveAsyncReusesCachedArchiveAcrossMeshCodeChanges()
+    public async Task ResolveAsyncReusesDatasetScopedArchiveAcrossMeshCodeChanges()
     {
         byte[] zipBytes = CreateZipArchive(("udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml", "<CityModel />"));
         int requestCount = 0;
@@ -187,18 +184,14 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
     }
 
     [Fact]
-    public async Task ResolveAsyncMigratesLegacyMeshScopedCache()
+    public async Task ResolveAsyncUsesFixedMetadataPathNextToArchive()
     {
         byte[] zipBytes = CreateZipArchive(("udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml", "<CityModel />"));
         using TemporaryDirectory workRoot = new();
         Uri archiveUri = new("https://example.test/533944.zip", UriKind.Absolute);
-        string archiveHash = CreateArchiveCacheKey(archiveUri);
-        string legacyCacheRoot = Path.Combine(workRoot.Path, "cache", "remote", "tokyo23ku", "533944", archiveHash);
-        Directory.CreateDirectory(legacyCacheRoot);
-        string legacyArchivePath = Path.Combine(legacyCacheRoot, "533944.zip");
-        string legacyMetadataPath = $"{legacyArchivePath}.meta.json";
-        await File.WriteAllBytesAsync(legacyArchivePath, zipBytes);
-        await File.WriteAllTextAsync(legacyMetadataPath, """{"etag":"\"v1\"","lastModifiedUtc":"2026-01-01T00:00:00+00:00"}""");
+        string archivePath = Path.Combine(workRoot.Path, "source-archive.zip");
+        await File.WriteAllBytesAsync(archivePath, zipBytes);
+        await File.WriteAllTextAsync($"{archivePath}.meta.json", """{"etag":"\"v1\"","lastModifiedUtc":"2026-01-01T00:00:00+00:00"}""");
 
         using StubHttpMessageHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.NotModified));
         using HttpClient httpClient = new(handler);
@@ -213,50 +206,9 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
                 ServerUri: archiveUri),
             workRoot.Path);
 
-        string newArchivePath = Path.Combine(workRoot.Path, "cache", "remote", "tokyo23ku", archiveHash, "533944.zip");
-        Assert.Equal(newArchivePath, resolvedRequest.LocalSourcePath);
-        Assert.True(File.Exists(newArchivePath));
-        Assert.True(File.Exists($"{newArchivePath}.meta.json"));
-        Assert.False(Directory.Exists(legacyCacheRoot));
-    }
-
-    [Fact]
-    public async Task ResolveAsyncMigratesRegexRequestWithoutDeletingSiblingLegacyCaches()
-    {
-        byte[] zipBytes = CreateZipArchive(("udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml", "<CityModel />"));
-        using TemporaryDirectory workRoot = new();
-        Uri archiveUri = new("https://example.test/533944.zip", UriKind.Absolute);
-        string archiveHash = CreateArchiveCacheKey(archiveUri);
-        string legacyMeshRoot = Path.Combine(workRoot.Path, "cache", "remote", "tokyo23ku", "533944");
-        string legacyCacheRoot = Path.Combine(legacyMeshRoot, archiveHash);
-        Directory.CreateDirectory(legacyCacheRoot);
-        string legacyArchivePath = Path.Combine(legacyCacheRoot, "533944.zip");
-        string legacyMetadataPath = $"{legacyArchivePath}.meta.json";
-        await File.WriteAllBytesAsync(legacyArchivePath, zipBytes);
-        await File.WriteAllTextAsync(legacyMetadataPath, """{"etag":"\"v1\"","lastModifiedUtc":"2026-01-01T00:00:00+00:00"}""");
-
-        string siblingArchiveHash = CreateArchiveCacheKey(new Uri("https://example.test/other.zip", UriKind.Absolute));
-        string siblingLegacyCacheRoot = Path.Combine(legacyMeshRoot, siblingArchiveHash);
-        Directory.CreateDirectory(siblingLegacyCacheRoot);
-        await File.WriteAllTextAsync(Path.Combine(siblingLegacyCacheRoot, "other.zip"), "placeholder");
-
-        using StubHttpMessageHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.NotModified));
-        using HttpClient httpClient = new(handler);
-        CkanPlateauDatasetSourceResolver resolver = new(httpClient);
-
-        PlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
-            new PlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394\\d",
-                SourceKind: DatasetSourceKind.Remote,
-                LocalSourcePath: null,
-                ServerUri: archiveUri),
-            workRoot.Path);
-
-        string newArchivePath = Path.Combine(workRoot.Path, "cache", "remote", "tokyo23ku", archiveHash, "533944.zip");
-        Assert.Equal(newArchivePath, resolvedRequest.LocalSourcePath);
-        Assert.True(File.Exists(newArchivePath));
-        Assert.True(Directory.Exists(siblingLegacyCacheRoot));
+        Assert.Equal(archivePath, resolvedRequest.LocalSourcePath);
+        Assert.True(File.Exists(archivePath));
+        Assert.True(File.Exists($"{archivePath}.meta.json"));
     }
 
     [Fact]
@@ -491,10 +443,8 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         byte[] zipBytes = CreateZipArchive(("udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml", "<CityModel />"));
         using TemporaryDirectory workRoot = new();
         Uri archiveUri = new("https://example.test/533944.zip", UriKind.Absolute);
-        string archiveHash = CreateArchiveCacheKey(archiveUri);
-        string cacheRoot = Path.Combine(workRoot.Path, "cache", "remote", "tokyo23ku", archiveHash);
-        Directory.CreateDirectory(cacheRoot);
-        string archivePath = Path.Combine(cacheRoot, "533944.zip");
+        string archivePath = Path.Combine(workRoot.Path, "source-archive.zip");
+        Directory.CreateDirectory(workRoot.Path);
         await File.WriteAllBytesAsync(archivePath, zipBytes);
 
         using StubHttpMessageHandler handler = new(_ => throw new HttpRequestException("offline"));
@@ -544,7 +494,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
     private static string CreateStaleMaterializedCacheDirectory(string workRoot, string localArchivePath)
     {
         string cacheName = GetMaterializedArchiveCacheKey(localArchivePath);
-        string materializedCachePath = Path.Combine(workRoot, ".generated-assets", ".dataset-cache", cacheName);
+        string materializedCachePath = Path.Combine(workRoot, "run", "stale-run", "materialized", cacheName);
         string staleFilePath = Path.Combine(materializedCachePath, "udx", "stale.dat");
         Directory.CreateDirectory(Path.GetDirectoryName(staleFilePath)!);
         File.WriteAllText(staleFilePath, "stale");
@@ -560,14 +510,6 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
             .ToLowerInvariant();
         return $"{fileStem}-{digest[..12]}";
     }
-
-    private static string CreateArchiveCacheKey(Uri archiveUri)
-    {
-        return Convert.ToHexString(
-                System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(archiveUri.ToString())))
-            .ToLowerInvariant();
-    }
-
     private sealed class FailingHttpContent(byte[] content, int failAfterBytes) : HttpContent
     {
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)

--- a/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverTests.cs
@@ -505,7 +505,9 @@ public sealed class CkanPlateauDatasetSourceResolverTests
     {
         Assert.NotNull(resolvedRequest.LocalSourcePath);
         Assert.True(File.Exists(resolvedRequest.LocalSourcePath));
-        Assert.Equal(expectedArchiveFileName, Path.GetFileName(resolvedRequest.LocalSourcePath));
+        Assert.Equal(
+            $"source-archive{Path.GetExtension(expectedArchiveFileName).ToLowerInvariant()}",
+            Path.GetFileName(resolvedRequest.LocalSourcePath));
 
         IPlateauDatasetContentSource datasetSource = await PlateauDatasetContentSourceFactory.CreateAsync(resolvedRequest.LocalSourcePath);
         Assert.Contains(expectedRelativePath, datasetSource.EnumerateFiles());

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -2220,7 +2220,7 @@ public sealed class PlateauImportServiceTests
 
         Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Resolved dataset source", StringComparison.Ordinal));
         Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Scene builder connection check completed", StringComparison.Ordinal));
-        Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Scanned ", StringComparison.Ordinal));
+        Assert.Contains(progressMessages, static message => message.StartsWith("[import][info] Scanned ", StringComparison.Ordinal));
         Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Parsed ", StringComparison.Ordinal));
         Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Prepared construction source", StringComparison.Ordinal));
         Assert.Contains(progressMessages, static message => string.Equals(message, "[import][info] Starting live scene initialization.", StringComparison.Ordinal));

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -63,6 +63,37 @@ public sealed class PlateauImportServiceTests
     }
 
     [Fact]
+    public async Task ExecuteAsyncUsesDatasetScopedWorkRoot()
+    {
+        StubResoniteSceneBuilder sceneBuilder = new();
+        RecordingDatasetSourceResolver datasetSourceResolver = new(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: "/resolved/source",
+                ServerUri: null));
+        PlateauImportService service = new(
+            sceneBuilder,
+            datasetSourceResolver,
+            constructionSourceFactory: new RecordingConstructionSourceFactory(CreateStubConstructionSource()));
+        using TemporaryDirectory workRoot = new();
+
+        await service.ExecuteAsync(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Remote,
+                LocalSourcePath: null,
+                ServerUri: new Uri("https://example.invalid/source.zip", UriKind.Absolute)),
+            workRoot.Path);
+
+        string expectedDatasetRoot = Path.Combine(workRoot.Path, "tokyo23ku");
+        Assert.Equal(expectedDatasetRoot, Assert.Single(datasetSourceResolver.WorkRoots));
+        Assert.Equal(expectedDatasetRoot, Assert.Single(sceneBuilder.BeginWorkRoots));
+    }
+
+    [Fact]
     public async Task ExecuteAsyncBuildsNormalizedSceneFromZipArchive()
     {
         using TemporaryDirectory archiveRoot = new();
@@ -2346,6 +2377,7 @@ public sealed class PlateauImportServiceTests
     private sealed class StubResoniteSceneBuilder : IResoniteSceneBuilder
     {
         public List<ResoniteConstructionCityObject> CityObjects { get; } = [];
+        public List<string> BeginWorkRoots { get; } = [];
         public int EnsureConnectedCallCount { get; private set; }
         public int DisposeCallCount { get; private set; }
         public PlateauImportRequest? LastEnsureConnectedRequest { get; private set; }
@@ -2376,6 +2408,7 @@ public sealed class PlateauImportServiceTests
         {
             ArgumentNullException.ThrowIfNull(metadata);
             ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
+            BeginWorkRoots.Add(workRoot);
             OnBegin?.Invoke();
             return Task.CompletedTask;
         }
@@ -2404,6 +2437,7 @@ public sealed class PlateauImportServiceTests
     private sealed class RecordingDatasetSourceResolver(PlateauImportRequest resolvedRequest) : IPlateauDatasetSourceResolver
     {
         public List<PlateauImportRequest> Requests { get; } = [];
+        public List<string> WorkRoots { get; } = [];
 
         public Task<PlateauImportRequest> ResolveAsync(
             PlateauImportRequest request,
@@ -2411,6 +2445,7 @@ public sealed class PlateauImportServiceTests
             CancellationToken cancellationToken = default)
         {
             Requests.Add(request);
+            WorkRoots.Add(workRoot);
             return Task.FromResult(resolvedRequest);
         }
     }

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -30,9 +30,7 @@ public sealed class CliArgumentsParserTests
         Assert.Equal("53394525", result.Options.Request.MeshCode);
         Assert.Equal(DatasetSourceKind.Local, result.Options.Request.SourceKind);
         Assert.Equal(CliTestData.DocumentedDefaultPackageNames, result.Options.Request.PackageNames);
-        Assert.Equal(
-            Path.Combine("runtime", GetCurrentOsDirectoryName(), "resonite"),
-            result.Options.WorkRoot);
+        Assert.Equal("local", result.Options.WorkRoot);
         Assert.Equal(new Uri("ws://localhost:12345/"), result.Options.ResoniteLinkUri);
         Assert.Equal(4, result.Options.ResoniteLinkConnectionCount);
         Assert.False(result.Options.EnableSendMetrics);
@@ -465,25 +463,5 @@ public sealed class CliArgumentsParserTests
             ]);
 
         Assert.Equal("Specify either --resonitelink-port or --resonitelink-url.", result.Error);
-    }
-
-    private static string GetCurrentOsDirectoryName()
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            return "windows";
-        }
-
-        if (OperatingSystem.IsLinux())
-        {
-            return "linux";
-        }
-
-        if (OperatingSystem.IsMacOS())
-        {
-            return "macos";
-        }
-
-        return "unknown";
     }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -3891,6 +3891,7 @@ public sealed class ResoniteLinkSceneBuilderTests
             cancellationToken.ThrowIfCancellationRequested();
             return Task.CompletedTask;
         }
+
     }
 
     private sealed class UncooperativeConnectClient : IResoniteLinkClient
@@ -4056,11 +4057,10 @@ public sealed class ResoniteLinkSceneBuilderTests
             DisposeCallCount++;
         }
 
-        public async Task ConnectAsync(Uri endpoint, CancellationToken cancellationToken)
+        public Task ConnectAsync(Uri endpoint, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            ConnectStarted.TrySetResult();
-            await connectNeverCompletes.Task;
+            return Task.CompletedTask;
         }
 
         public Task<string> AddComponentAsync(AddComponent request, CancellationToken cancellationToken)
@@ -4126,7 +4126,29 @@ public sealed class ResoniteLinkSceneBuilderTests
         public Task<Slot?> GetSlotAsync(string slotId, int depth, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult<Slot?>(null);
+            if (string.Equals(slotId, "Root", StringComparison.Ordinal))
+            {
+                Slot root = new()
+                {
+                    ID = "Root",
+                    Name = new Field_string
+                    {
+                        Value = "Root",
+                    },
+                };
+                if (depth > 0)
+                {
+                    root.Children = slotsById.Values
+                        .Where(static slot => string.Equals(slot.Parent?.TargetID, "Root", StringComparison.Ordinal))
+                        .Select(slot => CloneSlot(slot, depth - 1))
+                        .ToList();
+                }
+
+                return Task.FromResult<Slot?>(root);
+            }
+
+            slotsById.TryGetValue(slotId, out Slot? slot);
+            return Task.FromResult(slot is null ? null : CloneSlot(slot, depth));
         }
 
         public async Task<Uri> ImportMeshAsync(ImportMeshRawData request, CancellationToken cancellationToken)
@@ -4146,6 +4168,41 @@ public sealed class ResoniteLinkSceneBuilderTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.CompletedTask;
+        }
+
+        private Slot CloneSlot(Slot source, int depth)
+        {
+            Slot clone = new()
+            {
+                ID = source.ID,
+                Parent = source.Parent is null ? null : new Reference
+                {
+                    TargetID = source.Parent.TargetID,
+                },
+                Name = source.Name is null ? null : new Field_string
+                {
+                    Value = source.Name.Value,
+                },
+                Position = source.Position,
+                Rotation = source.Rotation,
+                Scale = source.Scale,
+            };
+
+            if (source.Components is not null)
+            {
+                clone.Components = [.. source.Components];
+            }
+
+            if (depth <= 0)
+            {
+                return clone;
+            }
+
+            clone.Children = slotsById.Values
+                .Where(slot => string.Equals(slot.Parent?.TargetID, source.ID, StringComparison.Ordinal))
+                .Select(slot => CloneSlot(slot, depth - 1))
+                .ToList();
+            return clone;
         }
     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -1943,6 +1943,12 @@ public sealed class ResoniteLinkSceneBuilderTests
         Assert.Single(destinations);
         Assert.True(client.PreexistingPresentationSiblingInjected);
         Assert.Equal(0, client.BatchMutationCount);
+        Assert.Contains(
+            session.AddedSlots,
+            addSlot =>
+                string.Equals(addSlot.Data.Name?.Value, "Building One", StringComparison.Ordinal)
+                && addSlot.Data.Parent is not null
+                && string.Equals(session.SlotPaths[addSlot.Data.Parent.TargetID], "PLATEAU tokyo23ku/53394525/bldg/LOD2", StringComparison.Ordinal));
         Assert.Equal(0, client.RejectedAliasMutationCount);
     }
 
@@ -4050,10 +4056,11 @@ public sealed class ResoniteLinkSceneBuilderTests
             DisposeCallCount++;
         }
 
-        public Task ConnectAsync(Uri endpoint, CancellationToken cancellationToken)
+        public async Task ConnectAsync(Uri endpoint, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return Task.CompletedTask;
+            ConnectStarted.TrySetResult();
+            await connectNeverCompletes.Task;
         }
 
         public Task<string> AddComponentAsync(AddComponent request, CancellationToken cancellationToken)
@@ -4119,20 +4126,7 @@ public sealed class ResoniteLinkSceneBuilderTests
         public Task<Slot?> GetSlotAsync(string slotId, int depth, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (string.Equals(slotId, "Root", StringComparison.Ordinal))
-            {
-                return Task.FromResult<Slot?>(new Slot
-                {
-                    ID = "Root",
-                    Name = new Field_string
-                    {
-                        Value = "Root",
-                    },
-                });
-            }
-
-            slotsById.TryGetValue(slotId, out Slot? slot);
-            return Task.FromResult(slot);
+            return Task.FromResult<Slot?>(null);
         }
 
         public async Task<Uri> ImportMeshAsync(ImportMeshRawData request, CancellationToken cancellationToken)


### PR DESCRIPTION
## What changed
- changed the default `--work-root` from `runtime/<os>/resonite` to `local`
- made the effective work root dataset-scoped as `local/<dataset>/`
- replaced the old remote cache layout with a fixed `source-archive.zip` or `source-archive.7z` under each dataset directory
- moved archive materialization and live-generated files into run-scoped temporary directories under the dataset root and clean them up after the run
- updated tests and English/Japanese docs to match the new layout

## Why
- the old default local data directory still reflected an obsolete runtime-oriented structure
- the new layout keeps only dataset-local state under the work root and removes the old multi-level cache and hidden directory assumptions

## Impact
- users who omit `--work-root` now get a simpler `local/<dataset>/` layout
- remote archive reuse is now per dataset, using a single fixed archive path instead of URI-hash cache trees
- generated/materialized files are treated as temporary runtime artifacts instead of persistent cache structure

## Validation
- `dotnet restore Plateau.ResoniteLink.sln --locked-mode`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --verbosity minimal -m:1 -p:UseSharedCompilation=false`
