### PR TITLE
[codex] Unify import request validation

### DIFF
--- a/src/Plateau.ResoniteLink.Application/Importing/CkanPlateauDatasetSourceResolver.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/CkanPlateauDatasetSourceResolver.cs
@@ -26,31 +26,26 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
         string workRoot,
         CancellationToken cancellationToken = default)
     {
+        ValidatedPlateauImportRequest validatedRequest =
+            PlateauImportRequestValidator.NormalizeAndValidateOrThrow(request);
+
+        return (await ResolveAsync(validatedRequest, workRoot, cancellationToken)).ToImportRequest();
+    }
+
+    public async Task<ValidatedPlateauImportRequest> ResolveAsync(
+        ValidatedPlateauImportRequest request,
+        string workRoot,
+        CancellationToken cancellationToken = default)
+    {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
 
-        if (request.Source is PlateauLocalImportSource)
+        if (request.Source is ValidatedPlateauLocalImportSource)
         {
             return request;
         }
 
-        if (request.Source is not PlateauRemoteImportSource remoteSource)
-        {
-            throw new PlateauImportValidationException(
-                ["Remote import requires --server-url to point directly to a .zip or .7z CityGML archive. Built-in dataset search is not supported."]);
-        }
-
-        if (remoteSource.ServerUri is null)
-        {
-            throw new PlateauImportValidationException(
-                ["Remote import requires --server-url to point directly to a .zip or .7z CityGML archive. Built-in dataset search is not supported."]);
-        }
-
-        if (!LooksLikeSupportedArchiveUri(remoteSource.ServerUri))
-        {
-            throw new PlateauImportValidationException(
-                [$"The direct archive URL '{remoteSource.ServerUri}' is not a supported archive. Supported extensions: .zip, .7z."]);
-        }
+        ValidatedPlateauRemoteImportSource remoteSource = (ValidatedPlateauRemoteImportSource)request.Source;
 
         _ = WorkRootLayout.CreateSafePathSegment(request.Dataset);
         _ = TryCreateSafePathSegment(request.MeshCode, out _);
@@ -69,7 +64,7 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
             {
                 return request with
                 {
-                    Source = new PlateauLocalImportSource(archivePath),
+                    Source = new ValidatedPlateauLocalImportSource(archivePath),
                 };
             }
         }
@@ -78,7 +73,7 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
 
         return request with
         {
-            Source = new PlateauLocalImportSource(archivePath),
+            Source = new ValidatedPlateauLocalImportSource(archivePath),
         };
     }
 
@@ -339,11 +334,6 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
         }
     }
 
