### PR TITLE
[codex] Make live-send scripts portable

### DIFF
--- a/docs/live-testing.ja.md
+++ b/docs/live-testing.ja.md
@@ -4,11 +4,11 @@
 
 この手順は、ローカルの PLATEAU dataset を ResoniteLink 経由で実際の Resonite session へ送れるかを、実機レベルで確認したいときの正本です。
 
-この文書を repository の canonical な live-send workflow かつ唯一の手順書とします。`skills/resonite-live-send-debug/` 配下の skill は、default、guardrail、報告要件だけを補足し、競合する手順を定義しません。
+この文書を repository の canonical な live-send workflow かつ唯一の手順書とします。`skills/resonite-live-send-debug/scripts/` 配下の bundled script を operator 向けの入口とし、root `scripts/` の PowerShell helper は同じ workflow を支える lower-level の repository utility として扱います。
 
 ## 事前条件
 
-- live testing は現在、Windows 上の Resonite session と PowerShell helper script を前提にした運用です。
+- live testing は現在、Windows 限定です。bundled helper script は Windows の Resonite session と PowerShell を前提にしています。
 - 破壊的な live run に入る前に、repository の verify flow を実行します。
 
 ```bash

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -4,11 +4,11 @@
 
 Use this workflow when you need machine-level confirmation that a local PLATEAU dataset can be streamed into a real Resonite session through ResoniteLink.
 
-This document is the canonical live-send workflow for the repository and the only procedural source for live-send runs. The skill under `skills/resonite-live-send-debug/` should add defaults, guardrails, and reporting requirements only, not define a competing workflow.
+This document is the canonical live-send workflow for the repository and the only procedural source for live-send runs. The bundled scripts under `skills/resonite-live-send-debug/scripts/` are the operator-facing entrypoint for this workflow; the root `scripts/` PowerShell helpers are lower-level repository utilities that support the same workflow.
 
 ## Preconditions
 
-- Live testing is currently a Windows-oriented workflow because the bundled helper scripts target a Windows Resonite session and PowerShell.
+- Live testing is currently Windows-only because the bundled helper scripts target a Windows Resonite session and PowerShell.
 - Run the repository verification flow before any destructive live run:
 
 ```bash
@@ -18,7 +18,7 @@ bash scripts/verify-ci.sh
 - Confirm the target dataset root exists on disk before cleanup or send steps.
 - Build outputs do not need to exist ahead of time; the helper scripts build the CLI or admin utility on demand.
 - The cleanup steps below are destructive. They remove matching dataset roots from the current Resonite session and stop matching live-send CLI processes launched from the same repository.
-- For this workflow, treat the bundled scripts under `skills/resonite-live-send-debug/scripts/` as the operator-facing command surface. The root `scripts/` PowerShell helpers are lower-level repository utilities and are not the procedural source for live runs.
+- For this workflow, use the bundled scripts under `skills/resonite-live-send-debug/scripts/` as the operator-facing command surface. The root `scripts/` PowerShell helpers remain lower-level repository utilities and are not the procedural source for live runs.
 
 ## Listener Discovery
 

--- a/scripts/cleanup-live-send.ps1
+++ b/scripts/cleanup-live-send.ps1
@@ -3,14 +3,39 @@ param(
     [string]$Endpoint,
 
     [string]$Dataset = '14100-yokohama-shi',
-    [string]$RepoPath = 'C:\Users\esnya\Documents\PLATEAU-ResoniteLink',
+    [string]$RepoPath = (Split-Path -Parent $PSScriptRoot),
     [switch]$ListOnly,
+    [switch]$KeepLogs,
     [int]$VerificationTimeoutSeconds = 20,
     [int]$PollIntervalSeconds = 2
 )
 
 $ErrorActionPreference = 'Stop'
 
