### PR TITLE
[codex] Reduce CLI info logs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -58,7 +58,7 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   --resonitelink-port <port>
 ```
 
-`--resonitelink-port` または `--resonitelink-url` は必須です。`--source remote` では direct な `.zip` / `.7z` CityGML archive URL が必要で、組み込みの dataset search は行いません。formatting、analyzer、build、test の検証は次を使います。
+`--resonitelink-port` または `--resonitelink-url` は必須です。`--source remote` では direct な `.zip` / `.7z` CityGML archive URL が必要で、組み込みの dataset search は行いません。CLI は既定でマイルストーン級の進捗だけを表示し、file ごとの詳細や live-send trace は隠します。debug レベルの import / ResoniteLink trace が必要なときは `--verbose` を付けてください。formatting、analyzer、build、test の検証は次を使います。
 
 ```bash
 bash scripts/verify-ci.sh

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
 
 `--resonitelink-port` or `--resonitelink-url` is required. `--source remote` requires a direct `.zip` or `.7z` CityGML archive URL and does not perform built-in dataset search. Validate formatting, analyzers, build, and tests with:
 
+By default, the CLI prints milestone-level progress and keeps detailed per-file and live-send trace logs hidden. Add `--verbose` when you need the debug-level import and ResoniteLink trace output.
+
 ```bash
 bash scripts/verify-ci.sh
 ```

