### PR TITLE
Fix live reconnect import cancellation hang

### DIFF
--- a/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.cs
+++ b/src/Plateau.ResoniteLink.Application/Importing/LocalCityGmlResonitePlanBuilder.cs
@@ -2616,20 +2616,30 @@ public static partial class LocalCityGmlResonitePlanBuilder
             return cityObjects.ToArray();
         }
 
-        Dictionary<int, (double WorldHeightSum, int Count)> groupedWorldHeights = [];
+        const double seaLevelWorldHeightTolerance = 1e-6;
+        Dictionary<int, (double WorldHeightSum, int Count, double NonSeaLevelWorldHeightSum, int NonSeaLevelCount)> groupedWorldHeights = [];
         foreach (HeightMapChunkAlignmentState state in chunkStates)
         {
             for (int localSampleIndex = 0; localSampleIndex < state.HeightSamples.Length; localSampleIndex++)
             {
                 int root = unionFind.Find(state.SampleOffset + localSampleIndex);
                 double worldHeight = state.BaseHeight + state.HeightSamples[localSampleIndex];
-                if (groupedWorldHeights.TryGetValue(root, out (double WorldHeightSum, int Count) current))
+                bool isSeaLevelFallbackCandidate = Math.Abs(worldHeight) <= seaLevelWorldHeightTolerance;
+                if (groupedWorldHeights.TryGetValue(root, out (double WorldHeightSum, int Count, double NonSeaLevelWorldHeightSum, int NonSeaLevelCount) current))
                 {
-                    groupedWorldHeights[root] = (current.WorldHeightSum + worldHeight, current.Count + 1);
+                    groupedWorldHeights[root] = (
+                        current.WorldHeightSum + worldHeight,
+                        current.Count + 1,
+                        current.NonSeaLevelWorldHeightSum + (isSeaLevelFallbackCandidate ? 0.0 : worldHeight),
+                        current.NonSeaLevelCount + (isSeaLevelFallbackCandidate ? 0 : 1));
                 }
                 else
                 {
-                    groupedWorldHeights[root] = (worldHeight, 1);
+                    groupedWorldHeights[root] = (
+                        worldHeight,
+                        1,
+                        isSeaLevelFallbackCandidate ? 0.0 : worldHeight,
+                        isSeaLevelFallbackCandidate ? 0 : 1);
                 }
             }
         }
@@ -2639,8 +2649,11 @@ public static partial class LocalCityGmlResonitePlanBuilder
             for (int localSampleIndex = 0; localSampleIndex < state.HeightSamples.Length; localSampleIndex++)
             {
                 int root = unionFind.Find(state.SampleOffset + localSampleIndex);
-                (double worldHeightSum, int count) = groupedWorldHeights[root];
-                state.HeightSamples[localSampleIndex] = (worldHeightSum / count) - state.BaseHeight;
+                (double worldHeightSum, int count, double nonSeaLevelWorldHeightSum, int nonSeaLevelCount) = groupedWorldHeights[root];
+                double alignedWorldHeight = nonSeaLevelCount > 0
+                    ? nonSeaLevelWorldHeightSum / nonSeaLevelCount
+                    : worldHeightSum / count;
+                state.HeightSamples[localSampleIndex] = alignedWorldHeight - state.BaseHeight;
             }
         }
 

--- a/src/Plateau.ResoniteLink.Cli/CliApplication.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliApplication.cs
@@ -97,5 +97,4 @@ public sealed class CliApplication
             return 1;
         }
     }
-
 }

--- a/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
@@ -42,7 +42,7 @@ public static class CliArgumentsParser
           --resonitelink-connections <count>
                                                              Optional. Experimental parallel ResoniteLink connection count for live sends. Default: 1.
           --resonitelink-import-mesh-timeout-ms <milliseconds>
-                                                            Optional. Experimental diagnostic timeout for ImportMesh. Default: 0 (disabled).
+                                                            Optional. Accepted for backward compatibility but ignored. Default: 0.
           --no-mesh-bake       Optional. Disable fixed-cell mesh baking for eligible LOD1 building city objects.
           --send-metrics         Optional. Enable opt-in live send metrics and CLI summary output.
           --verbose              Optional. Include debug-level progress logs.

--- a/src/Plateau.ResoniteLink.Cli/CliCompositionRoot.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliCompositionRoot.cs
@@ -46,7 +46,8 @@ public static class CliCompositionRoot
             reporter(
                 PlateauLog.Warning(
                     "live",
-                    $"--resonitelink-import-mesh-timeout-ms={options.ResoniteLinkImportMeshTimeoutMilliseconds} is diagnostic-only and experimental."));
+                    $"--resonitelink-import-mesh-timeout-ms={options.ResoniteLinkImportMeshTimeoutMilliseconds} is ignored. "
+                    + "Live imports no longer use a forced timeout."));
         }
         ResoniteLinkSendDiagnostics diagnostics = options.EnableSendMetrics
             ? ResoniteLinkSendDiagnostics.CreateEnabled(reporter)
@@ -59,7 +60,6 @@ public static class CliCompositionRoot
                 diagnostics,
                 CreateSceneBuilderDependencies(),
                 options.EnableMeshBake,
-                options.ResoniteLinkImportMeshTimeoutMilliseconds,
                 progressReporter: reporter),
             CreateDatasetSourceResolver(),
             CreateConstructionSourceFactory(),

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkClient.cs
@@ -161,7 +161,7 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
         ArgumentNullException.ThrowIfNull(textureImport);
         AssetData result = textureImport switch
         {
-            ResoniteFileTextureImport fileImport => await ImportFileTextureAsync(fileImport, cancellationToken),
+            ResoniteFileTextureImport fileImport => await ImportRawTextureFromFileAsync(fileImport, cancellationToken),
             ResoniteRawTextureImport rawImport => await ImportRawTextureAsync(rawImport),
             ResoniteRawHdrTextureImport rawHdrImport => await ImportRawHdrTextureAsync(rawHdrImport),
             _ => throw new InvalidOperationException($"Unsupported texture import type '{textureImport.GetType().Name}'."),
@@ -178,29 +178,10 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
         EnsureSuccess(response, "update component");
     }
 
-    private async Task<AssetData> ImportFileTextureAsync(
+    private async Task<AssetData> ImportRawTextureFromFileAsync(
         ResoniteFileTextureImport fileImport,
         CancellationToken cancellationToken)
     {
-        if (ShouldUseRawTextureImportForFile(fileImport.AbsolutePath))
-        {
-            ResoniteRawTextureImport eagerRawImport = await ResoniteTextureImportFactory.CreateRawFromFileAsync(
-                fileImport.AbsolutePath,
-                cancellationToken: cancellationToken);
-            return await ImportRawTextureAsync(eagerRawImport);
-        }
-
-        string importPath = TranslateFilePathForHost(fileImport.AbsolutePath);
-        AssetData result = await link.ImportTextureFileAsync(
-            new ImportTexture2DFile
-            {
-                FilePath = importPath,
-            });
-        if (result.Success || !ShouldFallbackToRawTextureImport(result.ErrorInfo, importPath, fileImport.AbsolutePath))
-        {
-            return result;
-        }
-
         ResoniteRawTextureImport rawImport = await ResoniteTextureImportFactory.CreateRawFromFileAsync(
             fileImport.AbsolutePath,
             cancellationToken: cancellationToken);
@@ -246,96 +227,6 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
             string.IsNullOrWhiteSpace(response.ErrorInfo)
                 ? $"ResoniteLink {operationName} failed."
                 : $"ResoniteLink {operationName} failed: {response.ErrorInfo}");
-    }
-
-    internal static bool ShouldFallbackToRawTextureImport(string? errorInfo, string absolutePath)
-    {
-        if (string.IsNullOrWhiteSpace(errorInfo) || string.IsNullOrWhiteSpace(absolutePath))
-        {
-            return false;
-        }
-
-        if (!File.Exists(absolutePath))
-        {
-            return false;
-        }
-
-        return errorInfo.Contains("Exception when generating file signature", StringComparison.Ordinal)
-            || errorInfo.Contains("Could not find file", StringComparison.Ordinal)
-            || errorInfo.Contains(absolutePath, StringComparison.Ordinal);
-    }
-
-    internal static bool ShouldFallbackToRawTextureImport(
-        string? errorInfo,
-        params string[] candidatePaths)
-    {
-        if (string.IsNullOrWhiteSpace(errorInfo) || candidatePaths.Length == 0)
-        {
-            return false;
-        }
-
-        return candidatePaths.Any(candidatePath => ShouldFallbackToRawTextureImport(errorInfo, candidatePath));
-    }
-
-    internal static string TranslateFilePathForHost(string absolutePath)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(absolutePath);
-
-        if (!IsRunningUnderWsl() || !Path.IsPathRooted(absolutePath))
-        {
-            return absolutePath;
-        }
-
-        if (TryTranslateMountedWindowsPath(absolutePath, out string? mountedWindowsPath))
-        {
-            return mountedWindowsPath;
-        }
-
-        string? distroName = Environment.GetEnvironmentVariable("WSL_DISTRO_NAME");
-        if (string.IsNullOrWhiteSpace(distroName))
-        {
-            return absolutePath;
-        }
-
-        string normalizedPath = absolutePath.Replace('\\', '/').TrimStart('/');
-        return $@"\\wsl.localhost\{distroName}\{normalizedPath.Replace('/', '\\')}";
-    }
-
-    internal static bool ShouldUseRawTextureImportForFile(string absolutePath)
-    {
-        return IsRunningUnderWsl()
-            && Path.IsPathRooted(absolutePath)
-            && File.Exists(absolutePath);
-    }
-
-    private static bool IsRunningUnderWsl()
-    {
-        return OperatingSystem.IsLinux()
-            && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("WSL_DISTRO_NAME"));
-    }
-
-    private static bool TryTranslateMountedWindowsPath(string absolutePath, out string translatedPath)
-    {
-        translatedPath = string.Empty;
-        string normalizedPath = absolutePath.Replace('\\', '/');
-        if (!normalizedPath.StartsWith("/mnt/", StringComparison.Ordinal)
-            || normalizedPath.Length < "/mnt/c".Length
-            || normalizedPath[6] != '/')
-        {
-            return false;
-        }
-
-        char driveLetter = normalizedPath[5];
-        if (!char.IsAsciiLetter(driveLetter))
-        {
-            return false;
-        }
-
-        string windowsRelativePath = normalizedPath[7..].Replace('/', '\\');
-        translatedPath = string.IsNullOrEmpty(windowsRelativePath)
-            ? $@"{char.ToUpperInvariant(driveLetter)}:\"
-            : $@"{char.ToUpperInvariant(driveLetter)}:\{windowsRelativePath}";
-        return true;
     }
 
     private static string CreateMutationOperationName(string operationName, string? subject, string? containerId)

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -943,6 +943,12 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         Justification = "Best-effort cleanup should observe and suppress orphaned import task failures after the primary send failure.")]
     private static async Task ObserveTaskFailureAsync(Task task)
     {
+        Task completedTask = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(1)));
+        if (completedTask != task)
+        {
+            return;
+        }
+
         try
         {
             await task;

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -29,7 +29,6 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
     private readonly Func<IResoniteLinkClient> clientFactory;
     private readonly Uri endpoint;
     private readonly int connectionCount;
-    private readonly int importMeshTimeoutMilliseconds;
     private readonly ResoniteLinkSendDiagnostics diagnostics;
     private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator;
     private readonly ResoniteGeometryAssetAssembler geometryAssetAssembler;
@@ -68,26 +67,12 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
     private SceneAnchor? sceneAnchor;
 
     public ResoniteLinkSceneBuilder(Uri endpoint, Action<string>? progressReporter = null)
-        : this(
-            endpoint,
-            4,
-            ResoniteLinkSendDiagnostics.Disabled,
-            ResoniteLinkSceneBuilderDependencies.CreateDefault(),
-            enableMeshBake: true,
-            CliDefaultOptions.ResoniteLinkImportMeshTimeoutMilliseconds,
-            progressReporter)
+        : this(endpoint, 4, ResoniteLinkSendDiagnostics.Disabled, static () => new ResoniteLinkClient(), new TerrainTextureAssetGenerator(), enableMeshBake: true, progressReporter: progressReporter)
     {
     }
 
     public ResoniteLinkSceneBuilder(Uri endpoint, int connectionCount, Action<string>? progressReporter = null)
-        : this(
-            endpoint,
-            connectionCount,
-            ResoniteLinkSendDiagnostics.Disabled,
-            ResoniteLinkSceneBuilderDependencies.CreateDefault(),
-            enableMeshBake: true,
-            CliDefaultOptions.ResoniteLinkImportMeshTimeoutMilliseconds,
-            progressReporter)
+        : this(endpoint, connectionCount, ResoniteLinkSendDiagnostics.Disabled, static () => new ResoniteLinkClient(), new TerrainTextureAssetGenerator(), enableMeshBake: true, progressReporter: progressReporter)
     {
     }
 
@@ -96,14 +81,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         int connectionCount,
         ResoniteLinkSendDiagnostics diagnostics,
         Action<string>? progressReporter = null)
