### PR TITLE
Choose regex live anchor near request origin

### DIFF
--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -763,16 +763,17 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             return meshCode;
         }
 
-        (string MeshCode, double DistanceSquared)? requestedMeshCode = metadata.SourceDataset.RequestedMeshCodes?
+        (string MeshCode, double DistanceSquared)[] concreteRequestedMeshCodes = metadata.SourceDataset.RequestedMeshCodes?
             .Select(candidate => TryResolveConcreteMeshCodeDistance(candidate, metadata.LocalOrigin))
             .Where(static candidate => candidate.HasValue)
             .Select(static candidate => candidate!.Value)
             .OrderBy(static candidate => candidate.DistanceSquared)
             .ThenBy(static candidate => candidate.MeshCode, StringComparer.Ordinal)
-            .FirstOrDefault();
-        if (requestedMeshCode.HasValue)
+            .ToArray()
+            ?? [];
+        if (concreteRequestedMeshCodes.Length > 0)
         {
-            return requestedMeshCode.Value.MeshCode;
+            return concreteRequestedMeshCodes[0].MeshCode;
         }
 
         throw new InvalidOperationException(

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -763,17 +763,36 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             return meshCode;
         }
 
-        string? requestedMeshCode = metadata.SourceDataset.RequestedMeshCodes?
-            .FirstOrDefault(static candidate => PlateauMeshCode.TryGetCenter(candidate, out _));
-        if (!string.IsNullOrWhiteSpace(requestedMeshCode))
+        (string MeshCode, double DistanceSquared)? requestedMeshCode = metadata.SourceDataset.RequestedMeshCodes?
+            .Select(candidate => TryResolveConcreteMeshCodeDistance(candidate, metadata.LocalOrigin))
+            .Where(static candidate => candidate.HasValue)
+            .Select(static candidate => candidate!.Value)
+            .OrderBy(static candidate => candidate.DistanceSquared)
+            .ThenBy(static candidate => candidate.MeshCode, StringComparer.Ordinal)
+            .FirstOrDefault();
+        if (requestedMeshCode.HasValue)
         {
-            return requestedMeshCode;
+            return requestedMeshCode.Value.MeshCode;
         }
 
         throw new InvalidOperationException(
             string.Create(
                 CultureInfo.InvariantCulture,
                 $"Live Offset V2 requires a concrete meshcode anchor, but '{meshCode}' did not resolve to any concrete meshcode."));
+    }
+
+    private static (string MeshCode, double DistanceSquared)? TryResolveConcreteMeshCodeDistance(
+        string meshCode,
+        ResoniteLocalOrigin requestOrigin)
+    {
+        if (!PlateauMeshCode.TryGetCenter(meshCode, out ResoniteLocalOrigin concreteCenter))
+        {
+            return null;
+        }
+
+        ResoniteFloat3 offset = ComputeOriginOffset(requestOrigin, concreteCenter);
+        double distanceSquared = (offset.X * offset.X) + (offset.Z * offset.Z);
+        return (meshCode, distanceSquared);
     }
 
     private async Task BuildPreparedCityObjectAsync(

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -1472,6 +1472,26 @@ public sealed class ResoniteLinkSceneBuilderTests
     }
 
     [Fact]
+    public async Task BuildAsyncChoosesConcreteCompletionMeshCodeClosestToRegexOrigin()
+    {
+        using FakeResoniteLinkClient fakeClient = new();
+        IReadOnlyList<string> destinations = await RunBuilderAsync(
+            new ResoniteLinkSceneBuilder(new Uri("ws://localhost:12345/"), 1, ResoniteLinkSendDiagnostics.Disabled, () => fakeClient),
+            CreateRegexRequestScene(
+                "5339452[56]",
+                new ResoniteLocalOrigin(35.6875, 139.69375, 0.0),
+                ["53394526", "53394525"]));
+
+        Slot datasetSlot = FindSlotByName(fakeClient.SlotsById, "PLATEAU tokyo23ku");
+        Slot completionAnchorSlot = FindDirectChildSlotByName(fakeClient.SlotsById, datasetSlot.ID, "53394525");
+        Assert.Contains("PLATEAU tokyo23ku/53394525", fakeClient.SlotPaths.Values);
+        Assert.DoesNotContain("PLATEAU tokyo23ku/53394526", fakeClient.SlotPaths.Values);
+        Assert.Equal(
+            [$"ws://localhost:12345/#{completionAnchorSlot.ID}"],
+            destinations);
+    }
+
+    [Fact]
     public async Task BuildAsyncImportsGeneratedDemTerrainTexture()
     {
         string fixturePath = TestData.GetFixturePath("LocalPlateauDatasetMixedObjects");
@@ -5052,6 +5072,14 @@ public sealed class ResoniteLinkSceneBuilderTests
 
     private static CapturedResoniteScene CreateRegexRequestScene(string meshCode, ResoniteLocalOrigin localOrigin)
     {
+        return CreateRegexRequestScene(meshCode, localOrigin, ["53394525"]);
+    }
+
+    private static CapturedResoniteScene CreateRegexRequestScene(
+        string meshCode,
+        ResoniteLocalOrigin localOrigin,
+        IReadOnlyList<string> requestedMeshCodes)
+    {
         ResoniteConstructionMetadata metadata = new(
             SchemaVersion: "3.0",
             WorldName: $"PLATEAU tokyo23ku {meshCode}",
@@ -5065,7 +5093,7 @@ public sealed class ResoniteLinkSceneBuilderTests
                 PackageNames: ["bldg", "dem"],
                 SourceFiles: ["udx/dem/533945/plateau_tokyo23ku_dem_533945.gml", "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml"],
                 TerrainTextureOverlays: [],
-                RequestedMeshCodes: ["53394525"]),
+                RequestedMeshCodes: requestedMeshCodes),
             Attribution: new ResoniteAttribution(
                 DatasetLicense: new ResoniteLicenseComponentMetadata(
                     RequireCredit: true,

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -1492,6 +1492,30 @@ public sealed class ResoniteLinkSceneBuilderTests
     }
 
     [Fact]
+    public async Task BuildAsyncThrowsWhenRegexSelectorHasNoConcreteRequestedMeshCodes()
+    {
+        using FakeResoniteLinkClient fakeClient = new();
+        ResoniteLinkSceneBuilder builder = new(
+            new Uri("ws://localhost:12345/"),
+            1,
+            ResoniteLinkSendDiagnostics.Disabled,
+            () => fakeClient);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await RunBuilderAsync(
+                builder,
+                CreateRegexRequestScene(
+                    "5339452[56]",
+                    new ResoniteLocalOrigin(35.6875, 139.69375, 0.0),
+                    [])));
+
+        Assert.Contains(
+            "did not resolve to any concrete meshcode",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task BuildAsyncImportsGeneratedDemTerrainTexture()
     {
         string fixturePath = TestData.GetFixturePath("LocalPlateauDatasetMixedObjects");


### PR DESCRIPTION
## Summary
- remove request mesh regex anchor selection's dependence on RequestedMeshCodes ordering
- choose the concrete live completion meshcode closest to the resolved request local origin
- add a regression test that reverses RequestedMeshCodes order and keeps the nearest anchor

## Testing
- bash scripts/verify-ci.sh