### PR TITLE
[codex] Unify canonical doc ownership

### DIFF
--- a/AGENTS.ja.md
+++ b/AGENTS.ja.md
@@ -3,14 +3,16 @@
 このファイルは、このリポジトリで Coding Agent を利用する際に読ませること。
 
 ## 対象
-このリポジトリは、PLATEAU のデータセットを Resonite 向けの構築データへ変換し、将来的には Resonite へ直接反映するアダプターまで含める .NET 10 ベースのインポートパイプラインを実装する。
+このリポジトリは、PLATEAU のデータセットを Resonite 向けの構築データへ変換し、ResoniteLink を通じた live scene update まで扱う .NET 10 の CLI-first インポートパイプラインを実装する。
 
 ## 作業ルール
 - 英語の Markdown を正本として扱う。英語の `.md` を変更したら、対応する `.ja.md` も同じ変更で必ず更新する。
 - ユーザーから明示的な依頼がない限り、ランタイムと SDK の前提は .NET 10 のまま維持する。
 - ビルド、パッケージ、フォーマット、Lint、Analyzer の共通方針はリポジトリルートで一元管理する。個別プロジェクトに重複設定を持ち込まない。
-- Codex や同種の sandbox 制約つき WSL 環境では、検証に `dotnet format <sln|csproj>` の solution / project モードを前提にしないこと。MSBuild workspace を開く段階で `System.Net.Sockets.SocketException (13): Permission denied /tmp/<guid>` で失敗することがある。その場合、whitespace 検証には `dotnet format whitespace . --folder --verify-no-changes` を使い、Analyzer / code-style ルールの検証には build 経由で `dotnet test Plateau.ResoniteLink.sln --configuration Release -m:1 -p:UseSharedCompilation=false` を使う。
+- Codex や同種の sandbox 制約つき WSL 環境では、検証フローの代わりに `dotnet format <sln|csproj>` の solution / project モードを使わないこと。MSBuild workspace を開く段階で `System.Net.Sockets.SocketException (13): Permission denied /tmp/<guid>` で失敗することがある。repository 標準の入口は `bash scripts/verify-ci.sh` であり、その中の whitespace 検証は `dotnet format whitespace . --folder --verify-no-changes` を使う。
+- push や pull request 更新の前には、必ず `bash scripts/verify-ci.sh` を実行すること。contributor 向けの検証フロー正本は `CONTRIBUTING.ja.md` であり、script の内部コマンド列を他文書に再定義したり順序を並べ替えたりしないこと。
 - `docs/` には、要件、アーキテクチャ意図、参照メモ、運用制約など、コードやテストだけでは表現しにくい内容だけを書く。
+- 一時的に保持したい大きな改善計画は `.tmp/plans/` 配下に置き、untracked のまま維持すること。`docs/` 配下には置かず、active documentation から現行運用の根拠としてリンクや引用をせず、採用した current outcome だけを tracked な docs / code / tests へ昇格させること。
 - データセット、タイル、アダプターの概念を設計するときは、`PLATEAU-SDK-for-UNITY` の用語とインポート意味論に揃える。
 - CLI のオーケストレーション、アプリケーションロジック、ドメインモデルをテスト可能でホスト非依存に保つため、Resonite 固有の I/O は抽象の背後に置く。
 - 決定的な出力、明示的なコマンド入力、再現可能なローカル/CI の挙動を優先する。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,15 +3,16 @@
 Read and apply this file when using a coding agent in this repository.
 
 ## Scope
-This repository builds a .NET 10 import pipeline that maps PLATEAU datasets into Resonite-oriented construction data and, later, live Resonite adapters.
+This repository builds a .NET 10 CLI-first import pipeline that maps PLATEAU datasets into Resonite-oriented construction data and live ResoniteLink scene updates.
 
 ## Working Rules
 - Treat English Markdown files as the canonical source. Whenever an English `.md` file changes, update the matching `.ja.md` file in the same change.
 - Keep runtime and SDK assumptions on .NET 10 unless the user explicitly requests an upgrade.
 - Keep shared build, package, formatting, lint, and analyzer policy centralized at the repository root. Do not duplicate those settings inside individual project files unless there is a project-specific exception.
-- In Codex or similarly sandboxed WSL environments, do not rely on `dotnet format <sln|csproj>` solution/project mode for verification. It can fail while opening the MSBuild workspace with `System.Net.Sockets.SocketException (13): Permission denied /tmp/<guid>`. Use `dotnet format whitespace . --folder --verify-no-changes` for whitespace verification, and use `dotnet test Plateau.ResoniteLink.sln --configuration Release -m:1 -p:UseSharedCompilation=false` to enforce analyzer and code-style rules through build.
-- Before every push or pull request update, run `bash scripts/verify-ci.sh`. For agents, keep the sequence explicit and in order: `dotnet restore Plateau.ResoniteLink.sln --locked-mode`, `dotnet format whitespace . --folder --verify-no-changes`, `dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore -m:1 -p:UseSharedCompilation=false`, then `dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 -p:UseSharedCompilation=false`.
+- In Codex or similarly sandboxed WSL environments, do not substitute `dotnet format <sln|csproj>` solution/project mode for the repository verification flow. It can fail while opening the MSBuild workspace with `System.Net.Sockets.SocketException (13): Permission denied /tmp/<guid>`. Keep the repository-standard verification entrypoint as `bash scripts/verify-ci.sh`; the whitespace check behind that flow is `dotnet format whitespace . --folder --verify-no-changes`.
+- Before every push or pull request update, run `bash scripts/verify-ci.sh`. `CONTRIBUTING.md` is the contributor-facing source of truth for that workflow; do not re-document or reorder the script's internal command sequence elsewhere.
 - Use `docs/` only for information that code and tests cannot express well, such as requirements, architecture intent, reference notes, and workflow constraints.