-        : this(
-            endpoint,
-            connectionCount,
-            diagnostics,
-            ResoniteLinkSceneBuilderDependencies.CreateDefault(),
-            enableMeshBake: true,
-            CliDefaultOptions.ResoniteLinkImportMeshTimeoutMilliseconds,
-            progressReporter)
+        : this(endpoint, connectionCount, diagnostics, static () => new ResoniteLinkClient(), new TerrainTextureAssetGenerator(), enableMeshBake: true, progressReporter: progressReporter)
     {
     }
 
@@ -112,16 +90,8 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         int connectionCount,
         ResoniteLinkSendDiagnostics diagnostics,
         bool enableMeshBake,
-        int importMeshTimeoutMilliseconds = CliDefaultOptions.ResoniteLinkImportMeshTimeoutMilliseconds,
         Action<string>? progressReporter = null)
-        : this(
-            endpoint,
-            connectionCount,
-            diagnostics,
-            ResoniteLinkSceneBuilderDependencies.CreateDefault(),
-            enableMeshBake,
-            importMeshTimeoutMilliseconds,
-            progressReporter)
+        : this(endpoint, connectionCount, diagnostics, static () => new ResoniteLinkClient(), new TerrainTextureAssetGenerator(), enableMeshBake, progressReporter: progressReporter)
     {
     }
 
@@ -137,7 +107,6 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             diagnostics,
             new ResoniteLinkSceneBuilderDependencies(clientFactory, new TerrainTextureAssetGenerator()),
             enableMeshBake: true,
-            CliDefaultOptions.ResoniteLinkImportMeshTimeoutMilliseconds,
             progressReporter)
     {
     }
@@ -156,7 +125,6 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             diagnostics,
             new ResoniteLinkSceneBuilderDependencies(clientFactory, terrainTextureAssetGenerator),
             enableMeshBake,
-            CliDefaultOptions.ResoniteLinkImportMeshTimeoutMilliseconds,
             progressReporter)
     {
     }
@@ -167,7 +135,6 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         ResoniteLinkSendDiagnostics diagnostics,
         ResoniteLinkSceneBuilderDependencies dependencies,
         bool enableMeshBake = true,
-        int importMeshTimeoutMilliseconds = CliDefaultOptions.ResoniteLinkImportMeshTimeoutMilliseconds,
         Action<string>? progressReporter = null)
     {
         ArgumentNullException.ThrowIfNull(dependencies);
@@ -176,7 +143,6 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
 
         this.endpoint = endpoint;
         this.connectionCount = connectionCount;
-        this.importMeshTimeoutMilliseconds = importMeshTimeoutMilliseconds;
         this.diagnostics = diagnostics;
         this.clientFactory = dependencies.ClientFactory;
         this.terrainTextureAssetGenerator = dependencies.TerrainTextureAssetGenerator;
@@ -378,8 +344,7 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
     {
         IResoniteLinkClient client = new RetryingResoniteLinkClient(
             clientFactory,
-            ReportProgress,
-            importMeshTimeoutMilliseconds);
+            ReportProgress);
         return diagnostics.Enabled ? new MetricsResoniteLinkClient(client, diagnostics) : client;
     }
 

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -58,7 +58,9 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
     private CancellationTokenSource? processingCancellationSource;
     private TaskCompletionSource<Exception>? firstProcessingFailureSource;
     private FixedCellCityObjectMeshBaker? meshBaker;
+    private int attemptedCityObjectCount;
     private int processedCityObjectCount;
+    private int failedCityObjectCount;
     private Stopwatch? sceneBuildStopwatch;
     private int firstQueuedCityObjectLogged;
     private int firstPreparedCityObjectLogged;
@@ -247,6 +249,8 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
                 }))
             .ToArray();
         processedCityObjectCount = 0;
+        attemptedCityObjectCount = 0;
+        failedCityObjectCount = 0;
         sceneBuildStopwatch = Stopwatch.StartNew();
         firstQueuedCityObjectLogged = 0;
         firstPreparedCityObjectLogged = 0;
@@ -492,9 +496,10 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         ReportProgress("[live] All send lanes drained.");
         diagnostics.CompleteSendWindow();
         ReportProgress(
-            $"[live] Completed {processedCityObjectCount} city objects.");
+            $"[live] Completed {processedCityObjectCount} city objects "
+            + $"(failed={failedCityObjectCount}, attempted={attemptedCityObjectCount}).");
         ReportProgress(
-            $"[live] Send summary: attempted={processedCityObjectCount} sent={processedCityObjectCount}.");
+            $"[live] Send summary: attempted={attemptedCityObjectCount} sent={processedCityObjectCount} failed={failedCityObjectCount}.");
 
         return [$"{endpoint}#{sceneAnchor?.SlotId ?? datasetRootSlot?.SlotId ?? string.Empty}"];
     }
@@ -592,20 +597,66 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         return Path.Combine(Path.GetFullPath(datasetRoot), "run", Guid.NewGuid().ToString("N"));
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Live send should log and skip individual city object send failures while keeping the lane alive.")]
     private async Task ProcessQueuedCityObjectAsync(
         IResoniteLinkClient client,
         QueuedCityObject queuedCityObject,
         CancellationToken cancellationToken)
     {
-        PreparedCityObject preparedCityObject = await queuedCityObject.PreparationTask.WaitAsync(cancellationToken);
-        await BuildPreparedCityObjectAsync(client, preparedCityObject, cancellationToken);
+        Interlocked.Increment(ref attemptedCityObjectCount);
+        try
+        {
+            PreparedCityObject preparedCityObject = await queuedCityObject.PreparationTask.WaitAsync(cancellationToken);
+            await BuildPreparedCityObjectAsync(client, preparedCityObject, cancellationToken);
 
-        int processedCount = Interlocked.Increment(ref processedCityObjectCount);
-        ReportProgress(
-            $"[live] Sent city object {processedCount}: "
-            + $"{preparedCityObject.CityObject.DisplayName} "
-            + $"({preparedCityObject.CityObject.PackageName}/{preparedCityObject.CityObject.SlotKey})",
-            PlateauLogLevel.Info);
+            int processedCount = Interlocked.Increment(ref processedCityObjectCount);
+            ReportProgress(
+                $"[live] Sent city object {processedCount}: "
+                + $"{preparedCityObject.CityObject.DisplayName} "
+                + $"({preparedCityObject.CityObject.PackageName}/{preparedCityObject.CityObject.SlotKey})",
+                PlateauLogLevel.Info);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            if (!IsRecoverableCityObjectSendFailure(exception))
+            {
+                throw;
+            }
+
+            int failedCount = Interlocked.Increment(ref failedCityObjectCount);
+            ReportProgress(
+                PlateauLog.Warning(
+                    "live",
+                    $"Skipping city object after send failure {failedCount}: "
+                    + $"{queuedCityObject.CityObject.DisplayName} "
+                    + $"({queuedCityObject.CityObject.PackageName}/{queuedCityObject.CityObject.SlotKey}). "
+                    + $"Reason: {exception.Message}"));
+        }
+    }
+
+    private static bool IsRecoverableCityObjectSendFailure(Exception exception)
+    {
+        return FindResoniteLinkOperationException(exception) is { OperationName: "ImportMesh" or "ImportTexture" or "GetSlot" or "GetComponent" };
+    }
+
+    private static ResoniteLinkOperationException? FindResoniteLinkOperationException(Exception exception)
+    {
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is ResoniteLinkOperationException operationException)
+            {
+                return operationException;
+            }
+        }
+
+        return null;
     }
 
     private async Task EnqueueCityObjectAsync(

--- a/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteLinkSceneBuilder.cs
@@ -857,21 +857,14 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             cancellationToken);
         slotHierarchyStopwatch.Stop();
 
-        ReportBuildStep(cityObject, $"Preparing geometry assets ({DescribePreparedGeometry(preparedCityObject.Geometry)}).");
-        Stopwatch geometryStopwatch = Stopwatch.StartNew();
         using CancellationTokenSource buildStepCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        Task<PreparedGeometryAssetBatch> preparedGeometryBatchTask = PrepareGeometryBatchAsync(
-            importClient,
-            cityObject,
-            preparedCityObject,
-            buildStepCancellation.Token);
-
         Dictionary<TextureReferenceKey, ResoniteTextureImport> preparedTextureDataByKey = preparedCityObject.Textures.ToDictionary(
             static texture => ResoniteMaterialAssetManager.CreateTextureReferenceKey(
                 texture.TexturePath,
                 texture.TextureSourceKind),
             static texture => texture.TextureImport);
         Stopwatch materialStopwatch = Stopwatch.StartNew();
+        Stopwatch geometryStopwatch = new();
         List<MaterialReferenceTarget> materialTargets = [];
         List<Task<PreparedDedicatedMaterialAssets>> dedicatedMaterialPreparationTasks = [];
         PreparedDedicatedMaterialAssets[] preparedDedicatedMaterialAssets;
@@ -907,15 +900,24 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
             }
             preparedDedicatedMaterialAssets = dedicatedMaterialPreparationTasks.Count == 0
                 ? []
-                : await Task.WhenAll(dedicatedMaterialPreparationTasks);
+                : await AwaitDedicatedMaterialPreparationsAsync(
+                    dedicatedMaterialPreparationTasks,
+                    buildStepCancellation);
             materialStopwatch.Stop();
-            preparedGeometryBatch = await preparedGeometryBatchTask;
+
+            ReportBuildStep(cityObject, $"Preparing geometry assets ({DescribePreparedGeometry(preparedCityObject.Geometry)}).");
+            geometryStopwatch.Start();
+            preparedGeometryBatch = await PrepareGeometryBatchAsync(
+                importClient,
+                cityObject,
+                preparedCityObject,
+                buildStepCancellation.Token);
             geometryStopwatch.Stop();
         }
         catch
         {
             await buildStepCancellation.CancelAsync();
-            await ObserveTaskFailureAsync(preparedGeometryBatchTask);
+            await ObserveTaskFailuresAsync(dedicatedMaterialPreparationTasks);
             throw;
         }
 
@@ -972,6 +974,40 @@ public sealed class ResoniteLinkSceneBuilder : IResoniteSceneBuilder
         catch
         {
         }
