### PR TITLE
[codex] Add CLI mesh bake toggle

### DIFF
--- a/src/Plateau.ResoniteLink.Cli/BuildCommandOptions.cs
+++ b/src/Plateau.ResoniteLink.Cli/BuildCommandOptions.cs
@@ -7,5 +7,6 @@ public sealed record BuildCommandOptions(
     string WorkRoot,
     Uri? ResoniteLinkUri,
     int ResoniteLinkConnectionCount,
+    bool EnableMeshBake,
     bool EnableSendMetrics,
     bool VerboseLogging);

--- a/src/Plateau.ResoniteLink.Cli/CliApplication.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliApplication.cs
@@ -129,6 +129,7 @@ public sealed class CliApplication
                 options.ResoniteLinkUri!,
                 options.ResoniteLinkConnectionCount,
                 diagnostics,
+                options.EnableMeshBake,
                 progressReporter: reporter),
             progressReporter: reporter);
     }

--- a/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
@@ -41,6 +41,7 @@ public static class CliArgumentsParser
           --resonitelink-url     Required unless --resonitelink-port is used. Absolute ws:// or wss:// endpoint for live ResoniteLink builds.
           --resonitelink-connections <count>
                                                              Optional. Number of parallel ResoniteLink connections for live sends. Default: 4.
+          --no-mesh-bake       Optional. Disable fixed-cell mesh baking for eligible LOD1 building city objects.
           --send-metrics         Optional. Enable opt-in live send metrics and CLI summary output.
           --verbose              Optional. Include debug-level progress logs.
           -h, --help             Show this help text.
@@ -66,6 +67,7 @@ public static class CliArgumentsParser
         string workRoot = "local";
         Uri? resoniteLinkUri = null;
         int resoniteLinkConnectionCount = CliDefaultOptions.ResoniteLinkConnectionCount;
+        bool enableMeshBake = true;
         bool enableSendMetrics = false;
         bool verboseLogging = false;
         DatasetSourceKind sourceKind = DatasetSourceKind.Local;
@@ -174,6 +176,9 @@ public static class CliArgumentsParser
 
                             break;
                         }
+                    case "--no-mesh-bake":
+                        enableMeshBake = false;
+                        break;
                     case "--send-metrics":
                         enableSendMetrics = true;
                         break;
@@ -346,6 +351,7 @@ public static class CliArgumentsParser
                 workRoot,
                 resoniteLinkUri,
                 resoniteLinkConnectionCount,
+                enableMeshBake,
                 enableSendMetrics,
                 verboseLogging));
     }