+function Get-DotNetCommandPath {
+    if ($env:DOTNET_EXE -and (Test-Path $env:DOTNET_EXE)) {
+        return (Get-Item $env:DOTNET_EXE).FullName
+    }
+
+    if ($env:DOTNET_HOST_PATH -and (Test-Path $env:DOTNET_HOST_PATH)) {
+        return (Get-Item $env:DOTNET_HOST_PATH).FullName
+    }
+
+    if ($env:DOTNET_ROOT) {
+        foreach ($candidate in @(
+            (Join-Path $env:DOTNET_ROOT 'dotnet.exe'),
+            (Join-Path $env:DOTNET_ROOT 'dotnet')
+        )) {
+            if (Test-Path $candidate) {
+                return (Get-Item $candidate).FullName
+            }
+        }
+    }
+
+    return (Get-Command dotnet -ErrorAction Stop).Source
+}
+
+$dotnet = Get-DotNetCommandPath
 $runtimeRoot = Join-Path $RepoPath 'runtime\windows\resonite'
 $adminProject = Join-Path $RepoPath 'scripts\ResoniteAdmin\ResoniteAdmin.csproj'
 $adminDll = Join-Path $RepoPath 'artifacts\build\windows\bin\ResoniteAdmin\Release\net10.0\ResoniteAdmin.dll'
@@ -27,7 +52,7 @@ if (-not $ListOnly) {
 }
 
 if (-not (Test-Path $adminDll)) {
-    & 'C:\Program Files\dotnet\dotnet.exe' build $adminProject -c Release | Out-Host
+    & $dotnet build $adminProject -c Release | Out-Host
     if (-not (Test-Path $adminDll)) {
         throw "ResoniteAdmin build output not found: $adminDll"
     }
@@ -41,14 +66,14 @@ Write-Output ("AdminDllPath={0}" -f $adminDll)
 Write-Output ("AdminDllLastWriteTime={0:o}" -f (Get-Item $adminDll).LastWriteTime)
 
 if (-not $ListOnly) {
-    & 'C:\Program Files\dotnet\dotnet.exe' $adminDll $Endpoint $Dataset | Out-Host
+    & $dotnet $adminDll $Endpoint $Dataset | Out-Host
 }
 
 $verification = @()
 $deadline = (Get-Date).AddSeconds($VerificationTimeoutSeconds)
 
 do {
-    $verification = & 'C:\Program Files\dotnet\dotnet.exe' $adminDll $Endpoint $Dataset --list-only
+    $verification = & $dotnet $adminDll $Endpoint $Dataset --list-only
     $verification | Out-Host
 
     if ($verification -match "Found 0 dataset root slot\(s\)") {
@@ -78,8 +103,11 @@ if ($verification -match "Found 0 dataset root slot\(s\)") {
         }
     }
 
-    Get-ChildItem $runtimeRoot -Filter '*.stdout.log' -Force -ErrorAction SilentlyContinue | Remove-Item -Force
-    Get-ChildItem $runtimeRoot -Filter '*.stderr.log' -Force -ErrorAction SilentlyContinue | Remove-Item -Force
+    if (-not $KeepLogs) {
+        Get-ChildItem $runtimeRoot -Filter '*.stdout.log' -Force -ErrorAction SilentlyContinue | Remove-Item -Force
+        Get-ChildItem $runtimeRoot -Filter '*.stderr.log' -Force -ErrorAction SilentlyContinue | Remove-Item -Force
+    }
+
     return
 }
 

--- a/scripts/run-live-send.ps1
+++ b/scripts/run-live-send.ps1
@@ -11,20 +11,79 @@ param(
     [string]$DemTerrainMode = 'heightmap',
     [string]$Connections = '8',
     [string]$LogPrefix = 'live-send',
-    [string]$RepoPath = 'C:\Users\esnya\Documents\PLATEAU-ResoniteLink',
+    [string]$RepoPath = '',
     [switch]$NoWait
 )
 
 $ErrorActionPreference = 'Stop'
 
-$runtimeRoot = Join-Path $RepoPath 'runtime\windows\resonite'
+function Resolve-RepositoryRoot {
+    param(
+        [string]$ConfiguredRepoPath
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ConfiguredRepoPath)) {
+        return (Resolve-Path -LiteralPath $ConfiguredRepoPath).Path
+    }
+
+    $scriptRoot = if ($PSScriptRoot) {
+        $PSScriptRoot
+    }
+    else {
+        Split-Path -Parent $MyInvocation.MyCommand.Path
+    }
+
+    return (Resolve-Path -LiteralPath (Join-Path $scriptRoot '..')).Path
+}
+
+function Resolve-DotNetExePath {
+    $candidates = @()
+
+    if (-not [string]::IsNullOrWhiteSpace($env:DOTNET_EXE)) {
+        $candidates += $env:DOTNET_EXE
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:DOTNET_HOST_PATH)) {
+        $candidates += $env:DOTNET_HOST_PATH
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:DOTNET_ROOT)) {
+        $candidates += (Join-Path $env:DOTNET_ROOT 'dotnet.exe')
+    }
+
+    $command = Get-Command -Name dotnet.exe -CommandType Application -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    $command = Get-Command -Name dotnet -CommandType Application -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:ProgramFiles)) {
+        $candidates += (Join-Path $env:ProgramFiles 'dotnet\dotnet.exe')
+    }
+
+    foreach ($candidate in $candidates) {
+        if (-not [string]::IsNullOrWhiteSpace($candidate) -and (Test-Path -LiteralPath $candidate)) {
+            return $candidate
+        }
+    }
+
+    throw 'Unable to locate dotnet.exe. Set DOTNET_EXE, DOTNET_HOST_PATH, or DOTNET_ROOT, or ensure dotnet is available on PATH.'
+}
+
+$repoRoot = Resolve-RepositoryRoot -ConfiguredRepoPath $RepoPath
+$dotNetExePath = Resolve-DotNetExePath
+$runtimeRoot = Join-Path $repoRoot 'runtime\windows\resonite'
 $stdoutLog = Join-Path $runtimeRoot ("{0}.stdout.log" -f $LogPrefix)
 $stderrLog = Join-Path $runtimeRoot ("{0}.stderr.log" -f $LogPrefix)
 $workRoot = $runtimeRoot
