### PR TITLE
[codex] Fix common material asset scope

### DIFF
--- a/src/Plateau.ResoniteLink.Application/Importing/DefaultMaterialCatalog.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/DefaultMaterialCatalog.cs
@@ -19,7 +19,8 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
                 ResoniteTextureSourceKind.Bundled,
                 ResoniteMaterialProjection.Uv,
                 Family: null,
-                TextureScale: null);
+                TextureScale: null,
+                AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
         }
 
         if (!string.IsNullOrWhiteSpace(texturePath))
@@ -30,7 +31,8 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
                 ResoniteTextureSourceKind.Dataset,
                 ResoniteMaterialProjection.Uv,
                 Family: null,
-                TextureScale: null);
+                TextureScale: null,
+                AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
         }
 
         bool useFacadeUvProjection = ShouldUseFacadeUvProjection(packageName, preferUvProjection);
@@ -42,7 +44,8 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
             ResoniteTextureSourceKind.Bundled,
             preferUvProjection ? ResoniteMaterialProjection.Uv : ResoniteMaterialProjection.Triplanar,
             family,
-            BundledDefaultMaterialProfiles.GetTilesPerMeter(selectedTexturePath));
+            BundledDefaultMaterialProfiles.GetTilesPerMeter(selectedTexturePath),
+            ResoniteMaterialAssetScope.Common);
     }
 
     private static bool ShouldUseWireframeMaterial(string packageName)

--- a/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.cs
@@ -1262,7 +1262,8 @@ public static partial class LocalCityGmlResonitePlanBuilder
                     DepthOffset: representativeSurface.DepthOffset,
                     SubmeshIndices: [materialIndex],
                     TextureScale: representativeSurface.Material.TextureScale,
-                    Family: representativeSurface.Material.Family));
+                    Family: representativeSurface.Material.Family,
+                    AssetScope: representativeSurface.Material.AssetScope));
         }
 
         return new ResoniteConstructionCityObject(
@@ -1314,7 +1315,8 @@ public static partial class LocalCityGmlResonitePlanBuilder
                     ResoniteTextureSourceKind.Bundled,
                     ResoniteMaterialProjection.Uv,
                     Family: null,
-                    TextureScale: null),
+                    TextureScale: null,
+                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
                 DepthOffset: null);
         }
 
@@ -1331,7 +1333,8 @@ public static partial class LocalCityGmlResonitePlanBuilder
                         ResoniteTextureSourceKind.Bundled,
                         ResoniteMaterialProjection.Uv,
                         Family: null,
-                        TextureScale: null),
+                        TextureScale: null,
+                        AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
                     DepthOffset: null);
             }
 
@@ -1343,7 +1346,8 @@ public static partial class LocalCityGmlResonitePlanBuilder
                     ResoniteTextureSourceKind.Bundled,
                     ResoniteMaterialProjection.Uv,
                     Family: null,
-                    TextureScale: null),
+                    TextureScale: null,
+                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
                 DepthOffset: null);
         }
 
@@ -1357,7 +1361,8 @@ public static partial class LocalCityGmlResonitePlanBuilder
                     ResoniteTextureSourceKind.Bundled,
                     ResoniteMaterialProjection.Uv,
                     Family: null,
-                    TextureScale: null),
+                    TextureScale: null,
+                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
                 DefaultTerrainAlignedMaterialDepthOffset);
         }
 
@@ -3283,7 +3288,8 @@ public static partial class LocalCityGmlResonitePlanBuilder
                     SubmeshIndices: [materialIndex],
                     TextureScale: textureScale ?? representativeSurface.Material.TextureScale,
                     Family: representativeSurface.Material.Family,
-                    TextureOffset: textureOffset);
+                    TextureOffset: textureOffset,
+                    AssetScope: representativeSurface.Material.AssetScope);
             })
             .ToArray();
     }

--- a/src/Plateau.ResoniteLink.Application/Importing/ResolvedMaterial.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/ResolvedMaterial.cs
@@ -8,4 +8,5 @@ public sealed record ResolvedMaterial(
     ResoniteTextureSourceKind TextureSourceKind,
     ResoniteMaterialProjection Projection,
     string? Family,
-    ResoniteFloat2? TextureScale);
+    ResoniteFloat2? TextureScale,
+    ResoniteMaterialAssetScope AssetScope);

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -816,9 +816,16 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             rootMeshCodePosition,
             null,
             cancellationToken);