--- a/src/Plateau.ResoniteLink.Cli/FixedCellCityObjectMeshBaker.cs
+++ b/src/Plateau.ResoniteLink.Cli/FixedCellCityObjectMeshBaker.cs
@@ -1,0 +1,467 @@
+using System.Globalization;
+
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Cli;
+
+internal sealed class FixedCellCityObjectMeshBaker
+{
+    internal const double DefaultCellSizeMeters = 128.0;
+    internal const int DefaultMaxCityObjectsPerBatch = 64;
+    internal const int DefaultMaxVerticesPerBatch = 200_000;
+
+    private readonly double cellSizeMeters;
+    private readonly int maxCityObjectsPerBatch;
+    private readonly int maxVerticesPerBatch;
+    private readonly Dictionary<CellKey, CellBuffer> buffers = [];
+    private readonly Dictionary<CellKey, int> flushSequenceByCell = [];
+
+    public FixedCellCityObjectMeshBaker()
+        : this(DefaultCellSizeMeters, DefaultMaxCityObjectsPerBatch, DefaultMaxVerticesPerBatch)
+    {
+    }
+
+    internal FixedCellCityObjectMeshBaker(
+        double cellSizeMeters,
+        int maxCityObjectsPerBatch,
+        int maxVerticesPerBatch)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(cellSizeMeters, 0.0);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxCityObjectsPerBatch);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxVerticesPerBatch);
+
+        this.cellSizeMeters = cellSizeMeters;
+        this.maxCityObjectsPerBatch = maxCityObjectsPerBatch;
+        this.maxVerticesPerBatch = maxVerticesPerBatch;
+    }
+
+    public int BakedInputCityObjectCount { get; private set; }
+
+    public int BakedOutputCityObjectCount { get; private set; }
+
+    public bool TryBuffer(
+        ResoniteConstructionCityObject cityObject,
+        out ResoniteConstructionCityObject? bakedCityObject)
+    {
+        ArgumentNullException.ThrowIfNull(cityObject);
+
+        bakedCityObject = null;
+        if (!CanBake(cityObject))
+        {
+            return false;
+        }
+
+        CellKey cellKey = CreateCellKey(cityObject);
+        if (!buffers.TryGetValue(cellKey, out CellBuffer? buffer))
+        {
+            buffer = new CellBuffer();
+            buffers.Add(cellKey, buffer);
+        }
+
+        buffer.CityObjects.Add(cityObject);
+        buffer.VertexCount += cityObject.Mesh.Vertices.Count;
+        BakedInputCityObjectCount++;
+
+        if (buffer.CityObjects.Count < maxCityObjectsPerBatch
+            && buffer.VertexCount < maxVerticesPerBatch)
+        {
+            return true;
+        }
+
+        buffers.Remove(cellKey);
+        bakedCityObject = BakeCell(cellKey, buffer);
+        return true;
+    }
+
+    public IReadOnlyList<ResoniteConstructionCityObject> FlushAll()
+    {
+        if (buffers.Count == 0)
+        {
+            return [];
+        }
+
+        List<ResoniteConstructionCityObject> bakedCityObjects = new(buffers.Count);
+        foreach ((CellKey cellKey, CellBuffer buffer) in buffers
+                     .OrderBy(static pair => pair.Key, CellKeyComparer.Instance))
+        {
+            bakedCityObjects.Add(BakeCell(cellKey, buffer));
+        }
+
+        buffers.Clear();
+        return bakedCityObjects;
+    }
+
+    private static bool CanBake(ResoniteConstructionCityObject cityObject)
+    {
+        return string.Equals(cityObject.PackageName, "bldg", StringComparison.OrdinalIgnoreCase)
+            && cityObject.LodLevel == 1
+            && cityObject.Geometry is ResoniteTriangleMeshGeometry
+            && cityObject.Transform.Rotation is null;
+    }
+
+    private CellKey CreateCellKey(ResoniteConstructionCityObject cityObject)
+    {
+        int cellX = (int)Math.Floor(cityObject.Transform.Position.X / cellSizeMeters);
+        int cellZ = (int)Math.Floor(cityObject.Transform.Position.Z / cellSizeMeters);
+        return new CellKey(
+            cityObject.ActualMeshCode,
+            cityObject.PackageName,
+            cityObject.LodLevel,
+            cellX,
+            cellZ);
+    }
+
+    private ResoniteConstructionCityObject BakeCell(CellKey cellKey, CellBuffer buffer)
+    {
+        int flushSequence = flushSequenceByCell.GetValueOrDefault(cellKey);
+        flushSequenceByCell[cellKey] = flushSequence + 1;
+
+        ResoniteFloat3 bakeOrigin = new(
+            cellKey.CellX * cellSizeMeters,
+            0.0,
+            cellKey.CellZ * cellSizeMeters);
+        List<ResoniteMeshVertex> vertices = [];
+        Dictionary<MaterialIdentity, List<int>> trianglesByMaterial = [];
+        Dictionary<MaterialIdentity, ResoniteMaterialBinding> materialByIdentity = [];
+
+        foreach (ResoniteConstructionCityObject cityObject in buffer.CityObjects
+                     .OrderBy(static candidate => candidate.SlotKey, StringComparer.Ordinal))
+        {
+            int vertexOffset = vertices.Count;
+            ResoniteFloat3 positionOffset = Subtract(cityObject.Transform.Position, bakeOrigin);
+            foreach (ResoniteMeshVertex vertex in cityObject.Mesh.Vertices)
+            {
+                vertices.Add(vertex with
+                {
+                    Position = Add(vertex.Position, positionOffset),
+                });
+            }
+
+            Dictionary<int, ResoniteMaterialBinding> materialBySubmeshIndex = cityObject.Materials
+                .SelectMany(material => material.SubmeshIndices.Select(submeshIndex => (submeshIndex, material)))
+                .ToDictionary(static pair => pair.submeshIndex, static pair => pair.material);
+
+            foreach (ResoniteMeshSubmesh submesh in cityObject.Mesh.Submeshes.OrderBy(static submesh => submesh.Index))
+            {
+                if (!materialBySubmeshIndex.TryGetValue(submesh.Index, out ResoniteMaterialBinding? material))
+                {
+                    continue;
+                }
+
+                MaterialIdentity identity = MaterialIdentity.From(material);
+                materialByIdentity.TryAdd(identity, material);
+                if (!trianglesByMaterial.TryGetValue(identity, out List<int>? indices))
+                {
+                    indices = [];
+                    trianglesByMaterial.Add(identity, indices);
+                }
+
+                foreach (int index in submesh.TriangleVertexIndices)
+                {
+                    indices.Add(index + vertexOffset);
+                }
+            }
+        }
+
+        List<ResoniteMaterialBinding> materials = [];
+        List<ResoniteMeshSubmesh> submeshes = [];
+        foreach (MaterialIdentity identity in trianglesByMaterial.Keys.OrderBy(static identity => identity, MaterialIdentityComparer.Instance))
+        {
+            List<int> indices = trianglesByMaterial[identity];
+            if (indices.Count == 0)
+            {
+                continue;
+            }
+
+            int submeshIndex = submeshes.Count;
+            ResoniteMaterialBinding material = materialByIdentity[identity];
+            submeshes.Add(new ResoniteMeshSubmesh(submeshIndex, material.MaterialKey, indices));
+            materials.Add(material with { SubmeshIndices = [submeshIndex] });
+        }
+
+        BakedOutputCityObjectCount++;
+        return new ResoniteConstructionCityObject(
+            SlotKey: CreateBatchSlotKey(cellKey, flushSequence),
+            DisplayName: CreateBatchDisplayName(cellKey, flushSequence),
+            PackageName: cellKey.PackageName,
+            ActualMeshCode: cellKey.ActualMeshCode,
+            LodLevel: cellKey.LodLevel,
+            Transform: new ResoniteTransform(bakeOrigin),
+            Mesh: new ResoniteImportedMesh(vertices, submeshes),
+            Materials: materials,
+            CollisionEnabled: buffer.CityObjects.Any(static cityObject => cityObject.CollisionEnabled),
+            SourceObjectKey: CreateBatchSourceObjectKey(cellKey, flushSequence));
+    }
+
+    private static string CreateBatchSlotKey(CellKey cellKey, int flushSequence)
+    {
+        string lodToken = cellKey.LodLevel?.ToString(CultureInfo.InvariantCulture) ?? "none";
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"meshbake_{cellKey.PackageName}_{cellKey.ActualMeshCode}_{lodToken}_{cellKey.CellX}_{cellKey.CellZ}_{flushSequence:D4}");
+    }
+
+    private static string CreateBatchDisplayName(CellKey cellKey, int flushSequence)
+    {
+        string lodToken = cellKey.LodLevel?.ToString(CultureInfo.InvariantCulture) ?? "none";
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"MeshBake {cellKey.PackageName} LOD{lodToken} {cellKey.CellX},{cellKey.CellZ} #{flushSequence + 1}");
+    }
+
+    private static string CreateBatchSourceObjectKey(CellKey cellKey, int flushSequence)
+    {
+        string lodToken = cellKey.LodLevel?.ToString(CultureInfo.InvariantCulture) ?? "none";
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"meshbake:{cellKey.ActualMeshCode}:{cellKey.PackageName}:{lodToken}:{cellKey.CellX}:{cellKey.CellZ}:{flushSequence:D4}");
+    }
+
+    private static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)
+    {
+        return new ResoniteFloat3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
+    }
+
+    private static ResoniteFloat3 Subtract(ResoniteFloat3 left, ResoniteFloat3 right)
+    {
+        return new ResoniteFloat3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
+    }
+
+    private sealed class CellBuffer
+    {
+        public List<ResoniteConstructionCityObject> CityObjects { get; } = [];
+
+        public int VertexCount { get; set; }
+    }
+
+    private sealed record CellKey(
+        string ActualMeshCode,
+        string PackageName,
+        int? LodLevel,
+        int CellX,
+        int CellZ);
+
+    private sealed record MaterialIdentity(
+        string MaterialKey,
+        ResoniteColor BaseColor,
+        ResoniteMaterialType MaterialType,
+        string? TexturePath,
+        ResoniteTextureSourceKind TextureSourceKind,
+        ResoniteMaterialProjection Projection,
+        ResoniteMaterialDepthOffset? DepthOffset,
+        ResoniteFloat2? TextureScale,
+        string? Family,
+        ResoniteFloat2? TextureOffset,
+        ResoniteMaterialAssetScope AssetScope)
+    {
+        public static MaterialIdentity From(ResoniteMaterialBinding material)
+        {
+            return new MaterialIdentity(
+                material.MaterialKey,
+                material.BaseColor,
+                material.MaterialType,
+                material.TexturePath,
+                material.TextureSourceKind,
+                material.Projection,
+                material.DepthOffset,
+                material.TextureScale,
+                material.Family,
+                material.TextureOffset,
+                material.AssetScope);
+        }
+    }
+
+    private sealed class CellKeyComparer : IComparer<CellKey>
+    {
+        public static CellKeyComparer Instance { get; } = new();
+
+        public int Compare(CellKey? x, CellKey? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
+            int compare = string.CompareOrdinal(x.ActualMeshCode, y.ActualMeshCode);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.CompareOrdinal(x.PackageName, y.PackageName);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = Nullable.Compare(x.LodLevel, y.LodLevel);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = x.CellX.CompareTo(y.CellX);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            return x.CellZ.CompareTo(y.CellZ);
+        }
+    }
+
+    private sealed class MaterialIdentityComparer : IComparer<MaterialIdentity>
+    {
+        public static MaterialIdentityComparer Instance { get; } = new();
+
+        public int Compare(MaterialIdentity? x, MaterialIdentity? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
+            int compare = string.CompareOrdinal(x.MaterialKey, y.MaterialKey);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = x.MaterialType.CompareTo(y.MaterialType);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.CompareOrdinal(x.TexturePath, y.TexturePath);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = x.TextureSourceKind.CompareTo(y.TextureSourceKind);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = x.Projection.CompareTo(y.Projection);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.CompareOrdinal(x.Family, y.Family);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = x.AssetScope.CompareTo(y.AssetScope);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = CompareNullableFloat2(x.TextureScale, y.TextureScale);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = CompareNullableFloat2(x.TextureOffset, y.TextureOffset);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = CompareNullableDepthOffset(x.DepthOffset, y.DepthOffset);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            return CompareColor(x.BaseColor, y.BaseColor);
+        }
+
+        private static int CompareNullableFloat2(ResoniteFloat2? x, ResoniteFloat2? y)
+        {
+            if (x is null && y is null)
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
+            int compare = x.X.CompareTo(y.X);
+            return compare != 0 ? compare : x.Y.CompareTo(y.Y);
+        }
+
+        private static int CompareNullableDepthOffset(ResoniteMaterialDepthOffset? x, ResoniteMaterialDepthOffset? y)
+        {
+            if (x is null && y is null)
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
+            int compare = x.Factor.CompareTo(y.Factor);
+            return compare != 0 ? compare : x.Units.CompareTo(y.Units);
+        }
+
+        private static int CompareColor(ResoniteColor x, ResoniteColor y)
+        {
+            int compare = x.R.CompareTo(y.R);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = x.G.CompareTo(y.G);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = x.B.CompareTo(y.B);
+            return compare != 0 ? compare : x.A.CompareTo(y.A);
+        }
+    }
+}

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -51,6 +51,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
     private Task[]? processingTasks;
     private CancellationTokenSource? processingCancellationSource;
     private TaskCompletionSource<Exception>? firstProcessingFailureSource;
