### PR TITLE
[codex] Bake LOD1 meshes per eight-digit mesh code

### DIFF
--- a/src/Plateau.ResoniteLink.Cli/FixedCellCityObjectMeshBaker.cs
+++ b/src/Plateau.ResoniteLink.Cli/FixedCellCityObjectMeshBaker.cs
@@ -73,8 +73,9 @@ internal sealed class FixedCellCityObjectMeshBaker
         buffer.LastTouchedSequence = nextBufferSequence++;
         BakedInputCityObjectCount++;
 
-        if (buffer.CityObjects.Count < maxCityObjectsPerBatch
-            && buffer.VertexCount < maxVerticesPerBatch)
+        if (IsMeshCodeWideBake(cellKey)
+            || (buffer.CityObjects.Count < maxCityObjectsPerBatch
+                && buffer.VertexCount < maxVerticesPerBatch))
         {
             _ = TryFlushOldestBufferExcept(cellKey, out bakedCityObject);
             return true;
@@ -113,6 +114,16 @@ internal sealed class FixedCellCityObjectMeshBaker
 
     private CellKey CreateCellKey(ResoniteConstructionCityObject cityObject)
     {
+        if (ShouldBakeAsSingleEightDigitMesh(cityObject))
+        {
+            return new CellKey(
+                cityObject.ActualMeshCode,
+                cityObject.PackageName,
+                cityObject.LodLevel,
+                CellX: 0,
+                CellZ: 0);
+        }
+
         int cellX = (int)Math.Floor(cityObject.Transform.Position.X / cellSizeMeters);
         int cellZ = (int)Math.Floor(cityObject.Transform.Position.Z / cellSizeMeters);
         return new CellKey(
@@ -121,6 +132,19 @@ internal sealed class FixedCellCityObjectMeshBaker
             cityObject.LodLevel,
             cellX,
             cellZ);
+    }
+
+    private static bool ShouldBakeAsSingleEightDigitMesh(ResoniteConstructionCityObject cityObject)
+    {
+        return CanBake(cityObject)
+            && cityObject.ActualMeshCode.Length == 8;
+    }
+
+    private static bool IsMeshCodeWideBake(CellKey cellKey)
+    {
+        return cellKey.ActualMeshCode.Length == 8
+            && cellKey.CellX == 0
+            && cellKey.CellZ == 0;
     }
 
     private bool TryFlushOldestBufferExcept(

--- a/tests/Plateau.ResoniteLink.Tests/Cli/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/FixedCellCityObjectMeshBakerTests.cs
@@ -9,8 +9,8 @@ public sealed class FixedCellCityObjectMeshBakerTests
     public void TryBufferBakesLod1BuildingsInSameCellIntoSingleMesh()
     {
         FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 2, maxVerticesPerBatch: 1000);
-        ResoniteConstructionCityObject first = CreateTriangleBuilding("first", x: 10.0, z: 12.0);
-        ResoniteConstructionCityObject second = CreateTriangleBuilding("second", x: 18.0, z: 20.0);
+        ResoniteConstructionCityObject first = CreateTriangleBuilding("first", x: 10.0, z: 12.0, actualMeshCode: "533945");
+        ResoniteConstructionCityObject second = CreateTriangleBuilding("second", x: 18.0, z: 20.0, actualMeshCode: "533945");
 
         bool firstBuffered = baker.TryBuffer(first, out ResoniteConstructionCityObject? firstBaked);
         bool secondBuffered = baker.TryBuffer(second, out ResoniteConstructionCityObject? baked);
@@ -40,8 +40,8 @@ public sealed class FixedCellCityObjectMeshBakerTests
     public void FlushAllReturnsSeparateBatchesPerCell()
     {
         FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
-        Assert.True(baker.TryBuffer(CreateTriangleBuilding("left", x: 10.0, z: 10.0), out _));
-        Assert.True(baker.TryBuffer(CreateTriangleBuilding("right", x: 80.0, z: 10.0), out _));
+        Assert.True(baker.TryBuffer(CreateTriangleBuilding("left", x: 10.0, z: 10.0, actualMeshCode: "533945"), out _));
+        Assert.True(baker.TryBuffer(CreateTriangleBuilding("right", x: 80.0, z: 10.0, actualMeshCode: "533945"), out _));
 
         IReadOnlyList<ResoniteConstructionCityObject> baked = baker.FlushAll();
 
@@ -58,21 +58,22 @@ public sealed class FixedCellCityObjectMeshBakerTests
             maxCityObjectsPerBatch: 10,
             maxVerticesPerBatch: 1000,
             maxBufferedCells: 2);
-        Assert.True(baker.TryBuffer(CreateTriangleBuilding("left", x: 10.0, z: 10.0), out ResoniteConstructionCityObject? firstBaked));
-        Assert.True(baker.TryBuffer(CreateTriangleBuilding("center", x: 80.0, z: 10.0), out ResoniteConstructionCityObject? secondBaked));
+        Assert.True(baker.TryBuffer(CreateTriangleBuilding("left", x: 10.0, z: 10.0, actualMeshCode: "53394525"), out ResoniteConstructionCityObject? firstBaked));
+        Assert.True(baker.TryBuffer(CreateTriangleBuilding("center", x: 80.0, z: 10.0, actualMeshCode: "53394526"), out ResoniteConstructionCityObject? secondBaked));
 
-        bool thirdBuffered = baker.TryBuffer(CreateTriangleBuilding("right", x: 138.0, z: 10.0), out ResoniteConstructionCityObject? flushed);
+        bool thirdBuffered = baker.TryBuffer(CreateTriangleBuilding("right", x: 138.0, z: 10.0, actualMeshCode: "53394527"), out ResoniteConstructionCityObject? flushed);
 
         Assert.True(thirdBuffered);
         Assert.Null(firstBaked);
         Assert.Null(secondBaked);
         Assert.NotNull(flushed);
         Assert.Equal(new ResoniteFloat3(0.0, 0.0, 0.0), flushed.Transform.Position);
+        Assert.Equal("53394525", flushed.ActualMeshCode);
 
         IReadOnlyList<ResoniteConstructionCityObject> remainingBatches = baker.FlushAll();
         Assert.Equal(2, remainingBatches.Count);
-        Assert.Contains(remainingBatches, static cityObject => cityObject.Transform.Position == new ResoniteFloat3(64.0, 0.0, 0.0));
-        Assert.Contains(remainingBatches, static cityObject => cityObject.Transform.Position == new ResoniteFloat3(128.0, 0.0, 0.0));
+        Assert.Contains(remainingBatches, static cityObject => cityObject.ActualMeshCode == "53394526");
+        Assert.Contains(remainingBatches, static cityObject => cityObject.ActualMeshCode == "53394527");
     }
 
     [Fact]
@@ -88,13 +89,42 @@ public sealed class FixedCellCityObjectMeshBakerTests
         Assert.Empty(baker.FlushAll());
     }
 