-        CreatedSlot assetPackageSlot = await GetOrCreateSharedChildSlotAsync(
+        CreatedSlot assetMeshRootSlot = await GetOrCreateSharedChildSlotAsync(
             client,
             datasetAssetsRoot,
+            rootMeshCode,
+            null,
+            null,
+            cancellationToken);
+        CreatedSlot assetPackageSlot = await GetOrCreateSharedChildSlotAsync(
+            client,
+            assetMeshRootSlot,
             cityObject.PackageName,
             null,
             null,
@@ -846,6 +853,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             cancellationToken);
         return new ObjectSlotHierarchy(
             meshRootSlot,
+            assetMeshRootSlot,
             assetPackageSlot,
             packageSlot,
             assetLodSlot,
@@ -881,14 +889,13 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(metadata is null, this);
-        ObjectDisposedException.ThrowIf(commonAssetsRootSlot is null, this);
         ObjectDisposedException.ThrowIf(materialAssetManager is null, this);
 
-        bool useCommonMaterialAssets = ShouldUseCommonMaterialAssets(material);
+        bool useCommonMaterialAssets = material.AssetScope == ResoniteMaterialAssetScope.Common;
         string materialScopeId = useCommonMaterialAssets
-            ? commonAssetsRootSlot.Value.SlotId
+            ? commonAssetsRootSlot!.Value.SlotId
             : objectSlots.MeshAssetSlot!.Value.SlotId;
-        string? materialSlotParentId = useCommonMaterialAssets ? commonAssetsRootSlot.Value.SlotId : null;
+        string? materialSlotParentId = useCommonMaterialAssets ? commonAssetsRootSlot!.Value.SlotId : null;
         string materialSlotName = CreateMaterialSlotName(material, useCommonMaterialAssets);
         return await materialAssetManager.CreateMaterialComponentAsync(
             client,
@@ -900,14 +907,6 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             objectSlots.AssetLodSlot.SlotId,
             objectSlots.MeshAssetSlot?.SlotId ?? objectSlots.AssetLodSlot.SlotId,
             cancellationToken);
-    }
-
-    private static bool ShouldUseCommonMaterialAssets(ResoniteMaterialBinding material)
-    {
-        return material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
-            && !string.IsNullOrWhiteSpace(material.TexturePath)
-            && !IsGeneratedDemTexturePath(material.TexturePath)
-            && material.TexturePath.StartsWith("default-materials/", StringComparison.Ordinal);
     }
 
     private static string CreateMaterialSlotName(ResoniteMaterialBinding material, bool useCommonMaterialAssets)
@@ -1773,6 +1772,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
 
     private sealed record ObjectSlotHierarchy(
         CreatedSlot MeshRootSlot,
+        CreatedSlot AssetMeshRootSlot,
         CreatedSlot AssetPackageSlot,
         CreatedSlot PackageSlot,
         CreatedSlot AssetLodSlot,

--- a/src/Plateau.ResoniteLink.Domain/Importing/ResoniteMaterialAssetScope.cs
+++ b/src/Plateau.ResoniteLink.Domain/Importing/ResoniteMaterialAssetScope.cs
@@ -1,0 +1,7 @@
+namespace Plateau.ResoniteLink.Domain.Importing;
+
+public enum ResoniteMaterialAssetScope
+{
+    PresentationSlotScoped = 0,
+    Common = 1,
+}

--- a/src/Plateau.ResoniteLink.Domain/Importing/ResoniteMaterialBinding.cs
+++ b/src/Plateau.ResoniteLink.Domain/Importing/ResoniteMaterialBinding.cs
@@ -11,4 +11,5 @@ public sealed record ResoniteMaterialBinding(
     IReadOnlyList<int> SubmeshIndices,
     ResoniteFloat2? TextureScale = null,
     string? Family = null,
-    ResoniteFloat2? TextureOffset = null);
+    ResoniteFloat2? TextureOffset = null,
+    ResoniteMaterialAssetScope AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped);

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
@@ -528,7 +528,8 @@ public sealed class ResoniteLinkSceneBuilderAssetReuseTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TextureScale: textureScale),
+                    TextureScale: textureScale,
+                    AssetScope: ResoniteMaterialAssetScope.Common),
             ],
             SourceObjectKey: objectIdentity);
     }

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -1397,7 +1397,7 @@ public sealed class ResoniteLinkSceneBuilderTests
 
         Slot datasetSlot = FindSlotByName(fakeClient.SlotsById, "PLATEAU tokyo23ku");
         Assert.Equal(["Assets", "53394525", "533945"], await GetDirectChildNamesAsync(fakeClient, datasetSlot.ID));