+    private FixedCellCityObjectMeshBaker? meshBaker;
     private int processedCityObjectCount;
     private Stopwatch? sceneBuildStopwatch;
     private int firstQueuedCityObjectLogged;
@@ -60,12 +61,12 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
     private SceneAnchor? sceneAnchor;
 
     public ResoniteLinkSceneBuilder(Uri endpoint, Action<string>? progressReporter = null)
-        : this(endpoint, 4, ResoniteLinkSendDiagnostics.Disabled, static () => new ResoniteLinkClient(), new TerrainTextureAssetGenerator(), progressReporter)
+        : this(endpoint, 4, ResoniteLinkSendDiagnostics.Disabled, static () => new ResoniteLinkClient(), new TerrainTextureAssetGenerator(), enableMeshBake: true, progressReporter)
     {
     }
 
     public ResoniteLinkSceneBuilder(Uri endpoint, int connectionCount, Action<string>? progressReporter = null)
-        : this(endpoint, connectionCount, ResoniteLinkSendDiagnostics.Disabled, static () => new ResoniteLinkClient(), new TerrainTextureAssetGenerator(), progressReporter)
+        : this(endpoint, connectionCount, ResoniteLinkSendDiagnostics.Disabled, static () => new ResoniteLinkClient(), new TerrainTextureAssetGenerator(), enableMeshBake: true, progressReporter)
     {
     }
 