+    }
+
+    private static Task ObserveTaskFailuresAsync(IEnumerable<Task> tasks)
+    {
+        return Task.WhenAll(tasks.Select(ObserveTaskFailureAsync));
+    }
+
+    private static async Task<PreparedDedicatedMaterialAssets[]> AwaitDedicatedMaterialPreparationsAsync(
+        IReadOnlyList<Task<PreparedDedicatedMaterialAssets>> tasks,
+        CancellationTokenSource buildStepCancellation)
+    {
+        PreparedDedicatedMaterialAssets[] results = new PreparedDedicatedMaterialAssets[tasks.Count];
+        List<(Task<PreparedDedicatedMaterialAssets> Task, int Index)> remaining = tasks
+            .Select(static (task, index) => (Task: task, Index: index))
+            .ToList();
+
+        while (remaining.Count > 0)
+        {
+            Task<PreparedDedicatedMaterialAssets> completedTask = await Task.WhenAny(
+                remaining.Select(static entry => entry.Task));
+            int completedIndex = remaining.FindIndex(entry => ReferenceEquals(entry.Task, completedTask));
+            (Task<PreparedDedicatedMaterialAssets> Task, int Index) entry = remaining[completedIndex];
+            remaining.RemoveAt(completedIndex);
+
+            if (completedTask.IsFaulted || completedTask.IsCanceled)
+            {
+                await buildStepCancellation.CancelAsync();
+                await completedTask;
+            }
+
+            results[entry.Index] = await completedTask;
+        }
+
+        return results;
     }
 
     private async Task<ObjectSlotHierarchy> CreateObjectSlotHierarchyAsync(

--- a/src/Plateau.ResoniteLink.Cli/ResoniteMaterialAssetManager.cs
+++ b/src/Plateau.ResoniteLink.Cli/ResoniteMaterialAssetManager.cs
@@ -243,21 +243,20 @@ internal sealed class ResoniteMaterialAssetManager(
             cancellationToken);
         materialContainerSlotId = createdMaterialSlot.SlotId;
 
-        if (!(wasCreatedInCurrentRun?.Invoke(materialContainerSlotId) ?? false))
-        {
-            Component? existingMaterialComponent = await TryGetExistingMaterialComponentAsync(
+        Component? existingMaterialComponent = (wasCreatedInCurrentRun?.Invoke(materialContainerSlotId) ?? false)
+            ? null
+            : await TryGetExistingMaterialComponentAsync(
                 client,
                 materialContainerSlotId,
                 materialComponentType,
                 cancellationToken);
-            if (existingMaterialComponent is not null)
-            {
-                ReportProgress(
-                    $"[live] Material '{material.MaterialKey}' reusing existing component '{materialComponentType}'.");
-                return new ResoniteLinkSceneBuilder.CreatedComponent(
-                    existingMaterialComponent.ID,
-                    materialComponentType);
-            }
+        if (existingMaterialComponent is not null)
+        {
+            ReportProgress(
+                $"[live] Material '{material.MaterialKey}' reusing existing component '{materialComponentType}'.");
+            return new ResoniteLinkSceneBuilder.CreatedComponent(
+                existingMaterialComponent.ID,
+                materialComponentType);
         }
 
         Stopwatch componentCreateStopwatch = Stopwatch.StartNew();

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics;
-using System.Reflection;
-
 using Plateau.ResoniteLink.Application.Logging;
 
 using ResoniteLink;
@@ -126,13 +124,9 @@ internal sealed class RetryingResoniteLinkClient(
 
     public Task<Uri> ImportMeshAsync(ImportMeshRawData request, CancellationToken cancellationToken)
     {
+        _ = importMeshTimeoutMilliseconds;
         return ExecuteTimedImportAsync(
-            (client, state, ct) => ExecuteImportMeshWithTimeoutAsync(
-                client,
-                state,
-                importMeshTimeoutMilliseconds,
-                reporter,
-                ct),
+            static (client, state, ct) => client.ImportMeshAsync(state, ct),
             request,
             "ImportMesh",
             SlowImportThreshold,
@@ -365,132 +359,6 @@ internal sealed class RetryingResoniteLinkClient(
 
         importCancellation.Dispose();
         importDrainSignal?.TrySetResult(true);
-    }
-
-    private static async Task<Uri> ExecuteImportMeshWithTimeoutAsync(
-        IResoniteLinkClient client,
-        ImportMeshRawData request,
-        int timeoutMilliseconds,
-        Action<string>? reporter,
-        CancellationToken cancellationToken)
-    {
-        if (timeoutMilliseconds <= 0)
-        {
-            return await client.ImportMeshAsync(request, cancellationToken);
-        }
-
-        using CancellationTokenSource timeoutCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        Task<Uri> importTask = client.ImportMeshAsync(request, timeoutCancellation.Token);
-        if (importTask.IsCompleted)
-        {
-            return await importTask;
-        }
-
-        Task completedTask = await Task.WhenAny(
-            importTask,
-            Task.Delay(timeoutMilliseconds, cancellationToken));
-        if (completedTask == importTask)
-        {
-            return await importTask;
-        }
-
-        await timeoutCancellation.CancelAsync();
-        _ = importTask.ContinueWith(
-            static completedImportTask => _ = completedImportTask.Exception,
-            CancellationToken.None,
-            TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
-        cancellationToken.ThrowIfCancellationRequested();
-        string diagnostic = DescribeClientStateForDiagnostics(client);
-        reporter?.Invoke(PlateauLog.Warning("live", diagnostic));
-        throw new TimeoutException(
-            string.IsNullOrWhiteSpace(diagnostic)
-                ? $"ResoniteLink ImportMesh did not complete within {timeoutMilliseconds}ms."
-                : $"ResoniteLink ImportMesh did not complete within {timeoutMilliseconds}ms. {diagnostic}");
-    }
-
-    [SuppressMessage(
-        "Design",
-        "CA1031:Do not catch general exception types",
-        Justification = "Diagnostic reflection should never mask the original timeout path.")]
-    private static string DescribeClientStateForDiagnostics(IResoniteLinkClient client)
-    {
-        try
-        {
-            List<string> clientChain = [];
-            object current = client;
-            object? link = null;
-
-            for (int depth = 0; depth < 8 && current is not null; depth++)
-            {
-                clientChain.Add(current.GetType().FullName ?? current.GetType().Name);
-                object? nestedLink = GetMemberValue(current, "link");
-                if (nestedLink is not null)
-                {
-                    link = nestedLink;
-                    break;
-                }
-
-                object? nestedInner = GetMemberValue(current, "inner");
-                if (nestedInner is null || ReferenceEquals(nestedInner, current))
-                {
-                    break;
-                }
-
-                current = nestedInner;
-            }
-
-            if (link is null)
-            {
-                return $"[live][diagnostic] ImportMesh timeout client_chain={string.Join(" -> ", clientChain)} link=unavailable.";
-            }
-
-            object? websocket = GetMemberValue(link, "_client");
-            object? pendingResponses = GetMemberValue(link, "_pendingResponses");
-            object? failureException = GetMemberValue(link, "FailureException");
-            object? isConnected = GetMemberValue(link, "IsConnected");
-            object? websocketState = websocket is null ? null : GetMemberValue(websocket, "State");
-
-            return $"[live][diagnostic] ImportMesh timeout client_chain={string.Join(" -> ", clientChain)} "
-                + $"link_type={link.GetType().FullName ?? link.GetType().Name} "
-                + $"is_connected={isConnected ?? "unknown"} websocket_state={websocketState ?? "unknown"} "
-                + $"pending_responses={TryGetCount(pendingResponses)?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "unknown"} "
-                + $"failure_exception={(failureException as Exception)?.GetType().Name ?? failureException?.ToString() ?? "null"}.";
-        }
-        catch (Exception exception)
-        {
-            return $"[live][diagnostic] ImportMesh timeout diagnostics failed: {exception.GetType().Name}: {exception.Message}";
-        }
-    }
-
-    private static object? GetMemberValue(object instance, string memberName)
-    {
-        const BindingFlags Flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-        Type type = instance.GetType();
-        FieldInfo? field = type.GetField(memberName, Flags);
-        if (field is not null)
-        {
-            return field.GetValue(instance);
-        }
-
-        PropertyInfo? property = type.GetProperty(memberName, Flags);
-        return property?.GetValue(instance);
-    }
-
-    private static int? TryGetCount(object? instance)
-    {
-        if (instance is null)
-        {
-            return null;
-        }
-
-        object? count = GetMemberValue(instance, "Count");
-        return count switch
-        {
-            int intCount => intCount,
-            long longCount when longCount is <= int.MaxValue and >= int.MinValue => (int)longCount,
-            _ => null,
-        };
     }
 
     [SuppressMessage(

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -15,8 +15,7 @@ internal sealed class RetryingResoniteLinkClient(
 {
     private const int AttemptLimit = 2;
     private static readonly TimeSpan SlowBatchThreshold = TimeSpan.FromSeconds(10);
-    private static readonly TimeSpan SlowImportMeshThreshold = TimeSpan.FromSeconds(30);
-    private static readonly TimeSpan SlowImportTextureThreshold = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan SlowImportThreshold = TimeSpan.FromSeconds(60);
     private readonly SemaphoreSlim operationGate = new(1, 1);
     private readonly SemaphoreSlim reconnectGate = new(1, 1);
     private readonly object clientStateGate = new();
@@ -136,7 +135,7 @@ internal sealed class RetryingResoniteLinkClient(
                 ct),
             request,
             "ImportMesh",
-            SlowImportMeshThreshold,
+            SlowImportThreshold,
             cancellationToken);
     }
 
@@ -146,7 +145,7 @@ internal sealed class RetryingResoniteLinkClient(
             static (client, state, ct) => client.ImportTextureAsync(state, ct),
             textureImport,
             "ImportTexture",
-            SlowImportTextureThreshold,
+            SlowImportThreshold,
             cancellationToken);
     }
 

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics;
+
 using Plateau.ResoniteLink.Application.Logging;
 
 using ResoniteLink;

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -14,12 +14,13 @@ internal sealed class RetryingResoniteLinkClient(
     int importMeshTimeoutMilliseconds = CliDefaultOptions.ResoniteLinkImportMeshTimeoutMilliseconds) : IResoniteLinkClient
 {
     private const int AttemptLimit = 2;
-    private const int MaxConcurrentImports = 4;
+    private const int MaxConcurrentMeshImports = 4;
     private static readonly TimeSpan SlowBatchThreshold = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan SlowImportMeshThreshold = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan SlowImportTextureThreshold = TimeSpan.FromSeconds(10);
     private readonly SemaphoreSlim operationGate = new(1, 1);
-    private readonly SemaphoreSlim importGate = new(MaxConcurrentImports, MaxConcurrentImports);
+    private readonly SemaphoreSlim meshImportGate = new(MaxConcurrentMeshImports, MaxConcurrentMeshImports);
+    private readonly SemaphoreSlim textureImportGate = new(1, 1);
     private readonly SemaphoreSlim reconnectGate = new(1, 1);
     private readonly object clientStateGate = new();
     private readonly HashSet<CancellationTokenSource> activeImportCancellations = [];
@@ -34,7 +35,8 @@ internal sealed class RetryingResoniteLinkClient(
     public void Dispose()
     {
         operationGate.Dispose();
-        importGate.Dispose();
+        meshImportGate.Dispose();
+        textureImportGate.Dispose();
         reconnectGate.Dispose();
         inner.Dispose();
     }
@@ -140,6 +142,7 @@ internal sealed class RetryingResoniteLinkClient(
             request,
             "ImportMesh",
             SlowImportMeshThreshold,
+            meshImportGate,
             cancellationToken);
     }
 
@@ -150,6 +153,7 @@ internal sealed class RetryingResoniteLinkClient(
             textureImport,
             "ImportTexture",
             SlowImportTextureThreshold,
+            textureImportGate,
             cancellationToken);
     }
 
@@ -262,6 +266,7 @@ internal sealed class RetryingResoniteLinkClient(
         TState state,
         string operationName,
         TimeSpan slowThreshold,
+        SemaphoreSlim importGate,
         CancellationToken cancellationToken)
     {
         Stopwatch stopwatch = Stopwatch.StartNew();
@@ -269,6 +274,7 @@ internal sealed class RetryingResoniteLinkClient(
             operation,
             state,
             operationName,
+            importGate,
             cancellationToken);
         stopwatch.Stop();
 
@@ -292,6 +298,7 @@ internal sealed class RetryingResoniteLinkClient(
         Func<IResoniteLinkClient, TState, CancellationToken, Task<TResult>> operation,
         TState state,
         string operationName,
+        SemaphoreSlim importGate,
         CancellationToken cancellationToken)
     {
         await importGate.WaitAsync(cancellationToken);

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -210,7 +210,7 @@ internal sealed class RetryingResoniteLinkClient(
                 PlateauLog.Warning(
                     "live",
                     $"ResoniteLink {operationName} failed without retry. Reason: {exception.Message}"));
-            throw;
+            throw ResoniteLinkOperationException.Wrap(operationName, exception);
         }
         finally
         {
@@ -344,7 +344,7 @@ internal sealed class RetryingResoniteLinkClient(
                 PlateauLog.Warning(
                     "live",
                     $"ResoniteLink {operationName} failed without retry. Reason: {exception.Message}"));
-            throw;
+            throw ResoniteLinkOperationException.Wrap(operationName, exception);
         }
     }
 
@@ -433,7 +433,7 @@ internal sealed class RetryingResoniteLinkClient(
                 }
             }
 
-            throw lastException!;
+            throw ResoniteLinkOperationException.Wrap(operationName, lastException!);
         }
         finally
         {
@@ -536,5 +536,22 @@ internal sealed class RetryingResoniteLinkClient(
         inner = clientFactory();
         Interlocked.Increment(ref generation);
         previous.Dispose();
+    }
+}
+
+internal sealed class ResoniteLinkOperationException : InvalidOperationException
+{
+    public ResoniteLinkOperationException(string operationName, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        OperationName = operationName;
+    }
+
+    public string OperationName { get; }
+
+    public static ResoniteLinkOperationException Wrap(string operationName, Exception exception)
+    {
+        return exception as ResoniteLinkOperationException
+            ?? new ResoniteLinkOperationException(operationName, exception.Message, exception);
     }
 }

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -469,50 +469,64 @@ internal sealed class RetryingResoniteLinkClient(
                     : (importDrainCompletion ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)).Task;
             }
 
-            if (activeImportCancellationsSnapshot.Length > 0)
-            {
-                reporter?.Invoke(
-                    PlateauLog.Warning(
-                        "live",
-                        $"Reconnect canceling {activeImportCancellationsSnapshot.Length} active import(s) before retry."));
-                await Task.WhenAll(activeImportCancellationsSnapshot.Select(static cancellation => cancellation.CancelAsync()));
-            }
-
-            await waitForImportsTask.WaitAsync(cancellationToken);
-            IResoniteLinkClient previous = inner;
-            IResoniteLinkClient replacement = clientFactory();
-
+            IResoniteLinkClient? replacement = null;
+            IResoniteLinkClient? previous = null;
             try
             {
+                if (activeImportCancellationsSnapshot.Length > 0)
+                {
+                    reporter?.Invoke(
+                        PlateauLog.Warning(
+                            "live",
+                            $"Reconnect canceling {activeImportCancellationsSnapshot.Length} active import(s) before retry."));
+                    await Task.WhenAll(
+                        activeImportCancellationsSnapshot.Select(CancelImportCancellationAsync));
+                }
+
+                await waitForImportsTask.WaitAsync(cancellationToken);
+                previous = inner;
+                replacement = clientFactory();
+
                 await replacement.ConnectAsync(endpoint, cancellationToken);
+
+                lock (clientStateGate)
+                {
+                    inner = replacement;
+                    replacement = null;
+                    Interlocked.Increment(ref generation);
+                }
+
+                previous.Dispose();
+                previous = null;
+                reporter?.Invoke(PlateauLog.Warning("live", $"Reconnected ResoniteLink client to {endpoint}."));
             }
-            catch
+            finally
             {
-                replacement.Dispose();
+                replacement?.Dispose();
+                previous?.Dispose();
                 lock (clientStateGate)
                 {
                     reconnectPending = false;
                     reconnectCompletion = null;
+                    importDrainCompletion = null;
                 }
                 reconnectCompletionSource.TrySetResult(true);
-                throw;
             }
-
-            lock (clientStateGate)
-            {
-                inner = replacement;
-                reconnectPending = false;
-                reconnectCompletion = null;
-                importDrainCompletion = null;
-                Interlocked.Increment(ref generation);
-            }
-            reconnectCompletionSource.TrySetResult(true);
-            previous.Dispose();
-            reporter?.Invoke(PlateauLog.Warning("live", $"Reconnected ResoniteLink client to {endpoint}."));
         }
         finally
         {
             reconnectGate.Release();
+        }
+    }
+
+    private static async Task CancelImportCancellationAsync(CancellationTokenSource cancellation)
+    {
+        try
+        {
+            await cancellation.CancelAsync();
+        }
+        catch (ObjectDisposedException)
+        {
         }
     }
 

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -22,6 +22,7 @@ internal sealed class RetryingResoniteLinkClient(
     private readonly SemaphoreSlim importGate = new(MaxConcurrentImports, MaxConcurrentImports);
     private readonly SemaphoreSlim reconnectGate = new(1, 1);
     private readonly object clientStateGate = new();
+    private readonly HashSet<CancellationTokenSource> activeImportCancellations = [];
     private IResoniteLinkClient inner = clientFactory();
     private Uri? endpoint;
     private int generation;
@@ -301,12 +302,15 @@ internal sealed class RetryingResoniteLinkClient(
                 cancellationToken.ThrowIfCancellationRequested();
                 Task reconnectTask;
                 IResoniteLinkClient? client = null;
+                CancellationTokenSource? importCancellation = null;
                 lock (clientStateGate)
                 {
                     if (!reconnectPending)
                     {
                         activeImportCount++;
                         client = inner;
+                        importCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                        activeImportCancellations.Add(importCancellation);
                         reconnectTask = Task.CompletedTask;
                     }
                     else
@@ -323,11 +327,11 @@ internal sealed class RetryingResoniteLinkClient(
 
                 try
                 {
-                    return await operation(client, state, cancellationToken);
+                    return await operation(client, state, importCancellation!.Token);
                 }
                 finally
                 {
-                    ReleaseActiveImport();
+                    ReleaseActiveImport(importCancellation!);
                 }
             }
         }
@@ -349,12 +353,13 @@ internal sealed class RetryingResoniteLinkClient(
         }
     }
 
-    private void ReleaseActiveImport()
+    private void ReleaseActiveImport(CancellationTokenSource importCancellation)
     {
         TaskCompletionSource<bool>? importDrainSignal = null;
         lock (clientStateGate)
         {
             activeImportCount--;
+            activeImportCancellations.Remove(importCancellation);
             if (activeImportCount == 0 && reconnectPending)
             {
                 importDrainSignal = importDrainCompletion;
@@ -362,6 +367,7 @@ internal sealed class RetryingResoniteLinkClient(
             }
         }
 
+        importCancellation.Dispose();
         importDrainSignal?.TrySetResult(true);
     }
 
@@ -560,14 +566,25 @@ internal sealed class RetryingResoniteLinkClient(
             }
 
             Task waitForImportsTask;
+            CancellationTokenSource[] activeImportCancellationsSnapshot;
             TaskCompletionSource<bool> reconnectCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             lock (clientStateGate)
             {
                 reconnectPending = true;
                 reconnectCompletion = reconnectCompletionSource;
+                activeImportCancellationsSnapshot = activeImportCancellations.ToArray();
                 waitForImportsTask = activeImportCount == 0
                     ? Task.CompletedTask
                     : (importDrainCompletion ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)).Task;
+            }
+
+            if (activeImportCancellationsSnapshot.Length > 0)
+            {
+                reporter?.Invoke(
+                    PlateauLog.Warning(
+                        "live",
+                        $"Reconnect canceling {activeImportCancellationsSnapshot.Length} active import(s) before retry."));
+                await Task.WhenAll(activeImportCancellationsSnapshot.Select(static cancellation => cancellation.CancelAsync()));
             }
 
             await waitForImportsTask.WaitAsync(cancellationToken);

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -17,15 +17,9 @@ internal sealed class RetryingResoniteLinkClient(
     private static readonly TimeSpan SlowImportThreshold = TimeSpan.FromSeconds(60);
     private readonly SemaphoreSlim operationGate = new(1, 1);
     private readonly SemaphoreSlim reconnectGate = new(1, 1);
-    private readonly object clientStateGate = new();
-    private readonly HashSet<CancellationTokenSource> activeImportCancellations = [];
     private IResoniteLinkClient inner = clientFactory();
     private Uri? endpoint;
     private int generation;
-    private int activeImportCount;
-    private bool reconnectPending;
-    private TaskCompletionSource<bool>? reconnectCompletion;
-    private TaskCompletionSource<bool>? importDrainCompletion;
 
     public void Dispose()
     {
@@ -193,7 +187,6 @@ internal sealed class RetryingResoniteLinkClient(
         string operationName,
         CancellationToken cancellationToken)
     {
-        await WaitForActiveImportsToDrainAsync(cancellationToken);
         await operationGate.WaitAsync(cancellationToken);
         try
         {
@@ -286,106 +279,11 @@ internal sealed class RetryingResoniteLinkClient(
         string operationName,
         CancellationToken cancellationToken)
     {
-        try
-        {
-            while (true)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                Task reconnectTask;
-                IResoniteLinkClient? client = null;
-                CancellationTokenSource? importCancellation = null;
-                await operationGate.WaitAsync(cancellationToken);
-                try
-                {
-                    lock (clientStateGate)
-                    {
-                        if (!reconnectPending)
-                        {
-                            activeImportCount++;
-                            client = inner;
-                            importCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                            activeImportCancellations.Add(importCancellation);
-                            reconnectTask = Task.CompletedTask;
-                        }
-                        else
-                        {
-                            reconnectTask = reconnectCompletion?.Task ?? Task.CompletedTask;
-                        }
-                    }
-                }
-                finally
-                {
-                    operationGate.Release();
-                }
-
-                if (client is null)
-                {
-                    await reconnectTask.WaitAsync(cancellationToken);
-                    continue;
-                }
-
-                try
-                {
-                    return await operation(client, state, importCancellation!.Token);
-                }
-                finally
-                {
-                    ReleaseActiveImport(importCancellation!);
-                }
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception exception)
-        {
-            reporter?.Invoke(
-                PlateauLog.Warning(
-                    "live",
-                    $"ResoniteLink {operationName} failed without retry. Reason: {exception.Message}"));
-            throw ResoniteLinkOperationException.Wrap(operationName, exception);
-        }
-    }
-
-    private void ReleaseActiveImport(CancellationTokenSource importCancellation)
-    {
-        TaskCompletionSource<bool>? importDrainSignal = null;
-        lock (clientStateGate)
-        {
-            activeImportCount--;
-            activeImportCancellations.Remove(importCancellation);
-            if (activeImportCount == 0)
-            {
-                importDrainSignal = importDrainCompletion;
-                importDrainCompletion = null;
-            }
-        }
-
-        importCancellation.Dispose();
-        importDrainSignal?.TrySetResult(true);
-    }
-
-    private async Task WaitForActiveImportsToDrainAsync(CancellationToken cancellationToken)
-    {
-        while (true)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            Task waitTask;
-            lock (clientStateGate)
-            {
-                if (activeImportCount == 0 && !reconnectPending)
-                {
-                    return;
-                }
-
-                waitTask = reconnectPending
-                    ? reconnectCompletion?.Task ?? Task.CompletedTask
-                    : (importDrainCompletion ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)).Task;
-            }
-
-            await waitTask.WaitAsync(cancellationToken);
-        }
+        return await ExecuteWithoutReconnectAsync(
+            operation,
+            state,
+            operationName,
+            cancellationToken);
     }
 
     [SuppressMessage(
@@ -456,45 +354,18 @@ internal sealed class RetryingResoniteLinkClient(
                 throw new InvalidOperationException("Cannot reconnect before an endpoint has been established.");
             }
 
-            Task waitForImportsTask;
-            CancellationTokenSource[] activeImportCancellationsSnapshot;
-            TaskCompletionSource<bool> reconnectCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            lock (clientStateGate)
-            {
-                reconnectPending = true;
-                reconnectCompletion = reconnectCompletionSource;
-                activeImportCancellationsSnapshot = activeImportCancellations.ToArray();
-                waitForImportsTask = activeImportCount == 0
-                    ? Task.CompletedTask
-                    : (importDrainCompletion ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)).Task;
-            }
-
             IResoniteLinkClient? replacement = null;
             IResoniteLinkClient? previous = null;
             try
             {
-                if (activeImportCancellationsSnapshot.Length > 0)
-                {
-                    reporter?.Invoke(
-                        PlateauLog.Warning(
-                            "live",
-                            $"Reconnect canceling {activeImportCancellationsSnapshot.Length} active import(s) before retry."));
-                    await Task.WhenAll(
-                        activeImportCancellationsSnapshot.Select(CancelImportCancellationAsync));
-                }
-
-                await waitForImportsTask.WaitAsync(cancellationToken);
                 previous = inner;
                 replacement = clientFactory();
 
                 await replacement.ConnectAsync(endpoint, cancellationToken);
 
-                lock (clientStateGate)
-                {
-                    inner = replacement;
-                    replacement = null;
-                    Interlocked.Increment(ref generation);
-                }
+                inner = replacement;
+                replacement = null;
+                Interlocked.Increment(ref generation);
 
                 previous.Dispose();
                 previous = null;
@@ -504,29 +375,11 @@ internal sealed class RetryingResoniteLinkClient(
             {
                 replacement?.Dispose();
                 previous?.Dispose();
-                lock (clientStateGate)
-                {
-                    reconnectPending = false;
-                    reconnectCompletion = null;
-                    importDrainCompletion = null;
-                }
-                reconnectCompletionSource.TrySetResult(true);
             }
         }
         finally
         {
             reconnectGate.Release();
-        }
-    }
-
-    private static async Task CancelImportCancellationAsync(CancellationTokenSource cancellation)
-    {
-        try
-        {
-            await cancellation.CancelAsync();
-        }
-        catch (ObjectDisposedException)
-        {
         }
     }
 

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -358,11 +358,11 @@ internal sealed class RetryingResoniteLinkClient(
             IResoniteLinkClient? previous = null;
             try
             {
-                previous = inner;
                 replacement = clientFactory();
 
                 await replacement.ConnectAsync(endpoint, cancellationToken);
 
+                previous = inner;
                 inner = replacement;
                 replacement = null;
                 Interlocked.Increment(ref generation);

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -14,13 +14,10 @@ internal sealed class RetryingResoniteLinkClient(
     int importMeshTimeoutMilliseconds = CliDefaultOptions.ResoniteLinkImportMeshTimeoutMilliseconds) : IResoniteLinkClient
 {
     private const int AttemptLimit = 2;
-    private const int MaxConcurrentMeshImports = 4;
     private static readonly TimeSpan SlowBatchThreshold = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan SlowImportMeshThreshold = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan SlowImportTextureThreshold = TimeSpan.FromSeconds(10);
     private readonly SemaphoreSlim operationGate = new(1, 1);
-    private readonly SemaphoreSlim meshImportGate = new(MaxConcurrentMeshImports, MaxConcurrentMeshImports);
-    private readonly SemaphoreSlim textureImportGate = new(1, 1);
     private readonly SemaphoreSlim reconnectGate = new(1, 1);
     private readonly object clientStateGate = new();
     private readonly HashSet<CancellationTokenSource> activeImportCancellations = [];
@@ -35,8 +32,6 @@ internal sealed class RetryingResoniteLinkClient(
     public void Dispose()
     {
         operationGate.Dispose();
-        meshImportGate.Dispose();
-        textureImportGate.Dispose();
         reconnectGate.Dispose();
         inner.Dispose();
     }
@@ -142,7 +137,6 @@ internal sealed class RetryingResoniteLinkClient(
             request,
             "ImportMesh",
             SlowImportMeshThreshold,
-            meshImportGate,
             cancellationToken);
     }
 
@@ -153,7 +147,6 @@ internal sealed class RetryingResoniteLinkClient(
             textureImport,
             "ImportTexture",
             SlowImportTextureThreshold,
-            textureImportGate,
             cancellationToken);
     }
 
@@ -266,7 +259,6 @@ internal sealed class RetryingResoniteLinkClient(
         TState state,
         string operationName,
         TimeSpan slowThreshold,
-        SemaphoreSlim importGate,
         CancellationToken cancellationToken)
     {
         Stopwatch stopwatch = Stopwatch.StartNew();
@@ -274,7 +266,6 @@ internal sealed class RetryingResoniteLinkClient(
             operation,
             state,
             operationName,
-            importGate,
             cancellationToken);
         stopwatch.Stop();
 
@@ -298,10 +289,9 @@ internal sealed class RetryingResoniteLinkClient(
         Func<IResoniteLinkClient, TState, CancellationToken, Task<TResult>> operation,
         TState state,
         string operationName,
-        SemaphoreSlim importGate,
         CancellationToken cancellationToken)
     {
-        await importGate.WaitAsync(cancellationToken);
+        await operationGate.WaitAsync(cancellationToken);
         try
         {
             while (true)
@@ -356,7 +346,7 @@ internal sealed class RetryingResoniteLinkClient(
         }
         finally
         {
-            importGate.Release();
+            operationGate.Release();
         }
     }
 

--- a/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
+++ b/src/Plateau.ResoniteLink.Cli/RetryingResoniteLinkClient.cs
@@ -193,6 +193,7 @@ internal sealed class RetryingResoniteLinkClient(
         string operationName,
         CancellationToken cancellationToken)
     {
+        await WaitForActiveImportsToDrainAsync(cancellationToken);
         await operationGate.WaitAsync(cancellationToken);
         try
         {
@@ -285,7 +286,6 @@ internal sealed class RetryingResoniteLinkClient(
         string operationName,
         CancellationToken cancellationToken)
     {
-        await operationGate.WaitAsync(cancellationToken);
         try
         {
             while (true)
@@ -294,20 +294,28 @@ internal sealed class RetryingResoniteLinkClient(
                 Task reconnectTask;
                 IResoniteLinkClient? client = null;
                 CancellationTokenSource? importCancellation = null;
-                lock (clientStateGate)
+                await operationGate.WaitAsync(cancellationToken);
+                try
                 {
-                    if (!reconnectPending)
+                    lock (clientStateGate)
                     {
-                        activeImportCount++;
-                        client = inner;
-                        importCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                        activeImportCancellations.Add(importCancellation);
-                        reconnectTask = Task.CompletedTask;
+                        if (!reconnectPending)
+                        {
+                            activeImportCount++;
+                            client = inner;
+                            importCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                            activeImportCancellations.Add(importCancellation);
+                            reconnectTask = Task.CompletedTask;
+                        }
+                        else
+                        {
+                            reconnectTask = reconnectCompletion?.Task ?? Task.CompletedTask;
+                        }
                     }
-                    else
-                    {
-                        reconnectTask = reconnectCompletion?.Task ?? Task.CompletedTask;
-                    }
+                }
+                finally
+                {
+                    operationGate.Release();
                 }
 
                 if (client is null)
@@ -338,10 +346,6 @@ internal sealed class RetryingResoniteLinkClient(
                     $"ResoniteLink {operationName} failed without retry. Reason: {exception.Message}"));
             throw;
         }
-        finally
-        {
-            operationGate.Release();
-        }
     }
 
     private void ReleaseActiveImport(CancellationTokenSource importCancellation)
@@ -351,7 +355,7 @@ internal sealed class RetryingResoniteLinkClient(
         {
             activeImportCount--;
             activeImportCancellations.Remove(importCancellation);
-            if (activeImportCount == 0 && reconnectPending)
+            if (activeImportCount == 0)
             {
                 importDrainSignal = importDrainCompletion;
                 importDrainCompletion = null;
@@ -360,6 +364,28 @@ internal sealed class RetryingResoniteLinkClient(
 
         importCancellation.Dispose();
         importDrainSignal?.TrySetResult(true);
+    }
+
+    private async Task WaitForActiveImportsToDrainAsync(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Task waitTask;
+            lock (clientStateGate)
+            {
+                if (activeImportCount == 0 && !reconnectPending)
+                {
+                    return;
+                }
+
+                waitTask = reconnectPending
+                    ? reconnectCompletion?.Task ?? Task.CompletedTask
+                    : (importDrainCompletion ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)).Task;
+            }
+
+            await waitTask.WaitAsync(cancellationToken);
+        }
     }
 
     [SuppressMessage(

--- a/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Application/PlateauImportServiceTests.cs
@@ -1407,6 +1407,51 @@ public sealed class PlateauImportServiceTests
     }
 
     [Fact]
+    public void AlignAdjacentDemHeightMapChunkBoundariesIgnoresSeaLevelFallbackWhenNeighborHasMeasuredBoundaryHeights()
+    {
+        ResoniteConstructionCityObject leftChunk = CreateHeightMapChunk(
+            "left",
+            positionX: 0.0,
+            positionY: 40.0,
+            positionZ: 0.0,
+            width: 2,
+            height: 2,
+            sizeX: 10.0,
+            sizeY: 10.0,
+            minHeight: 20.0,
+            maxHeight: 40.0,
+            heightSamples: [30.0, 40.0, 20.0, 30.0]);
+        ResoniteConstructionCityObject rightChunk = CreateHeightMapChunk(
+            "right",
+            positionX: 10.0,
+            positionY: 20.0,
+            positionZ: 0.0,
+            width: 2,
+            height: 2,
+            sizeX: 10.0,
+            sizeY: 10.0,
+            minHeight: 0.0,
+            maxHeight: 20.0,
+            heightSamples: [0.0, 20.0, 0.0, 20.0]);
+
+        ResoniteConstructionCityObject[] alignedChunks = AlignAdjacentDemHeightMapChunkBoundaries(leftChunk, rightChunk);
+
+        ResoniteConstructionCityObject alignedLeftChunk = alignedChunks
+            .OrderBy(static chunk => chunk.Transform.Position.X)
+            .First();
+        ResoniteConstructionCityObject alignedRightChunk = alignedChunks
+            .OrderBy(static chunk => chunk.Transform.Position.X)
+            .Last();
+        ResoniteHeightMapGridGeometry alignedLeftGeometry = Assert.IsType<ResoniteHeightMapGridGeometry>(alignedLeftChunk.Geometry);
+        ResoniteHeightMapGridGeometry alignedRightGeometry = Assert.IsType<ResoniteHeightMapGridGeometry>(alignedRightChunk.Geometry);
+
+        Assert.Equal(40.0, GetHeightMapWorldHeight(alignedLeftChunk, alignedLeftGeometry, row: 0, column: 1), 6);
+        Assert.Equal(30.0, GetHeightMapWorldHeight(alignedLeftChunk, alignedLeftGeometry, row: 1, column: 1), 6);
+        Assert.Equal(40.0, GetHeightMapWorldHeight(alignedRightChunk, alignedRightGeometry, row: 0, column: 0), 6);
+        Assert.Equal(30.0, GetHeightMapWorldHeight(alignedRightChunk, alignedRightGeometry, row: 1, column: 0), 6);
+    }
+
+    [Fact]
     public void AlignAdjacentDemHeightMapChunkBoundariesReconcilesSharedCornerAcrossTwoByTwoChunks()
     {
         ResoniteConstructionCityObject northWestChunk = CreateHeightMapChunk(

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -415,7 +415,7 @@ public sealed class CliArgumentsParserTests
             CliArgumentsParser.HelpText,
             StringComparison.Ordinal);
         Assert.Contains(
-            "Optional. Experimental diagnostic timeout for ImportMesh. Default: 0 (disabled).",
+            "Optional. Accepted for backward compatibility but ignored. Default: 0.",
             CliArgumentsParser.HelpText,
             StringComparison.Ordinal);
     }

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkClientTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkClientTests.cs
@@ -38,72 +38,8 @@ public sealed class ResoniteLinkClientTests
     }
 
     [Fact]
-    public async Task ImportTextureAsyncFallsBackToRawPayloadWhenFileImportPathIsNotResolvableByListener()
+    public async Task ImportTextureAsyncUsesRawPayloadForFileImports()
     {
-        using EnvironmentVariableScope scope = new("WSL_DISTRO_NAME", null);
-        using TemporaryDirectory temporaryDirectory = new();
-        string texturePath = Path.Combine(temporaryDirectory.Path, "albedo.png");
-        using (Image<Rgba32> image = new(1, 1, new Rgba32(255, 0, 0, 255)))
-        {
-            await image.SaveAsPngAsync(texturePath);
-        }
-
-        using FakeResoniteLinkTransport transport = new()
-        {
-            ImportTextureFileResult = new AssetData
-            {
-                Success = false,
-                ErrorInfo = $"Exception when generating file signature {texturePath}{Environment.NewLine}System.IO.FileNotFoundException: Could not find file '/home/resonite/{texturePath}'.",
-            },
-            ImportTextureRawResult = new AssetData
-            {
-                Success = true,
-                AssetURL = new Uri("file:///tmp/albedo.png"),
-            },
-        };
-
-        using ResoniteLinkClient client = new(transport);
-        Uri importedTexture = await client.ImportTextureAsync(
-            ResoniteTextureImportFactory.CreateFromFile(texturePath),
-            CancellationToken.None);
-
-        Assert.Equal(new Uri("file:///tmp/albedo.png"), importedTexture);
-        Assert.Equal(1, transport.ImportTextureFileCallCount);
-        Assert.Equal(1, transport.ImportTextureRawCallCount);
-        Assert.NotNull(transport.LastRawTextureRequest);
-        Assert.Equal(1, transport.LastRawTextureRequest!.Width);
-        Assert.Equal(1, transport.LastRawTextureRequest.Height);
-    }
-
-    [Fact]
-    public async Task ImportTextureAsyncDoesNotFallbackWhenLocalFileIsMissing()
-    {
-        using EnvironmentVariableScope scope = new("WSL_DISTRO_NAME", null);
-        string texturePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.png");
-        using FakeResoniteLinkTransport transport = new()
-        {
-            ImportTextureFileResult = new AssetData
-            {
-                Success = false,
-                ErrorInfo = "Exception when generating file signature missing texture",
-            },
-        };
-
-        using ResoniteLinkClient client = new(transport);
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await client.ImportTextureAsync(
-                ResoniteTextureImportFactory.CreateFromFile(texturePath),
-                CancellationToken.None));
-
-        Assert.Contains("ResoniteLink import texture failed", exception.Message, StringComparison.Ordinal);
-        Assert.Equal(1, transport.ImportTextureFileCallCount);
-        Assert.Equal(0, transport.ImportTextureRawCallCount);
-    }
-
-    [Fact]
-    public async Task ImportTextureAsyncUsesRawPayloadImmediatelyWhenRunningUnderWsl()
-    {
-        using EnvironmentVariableScope scope = new("WSL_DISTRO_NAME", "Ubuntu-24.04");
         using TemporaryDirectory temporaryDirectory = new();
         string texturePath = Path.Combine(temporaryDirectory.Path, "albedo.png");
         using (Image<Rgba32> image = new(1, 1, new Rgba32(255, 0, 0, 255)))
@@ -134,27 +70,53 @@ public sealed class ResoniteLinkClientTests
     }
 
     [Fact]
-    public void TranslateFilePathForHostConvertsMountedWindowsPathsUnderWsl()
+    public async Task ImportTextureAsyncThrowsWhenLocalFileIsMissing()
     {
-        using EnvironmentVariableScope scope = new("WSL_DISTRO_NAME", "Ubuntu-24.04");
+        string texturePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.png");
+        using FakeResoniteLinkTransport transport = new();
 
-        string translatedPath = ResoniteLinkClient.TranslateFilePathForHost(
-            "/mnt/c/Users/esnya/Documents/texture.png");
+        using ResoniteLinkClient client = new(transport);
+        FileNotFoundException exception = await Assert.ThrowsAsync<FileNotFoundException>(
+            async () => await client.ImportTextureAsync(
+                ResoniteTextureImportFactory.CreateFromFile(texturePath),
+                CancellationToken.None));
 
-        Assert.Equal(@"C:\Users\esnya\Documents\texture.png", translatedPath);
+        Assert.Contains(Path.GetFileName(texturePath), exception.Message, StringComparison.Ordinal);
+        Assert.Equal(0, transport.ImportTextureFileCallCount);
+        Assert.Equal(0, transport.ImportTextureRawCallCount);
     }
 
     [Fact]
-    public void TranslateFilePathForHostConvertsNonMountedPathsToWslUncPath()
+    public async Task ImportTextureAsyncUsesRawPayloadForFileImportsWhenRunningUnderWsl()
     {
         using EnvironmentVariableScope scope = new("WSL_DISTRO_NAME", "Ubuntu-24.04");
+        using TemporaryDirectory temporaryDirectory = new();
+        string texturePath = Path.Combine(temporaryDirectory.Path, "albedo.png");
+        using (Image<Rgba32> image = new(1, 1, new Rgba32(255, 0, 0, 255)))
+        {
+            await image.SaveAsPngAsync(texturePath);
+        }
 
-        string translatedPath = ResoniteLinkClient.TranslateFilePathForHost(
-            "/tmp/Plateau.ResoniteLink/default-materials/default-materials/roof/Concrete033_2K-JPG_Color.jpg");
+        using FakeResoniteLinkTransport transport = new()
+        {
+            ImportTextureRawResult = new AssetData
+            {
+                Success = true,
+                AssetURL = new Uri("file:///tmp/albedo.png"),
+            },
+        };
 
-        Assert.Equal(
-            @"\\wsl.localhost\Ubuntu-24.04\tmp\Plateau.ResoniteLink\default-materials\default-materials\roof\Concrete033_2K-JPG_Color.jpg",
-            translatedPath);
+        using ResoniteLinkClient client = new(transport);
+        Uri importedTexture = await client.ImportTextureAsync(
+            ResoniteTextureImportFactory.CreateFromFile(texturePath),
+            CancellationToken.None);
+
+        Assert.Equal(new Uri("file:///tmp/albedo.png"), importedTexture);
+        Assert.Equal(0, transport.ImportTextureFileCallCount);
+        Assert.Equal(1, transport.ImportTextureRawCallCount);
+        Assert.NotNull(transport.LastRawTextureRequest);
+        Assert.Equal(1, transport.LastRawTextureRequest!.Width);
+        Assert.Equal(1, transport.LastRawTextureRequest.Height);
     }
 
     private sealed class FakeResoniteLinkTransport : IResoniteLinkTransport

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -2457,28 +2457,6 @@ public sealed class ResoniteLinkSceneBuilderTests
             && string.Equals(slot.Name?.Value, "PLATEAU tokyo23ku", StringComparison.Ordinal)));
     }
 
-    [Fact]
-    public async Task BuildAsyncFreshRunDoesNotRereadNewlyCreatedSlots()
-    {
-        string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
-        CapturedResoniteScene scene = LoadScene(
-            new PlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                SourceKind: DatasetSourceKind.Local,
-                LocalSourcePath: fixturePath,
-                ServerUri: null));
-        FakeResoniteLinkSession session = new();
-
-        await RunBuilderAsync(
-            new ResoniteLinkSceneBuilder(
-                new Uri("ws://localhost:12345/"),
-                1,
-                ResoniteLinkSendDiagnostics.Disabled,
-                () => new FakeResoniteLinkClient(session, failNonRootGetSlot: true)),
-            scene);
-    }
-
     private static List<DataModelOperation> ResolveBatchLocalSlotReferences(
         IReadOnlyList<DataModelOperation> operations,
         Func<string> allocateSlotId,

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -1903,7 +1903,7 @@ public sealed class ResoniteLinkSceneBuilderTests
     }
 
     [Fact]
-    public async Task BuildAsyncSurfacesLaneFailureWhenCityObjectSendFails()
+    public async Task BuildAsyncSkipsFailedCityObjectsAndContinues()
     {
         string fixturePath = TestData.GetFixturePath("LocalPlateauDatasetMixedObjects");
         CapturedResoniteScene scene = LoadScene(
@@ -1926,16 +1926,26 @@ public sealed class ResoniteLinkSceneBuilderTests
                 () => Interlocked.Decrement(ref remainingMeshImportFailures) >= 0),
             progressReporter: progressMessages.Add);
 
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await RunBuilderAsync(builder, scene));
+        IReadOnlyList<string> destinations = await RunBuilderAsync(builder, scene);
 
-        Assert.Contains("Simulated mesh import failure.", exception.Message, StringComparison.Ordinal);
+        Assert.Single(destinations);
+        Assert.InRange(session.ImportedMeshes.Count, 1, scene.CityObjects.Count - 1);
         Assert.Contains(
+            progressMessages,
+            static message => message.Contains("[live][warn] Skipping city object after send failure", StringComparison.Ordinal));
+        Assert.DoesNotContain(
             progressMessages,
             static message => message.Contains("[live][error] Send lane 1/1 failed:", StringComparison.Ordinal));
         Assert.Contains(
             progressMessages,
             static message => message.Contains("[live][debug] Creating dataset root, asset groups, and anchor slots.", StringComparison.Ordinal));
+        Assert.Contains(
+            progressMessages,
+            static message => message.Contains("[live][info] Sent city object ", StringComparison.Ordinal));
+        Assert.Contains(
+            progressMessages,
+            static message => message.Contains("Send summary: attempted=", StringComparison.Ordinal)
+                && message.Contains(" failed=", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -1962,10 +1972,9 @@ public sealed class ResoniteLinkSceneBuilderTests
         await builder.ProcessCityObjectAsync(scene.CityObjects[0]);
 
         Task<IReadOnlyList<string>> completionTask = builder.CompleteAsync();
-        client.AllowImportMeshCompletion.TrySetResult();
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await completionTask.WaitAsync(TimeSpan.FromSeconds(5)));
-        Assert.Contains("Simulated texture import failure.", exception.Message, StringComparison.Ordinal);
+        await client.ImportMeshCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        IReadOnlyList<string> destinations = await completionTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Single(destinations);
     }
 
     [Fact]
@@ -1987,7 +1996,8 @@ public sealed class ResoniteLinkSceneBuilderTests
             ResoniteLinkSendDiagnostics.Disabled,
             () => new FailingImportMeshSharedClient(session, static () => true));
 
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await RunBuilderAsync(builder, scene));
+        IReadOnlyList<string> destinations = await RunBuilderAsync(builder, scene);
+        Assert.Single(destinations);
         Assert.DoesNotContain(
             session.SlotPaths.Values,
             static path => string.Equals(path, "PLATEAU tokyo23ku/53394525/bldg/LOD2/Building One", StringComparison.Ordinal));

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -1962,10 +1962,9 @@ public sealed class ResoniteLinkSceneBuilderTests
         await builder.ProcessCityObjectAsync(scene.CityObjects[0]);
 
         Task<IReadOnlyList<string>> completionTask = builder.CompleteAsync();
-        await client.ImportMeshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        await client.ImportMeshCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() => completionTask);
+        client.AllowImportMeshCompletion.TrySetResult();
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await completionTask.WaitAsync(TimeSpan.FromSeconds(5)));
         Assert.Contains("Simulated texture import failure.", exception.Message, StringComparison.Ordinal);
     }
 
@@ -2350,6 +2349,28 @@ public sealed class ResoniteLinkSceneBuilderTests
             && string.Equals(slot.Name?.Value, "PLATEAU tokyo23ku", StringComparison.Ordinal)));
     }
 