-        Slot anchorSlot = FindSlotByNameUnderAncestor(fakeClient.SlotsById, datasetSlot.ID, "53394525");
+        Slot anchorSlot = FindDirectChildSlotByName(fakeClient.SlotsById, datasetSlot.ID, "53394525");
         Field_float3 anchorPosition = Assert.IsType<Field_float3>(anchorSlot.Position);
         Assert.Equal(0.0f, anchorPosition.Value.x, precision: 4);
         Assert.Equal(0.0f, anchorPosition.Value.y, precision: 4);
@@ -1425,8 +1425,8 @@ public sealed class ResoniteLinkSceneBuilderTests
         await RunBuilderAsync(builder, scene);
 
         Slot datasetSlot = FindSlotByName(fakeClient.SlotsById, "PLATEAU tokyo23ku");
-        Slot anchorMeshRootSlot = FindSlotByNameUnderAncestor(fakeClient.SlotsById, datasetSlot.ID, "53394525");
-        Slot parentMeshRootSlot = FindSlotByNameUnderAncestor(fakeClient.SlotsById, datasetSlot.ID, "533945");
+        Slot anchorMeshRootSlot = FindDirectChildSlotByName(fakeClient.SlotsById, datasetSlot.ID, "53394525");
+        Slot parentMeshRootSlot = FindDirectChildSlotByName(fakeClient.SlotsById, datasetSlot.ID, "533945");
         Field_float3 anchorMeshRootPosition = Assert.IsType<Field_float3>(anchorMeshRootSlot.Position);
         Field_float3 parentMeshRootPosition = Assert.IsType<Field_float3>(parentMeshRootSlot.Position);
         Assert.True(PlateauMeshCode.TryGetCenter("53394525", out ResoniteLocalOrigin anchorMeshCenter));
@@ -1450,7 +1450,7 @@ public sealed class ResoniteLinkSceneBuilderTests
             CreateRegexRequestScene("5339452(56)"));
 
         Slot datasetSlot = FindSlotByName(fakeClient.SlotsById, "PLATEAU tokyo23ku");
-        Slot completionAnchorSlot = FindSlotByNameUnderAncestor(fakeClient.SlotsById, datasetSlot.ID, "53394525");
+        Slot completionAnchorSlot = FindDirectChildSlotByName(fakeClient.SlotsById, datasetSlot.ID, "53394525");
         Assert.Contains("PLATEAU tokyo23ku/53394525", fakeClient.SlotPaths.Values);
         Assert.Equal(
             [$"ws://localhost:12345/#{completionAnchorSlot.ID}"],
@@ -1973,8 +1973,8 @@ public sealed class ResoniteLinkSceneBuilderTests
             CreateAppendScene("53394526", "Building 26"));
 
         Slot datasetSlot = FindSlotByName(session.SlotsById, "PLATEAU tokyo23ku");
-        Slot firstMeshRootSlot = FindSlotByNameUnderAncestor(session.SlotsById, datasetSlot.ID, "53394525");
-        Slot secondMeshRootSlot = FindSlotByNameUnderAncestor(session.SlotsById, datasetSlot.ID, "53394526");
+        Slot firstMeshRootSlot = FindDirectChildSlotByName(session.SlotsById, datasetSlot.ID, "53394525");
+        Slot secondMeshRootSlot = FindDirectChildSlotByName(session.SlotsById, datasetSlot.ID, "53394526");
         Field_float3 firstMeshRootPosition = Assert.IsType<Field_float3>(firstMeshRootSlot.Position);
         Field_float3 secondMeshRootPosition = Assert.IsType<Field_float3>(secondMeshRootSlot.Position);
         Assert.True(PlateauMeshCode.TryGetCenter("53394525", out ResoniteLocalOrigin firstCenter));
@@ -4478,6 +4478,18 @@ public sealed class ResoniteLinkSceneBuilderTests
             slot =>
                 string.Equals(slot.Name?.Value, slotName, StringComparison.Ordinal)
                 && IsDescendantOf(slotsById, slot, ancestorSlotId));