@@ -74,7 +75,17 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         int connectionCount,
         ResoniteLinkSendDiagnostics diagnostics,
         Action<string>? progressReporter = null)
-        : this(endpoint, connectionCount, diagnostics, static () => new ResoniteLinkClient(), new TerrainTextureAssetGenerator(), progressReporter)
+        : this(endpoint, connectionCount, diagnostics, static () => new ResoniteLinkClient(), new TerrainTextureAssetGenerator(), enableMeshBake: true, progressReporter)
+    {
+    }
+
+    internal ResoniteLinkSceneBuilder(
+        Uri endpoint,
+        int connectionCount,
+        ResoniteLinkSendDiagnostics diagnostics,
+        bool enableMeshBake,
+        Action<string>? progressReporter = null)
+        : this(endpoint, connectionCount, diagnostics, static () => new ResoniteLinkClient(), new TerrainTextureAssetGenerator(), enableMeshBake, progressReporter)
     {
     }
 
@@ -84,6 +95,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         ResoniteLinkSendDiagnostics diagnostics,
         Func<IResoniteLinkClient> clientFactory,
         ITerrainTextureAssetGenerator? terrainTextureAssetGenerator = null,
+        bool enableMeshBake = true,
         Action<string>? progressReporter = null)
     {
         this.endpoint = endpoint;
@@ -91,9 +103,12 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         this.diagnostics = diagnostics;
         this.clientFactory = clientFactory;
         this.terrainTextureAssetGenerator = terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator();
+        MeshBakeEnabled = enableMeshBake;
         this.progressReporter = progressReporter;
         geometryAssetAssembler = new ResoniteGeometryAssetAssembler(ReportProgress);
     }