+    [Fact]
+    public async Task BuildAsyncFreshRunDoesNotRereadNewlyCreatedSlots()
+    {
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
+        CapturedResoniteScene scene = LoadScene(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: fixturePath,
+                ServerUri: null));
+        FakeResoniteLinkSession session = new();
+
+        await RunBuilderAsync(
+            new ResoniteLinkSceneBuilder(
+                new Uri("ws://localhost:12345/"),
+                1,
+                ResoniteLinkSendDiagnostics.Disabled,
+                () => new FakeResoniteLinkClient(session, failNonRootGetSlot: true)),
+            scene);
+    }
+
     private static List<DataModelOperation> ResolveBatchLocalSlotReferences(
         IReadOnlyList<DataModelOperation> operations,
         Func<string> allocateSlotId,
@@ -2546,10 +2567,13 @@ public sealed class ResoniteLinkSceneBuilderTests
         {
         }
 
-        public FakeResoniteLinkClient(FakeResoniteLinkSession session)
+        public FakeResoniteLinkClient(FakeResoniteLinkSession session, bool failNonRootGetSlot = false)
         {
             this.session = session;
+            this.failNonRootGetSlot = failNonRootGetSlot;
         }
+
+        private readonly bool failNonRootGetSlot;
 
         public int ConnectCallCount { get; private set; }
 
@@ -2683,6 +2707,11 @@ public sealed class ResoniteLinkSceneBuilderTests
                 if (string.Equals(slotId, "Root", StringComparison.Ordinal))
                 {
                     return Task.FromResult<Slot?>(CreateSyntheticRootSlot(session, depth, CloneSlot));
+                }
+
+                if (failNonRootGetSlot)
+                {
+                    throw new InvalidOperationException($"unexpected GetSlotAsync({slotId}, {depth})");
                 }
 
                 session.SlotsById.TryGetValue(slotId, out Slot? slot);

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ResoniteLinkSceneBuilderTests.cs
@@ -430,6 +430,100 @@ public sealed class ResoniteLinkSceneBuilderTests
     }
 
     [Fact]
