### PR TITLE
[codex] Instrument live send phase timings

### DIFF
--- a/src/Plateau.ResoniteLink.Application/Importing/IResoniteConstructionSource.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/IResoniteConstructionSource.cs
@@ -6,6 +6,9 @@ public interface IResoniteConstructionSource
 {
     ResoniteConstructionMetadata Metadata { get; }
 
+    IAsyncEnumerable<ResoniteMaterialBinding> ReadCommonMaterialsAsync(
+        CancellationToken cancellationToken = default);
+
     IEnumerable<ResoniteConstructionCityObject> ReadCityObjects();
 
     IAsyncEnumerable<ResoniteConstructionCityObject> ReadCityObjectsAsync(

--- a/src/Plateau.ResoniteLink.Application/Importing/IResoniteSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/IResoniteSceneBuilder.cs
@@ -18,6 +18,10 @@ public interface IResoniteSceneBuilder : IAsyncDisposable
         string workRoot,
         CancellationToken cancellationToken = default);
 
+    Task PrepareCommonMaterialAsync(
+        ResoniteMaterialBinding material,
+        CancellationToken cancellationToken = default);
+
     Task ProcessCityObjectAsync(
         ResoniteConstructionCityObject cityObject,
         CancellationToken cancellationToken = default);

--- a/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.cs
@@ -2455,6 +2455,60 @@ public static partial class LocalCityGmlResonitePlanBuilder
 
         public ResoniteConstructionMetadata Metadata { get; }
 
+        public async IAsyncEnumerable<ResoniteMaterialBinding> ReadCommonMaterialsAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            LocalCartesian? globalCartesian = referenceSystem.IsGeographic
+                ? new LocalCartesian(
+                    globalOriginPoint.Latitude,
+                    globalOriginPoint.Longitude,
+                    globalOriginPoint.Altitude,
+                    referenceSystem.Geocentric)
+                : null;
+            HashSet<string> emittedMaterialKeys = new(StringComparer.Ordinal);
+
+            foreach (SourceFilePipeline sourceFile in deferredSourceFiles)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                _ = sourceFile.GetParseTask();
+            }
+
+            foreach (SourceFilePipeline sourceFile in deferredSourceFiles)
+            {
+                await foreach (ResoniteMaterialBinding material in StreamCommonMaterialsAsync(
+                                   sourceFile,
+                                   referenceSystem,
+                                   globalOriginPoint,
+                                   globalCartesian,
+                                   demTerrainTextureOverlays,
+                                   terrainHeightSampler,
+                                   request,
+                                   sourceFile.GetParseTask(),
+                                   emittedMaterialKeys,
+                                   cancellationToken))
+                {
+                    yield return material;
+                }
+            }
+
+            foreach (CachedSourceFileDescriptor sourceFile in demSourceFiles)
+            {
+                foreach (ResoniteMaterialBinding material in EnumerateCommonMaterials(
+                             sourceFile,
+                             referenceSystem,
+                             globalOriginPoint,
+                             globalCartesian,
+                             demTerrainTextureOverlays,
+                             terrainHeightSampler,
+                             request,
+                             emittedMaterialKeys))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    yield return material;
+                }
+            }
+        }
+
         public IEnumerable<ResoniteConstructionCityObject> ReadCityObjects()
         {
             LocalCartesian? globalCartesian = referenceSystem.IsGeographic
@@ -2734,6 +2788,39 @@ public static partial class LocalCityGmlResonitePlanBuilder
         }
     }
 
+    private static async IAsyncEnumerable<ResoniteMaterialBinding> StreamCommonMaterialsAsync(
+        SourceFilePipeline sourceFile,
+        CoordinateReferenceSystem referenceSystem,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        TerrainHeightSampler? terrainHeightSampler,
+        PlateauImportRequest request,
+        Task<ParsedSourceFileResult>? parseTask,
+        HashSet<string> emittedMaterialKeys,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ParsedSourceFileResult parsedSourceFile = parseTask is null
+            ? await sourceFile.GetParseTask()
+            : await parseTask;
+
+        ValidateCompatibleReferenceSystem(referenceSystem, parsedSourceFile.ReferenceSystem);
+
+        foreach (ResoniteMaterialBinding material in EnumerateCommonMaterials(
+                     new CachedSourceFileDescriptor(sourceFile.SourceFile, parsedSourceFile.CityObjects),
+                     referenceSystem,
+                     globalOriginPoint,
+                     globalCartesian,
+                     demTerrainTextureOverlays,
+                     terrainHeightSampler,
+                     request,
+                     emittedMaterialKeys))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return material;
+        }
+    }
+
     internal static IEnumerable<ResoniteConstructionCityObject> MaterializeCityObjects(
         CachedSourceFileDescriptor sourceFile,
         CoordinateReferenceSystem referenceSystem,
@@ -2766,6 +2853,40 @@ public static partial class LocalCityGmlResonitePlanBuilder
                          materialResolver))
             {
                 yield return cityObject;
+            }
+        }
+    }
+
+    internal static IEnumerable<ResoniteMaterialBinding> EnumerateCommonMaterials(
+        CachedSourceFileDescriptor sourceFile,
+        CoordinateReferenceSystem referenceSystem,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        TerrainHeightSampler? terrainHeightSampler,
+        PlateauImportRequest request,
+        ISet<string>? emittedMaterialKeys = null)
+    {
+        ValidateCompatibleReferenceSystem(
+            referenceSystem,
+            sourceFile.CityObjects.FirstOrDefault()?.ReferenceSystem ?? referenceSystem);
+
+        foreach (ParsedCityObject parsedCityObject in sourceFile.CityObjects)
+        {
+            foreach (ResoniteMaterialBinding material in EnumerateCommonMaterialsForParsedCityObject(
+                         parsedCityObject,
+                         globalOriginPoint,
+                         globalCartesian,
+                         demTerrainTextureOverlays,
+                         terrainHeightSampler,
+                         request))
+            {
+                if (emittedMaterialKeys is not null && !emittedMaterialKeys.Add(material.MaterialKey))
+                {
+                    continue;
+                }
+
+                yield return material;
             }
         }
     }
@@ -2857,6 +2978,93 @@ public static partial class LocalCityGmlResonitePlanBuilder
         {
             yield return markingObject;
         }
