### PR TITLE
[codex] Fix PR #29 review feedback

### DIFF
--- a/src/Plateau.ResoniteLink.Application/Importing/CkanPlateauDatasetSourceResolver.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/CkanPlateauDatasetSourceResolver.cs
@@ -58,7 +58,7 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
         Uri archiveUri = remoteSource.ServerUri;
 
         string archiveFileName = GetArchiveFileName(archiveUri);
-        string archivePath = WorkRootLayout.GetSourceArchivePath(workRoot, archiveFileName);
+        string archivePath = WorkRootLayout.GetSourceArchivePath(workRoot, archiveUri, archiveFileName);
         string archiveMetadataPath = WorkRootLayout.GetSourceArchiveMetadataPath(archivePath);
 
         Directory.CreateDirectory(Path.GetDirectoryName(archivePath)!);

--- a/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlImportErrorMessages.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlImportErrorMessages.cs
@@ -38,13 +38,12 @@ internal static class LocalCityGmlImportErrorMessages
             return null;
         }
 
-        string zipPath = Path.Combine(fullPath, "source-archive.zip");
-        if (File.Exists(zipPath))
-        {
-            return zipPath;
-        }
-
-        string sevenZipPath = Path.Combine(fullPath, "source-archive.7z");
-        return File.Exists(sevenZipPath) ? sevenZipPath : null;
+        return Directory.EnumerateFiles(fullPath, "source-archive*", SearchOption.TopDirectoryOnly)
+            .Where(static path =>
+                string.Equals(Path.GetExtension(path), ".zip", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(Path.GetExtension(path), ".7z", StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(File.GetLastWriteTimeUtc)
+            .ThenBy(static path => path, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
     }
 }

--- a/src/Plateau.ResoniteLink.Application/Importing/WorkRootLayout.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/WorkRootLayout.cs
@@ -10,9 +10,10 @@ internal static class WorkRootLayout
         return Path.GetFullPath(Path.Combine(workRoot, safeDataset));
     }
 
-    public static string GetSourceArchivePath(string datasetRoot, string archiveFileName)
+    public static string GetSourceArchivePath(string datasetRoot, Uri archiveUri, string archiveFileName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(datasetRoot);
+        ArgumentNullException.ThrowIfNull(archiveUri);
         ArgumentException.ThrowIfNullOrWhiteSpace(archiveFileName);
 
         string extension = Path.GetExtension(archiveFileName);
@@ -25,7 +26,7 @@ internal static class WorkRootLayout
 
         return Path.Combine(
             Path.GetFullPath(datasetRoot),
-            $"source-archive{extension.ToLowerInvariant()}");
+            $"{GetSourceArchiveFileStem(archiveUri)}{extension.ToLowerInvariant()}");
     }
 
     public static string GetSourceArchiveMetadataPath(string archivePath)
@@ -65,6 +66,15 @@ internal static class WorkRootLayout
             System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(fullArchivePath)))
             .ToLowerInvariant();
         return $"{fileStem}-{digest[..12]}";
+    }
+
+    private static string GetSourceArchiveFileStem(Uri archiveUri)
+    {
+        string archiveIdentity = archiveUri.AbsoluteUri;
+        string digest = Convert.ToHexString(
+                System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(archiveIdentity)))
+            .ToLowerInvariant();
+        return $"source-archive-{digest[..12]}";
     }
 
     public static string CreateSafePathSegment(string value)