+    public async Task CompleteAsyncCancelsBlockedDedicatedMaterialImportAfterPeerTextureFailure()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        string textureOne = "textures/albedo-one.png";
+        string textureTwo = "textures/albedo-two.png";
+        Directory.CreateDirectory(Path.Combine(datasetDirectory.Path, "textures"));
+        await WriteSolidColorTextureAsync(
+            Path.Combine(datasetDirectory.Path, textureOne),
+            new Rgba32(255, 0, 0, 255));
+        await WriteSolidColorTextureAsync(
+            Path.Combine(datasetDirectory.Path, textureTwo),
+            new Rgba32(0, 255, 0, 255));
+
+        ResoniteConstructionMetadata metadata = new(
+            SchemaVersion: "3.0",
+            WorldName: "PLATEAU blocked-dedicated-material-test",
+            Request: new PlateauImportRequest(
+                Dataset: "blocked-dedicated-material-test",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: datasetDirectory.Path,
+                ServerUri: null),
+            SourceDataset: new PlateauSourceDataset(
+                PackageNames: ["bldg"],
+                SourceFiles: [textureOne, textureTwo],
+                TerrainTextureOverlays: []),
+            Attribution: new ResoniteAttribution(
+                DatasetLicense: new ResoniteLicenseComponentMetadata(
+                    RequireCredit: true,
+                    CreditText: "credit",
+                    LicenseName: "license",
+                    LicenseUrl: "https://example.invalid/license"),
+                MaterialLicenses: []),
+            LocalOrigin: new ResoniteLocalOrigin(35.6875, 139.69375, 0.0));
+        ResoniteConstructionCityObject cityObject = new(
+            SlotKey: "blocked-dedicated-material-building",
+            DisplayName: "Blocked Dedicated Material Building",
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 2,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Mesh: new ResoniteImportedMesh(
+                [
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(1.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 1.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(1.0, 1.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 1.0)),
+                ],
+                [
+                    new ResoniteMeshSubmesh(0, "mat-one", [0, 1, 2]),
+                    new ResoniteMeshSubmesh(1, "mat-two", [1, 3, 2]),
+                ]),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "mat-one",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePath: textureOne,
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0]),
+                new ResoniteMaterialBinding(
+                    MaterialKey: "mat-two",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePath: textureTwo,
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [1]),
+            ],
+            SourceObjectKey: "blocked-dedicated-material-building");
+        CapturedResoniteScene scene = new(metadata, [cityObject]);
+
+        using BlockingPeerTextureFailureClient client = new(textureOne, textureTwo);
+        await using ResoniteLinkSceneBuilder builder = new(
+            new Uri("ws://localhost:12345/"),
+            1,
+            ResoniteLinkSendDiagnostics.Disabled,
+            () => client);
+
+        using TemporaryDirectory workDirectory = new();
+        await builder.BeginAsync(scene.Metadata, workDirectory.Path);
+        await builder.ProcessCityObjectAsync(scene.CityObjects[0]);
+
+        IReadOnlyList<string> destinations = await builder.CompleteAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Single(destinations);
+        await client.BlockedTextureCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
     public async Task BuildAsyncOmitsMaterialPropertyBlocksForMixedRenderers()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -1972,8 +2066,12 @@ public sealed class ResoniteLinkSceneBuilderTests
         await builder.ProcessCityObjectAsync(scene.CityObjects[0]);
 
         Task<IReadOnlyList<string>> completionTask = builder.CompleteAsync();
