### PR TITLE
[codex] Restore Plaster002 tiling profile

### DIFF
--- a/src/Plateau.ResoniteLink.Domain/Importing/BundledDefaultMaterialProfiles.cs
+++ b/src/Plateau.ResoniteLink.Domain/Importing/BundledDefaultMaterialProfiles.cs
@@ -11,6 +11,7 @@ public static class BundledDefaultMaterialProfiles
     public static readonly ResoniteFloat2 RoofingTiles014BTilesPerMeter = CreateTilesPerMeter(2.9, 2.9);
     public static readonly ResoniteFloat2 Asphalt020LTilesPerMeter = CreateTilesPerMeter(4.6, 4.6);
     public static readonly ResoniteFloat2 Asphalt023LTilesPerMeter = CreateTilesPerMeter(2.5, 2.5);
+    public static readonly ResoniteFloat2 Plaster002TilesPerMeter = CreateTilesPerMeter(2.5, 2.5);
     public static readonly ResoniteFloat2 Ground054TilesPerMeter = CreateTilesPerMeter(3.5, 3.5);
 
     public static ResoniteFloat2 GetTilesPerMeter(string texturePath)
@@ -27,6 +28,7 @@ public static class BundledDefaultMaterialProfiles
             "default-materials/roof/roofingtiles014b_2k-jpg_color.jpg" => RoofingTiles014BTilesPerMeter,
             "default-materials/road/asphalt020l_2k-jpg_color.jpg" => Asphalt020LTilesPerMeter,
             "default-materials/road/asphalt023l_2k-jpg_color.jpg" => Asphalt023LTilesPerMeter,
+            "default-materials/city-furniture/plaster002_2k-jpg_color.jpg" => Plaster002TilesPerMeter,
             "default-materials/other/concrete012_2k-jpg_color.jpg" => ConcreteDefaultTilesPerMeter,
             "default-materials/other/ground054_2k-jpg_color.jpg" => Ground054TilesPerMeter,
             _ => BundledDefaultMaterialTiling.DefaultTilesPerMeter,

--- a/tests/Plateau.ResoniteLink.Tests/Application/DefaultMaterialResolverTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/DefaultMaterialResolverTests.cs
@@ -76,11 +76,11 @@ public sealed class DefaultMaterialResolverTests
         Assert.Equal(BundledDefaultMaterialFamilies.CityFurniture, material.Family);
         Assert.NotNull(material.TextureScale);
         Assert.Equal(
-            BundledDefaultMaterialProfiles.GetTilesPerMeter(material.TexturePath!).X,
+            BundledDefaultMaterialProfiles.Plaster002TilesPerMeter.X,
             material.TextureScale!.X,
             6);
         Assert.Equal(
-            BundledDefaultMaterialProfiles.GetTilesPerMeter(material.TexturePath!).Y,
+            BundledDefaultMaterialProfiles.Plaster002TilesPerMeter.Y,
             material.TextureScale.Y,
             6);
     }


### PR DESCRIPTION
## Summary
- Restore an explicit tiles-per-meter profile for the `city-furniture/Plaster002` fallback material.
- Keep the post-merge `Plaster002` asset swap, but prevent the fallback from silently dropping to the generic default tiling density.
- Tighten the resolver test to assert the dedicated `Plaster002TilesPerMeter` profile directly.

## Why
PR #32 switched the `frn` fallback asset from `Metal032` to `Plaster002`, but removed the only city-furniture-specific tiling entry from `BundledDefaultMaterialProfiles`. That made `Plaster002` fall back to `BundledDefaultMaterialTiling.DefaultTilesPerMeter`, changing texture density for all untextured/colorless city furniture surfaces. This patch restores the explicit profile so the asset swap does not also change scale.

## Validation
- `bash scripts/verify-ci.sh`