+    }
+
+    private static Slot FindDirectChildSlotByName(
+        IReadOnlyDictionary<string, Slot> slotsById,
+        string parentSlotId,
+        string slotName)
+    {
+        return Assert.Single(
+            slotsById.Values,
+            slot =>
+                string.Equals(slot.Name?.Value, slotName, StringComparison.Ordinal)
+                && string.Equals(slot.Parent?.TargetID, parentSlotId, StringComparison.Ordinal));
     }
 
     private static bool IsDescendantOf(

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -66,7 +66,7 @@ public sealed class ResoniteLinkSceneBuilderTests
             : "LOD0";
         Assert.Contains("PLATEAU tokyo23ku/Assets", fakeClient.SlotPaths.Values);
         Assert.Contains("PLATEAU tokyo23ku/Assets/Common", fakeClient.SlotPaths.Values);
-        Assert.Contains($"PLATEAU tokyo23ku/Assets/bldg/{buildingLodSlotName}/Building One", fakeClient.SlotPaths.Values);
+        Assert.Contains($"PLATEAU tokyo23ku/Assets/53394525/bldg/{buildingLodSlotName}/Building One", fakeClient.SlotPaths.Values);
         Assert.Contains($"PLATEAU tokyo23ku/53394525/bldg/{buildingLodSlotName}/Building One", fakeClient.SlotPaths.Values);
         Assert.DoesNotContain("PLATEAU tokyo23ku/Assets/Textures", fakeClient.SlotPaths.Values);
         Assert.DoesNotContain("PLATEAU tokyo23ku/Assets/Meshes", fakeClient.SlotPaths.Values);
@@ -141,7 +141,7 @@ public sealed class ResoniteLinkSceneBuilderTests
             meshAssetRequests,
             request => string.Equals(
                 fakeClient.SlotPaths[request.ContainerSlotId],
-                $"PLATEAU tokyo23ku/Assets/bldg/{buildingLodSlotName}/Building One",
+                $"PLATEAU tokyo23ku/Assets/53394525/bldg/{buildingLodSlotName}/Building One",
                 StringComparison.Ordinal));
 
         AddComponent[] materialRequests = fakeClient.AddedComponents
@@ -165,7 +165,7 @@ public sealed class ResoniteLinkSceneBuilderTests
             {
                 string slotPath = fakeClient.SlotPaths[request.ContainerSlotId];
                 return slotPath.StartsWith(
-                    $"PLATEAU tokyo23ku/Assets/bldg/{buildingLodSlotName}/Building One/",
+                    $"PLATEAU tokyo23ku/Assets/53394525/bldg/{buildingLodSlotName}/Building One/",
                     StringComparison.Ordinal);
             });
 
@@ -872,7 +872,7 @@ public sealed class ResoniteLinkSceneBuilderTests
         Assert.DoesNotContain("/Assets/Common/", fakeClient.SlotPaths[displacementTextureSlot.ID], StringComparison.Ordinal);
         Assert.DoesNotContain("/Assets/Common/", fakeClient.SlotPaths[materialTextureSlot.ID], StringComparison.Ordinal);
         Assert.StartsWith(
-            "PLATEAU tokyo23ku/Assets/dem/LOD0/HeightMap Overlay Test/",
+            "PLATEAU tokyo23ku/Assets/53394525/dem/LOD0/HeightMap Overlay Test/",
             fakeClient.SlotPaths[materialTextureSlot.ID],
             StringComparison.Ordinal);
     }
@@ -1029,7 +1029,7 @@ public sealed class ResoniteLinkSceneBuilderTests
                 "[FrooxEngine]FrooxEngine.PBS_Metallic",
                 StringComparison.Ordinal));
         string materialPath = fakeClient.SlotPaths[materialRequest.ContainerSlotId];
-        Assert.StartsWith("PLATEAU tokyo23ku/Assets/tran/LOD1/", materialPath, StringComparison.Ordinal);
+        Assert.StartsWith("PLATEAU tokyo23ku/Assets/53394525/tran/LOD1/", materialPath, StringComparison.Ordinal);
         Assert.DoesNotContain("/Assets/Common", materialPath, StringComparison.Ordinal);
     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderYOffsetTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderYOffsetTests.cs
@@ -40,7 +40,7 @@ public sealed class ResoniteLinkSceneBuilderYOffsetTests
         Field_float3 datasetPosition = Assert.IsType<Field_float3>(datasetSlot.Position);
         Assert.Equal(0.0f, datasetPosition.Value.y);
 