-    private static bool LooksLikeSupportedArchiveUri(Uri uri)
-    {
-        return TryGetArchiveKind(uri.AbsolutePath, out _);
-    }
-
     private static string GetArchiveFileName(Uri archiveUri)
     {
         string fileName = Path.GetFileName(archiveUri.LocalPath);
@@ -387,31 +377,6 @@ public sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceReso
             || normalized.Contains("..\\", StringComparison.Ordinal)
             || normalized.StartsWith("./", StringComparison.Ordinal)
             || normalized.StartsWith(".\\", StringComparison.Ordinal);
-    }
-
-    private static bool TryGetArchiveKind(string path, out SupportedArchiveKind archiveKind)
-    {
-        string extension = Path.GetExtension(path);
-        if (string.Equals(extension, ".zip", StringComparison.OrdinalIgnoreCase))
-        {
-            archiveKind = SupportedArchiveKind.Zip;
-            return true;
-        }
-
-        if (string.Equals(extension, ".7z", StringComparison.OrdinalIgnoreCase))
-        {
-            archiveKind = SupportedArchiveKind.SevenZip;
-            return true;
-        }
-
-        archiveKind = default;
-        return false;
-    }
-
-    private enum SupportedArchiveKind
-    {
-        Zip,
-        SevenZip,
     }
 
     private sealed record ArchiveMetadata(

--- a/src/Plateau.ResoniteLink.Application/Importing/IPlateauDatasetSourceResolver.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/IPlateauDatasetSourceResolver.cs
@@ -1,11 +1,9 @@
-using Plateau.ResoniteLink.Domain.Importing;
-
 namespace Plateau.ResoniteLink.Application.Importing;
 
 public interface IPlateauDatasetSourceResolver
 {
-    Task<PlateauImportRequest> ResolveAsync(
-        PlateauImportRequest request,
+    Task<ValidatedPlateauImportRequest> ResolveAsync(
+        ValidatedPlateauImportRequest request,
         string workRoot,
         CancellationToken cancellationToken = default);
 }

--- a/src/Plateau.ResoniteLink.Application/Importing/PlateauImportRequestValidator.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/PlateauImportRequestValidator.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 using Plateau.ResoniteLink.Domain.Importing;
 
 namespace Plateau.ResoniteLink.Application.Importing;
@@ -8,33 +10,62 @@ public static class PlateauImportRequestValidator
 
     public static IReadOnlyList<string> Validate(PlateauImportRequest request)
     {
+        _ = TryNormalizeAndValidate(request, out _, out IReadOnlyList<string> errors);
+        return errors;
+    }
+
+    public static bool TryNormalizeAndValidate(
+        PlateauImportRequest request,
+        out ValidatedPlateauImportRequest? validatedRequest,
+        out IReadOnlyList<string> errors)
+    {
         ArgumentNullException.ThrowIfNull(request);
 
-        List<string> errors = [];
+        PlateauImportRequest normalizedRequest = NormalizeRawRequest(request);
+        List<string> validationErrors = [];
+        Regex? meshCodePattern = null;
+        IReadOnlyList<string>? normalizedPackageNames = null;
+        IReadOnlyDictionary<string, IReadOnlySet<int>>? normalizedPackageExclusions = null;
+        IReadOnlyDictionary<string, string>? normalizedPackagePatterns = null;
+        ValidatedPlateauImportSource? validatedSource = null;
 
-        if (string.IsNullOrWhiteSpace(request.Dataset))
+        if (string.IsNullOrWhiteSpace(normalizedRequest.Dataset))
         {
-            errors.Add("The dataset value is required.");
+            validationErrors.Add("The dataset value is required.");
         }
 
-        if (string.IsNullOrWhiteSpace(request.MeshCode))
+        if (string.IsNullOrWhiteSpace(normalizedRequest.MeshCode))
         {
-            errors.Add("The mesh code value is required.");
+            validationErrors.Add("The mesh code value is required.");
         }
-        else if (!MeshCodeInput.TryCreateRegex(request.MeshCode, out _, out string? meshCodeError))
+        else if (!MeshCodeInput.TryCreateRegex(normalizedRequest.MeshCode, out meshCodePattern, out string? meshCodeError))
         {
-            errors.Add(meshCodeError!);
+            validationErrors.Add(meshCodeError!);
+        }
+        else if (meshCodePattern is null)
+        {
+            meshCodePattern = new Regex(
+                $@"\A(?:{Regex.Escape(normalizedRequest.MeshCode)})\z",
+                RegexOptions.Compiled | RegexOptions.CultureInvariant,
+                TimeSpan.FromSeconds(1));
+        }
+        else if (meshCodePattern is null)
+        {
+            meshCodePattern = new Regex(
+                $@"\A(?:{Regex.Escape(normalizedRequest.MeshCode)})\z",
+                RegexOptions.Compiled | RegexOptions.CultureInvariant,
+                TimeSpan.FromSeconds(1));
         }
 
-        if (request.PackageNames is not null)
+        if (normalizedRequest.PackageNames is not null)
         {
-            if (request.PackageNames.Count == 0)
+            if (normalizedRequest.PackageNames.Count == 0)
             {
-                errors.Add("At least one package name is required when packages are specified.");
+                validationErrors.Add("At least one package name is required when packages are specified.");
             }
             else
             {
-                string[] unsupportedPackageNames = request.PackageNames
+                string[] unsupportedPackageNames = normalizedRequest.PackageNames
                     .Select(static packageName => NormalizePackageNameInput(packageName))
                     .Where(static packageName => !PlateauPackageCatalog.TryNormalizePackageName(packageName, out _))
                     .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -43,20 +74,24 @@ public static class PlateauImportRequestValidator
 
                 if (unsupportedPackageNames.Length > 0)
                 {
-                    errors.Add(
+                    validationErrors.Add(
                         $"Unsupported package name(s): {string.Join(", ", unsupportedPackageNames)}. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.");
+                }
+                else
+                {
+                    normalizedPackageNames = PlateauPackageCatalog.NormalizeRequestedPackageNames(normalizedRequest.PackageNames);
                 }
             }
         }
 
-        if (request.ExcludeLodLevelsByPackage is not null)
+        if (normalizedRequest.ExcludeLodLevelsByPackage is not null)
         {
             AddDuplicatePackageMapKeyError(
-                request.ExcludeLodLevelsByPackage.Keys,
+                normalizedRequest.ExcludeLodLevelsByPackage.Keys,
                 "ExcludeLodLevelsByPackage",
-                errors);
+                validationErrors);
 
-            string[] unsupportedPackageNames = request.ExcludeLodLevelsByPackage.Keys
+            string[] unsupportedPackageNames = normalizedRequest.ExcludeLodLevelsByPackage.Keys
                 .Select(static packageName => NormalizePackageNameInput(packageName))
                 .Where(static packageName => !PlateauPackageCatalog.TryNormalizePackageName(packageName, out _))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -65,19 +100,23 @@ public static class PlateauImportRequestValidator
 
             if (unsupportedPackageNames.Length > 0)
             {
-                errors.Add(
+                validationErrors.Add(
                     $"Unsupported package name(s): {string.Join(", ", unsupportedPackageNames)}. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.");
+            }
+            else
+            {
+                normalizedPackageExclusions = NormalizePackageExclusionMap(normalizedRequest.ExcludeLodLevelsByPackage);
             }
         }
 
-        if (request.PackagePatterns is not null)
+        if (normalizedRequest.PackagePatterns is not null)
         {
             AddDuplicatePackageMapKeyError(
-                request.PackagePatterns.Keys,
+                normalizedRequest.PackagePatterns.Keys,
                 "PackagePatterns",
-                errors);
+                validationErrors);
 
-            string[] unsupportedPackageNames = request.PackagePatterns.Keys
+            string[] unsupportedPackageNames = normalizedRequest.PackagePatterns.Keys
                 .Select(static packageName => NormalizePackageNameInput(packageName))
                 .Where(static packageName => !PlateauPackageCatalog.TryNormalizePackageName(packageName, out _))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -86,59 +125,98 @@ public static class PlateauImportRequestValidator
 
             if (unsupportedPackageNames.Length > 0)
             {
-                errors.Add(
+                validationErrors.Add(
                     $"Unsupported package name(s): {string.Join(", ", unsupportedPackageNames)}. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.");
+            }
+            else
+            {
+                normalizedPackagePatterns = NormalizePackagePatternMap(normalizedRequest.PackagePatterns);
             }
         }
 
-        switch (request.Source)
+        switch (normalizedRequest.Source)
         {
             case PlateauLocalImportSource localSource:
                 if (string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
                 {
-                    errors.Add("The --local-source-path value is required when --source local is used.");
+                    validationErrors.Add("The --local-source-path value is required when --source local is used.");
                     break;
                 }
 
                 if (!Directory.Exists(localSource.LocalSourcePath)
                     && !File.Exists(localSource.LocalSourcePath))
                 {
-                    errors.Add($"The local source path '{localSource.LocalSourcePath}' does not exist.");
+                    validationErrors.Add($"The local source path '{localSource.LocalSourcePath}' does not exist.");
+                    break;
                 }
 
+                validatedSource = new ValidatedPlateauLocalImportSource(localSource.LocalSourcePath);
                 break;
             case PlateauRemoteImportSource remoteSource:
                 if (remoteSource.ServerUri is null)
                 {
-                    errors.Add("The --server-url value is required when --source remote is used.");
+                    validationErrors.Add("The --server-url value is required when --source remote is used.");
                     break;
                 }
 
                 if (!remoteSource.ServerUri.IsAbsoluteUri)
                 {
-                    errors.Add("The --server-url value must be an absolute URI.");
+                    validationErrors.Add("The --server-url value must be an absolute URI.");
                     break;
                 }
 
                 if (!LooksLikeSupportedArchiveUri(remoteSource.ServerUri))
                 {
-                    errors.Add("The --server-url value must point directly to a .zip or .7z CityGML archive over http or https.");
+                    validationErrors.Add("The --server-url value must point directly to a .zip or .7z CityGML archive over http or https.");
+                    break;
                 }
 
+                validatedSource = new ValidatedPlateauRemoteImportSource(remoteSource.ServerUri);
                 break;
         }
 
-        if (request.DemHeightmapMetersPerVertex <= 0)
+        if (normalizedRequest.DemHeightmapMetersPerVertex <= 0)
         {
-            errors.Add("The DEM heightmap meters-per-vertex value must be greater than zero.");
+            validationErrors.Add("The DEM heightmap meters-per-vertex value must be greater than zero.");
         }
 
-        if (request.DemHeightmapMaxResolution < 2)
+        if (normalizedRequest.DemHeightmapMaxResolution < 2)
         {
-            errors.Add("The DEM heightmap max resolution value must be at least 2.");
+            validationErrors.Add("The DEM heightmap max resolution value must be at least 2.");
         }
 
-        return errors;
+        if (validationErrors.Count > 0)
+        {
+            validatedRequest = null;
+            errors = validationErrors;
+            return false;
+        }
+
+        validatedRequest = new ValidatedPlateauImportRequest(
+            normalizedRequest.Dataset,
+            normalizedRequest.MeshCode,
+            meshCodePattern!,
+            validatedSource!,
+            normalizedPackageNames,
+            normalizedRequest.GlobalExcludeLodLevels,
+            normalizedPackageExclusions,
+            normalizedPackagePatterns,
+            normalizedRequest.IncludeMarkingAlways,
+            normalizedRequest.DemTerrainMode,
+            normalizedRequest.DemHeightmapMetersPerVertex,
+            normalizedRequest.DemHeightmapMaxResolution);
+        errors = Array.Empty<string>();
+        return true;
+    }
+
+    public static ValidatedPlateauImportRequest NormalizeAndValidateOrThrow(PlateauImportRequest request)
+    {
+        if (TryNormalizeAndValidate(request, out ValidatedPlateauImportRequest? validatedRequest, out IReadOnlyList<string> errors))
+        {
+            return validatedRequest!;
+        }
+
+        throw new PlateauImportValidationException(errors);
     }
 
     internal static bool LooksLikeSupportedArchiveUri(Uri serverUri)
@@ -191,5 +269,66 @@ public static class PlateauImportRequestValidator
         return PlateauPackageCatalog.TryNormalizePackageName(trimmedPackageName, out string normalizedPackageName)
             ? normalizedPackageName
             : null;
+    }
+
+    private static PlateauImportRequest NormalizeRawRequest(PlateauImportRequest request)
+    {
+        return request with
+        {
+            Dataset = TrimToEmpty(request.Dataset),
+            MeshCode = TrimToEmpty(request.MeshCode),
+            Source = NormalizeSource(request.Source),
+            PackageNames = request.PackageNames is null
+                ? null
+                : request.PackageNames.Select(static packageName => TrimToEmpty(packageName)).ToArray(),
+        };
+    }
+
+    private static PlateauImportSource NormalizeSource(PlateauImportSource source)
+    {
+        return source switch
+        {
+            PlateauLocalImportSource localSource => new PlateauLocalImportSource(
+                string.IsNullOrWhiteSpace(localSource.LocalSourcePath)
+                    ? null
+                    : localSource.LocalSourcePath.Trim()),
+            PlateauRemoteImportSource remoteSource => remoteSource.ServerUri is null
+                ? new PlateauRemoteImportSource(null)
+                : remoteSource,
+            _ => source,
+        };
+    }
+
+    private static Dictionary<string, IReadOnlySet<int>> NormalizePackageExclusionMap(
+        IReadOnlyDictionary<string, IReadOnlySet<int>> exclusionsByPackage)
+    {
+        Dictionary<string, IReadOnlySet<int>> normalized = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach ((string packageName, IReadOnlySet<int> excludedLods) in exclusionsByPackage)
+        {
+            PlateauPackageCatalog.TryNormalizePackageName(packageName, out string normalizedPackageName);
+            normalized[normalizedPackageName] = excludedLods;
+        }
+
+        return normalized;
+    }
+
+    private static Dictionary<string, string> NormalizePackagePatternMap(
+        IReadOnlyDictionary<string, string> patternsByPackage)
+    {
+        Dictionary<string, string> normalized = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach ((string packageName, string pattern) in patternsByPackage)
+        {
+            PlateauPackageCatalog.TryNormalizePackageName(packageName, out string normalizedPackageName);
+            normalized[normalizedPackageName] = pattern;
+        }
+
+        return normalized;
+    }
+
+    private static string TrimToEmpty(string? value)
+    {
+        return value?.Trim() ?? string.Empty;
     }
 }

--- a/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
@@ -25,18 +25,12 @@ public sealed class PlateauImportService(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
 
-        PlateauImportRequest validationRequest = NormalizeRequestForValidation(request);
-        IReadOnlyList<string> validationErrors = PlateauImportRequestValidator.Validate(validationRequest);
-        if (validationErrors.Count > 0)
-        {
-            throw new PlateauImportValidationException(validationErrors);
-        }
-
-        PlateauImportRequest normalizedRequest = NormalizeRequest(validationRequest);
-        string datasetWorkRoot = WorkRootLayout.ResolveDatasetRoot(workRoot, normalizedRequest.Dataset);
+        ValidatedPlateauImportRequest validatedRequest = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(request);
+        PlateauImportRequest normalizedRequest = validatedRequest.ToImportRequest();
+        string datasetWorkRoot = WorkRootLayout.ResolveDatasetRoot(workRoot, validatedRequest.Dataset);
 
         PlateauImportRequest resolvedRequest =
-            await datasetSourceResolver.ResolveAsync(normalizedRequest, datasetWorkRoot, cancellationToken);
+            (await datasetSourceResolver.ResolveAsync(validatedRequest, datasetWorkRoot, cancellationToken)).ToImportRequest();
         ReportProgress(
             PlateauLog.Debug("import", $"Resolved dataset source for '{resolvedRequest.Dataset}' mesh '{resolvedRequest.MeshCode}'."));
 
@@ -100,98 +94,5 @@ public sealed class PlateauImportService(
     private void ReportProgress(string message)
     {
         progressReporter?.Invoke(message);
-    }
-
-    private static PlateauImportRequest NormalizeRequestForValidation(PlateauImportRequest request)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-
-        return request with
-        {
-            Dataset = TrimToEmpty(request.Dataset),
-            MeshCode = TrimToEmpty(request.MeshCode),
-            Source = NormalizeSourceForValidation(request.Source),
-            PackageNames = request.PackageNames is null
-                ? null
-                : request.PackageNames.Select(static packageName => TrimToEmpty(packageName)).ToArray(),
-        };
-    }
-
-    private static string TrimToEmpty(string? value)
-    {
-        return value?.Trim() ?? string.Empty;
-    }
-
-    private static PlateauImportSource NormalizeSourceForValidation(PlateauImportSource source)
-    {
-        ArgumentNullException.ThrowIfNull(source);
-
-        return source switch
-        {
-            PlateauLocalImportSource localSource => new PlateauLocalImportSource(
-                string.IsNullOrWhiteSpace(localSource.LocalSourcePath)
-                    ? null
-                    : localSource.LocalSourcePath.Trim()),
-            PlateauRemoteImportSource remoteSource => remoteSource.ServerUri is null
-                ? new PlateauRemoteImportSource(null)
-                : remoteSource,
-            _ => source,
-        };
-    }
-
-    private static PlateauImportRequest NormalizeRequest(PlateauImportRequest request)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-
-        return request with
-        {
-            PackageNames = request.PackageNames is null
-                ? null
-                : PlateauPackageCatalog.NormalizeRequestedPackageNames(request.PackageNames),
-            ExcludeLodLevelsByPackage = request.ExcludeLodLevelsByPackage is null
-                ? null
-                : NormalizePackageExclusionMap(request.ExcludeLodLevelsByPackage),
-            PackagePatterns = request.PackagePatterns is null
-                ? null
-                : NormalizePackagePatternMap(request.PackagePatterns),
-        };
-    }
-
-    private static Dictionary<string, IReadOnlySet<int>> NormalizePackageExclusionMap(
-        IReadOnlyDictionary<string, IReadOnlySet<int>> exclusionsByPackage)
-    {
-        Dictionary<string, IReadOnlySet<int>> normalized = new(StringComparer.OrdinalIgnoreCase);
-
-        foreach ((string packageName, IReadOnlySet<int> excludedLods) in exclusionsByPackage)
-        {
-            if (!PlateauPackageCatalog.TryNormalizePackageName(packageName, out string normalizedPackageName))
-            {
-                throw new ArgumentException(
-                    $"Unsupported package '{packageName}'. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.");
-            }
-
-            normalized[normalizedPackageName] = excludedLods;
-        }
-
-        return normalized;
-    }
-
-    private static Dictionary<string, string> NormalizePackagePatternMap(
-        IReadOnlyDictionary<string, string> patternsByPackage)
-    {
-        Dictionary<string, string> normalized = new(StringComparer.OrdinalIgnoreCase);
-
-        foreach ((string packageName, string pattern) in patternsByPackage)
-        {
-            if (!PlateauPackageCatalog.TryNormalizePackageName(packageName, out string normalizedPackageName))
-            {
-                throw new ArgumentException(
-                    $"Unsupported package '{packageName}'. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.");
-            }
-
-            normalized[normalizedPackageName] = pattern;
-        }
-
-        return normalized;
     }
 }

--- a/src/Plateau.ResoniteLink.Application/Importing/ValidatedPlateauImportRequest.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/ValidatedPlateauImportRequest.cs
@@ -1,0 +1,49 @@
+using System.Text.RegularExpressions;
+
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Application.Importing;
+
+public sealed record ValidatedPlateauImportRequest(
+    string Dataset,
+    string MeshCode,
+    Regex MeshCodePattern,
+    ValidatedPlateauImportSource Source,
+    IReadOnlyList<string>? PackageNames = null,
+    IReadOnlySet<int>? GlobalExcludeLodLevels = null,
+    IReadOnlyDictionary<string, IReadOnlySet<int>>? ExcludeLodLevelsByPackage = null,
+    IReadOnlyDictionary<string, string>? PackagePatterns = null,
+    bool IncludeMarkingAlways = true,
+    DemTerrainMode DemTerrainMode = DemTerrainMode.Mesh,
+    double DemHeightmapMetersPerVertex = 2.0,
+    int DemHeightmapMaxResolution = 1024)
+{
+    public DatasetSourceKind SourceKind => Source.SourceKind;
+
+    public string? LocalSourcePath => Source is ValidatedPlateauLocalImportSource localSource ? localSource.LocalSourcePath : null;
+
+    public Uri? ServerUri => Source is ValidatedPlateauRemoteImportSource remoteSource ? remoteSource.ServerUri : null;
+
+    public PlateauImportRequest ToImportRequest()
+    {
+        PlateauImportSource rawSource = Source switch
+        {
+            ValidatedPlateauLocalImportSource localSource => new PlateauLocalImportSource(localSource.LocalSourcePath),
+            ValidatedPlateauRemoteImportSource remoteSource => new PlateauRemoteImportSource(remoteSource.ServerUri),
+            _ => throw new InvalidOperationException($"Unsupported validated source kind '{SourceKind}'."),
+        };
+
+        return new PlateauImportRequest(
+            Dataset,
+            MeshCode,
+            rawSource,
+            PackageNames,
+            GlobalExcludeLodLevels,
+            ExcludeLodLevelsByPackage,
+            PackagePatterns,
+            IncludeMarkingAlways,
+            DemTerrainMode,
+            DemHeightmapMetersPerVertex,
+            DemHeightmapMaxResolution);
+    }
+}

--- a/src/Plateau.ResoniteLink.Application/Importing/ValidatedPlateauImportSource.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/ValidatedPlateauImportSource.cs
@@ -1,0 +1,11 @@
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Application.Importing;
+
+public abstract record ValidatedPlateauImportSource(DatasetSourceKind SourceKind);
+
+public sealed record ValidatedPlateauLocalImportSource(string LocalSourcePath)
+    : ValidatedPlateauImportSource(DatasetSourceKind.Local);
+
+public sealed record ValidatedPlateauRemoteImportSource(Uri ServerUri)
+    : ValidatedPlateauImportSource(DatasetSourceKind.Remote);

--- a/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
@@ -102,12 +102,12 @@ public static class CliArgumentsParser
                     case "--packages":
                         {
                             string packageValue = ReadValue(args, ref index, token);
-                            if (!TryParsePackageNames(packageValue, out string[]? parsedPackageNames, out string? packageError))
+                            packageNames = ParsePackageNames(packageValue, out string? packageError);
+                            if (packageError is not null)
                             {
-                                return CliParseResult.Failure(packageError!);
+                                return CliParseResult.Failure(packageError);
                             }
 
-                            packageNames = parsedPackageNames!;
                             break;
                         }
                     case "--tile":
@@ -252,12 +252,6 @@ public static class CliArgumentsParser
                                     $"The value '{serverUrl}' is not a valid absolute URL.");
                             }
 
