### PR TITLE
Unify texture imports on raw payloads

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@ Plateau.ResoniteLink は、[PLATEAU](https://www.mlit.go.jp/plateau/) の CityGM
 
 - 対象 runtime は .NET SDK 10。release asset の実行にも .NET 10 が必要。
 - `--resonitelink-port` または `--resonitelink-url` で到達できる ResoniteLink listener が必要。
-- live adapter の asset import は現在、mesh に `ImportMesh(ImportMeshRawData)`、texture に `ImportTexture(ImportTexture2DFile)` を使います。
+- live adapter の asset import は mesh に `ImportMesh(ImportMeshRawData)` を使います。texture は bundled common material のような元から画像ファイルとして持つ asset だけ file import を維持し、dataset 由来または生成された texture は `ImportTexture` の raw payload を使います。
 - ResoniteLink の entity ID は session-scoped な opaque value として扱います。create が成功した場合、その session 内で正規 ID として扱うのは resolve 済み `Response` の ID です。requested ID は cityObject 単位の DataModel batch 内で使う参照ヒントに限定し、別 session へ永続化・再利用してはいけません。既存 entity の reuse 探索は、新規 create の確認とは別の仕組みとして扱います。
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Plateau.ResoniteLink is a .NET 10 CLI for streaming [PLATEAU](https://www.mlit.g
 
 - Target runtime: .NET SDK 10. Release assets also require .NET 10.
 - A running ResoniteLink listener reachable by `--resonitelink-port` or `--resonitelink-url` is required.
-- Live adapter asset import currently uses `ImportMesh(ImportMeshRawData)` for meshes and `ImportTexture(ImportTexture2DFile)` for textures.
+- Live adapter asset import uses `ImportMesh(ImportMeshRawData)` for meshes. Textures stay on file import only for direct image assets such as bundled common materials, while dataset-derived or generated textures use `ImportTexture` raw payloads.
 - ResoniteLink entity IDs are treated as session-scoped opaque values. For successful create operations, the resolved `Response` ID is authoritative within the session; requested IDs are only batch-local hints for per-cityObject DataModel batches, must not be persisted or reused across sessions, and reuse discovery is handled separately from create confirmation.
 
 ## Quick Start

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -145,11 +145,10 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         PlateauLocalImportSource localSource = metadata.Request.Source as PlateauLocalImportSource
             ?? throw new InvalidOperationException("Live scene building requires a resolved local dataset source.");
 
-        ReportProgress("[live] Opening resolved dataset content source for texture materialization.");
+        ReportProgress("[live] Opening resolved dataset content source for texture imports.");
         datasetContentSource = await PlateauDatasetContentSourceFactory.CreateAsync(localSource.LocalSourcePath!, cancellationToken);
         textureImportResolver = new ResoniteTextureImportResolver(
             datasetContentSource,
-            runRoot,
             metadata.SourceDataset.TerrainTextureOverlays,
             terrainTextureAssetGenerator);
         ReportProgress("[live] Creating dataset root, asset groups, and anchor slots.");

--- a/src/Plateau.ResoniteLink.Cli/ResoniteTextureImport.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteTextureImport.cs
@@ -53,6 +53,28 @@ internal static class ResoniteTextureImportFactory
         ArgumentException.ThrowIfNullOrWhiteSpace(colorProfile);
 
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(absolutePath, cancellationToken);
+        return CreateRawFromImage(image, colorProfile, absolutePath);
+    }
+
+    public static async Task<ResoniteRawTextureImport> CreateRawFromStreamAsync(
+        Stream stream,
+        string identity,
+        string colorProfile = ResoniteTextureColorProfiles.Srgb,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(colorProfile);
+
+        using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream, cancellationToken);
+        return CreateRawFromImage(image, colorProfile, identity);
+    }
+
+    private static ResoniteRawTextureImport CreateRawFromImage(
+        Image<Rgba32> image,
+        string colorProfile,
+        string identity)
+    {
         byte[] rawBytes = new byte[image.Width * image.Height * 4];
         image.CopyPixelDataTo(rawBytes);
         return new ResoniteRawTextureImport(
@@ -60,6 +82,6 @@ internal static class ResoniteTextureImportFactory
             image.Height,
             colorProfile,
             rawBytes,
-            absolutePath);
+            identity);
     }
 }