-        Slot meshRootSlot = FindSlotByNameUnderAncestor(
+        Slot meshRootSlot = FindDirectChildSlotByName(
             fakeClient.SlotsById,
             datasetSlot.ID,
             meshCode);
@@ -159,8 +159,9 @@ public sealed class ResoniteLinkSceneBuilderYOffsetTests
         await builder.ProcessCityObjectAsync(buildingCityObject);
         _ = await builder.CompleteAsync();
 
-        Slot demRootSlot = FindSlotByName(fakeClient.SlotsById, "533945");
-        Slot buildingRootSlot = FindSlotByName(fakeClient.SlotsById, requestedMeshCode);
+        Slot datasetSlot = FindSlotByName(fakeClient.SlotsById, $"PLATEAU {dataset}");
+        Slot demRootSlot = FindDirectChildSlotByName(fakeClient.SlotsById, datasetSlot.ID, "533945");
+        Slot buildingRootSlot = FindDirectChildSlotByName(fakeClient.SlotsById, datasetSlot.ID, requestedMeshCode);
         Slot demCityObjectSlot = FindSlotByNameUnderAncestor(
             fakeClient.SlotsById,
             demRootSlot.ID,
@@ -232,8 +233,9 @@ public sealed class ResoniteLinkSceneBuilderYOffsetTests
         await builder.ProcessCityObjectAsync(detailedMeshBuilding);
         _ = await builder.CompleteAsync();
 
-        Slot parentRootSlot = FindSlotByName(fakeClient.SlotsById, "533945");
-        Slot detailedRootSlot = FindSlotByName(fakeClient.SlotsById, requestedMeshCode);
+        Slot datasetSlot = FindSlotByName(fakeClient.SlotsById, $"PLATEAU {dataset}");
+        Slot parentRootSlot = FindDirectChildSlotByName(fakeClient.SlotsById, datasetSlot.ID, "533945");
+        Slot detailedRootSlot = FindDirectChildSlotByName(fakeClient.SlotsById, datasetSlot.ID, requestedMeshCode);
         Slot parentCityObjectSlot = FindSlotByNameUnderAncestor(
             fakeClient.SlotsById,
             parentRootSlot.ID,
@@ -321,7 +323,19 @@ public sealed class ResoniteLinkSceneBuilderYOffsetTests
             slotsById.Values,
             slot =>
                 string.Equals(slot.Name?.Value, slotName, StringComparison.Ordinal)
-                && IsDescendantOf(slotsById, slot, ancestorSlotId));
+                && IsDescendantOfNonAssetPath(slotsById, slot, ancestorSlotId));
+    }
+
+    private static Slot FindDirectChildSlotByName(
+        IReadOnlyDictionary<string, Slot> slotsById,
+        string parentSlotId,
+        string slotName)
+    {
+        return Assert.Single(
+            slotsById.Values,
+            slot =>
+                string.Equals(slot.Name?.Value, slotName, StringComparison.Ordinal)
+                && string.Equals(slot.Parent?.TargetID, parentSlotId, StringComparison.Ordinal));
     }
 
     private static bool IsDescendantOf(
@@ -335,6 +349,30 @@ public sealed class ResoniteLinkSceneBuilderYOffsetTests
             if (string.Equals(parentSlot.ID, ancestorSlotId, StringComparison.Ordinal))
             {
                 return true;
+            }
+
+            parent = parentSlot.Parent;
+        }
+
+        return false;
+    }
+
+    private static bool IsDescendantOfNonAssetPath(
+        IReadOnlyDictionary<string, Slot> slotsById,
+        Slot slot,
+        string ancestorSlotId)
+    {
+        Reference? parent = slot.Parent;
+        while (parent is not null && slotsById.TryGetValue(parent.TargetID, out Slot? parentSlot))
+        {
+            if (string.Equals(parentSlot.ID, ancestorSlotId, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            if (string.Equals(parentSlot.Name?.Value, "Assets", StringComparison.Ordinal))
+            {
+                return false;
             }
 
             parent = parentSlot.Parent;


### PR DESCRIPTION
## Summary
- add an explicit `ResoniteMaterialAssetScope` so Common-vs-object-scoped placement is decided during material resolution
- treat only pre-CityGML default materials as `Common`, and keep all other materials object-scoped
- keep non-Common material assets under `Assets/<mesh-code>/...` instead of falling back to package-only asset paths

## Why
Common materials should be limited to assets that can be prepared before reading CityGML. Dataset textures, vertex colors, and other appearance-derived materials should remain specific to each presentation slot while still preserving the mesh-code-based asset hierarchy.

## Validation
- `dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`
- `dotnet test Plateau.ResoniteLink.sln --configuration Release --no-build --filter "FullyQualifiedName~ResoniteLinkSceneBuilderAssetReuseTests|FullyQualifiedName~BuildAsyncImportsAssetsAndBuildsLiveComponents|FullyQualifiedName~BuildAsyncPlacesHeightMapDisplacementTextureOnDedicatedAssetSlot|FullyQualifiedName~BuildAsyncDoesNotPlaceDatasetScopedMaterialWithoutTextureInCommonAssets" -m:1 -p:UseSharedCompilation=false`
- `dotnet test Plateau.ResoniteLink.sln --configuration Release --no-build --filter "FullyQualifiedName~ExecuteAsyncUsesVertexColorMaterialsForVegetationAndFallsBackToGreenPbsMaterialWithoutDiffuseColor" -m:1 -p:UseSharedCompilation=false`