+
+    internal bool MeshBakeEnabled { get; }
 
     public async Task EnsureConnectedAsync(
         PlateauImportRequest request,
@@ -184,6 +199,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         firstQueuedCityObjectLogged = 0;
         firstPreparedCityObjectLogged = 0;
         firstBuiltCityObjectLogged = 0;
+        meshBaker = MeshBakeEnabled ? new FixedCellCityObjectMeshBaker() : null;
         diagnostics.StartSendWindow(connectionCount);
         processingCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         firstProcessingFailureSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -423,41 +439,39 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         ObjectDisposedException.ThrowIf(cityObjectChannels is null, this);
         ObjectDisposedException.ThrowIf(processingTasks is null, this);
 
-        await AwaitProcessingTasksIfCompletedAsync();
-
-        Task<PreparedCityObject> preparationTask = CreatePreparationTask(cityObject, cancellationToken);
-        if (Interlocked.CompareExchange(ref firstQueuedCityObjectLogged, 1, 0) == 0)
+        if (meshBaker?.TryBuffer(cityObject, out ResoniteConstructionCityObject? bakedCityObject) == true)
         {
-            ReportProgress(
-                $"[live] First city object queued after {GetSceneElapsedSeconds():F3}s: "
-                + $"{cityObject.DisplayName} ({cityObject.PackageName}/{cityObject.SlotKey})");
+            if (bakedCityObject is null)
+            {
+                return;
+            }
+
+            cityObject = bakedCityObject;
         }
 
-        ObjectDisposedException.ThrowIf(dispatchLaneAllocator is null, this);
-
-        int dispatchLane = dispatchLaneAllocator.GetLane(cityObject);
-        using CancellationTokenSource enqueueCancellation = CancellationTokenSource.CreateLinkedTokenSource(
-            cancellationToken,
-            processingCancellationSource?.Token ?? CancellationToken.None);
-        try
-        {
-            await cityObjectChannels[dispatchLane].Writer.WriteAsync(
-                new QueuedCityObject(cityObject, preparationTask),
-                enqueueCancellation.Token);
-        }
-        catch (OperationCanceledException) when (processingCancellationSource?.IsCancellationRequested == true)
-        {
-            await AwaitProcessingTasksIfCompletedAsync();
-            throw;
-        }
-
-        await AwaitProcessingTasksIfCompletedAsync();
+        await EnqueueCityObjectAsync(cityObject, cancellationToken);
     }
 
     public async Task<IReadOnlyList<string>> CompleteAsync(CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(cityObjectChannels is null, this);
         ObjectDisposedException.ThrowIf(processingTasks is null, this);
+
+        if (meshBaker is not null)
+        {
+            IReadOnlyList<ResoniteConstructionCityObject> bakedCityObjects = meshBaker.FlushAll();
+            foreach (ResoniteConstructionCityObject bakedCityObject in bakedCityObjects)
+            {
+                await EnqueueCityObjectAsync(bakedCityObject, cancellationToken);
+            }
+
+            if (meshBaker.BakedOutputCityObjectCount > 0)
+            {
+                ReportProgress(
+                    $"[live] MeshBake batched {meshBaker.BakedInputCityObjectCount} input city objects "
+                    + $"into {meshBaker.BakedOutputCityObjectCount} baked cell batches.");
+            }
+        }
 
         ReportProgress("[live] Completing live send. Closing lane writers.");
         foreach (Channel<QueuedCityObject> channel in cityObjectChannels)
@@ -556,6 +570,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             textureImportResolver = null;
             cityObjectChannels = null;
             processingTasks = null;
+            meshBaker = null;
             processingCancellationSource?.Dispose();
             processingCancellationSource = null;
             firstProcessingFailureSource = null;
@@ -604,6 +619,42 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             + $"{preparedCityObject.CityObject.DisplayName} "
             + $"({preparedCityObject.CityObject.PackageName}/{preparedCityObject.CityObject.SlotKey})",
             PlateauLogLevel.Info);