+- Large improvement plans that need temporary retention must live under `.tmp/plans/` and stay untracked. Do not keep them under `docs/`, do not link or cite them from active documentation as operational truth, and promote only accepted current outcomes into tracked docs, code, or tests.
 - Keep PLATEAU terminology and import semantics aligned with `PLATEAU-SDK-for-UNITY` when shaping dataset, tile, and adapter concepts.
 - Keep Resonite-specific I/O behind abstractions so CLI orchestration, application logic, and domain models remain testable and host-agnostic.
 - Prefer deterministic outputs, explicit command inputs, and reproducible local/CI behavior.

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -23,13 +23,16 @@ release label は必須ではありませんが、付けておくと生成ノー
 
 label がない PR は、生成される release notes の catch-all である `Other changes` section に入ります。
 
-`dotnet` がない Codex Cloud / 一時環境では、`./scripts/setup-codex-cloud.sh` を実行すると SDK 10 の bootstrap と標準チェックをまとめて実行できます。
-
-可能なら次を実行してください。
+正本となる検証コマンドは次です。
 
 ```bash
-dotnet format whitespace . --folder --verify-no-changes
-dotnet test Plateau.ResoniteLink.sln --configuration Release -m:1 -p:UseSharedCompilation=false
+bash scripts/verify-ci.sh
 ```
+
+この script が repository 所有の検証フローです。ほかの文書では内部の restore / format / build / test 手順を複写したり順序を並べ替えたりせず、この script を参照してください。
+
+Codex Cloud / 一時環境で、PATH 上に互換な .NET 10 SDK が無い場合は、先に `./scripts/setup-codex-cloud.sh` を実行してください。この helper はそのような環境を bootstrap したうえで `bash scripts/verify-ci.sh` へ処理を渡すためのものです。
+
+大きな repository-improvement plan を一時的に保持したい場合は、`.tmp/plans/` 配下に置き、untracked のまま維持してください。その領域を canonical documentation として扱わず、active docs から現行運用の案内としてリンクせず、採用した結論だけを tracked documentation と review 成果物へ反映してください。
 
 PR の説明には、何を変えたか、なぜ変えたか、残っている limitation や follow-up work があれば書いてください。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,13 +23,16 @@ Release labels are optional, but using them keeps generated notes readable:
 
 Unlabeled PRs fall through to the catch-all `Other changes` section in the generated release notes.
 
-For Codex Cloud / ephemeral agents where `dotnet` is missing, run `./scripts/setup-codex-cloud.sh` to bootstrap SDK 10 and execute the standard checks.
-
-If you can, run:
+The canonical verification command is:
 
 ```bash
-dotnet format whitespace . --folder --verify-no-changes
-dotnet test Plateau.ResoniteLink.sln --configuration Release -m:1 -p:UseSharedCompilation=false
+bash scripts/verify-ci.sh
 ```