--- a/src/Plateau.ResoniteLink.Application/Logging/PlateauLog.cs
+++ b/src/Plateau.ResoniteLink.Application/Logging/PlateauLog.cs
@@ -92,6 +92,20 @@ public readonly record struct PlateauLogEntry(
 
 public static class PlateauLog
 {
+    public static PlateauLogLevel InferLegacyDefaultLevel(string message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        if (TryParseLegacyScopeAndLevel(message, out _, out PlateauLogLevel level, out _))
+        {
+            return level;
+        }
+
+        return message.StartsWith("[live]", StringComparison.Ordinal)
+            ? PlateauLogLevel.Debug
+            : PlateauLogLevel.Info;
+    }
+
     public static string NormalizeLegacyMessage(string message, PlateauLogLevel defaultLevel = PlateauLogLevel.Info)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(message);
@@ -99,6 +113,11 @@ public static class PlateauLog
         if (PlateauLogEntry.TryParse(message, out _))
         {
             return message;
+        }
+
+        if (TryParseLegacyScopeAndLevel(message, out string? legacyScope, out PlateauLogLevel level, out string? legacyBody))
+        {
+            return new PlateauLogEntry(legacyScope, level, legacyBody).ToString();
         }
 
         if (message[0] != '[')
@@ -115,6 +134,49 @@ public static class PlateauLog
         string scope = message[1..scopeEnd];
         string body = message[(scopeEnd + 2)..];
         return new PlateauLogEntry(scope, defaultLevel, body).ToString();
+    }
+
+    private static bool TryParseLegacyScopeAndLevel(
+        string message,
+        out string scope,
+        out PlateauLogLevel level,
+        out string body)
+    {
+        scope = string.Empty;
+        level = default;
+        body = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(message) || message[0] != '[')
+        {
+            return false;
+        }
+
+        int scopeEnd = message.IndexOf(']');
+        if (scopeEnd <= 1
+            || scopeEnd + 2 >= message.Length
+            || message[scopeEnd + 1] != '[')
+        {
+            return false;
+        }
+
+        int levelStart = scopeEnd + 2;
+        int levelEnd = message.IndexOf(']', levelStart);
+        if (levelEnd <= levelStart
+            || levelEnd + 2 > message.Length
+            || message[levelEnd + 1] != ' ')
+        {
+            return false;
+        }
+
+        if (!PlateauLogEntry.TryParse($"[app][{message[levelStart..levelEnd]}] x", out PlateauLogEntry parsed))
+        {
+            return false;
+        }
+
+        scope = message[1..scopeEnd];
+        level = parsed.Level;
+        body = message[(levelEnd + 2)..];
+        return true;
     }
 
     public static string Debug(string scope, string message)

--- a/src/Plateau.ResoniteLink.Cli/CliApplication.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliApplication.cs
@@ -139,7 +139,7 @@ public sealed class CliApplication
         string message,
         PlateauLogLevel minimumLogLevel)
     {
-        string normalizedMessage = PlateauLog.NormalizeLegacyMessage(message, GetLegacyDefaultLevel(message));
+        string normalizedMessage = PlateauLog.NormalizeLegacyMessage(message, PlateauLog.InferLegacyDefaultLevel(message));
 
         if (PlateauLogEntry.TryParse(normalizedMessage, out PlateauLogEntry filteredEntry)
             && filteredEntry.Level < minimumLogLevel)
@@ -163,14 +163,6 @@ public sealed class CliApplication
 
         writer.WriteLine($"[{timestamp}] {normalizedMessage}");
     }