-        await client.ImportMeshCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
         IReadOnlyList<string> destinations = await completionTask.WaitAsync(TimeSpan.FromSeconds(5));
+        if (client.ImportMeshStarted.Task.IsCompleted)
+        {
+            Assert.True(client.ImportMeshCanceled.Task.IsCompleted);
+        }
+
         Assert.Single(destinations);
     }
 
@@ -4419,6 +4517,105 @@ public sealed class ResoniteLinkSceneBuilderTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             throw new InvalidOperationException("Simulated texture import failure.");
+        }
+
+        public Task UpdateComponentAsync(UpdateComponent request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class BlockingPeerTextureFailureClient(string failingTextureIdentitySuffix, string blockingTextureIdentitySuffix) : IResoniteLinkClient
+    {
+        private int nextComponentId;
+        private int nextSlotId;
+
+        public TaskCompletionSource BlockedTextureCanceled { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Dispose()
+        {
+        }
+
+        public Task ConnectAsync(Uri endpoint, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task<string> AddComponentAsync(AddComponent request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult($"srv_component_{Interlocked.Increment(ref nextComponentId)}");
+        }
+
+        public Task<string> AddSlotAsync(AddSlot request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult($"srv_slot_{Interlocked.Increment(ref nextSlotId)}");
+        }
+
+        public Task<BatchResponse> RunDataModelOperationBatchAsync(
+            IReadOnlyList<DataModelOperation> operations,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new BatchResponse
+            {
+                Success = true,
+                Responses = [],
+            });
+        }
+
+        public Task<Component?> GetComponentAsync(string componentId, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<Component?>(null);
+        }
+
+        public Task<Slot?> GetSlotAsync(string slotId, int depth, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<Slot?>(null);
+        }
+
+        public Task<Uri> ImportMeshAsync(ImportMeshRawData request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new Uri("resdb:///mesh/ok", UriKind.Absolute));
+        }
+
+        public async Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string? identity = textureImport switch
+            {
+                ResoniteFileTextureImport fileImport => fileImport.AbsolutePath,
+                ResoniteRawTextureImport rawImport => rawImport.Identity,
+                _ => null,
+            };
+
+            if (identity is not null
+                && identity.EndsWith(failingTextureIdentitySuffix, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Simulated texture import failure.");
+            }
+
+            if (identity is not null
+                && identity.EndsWith(blockingTextureIdentitySuffix, StringComparison.Ordinal))
+            {
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    BlockedTextureCanceled.TrySetResult();
+                    throw;
+                }
+            }
+
+            return new Uri("resdb:///texture/ok", UriKind.Absolute);
         }
 
         public Task UpdateComponentAsync(UpdateComponent request, CancellationToken cancellationToken)

--- a/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
@@ -23,7 +23,7 @@ public sealed class RetryingResoniteLinkClientTests
             progressMessages.Add);
 
         await client.ConnectAsync(new Uri("ws://localhost:12345/"), CancellationToken.None);
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        ResoniteLinkOperationException exception = await Assert.ThrowsAsync<ResoniteLinkOperationException>(
             () => client.ImportMeshAsync(
                 new ImportMeshRawData
                 {
@@ -31,6 +31,7 @@ public sealed class RetryingResoniteLinkClientTests
                     VertexCount = 3,
                 },
                 CancellationToken.None));