-                            if (!LooksLikeSupportedArchiveUri(serverUri))
-                            {
-                                return CliParseResult.Failure(
-                                    "The --server-url value must point directly to a .zip or .7z CityGML archive over http or https.");
-                            }
-
                             break;
                         }
                     case "--exclude-lod":
@@ -294,10 +288,10 @@ public static class CliArgumentsParser
                         }
                     default:
                         {
-                            if (TryParsePackagePatternOption(token, args, ref index, out string? normalizedPackageName, out string? patternValue))
+                            if (TryParsePackagePatternOption(token, args, ref index, out string? packageName, out string? patternValue))
                             {
-                                packagePatterns ??= new(StringComparer.OrdinalIgnoreCase);
-                                packagePatterns[normalizedPackageName!] = patternValue!;
+                                packagePatterns ??= new();
+                                packagePatterns[packageName!] = patternValue!;
                                 break;
                             }
 
@@ -395,12 +389,10 @@ public static class CliArgumentsParser
             out _);
     }
 
-    private static bool TryParsePackageNames(
+    private static string[] ParsePackageNames(
         string csvValue,
-        out string[]? packageNames,
         out string? error)
     {
-        packageNames = null;
         error = null;
 
         string[] parsedValues = csvValue
@@ -409,23 +401,9 @@ public static class CliArgumentsParser
         if (parsedValues.Length == 0)
         {
             error = "The --packages option requires at least one package name.";
-            return false;
         }
 
-        string[] unsupportedPackageNames = parsedValues
-            .Where(packageName => !PlateauPackageCatalog.TryNormalizePackageName(packageName, out _))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-
-        if (unsupportedPackageNames.Length > 0)
-        {
-            error =
-                $"Unsupported package name(s): {string.Join(", ", unsupportedPackageNames)}. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.";
-            return false;
-        }
-
-        packageNames = PlateauPackageCatalog.NormalizeRequestedPackageNames(parsedValues);
-        return true;
+        return parsedValues;
     }
 
     private static bool TryParseLodExclusionRules(
@@ -477,7 +455,7 @@ public static class CliArgumentsParser
         string[] pairs = csvValue
             .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
-        Dictionary<string, HashSet<int>> map = new(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, HashSet<int>> map = new();
 
         foreach (string pair in pairs)
         {
@@ -492,16 +470,10 @@ public static class CliArgumentsParser
             string packageName = parts[0];
             string lodStr = parts[1];
 
-            if (!PlateauPackageCatalog.TryNormalizePackageName(packageName, out string? normalizedName))
-            {
-                error = $"Unsupported package '{packageName}' in --exclude-lod-for-package.";
-                return false;
-            }
-
-            if (!map.TryGetValue(normalizedName!, out HashSet<int>? lodSet))
+            if (!map.TryGetValue(packageName, out HashSet<int>? lodSet))
             {
                 lodSet = new HashSet<int>();
-                map[normalizedName!] = lodSet;
+                map[packageName] = lodSet;
             }
 
             if (string.IsNullOrWhiteSpace(lodStr)
@@ -534,10 +506,10 @@ public static class CliArgumentsParser
         string token,
         string[] args,
         ref int index,
-        out string? normalizedPackageName,
+        out string? packageName,
         out string? patternValue)
     {
-        normalizedPackageName = null;
+        packageName = null;
         patternValue = null;
 
         const string suffix = "-pattern";
@@ -547,28 +519,8 @@ public static class CliArgumentsParser
             return false;
         }
 
-        string packageName = token[2..^suffix.Length];
-        if (!PlateauPackageCatalog.TryNormalizePackageName(packageName, out string? normalized))
-        {
-            return false;
-        }
-
-        normalizedPackageName = normalized;
+        packageName = token[2..^suffix.Length];
         patternValue = ReadValue(args, ref index, token);
         return true;
     }
-
-    private static bool LooksLikeSupportedArchiveUri(Uri serverUri)
-    {
-        if (!string.Equals(serverUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(serverUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        string extension = Path.GetExtension(serverUri.AbsolutePath);
-        return string.Equals(extension, ".zip", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(extension, ".7z", StringComparison.OrdinalIgnoreCase);
-    }
-
 }

--- a/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverCacheTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverCacheTests.cs
@@ -26,12 +26,13 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
 
         await Assert.ThrowsAsync<PlateauImportValidationException>(
             () => resolver.ResolveAsync(
-                new PlateauImportRequest(
+                PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+                    new PlateauImportRequest(
                     Dataset: dataset,
                     MeshCode: mesh,
                     SourceKind: DatasetSourceKind.Remote,
                     LocalSourcePath: null,
-                    ServerUri: new Uri("https://example.test/direct.zip", UriKind.Absolute)),
+                    ServerUri: new Uri("https://example.test/direct.zip", UriKind.Absolute))),
                 workRoot.Path));
     }
 
@@ -47,13 +48,14 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = new(httpClient);
 
-        PlateauImportRequest resolved = await resolver.ResolveAsync(
-            new PlateauImportRequest(
+        ValidatedPlateauImportRequest resolved = await resolver.ResolveAsync(
+            PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+                new PlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: @"^533944\d$",
                 SourceKind: DatasetSourceKind.Remote,
                 LocalSourcePath: null,
-                ServerUri: new Uri("https://example.test/direct.zip", UriKind.Absolute)),
+                ServerUri: new Uri("https://example.test/direct.zip", UriKind.Absolute))),
             workRoot.Path);
 
         Assert.NotNull(resolved.LocalSourcePath);
@@ -72,13 +74,14 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = new(httpClient);
 
-        PlateauImportRequest resolved = await resolver.ResolveAsync(
-            new PlateauImportRequest(
+        ValidatedPlateauImportRequest resolved = await resolver.ResolveAsync(
+            PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+                new PlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "533944|533945/branch",
                 SourceKind: DatasetSourceKind.Remote,
                 LocalSourcePath: null,
-                ServerUri: new Uri("https://example.test/direct.zip", UriKind.Absolute)),
+                ServerUri: new Uri("https://example.test/direct.zip", UriKind.Absolute))),
             workRoot.Path);
 
         Assert.NotNull(resolved.LocalSourcePath);
@@ -116,22 +119,24 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = new(httpClient);
 
-        PlateauImportRequest firstRequest = await resolver.ResolveAsync(
-            new PlateauImportRequest(
+        ValidatedPlateauImportRequest firstRequest = await resolver.ResolveAsync(
+            PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+                new PlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "533944",
                 SourceKind: DatasetSourceKind.Remote,
                 LocalSourcePath: null,
-                ServerUri: new Uri("https://example-a.test/533944.zip", UriKind.Absolute)),
+                ServerUri: new Uri("https://example-a.test/533944.zip", UriKind.Absolute))),
             workRoot.Path);
 
-        PlateauImportRequest secondRequest = await resolver.ResolveAsync(
-            new PlateauImportRequest(
+        ValidatedPlateauImportRequest secondRequest = await resolver.ResolveAsync(
+            PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+                new PlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "533944",
                 SourceKind: DatasetSourceKind.Remote,
                 LocalSourcePath: null,
-                ServerUri: new Uri("https://example-b.test/533944.zip", UriKind.Absolute)),
+                ServerUri: new Uri("https://example-b.test/533944.zip", UriKind.Absolute))),
             workRoot.Path);
 
         Assert.NotNull(firstRequest.LocalSourcePath);
