### PR TITLE
[codex] Restore batch limits for mesh-code bake

### DIFF
--- a/src/Plateau.ResoniteLink.Cli/FixedCellCityObjectMeshBaker.cs
+++ b/src/Plateau.ResoniteLink.Cli/FixedCellCityObjectMeshBaker.cs
@@ -73,9 +73,8 @@ internal sealed class FixedCellCityObjectMeshBaker
         buffer.LastTouchedSequence = nextBufferSequence++;
         BakedInputCityObjectCount++;
 
-        if (IsMeshCodeWideBake(cellKey)
-            || (buffer.CityObjects.Count < maxCityObjectsPerBatch
-                && buffer.VertexCount < maxVerticesPerBatch))
+        if (buffer.CityObjects.Count < maxCityObjectsPerBatch
+            && buffer.VertexCount < maxVerticesPerBatch)
         {
             _ = TryFlushOldestBufferExcept(cellKey, out bakedCityObject);
             return true;
@@ -138,13 +137,6 @@ internal sealed class FixedCellCityObjectMeshBaker
     {
         return CanBake(cityObject)
             && cityObject.ActualMeshCode.Length == 8;
-    }
-
-    private static bool IsMeshCodeWideBake(CellKey cellKey)
-    {
-        return cellKey.ActualMeshCode.Length == 8
-            && cellKey.CellX == 0
-            && cellKey.CellZ == 0;
     }
 
     private bool TryFlushOldestBufferExcept(

--- a/tests/Plateau.ResoniteLink.Tests/Cli/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/FixedCellCityObjectMeshBakerTests.cs
@@ -105,17 +105,22 @@ public sealed class FixedCellCityObjectMeshBakerTests
     }
 
     [Fact]
-    public void FlushAllIgnoresBatchSizeLimitsForEightDigitMeshBake()
+    public void TryBufferFlushesWhenEightDigitMeshBakeHitsBatchLimits()
     {
         FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 1, maxVerticesPerBatch: 3);
         Assert.True(baker.TryBuffer(CreateTriangleBuilding("first", x: 10.0, z: 10.0), out ResoniteConstructionCityObject? firstBaked));
         Assert.True(baker.TryBuffer(CreateTriangleBuilding("second", x: 80.0, z: 10.0), out ResoniteConstructionCityObject? secondBaked));
 
-        Assert.Null(firstBaked);
-        Assert.Null(secondBaked);
+        Assert.NotNull(firstBaked);
+        Assert.NotNull(secondBaked);
+        Assert.Equal("53394525", firstBaked.ActualMeshCode);
+        Assert.Equal("53394525", secondBaked.ActualMeshCode);
+        Assert.Equal(new ResoniteFloat3(0.0, 0.0, 0.0), firstBaked.Transform.Position);
+        Assert.Equal(new ResoniteFloat3(0.0, 0.0, 0.0), secondBaked.Transform.Position);
+        Assert.Equal(3, firstBaked.Mesh.Vertices.Count);
+        Assert.Equal(3, secondBaked.Mesh.Vertices.Count);
 
-        ResoniteConstructionCityObject baked = Assert.Single(baker.FlushAll());
-        Assert.Equal(6, baked.Mesh.Vertices.Count);
+        Assert.Empty(baker.FlushAll());
     }
 
     private static ResoniteConstructionCityObject CreateTriangleBuilding(string slotKey, double x, double z, string actualMeshCode = "53394525")


### PR DESCRIPTION
## Summary
- restore per-batch flush limits for eight-digit mesh-code baking while keeping mesh-code-wide grouping
- preserve the zero-origin mesh-code-wide bake behavior across cells
- replace the regression test so it asserts limit-triggered flushing instead of unlimited buffering

## Why
PR #44 changed eight-digit mesh-code baking to bypass batch-size flush conditions entirely. That kept all eligible LOD1 objects buffered until completion and regressed live streaming and memory usage on large imports.

## Validation
- dotnet test tests/Plateau.ResoniteLink.Tests/Plateau.ResoniteLink.Tests.csproj --filter FixedCellCityObjectMeshBakerTests
- bash scripts/verify-ci.sh

## Context
- follow-up for the unresolved review on PR #44