--- a/src/Plateau.ResoniteLink.Cli/ResoniteTextureImportResolver.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteTextureImportResolver.cs
@@ -6,24 +6,20 @@ namespace Plateau.ResoniteLink.Cli;
 internal sealed class ResoniteTextureImportResolver
 {
     private readonly IPlateauDatasetContentSource datasetContentSource;
-    private readonly string runRoot;
     private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator;
     private readonly TerrainTextureOverlayLookup terrainTextureOverlayLookup;
     private readonly AsyncCompletedResultCache<TextureReferenceKey, ResoniteTextureImport> resolvedTextureCache = new();
 
     public ResoniteTextureImportResolver(
         IPlateauDatasetContentSource datasetContentSource,
-        string runRoot,
         IEnumerable<TerrainTextureOverlay> terrainTextureOverlays,
         ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
     {
         ArgumentNullException.ThrowIfNull(datasetContentSource);
-        ArgumentException.ThrowIfNullOrWhiteSpace(runRoot);
         ArgumentNullException.ThrowIfNull(terrainTextureOverlays);
         ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
 
         this.datasetContentSource = datasetContentSource;
-        this.runRoot = runRoot;
         this.terrainTextureAssetGenerator = terrainTextureAssetGenerator;
         terrainTextureOverlayLookup = new TerrainTextureOverlayLookup(terrainTextureOverlays);
     }
@@ -54,16 +50,23 @@ internal sealed class ResoniteTextureImportResolver
                 cancellationToken);
         }
 
-        string absoluteTexturePath = textureSourceKind switch
+        return textureSourceKind switch
         {
-            ResoniteTextureSourceKind.Dataset => await datasetContentSource.MaterializeFileAsync(
-                texturePath,
-                runRoot,
-                cancellationToken),
-            ResoniteTextureSourceKind.Bundled => BundledDefaultMaterialAssetStore.GetAbsolutePath(texturePath),
+            ResoniteTextureSourceKind.Dataset => await CreateDatasetRawTextureImportAsync(texturePath, cancellationToken),
+            ResoniteTextureSourceKind.Bundled => ResoniteTextureImportFactory.CreateFromFile(
+                BundledDefaultMaterialAssetStore.GetAbsolutePath(texturePath)),
             _ => throw new InvalidOperationException($"Unsupported texture source kind '{textureSourceKind}'."),
         };
+    }
 
-        return ResoniteTextureImportFactory.CreateFromFile(absoluteTexturePath);
+    private async Task<ResoniteRawTextureImport> CreateDatasetRawTextureImportAsync(
+        string texturePath,
+        CancellationToken cancellationToken)
+    {
+        await using Stream textureStream = await datasetContentSource.OpenReadAsync(texturePath, cancellationToken);
+        return await ResoniteTextureImportFactory.CreateRawFromStreamAsync(
+            textureStream,
+            texturePath,
+            cancellationToken: cancellationToken);
     }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderAssetReuseTests.cs
@@ -68,7 +68,9 @@ public sealed class ResoniteLinkSceneBuilderAssetReuseTests
         await BuildSceneOnceAsync(scene, sharedClient, Path.Combine(datasetDirectory.Path, "work"));
 
         string importedTexturePath = Assert.Single(sharedClient.ImportedTexturePaths);
