### PR TITLE
Address remaining review feedback from #29

### DIFF
--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -18,12 +18,14 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
 {
     private const int MaxQueuedCityObjects = 4;
     private const int WorkerConnectTimeoutMilliseconds = 5000;
+    private const int DatasetRootLookupAttemptLimit = 5;
     private const string RootSlotId = "Root";
     private const string CommonAssetsSlotName = "Common";
     private const string DemPackageName = "dem";
     private const string HeightMapAssetSlotSuffix = "_heightmap";
     private const float DefaultNormalScale = 1.0f;
     private const float DefaultBundledHeightScale = 0.002f;
+    private static readonly TimeSpan DatasetRootLookupRetryDelay = TimeSpan.FromMilliseconds(100);
     private readonly Func<IResoniteLinkClient> clientFactory;
     private readonly Uri endpoint;
     private readonly int connectionCount;
@@ -240,10 +242,12 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         string slotName,
         CancellationToken cancellationToken)
     {
-        CreatedSlot? existingDatasetRoot = await TryGetUniqueChildSlotByNameAsync(
+        CreatedSlot? existingDatasetRoot = await TryGetUniqueChildSlotByNameWithRetryAsync(
             client,
             RootSlotId,
             slotName,
+            DatasetRootLookupAttemptLimit,
+            DatasetRootLookupRetryDelay,
             cancellationToken);
         if (existingDatasetRoot is not null)
         {
@@ -1773,6 +1777,35 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
     {
         Slot? parentSlot = await client.GetSlotAsync(parentId, 1, cancellationToken);
         return TryFindUniqueChildSlotByName(parentSlot, slotName, parentId);
+    }
+
+    private static async Task<CreatedSlot?> TryGetUniqueChildSlotByNameWithRetryAsync(
+        IResoniteLinkClient client,
+        string parentId,
+        string slotName,
+        int attemptLimit,
+        TimeSpan retryDelay,
+        CancellationToken cancellationToken)
+    {
+        for (int attempt = 1; attempt <= attemptLimit; attempt++)
+        {
+            CreatedSlot? existingSlot = await TryGetUniqueChildSlotByNameAsync(
+                client,
+                parentId,
+                slotName,
+                cancellationToken);
+            if (existingSlot is not null)
+            {
+                return existingSlot;
+            }
+
+            if (attempt < attemptLimit && retryDelay > TimeSpan.Zero)
+            {
+                await Task.Delay(retryDelay, cancellationToken);
+            }
+        }
+
+        return null;
     }
 
     private static CreatedSlot? TryFindUniqueChildSlotByName(

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -2206,6 +2206,52 @@ public sealed class ResoniteLinkSceneBuilderTests
                 && string.Equals(request.Data.Name?.Value, "Assets", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task BeginAsyncRetriesDatasetRootLookupBeforeCreatingDuplicateRoot()
+    {
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
+        CapturedResoniteScene scene = LoadScene(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: fixturePath,
+                ServerUri: null));
+        FakeResoniteLinkSession session = new();
+        string existingDatasetRootId = session.AllocateSlotId();
+        session.SlotsById[existingDatasetRootId] = new Slot
+        {
+            ID = existingDatasetRootId,
+            Parent = new Reference
+            {
+                TargetID = "Root",
+            },
+            Name = new Field_string
+            {
+                Value = "PLATEAU tokyo23ku",
+            },
+        };
+        session.SlotPaths[existingDatasetRootId] = "PLATEAU tokyo23ku";
+
+        using DelayedExistingDatasetRootClient fakeClient = new(session, "PLATEAU tokyo23ku", hiddenPollCount: 2);
+        await using ResoniteLinkSceneBuilder builder = new(
+            new Uri("ws://localhost:12345/"),
+            1,
+            ResoniteLinkSendDiagnostics.Disabled,
+            () => fakeClient);
+
+        using TemporaryDirectory workDirectory = new();
+        await builder.BeginAsync(scene.Metadata, workDirectory.Path);
+
+        Assert.DoesNotContain(
+            fakeClient.AddedSlots,
+            static request => string.Equals(request.Data.Name?.Value, "PLATEAU tokyo23ku", StringComparison.Ordinal));
+        Assert.True(fakeClient.RootLookupCount >= 3);
+        Assert.Equal(1, session.SlotsById.Values.Count(slot =>
+            string.Equals(slot.Parent?.TargetID, "Root", StringComparison.Ordinal)
+            && string.Equals(slot.Name?.Value, "PLATEAU tokyo23ku", StringComparison.Ordinal)));
+    }
+
     private static List<DataModelOperation> ResolveBatchLocalSlotReferences(
         IReadOnlyList<DataModelOperation> operations,
         Func<string> allocateSlotId,
@@ -3817,6 +3863,113 @@ public sealed class ResoniteLinkSceneBuilderTests
                     .ToList();
             }
 
+            return clone;
+        }
+    }
+
+    private sealed class DelayedExistingDatasetRootClient(
+        FakeResoniteLinkSession session,
+        string hiddenSlotName,
+        int hiddenPollCount) : IResoniteLinkClient
+    {
+        private readonly FakeResoniteLinkClient inner = new(session);
+        private int remainingHiddenPolls = hiddenPollCount;
+
+        public int RootLookupCount { get; private set; }
+
+        public List<AddSlot> AddedSlots => inner.AddedSlots;
+
+        public void Dispose()
+        {
+            inner.Dispose();
+        }
+
+        public Task ConnectAsync(Uri endpoint, CancellationToken cancellationToken)
+        {
+            return inner.ConnectAsync(endpoint, cancellationToken);
+        }
+
+        public Task<string> AddComponentAsync(AddComponent request, CancellationToken cancellationToken)
+        {
+            return inner.AddComponentAsync(request, cancellationToken);
+        }
+
+        public Task<string> AddSlotAsync(AddSlot request, CancellationToken cancellationToken)
+        {
+            return inner.AddSlotAsync(request, cancellationToken);
+        }
+
+        public Task<BatchResponse> RunDataModelOperationBatchAsync(
+            IReadOnlyList<DataModelOperation> operations,
+            CancellationToken cancellationToken)
+        {
+            return inner.RunDataModelOperationBatchAsync(operations, cancellationToken);
+        }
+
+        public Task<Component?> GetComponentAsync(string componentId, CancellationToken cancellationToken)
+        {
+            return inner.GetComponentAsync(componentId, cancellationToken);
+        }
+
+        public Task<Slot?> GetSlotAsync(string slotId, int depth, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!string.Equals(slotId, "Root", StringComparison.Ordinal))
+            {
+                return inner.GetSlotAsync(slotId, depth, cancellationToken);
+            }
+
+            lock (session.Gate)
+            {
+                RootLookupCount++;
+                Slot root = CreateSyntheticRootSlot(session, depth, CloneSlot);
+                if (depth > 0 && remainingHiddenPolls > 0)
+                {
+                    root.Children = root.Children?
+                        .Where(child => !string.Equals(child.Name?.Value, hiddenSlotName, StringComparison.Ordinal))
+                        .ToList();
+                    remainingHiddenPolls--;
+                }
+
+                return Task.FromResult<Slot?>(root);
+            }
+        }
+
+        public Task<Uri> ImportMeshAsync(ImportMeshRawData request, CancellationToken cancellationToken)
+        {
+            return inner.ImportMeshAsync(request, cancellationToken);
+        }
+
+        public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+        {
+            return inner.ImportTextureAsync(textureImport, cancellationToken);
+        }
+
+        public Task UpdateComponentAsync(UpdateComponent request, CancellationToken cancellationToken)
+        {
+            return inner.UpdateComponentAsync(request, cancellationToken);
+        }
+
+        private static Slot CloneSlot(Slot source, int depth)
+        {
+            Slot clone = new()
+            {
+                ID = source.ID,
+                Parent = source.Parent,
+                Name = source.Name,
+                Position = source.Position,
+                Rotation = source.Rotation,
+                Components = source.Components,
+            };
+
+            if (depth <= 0)
+            {
+                return clone;
+            }
+
+            clone.Children = source.Children?
+                .Select(child => CloneSlot(child, depth - 1))
+                .ToList();
             return clone;
         }
     }

--- a/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
@@ -168,6 +168,33 @@ public sealed class RetryingResoniteLinkClientTests
     }
 
     [Fact]