+
+That script is the repository-owned verification workflow. Keep other documents at the command level and refer back to this script instead of copying or reordering its internal restore/format/build/test sequence.
+
+For Codex Cloud / ephemeral agents where PATH does not already provide a compatible .NET 10 SDK, run `./scripts/setup-codex-cloud.sh` first. That helper exists only to bootstrap such environments and then hand off to `bash scripts/verify-ci.sh`.
+
+If you need to keep a large repository-improvement plan around temporarily, keep it under `.tmp/plans/` and leave it untracked. Do not treat that area as canonical documentation, do not link it from active docs as current operating guidance, and reflect only adopted conclusions in tracked documentation and code review artifacts.
 
 In the PR description, explain what changed, why, and any remaining limitations or follow-up work.

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,7 @@ Plateau.ResoniteLink は、[PLATEAU](https://www.mlit.go.jp/plateau/) の CityGM
 
 - ローカルの PLATEAU dataset または explicit な remote CityGML ZIP/7z archive を、起動中の ResoniteLink listener へ送る。
 - `ParameterizedTexture` appearance を保持しつつ、mesh / material 順序を決定的に保ち、source texture がない場合は bundled default material に fallback する。
-- dataset / mesh-code branch を段階的に構築し、全処理完了前から Resonite 側に取り込み結果を出し始める。
+- source bootstrap の完了後は、dataset / mesh-code branch を段階的に構築し、full live send 完了前から Resonite 側に取り込み結果を出し始める。
 
 ## Runtime And Prerequisites
 
@@ -19,19 +19,13 @@ Plateau.ResoniteLink は、[PLATEAU](https://www.mlit.go.jp/plateau/) の CityGM
 
 ## Quick Start
 
-まず依存関係を復元します。
+pull request を作成または更新する前に、repository の正本となる検証コマンドを実行します。
 
 ```bash
-dotnet restore Plateau.ResoniteLink.sln
+bash scripts/verify-ci.sh
 ```
 
-Codex Cloud のような一時環境では次を使います。
-
-```bash
-./scripts/setup-codex-cloud.sh
-```
-
-この script は必要なら .NET 10 を bootstrap し、その後 repository の verify flow を実行します。
+contributor workflow、環境 bootstrap、検証フローの ownership は [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) を参照してください。
 
 ## Usage
 
@@ -59,25 +53,17 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   --resonitelink-port <port>
 ```
 
-`--resonitelink-port` または `--resonitelink-url` は必須です。`--source remote` では direct な `.zip` / `.7z` CityGML archive URL が必要で、組み込みの dataset search は行いません。CI 相当の formatting、analyzer、build、test の検証は次を使います。
-
-```bash
-bash scripts/verify-ci.sh
-```
-
-日常の編集ループでは、`Category=Slow` の integration 寄りテストを除いた高速サブセットを使えます。
-
-```bash
-bash scripts/test-fast.sh
-```
+`--resonitelink-port` または `--resonitelink-url` は必須です。`--source remote` では direct な `.zip` / `.7z` CityGML archive URL が必要で、組み込みの dataset search は行いません。
 
 CLI は既定でマイルストーン級の進捗だけを表示し、file ごとの詳細や live-send trace は隠します。debug レベルの import / ResoniteLink trace が必要なときは `--verbose` を付けてください。
 
 `--work-root` を省略した場合、CLI は dataset ごとの archive と live temporary file を `local/<dataset>/` 配下に置きます。
 
-## Further Reading
+## 参考資料
 
-- Product requirements: [docs/requirements.ja.md](docs/requirements.ja.md)
+- contributor 向け workflow: [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md)
+- product requirements: [docs/requirements.ja.md](docs/requirements.ja.md)
+- live validation workflow: [docs/live-testing.ja.md](docs/live-testing.ja.md)
 
 ## License And Provenance
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Plateau.ResoniteLink is a .NET 10 CLI for streaming [PLATEAU](https://www.mlit.g
 
 - Stream local PLATEAU datasets or explicit remote CityGML ZIP/7z archives into a running ResoniteLink listener.
 - Preserve deterministic mesh/material ordering, keep `ParameterizedTexture` appearance data where present, and fall back to bundled default materials when source textures are missing.
-- Build dataset and mesh-code branches incrementally so imported content can begin appearing in Resonite before the full request completes.
+- After source bootstrap completes, build dataset and mesh-code branches incrementally so imported content can begin appearing in Resonite before the full live send completes.
 
 ## Runtime And Prerequisites
 
@@ -19,19 +19,13 @@ Plateau.ResoniteLink is a .NET 10 CLI for streaming [PLATEAU](https://www.mlit.g
 
 ## Quick Start
 
-Restore dependencies:
+Before opening or updating a pull request, run the canonical repository verification command:
 
 ```bash
-dotnet restore Plateau.ResoniteLink.sln
+bash scripts/verify-ci.sh
 ```
 
-For Codex Cloud or similar ephemeral environments, use:
-
-```bash
-./scripts/setup-codex-cloud.sh
-```
-
-That script bootstraps .NET 10 when needed, then runs the repository verification flow.
+For contributor workflow details, environment bootstrap guidance, and verification ownership, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Usage
 
@@ -59,17 +53,7 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   --resonitelink-port <port>
 ```
 
-`--resonitelink-port` or `--resonitelink-url` is required. `--source remote` requires a direct `.zip` or `.7z` CityGML archive URL and does not perform built-in dataset search. For the full CI-equivalent validation, run:
-
-```bash
-bash scripts/verify-ci.sh
-```
-
-For the everyday edit-test loop, run the fast subset that excludes `Category=Slow` integration-style tests:
-
-```bash
-bash scripts/test-fast.sh
-```
+`--resonitelink-port` or `--resonitelink-url` is required. `--source remote` requires a direct `.zip` or `.7z` CityGML archive URL and does not perform built-in dataset search.
 
 By default, the CLI prints milestone-level progress and keeps detailed per-file and live-send trace logs hidden. Add `--verbose` when you need the debug-level import and ResoniteLink trace output.
 
@@ -77,7 +61,9 @@ When `--work-root` is omitted, the CLI stores dataset-local archives and live te
 
 ## Further Reading
 
+- Contributor workflow: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Product requirements: [docs/requirements.md](docs/requirements.md)
+- Live validation workflow: [docs/live-testing.md](docs/live-testing.md)
 
 ## License And Provenance
 

--- a/docs/live-testing.ja.md
+++ b/docs/live-testing.ja.md
@@ -1,0 +1,116 @@
+# Live Testing
+
+## 目的
+
+この手順は、ローカルの PLATEAU dataset を ResoniteLink 経由で実際の Resonite session へ送れるかを、実機レベルで確認したいときの正本です。
+
+この文書を repository の canonical な live-send workflow かつ唯一の手順書とします。`skills/resonite-live-send-debug/` 配下の skill は、default、guardrail、報告要件だけを補足し、競合する手順を定義しません。
+
+## 事前条件
+
+- live testing は現在、Windows 上の Resonite session と PowerShell helper script を前提にした運用です。
+- 破壊的な live run に入る前に、repository の verify flow を実行します。
+
+```bash
+bash scripts/verify-ci.sh
+```
+
+- cleanup や send に入る前に、対象 dataset root がローカルに存在することを確認してください。
+- CLI や admin utility の build 産物は事前に無くても構いません。bundled helper script が必要に応じて build します。
+- 下記の cleanup は破壊的です。現在の Resonite session から一致する dataset root を削除し、同じ repository から起動した live-send CLI process も停止します。
+- この workflow では、operator 向けの command surface を `skills/resonite-live-send-debug/scripts/` 配下の bundled script に固定します。root `scripts/` 配下の PowerShell helper は下位の repository utility であり、live run の手順正本ではありません。
+
+## Listener Discovery
+
+ResoniteLink の UDP announcement を取るには、bundled discovery script を使います。
+
+```bash
+cmd.exe /c "powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\discover-session.ps1 -TimeoutSeconds 20 -MaxAnnouncements 5"
+```
+
+各比較 run の前に、次を記録してください。
+
+- `sessionName`
+- `sessionID`
+- `linkPort`
+
+ルール:
+
+- `sessionID` が取れるなら UDP discovery を優先します。
+- discovery と in-game UI が別 session を指すなら、その run は invalid とします。
+- 比較の各 rerun 前に discovery をやり直し、同じ session identity を再確認します。
+
+## Cleanup と Send
+
+各比較 run の前に、bundled cleanup wrapper で dataset root を削除し、matching root が 0 件に収束したことを確認します。
+
+```bash
+cmd.exe /c "powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\cleanup-session.ps1 -RepoPath C:\path\to\repo -Endpoint ws://localhost:<port>/ -Dataset <dataset>"
+cmd.exe /c "powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\cleanup-session.ps1 -RepoPath C:\path\to\repo -Endpoint ws://localhost:<port>/ -Dataset <dataset> -ListOnly"
+```
+
+polling window 内に list mode が 0 件を返した場合だけ次へ進みます。
+
+その後、bundled wrapper を使って Windows 側から send を起動します。
+
+```bash
+cmd.exe /c "powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\run-live-send.ps1 -RepoPath C:\path\to\repo -ResoniteLinkPort <port> -LocalSourcePath C:\path\to\dataset-root -Dataset <dataset> -MeshCode <mesh> -DemTerrainMode <heightmap|mesh> -Connections 8 -LogPrefix <name> -NoWait"
+```
+
+wrapper は次を返します。
+
+- `ProcessId`
+- `StdoutLog`
+- `StderrLog`
+- `CliDllPath`
+- `CliDllLastWriteTime`
+
+process id や log path は推測せず、返り値をそのまま使ってください。
+
+helper script は既定で per-run の stdout / stderr log を保持します。比較のため、固有名のまま残してください。
+
+## 比較と検証
+
+mode 差分を見たい場合でも、次は run 間で固定します。
+
+- dataset
+- mesh code
+- local source path
+- listener port
+- connection count
+
+推奨シーケンス:
+
+1. `heightmap`
+2. cleanup
+3. `mesh`
+4. cleanup
+5. `heightmap`
+
+標準の comparison driver が必要なら、次を使います。
+
+```bash
+cmd.exe /c "powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\compare-modes.ps1 -RepoPath C:\path\to\repo -ResoniteLinkPort <port> -Dataset <dataset> -MeshCode <mesh> -LocalSourcePath C:\path\to\dataset-root -ObserveSeconds 30 -ExpectedSessionId <session-id>"
+```
+
+まず `stderr` を見ます。`stderr` が空でない場合はそれを主な failure signal として扱います。`stderr` が空でも、stall と判断する前に、timestamp 付きの log sample を少なくとも 2 回取ってください。
+
+標準的な log 読み出し:
+
+```powershell
+Get-Content <stdout-log> -Tail 40
+Get-Content <stderr-log> -Tail 40
+```
+
+## Acceptance Signals
+
+`docs/requirements.md` の受け入れ条件には、少なくとも次で対応づけます。
+
+- deterministic な live payload:
+  同じ dataset、mesh code、mode、source path、listener port、connection count で複数回流し、log の並び、dataset root の構造、再利用 asset hierarchy に説明不能な差がないことを確認する。
+- 可視な imported content:
+  live world に期待した dataset root が現れ、対象 subtree に mesh、material、renderer、collider が揃うことを確認する。
+- CI 相当の検証:
+  `bash scripts/verify-ci.sh` が成功している状態で live 結果を評価する。
+
+途中で run を止めた場合は、起動した PID だけを止め、終了を確認してから cleanup を再実行し、log は保持します。自然終了した run でも、cleanup の前に exit code を記録してください。

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -1,0 +1,117 @@
+# Live Testing
+
+## Purpose
+
+Use this workflow when you need machine-level confirmation that a local PLATEAU dataset can be streamed into a real Resonite session through ResoniteLink.
+
+This document is the canonical live-send workflow for the repository and the only procedural source for live-send runs. The skill under `skills/resonite-live-send-debug/` should add defaults, guardrails, and reporting requirements only, not define a competing workflow.
+
+## Preconditions
+
+- Live testing is currently a Windows-oriented workflow because the bundled helper scripts target a Windows Resonite session and PowerShell.
+- Run the repository verification flow before any destructive live run:
+
+```bash
+bash scripts/verify-ci.sh
+```
+
+- Confirm the target dataset root exists on disk before cleanup or send steps.
+- Build outputs do not need to exist ahead of time; the helper scripts build the CLI or admin utility on demand.
+- The cleanup steps below are destructive. They remove matching dataset roots from the current Resonite session and stop matching live-send CLI processes launched from the same repository.
+- For this workflow, treat the bundled scripts under `skills/resonite-live-send-debug/scripts/` as the operator-facing command surface. The root `scripts/` PowerShell helpers are lower-level repository utilities and are not the procedural source for live runs.
+
+## Listener Discovery
+
+Use the bundled discovery script to capture ResoniteLink UDP announcements from port `12512`:
+
+```bash
+cmd.exe /c "powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\discover-session.ps1 -TimeoutSeconds 20 -MaxAnnouncements 5"
+```
+
+Record these values before every comparison run:
+
+- `sessionName`
+- `sessionID`
+- `linkPort`
+
+Rules:
+
+- Prefer UDP discovery when it yields `sessionID`.
+- If discovery and the in-game UI identify different sessions, treat the run as invalid.
+- Re-run discovery before each comparison rerun and confirm the same session identity again.
+
+## Cleanup And Send
+
+Before each comparison run, remove the dataset root and verify that zero matching roots remain with the bundled cleanup wrapper:
+
+```bash
+cmd.exe /c "powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\cleanup-session.ps1 -RepoPath C:\path\to\repo -Endpoint ws://localhost:<port>/ -Dataset <dataset>"
+cmd.exe /c "powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\cleanup-session.ps1 -RepoPath C:\path\to\repo -Endpoint ws://localhost:<port>/ -Dataset <dataset> -ListOnly"
+```
+
+Continue only if list mode reports zero matching dataset roots within the polling window.
+
+Then launch the send from Windows with the bundled wrapper:
+
+```bash
+cmd.exe /c "powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\run-live-send.ps1 -RepoPath C:\path\to\repo -ResoniteLinkPort <port> -LocalSourcePath C:\path\to\dataset-root -Dataset <dataset> -MeshCode <mesh> -DemTerrainMode <heightmap|mesh> -Connections 8 -LogPrefix <name> -NoWait"
+```
+
+The wrapper returns:
+
+- `ProcessId`
+- `StdoutLog`
+- `StderrLog`
+- `CliDllPath`
+- `CliDllLastWriteTime`
+
+Use those exact values. Do not guess the process ID or log path.
+
+The helper scripts preserve per-run stdout and stderr logs by default. Keep those logs with distinct names for later comparison.
+
+## Comparison And Validation
+
+For mode-sensitive investigations, keep these inputs constant across runs:
+
+- dataset
+- mesh code
+- local source path
+- listener port
+- connection count
+
+Preferred sequence:
+
+1. `heightmap`
+2. cleanup
+3. `mesh`
+4. cleanup
+5. `heightmap`
+
+If you need the bundled comparison driver, use:
+
+```bash
+cmd.exe /c "powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\compare-modes.ps1 -RepoPath C:\path\to\repo -ResoniteLinkPort <port> -Dataset <dataset> -MeshCode <mesh> -LocalSourcePath C:\path\to\dataset-root -ObserveSeconds 30 -ExpectedSessionId <session-id>"
+```
+
+Inspect `stderr` first. If it is non-empty, treat that as the primary failure signal. When `stderr` is empty, take at least two timestamped log samples before concluding that a run stalled.
+
+Canonical log reads:
+
+```powershell
+Get-Content <stdout-log> -Tail 40
+Get-Content <stderr-log> -Tail 40
+```
+
+## Acceptance Signals
+
+Map live validation back to `docs/requirements.md` with these checks:
+
+- Deterministic live payloads:
+  Run the same dataset, mesh code, mode, source path, listener port, and connection count more than once.
+  Compare the generated log sequence, observed dataset root structure, and any reusable asset hierarchy for unexplained differences.
+- Visible imported content:
+  Confirm the expected dataset root appears in the live world and that the target subtree contains the expected mesh, material, renderer, and collider data.
+- CI-equivalent validation:
+  Keep `bash scripts/verify-ci.sh` green before treating any live result as trustworthy.
+
+When you stop a run early, stop only the specific launched PID, verify that it exited, then run cleanup again and keep the logs. When a run exits on its own, record the exit code before cleanup.

--- a/skills/resonite-live-send-debug/SKILL.ja.md
+++ b/skills/resonite-live-send-debug/SKILL.ja.md
@@ -1,0 +1,81 @@
+---
+name: resonite-live-send-debug
+description: 実際の Windows ResoniteLink session に対して PLATEAU-ResoniteLink の live-send 再現と調査を行う skill。simulated test ではなく machine-level の検証が必要なときに使い、listener discovery、run 間の DatasetRoot cleanup、`heightmap` と `mesh` の比較、log 採取、生成された Resonite world state の確認まで扱う。
+---
+
+# Resonite Live Send Debug
+
+この skill は実際の ResoniteLink run にだけ使ってください。まず local test を優先し、failure が live な Windows session や生成された Resonite world state に依存するときだけこの skill に切り替えます。
+
+警告: この workflow の cleanup は、現在の Resonite session の live world result を破壊し、この repository から起動した matching な live-send CLI process を停止することがあります。明示的に破棄可能な experiment session でだけ使うか、現在の `DatasetRoot` と関連結果を破壊してよいことを user が明確に承認した後に使ってください。
+
+code-only review や static な log 読みには使わないでください。実際の Windows send、実際の Resonite world inspection、または machine-level execution がないと無効な比較が必要なときにだけ使います。
+
+## Dataset Defaults
+
+user が別 target を指定しない限り、document-backed な再現と比較では Matsumoto dataset `plateau-20202-matsumoto-shi-2020` と、隣接する detailed-building mesh `54372778` / `54372788` を使ってください。この 2 mesh を default fixture とする理由は、この repository に `54372778` の成功した live-send 証跡がすでにあり、現在の workspace dataset sample に両方の mesh の detailed-building source file が含まれているためです。
+
+task が `frn` または city-furniture content を必要とする場合だけ、Yokohama mesh `53391530` を使ってください。この repository にはその mesh の成功した Yokohama live-send log があり、現在の workspace dataset sample に必要な `frn` source が含まれています。上の Matsumoto default pair は building 中心の確認用です。
+
+これら fixture について、固定の on-disk cache layout を仮定してはいけません。現在の dataset resolver の挙動から actual local source path を解決し、dataset root がローカルに存在することを確認したうえで、requested dataset と mesh が destructive step の前に妥当であることを、既存の live-send 証跡や repository fixture で確認してください。
+
+## Canonical Procedure
+
+repository の live-send 手順は [docs/live-testing.ja.md](../../../docs/live-testing.ja.md) を参照してください。この skill は cleanup、send、comparison の手順を再定義しません。
+
+[references/workflow.ja.md](./references/workflow.ja.md) は、skill 固有の default、guardrail、script inventory だけに使ってください。
+
+## Run Worksheet
+
+比較 run の間では、次の事実を固定するか、変更したら明示的に更新してください。
+
+- dataset
+- mesh code
+- local source path
+- listener port
+- session name
+- session id
+- connection count
+- mode
+- log prefix
+- launched PID
+- launched CLI binary path と last write time
+
+## Rules
+
+- 自分で live send を実行できるなら、user に代わりに実行させない。
+- world-side cleanup が確認される前に run を比較しない。
+- redirected stdout が途切れただけで hang と判定しない。source parsing など同一 process 内で進んでいる仕事を除外してから判断する。
+- ResoniteLink port を source control や skill に hard-code しない。
+- `-NoWait` run の結論は、process exit を観測するか provisional と明記するまで final として扱わない。
+- experiment 終了時に helper process や dataset root を残さない。
+- root-only cleanup で orphan descendant が存在しないと断定しない。汚染の可能性があるなら明記する。
+- failed / interrupted run 後の構造上の結論は、orphan audit がない限り provisional とする。
+
+## Bundled Scripts
+
+- `scripts/discover-session.ps1`
+UDP `12512` の live ResoniteLink announcement を取得する。
+- `scripts/cleanup-session.ps1`
+live world から dataset root を消し、残存 CLI process を止め、local runtime artifact を消す。
+- `scripts/run-live-send.ps1`
+Windows 側で 1 回の live send を explicit log 付きで起動する。
+- `scripts/compare-modes.ps1`
+cleanup を挟んだ標準 `heightmap -> mesh -> heightmap` 比較を実行する。
+
+上記 4 path はすべて `skills/resonite-live-send-debug/` からの相対 path です。
+
+## Outputs
+
+- 各 run の stdout / stderr log は repository runtime directory 配下に distinct な name で保持する。
+- 各 run は次で要約する。
+  - listener endpoint
+  - cleanup verification result
+  - process status と exit code
+  - exact な mode と mesh code
+  - 最後の timestamped `import` line
+  - 最後の timestamped `live` line
+  - `stderr` が空だったか
+  - world snapshot: dataset root count、top-level child slot 名、疑わしい slot component count
+  - log と world-state 観測時刻
+  - 結論が valid か contaminated か

--- a/skills/resonite-live-send-debug/SKILL.md
+++ b/skills/resonite-live-send-debug/SKILL.md
@@ -17,25 +17,13 @@ Unless the user asks for a different target, use the Matsumoto dataset `plateau-
 
 When the task specifically needs `frn` or city-furniture content, use Yokohama mesh `53391530` instead. This repo already contains successful Yokohama live-send logs for that mesh, and the current workspace dataset sample includes the needed `frn` source there, while the Matsumoto default pair above is for building-focused checks.
 
-Do not assume a fixed on-disk cache layout for these fixtures. Resolve the actual local source path from the current dataset resolver behavior, and use the matching `--dry-run` import or live-send logs to confirm that the requested dataset and mesh resolve before running destructive steps.
+Do not assume a fixed on-disk cache layout for these fixtures. Resolve the actual local source path from the current dataset resolver behavior, confirm that the dataset root exists on disk, and use prior live-send evidence or repo fixtures to confirm that the requested dataset and mesh resolve before running destructive steps.
 
-## Quick Start
+## Canonical Procedure
 
-Before any destructive live run, clear the local gate first:
+Follow [docs/live-testing.md](../../../docs/live-testing.md) for the repository's live-send procedure. This skill does not redefine cleanup, send, or comparison steps.
 
-1. Run the repo CI-equivalent verification.
-2. Run one matching `--dry-run` import for the dataset and mesh code you intend to send.
-3. Then continue with the live workflow below.
-
-```powershell
-cmd.exe /c "cd /d C:\path\to\repo && bash scripts/verify-ci.sh"
-dotnet run --project C:\path\to\repo\src\Plateau.ResoniteLink.Cli\Plateau.ResoniteLink.Cli.csproj -- build --dataset <dataset> --mesh-code <mesh-code> --source local --local-source-path <dataset-root> --dry-run
-powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\discover-session.ps1 -TimeoutSeconds 20 -MaxAnnouncements 5
-powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\cleanup-session.ps1 -RepoPath C:\path\to\repo -Endpoint ws://localhost:<port>/ -Dataset <dataset>
-powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\run-live-send.ps1 -RepoPath C:\path\to\repo -ResoniteLinkPort <port> -LocalSourcePath <dataset-root> -Dataset <dataset> -MeshCode <mesh-code> -DemTerrainMode heightmap -Connections 8 -LogPrefix send.<mesh-code>.heightmap.1 -NoWait
-```
-
-Record the returned `ProcessId`, `StdoutLog`, and `StderrLog` values immediately, then tail those exact files.
+Use [references/workflow.md](./references/workflow.md) only for skill-specific defaults, guardrails, and script inventory.
 
 ## Run Worksheet
 
@@ -52,32 +40,6 @@ Keep these facts fixed or explicitly updated between comparison runs:
 - log prefix
 - launched PID
 - launched CLI binary path and last write time
-
-## Workflow
-
-1. Locate the workspace root.
-Look for `scripts/ResoniteAdmin`. Use the bundled skill scripts for execution.
-
-2. Read the skill contract before running.
-Read [references/workflow.md](./references/workflow.md). Follow the Windows-process and cleanup rules exactly.
-
-3. Verify the listener and target session.
-Resolve the active ResoniteLink listener from UDP `12512` or the in-game session UI. Do not guess the port. Prefer UDP discovery when it yields `sessionID`; otherwise require explicit UI confirmation and record any disagreement as invalid. Match the session by `sessionID` first, then `sessionName`.
-
-4. Invalidate stale test state before every comparison run.
-Remove any existing dataset root for the target dataset from the live world, then verify that zero matching roots remain. Poll every 2 seconds for up to 20 seconds before accepting cleanup. Clear local runtime artifacts before the next run. If cleanup is incomplete, treat the run as invalid and redo it.
-
-5. Run the send from Windows, not WSL.
-Use the bundled PowerShell scripts under `skills/resonite-live-send-debug/scripts/`. Prefer asynchronous launch with unique log prefixes so the logs can be tailed while the send is still running.
-
-6. Compare like for like.
-When isolating mode-sensitive failures, keep dataset, mesh code, connection count, source path, and listener constant. Re-run listener discovery before each comparison run and confirm the same `sessionName` or `sessionID`. Alternate modes such as `heightmap -> cleanup -> mesh -> cleanup -> heightmap` so differences are attributable to the mode, not to accumulated world state.
-
-7. Inspect both logs and world state.
-Check `stderr` first, then `stdout`. Distinguish parse or materialization work from live-send stalls. Record the launched PID, whether it is still alive, and its exit code once it exits. Sample logs at least twice with recorded timestamps before calling a hang. When checking world state during a quiet interval, take at least two timestamped snapshots. Do not assume the last visible `Sent city object ...` line is the true stop point.
-
-8. Report facts, not guesses.
-State the exact command, listener endpoint, cleanup result, launched PID, exit status, exit code, last timestamped `import` line, last timestamped `live` line, and whether the world contained the expected dataset root, top-level child slots, and suspicious slot component counts. If a run was contaminated by stale state, say so and discard the conclusion.
 
 ## Rules
 

--- a/skills/resonite-live-send-debug/references/workflow.ja.md
+++ b/skills/resonite-live-send-debug/references/workflow.ja.md
@@ -1,0 +1,69 @@
+# Workflow
+
+この reference は `SKILL.md` が発火した後に使ってください。
+
+repository の canonical workflow は [docs/live-testing.ja.md](../../../docs/live-testing.ja.md) です。この file は cleanup、send、comparison の手順を繰り返さないようにしています。
+
+既定の document fixture:
+
+- 別の dataset が必要でない限り、`plateau-20202-matsumoto-shi-2020` と隣接する detailed-building mesh `54372778` / `54372788` を使う。
+- `frn` 検証が必要なときだけ Yokohama mesh `53391530` に切り替える。
+- これら fixture choice は dataset / mesh selector であり、cache path の保証ではない。cleanup や file inspection の前に、actual local source path がローカルに存在することを確認する。
+
+## Required Repo Artifacts
+
+workspace root 配下には次の file がある前提です。
+
+- `scripts/ResoniteAdmin/ResoniteAdmin.csproj`
+
+ad hoc な repository script より bundled skill script を優先してください。これらの wrapper は admin utility や CLI binary を必要に応じて build するため、別の手動 build command は canonical procedure には含めません。
+
+## Skill Guardrails
+
+この skill にだけ残す実務 rule:
+
+- UDP `12512` announcement を受けるのに十分待つ。
+- `sessionName`、`sessionID`、`linkPort` を取得する。
+- 解決した `linkPort` は run note と一緒に保持する。
+- listener が不在なら停止し、user に Resonite を再起動してもらう。
+- UDP discovery が `sessionID` を返すならそれを優先し、返さなければ UI による明示確認を必須にする。
+- UDP と UI が異なる session を指すなら、その run は invalid とする。
+- 比較 rerun の前に listener を再発見し、同じ session identity を再確認する。
+- listener port、process ID、log path を推測しないこと。discovery の出力と wrapper の返り値を使ってください。
+- root `scripts/` 配下の live-send helper は下位の repository utility として扱い、この skill の operator-facing surface は `skills/resonite-live-send-debug/scripts/` 配下の bundled script に固定します。
+- 警告: cleanup は destructive です。live world から dataset root を削除し、同じ repository から起動した matching な live-send CLI process を停止し、local runtime artifact も消します。
+
+send wrapper は次の property を持つ PowerShell object を返します。
+
+- `ProcessId`
+- `StdoutLog`
+- `StderrLog`
+- `CliDllPath`
+- `CliDllLastWriteTime`
+
+これらの値を使ってください。log path や process id を推測してはいけません。
+
+launch 後の canonical な log 読み出し:
+
+```powershell
+Get-Content <stdout-log> -Tail 40
+Get-Content <stderr-log> -Tail 40
+```
+
+WSL から:
+
+```bash
+tail -n 40 /mnt/c/path/to/stdout.log
+tail -n 40 /mnt/c/path/to/stderr.log
+```
+
+## Script Inventory
+
+- `scripts/discover-session.ps1`
+  UDP `12512` の live ResoniteLink announcement を取得する。
+- `scripts/cleanup-session.ps1`
+  live world から dataset root を削除し、残存 CLI process を停止し、local runtime artifact を消す。
+- `scripts/run-live-send.ps1`
+  Windows 側で 1 回の live send を explicit log 付きで起動する。
+- `scripts/compare-modes.ps1`
+  cleanup を挟んだ標準 `heightmap -> mesh -> heightmap` 比較を実行する。

--- a/skills/resonite-live-send-debug/references/workflow.md
+++ b/skills/resonite-live-send-debug/references/workflow.md
@@ -2,11 +2,13 @@
 
 Use this reference after `SKILL.md` triggers.
 
+The canonical repository workflow lives in [docs/live-testing.md](../../../docs/live-testing.md). This file intentionally does not repeat cleanup, send, or comparison procedure steps.
+
 Default document fixtures:
 
 - Use `plateau-20202-matsumoto-shi-2020` with adjacent detailed-building meshes `54372778` and `54372788` unless the task requires a different dataset.
 - Switch to Yokohama mesh `53391530` only when the task needs `frn` validation.
-- Treat those fixture choices as dataset and mesh selectors, not as a promise about cache paths. Confirm the actual local source path with the current resolver or a matching `--dry-run` import before you inspect files or launch cleanup.
+- Treat those fixture choices as dataset and mesh selectors, not as a promise about cache paths. Confirm the actual local source path on disk before you inspect files or launch cleanup.
 
 ## Required Repo Artifacts
 
@@ -14,20 +16,11 @@ Expect these files under the workspace root:
 
 - `scripts/ResoniteAdmin/ResoniteAdmin.csproj`
 
-Prefer the bundled skill scripts over any ad hoc repo scripts.
+Prefer the bundled skill scripts over any ad hoc repo scripts. Those wrappers build the admin utility or CLI binaries on demand, so a separate manual build command is not part of the canonical procedure.
 
-If the admin utility or CLI binaries are missing, build them before running:
+## Skill Guardrails
 
-```bash
-cmd.exe /c "cd /d C:\path\to\repo && dotnet.exe build scripts\ResoniteAdmin\ResoniteAdmin.csproj -c Release"
-cmd.exe /c "cd /d C:\path\to\repo && dotnet.exe build src\Plateau.ResoniteLink.Cli\Plateau.ResoniteLink.Cli.csproj -c Release"
-```
-
-## Listener Discovery
-
-Use this workflow as the source of truth for live listener discovery.
-
-Practical rules:
+Practical rules that stay local to this skill:
 
 - Wait long enough for UDP `12512` announcements.
 - Capture `sessionName`, `sessionID`, and `linkPort`.
@@ -36,42 +29,11 @@ Practical rules:
 - Prefer UDP discovery when it yields `sessionID`; otherwise require explicit UI confirmation.
 - If UDP and UI identify different sessions, mark the run invalid.
 - Before each comparison rerun, rediscover the listener and confirm the same session identity again.
+- Do not guess the listener port, process ID, or log path. Use discovery output and wrapper return values.
+- Treat the root `scripts/` live-send helpers as lower-level repository utilities. The operator-facing surface for this skill is the bundled script set under `skills/resonite-live-send-debug/scripts/`.
+- Warning: cleanup is destructive. It removes dataset roots from the live world, stops matching live-send CLI processes launched from the same repo, and clears local runtime artifacts.
 
-## World Cleanup
-
-Warning: this step is destructive. Removing the dataset root destroys live-world results in the current Resonite session, and the bundled cleanup script also stops matching live-send CLI processes launched from the same repo. Do not run it against a session the user wants to preserve.
-
-Before each comparison run:
-
-1. Remove the dataset root from the current world with the admin utility.
-2. Re-run the admin utility in list mode every 2 seconds.
-3. Continue only if it reports zero matching dataset roots within 20 seconds.
-4. If it does not converge, invalidate the run.
-
-Example pattern:
-
-```bash
-cmd.exe /c "cd /d C:\path\to\repo && dotnet.exe artifacts\build\windows\bin\ResoniteAdmin\Release\net10.0\ResoniteAdmin.dll ws://localhost:<port>/ <dataset>"
-cmd.exe /c "cd /d C:\path\to\repo && dotnet.exe artifacts\build\windows\bin\ResoniteAdmin\Release\net10.0\ResoniteAdmin.dll ws://localhost:<port>/ <dataset> --list-only"
-```
-
-Treat the test as invalid if the verification does not reach zero within the polling window.
-
-After world cleanup, clear local artifacts with the bundled cleanup script:
-
-```bash
-cmd.exe /c "powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\cleanup-session.ps1 -RepoPath C:\path\to\repo -Endpoint ws://localhost:<port>/ -Dataset <dataset>"
-```
-
-## Running the Send
-
-Prefer the bundled wrapper because it standardizes log capture:
-
-```bash
-cmd.exe /c "powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\run-live-send.ps1 -RepoPath C:\path\to\repo -ResoniteLinkPort <port> -LocalSourcePath C:\path\to\dataset-root -Dataset <dataset> -MeshCode <mesh> -DemTerrainMode <heightmap|mesh> -Connections 8 -LogPrefix <name> -NoWait"
-```
-
-The wrapper returns a PowerShell object with these properties:
+The send wrapper returns a PowerShell object with these properties:
 
 - `ProcessId`
 - `StdoutLog`
@@ -81,7 +43,7 @@ The wrapper returns a PowerShell object with these properties:
 
 Use those values. Do not guess the log path or process id.
 
-Canonical log reads:
+Canonical log reads after a launch:
 
 ```powershell
 Get-Content <stdout-log> -Tail 40
@@ -95,69 +57,13 @@ tail -n 40 /mnt/c/path/to/stdout.log
 tail -n 40 /mnt/c/path/to/stderr.log
 ```
 
-## Comparison Pattern
+## Script Inventory
 
-For mode-sensitive bugs, use a fixed sequence:
-
-1. `heightmap`
-2. cleanup
-3. `mesh`
-4. cleanup
-5. `heightmap`
-
-Keep these constant across all runs:
-
-- dataset
-- mesh code
-- source path
-- listener port
-- connection count
-
-If you need the standard sequence quickly, use the bundled comparison driver:
-
-```bash
-cmd.exe /c "powershell -ExecutionPolicy Bypass -File C:\path\to\repo\skills\resonite-live-send-debug\scripts\compare-modes.ps1 -RepoPath C:\path\to\repo -ResoniteLinkPort <port> -Dataset <dataset> -MeshCode <mesh> -LocalSourcePath C:\path\to\dataset-root -ObserveSeconds 30 -ExpectedSessionId <session-id>"
-```
-
-## Interpreting Logs
-
-Check `stderr` first. If it is non-empty, treat that as the primary failure signal.
-
-When `stderr` is empty:
-
-- tail `stdout`
-- wait a measured interval and tail again
-- record the observation timestamps
-- note the last `live` and `import` lines
-- note whether the launched PID is still alive
-- distinguish these cases:
-  - parse or materialization still progressing
-  - live send still progressing
-  - no new output at all
-
-Do not conclude "silent hang after Sent" unless you have confirmed that the process is still alive, neither `import` nor `live` logs are advancing across multiple timestamped samples, and the target world subtree is not advancing across multiple timestamped snapshots either.
-
-## Ending the Experiment
-
-When you stop a run early:
-
-1. stop only the specific CLI process you launched
-2. verify that the targeted PID is no longer alive
-3. remove the dataset root from the world
-4. verify zero matching dataset roots remain
-5. keep the logs with their unique names
-
-When a run exits on its own:
-
-1. record the exit code for the launched PID
-2. remove the dataset root unless the user explicitly asked to keep it
-3. verify zero matching dataset roots remain
-4. record whether root-only cleanup may still leave orphan contamination
-5. if the run failed or was interrupted, treat structure-level conclusions as provisional unless an orphan audit was performed
-
-Record whether the run was:
-
-- valid
-- invalid due to stale world state
-- invalid due to listener loss
-- invalid due to user interruption
+- `scripts/discover-session.ps1`
+  Capture live ResoniteLink announcements from UDP `12512`.
+- `scripts/cleanup-session.ps1`
+  Remove dataset roots from the live world, stop leftover CLI processes, and clear local runtime artifacts.
+- `scripts/run-live-send.ps1`
+  Launch one Windows-side live send with explicit logs.
+- `scripts/compare-modes.ps1`
+  Run the standard `heightmap -> mesh -> heightmap` comparison with cleanup between runs.


### PR DESCRIPTION
## What changed
- unified documentation ownership so contributor verification lives in `CONTRIBUTING*`, live-send procedure lives in `docs/live-testing*`, and skill docs keep only skill-specific defaults and guardrails
- aligned the English/Japanese doc pairs for the affected files
- documented the temporary `.tmp/plans/` rule in tracked docs so large working plans stay out of the canonical documentation namespace

## Why
- the repository had overlapping procedural docs for verification and live-send workflows
- skill docs were re-stating executable live-send steps instead of deferring to one canonical workflow document
- temporary improvement plans needed an explicit non-canonical holding area so they do not drift into active documentation

## Impact
- contributors and agents now have one authoritative place per workflow concern
- live-send procedure references now point at the bundled skill script surface consistently
- temporary improvement plans are kept out of `docs/` and out of active doc references

## Validation
- `git diff --check`
- repository-wide `rg` checks for duplicate procedure definitions and active-doc references
- 6 sub-agent review pass; 5 returned findings/no-findings, 1 shut down without a result