+        Assert.Equal("ImportMesh", exception.OperationName);
 
         Assert.Equal(1, firstClient.ImportMeshCallCount);
         Assert.Equal(0, secondClient.ImportMeshCallCount);

--- a/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
@@ -217,7 +217,7 @@ public sealed class RetryingResoniteLinkClientTests
     }
 
     [Fact]
-    public async Task GetSlotAsyncWaitsForImportMeshToCompleteBeforeRetryingReconnect()
+    public async Task GetSlotAsyncCancelsActiveImportBeforeRetryingReconnect()
     {
         int createdClientCount = 0;
         using CoordinatedReconnectableClient firstClient = new(failGetSlot: true);
@@ -244,15 +244,10 @@ public sealed class RetryingResoniteLinkClientTests
         Task<Slot?> getSlotTask = client.GetSlotAsync("slot-id", 0, CancellationToken.None);
 
         await Task.Delay(100);
-        Assert.False(getSlotTask.IsCompleted);
-        Assert.Equal(0, firstClient.DisposeCallCount);
-
-        firstClient.AllowImportMeshCompletion.SetResult();
-
-        Uri importedMesh = await importTask;
+        await firstClient.ImportMeshCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Slot? slot = await getSlotTask;
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => importTask);
 
-        Assert.Equal(new Uri("resdb:///mesh/ok", UriKind.Absolute), importedMesh);
         Assert.NotNull(slot);
         Assert.Equal("slot-id", slot!.ID);
         Assert.Equal(1, firstClient.DisposeCallCount);

--- a/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
@@ -248,17 +248,45 @@ public sealed class RetryingResoniteLinkClientTests
         await firstClient.ImportMeshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         Task<Slot?> getSlotTask = client.GetSlotAsync("slot-id", 0, CancellationToken.None);
-
-        await Task.Delay(100);
-        Assert.False(getSlotTask.IsCompleted);
-        Assert.Equal(0, firstClient.DisposeCallCount);
-
-        firstClient.AllowImportMeshCompletion.SetResult();
-
-        Uri importedMesh = await importTask;
+        await firstClient.ImportMeshCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Slot? slot = await getSlotTask;
 
-        Assert.Equal(new Uri("resdb:///mesh/ok", UriKind.Absolute), importedMesh);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => importTask);
+        Assert.NotNull(slot);
+        Assert.Equal("slot-id", slot!.ID);
+        Assert.Equal(1, firstClient.DisposeCallCount);
+        Assert.Equal(1, secondClient.ConnectCallCount);
+    }
+
+    [Fact]
+    public async Task GetSlotAsyncReconnectCancelsConcurrentImportBeforeRetry()
+    {
+        int createdClientCount = 0;
+        using CoordinatedReconnectableClient firstClient = new(failGetSlot: true);
+        using CoordinatedReconnectableClient secondClient = new();
+
+        using RetryingResoniteLinkClient client = new(
+            () =>
+            {
+                createdClientCount++;
+                return createdClientCount == 1 ? firstClient : secondClient;
+            });
+
+        await client.ConnectAsync(new Uri("ws://localhost:12345/"), CancellationToken.None);
+
+        Task<Uri> importTask = client.ImportMeshAsync(
+            new ImportMeshRawData
+            {
+                RawBinaryPayload = [1, 2, 3],
+                VertexCount = 3,
+            },
+            CancellationToken.None);
+        await firstClient.ImportMeshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Slot? slot = await client.GetSlotAsync("slot-id", 0, CancellationToken.None);
+        await firstClient.ImportMeshCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => importTask);
         Assert.NotNull(slot);
         Assert.Equal("slot-id", slot!.ID);
         Assert.Equal(1, firstClient.DisposeCallCount);
@@ -474,6 +502,8 @@ public sealed class RetryingResoniteLinkClientTests
 
         public TaskCompletionSource AllowImportMeshCompletion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        public TaskCompletionSource ImportMeshCanceled { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public int ConnectCallCount { get; private set; }
 
         public int DisposeCallCount { get; private set; }
@@ -539,7 +569,15 @@ public sealed class RetryingResoniteLinkClientTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             ImportMeshStarted.TrySetResult();
-            await AllowImportMeshCompletion.Task.WaitAsync(cancellationToken);
+            try
+            {
+                await AllowImportMeshCompletion.Task.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                ImportMeshCanceled.TrySetResult();
+                throw;
+            }
             ObjectDisposedException.ThrowIf(disposed, this);
 
             return new Uri("resdb:///mesh/ok", UriKind.Absolute);

--- a/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
@@ -83,7 +83,7 @@ public sealed class RetryingResoniteLinkClientTests
     }
 
     [Fact]
-    public async Task MutationOperationsDoNotWaitForImportMeshToComplete()
+    public async Task MutationOperationsWaitForImportMeshToComplete()
     {
         using BlockingReconnectableClient innerClient = new();
         using RetryingResoniteLinkClient client = new(() => innerClient);
@@ -119,7 +119,7 @@ public sealed class RetryingResoniteLinkClientTests
             CancellationToken.None);
 
         await Task.Delay(100);
-        Assert.True(addSlotTask.IsCompletedSuccessfully);
+        Assert.False(addSlotTask.IsCompleted);
 
         innerClient.AllowImportMeshCompletion.SetResult();
 
@@ -128,7 +128,7 @@ public sealed class RetryingResoniteLinkClientTests
 
         Assert.Equal(1, innerClient.ImportMeshCallCount);
         Assert.Equal(1, innerClient.AddSlotCallCount);
-        Assert.False(innerClient.AddSlotStartedAfterImportCompleted);
+        Assert.True(innerClient.AddSlotStartedAfterImportCompleted);
     }
 
     [Fact]
@@ -223,7 +223,7 @@ public sealed class RetryingResoniteLinkClientTests
     }
 
     [Fact]
-    public async Task GetSlotAsyncReconnectWaitsForConcurrentImportBeforeDisposingClient()
+    public async Task GetSlotAsyncWaitsForImportMeshToCompleteBeforeRetryingReconnect()
     {
         int createdClientCount = 0;
         using CoordinatedReconnectableClient firstClient = new(failGetSlot: true);
@@ -248,45 +248,17 @@ public sealed class RetryingResoniteLinkClientTests
         await firstClient.ImportMeshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         Task<Slot?> getSlotTask = client.GetSlotAsync("slot-id", 0, CancellationToken.None);
-        await firstClient.ImportMeshCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Task.Delay(100);
+        Assert.False(getSlotTask.IsCompleted);
+        Assert.Equal(0, firstClient.DisposeCallCount);
+
+        firstClient.AllowImportMeshCompletion.SetResult();
+
+        Uri importedMesh = await importTask;
         Slot? slot = await getSlotTask;
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => importTask);
-        Assert.NotNull(slot);
-        Assert.Equal("slot-id", slot!.ID);
-        Assert.Equal(1, firstClient.DisposeCallCount);
-        Assert.Equal(1, secondClient.ConnectCallCount);
-    }
-
-    [Fact]
-    public async Task GetSlotAsyncReconnectCancelsConcurrentImportBeforeRetry()
-    {
-        int createdClientCount = 0;
-        using CoordinatedReconnectableClient firstClient = new(failGetSlot: true);
-        using CoordinatedReconnectableClient secondClient = new();
-
-        using RetryingResoniteLinkClient client = new(
-            () =>
-            {
-                createdClientCount++;
-                return createdClientCount == 1 ? firstClient : secondClient;
-            });
-
-        await client.ConnectAsync(new Uri("ws://localhost:12345/"), CancellationToken.None);
-
-        Task<Uri> importTask = client.ImportMeshAsync(
-            new ImportMeshRawData
-            {
-                RawBinaryPayload = [1, 2, 3],
-                VertexCount = 3,
-            },
-            CancellationToken.None);
-        await firstClient.ImportMeshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        Slot? slot = await client.GetSlotAsync("slot-id", 0, CancellationToken.None);
-        await firstClient.ImportMeshCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => importTask);
+        Assert.Equal(new Uri("resdb:///mesh/ok", UriKind.Absolute), importedMesh);
         Assert.NotNull(slot);
         Assert.Equal("slot-id", slot!.ID);
         Assert.Equal(1, firstClient.DisposeCallCount);