-    private static ResoniteConstructionCityObject CreateTriangleBuilding(string slotKey, double x, double z)
+    [Fact]
+    public void FlushAllReturnsSingleBatchPerEightDigitMeshCodeAcrossCells()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
+        Assert.True(baker.TryBuffer(CreateTriangleBuilding("left", x: 10.0, z: 10.0), out _));
+        Assert.True(baker.TryBuffer(CreateTriangleBuilding("right", x: 80.0, z: 10.0), out _));
+
+        IReadOnlyList<ResoniteConstructionCityObject> baked = baker.FlushAll();
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(baked);
+        Assert.Equal("53394525", cityObject.ActualMeshCode);
+        Assert.Equal(new ResoniteFloat3(0.0, 0.0, 0.0), cityObject.Transform.Position);
+        Assert.Equal(6, cityObject.Mesh.Vertices.Count);
+    }
+
+    [Fact]
+    public void FlushAllIgnoresBatchSizeLimitsForEightDigitMeshBake()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 1, maxVerticesPerBatch: 3);
+        Assert.True(baker.TryBuffer(CreateTriangleBuilding("first", x: 10.0, z: 10.0), out ResoniteConstructionCityObject? firstBaked));
+        Assert.True(baker.TryBuffer(CreateTriangleBuilding("second", x: 80.0, z: 10.0), out ResoniteConstructionCityObject? secondBaked));
+
+        Assert.Null(firstBaked);
+        Assert.Null(secondBaked);
+
+        ResoniteConstructionCityObject baked = Assert.Single(baker.FlushAll());
+        Assert.Equal(6, baked.Mesh.Vertices.Count);
+    }
+
+    private static ResoniteConstructionCityObject CreateTriangleBuilding(string slotKey, double x, double z, string actualMeshCode = "53394525")
     {
         return new ResoniteConstructionCityObject(
             SlotKey: slotKey,
             DisplayName: slotKey,
             PackageName: "bldg",
-            ActualMeshCode: "53394525",
+            ActualMeshCode: actualMeshCode,
             LodLevel: 1,
             Transform: new ResoniteTransform(new ResoniteFloat3(x, 0.0, z)),
             Mesh: new ResoniteImportedMesh(


### PR DESCRIPTION
## Summary
- bake eligible LOD1 building meshes as a single batch for each eight-digit mesh code instead of splitting them by fixed cell
- preserve fixed-cell batching behavior for non-eight-digit mesh codes and keep sparse-buffer eviction coverage in tests
- add regression tests for cross-cell eight-digit aggregation and for ignoring per-batch size limits during mesh-code-wide baking

## Root cause
The mesh baker keyed LOD1 batches by fixed spatial cell for every building, so eight-digit mesh requests were still fragmented into multiple baked meshes inside the same requested mesh area.

## Validation
- dotnet test tests/Plateau.ResoniteLink.Tests/Plateau.ResoniteLink.Tests.csproj --filter FixedCellCityObjectMeshBakerTests
- bash scripts/verify-ci.sh