@@ -207,13 +212,14 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = new(httpClient);
 
-        PlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
-            new PlateauImportRequest(
+        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+            PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+                new PlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "533944",
                 SourceKind: DatasetSourceKind.Remote,
                 LocalSourcePath: null,
-                ServerUri: archiveUri),
+                ServerUri: archiveUri)),
             workRoot.Path);
 
         Assert.Equal(archivePath, resolvedRequest.LocalSourcePath);

--- a/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/CkanPlateauDatasetSourceResolverTests.cs
@@ -14,29 +14,6 @@ namespace Plateau.ResoniteLink.Tests.Application;
 public sealed class CkanPlateauDatasetSourceResolverTests
 {
     [Fact]
-    public async Task ResolveAsyncRejectsMissingServerUrl()
-    {
-        using TemporaryDirectory workRoot = new();
-        using StubHttpMessageHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
-        using HttpClient httpClient = new(handler);
-        CkanPlateauDatasetSourceResolver resolver = new(httpClient);
-
-        PlateauImportValidationException exception = await Assert.ThrowsAsync<PlateauImportValidationException>(
-            () => resolver.ResolveAsync(
-                new PlateauImportRequest(
-                    Dataset: "tokyo23ku",
-                    MeshCode: "533944",
-                    SourceKind: DatasetSourceKind.Remote,
-                    LocalSourcePath: null,
-                    ServerUri: null),
-                workRoot.Path));
-
-        Assert.Contains(
-            exception.Errors,
-            error => error.Contains("--server-url", StringComparison.Ordinal));
-    }
-
-    [Fact]
     public async Task ResolveAsyncAcceptsDirectArchiveUri()
     {
         byte[] zipBytes = CreateZipArchive(
@@ -60,18 +37,19 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = new(httpClient);
 
-        PlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
-            new PlateauImportRequest(
+        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+            PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+                new PlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "533944",
                 SourceKind: DatasetSourceKind.Remote,
                 LocalSourcePath: null,
-                ServerUri: new Uri("https://example.test/direct.zip", UriKind.Absolute)),
+                ServerUri: new Uri("https://example.test/direct.zip", UriKind.Absolute))),
             workRoot.Path);
 
         Assert.Equal(DatasetSourceKind.Local, resolvedRequest.SourceKind);
         await AssertResolvedArchiveContainsAsync(
-            resolvedRequest,
+            resolvedRequest.ToImportRequest(),
             "direct.zip",
             "udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml");
     }