+    public async Task ImportMeshAsyncDoesNotApplyTimeoutWhenDisabledByDefault()
+    {
+        using BlockingReconnectableClient innerClient = new();
+        using RetryingResoniteLinkClient client = new(() => innerClient);
+        using CancellationTokenSource cancellation = new();
+
+        await client.ConnectAsync(new Uri("ws://localhost:12345/"), CancellationToken.None);
+
+        Task<Uri> importTask = client.ImportMeshAsync(
+            new ImportMeshRawData
+            {
+                RawBinaryPayload = [1, 2, 3],
+                VertexCount = 3,
+            },
+            cancellation.Token);
+
+        await innerClient.ImportMeshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.Delay(150);
+
+        Assert.False(importTask.IsCompleted);
+
+        await cancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => importTask);
+        Assert.Equal(1, innerClient.ImportMeshCallCount);
+    }
+
+    [Fact]
     public async Task AddSlotAsyncReturnsCreatedIdFromInnerClient()
     {
         using StubReconnectableClient innerClient = new();


### PR DESCRIPTION
## Summary
- retry dataset root lookup a bounded number of times before creating a new root slot so transient visibility lag does not create duplicate `PLATEAU <dataset>` roots
- add a regression test that proves the default `RetryingResoniteLinkClient` path does not apply an `ImportMesh` timeout unless the diagnostic option is explicitly enabled
- cover the delayed-root-visibility case with a scene builder test

## Verification
- `bash scripts/verify-ci.sh`

## Review thread mapping
- `ResoniteLinkSceneBuilder.GetOrCreateDatasetRootAsync`: addressed by bounded retry before fallback creation
- `RetryingResoniteLinkClient` 30s timeout thread: current `main` already defaults `ResoniteLinkImportMeshTimeoutMilliseconds` to `0`; this PR adds a regression test to keep that behavior fixed