-$cliDllPath = Join-Path $RepoPath 'artifacts\build\windows\bin\Plateau.ResoniteLink.Cli\Release\net10.0\Plateau.ResoniteLink.Cli.dll'
+$cliDllPath = Join-Path $repoRoot 'artifacts\build\windows\bin\Plateau.ResoniteLink.Cli\Release\net10.0\Plateau.ResoniteLink.Cli.dll'
 
 if (-not (Test-Path $cliDllPath)) {
-    & 'C:\Program Files\dotnet\dotnet.exe' build (Join-Path $RepoPath 'src\Plateau.ResoniteLink.Cli\Plateau.ResoniteLink.Cli.csproj') -c Release | Out-Host
+    & $dotNetExePath build (Join-Path $repoRoot 'src\Plateau.ResoniteLink.Cli\Plateau.ResoniteLink.Cli.csproj') -c Release | Out-Host
     if (-not (Test-Path $cliDllPath)) {
         throw "CLI build output not found: $cliDllPath"
     }
@@ -37,8 +96,8 @@ foreach ($path in @($stdoutLog, $stderrLog)) {
 }
 
 $process = Start-Process `
-    -FilePath 'C:\Program Files\dotnet\dotnet.exe' `
-    -WorkingDirectory $RepoPath `
+    -FilePath $dotNetExePath `
+    -WorkingDirectory $repoRoot `
     -ArgumentList @(
         $cliDllPath,
         'build',

--- a/scripts/run-resonite-admin.ps1
+++ b/scripts/run-resonite-admin.ps1
@@ -10,11 +10,36 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$dllPath = 'C:\Users\esnya\Documents\PLATEAU-ResoniteLink\artifacts\build\windows\bin\ResoniteAdmin\Release\net10.0\ResoniteAdmin.dll'
+function Get-DotNetCommandPath {
+    if ($env:DOTNET_EXE -and (Test-Path $env:DOTNET_EXE)) {
+        return (Get-Item $env:DOTNET_EXE).FullName
+    }
+
+    if ($env:DOTNET_HOST_PATH -and (Test-Path $env:DOTNET_HOST_PATH)) {
+        return (Get-Item $env:DOTNET_HOST_PATH).FullName
+    }
+
+    if ($env:DOTNET_ROOT) {
+        foreach ($candidate in @(
+            (Join-Path $env:DOTNET_ROOT 'dotnet.exe'),
+            (Join-Path $env:DOTNET_ROOT 'dotnet')
+        )) {
+            if (Test-Path $candidate) {
+                return (Get-Item $candidate).FullName
+            }
+        }
+    }
+
+    return (Get-Command dotnet -ErrorAction Stop).Source
+}
+
+$repoRoot = (Split-Path -Parent $PSScriptRoot)
+$dllPath = Join-Path $repoRoot 'artifacts\build\windows\bin\ResoniteAdmin\Release\net10.0\ResoniteAdmin.dll'
+$dotnet = Get-DotNetCommandPath
 $arguments = @($dllPath, $Endpoint, $Dataset)
 if ($ListOnly) {
     $arguments += '--list-only'
 }
 
-& 'C:\Program Files\dotnet\dotnet.exe' @arguments
+& $dotnet @arguments
 exit $LASTEXITCODE

--- a/skills/resonite-live-send-debug/scripts/cleanup-session.ps1
+++ b/skills/resonite-live-send-debug/scripts/cleanup-session.ps1
@@ -15,74 +15,14 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$runtimeRoot = Join-Path $RepoPath 'runtime\windows\resonite'
-$adminProject = Join-Path $RepoPath 'scripts\ResoniteAdmin\ResoniteAdmin.csproj'
-$adminDll = Join-Path $RepoPath 'artifacts\build\windows\bin\ResoniteAdmin\Release\net10.0\ResoniteAdmin.dll'
+$delegatePath = Join-Path (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..\..')).Path 'scripts\cleanup-live-send.ps1'
 
-$stoppedProcessIds = @()
-if (-not $ListOnly) {
-    Write-Warning "This cleanup removes live dataset roots from the current Resonite session and can destroy experiment results."
-    Get-CimInstance Win32_Process -Filter "Name = 'dotnet.exe'" |
-        Where-Object { $_.CommandLine -like '*Plateau.ResoniteLink.Cli*' -and $_.CommandLine -like "*$RepoPath*" } |
-        ForEach-Object {
-            $stoppedProcessIds += $_.ProcessId
-            Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
-        }
-}
-
-if (-not (Test-Path $adminDll)) {
-    & 'C:\Program Files\dotnet\dotnet.exe' build $adminProject -c Release | Out-Host
-    if (-not (Test-Path $adminDll)) {
-        throw "ResoniteAdmin build output not found: $adminDll"
-    }
-}
-
-if ($stoppedProcessIds.Count -gt 0) {
-    Write-Output ("Stopped stale sender PID(s): {0}" -f ($stoppedProcessIds -join ', '))
-}
-
-Write-Output ("AdminDllPath={0}" -f $adminDll)
-Write-Output ("AdminDllLastWriteTime={0:o}" -f (Get-Item $adminDll).LastWriteTime)
-
-if (-not $ListOnly) {
-    & 'C:\Program Files\dotnet\dotnet.exe' $adminDll $Endpoint $Dataset | Out-Host
-}
-
-$verification = @()
-$deadline = (Get-Date).AddSeconds($VerificationTimeoutSeconds)
-
-do {
-    $verification = & 'C:\Program Files\dotnet\dotnet.exe' $adminDll $Endpoint $Dataset --list-only
-    $verification | Out-Host
-
-    if ($verification -match "Found 0 dataset root slot\(s\)") {
-        break
-    }
-
-    if ($ListOnly -or (Get-Date) -ge $deadline) {
-        break
-    }
-
-    Start-Sleep -Seconds $PollIntervalSeconds
-}
-while ($true)
-
-if ($ListOnly) {
-    return
-}
-
-if ($verification -match "Found 0 dataset root slot\(s\)") {
-    foreach ($path in @(
-        (Join-Path $runtimeRoot '.generated-assets'),
-        (Join-Path $runtimeRoot 'resonite-live-asset-state.json'),
-        (Join-Path $runtimeRoot 'resonite-live-asset-state.json.778de27fa819415a8310f8d02019bc12.tmp')
-    )) {
-        if (Test-Path $path) {
-            Remove-Item $path -Recurse -Force
-        }
-    }
-
-    return
-}
-
-throw "Dataset root cleanup did not converge to zero roots for '$Dataset'."
+& $delegatePath `
+    -RepoPath $RepoPath `
+    -Endpoint $Endpoint `
+    -Dataset $Dataset `
+    -ListOnly:$ListOnly `
+    -KeepLogs `
+    -VerificationTimeoutSeconds $VerificationTimeoutSeconds `
+    -PollIntervalSeconds $PollIntervalSeconds
+exit $LASTEXITCODE

--- a/skills/resonite-live-send-debug/scripts/run-live-send.ps1
+++ b/skills/resonite-live-send-debug/scripts/run-live-send.ps1
@@ -22,69 +22,16 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$runtimeRoot = Join-Path $RepoPath 'runtime\windows\resonite'
-$stdoutLog = Join-Path $runtimeRoot ("{0}.stdout.log" -f $LogPrefix)
-$stderrLog = Join-Path $runtimeRoot ("{0}.stderr.log" -f $LogPrefix)
-$workRoot = $runtimeRoot
-$cliDllPath = Join-Path $RepoPath 'artifacts\build\windows\bin\Plateau.ResoniteLink.Cli\Release\net10.0\Plateau.ResoniteLink.Cli.dll'
+$delegatePath = Join-Path (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..\..')).Path 'scripts\run-live-send.ps1'
 
-if (-not (Test-Path $cliDllPath)) {
-    & 'C:\Program Files\dotnet\dotnet.exe' build (Join-Path $RepoPath 'src\Plateau.ResoniteLink.Cli\Plateau.ResoniteLink.Cli.csproj') -c Release | Out-Host
-    if (-not (Test-Path $cliDllPath)) {
-        throw "CLI build output not found: $cliDllPath"
-    }
-}
-
-foreach ($path in @($stdoutLog, $stderrLog)) {
-    if (Test-Path $path) {
-        Remove-Item $path -Force
-    }
-}
-
-$process = Start-Process `
-    -FilePath 'C:\Program Files\dotnet\dotnet.exe' `
-    -WorkingDirectory $RepoPath `
-    -ArgumentList @(
-        $cliDllPath,
-        'build',
-        '--dataset', $Dataset,
-        '--source', 'local',
-        '--local-source-path', $LocalSourcePath,
-        '--work-root', $workRoot,
-        '--dem-terrain-mode', $DemTerrainMode,
-        '--resonitelink-port', $ResoniteLinkPort,
-        '--mesh-code', $MeshCode,
-        '--resonitelink-connections', $Connections
-    ) `
-    -PassThru `
-    -RedirectStandardOutput $stdoutLog `
-    -RedirectStandardError $stderrLog
-
-if ($NoWait) {
-    [pscustomobject]@{
-        ProcessId      = $process.Id
-        Dataset        = $Dataset
-        MeshCode       = $MeshCode
-        DemTerrainMode = $DemTerrainMode
-        StdoutLog      = $stdoutLog
-        StderrLog      = $stderrLog
-        CliDllPath     = $cliDllPath
-        CliDllLastWriteTime = (Get-Item $cliDllPath).LastWriteTime
-    }
-    exit 0
-}
-
-$null = $process | Wait-Process
-$process.Refresh()
-
-[pscustomobject]@{
-    ProcessId      = $process.Id
-    ExitCode       = $process.ExitCode
-    Dataset        = $Dataset
-    MeshCode       = $MeshCode
-    DemTerrainMode = $DemTerrainMode
-    StdoutLog      = $stdoutLog
-    StderrLog      = $stderrLog
-    CliDllPath     = $cliDllPath
-    CliDllLastWriteTime = (Get-Item $cliDllPath).LastWriteTime
-}
+& $delegatePath `
+    -RepoPath $RepoPath `
+    -ResoniteLinkPort $ResoniteLinkPort `
+    -LocalSourcePath $LocalSourcePath `
+    -Dataset $Dataset `
+    -MeshCode $MeshCode `
+    -DemTerrainMode $DemTerrainMode `
+    -Connections $Connections `
+    -LogPrefix $LogPrefix `
+    -NoWait:$NoWait
+exit $LASTEXITCODE


### PR DESCRIPTION
## What changed
- removed machine-specific repository path assumptions from the live-send helper scripts
- replaced hard-coded `dotnet.exe` paths with environment/PATH-based resolution
- aligned the operator-facing skill wrappers with the root repository utilities while preserving the documented live workflow
- clarified the canonical live-testing docs and kept the Japanese translation aligned

## Why
The live-send helper scripts were tied to one Windows machine layout, which made the repository utilities and the documented workflow brittle outside that checkout.

## Impact
Windows operators can run the same helper flow from different repository locations and dotnet installations without editing the scripts first. The skill wrappers remain the operator-facing entrypoint, and cleanup keeps per-run logs for comparison workflows.

## Validation
- `bash scripts/verify-ci.sh`