@@ -100,18 +78,19 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = new(httpClient);
 
-        PlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
-            new PlateauImportRequest(
+        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+            PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+                new PlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "533944",
                 SourceKind: DatasetSourceKind.Remote,
                 LocalSourcePath: null,
-                ServerUri: new Uri("https://example.test/direct.7z", UriKind.Absolute)),
+                ServerUri: new Uri("https://example.test/direct.7z", UriKind.Absolute))),
             workRoot.Path);
 
         Assert.Equal(DatasetSourceKind.Local, resolvedRequest.SourceKind);
         await AssertResolvedArchiveContainsAsync(
-            resolvedRequest,
+            resolvedRequest.ToImportRequest(),
             "direct.7z",
             "udx/bldg/533944/plateau_tokyo23ku_bldg_533944.gml");
     }
@@ -140,18 +119,19 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = new(httpClient);
 
-        PlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
-            new PlateauImportRequest(
+        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+            PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+                new PlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "53394611",
                 SourceKind: DatasetSourceKind.Remote,
                 LocalSourcePath: null,
-                ServerUri: new Uri("https://example.test/wrapped.zip", UriKind.Absolute)),
+                ServerUri: new Uri("https://example.test/wrapped.zip", UriKind.Absolute))),
             workRoot.Path);
 
         Assert.Equal(DatasetSourceKind.Local, resolvedRequest.SourceKind);
         await AssertResolvedArchiveContainsAsync(
-            resolvedRequest,
+            resolvedRequest.ToImportRequest(),
             "wrapped.zip",
             "udx/bldg/53394611_bldg_6697_2_op.gml");
     }
