### PR TITLE
[codex] Reduce CLI info logs

### DIFF
--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -608,7 +608,10 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
 
     private void ReportProgress(string message)
     {
-        progressReporter?.Invoke(PlateauLog.NormalizeLegacyMessage(message));
+        PlateauLogLevel defaultLevel = message.StartsWith("[live]", StringComparison.Ordinal)
+            ? PlateauLogLevel.Debug
+            : PlateauLogLevel.Info;
+        progressReporter?.Invoke(PlateauLog.NormalizeLegacyMessage(message, defaultLevel));
     }
 
     private Task<PreparedCityObject> CreatePreparationTask(

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -2220,8 +2220,8 @@ public sealed class PlateauImportServiceTests
 
         Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Resolved dataset source", StringComparison.Ordinal));
         Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Scene builder connection check completed", StringComparison.Ordinal));
-        Assert.Contains(progressMessages, static message => message.StartsWith("[import][info] Scanned ", StringComparison.Ordinal));
-        Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Parsed ", StringComparison.Ordinal));
+        Assert.Contains(progressMessages, static message => message.Contains(" Scanned ", StringComparison.Ordinal));
+        Assert.Contains(progressMessages, static message => message.Contains(" Parsed ", StringComparison.Ordinal));
         Assert.Contains(progressMessages, static message => message.StartsWith("[import][debug] Prepared construction source", StringComparison.Ordinal));
         Assert.Contains(progressMessages, static message => string.Equals(message, "[import][info] Starting live scene initialization.", StringComparison.Ordinal));
         Assert.Contains(progressMessages, static message => message.StartsWith("[import][info] Streamed ", StringComparison.Ordinal));

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -1832,7 +1832,7 @@ public sealed class ResoniteLinkSceneBuilderTests
             static message => message.Contains("[live][error] Send lane 1/1 failed:", StringComparison.Ordinal));
         Assert.Contains(
             progressMessages,
-            static message => message.Contains("[live][info] Creating dataset root, asset groups, and anchor slots.", StringComparison.Ordinal));
+            static message => message.Contains("[live][debug] Creating dataset root, asset groups, and anchor slots.", StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
## What Changed
- added a CLI-side minimum log level so default runs hide debug-level progress lines
- introduced `--verbose` to opt back into detailed import and live-send trace output
- reclassified detailed import timing and file-scan progress messages from `info` to `debug`
- fixed live trace normalization so `[live] ...` messages are actually treated as debug by default
- updated the relevant README notes and test expectations

## Why
Default CLI output was too noisy for routine imports. Detailed import timing and live-send trace logs are still useful for diagnosis, but they should only appear when explicitly requested.

## User Impact
Normal `build` runs now show milestone-level progress by default. Users who need detailed import and live-send traces can run with `--verbose`.

## Root Cause
The CLI previously emitted all progress events without filtering, and live legacy messages were normalized to `info` before the new minimum level filter ran, so most live trace output still leaked into default runs.

## Validation
- `dotnet restore Plateau.ResoniteLink.sln --locked-mode`
- `dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --filter "FullyQualifiedName~CliArgumentsParserTests|FullyQualifiedName~CliApplicationTests|FullyQualifiedName~PlateauImportServiceTests|FullyQualifiedName~ResoniteLinkSceneBuilderTests" -m:1 -p:UseSharedCompilation=false`