-
-    private static PlateauLogLevel GetLegacyDefaultLevel(string message)
-    {
-        return message.StartsWith("[live]", StringComparison.Ordinal)
-            ? PlateauLogLevel.Debug
-            : PlateauLogLevel.Info;
-    }
-
     private static ConsoleColor GetLogLevelColor(PlateauLogLevel level)
     {
         return level switch

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -614,9 +614,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
 
     private void ReportProgress(string message, PlateauLogLevel? defaultLevel)
     {
-        PlateauLogLevel resolvedDefaultLevel = defaultLevel ?? (message.StartsWith("[live]", StringComparison.Ordinal)
-            ? PlateauLogLevel.Debug
-            : PlateauLogLevel.Info);
+        PlateauLogLevel resolvedDefaultLevel = defaultLevel ?? PlateauLog.InferLegacyDefaultLevel(message);
         progressReporter?.Invoke(PlateauLog.NormalizeLegacyMessage(message, resolvedDefaultLevel));
     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverCacheTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverCacheTests.cs
@@ -86,9 +86,10 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
     }
 
     [Fact]
-    public async Task ResolveAsyncUsesDatasetScopedFixedArchivePath()
+    public async Task ResolveAsyncUsesDistinctArchivePathsForDifferentSourceUrls()
     {
-        byte[] zipBytes = CreateZipArchive(("udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml", "<CityModel />"));
+        byte[] firstZipBytes = CreateZipArchive(("udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml", "<CityModel>source-a</CityModel>"));
+        byte[] secondZipBytes = CreateZipArchive(("udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml", "<CityModel>source-b</CityModel>"));
         using TemporaryDirectory workRoot = new();
         using StubHttpMessageHandler handler = new(request =>
         {
@@ -98,7 +99,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
                     "https://example-a.test/533944.zip",
                     StringComparison.Ordinal))
             {
-                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(zipBytes) };
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(firstZipBytes) };
             }
 
             if (request.RequestUri is not null
@@ -107,7 +108,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
                     "https://example-b.test/533944.zip",
                     StringComparison.Ordinal))
             {
-                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(zipBytes) };
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(secondZipBytes) };
             }
 
             return new HttpResponseMessage(HttpStatusCode.NotFound);
@@ -135,11 +136,19 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
 
         Assert.NotNull(firstRequest.LocalSourcePath);
         Assert.NotNull(secondRequest.LocalSourcePath);
-        string expectedArchivePath = Path.Combine(workRoot.Path, "source-archive.zip");
-        Assert.Equal(expectedArchivePath, firstRequest.LocalSourcePath);
-        Assert.Equal(expectedArchivePath, secondRequest.LocalSourcePath);
+        Assert.NotEqual(firstRequest.LocalSourcePath, secondRequest.LocalSourcePath);
+        Assert.StartsWith(workRoot.Path, firstRequest.LocalSourcePath, StringComparison.Ordinal);
+        Assert.StartsWith(workRoot.Path, secondRequest.LocalSourcePath, StringComparison.Ordinal);
+        Assert.StartsWith("source-archive-", Path.GetFileNameWithoutExtension(firstRequest.LocalSourcePath), StringComparison.Ordinal);
+        Assert.StartsWith("source-archive-", Path.GetFileNameWithoutExtension(secondRequest.LocalSourcePath), StringComparison.Ordinal);
         Assert.True(File.Exists(firstRequest.LocalSourcePath));
         Assert.True(File.Exists(secondRequest.LocalSourcePath));
+        Assert.Equal(
+            "<CityModel>source-a</CityModel>",
+            ReadZipEntry(firstRequest.LocalSourcePath, "udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml"));
+        Assert.Equal(
+            "<CityModel>source-b</CityModel>",
+            ReadZipEntry(secondRequest.LocalSourcePath, "udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml"));
     }
 
     [Fact]
@@ -190,7 +199,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         byte[] zipBytes = CreateZipArchive(("udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml", "<CityModel />"));
         using TemporaryDirectory workRoot = new();
         Uri archiveUri = new("https://example.test/533944.zip", UriKind.Absolute);
-        string archivePath = Path.Combine(workRoot.Path, "source-archive.zip");
+        string archivePath = GetExpectedArchivePath(workRoot.Path, archiveUri);
         await File.WriteAllBytesAsync(archivePath, zipBytes);
         await File.WriteAllTextAsync($"{archivePath}.meta.json", """{"etag":"\"v1\"","lastModifiedUtc":"2026-01-01T00:00:00+00:00"}""");
 
@@ -444,7 +453,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         byte[] zipBytes = CreateZipArchive(("udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml", "<CityModel />"));
         using TemporaryDirectory workRoot = new();
         Uri archiveUri = new("https://example.test/533944.zip", UriKind.Absolute);
-        string archivePath = Path.Combine(workRoot.Path, "source-archive.zip");
+        string archivePath = GetExpectedArchivePath(workRoot.Path, archiveUri);
         Directory.CreateDirectory(workRoot.Path);
         await File.WriteAllBytesAsync(archivePath, zipBytes);
 