--- a/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
@@ -218,7 +218,7 @@ public sealed class RetryingResoniteLinkClientTests
     }
 
     [Fact]
-    public async Task GetSlotAsyncCancelsActiveImportBeforeRetryingReconnect()
+    public async Task GetSlotAsyncWaitsForActiveImportBeforeRetryingReconnect()
     {
         int createdClientCount = 0;
         using CoordinatedReconnectableClient firstClient = new(failGetSlot: true);
@@ -245,9 +245,11 @@ public sealed class RetryingResoniteLinkClientTests
         Task<Slot?> getSlotTask = client.GetSlotAsync("slot-id", 0, CancellationToken.None);
 
         await Task.Delay(100);
-        await firstClient.ImportMeshCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(getSlotTask.IsCompleted);
+
+        firstClient.AllowImportMeshCompletion.TrySetResult();
+        await importTask;
         Slot? slot = await getSlotTask;
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => importTask);
 
         Assert.NotNull(slot);
         Assert.Equal("slot-id", slot!.ID);
@@ -256,18 +258,10 @@ public sealed class RetryingResoniteLinkClientTests
     }
 
     [Fact]
-    public async Task ReconnectCancellationClearsPendingStateForLaterOperations()
+    public async Task CancelingQueuedGetSlotDoesNotBlockLaterOperations()
     {
-        int createdClientCount = 0;
-        using CoordinatedReconnectableClient firstClient = new(failGetSlot: true, blockImportCancellationCompletion: true);
-        using CoordinatedReconnectableClient secondClient = new();
-
-        using RetryingResoniteLinkClient client = new(
-            () =>
-            {
-                createdClientCount++;
-                return createdClientCount == 1 ? firstClient : secondClient;
-            });
+        using CoordinatedReconnectableClient firstClient = new();
+        using RetryingResoniteLinkClient client = new(() => firstClient);
 
         await client.ConnectAsync(new Uri("ws://localhost:12345/"), CancellationToken.None);
 
@@ -283,12 +277,13 @@ public sealed class RetryingResoniteLinkClientTests
         using CancellationTokenSource getSlotCancellation = new();
         Task<Slot?> getSlotTask = client.GetSlotAsync("slot-id", 0, getSlotCancellation.Token);
 
-        await firstClient.ImportMeshCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.Delay(100);
+        Assert.False(getSlotTask.IsCompleted);
         await getSlotCancellation.CancelAsync();
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => getSlotTask);
 
-        firstClient.AllowImportMeshCancellationCompletion.TrySetResult();
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => importTask);
+        firstClient.AllowImportMeshCompletion.TrySetResult();
+        await importTask;
 
         string slotId = await client.AddSlotAsync(
             new AddSlot
@@ -309,7 +304,6 @@ public sealed class RetryingResoniteLinkClientTests
             CancellationToken.None);
 
         Assert.Equal("srv_slot_1", slotId);
-        Assert.Equal(0, secondClient.ConnectCallCount);
     }
 
     private sealed class StubReconnectableClient(bool failImportMesh = false, bool failGetSlot = false) : IResoniteLinkClient
@@ -522,22 +516,13 @@ public sealed class RetryingResoniteLinkClientTests
 
         public TaskCompletionSource AllowImportMeshCompletion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public TaskCompletionSource ImportMeshCanceled { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        public TaskCompletionSource AllowImportMeshCancellationCompletion { get; } =
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
-
         public int ConnectCallCount { get; private set; }
 
         public int DisposeCallCount { get; private set; }
 
-        public CoordinatedReconnectableClient(bool failGetSlot = false, bool blockImportCancellationCompletion = false)
+        public CoordinatedReconnectableClient(bool failGetSlot = false)
         {
             this.failGetSlot = failGetSlot;
-            if (!blockImportCancellationCompletion)
-            {
-                AllowImportMeshCancellationCompletion.TrySetResult();
-            }
         }
 
         public void Dispose()
@@ -601,16 +586,7 @@ public sealed class RetryingResoniteLinkClientTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             ImportMeshStarted.TrySetResult();
-            try
-            {
-                await AllowImportMeshCompletion.Task.WaitAsync(cancellationToken);
-            }
-            catch (OperationCanceledException)
-            {
-                ImportMeshCanceled.TrySetResult();
-                await AllowImportMeshCancellationCompletion.Task;
-                throw;
-            }
+            await AllowImportMeshCompletion.Task.WaitAsync(cancellationToken);
             ObjectDisposedException.ThrowIf(disposed, this);
 
             return new Uri("resdb:///mesh/ok", UriKind.Absolute);

--- a/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
@@ -132,16 +132,16 @@ public sealed class RetryingResoniteLinkClientTests
     }
 
     [Fact]
-    public async Task ImportMeshAsyncTimesOutWhenInnerClientStopsResponding()
+    public async Task ImportMeshAsyncIgnoresConfiguredDiagnosticTimeout()
     {
-        List<string> progressMessages = [];
         using BlockingReconnectableClient innerClient = new();
         using RetryingResoniteLinkClient client = new(
             () => innerClient,
-            progressMessages.Add,
+            reporter: null,
             importMeshTimeoutMilliseconds: 100);
 
         await client.ConnectAsync(new Uri("ws://localhost:12345/"), CancellationToken.None);
+        using CancellationTokenSource cancellation = new();
 
         Task<Uri> importTask = client.ImportMeshAsync(
             new ImportMeshRawData
@@ -149,21 +149,15 @@ public sealed class RetryingResoniteLinkClientTests
                 RawBinaryPayload = [1, 2, 3],
                 VertexCount = 3,
             },
-            CancellationToken.None);
+            cancellation.Token);
 
         await innerClient.ImportMeshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.Delay(150);
 
-        TimeoutException exception = await Assert.ThrowsAsync<TimeoutException>(() => importTask);
+        Assert.False(importTask.IsCompleted);
 
-        Assert.Contains("did not complete within 100ms", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("pending_responses=2", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("failure_exception=InvalidOperationException", exception.Message, StringComparison.Ordinal);
-        Assert.Contains(
-            progressMessages,
-            static message => message.Contains("ImportMesh failed without retry", StringComparison.Ordinal));
-        Assert.Contains(
-            progressMessages,
-            static message => message.Contains("[live][diagnostic] ImportMesh timeout", StringComparison.Ordinal));
+        await cancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => importTask);
         Assert.Equal(1, innerClient.ImportMeshCallCount);
     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
@@ -306,7 +306,53 @@ public sealed class RetryingResoniteLinkClientTests
         Assert.Equal("srv_slot_1", slotId);
     }
 
-    private sealed class StubReconnectableClient(bool failImportMesh = false, bool failGetSlot = false) : IResoniteLinkClient
+    [Fact]
+    public async Task FailedReconnectConnectLeavesExistingClientUsable()
+    {
+        int createdClientCount = 0;
+        using StubReconnectableClient firstClient = new(failGetSlot: true);
+        using StubReconnectableClient secondClient = new(failConnect: true);
+
+        using RetryingResoniteLinkClient client = new(
+            () =>
+            {
+                createdClientCount++;
+                return createdClientCount == 1 ? firstClient : secondClient;
+            });
+
+        await client.ConnectAsync(new Uri("ws://localhost:12345/"), CancellationToken.None);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.GetSlotAsync("slot-id", 0, CancellationToken.None));
+
+        string createdSlotId = await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    ID = null!,
+                    Parent = new Reference
+                    {
+                        TargetID = "parent-id",
+                    },
+                    Name = new Field_string
+                    {
+                        Value = "Slot",
+                    },
+                },
+            },
+            CancellationToken.None);
+
+        Assert.Equal("srv_slot_1", createdSlotId);
+        Assert.False(firstClient.IsDisposed);
+        Assert.Equal(1, firstClient.ConnectCallCount);
+        Assert.Equal(1, secondClient.ConnectCallCount);
+    }
+
+    private sealed class StubReconnectableClient(
+        bool failImportMesh = false,
+        bool failGetSlot = false,
+        bool failConnect = false) : IResoniteLinkClient
     {
         private int nextComponentId;
         private int nextSlotId;
@@ -317,14 +363,22 @@ public sealed class RetryingResoniteLinkClientTests
 
         public int GetSlotCallCount { get; private set; }
 
+        public bool IsDisposed { get; private set; }
+
         public void Dispose()
         {
+            IsDisposed = true;
         }
 
         public Task ConnectAsync(Uri endpoint, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ConnectCallCount++;
+            if (failConnect)
+            {
+                throw new InvalidOperationException("Simulated connect failure.");
+            }
+
             return Task.CompletedTask;
         }
 

--- a/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/RetryingResoniteLinkClientTests.cs
@@ -254,6 +254,63 @@ public sealed class RetryingResoniteLinkClientTests
         Assert.Equal(1, secondClient.ConnectCallCount);
     }
 
+    [Fact]
+    public async Task ReconnectCancellationClearsPendingStateForLaterOperations()
+    {
+        int createdClientCount = 0;
+        using CoordinatedReconnectableClient firstClient = new(failGetSlot: true, blockImportCancellationCompletion: true);
+        using CoordinatedReconnectableClient secondClient = new();
+
+        using RetryingResoniteLinkClient client = new(
+            () =>
+            {
+                createdClientCount++;
+                return createdClientCount == 1 ? firstClient : secondClient;
+            });
+
+        await client.ConnectAsync(new Uri("ws://localhost:12345/"), CancellationToken.None);
+
+        Task<Uri> importTask = client.ImportMeshAsync(
+            new ImportMeshRawData
+            {
+                RawBinaryPayload = [1, 2, 3],
+                VertexCount = 3,
+            },
+            CancellationToken.None);
+        await firstClient.ImportMeshStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        using CancellationTokenSource getSlotCancellation = new();
+        Task<Slot?> getSlotTask = client.GetSlotAsync("slot-id", 0, getSlotCancellation.Token);
+
+        await firstClient.ImportMeshCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await getSlotCancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => getSlotTask);
+
+        firstClient.AllowImportMeshCancellationCompletion.TrySetResult();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => importTask);
+
+        string slotId = await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    ID = null!,
+                    Parent = new Reference
+                    {
+                        TargetID = "parent-id",
+                    },
+                    Name = new Field_string
+                    {
+                        Value = "Slot",
+                    },
+                },
+            },
+            CancellationToken.None);
+
+        Assert.Equal("srv_slot_1", slotId);
+        Assert.Equal(0, secondClient.ConnectCallCount);
+    }
+
     private sealed class StubReconnectableClient(bool failImportMesh = false, bool failGetSlot = false) : IResoniteLinkClient
     {
         private int nextComponentId;
@@ -454,8 +511,9 @@ public sealed class RetryingResoniteLinkClientTests
         }
     }
 
-    private sealed class CoordinatedReconnectableClient(bool failGetSlot = false) : IResoniteLinkClient
+    private sealed class CoordinatedReconnectableClient : IResoniteLinkClient
     {
+        private readonly bool failGetSlot;
         private bool disposed;
         private int nextSlotId;
 
@@ -465,9 +523,21 @@ public sealed class RetryingResoniteLinkClientTests
 
         public TaskCompletionSource ImportMeshCanceled { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        public TaskCompletionSource AllowImportMeshCancellationCompletion { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public int ConnectCallCount { get; private set; }
 
         public int DisposeCallCount { get; private set; }
+
+        public CoordinatedReconnectableClient(bool failGetSlot = false, bool blockImportCancellationCompletion = false)
+        {
+            this.failGetSlot = failGetSlot;
+            if (!blockImportCancellationCompletion)
+            {
+                AllowImportMeshCancellationCompletion.TrySetResult();
+            }
+        }
 
         public void Dispose()
         {
@@ -537,6 +607,7 @@ public sealed class RetryingResoniteLinkClientTests
             catch (OperationCanceledException)
             {
                 ImportMeshCanceled.TrySetResult();
+                await AllowImportMeshCancellationCompletion.Task;
                 throw;
             }
             ObjectDisposedException.ThrowIf(disposed, this);


### PR DESCRIPTION
## Summary
- cancel active imports when a reconnecting GetSlot/GetComponent retry path takes over
- wait for canceled imports to drain before swapping the live client
- add regression tests covering reconnect-triggered import cancellation

## Testing
- bash scripts/verify-ci.sh