--- a/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.Bootstrap.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.Bootstrap.cs
@@ -60,7 +60,7 @@ public static partial class LocalCityGmlResonitePlanBuilder
         MeshCodeArea? effectiveRequestedMeshArea = MeshCodeArea.TryMerge(requestedMeshAreas);
         scanStopwatch.Stop();
         progressReporter?.Invoke(
-            PlateauLog.Info("import", $"Scanned {sourceFiles.Length} matching CityGML files in {scanStopwatch.Elapsed.TotalSeconds:F3}s."));
+            PlateauLog.Debug("import", $"Scanned {sourceFiles.Length} matching CityGML files in {scanStopwatch.Elapsed.TotalSeconds:F3}s."));
 
         if (sourceFiles.Length == 0)
         {
@@ -123,7 +123,7 @@ public static partial class LocalCityGmlResonitePlanBuilder
         if (demPipelines.Count > 0)
         {
             progressReporter?.Invoke(
-                PlateauLog.Info(
+                PlateauLog.Debug(
                     "import",
                     $"DEM bootstrap parsed {demParsedSourceFiles.Sum(static parsed => parsed.CityObjects.Length)} city objects "
                     + $"from {demPipelines.Count} files in {demStopwatch.Elapsed.TotalSeconds:F3}s."));
@@ -159,8 +159,8 @@ public static partial class LocalCityGmlResonitePlanBuilder
             : null;
         progressReporter?.Invoke(
             terrainHeightSampler is null
-                ? PlateauLog.Info("import", "Terrain height sampler disabled for this dataset.")
-                : PlateauLog.Info("import", $"Terrain height sampler indexed {demTerrainTriangles.Count} DEM triangles."));
+                ? PlateauLog.Debug("import", "Terrain height sampler disabled for this dataset.")
+                : PlateauLog.Debug("import", $"Terrain height sampler indexed {demTerrainTriangles.Count} DEM triangles."));
         ResoniteAttribution attribution = PlateauResoniteAttributionFactory.Create(request);
         ResoniteConstructionMetadata metadata = new(
             SchemaVersion: "3.0",
@@ -182,7 +182,7 @@ public static partial class LocalCityGmlResonitePlanBuilder
                 Altitude: globalOriginPoint.Altitude));
         totalStopwatch.Stop();
         progressReporter?.Invoke(
-            PlateauLog.Info("import", $"Construction source ready in {totalStopwatch.Elapsed.TotalSeconds:F3}s."));
+            PlateauLog.Debug("import", $"Construction source ready in {totalStopwatch.Elapsed.TotalSeconds:F3}s."));
 
         return new ConstructionSource(
             metadata,
@@ -259,7 +259,7 @@ public static partial class LocalCityGmlResonitePlanBuilder
             : [];
 
         progressReporter?.Invoke(
-            PlateauLog.Info(
+            PlateauLog.Debug(
                 "import",
                 $"Parsed file '{sourceFile.RelativePath}' "
                 + $"({sourceFile.PackageName}, {cityObjectArray.Length} city objects) "

--- a/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
@@ -37,7 +37,7 @@ public sealed class PlateauImportService(
         PlateauImportRequest resolvedRequest =
             await datasetSourceResolver.ResolveAsync(normalizedRequest, workRoot, cancellationToken);
         ReportProgress(
-            PlateauLog.Info("import", $"Resolved dataset source for '{resolvedRequest.Dataset}' mesh '{resolvedRequest.MeshCode}'."));
+            PlateauLog.Debug("import", $"Resolved dataset source for '{resolvedRequest.Dataset}' mesh '{resolvedRequest.MeshCode}'."));
 
         try
         {
@@ -45,7 +45,7 @@ public sealed class PlateauImportService(
             await sceneBuilder.EnsureConnectedAsync(normalizedRequest, cancellationToken);
             connectStopwatch.Stop();
             ReportProgress(
-                PlateauLog.Info("import", $"Scene builder connection check completed in {connectStopwatch.Elapsed.TotalSeconds:F3}s."));
+                PlateauLog.Debug("import", $"Scene builder connection check completed in {connectStopwatch.Elapsed.TotalSeconds:F3}s."));
 
             Stopwatch sourceStopwatch = Stopwatch.StartNew();
             IResoniteConstructionSource source = await constructionSourceFactory.CreateAsync(
@@ -54,13 +54,13 @@ public sealed class PlateauImportService(
                 cancellationToken);
             sourceStopwatch.Stop();
             ReportProgress(
-                PlateauLog.Info("import", $"Prepared construction source in {sourceStopwatch.Elapsed.TotalSeconds:F3}s."));
+                PlateauLog.Debug("import", $"Prepared construction source in {sourceStopwatch.Elapsed.TotalSeconds:F3}s."));
 
             Stopwatch beginStopwatch = Stopwatch.StartNew();
             ReportProgress(PlateauLog.Info("import", "Starting live scene initialization."));
             await sceneBuilder.BeginAsync(source.Metadata, workRoot, cancellationToken);
             beginStopwatch.Stop();
-            ReportProgress(PlateauLog.Info("import", $"Scene builder initialization completed in {beginStopwatch.Elapsed.TotalSeconds:F3}s."));
+            ReportProgress(PlateauLog.Debug("import", $"Scene builder initialization completed in {beginStopwatch.Elapsed.TotalSeconds:F3}s."));
 
             bool processedAnyCityObject = false;
             int processedCityObjectCount = 0;
@@ -87,7 +87,7 @@ public sealed class PlateauImportService(
             IReadOnlyList<string> destinations = await sceneBuilder.CompleteAsync(cancellationToken);
             completeStopwatch.Stop();
             ReportProgress(
-                PlateauLog.Info("import", $"Scene builder completion finished in {completeStopwatch.Elapsed.TotalSeconds:F3}s."));
+                PlateauLog.Debug("import", $"Scene builder completion finished in {completeStopwatch.Elapsed.TotalSeconds:F3}s."));
             return new ImportExecutionResult(source.Metadata, destinations);
         }
         finally

--- a/src/Plateau.ResoniteLink.Cli/BuildCommandOptions.cs
+++ b/src/Plateau.ResoniteLink.Cli/BuildCommandOptions.cs
@@ -7,4 +7,5 @@ public sealed record BuildCommandOptions(
     string WorkRoot,
     Uri? ResoniteLinkUri,
     int ResoniteLinkConnectionCount,
-    bool EnableSendMetrics);
+    bool EnableSendMetrics,
+    bool VerboseLogging);

--- a/src/Plateau.ResoniteLink.Cli/CliApplication.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliApplication.cs
@@ -111,8 +111,14 @@ public sealed class CliApplication
     {
         Action<string> reporter = static message =>
         {
+        };
+        PlateauLogLevel minimumLogLevel = options.VerboseLogging
+            ? PlateauLogLevel.Debug
+            : PlateauLogLevel.Info;
+        reporter = message =>
+        {
             string timestamp = DateTimeOffset.Now.ToString("yyyy-MM-ddTHH:mm:ss.fffzzz", CultureInfo.InvariantCulture);
-            WriteLogLine(Console.Out, timestamp, message);
+            WriteLogLine(Console.Out, timestamp, message, minimumLogLevel);
         };
         ResoniteLinkSendDiagnostics diagnostics = options.EnableSendMetrics
             ? ResoniteLinkSendDiagnostics.CreateEnabled(reporter)
@@ -127,9 +133,19 @@ public sealed class CliApplication
             progressReporter: reporter);
     }
 
-    private static void WriteLogLine(TextWriter writer, string timestamp, string message)
+    private static void WriteLogLine(
+        TextWriter writer,
+        string timestamp,
+        string message,
+        PlateauLogLevel minimumLogLevel)
     {
-        string normalizedMessage = PlateauLog.NormalizeLegacyMessage(message);
+        string normalizedMessage = PlateauLog.NormalizeLegacyMessage(message, GetLegacyDefaultLevel(message));
+
+        if (PlateauLogEntry.TryParse(normalizedMessage, out PlateauLogEntry filteredEntry)
+            && filteredEntry.Level < minimumLogLevel)
+        {
+            return;
+        }
 
         if (ReferenceEquals(writer, Console.Out)
             && !Console.IsOutputRedirected
@@ -146,6 +162,13 @@ public sealed class CliApplication
         }
 
         writer.WriteLine($"[{timestamp}] {normalizedMessage}");
+    }
+
+    private static PlateauLogLevel GetLegacyDefaultLevel(string message)
+    {
+        return message.StartsWith("[live]", StringComparison.Ordinal)
+            ? PlateauLogLevel.Debug
+            : PlateauLogLevel.Info;
     }
 
     private static ConsoleColor GetLogLevelColor(PlateauLogLevel level)

--- a/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
@@ -42,6 +42,7 @@ public static class CliArgumentsParser
           --resonitelink-connections <count>
                                                              Optional. Number of parallel ResoniteLink connections for live sends. Default: 4.
           --send-metrics         Optional. Enable opt-in live send metrics and CLI summary output.
+          --verbose              Optional. Include debug-level progress logs.
           -h, --help             Show this help text.
         """;
 
@@ -66,6 +67,7 @@ public static class CliArgumentsParser
         Uri? resoniteLinkUri = null;
         int resoniteLinkConnectionCount = CliDefaultOptions.ResoniteLinkConnectionCount;
         bool enableSendMetrics = false;
+        bool verboseLogging = false;
         DatasetSourceKind sourceKind = DatasetSourceKind.Local;
         Uri? serverUri = null;
         IReadOnlyList<string> packageNames = DefaultPackageNames;
@@ -174,6 +176,9 @@ public static class CliArgumentsParser
                         }
                     case "--send-metrics":
                         enableSendMetrics = true;
+                        break;
+                    case "--verbose":
+                        verboseLogging = true;
                         break;
                     case "--source":
                         {
@@ -341,7 +346,8 @@ public static class CliArgumentsParser
                 workRoot,
                 resoniteLinkUri,
                 resoniteLinkConnectionCount,
-                enableSendMetrics));
+                enableSendMetrics,
+                verboseLogging));
     }
 
     private static string ReadValue(

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -2187,14 +2187,14 @@ public sealed class PlateauImportServiceTests
                 ServerUri: null),
             workRoot: "runtime/resonite");
 
-        Assert.Contains(progressMessages, static message => message.StartsWith("[import][info] Resolved dataset source", StringComparison.Ordinal));
-        Assert.Contains(progressMessages, static message => message.StartsWith("[import][info] Scene builder connection check completed", StringComparison.Ordinal));
-        Assert.Contains(progressMessages, static message => message.StartsWith("[import][info] Scanned ", StringComparison.Ordinal));
-        Assert.Contains(progressMessages, static message => message.StartsWith("[import][info] Parsed ", StringComparison.Ordinal));
-        Assert.Contains(progressMessages, static message => message.StartsWith("[import][info] Prepared construction source", StringComparison.Ordinal));
+        Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Resolved dataset source", StringComparison.Ordinal));
+        Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Scene builder connection check completed", StringComparison.Ordinal));
+        Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Scanned ", StringComparison.Ordinal));
+        Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Parsed ", StringComparison.Ordinal));
+        Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Prepared construction source", StringComparison.Ordinal));
         Assert.Contains(progressMessages, static message => string.Equals(message, "[import][info] Starting live scene initialization.", StringComparison.Ordinal));
         Assert.Contains(progressMessages, static message => message.StartsWith("[import][info] Streamed ", StringComparison.Ordinal));
-        Assert.Contains(progressMessages, static message => message.StartsWith("[import][info] Scene builder completion finished", StringComparison.Ordinal));
+        Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Scene builder completion finished", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -36,6 +36,7 @@ public sealed class CliArgumentsParserTests
         Assert.Equal(new Uri("ws://localhost:12345/"), result.Options.ResoniteLinkUri);
         Assert.Equal(4, result.Options.ResoniteLinkConnectionCount);
         Assert.False(result.Options.EnableSendMetrics);
+        Assert.False(result.Options.VerboseLogging);
     }
 
     [Fact]
@@ -201,6 +202,27 @@ public sealed class CliArgumentsParserTests
             new Uri("https://example.invalid/plateau.zip"),
             result.Options.Request.ServerUri);
         Assert.Equal(new Uri("ws://localhost:12345/"), result.Options.ResoniteLinkUri);
+    }
+
+    [Fact]
+    public void ParseEnablesVerboseLoggingWhenRequested()
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "build",
+                "--dataset",
+                "tokyo23ku",
+                "--mesh-code",
+                "53394525",
+                "--local-source-path",
+                "/data/plateau",
+                "--resonitelink-port",
+                "12345",
+                "--verbose",
+            ]);
+
+        Assert.Null(result.Error);
+        Assert.True(result.Options!.VerboseLogging);
     }
 
     [Fact]


### PR DESCRIPTION
## What Changed
- added a CLI-side minimum log level so default runs hide debug-level progress lines
- introduced `--verbose` to opt back into detailed import and live-send trace output
- reclassified detailed import timing and file-scan progress messages from `info` to `debug`
- updated the English and Japanese README usage notes and adjusted parser/import-service tests

## Why
Default CLI output was too noisy for normal imports. Detailed scan timings and setup traces are still useful for diagnosis, but they do not need to be shown on every run.

## User Impact
Normal `build` runs now show milestone-level progress by default. Users who need the previous level of detail can run with `--verbose`.

## Root Cause
The CLI printed every progress event without any level filtering, and several operational diagnostics were emitted at `info` even though they were primarily debug-oriented.

## Validation
- `dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --filter "FullyQualifiedName~CliArgumentsParserTests|FullyQualifiedName~CliApplicationTests|FullyQualifiedName~PlateauImportServiceTests" -m:1 -p:UseSharedCompilation=false`