+    }
+
+    internal static IEnumerable<ResoniteMaterialBinding> EnumerateCommonMaterialsForParsedCityObject(
+        ParsedCityObject parsedCityObject,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        TerrainHeightSampler? terrainHeightSampler,
+        PlateauImportRequest request)
+    {
+        ParsedCityObject terrainAlignedCityObject = ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler);
+        IDefaultMaterialResolver materialResolver = new DefaultMaterialResolver();
+
+        foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject in SplitParsedCityObject(
+                     terrainAlignedCityObject,
+                     demTerrainTextureOverlays))
+        {
+            GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(splitCityObject.CityObject);
+            LocalCartesian? cityObjectCartesian = splitCityObject.CityObject.ReferenceSystem.IsGeographic
+                ? new LocalCartesian(
+                    cityObjectOrigin.Latitude,
+                    cityObjectOrigin.Longitude,
+                    cityObjectOrigin.Altitude,
+                    splitCityObject.CityObject.ReferenceSystem.Geocentric)
+                : null;
+
+            foreach (ResoniteMaterialBinding material in request.DemTerrainMode == DemTerrainMode.HeightMap
+                         && string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
+                            ? CreateDemHeightMapMaterials(
+                                splitCityObject.CityObject,
+                                cityObjectOrigin,
+                                cityObjectCartesian,
+                                splitCityObject.Overlay,
+                                materialResolver)
+                            : CreateCommonMaterialBindings(
+                                splitCityObject.CityObject,
+                                cityObjectOrigin,
+                                cityObjectCartesian,
+                                materialResolver))
+            {
+                yield return material;
+            }
+        }
+    }
+
+    private static ResoniteMaterialBinding[] CreateCommonMaterialBindings(
+        ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        IDefaultMaterialResolver materialResolver)
+    {
+        List<MaterializedSurface> materializedSurfaces =
+        [
+            .. cityObject.Surfaces.Select(surface => MaterializeSurfaceMaterial(cityObject, cityObjectOrigin, cityObjectCartesian, surface, materialResolver)),
+        ];
+
+        return materializedSurfaces
+            .GroupBy(
+                static materializedSurface => CreateMaterialKey(
+                    materializedSurface.Material.MaterialType,
+                    materializedSurface.Material.TexturePath,
+                    materializedSurface.Material.TextureSourceKind,
+                    materializedSurface.Material.Projection,
+                    materializedSurface.DepthOffset,
+                    materializedSurface.Material.TextureScale,
+                    materializedSurface.Material.Family,
+                    materializedSurface.Surface.BaseColor),
+                StringComparer.Ordinal)
+            .OrderBy(static group => group.Key, StringComparer.Ordinal)
+            .Select((group, materialIndex) =>
+            {
+                MaterializedSurface representativeSurface = group.First();
+                return new ResoniteMaterialBinding(
+                    MaterialKey: group.Key,
+                    BaseColor: representativeSurface.Surface.BaseColor,
+                    MaterialType: representativeSurface.Material.MaterialType,
+                    TexturePath: representativeSurface.Material.TexturePath,
+                    TextureSourceKind: representativeSurface.Material.TextureSourceKind,
+                    Projection: representativeSurface.Material.Projection,
+                    DepthOffset: representativeSurface.DepthOffset,
+                    SubmeshIndices: [materialIndex],
+                    TextureScale: representativeSurface.Material.TextureScale,
+                    Family: representativeSurface.Material.Family,
+                    AssetScope: representativeSurface.Material.AssetScope);
+            })
+            .Where(static material => material.AssetScope == ResoniteMaterialAssetScope.Common)
+            .ToArray();
     }
 
     private static ResoniteConstructionCityObject[] AlignAdjacentDemHeightMapChunkBoundaries(

--- a/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/PlateauImportService.cs
@@ -40,6 +40,8 @@ public sealed class PlateauImportService(
         ReportProgress(
             PlateauLog.Debug("import", $"Resolved dataset source for '{resolvedRequest.Dataset}' mesh '{resolvedRequest.MeshCode}'."));
 
+        Task commonMaterialPrewarmTask = Task.CompletedTask;
+        CancellationTokenSource? commonMaterialPrewarmCancellation = null;
         try
         {
             Stopwatch connectStopwatch = Stopwatch.StartNew();
@@ -62,6 +64,8 @@ public sealed class PlateauImportService(
             await sceneBuilder.BeginAsync(source.Metadata, datasetWorkRoot, cancellationToken);
             beginStopwatch.Stop();
             ReportProgress(PlateauLog.Debug("import", $"Scene builder initialization completed in {beginStopwatch.Elapsed.TotalSeconds:F3}s."));
+            commonMaterialPrewarmCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            commonMaterialPrewarmTask = PrewarmCommonMaterialsAsync(source, commonMaterialPrewarmCancellation.Token);
 
             bool processedAnyCityObject = false;
             int processedCityObjectCount = 0;
@@ -73,6 +77,8 @@ public sealed class PlateauImportService(
                 await sceneBuilder.ProcessCityObjectAsync(cityObject, cancellationToken);
                 processedCityObjectCount++;
             }
+
+            await commonMaterialPrewarmTask;
 
             cityObjectStopwatch.Stop();
             ReportProgress(
@@ -93,6 +99,25 @@ public sealed class PlateauImportService(
         }
         finally
         {
+            if (commonMaterialPrewarmCancellation is not null)
+            {
+                await commonMaterialPrewarmCancellation.CancelAsync();
+                if (!commonMaterialPrewarmTask.IsCompleted)
+                {
+                    _ = commonMaterialPrewarmTask.ContinueWith(
+                        static completedTask => _ = completedTask.Exception,
+                        CancellationToken.None,
+                        TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
+                }
+                else if (commonMaterialPrewarmTask.IsFaulted)
+                {
+                    _ = commonMaterialPrewarmTask.Exception;
+                }
+
+                commonMaterialPrewarmCancellation.Dispose();
+            }
+
             await sceneBuilder.DisposeAsync();
         }
     }
@@ -100,6 +125,24 @@ public sealed class PlateauImportService(
     private void ReportProgress(string message)
     {
         progressReporter?.Invoke(message);
+    }
+
+    private async Task PrewarmCommonMaterialsAsync(
+        IResoniteConstructionSource source,
+        CancellationToken cancellationToken)
+    {
+        int preparedCommonMaterialCount = 0;
+        await foreach (ResoniteMaterialBinding material in source.ReadCommonMaterialsAsync(cancellationToken))
+        {
+            await sceneBuilder.PrepareCommonMaterialAsync(material, cancellationToken);
+            preparedCommonMaterialCount++;
+        }
+
+        if (preparedCommonMaterialCount > 0)
+        {
+            ReportProgress(
+                PlateauLog.Debug("import", $"Prepared {preparedCommonMaterialCount} Common materials during source parsing."));
+        }
     }
 
     private static PlateauImportRequest NormalizeRequestForValidation(PlateauImportRequest request)

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkClient.cs
@@ -182,12 +182,21 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
         ResoniteFileTextureImport fileImport,
         CancellationToken cancellationToken)
     {
+        if (ShouldUseRawTextureImportForFile(fileImport.AbsolutePath))
+        {
+            ResoniteRawTextureImport eagerRawImport = await ResoniteTextureImportFactory.CreateRawFromFileAsync(
+                fileImport.AbsolutePath,
+                cancellationToken: cancellationToken);
+            return await ImportRawTextureAsync(eagerRawImport);
+        }
+
+        string importPath = TranslateFilePathForHost(fileImport.AbsolutePath);
         AssetData result = await link.ImportTextureFileAsync(
             new ImportTexture2DFile
             {
-                FilePath = fileImport.AbsolutePath,
+                FilePath = importPath,
             });
-        if (result.Success || !ShouldFallbackToRawTextureImport(result.ErrorInfo, fileImport.AbsolutePath))
+        if (result.Success || !ShouldFallbackToRawTextureImport(result.ErrorInfo, importPath, fileImport.AbsolutePath))
         {
             return result;
         }
@@ -254,6 +263,79 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
         return errorInfo.Contains("Exception when generating file signature", StringComparison.Ordinal)
             || errorInfo.Contains("Could not find file", StringComparison.Ordinal)
             || errorInfo.Contains(absolutePath, StringComparison.Ordinal);
+    }
+
+    internal static bool ShouldFallbackToRawTextureImport(
+        string? errorInfo,
+        params string[] candidatePaths)
+    {
+        if (string.IsNullOrWhiteSpace(errorInfo) || candidatePaths.Length == 0)
+        {
+            return false;
+        }
+
+        return candidatePaths.Any(candidatePath => ShouldFallbackToRawTextureImport(errorInfo, candidatePath));
+    }
+
+    internal static string TranslateFilePathForHost(string absolutePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(absolutePath);
+
+        if (!IsRunningUnderWsl() || !Path.IsPathRooted(absolutePath))
+        {
+            return absolutePath;
+        }
+
+        if (TryTranslateMountedWindowsPath(absolutePath, out string? mountedWindowsPath))
+        {
+            return mountedWindowsPath;
+        }
+
+        string? distroName = Environment.GetEnvironmentVariable("WSL_DISTRO_NAME");
+        if (string.IsNullOrWhiteSpace(distroName))
+        {
+            return absolutePath;
+        }
+
+        string normalizedPath = absolutePath.Replace('\\', '/').TrimStart('/');
+        return $@"\\wsl.localhost\{distroName}\{normalizedPath.Replace('/', '\\')}";
+    }
+
+    internal static bool ShouldUseRawTextureImportForFile(string absolutePath)
+    {
+        return IsRunningUnderWsl()
+            && Path.IsPathRooted(absolutePath)
+            && File.Exists(absolutePath);
+    }
+
+    private static bool IsRunningUnderWsl()
+    {
+        return OperatingSystem.IsLinux()
+            && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("WSL_DISTRO_NAME"));
+    }
+
+    private static bool TryTranslateMountedWindowsPath(string absolutePath, out string translatedPath)
+    {
+        translatedPath = string.Empty;
+        string normalizedPath = absolutePath.Replace('\\', '/');
+        if (!normalizedPath.StartsWith("/mnt/", StringComparison.Ordinal)
+            || normalizedPath.Length < "/mnt/c".Length
+            || normalizedPath[6] != '/')
+        {
+            return false;
+        }
+
+        char driveLetter = normalizedPath[5];
+        if (!char.IsAsciiLetter(driveLetter))
+        {
+            return false;
+        }
+
+        string windowsRelativePath = normalizedPath[7..].Replace('/', '\\');
+        translatedPath = string.IsNullOrEmpty(windowsRelativePath)
+            ? $@"{char.ToUpperInvariant(driveLetter)}:\"
+            : $@"{char.ToUpperInvariant(driveLetter)}:\{windowsRelativePath}";
+        return true;
     }
 
     private static string CreateMutationOperationName(string operationName, string? subject, string? containerId)

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -825,12 +825,11 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
 
         ReportBuildStep(cityObject, $"Preparing geometry assets ({DescribePreparedGeometry(preparedCityObject.Geometry)}).");
         Stopwatch geometryStopwatch = Stopwatch.StartNew();
-        PreparedGeometryAssetBatch preparedGeometryBatch = await PrepareGeometryBatchAsync(
+        Task<PreparedGeometryAssetBatch> preparedGeometryBatchTask = PrepareGeometryBatchAsync(
             importClient,
             cityObject,
             preparedCityObject,
             cancellationToken);
-        geometryStopwatch.Stop();
 
         Dictionary<TextureReferenceKey, ResoniteTextureImport> preparedTextureDataByKey = preparedCityObject.Textures.ToDictionary(
             static texture => ResoniteMaterialAssetManager.CreateTextureReferenceKey(
@@ -839,6 +838,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             static texture => texture.TextureImport);
         Stopwatch materialStopwatch = Stopwatch.StartNew();
         List<MaterialReferenceTarget> materialTargets = [];
+        List<Task<PreparedDedicatedMaterialAssets>> dedicatedMaterialPreparationTasks = [];
         for (int materialIndex = 0; materialIndex < cityObject.Materials.Count; materialIndex++)
         {
             ResoniteMaterialBinding material = cityObject.Materials[materialIndex];
@@ -858,9 +858,20 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             else
             {
                 materialTargets.Add(MaterialReferenceTarget.FromDedicatedMaterial(material));
+                dedicatedMaterialPreparationTasks.Add(
+                    PrepareDedicatedMaterialAssetsAsync(
+                        importClient,
+                        material,
+                        preparedTextureDataByKey,
+                        cancellationToken));
             }
         }
+        PreparedDedicatedMaterialAssets[] preparedDedicatedMaterialAssets = dedicatedMaterialPreparationTasks.Count == 0
+            ? []
+            : await Task.WhenAll(dedicatedMaterialPreparationTasks);
         materialStopwatch.Stop();
+        PreparedGeometryAssetBatch preparedGeometryBatch = await preparedGeometryBatchTask;
+        geometryStopwatch.Stop();
 
         ReportBuildStep(cityObject, "Creating object-scoped DataModel batch.");
         Stopwatch batchStopwatch = Stopwatch.StartNew();
@@ -872,6 +883,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             preparedTextureDataByKey,
             preparedGeometryBatch,
             materialTargets,
+            preparedDedicatedMaterialAssets,
             cancellationToken);
         batchStopwatch.Stop();
 
@@ -1161,9 +1173,10 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         IResoniteLinkClient importClient,
         ObjectSlotHierarchy objectSlots,
         ResoniteConstructionCityObject cityObject,
-        IReadOnlyDictionary<TextureReferenceKey, ResoniteTextureImport> preparedTextureDataByKey,
+        Dictionary<TextureReferenceKey, ResoniteTextureImport> preparedTextureDataByKey,
         PreparedGeometryAssetBatch preparedGeometryBatch,
         IReadOnlyList<MaterialReferenceTarget> materialTargets,
+        IReadOnlyList<PreparedDedicatedMaterialAssets> preparedDedicatedMaterialAssets,
         CancellationToken cancellationToken)
     {
         CityObjectBatchBuilder batchBuilder = new();
@@ -1240,6 +1253,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         }
 
         List<MaterialReferenceTarget> resolvedMaterialTargets = [];
+        int preparedDedicatedMaterialAssetIndex = 0;
         foreach (MaterialReferenceTarget materialTarget in materialTargets)
         {
             if (materialTarget.DedicatedMaterial is null)
@@ -1250,10 +1264,9 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
 
             PendingBatchComponent dedicatedMaterial = await AddDedicatedMaterialOperationsAsync(
                 batchBuilder,
-                importClient,
                 meshAssetSlot.LocalId,
                 materialTarget.DedicatedMaterial,
-                preparedTextureDataByKey,
+                preparedDedicatedMaterialAssets[preparedDedicatedMaterialAssetIndex++],
                 cancellationToken);
             resolvedMaterialTargets.Add(materialTarget with
             {
@@ -1318,12 +1331,11 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         }
     }
 
-    private async Task<PendingBatchComponent> AddDedicatedMaterialOperationsAsync(
+    private static Task<PendingBatchComponent> AddDedicatedMaterialOperationsAsync(
         CityObjectBatchBuilder batchBuilder,
-        IResoniteLinkClient importClient,
         string meshAssetSlotLocalId,
         ResoniteMaterialBinding material,
-        IReadOnlyDictionary<TextureReferenceKey, ResoniteTextureImport> preparedTextureDataByKey,
+        PreparedDedicatedMaterialAssets preparedAssets,
         CancellationToken cancellationToken)
     {
         string materialSlotName = CreateMaterialSlotName(material, useCommonMaterialAssets: false);
@@ -1334,109 +1346,170 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             null);
         Dictionary<string, Member> materialMembers = ResoniteMaterialComponentBuilder.CreateMembers(material);
 
-        if (material.TexturePath is not null
-            && preparedTextureDataByKey.TryGetValue(
-                ResoniteMaterialAssetManager.CreateTextureReferenceKey(material.TexturePath, material.TextureSourceKind),
-                out ResoniteTextureImport? albedoTextureImport))
+        if (preparedAssets.AlbedoTextureUri is not null)
         {
-            Uri albedoTextureUri = await ImportTextureAsync(importClient, albedoTextureImport, cancellationToken);
             PendingBatchComponent albedoTexture = batchBuilder.AddComponent(
                 materialSlot.LocalId,
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                CreateTextureMembers(albedoTextureUri));
+                CreateTextureMembers(preparedAssets.AlbedoTextureUri));
             materialMembers["AlbedoTexture"] = new Reference
             {
                 TargetID = albedoTexture.LocalId,
             };
         }
 
+        if (preparedAssets.NormalTextureUri is not null)
+        {
+            PendingBatchComponent normalTexture = batchBuilder.AddComponent(
+                materialSlot.LocalId,
+                "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                CreateTextureMembers(preparedAssets.NormalTextureUri));
+            materialMembers["NormalMap"] = new Reference
+            {
+                TargetID = normalTexture.LocalId,
+            };
+            materialMembers["NormalScale"] = new Field_float
+            {
+                Value = DefaultNormalScale,
+            };
+        }
+
+        if (preparedAssets.HeightTextureUri is not null)
+        {
+            PendingBatchComponent heightTexture = batchBuilder.AddComponent(
+                materialSlot.LocalId,
+                "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                CreateTextureMembers(preparedAssets.HeightTextureUri));
+            materialMembers["HeightMap"] = new Reference
+            {
+                TargetID = heightTexture.LocalId,
+            };
+            materialMembers["HeightScale"] = new Field_float
+            {
+                Value = DefaultBundledHeightScale,
+            };
+        }
+
+        if (preparedAssets.MetallicTextureUri is not null)
+        {
+            PendingBatchComponent metallicTexture = batchBuilder.AddComponent(
+                materialSlot.LocalId,
+                "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                CreateTextureMembers(preparedAssets.MetallicTextureUri));
+            materialMembers["MetallicMap"] = new Reference
+            {
+                TargetID = metallicTexture.LocalId,
+            };
+            materialMembers["OcclusionMap"] = new Reference
+            {
+                TargetID = metallicTexture.LocalId,
+            };
+        }
+
+        if (preparedAssets.EmissionTextureUri is not null)
+        {
+            PendingBatchComponent emissionTexture = batchBuilder.AddComponent(
+                materialSlot.LocalId,
+                "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                CreateTextureMembers(preparedAssets.EmissionTextureUri));
+            materialMembers["EmissiveMap"] = new Reference
+            {
+                TargetID = emissionTexture.LocalId,
+            };
+            materialMembers["EmissiveColor"] = ResoniteMaterialComponentBuilder.CreateColorMember(
+                new ResoniteColor(1.0, 1.0, 1.0, 1.0));
+        }
+
+        return Task.FromResult(batchBuilder.AddComponent(
+            materialSlot.LocalId,
+            ResoniteMaterialComponentBuilder.GetComponentType(material),
+            materialMembers));
+    }
+
+    private async Task<PreparedDedicatedMaterialAssets> PrepareDedicatedMaterialAssetsAsync(
+        IResoniteLinkClient importClient,
+        ResoniteMaterialBinding material,
+        Dictionary<TextureReferenceKey, ResoniteTextureImport> preparedTextureDataByKey,
+        CancellationToken cancellationToken)
+    {
+        Task<Uri?> albedoTextureTask = material.TexturePath is not null
+            && preparedTextureDataByKey.TryGetValue(
+                ResoniteMaterialAssetManager.CreateTextureReferenceKey(material.TexturePath, material.TextureSourceKind),
+                out ResoniteTextureImport? albedoTextureImport)
+            ? ImportOptionalTextureAsync(importClient, albedoTextureImport, cancellationToken)
+            : Task.FromResult<Uri?>(null);
+
+        Task<Uri?> normalTextureTask = Task.FromResult<Uri?>(null);
+        Task<Uri?> heightTextureTask = Task.FromResult<Uri?>(null);
+        Task<Uri?> metallicTextureTask = Task.FromResult<Uri?>(null);
+        Task<Uri?> emissionTextureTask = Task.FromResult<Uri?>(null);
+
         if (ResoniteMaterialComponentBuilder.TryGetBundledCompanionTextureSet(material, out BundledDefaultMaterialTextureSet? textureSet)
             && textureSet is not null)
         {
             if (textureSet.NormalPath is not null)
             {
-                Uri normalTextureUri = await ImportTextureAsync(
+                normalTextureTask = ImportOptionalTextureAsync(
                     importClient,
                     ResoniteTextureImportFactory.CreateFromFile(textureSet.NormalPath),
                     cancellationToken);
-                PendingBatchComponent normalTexture = batchBuilder.AddComponent(
-                    materialSlot.LocalId,
-                    "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                    CreateTextureMembers(normalTextureUri));
-                materialMembers["NormalMap"] = new Reference
-                {
-                    TargetID = normalTexture.LocalId,
-                };
-                materialMembers["NormalScale"] = new Field_float
-                {
-                    Value = DefaultNormalScale,
-                };
             }
 
             if (textureSet.HeightPath is not null
                 && material.Projection == ResoniteMaterialProjection.Uv)
             {
-                Uri heightTextureUri = await ImportTextureAsync(
+                heightTextureTask = ImportOptionalTextureAsync(
                     importClient,
                     ResoniteTextureImportFactory.CreateFromFile(textureSet.HeightPath),
                     cancellationToken);
-                PendingBatchComponent heightTexture = batchBuilder.AddComponent(
-                    materialSlot.LocalId,
-                    "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                    CreateTextureMembers(heightTextureUri));
-                materialMembers["HeightMap"] = new Reference
-                {
-                    TargetID = heightTexture.LocalId,
-                };
-                materialMembers["HeightScale"] = new Field_float
-                {
-                    Value = DefaultBundledHeightScale,
-                };
             }
 
             if (textureSet.MetallicPath is not null)
             {
-                Uri metallicTextureUri = await ImportTextureAsync(
+                metallicTextureTask = ImportOptionalTextureAsync(
                     importClient,
                     ResoniteTextureImportFactory.CreateFromFile(textureSet.MetallicPath),
                     cancellationToken);
-                PendingBatchComponent metallicTexture = batchBuilder.AddComponent(
-                    materialSlot.LocalId,
-                    "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                    CreateTextureMembers(metallicTextureUri));
-                materialMembers["MetallicMap"] = new Reference
-                {
-                    TargetID = metallicTexture.LocalId,
-                };
-                materialMembers["OcclusionMap"] = new Reference
-                {
-                    TargetID = metallicTexture.LocalId,
-                };
             }
 
             if (textureSet.EmissionPath is not null)
             {
-                Uri emissionTextureUri = await ImportTextureAsync(
+                emissionTextureTask = ImportOptionalTextureAsync(
                     importClient,
                     ResoniteTextureImportFactory.CreateFromFile(textureSet.EmissionPath),
                     cancellationToken);
-                PendingBatchComponent emissionTexture = batchBuilder.AddComponent(
-                    materialSlot.LocalId,
-                    "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                    CreateTextureMembers(emissionTextureUri));
-                materialMembers["EmissiveMap"] = new Reference
-                {
-                    TargetID = emissionTexture.LocalId,
-                };
-                materialMembers["EmissiveColor"] = ResoniteMaterialComponentBuilder.CreateColorMember(
-                    new ResoniteColor(1.0, 1.0, 1.0, 1.0));
             }
         }
 
-        return batchBuilder.AddComponent(
-            materialSlot.LocalId,
-            ResoniteMaterialComponentBuilder.GetComponentType(material),
-            materialMembers);
+        await Task.WhenAll(
+            albedoTextureTask,
+            normalTextureTask,
+            heightTextureTask,
+            metallicTextureTask,
+            emissionTextureTask);
+
+        return new PreparedDedicatedMaterialAssets(
+            await albedoTextureTask,
+            await normalTextureTask,
+            await heightTextureTask,
+            await metallicTextureTask,
+            await emissionTextureTask);
+    }
+
+    private Task<Uri?> ImportOptionalTextureAsync(
+        IResoniteLinkClient importClient,
+        ResoniteTextureImport textureImport,
+        CancellationToken cancellationToken)
+    {
+        return ImportOptionalTextureCoreAsync(importClient, textureImport, cancellationToken);
+    }
+
+    private async Task<Uri?> ImportOptionalTextureCoreAsync(
+        IResoniteLinkClient importClient,
+        ResoniteTextureImport textureImport,
+        CancellationToken cancellationToken)
+    {
+        return await ImportTextureAsync(importClient, textureImport, cancellationToken);
     }
 
     private static Dictionary<string, Member> CreateTextureMembers(Uri assetUri)
@@ -2242,4 +2315,11 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         string TexturePath,
         ResoniteTextureSourceKind TextureSourceKind,
         ResoniteTextureImport TextureImport);
+
+    private sealed record PreparedDedicatedMaterialAssets(
+        Uri? AlbedoTextureUri,
+        Uri? NormalTextureUri,
+        Uri? HeightTextureUri,
+        Uri? MetallicTextureUri,
+        Uri? EmissionTextureUri);
 }

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -210,6 +210,34 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         ReportProgress($"[live] Send lanes ready (setup=1, workers={Math.Max(connectionCount - 1, 0)}).");
     }
 
+    public async Task PrepareCommonMaterialAsync(
+        ResoniteMaterialBinding material,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+
+        if (material.AssetScope != ResoniteMaterialAssetScope.Common)
+        {
+            return;
+        }
+
+        ObjectDisposedException.ThrowIf(setupClient is null, this);
+        ObjectDisposedException.ThrowIf(commonAssetsRootSlot is null, this);
+        ObjectDisposedException.ThrowIf(materialAssetManager is null, this);
+        string commonAssetsSlotId = commonAssetsRootSlot.Value.SlotId;
+        string materialSlotName = CreateMaterialSlotName(material, useCommonMaterialAssets: true);
+        await materialAssetManager.CreateMaterialComponentAsync(
+            setupClient,
+            material,
+            preparedTexturePathsByKey: new Dictionary<TextureReferenceKey, ResoniteTextureImport>(),
+            materialSlotId: commonAssetsSlotId,
+            materialSlotParentId: commonAssetsSlotId,
+            materialSlotName: materialSlotName,
+            rendererSlotId: commonAssetsSlotId,
+            textureOverrideAssetSlotId: commonAssetsSlotId,
+            cancellationToken);
+    }
+
     private async Task<(CreatedSlot DatasetRoot, CreatedSlot DatasetAssetsRoot, CreatedSlot CommonAssetsRoot, bool DatasetRootExisted)> CreateSetupSlotHierarchyAsync(
         IResoniteLinkClient client,
         CancellationToken cancellationToken)

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -812,26 +812,32 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
 
         ResoniteConstructionCityObject cityObject = preparedCityObject.CityObject;
         using ResoniteLinkSendDiagnostics.CityObjectSendScope sendScope = diagnostics.BeginCityObjectSend(cityObject.PackageName);
+        Stopwatch cityObjectStopwatch = Stopwatch.StartNew();
         ReportBuildStep(cityObject, "Creating object slot hierarchy.");
+        Stopwatch slotHierarchyStopwatch = Stopwatch.StartNew();
         ObjectSlotHierarchy objectSlots = await CreateObjectSlotHierarchyAsync(
             setupClient,
             datasetRootSlot.Value,
             datasetAssetsRootSlot.Value,
             cityObject,
             cancellationToken);
+        slotHierarchyStopwatch.Stop();
 
         ReportBuildStep(cityObject, $"Preparing geometry assets ({DescribePreparedGeometry(preparedCityObject.Geometry)}).");
+        Stopwatch geometryStopwatch = Stopwatch.StartNew();
         PreparedGeometryAssetBatch preparedGeometryBatch = await PrepareGeometryBatchAsync(
             importClient,
             cityObject,
             preparedCityObject,
             cancellationToken);
+        geometryStopwatch.Stop();
 
         Dictionary<TextureReferenceKey, ResoniteTextureImport> preparedTextureDataByKey = preparedCityObject.Textures.ToDictionary(
             static texture => ResoniteMaterialAssetManager.CreateTextureReferenceKey(
                 texture.TexturePath,
                 texture.TextureSourceKind),
             static texture => texture.TextureImport);
+        Stopwatch materialStopwatch = Stopwatch.StartNew();
         List<MaterialReferenceTarget> materialTargets = [];
         for (int materialIndex = 0; materialIndex < cityObject.Materials.Count; materialIndex++)
         {
@@ -854,8 +860,10 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
                 materialTargets.Add(MaterialReferenceTarget.FromDedicatedMaterial(material));
             }
         }
+        materialStopwatch.Stop();
 
         ReportBuildStep(cityObject, "Creating object-scoped DataModel batch.");
+        Stopwatch batchStopwatch = Stopwatch.StartNew();
         await CreateCityObjectBatchAsync(
             mutationClient,
             importClient,
@@ -865,8 +873,19 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             preparedGeometryBatch,
             materialTargets,
             cancellationToken);
+        batchStopwatch.Stop();
 
         ReportBuildStep(cityObject, "Live build completed.");
+        cityObjectStopwatch.Stop();
+        ReportProgress(
+            PlateauLog.Debug(
+                "live",
+                $"City object '{cityObject.DisplayName}' phase timings: "
+                + $"slot_hierarchy_s={slotHierarchyStopwatch.Elapsed.TotalSeconds:F3} "
+                + $"geometry_assets_s={geometryStopwatch.Elapsed.TotalSeconds:F3} "
+                + $"materials_s={materialStopwatch.Elapsed.TotalSeconds:F3} "
+                + $"batch_s={batchStopwatch.Elapsed.TotalSeconds:F3} "
+                + $"total_send_s={cityObjectStopwatch.Elapsed.TotalSeconds:F3}."));
         sendScope.MarkSent();
         if (Interlocked.CompareExchange(ref firstBuiltCityObjectLogged, 1, 0) == 0)
         {

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -853,11 +853,12 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
 
         ReportBuildStep(cityObject, $"Preparing geometry assets ({DescribePreparedGeometry(preparedCityObject.Geometry)}).");
         Stopwatch geometryStopwatch = Stopwatch.StartNew();
+        using CancellationTokenSource buildStepCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         Task<PreparedGeometryAssetBatch> preparedGeometryBatchTask = PrepareGeometryBatchAsync(
             importClient,
             cityObject,
             preparedCityObject,
-            cancellationToken);
+            buildStepCancellation.Token);
 
         Dictionary<TextureReferenceKey, ResoniteTextureImport> preparedTextureDataByKey = preparedCityObject.Textures.ToDictionary(
             static texture => ResoniteMaterialAssetManager.CreateTextureReferenceKey(
@@ -867,39 +868,50 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         Stopwatch materialStopwatch = Stopwatch.StartNew();
         List<MaterialReferenceTarget> materialTargets = [];
         List<Task<PreparedDedicatedMaterialAssets>> dedicatedMaterialPreparationTasks = [];
-        for (int materialIndex = 0; materialIndex < cityObject.Materials.Count; materialIndex++)
+        PreparedDedicatedMaterialAssets[] preparedDedicatedMaterialAssets;
+        PreparedGeometryAssetBatch preparedGeometryBatch;
+        try
         {
-            ResoniteMaterialBinding material = cityObject.Materials[materialIndex];
-            ReportBuildStep(
-                cityObject,
-                $"Creating material {materialIndex + 1}/{cityObject.Materials.Count} ({material.MaterialKey}).");
-            if (material.AssetScope == ResoniteMaterialAssetScope.Common)
+            for (int materialIndex = 0; materialIndex < cityObject.Materials.Count; materialIndex++)
             {
-                CreatedMaterialAsset materialAsset = await CreateMaterialComponentAsync(
-                    importClient,
-                    material,
-                    preparedTextureDataByKey,
-                    objectSlots,
-                    cancellationToken);
-                materialTargets.Add(MaterialReferenceTarget.FromCanonical(materialAsset.MaterialComponentId));
-            }
-            else
-            {
-                materialTargets.Add(MaterialReferenceTarget.FromDedicatedMaterial(material));
-                dedicatedMaterialPreparationTasks.Add(
-                    PrepareDedicatedMaterialAssetsAsync(
+                ResoniteMaterialBinding material = cityObject.Materials[materialIndex];
+                ReportBuildStep(
+                    cityObject,
+                    $"Creating material {materialIndex + 1}/{cityObject.Materials.Count} ({material.MaterialKey}).");
+                if (material.AssetScope == ResoniteMaterialAssetScope.Common)
+                {
+                    CreatedMaterialAsset materialAsset = await CreateMaterialComponentAsync(
                         importClient,
                         material,
                         preparedTextureDataByKey,
-                        cancellationToken));
+                        objectSlots,
+                        buildStepCancellation.Token);
+                    materialTargets.Add(MaterialReferenceTarget.FromCanonical(materialAsset.MaterialComponentId));
+                }
+                else
+                {
+                    materialTargets.Add(MaterialReferenceTarget.FromDedicatedMaterial(material));
+                    dedicatedMaterialPreparationTasks.Add(
+                        PrepareDedicatedMaterialAssetsAsync(
+                            importClient,
+                            material,
+                            preparedTextureDataByKey,
+                            buildStepCancellation.Token));
+                }
             }
+            preparedDedicatedMaterialAssets = dedicatedMaterialPreparationTasks.Count == 0
+                ? []
+                : await Task.WhenAll(dedicatedMaterialPreparationTasks);
+            materialStopwatch.Stop();
+            preparedGeometryBatch = await preparedGeometryBatchTask;
+            geometryStopwatch.Stop();
         }
-        PreparedDedicatedMaterialAssets[] preparedDedicatedMaterialAssets = dedicatedMaterialPreparationTasks.Count == 0
-            ? []
-            : await Task.WhenAll(dedicatedMaterialPreparationTasks);
-        materialStopwatch.Stop();
-        PreparedGeometryAssetBatch preparedGeometryBatch = await preparedGeometryBatchTask;
-        geometryStopwatch.Stop();
+        catch
+        {
+            await buildStepCancellation.CancelAsync();
+            await ObserveTaskFailureAsync(preparedGeometryBatchTask);
+            throw;
+        }
 
         ReportBuildStep(cityObject, "Creating object-scoped DataModel batch.");
         Stopwatch batchStopwatch = Stopwatch.StartNew();
@@ -932,6 +944,21 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             ReportProgress(
                 $"[live] First city object built after {GetSceneElapsedSeconds():F3}s: "
                 + $"{cityObject.DisplayName} ({cityObject.PackageName}/{cityObject.SlotKey})");
+        }
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Best-effort cleanup should observe and suppress orphaned import task failures after the primary send failure.")]
+    private static async Task ObserveTaskFailureAsync(Task task)
+    {
+        try
+        {
+            await task;
+        }
+        catch
+        {
         }
     }
 

--- a/src/Plateau.ResoniteLink.Cli/ResoniteMaterialAssetManager.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteMaterialAssetManager.cs
@@ -137,12 +137,12 @@ internal sealed class ResoniteMaterialAssetManager(
             return reusedSharedMaterial.Value;
         }
 
-        Uri? albedoTextureUri = null;
-        Uri? normalTextureUri = null;
-        Uri? heightTextureUri = null;
-        Uri? metallicTextureUri = null;
-        Uri? emissionTextureUri = null;
         Stopwatch textureImportStopwatch = Stopwatch.StartNew();
+        Task<Uri?> albedoTextureTask = Task.FromResult<Uri?>(null);
+        Task<Uri?> normalTextureTask = Task.FromResult<Uri?>(null);
+        Task<Uri?> heightTextureTask = Task.FromResult<Uri?>(null);
+        Task<Uri?> metallicTextureTask = Task.FromResult<Uri?>(null);
+        Task<Uri?> emissionTextureTask = Task.FromResult<Uri?>(null);
 
         if (!suppressAlbedoTexture
             && material.TexturePath is not null
@@ -151,7 +151,7 @@ internal sealed class ResoniteMaterialAssetManager(
                 out ResoniteTextureImport? textureAsset))
         {
             ReportProgress($"[live] Material '{material.MaterialKey}' importing albedo texture.");
-            albedoTextureUri = await importTextureAsync(client, textureAsset, cancellationToken);
+            albedoTextureTask = ImportOptionalTextureAsync(client, textureAsset, cancellationToken);
         }
 
         if (ResoniteMaterialComponentBuilder.TryGetBundledCompanionTextureSet(material, out BundledDefaultMaterialTextureSet? textureSet)
@@ -161,7 +161,7 @@ internal sealed class ResoniteMaterialAssetManager(
             {
                 ReportProgress(
                     $"[live] Material '{material.MaterialKey}' importing bundled normal map from '{textureSet.NormalPath}'.");
-                normalTextureUri = await importTextureAsync(
+                normalTextureTask = ImportOptionalTextureAsync(
                     client,
                     ResoniteTextureImportFactory.CreateFromFile(textureSet.NormalPath),
                     cancellationToken);
@@ -176,7 +176,7 @@ internal sealed class ResoniteMaterialAssetManager(
             {
                 ReportProgress(
                     $"[live] Material '{material.MaterialKey}' importing bundled height map from '{textureSet.HeightPath}'.");
-                heightTextureUri = await importTextureAsync(
+                heightTextureTask = ImportOptionalTextureAsync(
                     client,
                     ResoniteTextureImportFactory.CreateFromFile(textureSet.HeightPath),
                     cancellationToken);
@@ -190,7 +190,7 @@ internal sealed class ResoniteMaterialAssetManager(
             {
                 ReportProgress(
                     $"[live] Material '{material.MaterialKey}' importing bundled metallic map from '{textureSet.MetallicPath}'.");
-                metallicTextureUri = await importTextureAsync(
+                metallicTextureTask = ImportOptionalTextureAsync(
                     client,
                     ResoniteTextureImportFactory.CreateFromFile(textureSet.MetallicPath),
                     cancellationToken);
@@ -200,7 +200,7 @@ internal sealed class ResoniteMaterialAssetManager(
             {
                 ReportProgress(
                     $"[live] Material '{material.MaterialKey}' importing bundled emission map from '{textureSet.EmissionPath}'.");
-                emissionTextureUri = await importTextureAsync(
+                emissionTextureTask = ImportOptionalTextureAsync(
                     client,
                     ResoniteTextureImportFactory.CreateFromFile(textureSet.EmissionPath),
                     cancellationToken);
@@ -208,6 +208,17 @@ internal sealed class ResoniteMaterialAssetManager(
                     new ResoniteColor(1.0, 1.0, 1.0, 1.0));
             }
         }
+        await Task.WhenAll(
+            albedoTextureTask,
+            normalTextureTask,
+            heightTextureTask,
+            metallicTextureTask,
+            emissionTextureTask);
+        Uri? albedoTextureUri = await albedoTextureTask;
+        Uri? normalTextureUri = await normalTextureTask;
+        Uri? heightTextureUri = await heightTextureTask;
+        Uri? metallicTextureUri = await metallicTextureTask;
+        Uri? emissionTextureUri = await emissionTextureTask;
         textureImportStopwatch.Stop();
 
         string materialContainerParentId = materialSlotParentId ?? materialSlotId;
@@ -390,6 +401,22 @@ internal sealed class ResoniteMaterialAssetManager(
                 },
             },
             cancellationToken);
+    }
+
+    private Task<Uri?> ImportOptionalTextureAsync(
+        IResoniteLinkClient client,
+        ResoniteTextureImport textureImport,
+        CancellationToken cancellationToken)
+    {
+        return ImportOptionalTextureCoreAsync(client, textureImport, cancellationToken);
+    }
+
+    private async Task<Uri?> ImportOptionalTextureCoreAsync(
+        IResoniteLinkClient client,
+        ResoniteTextureImport textureImport,
+        CancellationToken cancellationToken)
+    {
+        return await importTextureAsync(client, textureImport, cancellationToken);
     }
 
     internal static TextureReferenceKey CreateTextureReferenceKey(string texturePath, ResoniteTextureSourceKind textureSourceKind)

--- a/src/Plateau.ResoniteLink.Cli/ResoniteMaterialAssetManager.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteMaterialAssetManager.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+
+using Plateau.ResoniteLink.Application.Logging;
 using Plateau.ResoniteLink.Domain.Importing;
 
 using ResoniteLink;
@@ -83,6 +86,7 @@ internal sealed class ResoniteMaterialAssetManager(
         bool suppressAlbedoTexture,
         CancellationToken cancellationToken)
     {
+        Stopwatch totalStopwatch = Stopwatch.StartNew();
         string materialContainerSlotId = materialSlotId;
 
         Func<string, string, Func<CancellationToken, Task<Uri>>, CancellationToken, Task<ResoniteLinkSceneBuilder.CreatedComponent>> createAssetComponentAsync =
@@ -112,11 +116,33 @@ internal sealed class ResoniteMaterialAssetManager(
             $"[live] Material '{material.MaterialKey}' resolving as '{materialComponentType}' "
             + $"(projection={material.Projection}, texture={material.TexturePath ?? "none"}).");
 
+        Stopwatch lookupStopwatch = Stopwatch.StartNew();
+        ResoniteLinkSceneBuilder.CreatedComponent? reusedSharedMaterial = await TryReuseExistingSharedMaterialComponentAsync(
+            client,
+            materialSlotParentId,
+            materialSlotName,
+            materialComponentType,
+            cancellationToken);
+        lookupStopwatch.Stop();
+        if (reusedSharedMaterial is not null)
+        {
+            totalStopwatch.Stop();
+            ReportProgress(
+                PlateauLog.Debug(
+                    "live",
+                    $"Material '{material.MaterialKey}' phase timings: "
+                    + $"lookup_s={lookupStopwatch.Elapsed.TotalSeconds:F3} "
+                    + $"texture_imports_s=0.000 component_create_s=0.000 total_s={totalStopwatch.Elapsed.TotalSeconds:F3} "
+                    + "reused_existing=true."));
+            return reusedSharedMaterial.Value;
+        }
+
         Uri? albedoTextureUri = null;
         Uri? normalTextureUri = null;
         Uri? heightTextureUri = null;
         Uri? metallicTextureUri = null;
         Uri? emissionTextureUri = null;
+        Stopwatch textureImportStopwatch = Stopwatch.StartNew();
 
         if (!suppressAlbedoTexture
             && material.TexturePath is not null
@@ -182,6 +208,7 @@ internal sealed class ResoniteMaterialAssetManager(
                     new ResoniteColor(1.0, 1.0, 1.0, 1.0));
             }
         }
+        textureImportStopwatch.Stop();
 
         string materialContainerParentId = materialSlotParentId ?? materialSlotId;
         ResoniteLinkSceneBuilder.CreatedSlot createdMaterialSlot = await getOrCreateSharedChildSlotAsync(
@@ -205,6 +232,7 @@ internal sealed class ResoniteMaterialAssetManager(
                 materialComponentType);
         }
 
+        Stopwatch componentCreateStopwatch = Stopwatch.StartNew();
         if (albedoTextureUri is not null)
         {
             ResoniteLinkSceneBuilder.CreatedComponent albedoTexture = await CreateTextureComponentFromImportedUriAsync(
@@ -284,8 +312,64 @@ internal sealed class ResoniteMaterialAssetManager(
             materialComponentType,
             materialMembers,
             cancellationToken);
+        componentCreateStopwatch.Stop();
+        totalStopwatch.Stop();
+        ReportProgress(
+            PlateauLog.Debug(
+                "live",
+                $"Material '{material.MaterialKey}' phase timings: "
+                + $"lookup_s={lookupStopwatch.Elapsed.TotalSeconds:F3} "
+                + $"texture_imports_s={textureImportStopwatch.Elapsed.TotalSeconds:F3} "
+                + $"component_create_s={componentCreateStopwatch.Elapsed.TotalSeconds:F3} "
+                + $"total_s={totalStopwatch.Elapsed.TotalSeconds:F3} reused_existing=false."));
         ReportProgress($"[live] Material '{material.MaterialKey}' ready.");
         return materialComponent;
+    }
+
+    private async Task<ResoniteLinkSceneBuilder.CreatedComponent?> TryReuseExistingSharedMaterialComponentAsync(
+        IResoniteLinkClient client,
+        string? materialSlotParentId,
+        string materialSlotName,
+        string materialComponentType,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(materialSlotParentId))
+        {
+            return null;
+        }
+
+        Slot? parentSlot = await getSlotAsync(client, materialSlotParentId, 1, cancellationToken);
+        if (parentSlot?.Children is null)
+        {
+            return null;
+        }
+
+        Slot[] matchingSlots = parentSlot.Children
+            .Where(child => string.Equals(child.Name?.Value, materialSlotName, StringComparison.Ordinal))
+            .ToArray();
+        if (matchingSlots.Length == 0)
+        {
+            return null;
+        }
+
+        if (matchingSlots.Length > 1)
+        {
+            throw new InvalidOperationException(
+                $"Parent slot '{materialSlotParentId}' contains multiple child slots named '{materialSlotName}'.");
+        }
+
+        Component? existingMaterialComponent = matchingSlots[0].Components?.FirstOrDefault(component =>
+            string.Equals(component.ComponentType, materialComponentType, StringComparison.Ordinal));
+        if (existingMaterialComponent is null)
+        {
+            return null;
+        }
+
+        ReportProgress(
+            $"[live] Material slot '{materialSlotName}' reusing existing component '{materialComponentType}' without texture import.");
+        return new ResoniteLinkSceneBuilder.CreatedComponent(
+            existingMaterialComponent.ID,
+            materialComponentType);
     }
 
     private Task<ResoniteLinkSceneBuilder.CreatedComponent> CreateTextureComponentFromImportedUriAsync(

--- a/src/Plateau.ResoniteLink.Cli/ResoniteMaterialAssetManager.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteMaterialAssetManager.cs
@@ -146,8 +146,9 @@ internal sealed class ResoniteMaterialAssetManager(
 
         if (!suppressAlbedoTexture
             && material.TexturePath is not null
-            && preparedTexturePathsByKey.TryGetValue(
-                CreateTextureReferenceKey(material.TexturePath, material.TextureSourceKind),
+            && TryResolveAlbedoTextureImport(
+                material,
+                preparedTexturePathsByKey,
                 out ResoniteTextureImport? textureAsset))
         {
             ReportProgress($"[live] Material '{material.MaterialKey}' importing albedo texture.");
@@ -423,6 +424,35 @@ internal sealed class ResoniteMaterialAssetManager(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(texturePath);
         return new TextureReferenceKey(textureSourceKind, texturePath);
+    }
+
+    private static bool TryResolveAlbedoTextureImport(
+        ResoniteMaterialBinding material,
+        IReadOnlyDictionary<TextureReferenceKey, ResoniteTextureImport> preparedTexturePathsByKey,
+        out ResoniteTextureImport textureImport)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+        ArgumentNullException.ThrowIfNull(preparedTexturePathsByKey);
+
+        if (material.TexturePath is not null
+            && preparedTexturePathsByKey.TryGetValue(
+                CreateTextureReferenceKey(material.TexturePath, material.TextureSourceKind),
+                out ResoniteTextureImport? preparedTextureImport))
+        {
+            textureImport = preparedTextureImport;
+            return true;
+        }
+
+        if (material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
+            && material.TexturePath is not null)
+        {
+            textureImport = ResoniteTextureImportFactory.CreateFromFile(
+                BundledDefaultMaterialAssetStore.GetAbsolutePath(material.TexturePath));
+            return true;
+        }
+
+        textureImport = null!;
+        return false;
     }
 
     private async Task<Component?> TryGetExistingMaterialComponentAsync(

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -14,10 +14,12 @@ internal sealed class RetryingResoniteLinkClient(
     int importMeshTimeoutMilliseconds = CliDefaultOptions.ResoniteLinkImportMeshTimeoutMilliseconds) : IResoniteLinkClient
 {
     private const int AttemptLimit = 2;
+    private const int MaxConcurrentImports = 4;
     private static readonly TimeSpan SlowBatchThreshold = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan SlowImportMeshThreshold = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan SlowImportTextureThreshold = TimeSpan.FromSeconds(10);
     private readonly SemaphoreSlim operationGate = new(1, 1);
+    private readonly SemaphoreSlim importGate = new(MaxConcurrentImports, MaxConcurrentImports);
     private readonly SemaphoreSlim reconnectGate = new(1, 1);
     private IResoniteLinkClient inner = clientFactory();
     private Uri? endpoint;
@@ -26,6 +28,7 @@ internal sealed class RetryingResoniteLinkClient(
     public void Dispose()
     {
         operationGate.Dispose();
+        importGate.Dispose();
         reconnectGate.Dispose();
         inner.Dispose();
     }
@@ -121,7 +124,7 @@ internal sealed class RetryingResoniteLinkClient(
 
     public Task<Uri> ImportMeshAsync(ImportMeshRawData request, CancellationToken cancellationToken)
     {
-        return ExecuteTimedWithoutReconnectAsync(
+        return ExecuteTimedImportAsync(
             (client, state, ct) => ExecuteImportMeshWithTimeoutAsync(
                 client,
                 state,
@@ -136,7 +139,7 @@ internal sealed class RetryingResoniteLinkClient(
 
     public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
     {
-        return ExecuteTimedWithoutReconnectAsync(
+        return ExecuteTimedImportAsync(
             static (client, state, ct) => client.ImportTextureAsync(state, ct),
             textureImport,
             "ImportTexture",
@@ -246,6 +249,67 @@ internal sealed class RetryingResoniteLinkClient(
         }
 
         return result;
+    }
+
+    private async Task<TResult> ExecuteTimedImportAsync<TState, TResult>(
+        Func<IResoniteLinkClient, TState, CancellationToken, Task<TResult>> operation,
+        TState state,
+        string operationName,
+        TimeSpan slowThreshold,
+        CancellationToken cancellationToken)
+    {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        TResult result = await ExecuteImportAsync(
+            operation,
+            state,
+            operationName,
+            cancellationToken);
+        stopwatch.Stop();
+
+        reporter?.Invoke(
+            PlateauLog.Debug(
+                "live",
+                $"ResoniteLink {operationName} completed in {stopwatch.Elapsed.TotalSeconds:F3}s."));
+        if (stopwatch.Elapsed >= slowThreshold)
+        {
+            reporter?.Invoke(
+                PlateauLog.Warning(
+                    "live",
+                    $"ResoniteLink {operationName} exceeded slow threshold {slowThreshold.TotalSeconds:F1}s "
+                    + $"(actual={stopwatch.Elapsed.TotalSeconds:F3}s)."));
+        }
+
+        return result;
+    }
+
+    private async Task<TResult> ExecuteImportAsync<TState, TResult>(
+        Func<IResoniteLinkClient, TState, CancellationToken, Task<TResult>> operation,
+        TState state,
+        string operationName,
+        CancellationToken cancellationToken)
+    {
+        await importGate.WaitAsync(cancellationToken);
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await operation(inner, state, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            reporter?.Invoke(
+                PlateauLog.Warning(
+                    "live",
+                    $"ResoniteLink {operationName} failed without retry. Reason: {exception.Message}"));
+            throw;
+        }
+        finally
+        {
+            importGate.Release();
+        }
     }
 
     private static async Task<Uri> ExecuteImportMeshWithTimeoutAsync(

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
 using System.Reflection;
 
 using Plateau.ResoniteLink.Application.Logging;
@@ -13,6 +14,9 @@ internal sealed class RetryingResoniteLinkClient(
     int importMeshTimeoutMilliseconds = CliDefaultOptions.ResoniteLinkImportMeshTimeoutMilliseconds) : IResoniteLinkClient
 {
     private const int AttemptLimit = 2;
+    private static readonly TimeSpan SlowBatchThreshold = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan SlowImportMeshThreshold = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan SlowImportTextureThreshold = TimeSpan.FromSeconds(10);
     private readonly SemaphoreSlim operationGate = new(1, 1);
     private readonly SemaphoreSlim reconnectGate = new(1, 1);
     private IResoniteLinkClient inner = clientFactory();
@@ -89,10 +93,11 @@ internal sealed class RetryingResoniteLinkClient(
         IReadOnlyList<DataModelOperation> operations,
         CancellationToken cancellationToken)
     {
-        return ExecuteWithoutReconnectAsync(
+        return ExecuteTimedWithoutReconnectAsync(
             static (client, state, ct) => client.RunDataModelOperationBatchAsync(state, ct),
             operations,
             "RunDataModelOperationBatch",
+            SlowBatchThreshold,
             cancellationToken);
     }
 
@@ -116,7 +121,7 @@ internal sealed class RetryingResoniteLinkClient(
 
     public Task<Uri> ImportMeshAsync(ImportMeshRawData request, CancellationToken cancellationToken)
     {
-        return ExecuteWithoutReconnectAsync(
+        return ExecuteTimedWithoutReconnectAsync(
             (client, state, ct) => ExecuteImportMeshWithTimeoutAsync(
                 client,
                 state,
@@ -125,15 +130,17 @@ internal sealed class RetryingResoniteLinkClient(
                 ct),
             request,
             "ImportMesh",
+            SlowImportMeshThreshold,
             cancellationToken);
     }
 
     public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
     {
-        return ExecuteWithoutReconnectAsync(
+        return ExecuteTimedWithoutReconnectAsync(
             static (client, state, ct) => client.ImportTextureAsync(state, ct),
             textureImport,
             "ImportTexture",
+            SlowImportTextureThreshold,
             cancellationToken);
     }
 
@@ -208,6 +215,37 @@ internal sealed class RetryingResoniteLinkClient(
         {
             operationGate.Release();
         }
+    }
+
+    private async Task<TResult> ExecuteTimedWithoutReconnectAsync<TState, TResult>(
+        Func<IResoniteLinkClient, TState, CancellationToken, Task<TResult>> operation,
+        TState state,
+        string operationName,
+        TimeSpan slowThreshold,
+        CancellationToken cancellationToken)
+    {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        TResult result = await ExecuteWithoutReconnectAsync(
+            operation,
+            state,
+            operationName,
+            cancellationToken);
+        stopwatch.Stop();
+
+        reporter?.Invoke(
+            PlateauLog.Debug(
+                "live",
+                $"ResoniteLink {operationName} completed in {stopwatch.Elapsed.TotalSeconds:F3}s."));
+        if (stopwatch.Elapsed >= slowThreshold)
+        {
+            reporter?.Invoke(
+                PlateauLog.Warning(
+                    "live",
+                    $"ResoniteLink {operationName} exceeded slow threshold {slowThreshold.TotalSeconds:F1}s "
+                    + $"(actual={stopwatch.Elapsed.TotalSeconds:F3}s)."));
+        }
+
+        return result;
     }
 
     private static async Task<Uri> ExecuteImportMeshWithTimeoutAsync(

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -21,9 +21,14 @@ internal sealed class RetryingResoniteLinkClient(
     private readonly SemaphoreSlim operationGate = new(1, 1);
     private readonly SemaphoreSlim importGate = new(MaxConcurrentImports, MaxConcurrentImports);
     private readonly SemaphoreSlim reconnectGate = new(1, 1);
+    private readonly object clientStateGate = new();
     private IResoniteLinkClient inner = clientFactory();
     private Uri? endpoint;
     private int generation;
+    private int activeImportCount;
+    private bool reconnectPending;
+    private TaskCompletionSource<bool>? reconnectCompletion;
+    private TaskCompletionSource<bool>? importDrainCompletion;
 
     public void Dispose()
     {
@@ -291,8 +296,40 @@ internal sealed class RetryingResoniteLinkClient(
         await importGate.WaitAsync(cancellationToken);
         try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            return await operation(inner, state, cancellationToken);
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Task reconnectTask;
+                IResoniteLinkClient? client = null;
+                lock (clientStateGate)
+                {
+                    if (!reconnectPending)
+                    {
+                        activeImportCount++;
+                        client = inner;
+                        reconnectTask = Task.CompletedTask;
+                    }
+                    else
+                    {
+                        reconnectTask = reconnectCompletion?.Task ?? Task.CompletedTask;
+                    }
+                }
+
+                if (client is null)
+                {
+                    await reconnectTask.WaitAsync(cancellationToken);
+                    continue;
+                }
+
+                try
+                {
+                    return await operation(client, state, cancellationToken);
+                }
+                finally
+                {
+                    ReleaseActiveImport();
+                }
+            }
         }
         catch (OperationCanceledException)
         {
@@ -310,6 +347,22 @@ internal sealed class RetryingResoniteLinkClient(
         {
             importGate.Release();
         }
+    }
+
+    private void ReleaseActiveImport()
+    {
+        TaskCompletionSource<bool>? importDrainSignal = null;
+        lock (clientStateGate)
+        {
+            activeImportCount--;
+            if (activeImportCount == 0 && reconnectPending)
+            {
+                importDrainSignal = importDrainCompletion;
+                importDrainCompletion = null;
+            }
+        }
+
+        importDrainSignal?.TrySetResult(true);
     }
 
     private static async Task<Uri> ExecuteImportMeshWithTimeoutAsync(
@@ -506,6 +559,18 @@ internal sealed class RetryingResoniteLinkClient(
                 throw new InvalidOperationException("Cannot reconnect before an endpoint has been established.");
             }
 
+            Task waitForImportsTask;
+            TaskCompletionSource<bool> reconnectCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            lock (clientStateGate)
+            {
+                reconnectPending = true;
+                reconnectCompletion = reconnectCompletionSource;
+                waitForImportsTask = activeImportCount == 0
+                    ? Task.CompletedTask
+                    : (importDrainCompletion ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)).Task;
+            }
+
+            await waitForImportsTask.WaitAsync(cancellationToken);
             IResoniteLinkClient previous = inner;
             IResoniteLinkClient replacement = clientFactory();
 
@@ -516,11 +581,24 @@ internal sealed class RetryingResoniteLinkClient(
             catch
             {
                 replacement.Dispose();
+                lock (clientStateGate)
+                {
+                    reconnectPending = false;
+                    reconnectCompletion = null;
+                }
+                reconnectCompletionSource.TrySetResult(true);
                 throw;
             }
 
-            inner = replacement;
-            Interlocked.Increment(ref generation);
+            lock (clientStateGate)
+            {
+                inner = replacement;
+                reconnectPending = false;
+                reconnectCompletion = null;
+                importDrainCompletion = null;
+                Interlocked.Increment(ref generation);
+            }
+            reconnectCompletionSource.TrySetResult(true);
             previous.Dispose();
             reporter?.Invoke(PlateauLog.Warning("live", $"Reconnected ResoniteLink client to {endpoint}."));
         }

--- a/tests/Plateau.ResoniteLink.Tests/Application/LocalCityGmlConstructionSourceFactoryTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/LocalCityGmlConstructionSourceFactoryTests.cs
@@ -93,6 +93,13 @@ public sealed class LocalCityGmlConstructionSourceFactoryTests
                 []),
             LocalOrigin: new ResoniteLocalOrigin(35.0, 139.0, 0.0));
 
+        public async IAsyncEnumerable<ResoniteMaterialBinding> ReadCommonMaterialsAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
         public IEnumerable<ResoniteConstructionCityObject> ReadCityObjects()
         {
             return [];

--- a/tests/Plateau.ResoniteLink.Tests/Application/LocalCityGmlResonitePlanBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/LocalCityGmlResonitePlanBuilderTests.cs
@@ -146,6 +146,14 @@ public sealed class LocalCityGmlResonitePlanBuilderTests
             return Task.CompletedTask;
         }
 
+        public Task PrepareCommonMaterialAsync(
+            ResoniteMaterialBinding material,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
         public Task ProcessCityObjectAsync(
             ResoniteConstructionCityObject cityObject,
             CancellationToken cancellationToken = default)

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -95,6 +95,36 @@ public sealed class PlateauImportServiceTests
     }
 
     [Fact]
+    public async Task ExecuteAsyncPrewarmsCommonMaterialsDuringStreaming()
+    {
+        StubResoniteSceneBuilder sceneBuilder = new();
+        RecordingDatasetSourceResolver datasetSourceResolver = new(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: "/resolved/source",
+                ServerUri: null));
+        PlateauImportService service = new(
+            sceneBuilder,
+            datasetSourceResolver,
+            constructionSourceFactory: new RecordingConstructionSourceFactory(CreateStubConstructionSource()));
+
+        await service.ExecuteAsync(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Remote,
+                LocalSourcePath: null,
+                ServerUri: new Uri("https://example.invalid/source.zip", UriKind.Absolute)),
+            workRoot: "runtime/resonite");
+
+        ResoniteMaterialBinding commonMaterial = Assert.Single(sceneBuilder.CommonMaterials);
+        Assert.Equal("stub-material", commonMaterial.MaterialKey);
+        Assert.Equal(ResoniteMaterialAssetScope.Common, commonMaterial.AssetScope);
+    }
+
+    [Fact]
     public async Task ExecuteAsyncBuildsNormalizedSceneFromZipArchive()
     {
         using TemporaryDirectory archiveRoot = new();
@@ -2430,6 +2460,7 @@ public sealed class PlateauImportServiceTests
     private sealed class StubResoniteSceneBuilder : IResoniteSceneBuilder
     {
         public List<ResoniteConstructionCityObject> CityObjects { get; } = [];
+        public List<ResoniteMaterialBinding> CommonMaterials { get; } = [];
         public List<string> BeginWorkRoots { get; } = [];
         public int EnsureConnectedCallCount { get; private set; }
         public int DisposeCallCount { get; private set; }
@@ -2463,6 +2494,15 @@ public sealed class PlateauImportServiceTests
             ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
             BeginWorkRoots.Add(workRoot);
             OnBegin?.Invoke();
+            return Task.CompletedTask;
+        }
+
+        public Task PrepareCommonMaterialAsync(
+            ResoniteMaterialBinding material,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(material);
+            CommonMaterials.Add(material);
             return Task.CompletedTask;
         }
 
@@ -2539,6 +2579,21 @@ public sealed class PlateauImportServiceTests
     {
         public ResoniteConstructionMetadata Metadata { get; } = metadata;
 
+        public async IAsyncEnumerable<ResoniteMaterialBinding> ReadCommonMaterialsAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (ResoniteMaterialBinding material in cityObjects
+                         .SelectMany(static cityObject => cityObject.Materials)
+                         .Where(static material => material.AssetScope == ResoniteMaterialAssetScope.Common)
+                         .GroupBy(static material => material.MaterialKey, StringComparer.Ordinal)
+                         .Select(static group => group.First()))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return material;
+                await Task.Yield();
+            }
+        }
+
         public IEnumerable<ResoniteConstructionCityObject> ReadCityObjects()
         {
             return cityObjects;
@@ -2598,7 +2653,8 @@ public sealed class PlateauImportServiceTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     TextureScale: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    AssetScope: ResoniteMaterialAssetScope.Common),
             ]);
 
         return new StubConstructionSource(

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliApplicationTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliApplicationTests.cs
@@ -196,6 +196,13 @@ public sealed class CliApplicationTests
             return Task.CompletedTask;
         }
 
+        public Task PrepareCommonMaterialAsync(
+            ResoniteMaterialBinding material,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
         public Task ProcessCityObjectAsync(
             ResoniteConstructionCityObject cityObject,
             CancellationToken cancellationToken = default)

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkClientTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkClientTests.cs
@@ -40,6 +40,7 @@ public sealed class ResoniteLinkClientTests
     [Fact]
     public async Task ImportTextureAsyncFallsBackToRawPayloadWhenFileImportPathIsNotResolvableByListener()
     {
+        using EnvironmentVariableScope scope = new("WSL_DISTRO_NAME", null);
         using TemporaryDirectory temporaryDirectory = new();
         string texturePath = Path.Combine(temporaryDirectory.Path, "albedo.png");
         using (Image<Rgba32> image = new(1, 1, new Rgba32(255, 0, 0, 255)))
@@ -77,6 +78,7 @@ public sealed class ResoniteLinkClientTests
     [Fact]
     public async Task ImportTextureAsyncDoesNotFallbackWhenLocalFileIsMissing()
     {
+        using EnvironmentVariableScope scope = new("WSL_DISTRO_NAME", null);
         string texturePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.png");
         using FakeResoniteLinkTransport transport = new()
         {
@@ -98,6 +100,63 @@ public sealed class ResoniteLinkClientTests
         Assert.Equal(0, transport.ImportTextureRawCallCount);
     }
 
+    [Fact]
+    public async Task ImportTextureAsyncUsesRawPayloadImmediatelyWhenRunningUnderWsl()
+    {
+        using EnvironmentVariableScope scope = new("WSL_DISTRO_NAME", "Ubuntu-24.04");
+        using TemporaryDirectory temporaryDirectory = new();
+        string texturePath = Path.Combine(temporaryDirectory.Path, "albedo.png");
+        using (Image<Rgba32> image = new(1, 1, new Rgba32(255, 0, 0, 255)))
+        {
+            await image.SaveAsPngAsync(texturePath);
+        }
+
+        using FakeResoniteLinkTransport transport = new()
+        {
+            ImportTextureRawResult = new AssetData
+            {
+                Success = true,
+                AssetURL = new Uri("file:///tmp/albedo.png"),
+            },
+        };
+
+        using ResoniteLinkClient client = new(transport);
+        Uri importedTexture = await client.ImportTextureAsync(
+            ResoniteTextureImportFactory.CreateFromFile(texturePath),
+            CancellationToken.None);
+
+        Assert.Equal(new Uri("file:///tmp/albedo.png"), importedTexture);
+        Assert.Equal(0, transport.ImportTextureFileCallCount);
+        Assert.Equal(1, transport.ImportTextureRawCallCount);
+        Assert.NotNull(transport.LastRawTextureRequest);
+        Assert.Equal(1, transport.LastRawTextureRequest!.Width);
+        Assert.Equal(1, transport.LastRawTextureRequest.Height);
+    }
+
+    [Fact]
+    public void TranslateFilePathForHostConvertsMountedWindowsPathsUnderWsl()
+    {
+        using EnvironmentVariableScope scope = new("WSL_DISTRO_NAME", "Ubuntu-24.04");
+
+        string translatedPath = ResoniteLinkClient.TranslateFilePathForHost(
+            "/mnt/c/Users/esnya/Documents/texture.png");
+
+        Assert.Equal(@"C:\Users\esnya\Documents\texture.png", translatedPath);
+    }
+
+    [Fact]
+    public void TranslateFilePathForHostConvertsNonMountedPathsToWslUncPath()
+    {
+        using EnvironmentVariableScope scope = new("WSL_DISTRO_NAME", "Ubuntu-24.04");
+
+        string translatedPath = ResoniteLinkClient.TranslateFilePathForHost(
+            "/tmp/Plateau.ResoniteLink/default-materials/default-materials/roof/Concrete033_2K-JPG_Color.jpg");
+
+        Assert.Equal(
+            @"\\wsl.localhost\Ubuntu-24.04\tmp\Plateau.ResoniteLink\default-materials\default-materials\roof\Concrete033_2K-JPG_Color.jpg",
+            translatedPath);
+    }
+
     private sealed class FakeResoniteLinkTransport : IResoniteLinkTransport
     {
         public AssetData ImportTextureFileResult { get; set; } = new() { Success = true };
@@ -109,6 +168,8 @@ public sealed class ResoniteLinkClientTests
         public int ImportTextureRawCallCount { get; private set; }
 
         public ImportTexture2DRawData? LastRawTextureRequest { get; private set; }
+
+        public ImportTexture2DFile? LastFileTextureRequest { get; private set; }
 
         public void Dispose()
         {
@@ -129,6 +190,7 @@ public sealed class ResoniteLinkClientTests
         public Task<AssetData> ImportTextureFileAsync(ImportTexture2DFile request)
         {
             ImportTextureFileCallCount++;
+            LastFileTextureRequest = request;
             return Task.FromResult(ImportTextureFileResult);
         }
 
@@ -144,5 +206,23 @@ public sealed class ResoniteLinkClientTests
         public Task<BatchResponse> RunDataModelOperationBatchAsync(List<DataModelOperation> operations) => throw new NotSupportedException();
 
         public Task<Response> UpdateComponentAsync(UpdateComponent request) => throw new NotSupportedException();
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string variableName;
+        private readonly string? previousValue;
+
+        public EnvironmentVariableScope(string variableName, string? value)
+        {
+            this.variableName = variableName;
+            previousValue = Environment.GetEnvironmentVariable(variableName);
+            Environment.SetEnvironmentVariable(variableName, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(variableName, previousValue);
+        }
     }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -1916,6 +1916,37 @@ public sealed class ResoniteLinkSceneBuilderTests
     }
 
     [Fact]
+    public async Task CompleteAsyncWaitsForBlockedGeometryImportAfterMaterialFailure()
+    {
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
+        CapturedResoniteScene scene = LoadScene(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: fixturePath,
+                ServerUri: null));
+
+        using BlockingMeshFailingTextureClient client = new();
+        await using ResoniteLinkSceneBuilder builder = new(
+            new Uri("ws://localhost:12345/"),
+            1,
+            ResoniteLinkSendDiagnostics.Disabled,
+            () => client);
+
+        using TemporaryDirectory workDirectory = new();
+        await builder.BeginAsync(scene.Metadata, workDirectory.Path);
+        await builder.ProcessCityObjectAsync(scene.CityObjects[0]);
+
+        Task<IReadOnlyList<string>> completionTask = builder.CompleteAsync();
+        await client.ImportMeshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await client.ImportMeshCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() => completionTask);
+        Assert.Contains("Simulated texture import failure.", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task BuildAsyncDoesNotLeavePresentationSlotWhenGeometryImportFails()
     {
         string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
@@ -4148,6 +4179,93 @@ public sealed class ResoniteLinkSceneBuilderTests
         public void ReleaseMeshImports()
         {
             meshImportRelease.TrySetResult();
+        }
+
+        public Task UpdateComponentAsync(UpdateComponent request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class BlockingMeshFailingTextureClient : IResoniteLinkClient
+    {
+        private int nextComponentId;
+        private int nextSlotId;
+
+        public TaskCompletionSource ImportMeshStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowImportMeshCompletion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ImportMeshCanceled { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Dispose()
+        {
+        }
+
+        public Task ConnectAsync(Uri endpoint, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task<string> AddComponentAsync(AddComponent request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult($"srv_component_{Interlocked.Increment(ref nextComponentId)}");
+        }
+
+        public Task<string> AddSlotAsync(AddSlot request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult($"srv_slot_{Interlocked.Increment(ref nextSlotId)}");
+        }
+
+        public Task<BatchResponse> RunDataModelOperationBatchAsync(
+            IReadOnlyList<DataModelOperation> operations,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new BatchResponse
+            {
+                Success = true,
+                Responses = [],
+            });
+        }
+
+        public Task<Component?> GetComponentAsync(string componentId, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<Component?>(null);
+        }
+
+        public Task<Slot?> GetSlotAsync(string slotId, int depth, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<Slot?>(null);
+        }
+
+        public async Task<Uri> ImportMeshAsync(ImportMeshRawData request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ImportMeshStarted.TrySetResult();
+            try
+            {
+                await AllowImportMeshCompletion.Task.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                ImportMeshCanceled.TrySetResult();
+                throw;
+            }
+
+            return new Uri("resdb:///mesh/blocked", UriKind.Absolute);
+        }
+
+        public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new InvalidOperationException("Simulated texture import failure.");
         }
 
         public Task UpdateComponentAsync(UpdateComponent request, CancellationToken cancellationToken)

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteMaterialAssetManagerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteMaterialAssetManagerTests.cs
@@ -224,6 +224,77 @@ public sealed class ResoniteMaterialAssetManagerTests
         Assert.Equal([], calls);
     }
 
+    [Fact]
+    public async Task CreateMaterialComponentAsyncReusesExistingSharedMaterialBeforeTextureImport()
+    {
+        List<string> calls = [];
+        Slot parentSlot = new()
+        {
+            ID = "common-slot",
+            Children =
+            [
+                new Slot
+                {
+                    ID = "existing-material-slot",
+                    Name = new Field_string
+                    {
+                        Value = "Material",
+                    },
+                    Components =
+                    [
+                        new Component
+                        {
+                            ID = "existing-material-component",
+                            ComponentType = "[FrooxEngine]FrooxEngine.PBS_Metallic",
+                        },
+                    ],
+                },
+            ],
+        };
+        ResoniteMaterialAssetManager manager = new(
+            static (_, _, _, _, _) => throw new NotSupportedException(),
+            static (_, _, _, _, _) => throw new NotSupportedException(),
+            (_, _, _, _) =>
+            {
+                calls.Add("create-shared-slot");
+                return Task.FromResult(new ResoniteLinkSceneBuilder.CreatedSlot("shared-slot", "Material"));
+            },
+            (_, _, componentType, _, _) =>
+            {
+                calls.Add($"create-component:{componentType}");
+                return Task.FromResult(new ResoniteLinkSceneBuilder.CreatedComponent("material-component", componentType));
+            },
+            (_, slotId, _, _) =>
+            {
+                calls.Add($"get-slot:{slotId}");
+                return Task.FromResult<Slot?>(parentSlot);
+            },
+            static (_, _, _) => throw new InvalidOperationException("texture import should not run"));
+        using StubResoniteLinkClient client = new();
+        Dictionary<TextureReferenceKey, ResoniteTextureImport> preparedTextures = new()
+        {
+            [ResoniteMaterialAssetManager.CreateTextureReferenceKey("textures/albedo.png", ResoniteTextureSourceKind.Dataset)] =
+                ResoniteTextureImportFactory.CreateFromFile("/tmp/albedo.png"),
+        };
+
+        CreatedMaterialAsset created = await manager.CreateMaterialComponentAsync(
+            client,
+            CreateMaterial(
+                texturePath: "textures/albedo.png",
+                textureSourceKind: ResoniteTextureSourceKind.Dataset,
+                baseColor: new ResoniteColor(0.8, 0.8, 0.8, 1.0)),
+            preparedTextures,
+            "scope-slot",
+            "common-slot",
+            "Material",
+            "renderer-slot",
+            "texture-slot",
+            CancellationToken.None);
+
+        Assert.Equal("existing-material-component", created.MaterialComponentId);
+        Assert.Equal(["get-slot:common-slot"], calls);
+    }
+
     private static ResoniteMaterialBinding CreateMaterial(
         string? texturePath = null,
         ResoniteTextureSourceKind textureSourceKind = ResoniteTextureSourceKind.Bundled,

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteMaterialAssetManagerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteMaterialAssetManagerTests.cs
@@ -295,6 +295,49 @@ public sealed class ResoniteMaterialAssetManagerTests
         Assert.Equal(["get-slot:common-slot"], calls);
     }
 
+    [Fact]
+    public async Task CreateMaterialComponentAsyncImportsBundledAlbedoWithoutPreparedTextureMap()
+    {
+        List<string> calls = [];
+        ResoniteMaterialAssetManager manager = new(
+            static (_, _, _, _, _) => throw new NotSupportedException(),
+            static (_, _, _, _, _) => throw new NotSupportedException(),
+            static (_, _, _, _) => Task.FromResult(new ResoniteLinkSceneBuilder.CreatedSlot("shared-slot", "Material")),
+            (_, _, componentType, _, _) =>
+            {
+                calls.Add($"create-component:{componentType}");
+                return Task.FromResult(new ResoniteLinkSceneBuilder.CreatedComponent("material-component", componentType));
+            },
+            static (_, _, _, _) => Task.FromResult<Slot?>(null),
+            (_, textureImport, _) =>
+            {
+                calls.Add(textureImport switch
+                {
+                    ResoniteFileTextureImport fileImport => $"import-file:{Path.GetFileName(fileImport.AbsolutePath)}",
+                    _ => $"import:{textureImport.GetType().Name}",
+                });
+
+                return Task.FromResult(new Uri("file:///tmp/bundled.png"));
+            });
+        using StubResoniteLinkClient client = new();
+
+        await manager.CreateMaterialComponentAsync(
+            client,
+            CreateMaterial(
+                texturePath: "default-materials/roof/Concrete033_2K-JPG_Color.jpg",
+                textureSourceKind: ResoniteTextureSourceKind.Bundled),
+            new Dictionary<TextureReferenceKey, ResoniteTextureImport>(),
+            "scope-slot",
+            "common-slot",
+            "Material",
+            "renderer-slot",
+            "texture-slot",
+            CancellationToken.None);
+
+        Assert.Contains(calls, static call => call.StartsWith("import-file:Concrete033_2K-JPG_Color", StringComparison.Ordinal));
+        Assert.Contains(calls, static call => call == "create-component:[FrooxEngine]FrooxEngine.PBS_Metallic");
+    }
+
     private static ResoniteMaterialBinding CreateMaterial(
         string? texturePath = null,
         ResoniteTextureSourceKind textureSourceKind = ResoniteTextureSourceKind.Bundled,

--- a/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
@@ -83,7 +83,7 @@ public sealed class RetryingResoniteLinkClientTests
     }
 
     [Fact]
-    public async Task ConcurrentOperationsAreSerializedPerClient()
+    public async Task MutationOperationsDoNotWaitForImportMeshToComplete()
     {
         using BlockingReconnectableClient innerClient = new();
         using RetryingResoniteLinkClient client = new(() => innerClient);
@@ -119,7 +119,7 @@ public sealed class RetryingResoniteLinkClientTests
             CancellationToken.None);
 
         await Task.Delay(100);
-        Assert.False(addSlotTask.IsCompleted);
+        Assert.True(addSlotTask.IsCompletedSuccessfully);
 
         innerClient.AllowImportMeshCompletion.SetResult();
 
@@ -128,7 +128,7 @@ public sealed class RetryingResoniteLinkClientTests
 
         Assert.Equal(1, innerClient.ImportMeshCallCount);
         Assert.Equal(1, innerClient.AddSlotCallCount);
-        Assert.True(innerClient.AddSlotStartedAfterImportCompleted);
+        Assert.False(innerClient.AddSlotStartedAfterImportCompleted);
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
@@ -222,6 +222,49 @@ public sealed class RetryingResoniteLinkClientTests
         Assert.Equal("srv_slot_1", createdSlotId);
     }
 
+    [Fact]
+    public async Task GetSlotAsyncReconnectWaitsForConcurrentImportBeforeDisposingClient()
+    {
+        int createdClientCount = 0;
+        using CoordinatedReconnectableClient firstClient = new(failGetSlot: true);
+        using CoordinatedReconnectableClient secondClient = new();
+
+        using RetryingResoniteLinkClient client = new(
+            () =>
+            {
+                createdClientCount++;
+                return createdClientCount == 1 ? firstClient : secondClient;
+            });
+
+        await client.ConnectAsync(new Uri("ws://localhost:12345/"), CancellationToken.None);
+
+        Task<Uri> importTask = client.ImportMeshAsync(
+            new ImportMeshRawData
+            {
+                RawBinaryPayload = [1, 2, 3],
+                VertexCount = 3,
+            },
+            CancellationToken.None);
+        await firstClient.ImportMeshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task<Slot?> getSlotTask = client.GetSlotAsync("slot-id", 0, CancellationToken.None);
+
+        await Task.Delay(100);
+        Assert.False(getSlotTask.IsCompleted);
+        Assert.Equal(0, firstClient.DisposeCallCount);
+
+        firstClient.AllowImportMeshCompletion.SetResult();
+
+        Uri importedMesh = await importTask;
+        Slot? slot = await getSlotTask;
+
+        Assert.Equal(new Uri("resdb:///mesh/ok", UriKind.Absolute), importedMesh);
+        Assert.NotNull(slot);
+        Assert.Equal("slot-id", slot!.ID);
+        Assert.Equal(1, firstClient.DisposeCallCount);
+        Assert.Equal(1, secondClient.ConnectCallCount);
+    }
+
     private sealed class StubReconnectableClient(bool failImportMesh = false, bool failGetSlot = false) : IResoniteLinkClient
     {
         private int nextComponentId;
@@ -419,6 +462,99 @@ public sealed class RetryingResoniteLinkClientTests
         private sealed class FakeWebSocket
         {
             public string State { get; } = "Open";
+        }
+    }
+
+    private sealed class CoordinatedReconnectableClient(bool failGetSlot = false) : IResoniteLinkClient
+    {
+        private bool disposed;
+        private int nextSlotId;
+
+        public TaskCompletionSource ImportMeshStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowImportMeshCompletion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int ConnectCallCount { get; private set; }
+
+        public int DisposeCallCount { get; private set; }
+
+        public void Dispose()
+        {
+            disposed = true;
+            DisposeCallCount++;
+        }
+
+        public Task ConnectAsync(Uri endpoint, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ConnectCallCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task<string> AddComponentAsync(AddComponent request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult("srv_component_1");
+        }
+
+        public Task<string> AddSlotAsync(AddSlot request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult($"srv_slot_{Interlocked.Increment(ref nextSlotId)}");
+        }
+
+        public Task<BatchResponse> RunDataModelOperationBatchAsync(
+            IReadOnlyList<DataModelOperation> operations,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new BatchResponse
+            {
+                Success = true,
+                Responses = [],
+            });
+        }
+
+        public Task<Component?> GetComponentAsync(string componentId, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<Component?>(null);
+        }
+
+        public Task<Slot?> GetSlotAsync(string slotId, int depth, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (failGetSlot)
+            {
+                throw new InvalidOperationException("Simulated get slot failure.");
+            }
+
+            return Task.FromResult<Slot?>(new Slot
+            {
+                ID = slotId,
+            });
+        }
+
+        public async Task<Uri> ImportMeshAsync(ImportMeshRawData request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ImportMeshStarted.TrySetResult();
+            await AllowImportMeshCompletion.Task.WaitAsync(cancellationToken);
+            ObjectDisposedException.ThrowIf(disposed, this);
+
+            return new Uri("resdb:///mesh/ok", UriKind.Absolute);
+        }
+
+        public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new Uri("resdb:///texture/ok", UriKind.Absolute));
+        }
+
+        public Task UpdateComponentAsync(UpdateComponent request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
## What changed

- added per-city-object live send phase timing logs for slot hierarchy, geometry asset preparation, material creation, batch submission, and total send time
- added RPC duration logs and slow-threshold warnings for `RunDataModelOperationBatch`, `ImportMesh`, and `ImportTexture`
- added a shared-material fast path that reuses an existing shared material component before any texture import work starts
- added regression coverage for the shared-material reuse path

## Why it changed

Recent live-send runs were showing extreme latency for single LOD2 objects. The existing metrics only exposed whole-city-object send duration and RPC counts, which was not enough to identify whether the stall was in geometry import, texture import, material setup, or final DataModel batch submission.

This change makes the slow phase visible in logs and removes one avoidable source of repeated work when shared materials already exist in the live session.

## Impact

- `--verbose` live-send runs now show where a slow object is actually spending time
- slow `ImportMesh`, `ImportTexture`, and batch RPCs now emit explicit warnings instead of only appearing as an overall stall
- repeated sends that can reuse shared materials skip unnecessary texture-import work for those materials

## Root cause addressed

The immediate root cause of poor diagnosability was missing phase-level instrumentation in the live send path. A secondary inefficiency was that shared material reuse still paid texture-import cost before checking whether the target material already existed.

## Validation

- `dotnet test tests/Plateau.ResoniteLink.Tests/Plateau.ResoniteLink.Tests.csproj -c Release --filter "FullyQualifiedName~ResoniteMaterialAssetManagerTests|FullyQualifiedName~RetryingResoniteLinkClientTests"`
- `bash scripts/verify-ci.sh`