+    }
+
+    private async Task EnqueueCityObjectAsync(
+        ResoniteConstructionCityObject cityObject,
+        CancellationToken cancellationToken)
+    {
+        await AwaitProcessingTasksIfCompletedAsync();
+
+        Task<PreparedCityObject> preparationTask = CreatePreparationTask(cityObject, cancellationToken);
+        if (Interlocked.CompareExchange(ref firstQueuedCityObjectLogged, 1, 0) == 0)
+        {
+            ReportProgress(
+                $"[live] First city object queued after {GetSceneElapsedSeconds():F3}s: "
+                + $"{cityObject.DisplayName} ({cityObject.PackageName}/{cityObject.SlotKey})");
+        }
+
+        ObjectDisposedException.ThrowIf(dispatchLaneAllocator is null, this);
+        ObjectDisposedException.ThrowIf(cityObjectChannels is null, this);
+
+        int dispatchLane = dispatchLaneAllocator.GetLane(cityObject);
+        using CancellationTokenSource enqueueCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            processingCancellationSource?.Token ?? CancellationToken.None);
+        try
+        {
+            await cityObjectChannels[dispatchLane].Writer.WriteAsync(
+                new QueuedCityObject(cityObject, preparationTask),
+                enqueueCancellation.Token);
+        }
+        catch (OperationCanceledException) when (processingCancellationSource?.IsCancellationRequested == true)
+        {
+            await AwaitProcessingTasksIfCompletedAsync();
+            throw;
+        }
+
+        await AwaitProcessingTasksIfCompletedAsync();
     }
 
     private void ReportProgress(string message)

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliApplicationTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliApplicationTests.cs
@@ -95,6 +95,34 @@ public sealed class CliApplicationTests
     }
 
     [Fact]
