### PR TITLE
[codex] Fix append live-send mutation bottleneck

### DIFF
--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -609,9 +609,8 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         QueuedCityObject queuedCityObject,
         CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(setupClient is null, this);
         PreparedCityObject preparedCityObject = await queuedCityObject.PreparationTask.WaitAsync(cancellationToken);
-        await BuildPreparedCityObjectAsync(setupClient, client, preparedCityObject, cancellationToken);
+        await BuildPreparedCityObjectAsync(client, client, preparedCityObject, cancellationToken);
 
         int processedCount = Interlocked.Increment(ref processedCityObjectCount);
         ReportProgress(
@@ -1671,7 +1670,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         ResoniteFloatQ? rotation,
         CancellationToken cancellationToken)
     {
-        return await sharedSlotCache.GetOrCreateAsync(
+        CreatedSlot createdSlot = await sharedSlotCache.GetOrCreateAsync(
             (parentId, slotName),
             ct => GetOrCreateSharedChildSlotCoreAsync(
                 client,
@@ -1681,6 +1680,8 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
                 rotation,
                 ct),
             cancellationToken);
+        await WaitForSlotAvailableAsync(client, createdSlot.SlotId, cancellationToken);
+        return createdSlot;
     }
 
     private static async Task<CreatedSlot> GetOrCreateSharedChildSlotCoreAsync(

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -1558,6 +1558,7 @@ public sealed class ResoniteLinkSceneBuilderTests
 
         Assert.True(clients.All(client => client.ConnectCallCount == 1));
         Assert.True(clients.All(client => client.ImportedMeshCount > 0));
+        Assert.True(clients.All(client => client.BatchMutationCount > 0));
         Assert.Equal(scene.CityObjects.Count, clients.Sum(client => client.ImportedMeshCount));
     }
 
@@ -2556,6 +2557,8 @@ public sealed class ResoniteLinkSceneBuilderTests
 
         public int ImportedMeshCount { get; private set; }
 
+        public int BatchMutationCount { get; private set; }
+
         public void Dispose()
         {
         }
@@ -2624,6 +2627,7 @@ public sealed class ResoniteLinkSceneBuilderTests
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            BatchMutationCount++;
             lock (session.Gate)
             {
                 session.Batches.Add(operations.ToArray());


### PR DESCRIPTION
## Summary
- route city-object mutation work through each lane-local client instead of funneling every append-path mutation through the shared setup client
- wait for shared-slot visibility after cache resolution so workers only mutate slots that are visible to their own ResoniteLink session
- add a regression assertion that parallel connections distribute DataModel batch mutations across clients

## Root Cause
append runs increased shared hierarchy lookups and scene mutations, but `ResoniteLinkSceneBuilder` still sent city-object mutation work through the single setup client. With high connection counts, preparation/import work scaled out while authoritative mutation throughput remained serialized behind one client, which matched the observed stalls after 100-200 objects.

## Validation
- `bash scripts/verify-ci.sh`

## Follow-Up
- The current visibility wait may be only a mitigation. Revisit the live-send writer boundary so callers cannot observe partial mutation state across async boundaries, which may let us remove the explicit "wait until visible" step.