@@ -180,18 +160,19 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = new(httpClient);
 
-        PlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
-            new PlateauImportRequest(
+        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+            PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+                new PlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "53394611",
                 SourceKind: DatasetSourceKind.Remote,
                 LocalSourcePath: null,
-                ServerUri: new Uri("https://example.test/wrapped.7z", UriKind.Absolute)),
+                ServerUri: new Uri("https://example.test/wrapped.7z", UriKind.Absolute))),
             workRoot.Path);
 
         Assert.Equal(DatasetSourceKind.Local, resolvedRequest.SourceKind);
         await AssertResolvedArchiveContainsAsync(
-            resolvedRequest,
+            resolvedRequest.ToImportRequest(),
             "wrapped.7z",
             "udx/bldg/53394611_bldg_6697_2_op.gml");
     }
@@ -338,7 +319,9 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         Assert.Contains(
             exception.Errors,
-            error => error.Contains("not a supported archive", StringComparison.Ordinal));
+            error => error.Contains(
+                "must point directly to a .zip or .7z CityGML archive",
+                StringComparison.Ordinal));
     }
 
     [Fact]
@@ -386,7 +369,9 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         Assert.Contains(
             exception.Errors,
-            error => error.Contains("not a supported archive", StringComparison.Ordinal));
+            error => error.Contains(
+                "must point directly to a .zip or .7z CityGML archive",
+                StringComparison.Ordinal));
     }
 
     private static byte[] CreateZipArchive(params (string Path, string Content)[] entries)

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -46,6 +46,62 @@ public sealed class PlateauImportRequestValidatorTests
     }
 
     [Fact]