+    public async Task RunAsyncPassesMeshBakeDisableOptionToFactory()
+    {
+        using StringWriter standardOutput = new();
+        using StringWriter standardError = new();
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
+        BuildCommandOptions? capturedOptions = null;
+
+        CliApplication application = new(
+            standardOutput,
+            standardError,
+            options =>
+            {
+                capturedOptions = options;
+                return new PlateauImportService(new StubSceneBuilder());
+            });
+
+        int exitCode = await application.RunAsync(
+            [
+                ..BuildLiveArgs(fixturePath),
+                "--no-mesh-bake",
+            ]);
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(capturedOptions);
+        Assert.False(capturedOptions!.EnableMeshBake);
+    }
+
+    [Fact]
     public async Task RunAsyncPropagatesCancellation()
     {
         using StringWriter standardOutput = new();

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -33,6 +33,7 @@ public sealed class CliArgumentsParserTests
         Assert.Equal("local", result.Options.WorkRoot);
         Assert.Equal(new Uri("ws://localhost:12345/"), result.Options.ResoniteLinkUri);
         Assert.Equal(4, result.Options.ResoniteLinkConnectionCount);
+        Assert.True(result.Options.EnableMeshBake);
         Assert.False(result.Options.EnableSendMetrics);
         Assert.False(result.Options.VerboseLogging);
     }
@@ -376,6 +377,27 @@ public sealed class CliArgumentsParserTests
 
         Assert.Null(result.Error);
         Assert.True(result.Options!.EnableSendMetrics);
