### PR TITLE
[codex] speed up local test loop

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -59,11 +59,19 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   --resonitelink-port <port>
 ```
 
-`--resonitelink-port` または `--resonitelink-url` は必須です。`--source remote` では direct な `.zip` / `.7z` CityGML archive URL が必要で、組み込みの dataset search は行いません。CLI は既定でマイルストーン級の進捗だけを表示し、file ごとの詳細や live-send trace は隠します。debug レベルの import / ResoniteLink trace が必要なときは `--verbose` を付けてください。formatting、analyzer、build、test の検証は次を使います。
+`--resonitelink-port` または `--resonitelink-url` は必須です。`--source remote` では direct な `.zip` / `.7z` CityGML archive URL が必要で、組み込みの dataset search は行いません。CI 相当の formatting、analyzer、build、test の検証は次を使います。
 
 ```bash
 bash scripts/verify-ci.sh
 ```
+
+日常の編集ループでは、`Category=Slow` の integration 寄りテストを除いた高速サブセットを使えます。
+
+```bash
+bash scripts/test-fast.sh
+```
+
+CLI は既定でマイルストーン級の進捗だけを表示し、file ごとの詳細や live-send trace は隠します。debug レベルの import / ResoniteLink trace が必要なときは `--verbose` を付けてください。
 
 `--work-root` を省略した場合、CLI は dataset ごとの archive と live temporary file を `local/<dataset>/` 配下に置きます。
 

--- a/README.md
+++ b/README.md
@@ -59,13 +59,19 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   --resonitelink-port <port>
 ```
 
-`--resonitelink-port` or `--resonitelink-url` is required. `--source remote` requires a direct `.zip` or `.7z` CityGML archive URL and does not perform built-in dataset search. Validate formatting, analyzers, build, and tests with:
-
-By default, the CLI prints milestone-level progress and keeps detailed per-file and live-send trace logs hidden. Add `--verbose` when you need the debug-level import and ResoniteLink trace output.
+`--resonitelink-port` or `--resonitelink-url` is required. `--source remote` requires a direct `.zip` or `.7z` CityGML archive URL and does not perform built-in dataset search. For the full CI-equivalent validation, run:
 
 ```bash
 bash scripts/verify-ci.sh
 ```
+
+For the everyday edit-test loop, run the fast subset that excludes `Category=Slow` integration-style tests:
+
+```bash
+bash scripts/test-fast.sh
+```
+
+By default, the CLI prints milestone-level progress and keeps detailed per-file and live-send trace logs hidden. Add `--verbose` when you need the debug-level import and ResoniteLink trace output.
 
 When `--work-root` is omitted, the CLI stores dataset-local archives and live temporary files under `local/<dataset>/`.
 

--- a/scripts/test-fast.sh
+++ b/scripts/test-fast.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+dotnet test Plateau.ResoniteLink.sln \
+  --configuration Release \
+  --no-restore \
+  --verbosity minimal \
+  --filter "Category!=Slow" \
+  -m:1 \
+  -p:UseSharedCompilation=false

--- a/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverCacheTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverCacheTests.cs
@@ -8,6 +8,7 @@ using Plateau.ResoniteLink.Domain.Importing;
 
 namespace Plateau.ResoniteLink.Tests.Application;
 
+[Trait("Category", "Slow")]
 public sealed class CkanPlateauDatasetSourceResolverCacheTests
 {
     [Theory]

--- a/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverTests.cs
@@ -10,6 +10,7 @@ using SharpCompress.Writers.SevenZip;
 
 namespace Plateau.ResoniteLink.Tests.Application;
 
+[Trait("Category", "Slow")]
 public sealed class CkanPlateauDatasetSourceResolverTests
 {
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -14,6 +14,7 @@ namespace Plateau.ResoniteLink.Tests.Application;
     "Reliability",
     "CA2000:Dispose objects before losing scope",
     Justification = "The tests intentionally hand ownership to PlateauImportService or helper methods.")]
+[Trait("Category", "Slow")]
 public sealed class PlateauImportServiceTests
 {
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
@@ -9,6 +9,7 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace Plateau.ResoniteLink.Tests.Cli;
 
 [Collection(BundledCompanionTextureIsolationGroup.Name)]
+[Trait("Category", "Slow")]
 public sealed class ResoniteLinkSceneBuilderAssetReuseTests
 {
     private const string DatasetName = "reuse-test";

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderYOffsetTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderYOffsetTests.cs
@@ -7,6 +7,7 @@ using ResoniteLink;
 
 namespace Plateau.ResoniteLink.Tests.Cli;
 
+[Trait("Category", "Slow")]
 public sealed class ResoniteLinkSceneBuilderYOffsetTests
 {
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/TestData.cs
+++ b/tests/Plateau.ResoniteLink.Tests/TestData.cs
@@ -2,9 +2,11 @@ namespace Plateau.ResoniteLink.Tests;
 
 internal static class TestData
 {
+    private static readonly string RepositoryRoot = GetRepositoryRoot();
+
     public static string GetFixturePath(string fixtureName)
     {
-        return Path.Combine(GetRepositoryRoot(), "tests", "Fixtures", fixtureName);
+        return Path.Combine(RepositoryRoot, "tests", "Fixtures", fixtureName);
     }
 
     private static string GetRepositoryRoot()


### PR DESCRIPTION
## Summary
- tag integration-style and dataset-heavy test classes with `Category=Slow`
- add `scripts/test-fast.sh` for the everyday loop while keeping `scripts/verify-ci.sh` as the full CI-equivalent path
- cache repository root lookup in test fixture resolution to remove repeated directory walking

## Why
Full test execution takes long enough to slow down local iteration. Most of that cost sits in a smaller set of heavier tests, so the change separates the default local loop from the full CI path without weakening CI coverage.

## Impact
Developers can run a fast filtered suite during normal editing and still use the existing full verification flow before pushing.

## Validation
- `dotnet test tests/Plateau.ResoniteLink.Tests/Plateau.ResoniteLink.Tests.csproj --configuration Release --no-restore --verbosity minimal -m:1 -p:UseSharedCompilation=false`
- `dotnet test tests/Plateau.ResoniteLink.Tests/Plateau.ResoniteLink.Tests.csproj --configuration Release --no-build --verbosity minimal --filter "Category!=Slow" -m:1 -p:UseSharedCompilation=false`
- `dotnet format whitespace . --folder --verify-no-changes`