-        Assert.Equal(Path.Combine(datasetDirectory.Path, texturePath), importedTexturePath);
+        Assert.Equal(texturePath, importedTexturePath);
+        ResoniteRawTextureImport importedRawTexture = Assert.Single(sharedClient.ImportedRawTextures);
+        Assert.Equal(texturePath, importedRawTexture.Identity);
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -97,7 +97,7 @@ public sealed class ResoniteLinkSceneBuilderTests
             fakeClient.ImportedTexturePaths,
             path => string.Equals(
                 path,
-                Path.GetFullPath(Path.Combine(fixturePath, "udx/bldg/53394525/appearance/roof.png")),
+                "udx/bldg/53394525/appearance/roof.png",
                 StringComparison.Ordinal));
         Assert.Contains(
             fakeClient.ImportedTexturePaths,
@@ -112,7 +112,12 @@ public sealed class ResoniteLinkSceneBuilderTests
         Assert.Contains(
             fakeClient.ImportedTexturePaths,
             static path => path.EndsWith("_Metallic.png", StringComparison.Ordinal));
-        Assert.Empty(fakeClient.ImportedRawTextures);
+        Assert.Contains(
+            fakeClient.ImportedRawTextures,
+            rawImport => string.Equals(
+                rawImport.Identity,
+                "udx/bldg/53394525/appearance/roof.png",
+                StringComparison.Ordinal));
 
         Assert.All(staticTextureRequests, request =>
         {

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteTextureImportResolverTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteTextureImportResolverTests.cs
@@ -10,10 +10,9 @@ namespace Plateau.ResoniteLink.Tests.Cli;
 public sealed class ResoniteTextureImportResolverTests
 {
     [Fact]
-    public async Task ResolveAsyncMaterializesDatasetTextureAndCachesResult()
+    public async Task ResolveAsyncReadsDatasetTextureAsRawAndCachesResult()
     {
         using TemporaryDirectory datasetRoot = new();
-        using TemporaryDirectory workRoot = new();
 
         string relativeTexturePath = "textures/albedo.png";
         WriteDatasetImage(datasetRoot.Path, relativeTexturePath);
@@ -22,7 +21,6 @@ public sealed class ResoniteTextureImportResolverTests
 
         ResoniteTextureImportResolver resolver = new(
             datasetContentSource,
-            workRoot.Path,
             [],
             terrainTextureAssetGenerator);
 
@@ -36,11 +34,14 @@ public sealed class ResoniteTextureImportResolverTests
             CancellationToken.None);
 
         Assert.Same(firstResolution, secondResolution);
-        Assert.Equal(1, datasetContentSource.MaterializeCount);
+        Assert.Equal(1, datasetContentSource.OpenReadCount);
         Assert.Empty(terrainTextureAssetGenerator.RequestedOverlays);
 
-        ResoniteFileTextureImport fileImport = Assert.IsType<ResoniteFileTextureImport>(firstResolution);
-        Assert.StartsWith(workRoot.Path, fileImport.AbsolutePath, StringComparison.Ordinal);
+        ResoniteRawTextureImport rawImport = Assert.IsType<ResoniteRawTextureImport>(firstResolution);
+        Assert.Equal(1, rawImport.Width);
+        Assert.Equal(1, rawImport.Height);
+        Assert.Equal("sRGB", rawImport.ColorProfile);
+        Assert.Equal(relativeTexturePath, rawImport.Identity);
     }
 
     [Fact]
@@ -64,7 +65,6 @@ public sealed class ResoniteTextureImportResolverTests
 
         ResoniteTextureImportResolver resolver = new(
             datasetContentSource,
-            workRoot.Path,
             [terrainTextureOverlay],
             terrainTextureAssetGenerator);
 
@@ -79,7 +79,7 @@ public sealed class ResoniteTextureImportResolverTests
 
         Assert.Same(firstResolution, secondResolution);
         Assert.Single(terrainTextureAssetGenerator.RequestedOverlays);
-        Assert.Equal(0, datasetContentSource.MaterializeCount);
+        Assert.Equal(0, datasetContentSource.OpenReadCount);
 
         ResoniteRawTextureImport rawTextureImport = Assert.IsType<ResoniteRawTextureImport>(firstResolution);
         Assert.Equal(1, rawTextureImport.Width);
@@ -92,16 +92,14 @@ public sealed class ResoniteTextureImportResolverTests
     public async Task ResolveAsyncDoesNotPoisonSharedResolutionWhenFirstWaiterIsCanceled()
     {
         using TemporaryDirectory datasetRoot = new();
-        using TemporaryDirectory workRoot = new();
 
         string relativeTexturePath = "textures/albedo.png";
         WriteDatasetImage(datasetRoot.Path, relativeTexturePath);
-        FakeDatasetContentSource datasetContentSource = new(datasetRoot.Path, materializeDelay: TimeSpan.FromMilliseconds(100));
+        FakeDatasetContentSource datasetContentSource = new(datasetRoot.Path, openReadDelay: TimeSpan.FromMilliseconds(100));
         StubTerrainTextureAssetGenerator terrainTextureAssetGenerator = new();
 
         ResoniteTextureImportResolver resolver = new(
             datasetContentSource,
-            workRoot.Path,
             [],
             terrainTextureAssetGenerator);
 
@@ -118,20 +116,18 @@ public sealed class ResoniteTextureImportResolverTests
             ResoniteTextureSourceKind.Dataset,
             CancellationToken.None);
 
-        Assert.Equal(1, datasetContentSource.MaterializeCount);
+        Assert.Equal(1, datasetContentSource.OpenReadCount);
         Assert.Empty(terrainTextureAssetGenerator.RequestedOverlays);
-        Assert.IsType<ResoniteFileTextureImport>(successfulResolution);
+        Assert.IsType<ResoniteRawTextureImport>(successfulResolution);
     }
 
     [Fact]
     public async Task ResolveAsyncDoesNotLetCallerCancellationPoisonSharedResolution()
     {
-        using TemporaryDirectory workRoot = new();
         DelayedDatasetContentSource datasetContentSource = new();
         StubTerrainTextureAssetGenerator terrainTextureAssetGenerator = new();
         ResoniteTextureImportResolver resolver = new(
             datasetContentSource,
-            workRoot.Path,
             [],
             terrainTextureAssetGenerator);
         using CancellationTokenSource cancellationTokenSource = new();
@@ -141,33 +137,31 @@ public sealed class ResoniteTextureImportResolverTests
             ResoniteTextureSourceKind.Dataset,
             cancellationTokenSource.Token);
 
-        await datasetContentSource.MaterializeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await datasetContentSource.OpenReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         await cancellationTokenSource.CancelAsync();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             async () => await canceledRequest);
 
-        datasetContentSource.AllowMaterializeCompletion.SetResult();
+        datasetContentSource.AllowOpenReadCompletion.SetResult();
 
         ResoniteTextureImport resolvedTexture = await resolver.ResolveAsync(
             "textures/albedo.png",
             ResoniteTextureSourceKind.Dataset,
             CancellationToken.None);
 
-        ResoniteFileTextureImport fileImport = Assert.IsType<ResoniteFileTextureImport>(resolvedTexture);
-        Assert.Equal("/generated/textures/albedo.png", fileImport.AbsolutePath);
-        Assert.Equal(1, datasetContentSource.MaterializeCount);
+        ResoniteRawTextureImport rawImport = Assert.IsType<ResoniteRawTextureImport>(resolvedTexture);
+        Assert.Equal("textures/albedo.png", rawImport.Identity);
+        Assert.Equal(1, datasetContentSource.OpenReadCount);
     }
 
     [Fact]
     public async Task ResolveAsyncRemovesFaultedSharedResolutionAndRetries()
     {
-        using TemporaryDirectory workRoot = new();
         FlakyDatasetContentSource datasetContentSource = new();
         StubTerrainTextureAssetGenerator terrainTextureAssetGenerator = new();
         ResoniteTextureImportResolver resolver = new(
             datasetContentSource,
-            workRoot.Path,
             [],
             terrainTextureAssetGenerator);
 
@@ -182,9 +176,9 @@ public sealed class ResoniteTextureImportResolverTests
             ResoniteTextureSourceKind.Dataset,
             CancellationToken.None);
 