@@ -511,6 +520,16 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
             .ToLowerInvariant();
         return $"{fileStem}-{digest[..12]}";
     }
+
+    private static string GetExpectedArchivePath(string workRoot, Uri archiveUri)
+    {
+        string extension = Path.GetExtension(archiveUri.LocalPath).ToLowerInvariant();
+        string digest = Convert.ToHexString(
+                System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(archiveUri.AbsoluteUri)))
+            .ToLowerInvariant();
+        return Path.Combine(workRoot, $"source-archive-{digest[..12]}{extension}");
+    }
+
     private sealed class FailingHttpContent(byte[] content, int failAfterBytes) : HttpContent
     {
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)

--- a/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverTests.cs
@@ -507,8 +507,12 @@ public sealed class CkanPlateauDatasetSourceResolverTests
         Assert.NotNull(resolvedRequest.LocalSourcePath);
         Assert.True(File.Exists(resolvedRequest.LocalSourcePath));
         Assert.Equal(
-            $"source-archive{Path.GetExtension(expectedArchiveFileName).ToLowerInvariant()}",
-            Path.GetFileName(resolvedRequest.LocalSourcePath));
+            Path.GetExtension(expectedArchiveFileName).ToLowerInvariant(),
+            Path.GetExtension(resolvedRequest.LocalSourcePath));
+        Assert.StartsWith(
+            "source-archive-",
+            Path.GetFileNameWithoutExtension(resolvedRequest.LocalSourcePath),
+            StringComparison.Ordinal);
 
         IPlateauDatasetContentSource datasetSource = await PlateauDatasetContentSourceFactory.CreateAsync(resolvedRequest.LocalSourcePath);
         Assert.Contains(expectedRelativePath, datasetSource.EnumerateFiles());

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -1748,7 +1748,7 @@ public sealed class PlateauImportServiceTests
     public async Task ExecuteAsyncGuidesUserToArchiveWhenDatasetRootDirectoryIsPassedAsLocalSourcePath()
     {
         using TemporaryDirectory datasetRoot = new();
-        string archivePath = Path.Combine(datasetRoot.Path, "source-archive.zip");
+        string archivePath = Path.Combine(datasetRoot.Path, "source-archive-123456789abc.zip");
         await File.WriteAllTextAsync(archivePath, string.Empty);
 
         StubResoniteSceneBuilder sceneBuilder = new();

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauLogTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauLogTests.cs
@@ -1,0 +1,20 @@
+using Plateau.ResoniteLink.Application.Logging;
+
+namespace Plateau.ResoniteLink.Tests.Application;
+
+public sealed class PlateauLogTests
+{
+    [Theory]
+    [InlineData("[live][warn] Send lane 1/1 canceled.", PlateauLogLevel.Warning, "[live][warn] Send lane 1/1 canceled.")]
+    [InlineData("[live][error] Send lane 1/1 failed: boom", PlateauLogLevel.Error, "[live][error] Send lane 1/1 failed: boom")]
+    [InlineData("[live] Preparing city objects.", PlateauLogLevel.Debug, "[live][debug] Preparing city objects.")]
+    [InlineData("Plain message", PlateauLogLevel.Info, "[app][info] Plain message")]
+    public void NormalizeLegacyMessageInfersExpectedLevel(string message, PlateauLogLevel expectedLevel, string expectedNormalizedMessage)
+    {
+        PlateauLogLevel defaultLevel = PlateauLog.InferLegacyDefaultLevel(message);
+        string normalized = PlateauLog.NormalizeLegacyMessage(message, defaultLevel);
+
+        Assert.Equal(expectedLevel, defaultLevel);
+        Assert.Equal(expectedNormalizedMessage, normalized);
+    }
+}


### PR DESCRIPTION
## Summary
- key remote archive cache paths by source URL so different --server-url values never reuse the wrong cached archive
- preserve warn/error severity when normalizing legacy [live] messages and add regression coverage
- update archive discovery tests and dataset-root guidance for hashed source-archive filenames

## Verification
- bash scripts/verify-ci.sh