+    public void TryNormalizeAndValidateTrimsAndNormalizesRequestData()
+    {
+        using TemporaryDirectory sourceRoot = new();
+
+        PlateauImportRequest request = new(
+            Dataset: " tokyo23ku ",
+            MeshCode: " 53394525 ",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: $"  {sourceRoot.Path}  ",
+            ServerUri: null,
+            PackageNames: [" waterbody ", " tran "]);
+
+        bool success = PlateauImportRequestValidator.TryNormalizeAndValidate(
+            request,
+            out ValidatedPlateauImportRequest? validatedRequest,
+            out IReadOnlyList<string> errors);
+
+        Assert.True(success);
+        Assert.Empty(errors);
+        Assert.NotNull(validatedRequest);
+        Assert.Equal("tokyo23ku", validatedRequest!.Dataset);
+        Assert.Equal("53394525", validatedRequest.MeshCode);
+        Assert.Matches(validatedRequest.MeshCodePattern, "53394525");
+        Assert.DoesNotMatch(validatedRequest.MeshCodePattern, "53394526");
+        Assert.IsType<ValidatedPlateauLocalImportSource>(validatedRequest.Source);
+        Assert.Equal(sourceRoot.Path, validatedRequest.LocalSourcePath);
+        Assert.Equal(["wtr", "tran"], validatedRequest.PackageNames);
+
+        PlateauImportRequest roundTrippedRequest = validatedRequest.ToImportRequest();
+        Assert.Equal("tokyo23ku", roundTrippedRequest.Dataset);
+        Assert.Equal("53394525", roundTrippedRequest.MeshCode);
+        Assert.Equal(sourceRoot.Path, roundTrippedRequest.LocalSourcePath);
+        Assert.Equal(["wtr", "tran"], roundTrippedRequest.PackageNames);
+    }
+
+    [Fact]
+    public void ValidateRejectsUnsupportedPackageNamesInPackageList()
+    {
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "C:/dataset",
+            ServerUri: null,
+            PackageNames: ["bldg", "unknown", "waterbody"]);
+
+        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
+
+        Assert.Contains(
+            errors,
+            error => error.Contains(
+                "Unsupported package name(s): unknown.",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void ValidateRejectsUnsupportedPackageKeysInPackageMaps()
     {
         PlateauImportRequest request = new(
@@ -104,6 +160,73 @@ public sealed class PlateauImportRequestValidatorTests
             errors,
             error => error.Contains(
                 "The PackagePatterns value contains duplicate package keys after normalization: wtr.",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRequiresLocalSourcePathForLocalSource()
+    {
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: null,
+            ServerUri: null);
+
+        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
+
+        Assert.Contains(
+            errors,
+            error => string.Equals(
+                error,
+                "The --local-source-path value is required when --source local is used.",
+                StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ValidateAcceptsExistingLocalSourcePath(bool createFile)
+    {
+        using TemporaryDirectory sourceRoot = new();
+        string localSourcePath = createFile
+            ? Path.Combine(sourceRoot.Path, "source.gml")
+            : sourceRoot.Path;
+
+        if (createFile)
+        {
+            File.WriteAllText(localSourcePath, "<CityModel />");
+        }
+
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: localSourcePath,
+            ServerUri: null);
+
+        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ValidateRejectsMissingLocalSourcePath()
+    {
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "/path/that/does/not/exist",
+            ServerUri: null);
+
+        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
+
+        Assert.Contains(
+            errors,
+            error => string.Equals(
+                error,
+                "The local source path '/path/that/does/not/exist' does not exist.",
                 StringComparison.Ordinal));
     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -2466,14 +2466,35 @@ public sealed class PlateauImportServiceTests
         public List<PlateauImportRequest> Requests { get; } = [];
         public List<string> WorkRoots { get; } = [];
 
-        public Task<PlateauImportRequest> ResolveAsync(
-            PlateauImportRequest request,
+        public Task<ValidatedPlateauImportRequest> ResolveAsync(
+            ValidatedPlateauImportRequest request,
             string workRoot,
             CancellationToken cancellationToken = default)
         {
-            Requests.Add(request);
+            Requests.Add(request.ToImportRequest());
             WorkRoots.Add(workRoot);
-            return Task.FromResult(resolvedRequest);
+
+            ValidatedPlateauImportSource resolvedSource = resolvedRequest.Source switch
+            {
+                PlateauLocalImportSource localSource => new ValidatedPlateauLocalImportSource(localSource.LocalSourcePath!),
+                PlateauRemoteImportSource remoteSource => new ValidatedPlateauRemoteImportSource(remoteSource.ServerUri!),
+                _ => throw new InvalidOperationException($"Unsupported source kind '{resolvedRequest.SourceKind}'."),
+            };
+
+            return Task.FromResult(
+                new ValidatedPlateauImportRequest(
+                    resolvedRequest.Dataset,
+                    resolvedRequest.MeshCode,
+                    request.MeshCodePattern,
+                    resolvedSource,
+                    resolvedRequest.PackageNames,
+                    resolvedRequest.GlobalExcludeLodLevels,
+                    resolvedRequest.ExcludeLodLevelsByPackage,
+                    resolvedRequest.PackagePatterns,
+                    resolvedRequest.IncludeMarkingAlways,
+                    resolvedRequest.DemTerrainMode,
+                    resolvedRequest.DemHeightmapMetersPerVertex,
+                    resolvedRequest.DemHeightmapMaxResolution));
         }
     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -55,7 +55,7 @@ public sealed class CliArgumentsParserTests
             ]);
 
         Assert.Null(result.Error);
-        Assert.Equal(["tran", "wtr", "brid"], result.Options!.Request.PackageNames);
+        Assert.Equal(["tran", "waterbody", "tran", "brid"], result.Options!.Request.PackageNames);
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public sealed class CliArgumentsParserTests
     }
 
     [Fact]
-    public void ParseRejectsUnsupportedPackageName()
+    public void ParseParsesUnsupportedPackageName()
     {
         CliParseResult result = CliArgumentsParser.Parse(
             [
@@ -94,9 +94,8 @@ public sealed class CliArgumentsParserTests
                 "12345",
             ]);
 
-        Assert.Equal(
-            "Unsupported package name(s): unknown. Supported packages: area, bldg, brid, cons, dem, fld, frn, gen, htd, ifld, lsld, luse, rfld, rwy, squr, tnm, tran, trk, tun, ubld, unf, urf, veg, wtr, wwy.",
-            result.Error);
+        Assert.Null(result.Error);
+        Assert.Equal(["bldg", "unknown"], result.Options!.Request.PackageNames);
     }
 
     [Fact]
@@ -225,7 +224,7 @@ public sealed class CliArgumentsParserTests
     }
 
     [Fact]
-    public void ParseRejectsRemoteCommandWhenServerUrlIsNotDirectArchive()
+    public void ParseParsesRemoteCommandWhenServerUrlIsNotDirectArchive()
     {
         CliParseResult result = CliArgumentsParser.Parse(
             [
@@ -242,9 +241,10 @@ public sealed class CliArgumentsParserTests
                 "ws://localhost:12345/",
             ]);
 
+        Assert.Null(result.Error);
         Assert.Equal(
-            "The --server-url value must point directly to a .zip or .7z CityGML archive over http or https.",
-            result.Error);
+            new Uri("https://example.invalid/plateau"),
+            result.Options!.Request.ServerUri);
     }
 
     [Fact]
@@ -268,7 +268,34 @@ public sealed class CliArgumentsParserTests
         Assert.Null(result.Error);
         Assert.NotNull(result.Options);
         Assert.NotNull(result.Options.Request.PackagePatterns);
-        Assert.Equal("*Water*", result.Options.Request.PackagePatterns["wtr"]);
+        Assert.Equal("*Water*", result.Options.Request.PackagePatterns["waterbody"]);
+    }
+
+    [Fact]
+    public void ParsePreservesPackageSpecificLodKeysWithoutSemanticNormalization()
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "build",
+                "--dataset",
+                "tokyo23ku",
+                "--mesh-code",
+                "53394525",
+                "--local-source-path",
+                "/data/plateau",
+                "--exclude-lod-for-package",
+                "waterbody:1,unknown:2",
+                "--resonitelink-port",
+                "12345",
+            ]);
+
+        Assert.Null(result.Error);
+        Assert.NotNull(result.Options!.Request.ExcludeLodLevelsByPackage);
+        Assert.Equal(2, result.Options.Request.ExcludeLodLevelsByPackage.Count);
+        Assert.True(result.Options.Request.ExcludeLodLevelsByPackage.TryGetValue("waterbody", out IReadOnlySet<int>? waterbodyLods));
+        Assert.True(result.Options.Request.ExcludeLodLevelsByPackage.TryGetValue("unknown", out IReadOnlySet<int>? unknownLods));
+        Assert.Equal(new HashSet<int> { 1 }, waterbodyLods);
+        Assert.Equal(new HashSet<int> { 2 }, unknownLods);
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Domain/PlateauImportRequestSourceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Domain/PlateauImportRequestSourceTests.cs
@@ -5,6 +5,21 @@ namespace Plateau.ResoniteLink.Tests.Domain;
 public sealed class PlateauImportRequestSourceTests
 {
     [Fact]
+    public void SourceFactoriesCreateTypedSources()
+    {
+        PlateauImportSource localSource = PlateauImportSource.Local("/data/plateau");
+        PlateauImportSource remoteSource = PlateauImportSource.Remote(new Uri("https://example.invalid/plateau.zip"));
+
+        PlateauLocalImportSource typedLocalSource = Assert.IsType<PlateauLocalImportSource>(localSource);
+        PlateauRemoteImportSource typedRemoteSource = Assert.IsType<PlateauRemoteImportSource>(remoteSource);
+
+        Assert.Equal("/data/plateau", typedLocalSource.LocalSourcePath);
+        Assert.Equal(DatasetSourceKind.Local, typedLocalSource.SourceKind);
+        Assert.Equal(new Uri("https://example.invalid/plateau.zip"), typedRemoteSource.ServerUri);
+        Assert.Equal(DatasetSourceKind.Remote, typedRemoteSource.SourceKind);
+    }
+
+    [Fact]
     public void LegacyConstructorMapsLocalSourceIntoTypedSource()
     {
         PlateauImportRequest request = new(


### PR DESCRIPTION
## What changed
- introduced a validated application-level import request boundary for execution
- moved semantic request normalization and validation into `PlateauImportRequestValidator`
- reduced CLI parsing to syntax and type conversion only
- updated the dataset resolver and import service to operate on validated requests instead of re-owning business-rule checks
- refreshed tests around parser, validator, resolver, and import service behavior

## Why
Input rules were split across the CLI parser, validator, and resolver. That made the same rule easy to implement inconsistently and made execution code accept partially valid request shapes.

## Impact
Execution-facing code now receives a validated request model, semantic archive and package checks are centralized, and the resolver is more clearly focused on I/O and source resolution. CLI behavior stays the same at the command level, but semantic validation now happens after parsing instead of inside the parser.

## Validation
- `bash scripts/verify-ci.sh`
