### PR TITLE
Improve local source path guidance

### DIFF
--- a/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlDocumentReader.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlDocumentReader.cs
@@ -17,7 +17,7 @@ internal sealed class LocalCityGmlDocumentReader : ICityGmlDocumentReader
         if (request.Source is not PlateauLocalImportSource localSource || string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
         {
             throw new PlateauImportValidationException(
-                ["Local CityGML import requires --source local and a local source path via --local-source-path."]);
+                [LocalCityGmlImportErrorMessages.MissingLocalSourcePath()]);
         }
 
         IPlateauDatasetContentSource datasetSource = await PlateauDatasetContentSourceFactory.CreateAsync(
@@ -51,7 +51,7 @@ internal sealed class LocalCityGmlDocumentReader : ICityGmlDocumentReader
         if (sourceFiles.Length == 0)
         {
             throw new PlateauImportValidationException(
-                [$"No local PLATEAU CityGML files were found for mesh code '{request.MeshCode}' under udx/<package>/<mesh-code>/."]);
+                [LocalCityGmlImportErrorMessages.NoMatchingFiles(request, localSource.LocalSourcePath!)]);
         }
 
         LodFilteringStrategy lodFilteringStrategy = new(

--- a/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlImportErrorMessages.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlImportErrorMessages.cs
@@ -1,0 +1,50 @@
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Application.Importing;
+
+internal static class LocalCityGmlImportErrorMessages
+{
+    public static string MissingLocalSourcePath()
+    {
+        return "Local CityGML import requires --source local and --local-source-path pointing to either an extracted PLATEAU dataset directory or a .zip/.7z archive.";
+    }
+
+    public static string NoMatchingFiles(PlateauImportRequest request, string localSourcePath)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(localSourcePath);
+
+        string fullPath = Path.GetFullPath(localSourcePath);
+        string baseMessage =
+            $"No local PLATEAU CityGML files were found for mesh code '{request.MeshCode}' in '{fullPath}'. "
+            + "Expected files under udx/<package>/<mesh-code>/.";
+
+        string? persistedArchivePath = TryResolvePersistedArchivePath(fullPath);
+        if (persistedArchivePath is null)
+        {
+            return baseMessage;
+        }
+
+        return baseMessage
+            + " The directory looks like a dataset root created by --work-root. "
+            + $"Pass the archive file itself via --local-source-path, for example '{persistedArchivePath}', "
+            + "or pass an extracted dataset directory that contains udx/<package>/<mesh-code>/.";
+    }
+
+    private static string? TryResolvePersistedArchivePath(string fullPath)
+    {
+        if (!Directory.Exists(fullPath))
+        {
+            return null;
+        }
+
+        string zipPath = Path.Combine(fullPath, "source-archive.zip");
+        if (File.Exists(zipPath))
+        {
+            return zipPath;
+        }
+
+        string sevenZipPath = Path.Combine(fullPath, "source-archive.7z");
+        return File.Exists(sevenZipPath) ? sevenZipPath : null;
+    }
+}

--- a/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.Bootstrap.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.Bootstrap.cs
@@ -36,7 +36,7 @@ public static partial class LocalCityGmlResonitePlanBuilder
         if (request.Source is not PlateauLocalImportSource localSource || string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
         {
             throw new PlateauImportValidationException(
-                ["Local CityGML import requires --source local and a local source path via --local-source-path."]);
+                [LocalCityGmlImportErrorMessages.MissingLocalSourcePath()]);
         }
 
         IPlateauDatasetContentSource datasetSource = await PlateauDatasetContentSourceFactory.CreateAsync(
@@ -68,7 +68,7 @@ public static partial class LocalCityGmlResonitePlanBuilder
         if (sourceFiles.Length == 0)
         {
             throw new PlateauImportValidationException(
-                [$"No local PLATEAU CityGML files were found for mesh code '{request.MeshCode}' under udx/<package>/<mesh-code>/."]);
+                [LocalCityGmlImportErrorMessages.NoMatchingFiles(request, localSource.LocalSourcePath!)]);
         }
 
         // Create LOD filtering strategy from the request

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -1744,6 +1744,32 @@ public sealed class PlateauImportServiceTests
     }
 
     [Fact]
+    public async Task ExecuteAsyncGuidesUserToArchiveWhenDatasetRootDirectoryIsPassedAsLocalSourcePath()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        string archivePath = Path.Combine(datasetRoot.Path, "source-archive.zip");
+        await File.WriteAllTextAsync(archivePath, string.Empty);
+
+        StubResoniteSceneBuilder sceneBuilder = new();
+        PlateauImportService service = new(sceneBuilder);
+
+        PlateauImportValidationException exception = await Assert.ThrowsAsync<PlateauImportValidationException>(() =>
+            service.ExecuteAsync(
+                new PlateauImportRequest(
+                    Dataset: "14100-yokohama-shi",
+                    MeshCode: "53391570",
+                    SourceKind: DatasetSourceKind.Local,
+                    LocalSourcePath: datasetRoot.Path,
+                    ServerUri: null),
+                workRoot: "runtime/resonite"));
+
+        string message = Assert.Single(exception.Errors);
+        Assert.Contains($"mesh code '53391570' in '{datasetRoot.Path}'", message, StringComparison.Ordinal);
+        Assert.Contains($"'{archivePath}'", message, StringComparison.Ordinal);
+        Assert.Contains("contains udx/<package>/<mesh-code>/", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ExecuteAsyncRejectsUnsupportedPackagePatternWithValidationException()
     {
         StubResoniteSceneBuilder sceneBuilder = new();


### PR DESCRIPTION
## Summary
- improve local local-source-path validation guidance
- detect dataset root directories that only contain persisted source archives
- add a regression test for passing local/<dataset> instead of source-archive.zip

## Testing
- dotnet restore Plateau.ResoniteLink.sln --locked-mode
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false
- dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 -p:UseSharedCompilation=false
- bash scripts/verify-ci.sh