-        ResoniteFileTextureImport fileImport = Assert.IsType<ResoniteFileTextureImport>(resolvedTexture);
-        Assert.Equal("/generated/textures/albedo.png", fileImport.AbsolutePath);
-        Assert.Equal(2, datasetContentSource.MaterializeCount);
+        ResoniteRawTextureImport rawImport = Assert.IsType<ResoniteRawTextureImport>(resolvedTexture);
+        Assert.Equal("textures/albedo.png", rawImport.Identity);
+        Assert.Equal(2, datasetContentSource.OpenReadCount);
     }
 
     private static void WriteDatasetImage(string datasetRoot, string relativePath)
@@ -195,9 +189,9 @@ public sealed class ResoniteTextureImportResolverTests
         image.SaveAsPng(absolutePath);
     }
 
-    private sealed class FakeDatasetContentSource(string sourceRoot, TimeSpan? materializeDelay = null) : IPlateauDatasetContentSource
+    private sealed class FakeDatasetContentSource(string sourceRoot, TimeSpan? openReadDelay = null) : IPlateauDatasetContentSource
     {
-        public int MaterializeCount { get; private set; }
+        public int OpenReadCount { get; private set; }
 
         public string SourcePath => sourceRoot;
 
@@ -216,9 +210,7 @@ public sealed class ResoniteTextureImportResolverTests
         public ValueTask<Stream> OpenReadAsync(string relativePath, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-#pragma warning disable CA2000
-            return ValueTask.FromResult<Stream>(File.OpenRead(GetAbsolutePath(relativePath)));
-#pragma warning restore CA2000
+            return OpenReadCoreAsync(relativePath, cancellationToken);
         }
 
         public async Task<string> MaterializeFileAsync(
@@ -226,20 +218,21 @@ public sealed class ResoniteTextureImportResolverTests
             string outputRoot,
             CancellationToken cancellationToken = default)
         {
+            throw new NotSupportedException();
+        }
+
+        private async ValueTask<Stream> OpenReadCoreAsync(string relativePath, CancellationToken cancellationToken)
+        {
             cancellationToken.ThrowIfCancellationRequested();
-            if (materializeDelay is { } delay)
+            if (openReadDelay is { } delay)
             {
                 await Task.Delay(delay, cancellationToken);
             }
 
-            string sourcePath = GetAbsolutePath(relativePath);
-            string outputPath = Path.GetFullPath(Path.Combine(outputRoot, relativePath));
-            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-            await using FileStream sourceStream = new(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            await using FileStream outputStream = new(outputPath, FileMode.Create, FileAccess.Write, FileShare.None);
-            await sourceStream.CopyToAsync(outputStream, cancellationToken);
-            MaterializeCount++;
-            return outputPath;
+            OpenReadCount++;
+#pragma warning disable CA2000
+            return File.OpenRead(GetAbsolutePath(relativePath));
+#pragma warning restore CA2000
         }
 
         private string GetAbsolutePath(string relativePath)
@@ -270,11 +263,11 @@ public sealed class ResoniteTextureImportResolverTests
 
     private sealed class DelayedDatasetContentSource : IPlateauDatasetContentSource
     {
-        public TaskCompletionSource MaterializeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource OpenReadStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public TaskCompletionSource AllowMaterializeCompletion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource AllowOpenReadCompletion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public int MaterializeCount { get; private set; }
+        public int OpenReadCount { get; private set; }
 
         public string SourcePath => "/dataset";
 
@@ -283,25 +276,28 @@ public sealed class ResoniteTextureImportResolverTests
         public bool FileExists(string relativePath) => true;
 
         public ValueTask<Stream> OpenReadAsync(string relativePath, CancellationToken cancellationToken = default)
-        {
-            throw new NotSupportedException();
-        }
+            => OpenReadCoreAsync(cancellationToken);
 
         public async Task<string> MaterializeFileAsync(
             string relativePath,
             string outputRoot,
             CancellationToken cancellationToken = default)
         {
-            MaterializeStarted.TrySetResult();
-            await AllowMaterializeCompletion.Task.WaitAsync(cancellationToken);
-            MaterializeCount++;
-            return "/generated/" + relativePath.Replace('\\', '/');
+            throw new NotSupportedException();
+        }
+
+        private async ValueTask<Stream> OpenReadCoreAsync(CancellationToken cancellationToken)
+        {
+            OpenReadStarted.TrySetResult();
+            await AllowOpenReadCompletion.Task.WaitAsync(cancellationToken);
+            OpenReadCount++;
+            return new MemoryStream(CreateSinglePixelPng(), writable: false);
         }
     }
 
     private sealed class FlakyDatasetContentSource : IPlateauDatasetContentSource
     {
-        public int MaterializeCount { get; private set; }
+        public int OpenReadCount { get; private set; }
 
         public string SourcePath => "/dataset";
 
@@ -310,23 +306,37 @@ public sealed class ResoniteTextureImportResolverTests
         public bool FileExists(string relativePath) => true;
 
         public ValueTask<Stream> OpenReadAsync(string relativePath, CancellationToken cancellationToken = default)
-        {
-            throw new NotSupportedException();
-        }
+            => OpenReadCoreAsync(cancellationToken);
 
         public Task<string> MaterializeFileAsync(
             string relativePath,
             string outputRoot,
             CancellationToken cancellationToken = default)
         {
+            throw new NotSupportedException();
+        }
+
+        private ValueTask<Stream> OpenReadCoreAsync(CancellationToken cancellationToken)
+        {
             cancellationToken.ThrowIfCancellationRequested();
-            MaterializeCount++;
-            if (MaterializeCount == 1)
+            OpenReadCount++;
+            if (OpenReadCount == 1)
             {
-                throw new InvalidOperationException("Simulated materialization failure.");
+                throw new InvalidOperationException("Simulated open-read failure.");
             }
 
-            return Task.FromResult("/generated/" + relativePath.Replace('\\', '/'));
+            return ValueTask.FromResult<Stream>(new MemoryStream(CreateSinglePixelPng(), writable: false));
         }
+    }
+
+    private static byte[] CreateSinglePixelPng()
+    {
+        using MemoryStream stream = new();
+        using (Image<Rgba32> image = new(1, 1, new Rgba32(255, 0, 0, 255)))
+        {
+            image.SaveAsPng(stream);
+        }
+
+        return stream.ToArray();
     }
 }


### PR DESCRIPTION
## Summary
- remove the file-texture import path and route every texture import through raw payloads
- keep dataset, bundled companion, and generated texture identities on the raw import cache path
- update live-scene tests and README documentation to match the single texture import path

## Verification
- bash scripts/verify-ci.sh