+    }
+
+    [Fact]
+    public void ParseDisablesMeshBakeWhenRequested()
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "build",
+                "--dataset",
+                "tokyo23ku",
+                "--mesh-code",
+                "53394525",
+                "--local-source-path",
+                "/data/plateau",
+                "--resonitelink-port",
+                "12345",
+                "--no-mesh-bake",
+            ]);
+
+        Assert.Null(result.Error);
+        Assert.False(result.Options!.EnableMeshBake);
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Cli/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/FixedCellCityObjectMeshBakerTests.cs
@@ -1,0 +1,100 @@
+using Plateau.ResoniteLink.Cli;
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Tests.Cli;
+
+public sealed class FixedCellCityObjectMeshBakerTests
+{
+    [Fact]
+    public void TryBufferBakesLod1BuildingsInSameCellIntoSingleMesh()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 2, maxVerticesPerBatch: 1000);
+        ResoniteConstructionCityObject first = CreateTriangleBuilding("first", x: 10.0, z: 12.0);
+        ResoniteConstructionCityObject second = CreateTriangleBuilding("second", x: 18.0, z: 20.0);
+
+        bool firstBuffered = baker.TryBuffer(first, out ResoniteConstructionCityObject? firstBaked);
+        bool secondBuffered = baker.TryBuffer(second, out ResoniteConstructionCityObject? baked);
+
+        Assert.True(firstBuffered);
+        Assert.Null(firstBaked);
+        Assert.True(secondBuffered);
+        Assert.NotNull(baked);
+        Assert.Equal("bldg", baked.PackageName);
+        Assert.Equal(1, baked.LodLevel);
+        Assert.Equal(6, baked.Mesh.Vertices.Count);
+        Assert.Single(baked.Mesh.Submeshes);
+        Assert.Single(baked.Materials);
+        Assert.Equal([0], baked.Materials[0].SubmeshIndices);
+        Assert.Equal(new ResoniteFloat3(0.0, 0.0, 0.0), baked.Transform.Position);
+
+        ResoniteFloat3[] positions = baked.Mesh.Vertices.Select(static vertex => vertex.Position).ToArray();
+        Assert.Contains(new ResoniteFloat3(10.0, 0.0, 12.0), positions);
+        Assert.Contains(new ResoniteFloat3(11.0, 0.0, 12.0), positions);
+        Assert.Contains(new ResoniteFloat3(10.0, 0.0, 13.0), positions);
+        Assert.Contains(new ResoniteFloat3(18.0, 0.0, 20.0), positions);
+        Assert.Contains(new ResoniteFloat3(19.0, 0.0, 20.0), positions);
+        Assert.Contains(new ResoniteFloat3(18.0, 0.0, 21.0), positions);
+    }
+
+    [Fact]
+    public void FlushAllReturnsSeparateBatchesPerCell()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
+        Assert.True(baker.TryBuffer(CreateTriangleBuilding("left", x: 10.0, z: 10.0), out _));
+        Assert.True(baker.TryBuffer(CreateTriangleBuilding("right", x: 80.0, z: 10.0), out _));
+
+        IReadOnlyList<ResoniteConstructionCityObject> baked = baker.FlushAll();
+
+        Assert.Equal(2, baked.Count);
+        Assert.Contains(baked, static cityObject => cityObject.Transform.Position == new ResoniteFloat3(0.0, 0.0, 0.0));
+        Assert.Contains(baked, static cityObject => cityObject.Transform.Position == new ResoniteFloat3(64.0, 0.0, 0.0));
+    }
+
+    [Fact]
+    public void TryBufferSkipsNonTargetCityObjects()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 2, maxVerticesPerBatch: 1000);
+        ResoniteConstructionCityObject lod2Building = CreateTriangleBuilding("lod2", x: 10.0, z: 10.0) with { LodLevel = 2 };
+
+        bool buffered = baker.TryBuffer(lod2Building, out ResoniteConstructionCityObject? baked);
+
+        Assert.False(buffered);
+        Assert.Null(baked);
+        Assert.Empty(baker.FlushAll());
+    }
+
+    private static ResoniteConstructionCityObject CreateTriangleBuilding(string slotKey, double x, double z)
+    {
+        return new ResoniteConstructionCityObject(
+            SlotKey: slotKey,
+            DisplayName: slotKey,
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 1,
+            Transform: new ResoniteTransform(new ResoniteFloat3(x, 0.0, z)),
+            Mesh: new ResoniteImportedMesh(
+                [
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(1.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 1.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 1.0)),
+                ],
+                [
+                    new ResoniteMeshSubmesh(
+                        Index: 0,
+                        MaterialKey: "shared-material",
+                        TriangleVertexIndices: [0, 1, 2]),
+                ]),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "shared-material",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePath: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0]),
+            ]);
+    }
+}

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderConfigurationTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderConfigurationTests.cs
@@ -1,0 +1,29 @@
+using Plateau.ResoniteLink.Cli;
+
+namespace Plateau.ResoniteLink.Tests.Cli;
+
+public sealed class ResoniteLinkSceneBuilderConfigurationTests
+{
+    [Fact]
+    public async Task ConstructorEnablesMeshBakeByDefault()
+    {
+        await using ResoniteLinkSceneBuilder builder = new(new Uri("ws://localhost:12345/"), progressReporter: null);
+
+        Assert.True(builder.MeshBakeEnabled);
+    }
+
+    [Fact]
+    public async Task ConstructorCanDisableMeshBake()
+    {
+        await using ResoniteLinkSceneBuilder builder = new(
+            new Uri("ws://localhost:12345/"),
+            1,
+            ResoniteLinkSendDiagnostics.Disabled,
+            static () => throw new InvalidOperationException("unused"),
+            terrainTextureAssetGenerator: null,
+            enableMeshBake: false,
+            progressReporter: null);
+
+        Assert.False(builder.MeshBakeEnabled);
+    }
+}


### PR DESCRIPTION
## Summary
- add a default-on CLI mesh bake toggle via `--no-mesh-bake`
- thread the option through `BuildCommandOptions`, `CliApplication`, and `ResoniteLinkSceneBuilder`
- keep fixed-cell LOD1 building mesh baking enabled by default and make the builder configuration testable

## Why
LOD1 `bldg` live-send now benefits from fixed-cell mesh baking by default, but we still need an explicit escape hatch for regression checks and operational fallback.

## Impact
Users can disable mesh baking from the CLI without changing code, while existing default behavior remains unchanged.

## Validation
- `dotnet test tests/Plateau.ResoniteLink.Tests/Plateau.ResoniteLink.Tests.csproj --filter "CliArgumentsParserTests|CliApplicationTests|ResoniteLinkSceneBuilderConfigurationTests|FixedCellCityObjectMeshBakerTests"`
- `bash scripts/verify-ci.sh`
