### PR TITLE
feat(import): atlas budgeting and shared material reuse

### DIFF
--- a/src/Plateau.ResoniteLink.Cli/BuildCommandOptions.cs
+++ b/src/Plateau.ResoniteLink.Cli/BuildCommandOptions.cs
@@ -7,6 +7,7 @@ public sealed record BuildCommandOptions(
     string WorkRoot,
     Uri? ResoniteLinkUri,
     int ResoniteLinkConnectionCount,
+    PlateauImportMemoryProfile MemoryProfile,
     bool EnableMeshBake,
     string? TerrainTileCacheRoot,
     bool DisableTerrainTileCache,

--- a/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
@@ -47,6 +47,8 @@ public static class CliArgumentsParser
           --resonitelink-url     Required unless --resonitelink-port is used. Absolute ws:// or wss:// endpoint for live ResoniteLink builds.
           --resonitelink-connections <count>
                                 Optional. Parallel ResoniteLink connection count for live sends. Default: 4.
+          --memory-profile <small|large>
+                                Optional. Texture/import memory budget profile. Default: large.
           --no-mesh-bake         Optional. Disable fixed-cell mesh baking for eligible LOD1 building city objects.
           --send-metrics         Optional. Enable opt-in live send metrics and CLI summary output.
           --verbose              Optional. Include debug-level progress logs.
@@ -89,6 +91,7 @@ public static class CliArgumentsParser
         bool disableTerrainTileCache = false;
         Uri? resoniteLinkUri = null;
         int resoniteLinkConnectionCount = CliDefaultOptions.ResoniteLinkConnectionCount;
+        PlateauImportMemoryProfile memoryProfile = CliDefaultOptions.MemoryProfile;
         bool enableMeshBake = true;
         bool enableSendMetrics = false;
         bool verboseLogging = false;
@@ -200,6 +203,17 @@ public static class CliArgumentsParser
                             {
                                 return CliParseResult.Failure(
                                     $"The value '{connectionCountValue}' is not a valid ResoniteLink connection count.");
+                            }
+
+                            break;
+                        }
+                    case "--memory-profile":
+                        {
+                            string memoryProfileValue = ReadValue(args, ref index, token);
+                            if (!Enum.TryParse(memoryProfileValue, ignoreCase: true, out memoryProfile))
+                            {
+                                return CliParseResult.Failure(
+                                    $"The value '{memoryProfileValue}' is not a valid memory profile. Use 'small' or 'large'.");
                             }
 
                             break;
@@ -373,6 +387,7 @@ public static class CliArgumentsParser
                 workRoot,
                 resoniteLinkUri,
                 resoniteLinkConnectionCount,
+                memoryProfile,
                 enableMeshBake,
                 terrainTileCacheRoot,
                 disableTerrainTileCache,

--- a/src/Plateau.ResoniteLink.Cli/CliDefaultOptions.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliDefaultOptions.cs
@@ -1,8 +1,11 @@
+using Plateau.ResoniteLink.Domain.Importing;
+
 namespace Plateau.ResoniteLink.Cli;
 
 internal static class CliDefaultOptions
 {
     public const int ResoniteLinkConnectionCount = 4;
+    public const PlateauImportMemoryProfile MemoryProfile = PlateauImportMemoryProfile.Large;
 
     public static readonly string[] PackageNames =
     [

--- a/src/Plateau.ResoniteLink.Cli/CliHostFactory.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliHostFactory.cs
@@ -110,6 +110,7 @@ internal sealed class DefaultSceneImportTargetFactory(IHttpClientFactory httpCli
             options.ResoniteLinkUri!,
             options.ResoniteLinkConnectionCount,
             options.EnableSendMetrics,
+            options.MemoryProfile,
             options.EnableMeshBake,
             options.TerrainTileCacheRoot,
             options.DisableTerrainTileCache,

--- a/src/Plateau.ResoniteLink/Model3d/PlateauImportMemoryProfile.cs
+++ b/src/Plateau.ResoniteLink/Model3d/PlateauImportMemoryProfile.cs
@@ -1,0 +1,7 @@
+namespace Plateau.ResoniteLink.Domain.Importing;
+
+public enum PlateauImportMemoryProfile
+{
+    Small,
+    Large,
+}

--- a/src/Plateau.ResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
@@ -58,6 +58,7 @@ internal sealed record LiveSendRunPlan(
     string ResolvedWorkRoot,
     ResoniteLocalOrigin RequestLocalOrigin,
     IReadOnlyDictionary<string, string> SourceFileSlotNamesByRelativePath,
+    ResoniteImportBudgetProfile ResourceBudget,
     LiveSendQueuePlan Queue,
     bool MeshBakeEnabled);
 

--- a/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -15,7 +15,8 @@ internal sealed class Lod2AtlasCityObjectBaker(
     int tilePaddingPixels = 2,
     IReadOnlyList<Lod2AtlasCityObjectBakePolicy>? bakePolicies = null,
     int maxBufferedSourceUnits = 32,
-    int maxBufferedCityObjectsPerSourceUnit = 256) : IResoniteBufferedCityObjectBaker
+    int maxBufferedCityObjectsPerSourceUnit = 256,
+    ResoniteImportBudgetProfile? resourceBudget = null) : IResoniteBufferedCityObjectBaker
 {
     internal const int DefaultMaxAtlasSize = 4096;
     internal const int DefaultTilePaddingPixels = 2;
@@ -32,6 +33,17 @@ internal sealed class Lod2AtlasCityObjectBaker(
     public int BakedInputCityObjectCount { get; private set; }
 
     public int BakedOutputCityObjectCount { get; private set; }
+
+    private int EffectiveMaxAtlasSize => Math.Max(1, Math.Min(maxAtlasSize, resourceBudget?.MaxAtlasSize ?? maxAtlasSize));
+
+    private int EffectiveMaxAtlasTextureEdge
+    {
+        get
+        {
+            int profileMaxTileEdge = resourceBudget?.MaxAtlasTextureEdge ?? EffectiveMaxAtlasSize;
+            return Math.Max(1, Math.Min(EffectiveMaxAtlasSize - (tilePaddingPixels * 2), profileMaxTileEdge));
+        }
+    }
 
     public async ValueTask<BufferedCityObjectBufferResult> TryBufferAsync(
         ResoniteConstructionCityObject cityObject,
@@ -312,8 +324,8 @@ internal sealed class Lod2AtlasCityObjectBaker(
             ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
             cancellationToken);
 
-        int maxTileWidth = Math.Max(1, maxAtlasSize - (tilePaddingPixels * 2));
-        int maxTileHeight = Math.Max(1, maxAtlasSize - (tilePaddingPixels * 2));
+        int maxTileWidth = EffectiveMaxAtlasTextureEdge;
+        int maxTileHeight = EffectiveMaxAtlasTextureEdge;
         int targetWidth = Math.Max(1, Math.Min(maxTileWidth, (int)Math.Ceiling(sourceImage.Width * uvBounds.Width)));
         int targetHeight = Math.Max(1, Math.Min(maxTileHeight, (int)Math.Ceiling(sourceImage.Height * uvBounds.Height)));
         using Image<Rgba32> bakedImage = BakeUsedUvRegion(sourceImage, uvBounds, targetWidth, targetHeight);
@@ -718,49 +730,166 @@ internal sealed class Lod2AtlasCityObjectBaker(
         IReadOnlyList<AtlasBatchEntry> entries,
         out AtlasLayout? layout)
     {
+        int atlasMaxSize = EffectiveMaxAtlasSize;
         List<AtlasPlacement> placements = [];
-        int cursorX = 0;
-        int cursorY = 0;
-        int rowHeight = 0;
+        List<Rect> freeRectangles = [new Rect(0, 0, atlasMaxSize, atlasMaxSize)];
         int usedWidth = 0;
+        int usedHeight = 0;
 
         foreach (AtlasBatchEntry entry in entries)
         {
             int paddedWidth = entry.Tile.Image.Width + (tilePaddingPixels * 2);
             int paddedHeight = entry.Tile.Image.Height + (tilePaddingPixels * 2);
-            if (paddedWidth > maxAtlasSize || paddedHeight > maxAtlasSize)
+            if (paddedWidth > atlasMaxSize || paddedHeight > atlasMaxSize)
             {
                 layout = null;
                 return false;
             }
 
-            if (cursorX > 0 && cursorX + paddedWidth > maxAtlasSize)
-            {
-                cursorX = 0;
-                cursorY += rowHeight;
-                rowHeight = 0;
-            }
-
-            if (cursorY + paddedHeight > maxAtlasSize)
+            if (!TryChooseFreeRectangle(freeRectangles, paddedWidth, paddedHeight, out Rect selectedRect))
             {
                 layout = null;
                 return false;
             }
 
-            Rect outerRect = new(cursorX, cursorY, paddedWidth, paddedHeight);
-            Rect innerRect = new(cursorX + tilePaddingPixels, cursorY + tilePaddingPixels, entry.Tile.Image.Width, entry.Tile.Image.Height);
+            Rect outerRect = new(selectedRect.X, selectedRect.Y, paddedWidth, paddedHeight);
+            Rect innerRect = new(selectedRect.X + tilePaddingPixels, selectedRect.Y + tilePaddingPixels, entry.Tile.Image.Width, entry.Tile.Image.Height);
             placements.Add(new AtlasPlacement(entry, outerRect, innerRect));
-            cursorX += paddedWidth;
-            rowHeight = Math.Max(rowHeight, paddedHeight);
-            usedWidth = Math.Max(usedWidth, cursorX);
+            SplitFreeRectangles(freeRectangles, outerRect);
+            PruneFreeRectangles(freeRectangles);
+            usedWidth = Math.Max(usedWidth, outerRect.X + outerRect.Width);
+            usedHeight = Math.Max(usedHeight, outerRect.Y + outerRect.Height);
         }
 
-        int usedHeight = cursorY + rowHeight;
         layout = new AtlasLayout(
             Math.Max(1, usedWidth),
             Math.Max(1, usedHeight),
             placements);
         return true;
+    }
+
+    private static bool TryChooseFreeRectangle(
+        IReadOnlyList<Rect> freeRectangles,
+        int requiredWidth,
+        int requiredHeight,
+        out Rect selectedRect)
+    {
+        selectedRect = default;
+        bool found = false;
+        int bestAreaFit = int.MaxValue;
+        int bestShortSideFit = int.MaxValue;
+
+        foreach (Rect freeRect in freeRectangles)
+        {
+            if (requiredWidth > freeRect.Width || requiredHeight > freeRect.Height)
+            {
+                continue;
+            }
+
+            int areaFit = (freeRect.Width * freeRect.Height) - (requiredWidth * requiredHeight);
+            int shortSideFit = Math.Min(freeRect.Width - requiredWidth, freeRect.Height - requiredHeight);
+            if (areaFit < bestAreaFit
+                || (areaFit == bestAreaFit && shortSideFit < bestShortSideFit)
+                || (areaFit == bestAreaFit && shortSideFit == bestShortSideFit
+                    && (freeRect.Y < selectedRect.Y
+                        || (freeRect.Y == selectedRect.Y && freeRect.X < selectedRect.X))))
+            {
+                selectedRect = freeRect;
+                bestAreaFit = areaFit;
+                bestShortSideFit = shortSideFit;
+                found = true;
+            }
+        }
+
+        return found;
+    }
+
+    private static void SplitFreeRectangles(List<Rect> freeRectangles, Rect usedRect)
+    {
+        for (int index = freeRectangles.Count - 1; index >= 0; index--)
+        {
+            Rect freeRect = freeRectangles[index];
+            if (!Intersects(freeRect, usedRect))
+            {
+                continue;
+            }
+
+            freeRectangles.RemoveAt(index);
+
+            if (usedRect.X > freeRect.X)
+            {
+                freeRectangles.Add(new Rect(
+                    freeRect.X,
+                    freeRect.Y,
+                    usedRect.X - freeRect.X,
+                    freeRect.Height));
+            }
+
+            if (usedRect.X + usedRect.Width < freeRect.X + freeRect.Width)
+            {
+                freeRectangles.Add(new Rect(
+                    usedRect.X + usedRect.Width,
+                    freeRect.Y,
+                    (freeRect.X + freeRect.Width) - (usedRect.X + usedRect.Width),
+                    freeRect.Height));
+            }
+
+            if (usedRect.Y > freeRect.Y)
+            {
+                freeRectangles.Add(new Rect(
+                    freeRect.X,
+                    freeRect.Y,
+                    freeRect.Width,
+                    usedRect.Y - freeRect.Y));
+            }
+
+            if (usedRect.Y + usedRect.Height < freeRect.Y + freeRect.Height)
+            {
+                freeRectangles.Add(new Rect(
+                    freeRect.X,
+                    usedRect.Y + usedRect.Height,
+                    freeRect.Width,
+                    (freeRect.Y + freeRect.Height) - (usedRect.Y + usedRect.Height)));
+            }
+        }
+    }
+
+    private static void PruneFreeRectangles(List<Rect> freeRectangles)
+    {
+        for (int leftIndex = freeRectangles.Count - 1; leftIndex >= 0; leftIndex--)
+        {
+            Rect left = freeRectangles[leftIndex];
+            for (int rightIndex = freeRectangles.Count - 1; rightIndex >= 0; rightIndex--)
+            {
+                if (leftIndex == rightIndex)
+                {
+                    continue;
+                }
+
+                Rect right = freeRectangles[rightIndex];
+                if (Contains(right, left))
+                {
+                    freeRectangles.RemoveAt(leftIndex);
+                    break;
+                }
+            }
+        }
+    }
+
+    private static bool Intersects(Rect left, Rect right)
+    {
+        return left.X < right.X + right.Width
+            && left.X + left.Width > right.X
+            && left.Y < right.Y + right.Height
+            && left.Y + left.Height > right.Y;
+    }
+
+    private static bool Contains(Rect outer, Rect inner)
+    {
+        return inner.X >= outer.X
+            && inner.Y >= outer.Y
+            && inner.X + inner.Width <= outer.X + outer.Width
+            && inner.Y + inner.Height <= outer.Y + outer.Height;
     }
 
     private static void ApplyBaseColor(Image<Rgba32> image, ResoniteColor color)

--- a/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -20,6 +20,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
 {
     internal const int DefaultMaxAtlasSize = 4096;
     internal const int DefaultTilePaddingPixels = 2;
+    private const byte BackgroundDetectionAlphaThreshold = 16;
 
     private readonly Dictionary<SourceUnitBatchKey, List<BufferedCityObject>> bufferedCityObjectsBySourceUnit = [];
     private readonly Dictionary<SourceUnitBatchKey, int> nextBatchIndexBySourceUnit = [];
@@ -323,15 +324,21 @@ internal sealed class Lod2AtlasCityObjectBaker(
         using Image<Rgba32> sourceImage = await textureImageLoader.LoadAsync(
             ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
             cancellationToken);
+        Rgba32 detectedBackgroundColor = DetectRepresentativeBackgroundColor(sourceImage);
+        using Image<Rgba32> preparedSourceImage = sourceImage.Clone();
+        FillTransparentRgb(preparedSourceImage, detectedBackgroundColor);
 
         int maxTileWidth = EffectiveMaxAtlasTextureEdge;
         int maxTileHeight = EffectiveMaxAtlasTextureEdge;
         int targetWidth = Math.Max(1, Math.Min(maxTileWidth, (int)Math.Ceiling(sourceImage.Width * uvBounds.Width)));
         int targetHeight = Math.Max(1, Math.Min(maxTileHeight, (int)Math.Ceiling(sourceImage.Height * uvBounds.Height)));
-        using Image<Rgba32> bakedImage = BakeUsedUvRegion(sourceImage, uvBounds, targetWidth, targetHeight);
+        using Image<Rgba32> bakedImage = BakeUsedUvRegion(preparedSourceImage, uvBounds, targetWidth, targetHeight);
 
         ApplyBaseColor(bakedImage, material.BaseColor);
-        return new MaterialAtlasTile(material.TexturePayload.Identity ?? material.MaterialKey, bakedImage.Clone());
+        return new MaterialAtlasTile(
+            material.TexturePayload.Identity ?? material.MaterialKey,
+            bakedImage.Clone(),
+            MultiplyPixel(detectedBackgroundColor, ToPixel(material.BaseColor)));
     }
 
     private static MaterialAtlasTile CreateSolidColorTile(ResoniteColor color)
@@ -339,7 +346,8 @@ internal sealed class Lod2AtlasCityObjectBaker(
         using Image<Rgba32> image = new(1, 1, ToPixel(color));
         return new MaterialAtlasTile(
             $"solid:{color.R:0.###},{color.G:0.###},{color.B:0.###},{color.A:0.###}",
-            image.Clone());
+            image.Clone(),
+            ToPixel(color));
     }
 
     private static bool CanBufferCityObjectMaterials(
@@ -494,14 +502,22 @@ internal sealed class Lod2AtlasCityObjectBaker(
 
         using Image<Rgba32>? atlasImage = layout is null
             ? null
-            : new Image<Rgba32>(layout.Width, layout.Height, new Rgba32(255, 255, 255, 255));
+            : new Image<Rgba32>(layout.Width, layout.Height, new Rgba32(0, 0, 0, 0));
+        bool[]? atlasCoverage = layout is null
+            ? null
+            : new bool[layout.Width * layout.Height];
         if (layout is not null)
         {
             foreach (AtlasPlacement placement in layout.Placements)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                DrawAtlasTile(atlasImage!, placement);
+                DrawAtlasTile(atlasImage!, atlasCoverage!, layout.Width, placement);
             }
+
+            FillUncoveredAtlasPixels(
+                atlasImage!,
+                atlasCoverage!,
+                ComputeAtlasBackgroundColor(layout.Placements));
         }
 
         ResoniteConstructionCityObject firstCityObject = candidates[0].CityObject;
@@ -689,13 +705,19 @@ internal sealed class Lod2AtlasCityObjectBaker(
             : new ResoniteFloat3(minX, minY, minZ);
     }
 
-    private void DrawAtlasTile(Image<Rgba32> atlasImage, AtlasPlacement placement)
+    private void DrawAtlasTile(Image<Rgba32> atlasImage, bool[] atlasCoverage, int atlasWidth, AtlasPlacement placement)
     {
         for (int y = 0; y < placement.Entry.Tile.Image.Height; y++)
         {
             for (int x = 0; x < placement.Entry.Tile.Image.Width; x++)
             {
-                atlasImage[placement.InnerRect.X + x, placement.InnerRect.Y + y] = placement.Entry.Tile.Image[x, y];
+                SetAtlasPixel(
+                    atlasImage,
+                    atlasCoverage,
+                    atlasWidth,
+                    placement.InnerRect.X + x,
+                    placement.InnerRect.Y + y,
+                    placement.Entry.Tile.Image[x, y]);
             }
         }
 
@@ -705,8 +727,20 @@ internal sealed class Lod2AtlasCityObjectBaker(
             Rgba32 rightEdge = atlasImage[placement.InnerRect.X + placement.InnerRect.Width - 1, placement.InnerRect.Y + y];
             for (int pad = 1; pad <= tilePaddingPixels; pad++)
             {
-                atlasImage[placement.InnerRect.X - pad, placement.InnerRect.Y + y] = leftEdge;
-                atlasImage[placement.InnerRect.X + placement.InnerRect.Width - 1 + pad, placement.InnerRect.Y + y] = rightEdge;
+                SetAtlasPixel(
+                    atlasImage,
+                    atlasCoverage,
+                    atlasWidth,
+                    placement.InnerRect.X - pad,
+                    placement.InnerRect.Y + y,
+                    leftEdge);
+                SetAtlasPixel(
+                    atlasImage,
+                    atlasCoverage,
+                    atlasWidth,
+                    placement.InnerRect.X + placement.InnerRect.Width - 1 + pad,
+                    placement.InnerRect.Y + y,
+                    rightEdge);
             }
         }
 
@@ -720,8 +754,20 @@ internal sealed class Lod2AtlasCityObjectBaker(
             for (int x = 0; x < fullWidth; x++)
             {
                 int sampleX = placement.InnerRect.X - tilePaddingPixels + x;
-                atlasImage[sampleX, targetTopY] = atlasImage[sampleX, sourceTopY];
-                atlasImage[sampleX, targetBottomY] = atlasImage[sampleX, sourceBottomY];
+                SetAtlasPixel(
+                    atlasImage,
+                    atlasCoverage,
+                    atlasWidth,
+                    sampleX,
+                    targetTopY,
+                    atlasImage[sampleX, sourceTopY]);
+                SetAtlasPixel(
+                    atlasImage,
+                    atlasCoverage,
+                    atlasWidth,
+                    sampleX,
+                    targetBottomY,
+                    atlasImage[sampleX, sourceBottomY]);
             }
         }
     }
@@ -914,6 +960,15 @@ internal sealed class Lod2AtlasCityObjectBaker(
         return (byte)Math.Clamp((left * right + 127) / 255, 0, 255);
     }
 
+    private static Rgba32 MultiplyPixel(Rgba32 left, Rgba32 right)
+    {
+        return new Rgba32(
+            MultiplyChannel(left.R, right.R),
+            MultiplyChannel(left.G, right.G),
+            MultiplyChannel(left.B, right.B),
+            MultiplyChannel(left.A, right.A));
+    }
+
     private static Rgba32 ToPixel(ResoniteColor color)
     {
         return new Rgba32(
@@ -1049,6 +1104,198 @@ internal sealed class Lod2AtlasCityObjectBaker(
         }
 
         return bakedImage;
+    }
+
+    private static Rgba32 DetectRepresentativeBackgroundColor(Image<Rgba32> image)
+    {
+        if (TryAverageBoundaryOpaquePixels(image, out Rgba32 boundaryAverage))
+        {
+            return boundaryAverage;
+        }
+
+        if (TryAverageOpaquePixels(image, out Rgba32 opaqueAverage))
+        {
+            return opaqueAverage;
+        }
+
+        if (TryAverageAllPixels(image, out Rgba32 allPixelAverage))
+        {
+            return new Rgba32(allPixelAverage.R, allPixelAverage.G, allPixelAverage.B, byte.MaxValue);
+        }
+
+        return new Rgba32(255, 255, 255, 255);
+    }
+
+    private static void FillTransparentRgb(Image<Rgba32> image, Rgba32 backgroundColor)
+    {
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                Rgba32 pixel = image[x, y];
+                if (pixel.A == byte.MaxValue)
+                {
+                    continue;
+                }
+
+                double alpha = pixel.A / 255.0;
+                image[x, y] = new Rgba32(
+                    BlendBackgroundChannel(pixel.R, backgroundColor.R, alpha),
+                    BlendBackgroundChannel(pixel.G, backgroundColor.G, alpha),
+                    BlendBackgroundChannel(pixel.B, backgroundColor.B, alpha),
+                    pixel.A);
+            }
+        }
+    }
+
+    private static bool TryAverageBoundaryOpaquePixels(Image<Rgba32> image, out Rgba32 color)
+    {
+        long sumR = 0;
+        long sumG = 0;
+        long sumB = 0;
+        long count = 0;
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                Rgba32 pixel = image[x, y];
+                if (pixel.A <= BackgroundDetectionAlphaThreshold || !TouchesTransparentNeighbor(image, x, y))
+                {
+                    continue;
+                }
+
+                sumR += pixel.R;
+                sumG += pixel.G;
+                sumB += pixel.B;
+                count++;
+            }
+        }
+
+        color = count == 0
+            ? default
+            : new Rgba32(
+                (byte)Math.Clamp(Math.Round(sumR / (double)count), 0.0, 255.0),
+                (byte)Math.Clamp(Math.Round(sumG / (double)count), 0.0, 255.0),
+                (byte)Math.Clamp(Math.Round(sumB / (double)count), 0.0, 255.0),
+                byte.MaxValue);
+        return count > 0;
+    }
+
+    private static bool TouchesTransparentNeighbor(Image<Rgba32> image, int x, int y)
+    {
+        return IsTransparentOrOutOfBounds(image, x - 1, y)
+            || IsTransparentOrOutOfBounds(image, x + 1, y)
+            || IsTransparentOrOutOfBounds(image, x, y - 1)
+            || IsTransparentOrOutOfBounds(image, x, y + 1);
+    }
+
+    private static bool IsTransparentOrOutOfBounds(Image<Rgba32> image, int x, int y)
+    {
+        if (x < 0 || y < 0 || x >= image.Width || y >= image.Height)
+        {
+            return true;
+        }
+
+        return image[x, y].A <= BackgroundDetectionAlphaThreshold;
+    }
+
+    private static bool TryAverageOpaquePixels(Image<Rgba32> image, out Rgba32 color)
+    {
+        return TryAveragePixels(image, static pixel => pixel.A > BackgroundDetectionAlphaThreshold, out color);
+    }
+
+    private static bool TryAverageAllPixels(Image<Rgba32> image, out Rgba32 color)
+    {
+        return TryAveragePixels(image, static _ => true, out color);
+    }
+
+    private static bool TryAveragePixels(Image<Rgba32> image, Func<Rgba32, bool> predicate, out Rgba32 color)
+    {
+        long sumR = 0;
+        long sumG = 0;
+        long sumB = 0;
+        long count = 0;
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                Rgba32 pixel = image[x, y];
+                if (!predicate(pixel))
+                {
+                    continue;
+                }
+
+                sumR += pixel.R;
+                sumG += pixel.G;
+                sumB += pixel.B;
+                count++;
+            }
+        }
+
+        color = count == 0
+            ? default
+            : new Rgba32(
+                (byte)Math.Clamp(Math.Round(sumR / (double)count), 0.0, 255.0),
+                (byte)Math.Clamp(Math.Round(sumG / (double)count), 0.0, 255.0),
+                (byte)Math.Clamp(Math.Round(sumB / (double)count), 0.0, 255.0),
+                byte.MaxValue);
+        return count > 0;
+    }
+
+    private static byte BlendBackgroundChannel(byte foreground, byte background, double alpha)
+    {
+        double blended = (foreground * alpha) + (background * (1.0 - alpha));
+        return (byte)Math.Clamp(Math.Round(blended), 0.0, 255.0);
+    }
+
+    private static Rgba32 ComputeAtlasBackgroundColor(IReadOnlyList<AtlasPlacement> placements)
+    {
+        long sumR = 0;
+        long sumG = 0;
+        long sumB = 0;
+        long totalWeight = 0;
+        foreach (AtlasPlacement placement in placements)
+        {
+            long weight = Math.Max(1, placement.Entry.Tile.Image.Width * placement.Entry.Tile.Image.Height);
+            sumR += placement.Entry.Tile.BackgroundColor.R * weight;
+            sumG += placement.Entry.Tile.BackgroundColor.G * weight;
+            sumB += placement.Entry.Tile.BackgroundColor.B * weight;
+            totalWeight += weight;
+        }
+
+        if (totalWeight == 0)
+        {
+            return new Rgba32(255, 255, 255, 255);
+        }
+
+        return new Rgba32(
+            (byte)Math.Clamp(Math.Round(sumR / (double)totalWeight), 0.0, 255.0),
+            (byte)Math.Clamp(Math.Round(sumG / (double)totalWeight), 0.0, 255.0),
+            (byte)Math.Clamp(Math.Round(sumB / (double)totalWeight), 0.0, 255.0),
+            byte.MaxValue);
+    }
+
+    private static void FillUncoveredAtlasPixels(Image<Rgba32> atlasImage, bool[] atlasCoverage, Rgba32 backgroundColor)
+    {
+        for (int y = 0; y < atlasImage.Height; y++)
+        {
+            for (int x = 0; x < atlasImage.Width; x++)
+            {
+                int offset = (y * atlasImage.Width) + x;
+                if (atlasCoverage[offset])
+                {
+                    continue;
+                }
+
+                atlasImage[x, y] = backgroundColor;
+            }
+        }
+    }
+
+    private static void SetAtlasPixel(Image<Rgba32> atlasImage, bool[] atlasCoverage, int atlasWidth, int x, int y, Rgba32 pixel)
+    {
+        atlasImage[x, y] = pixel;
+        atlasCoverage[(y * atlasWidth) + x] = true;
     }
 
     private static Rgba32 SampleWrappedPixelBilinear(Image<Rgba32> sourceImage, double u, double v)
@@ -1250,7 +1497,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
         }
     }
 
-    private sealed record MaterialAtlasTile(string Identity, Image<Rgba32> Image);
+    private sealed record MaterialAtlasTile(string Identity, Image<Rgba32> Image, Rgba32 BackgroundColor);
 
     private readonly record struct BufferedCityObject(
         ResoniteConstructionCityObject CityObject,

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteImportBudgetProfile.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteImportBudgetProfile.cs
@@ -1,0 +1,37 @@
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Targets.Resonite;
+
+internal sealed record ResoniteImportBudgetProfile(
+    PlateauImportMemoryProfile Name,
+    long ImportWorkingSetBytes,
+    long RuntimeVramBudgetBytes,
+    int MaxAtlasSize,
+    int MaxAtlasTextureEdge);
+
+internal static class ResoniteImportBudgetProfiles
+{
+    public static readonly ResoniteImportBudgetProfile Small = new(
+        PlateauImportMemoryProfile.Small,
+        ImportWorkingSetBytes: 384L * 1024L * 1024L,
+        RuntimeVramBudgetBytes: 1536L * 1024L * 1024L,
+        MaxAtlasSize: 1024,
+        MaxAtlasTextureEdge: 512);
+
+    public static readonly ResoniteImportBudgetProfile Large = new(
+        PlateauImportMemoryProfile.Large,
+        ImportWorkingSetBytes: 1024L * 1024L * 1024L,
+        RuntimeVramBudgetBytes: 4096L * 1024L * 1024L,
+        MaxAtlasSize: 4096,
+        MaxAtlasTextureEdge: 4096);
+
+    public static ResoniteImportBudgetProfile ForProfile(PlateauImportMemoryProfile profile)
+    {
+        return profile switch
+        {
+            PlateauImportMemoryProfile.Small => Small,
+            PlateauImportMemoryProfile.Large => Large,
+            _ => throw new ArgumentOutOfRangeException(nameof(profile), profile, "Unsupported memory profile."),
+        };
+    }
+}

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -39,6 +39,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             endpoint,
             4,
             ResoniteLinkSendDiagnostics.Disabled,
+            PlateauImportMemoryProfile.Large,
             CreateDefaultDependencies(
                 endpoint,
                 4,
@@ -55,6 +56,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             endpoint,
             connectionCount,
             ResoniteLinkSendDiagnostics.Disabled,
+            PlateauImportMemoryProfile.Large,
             CreateDefaultDependencies(
                 endpoint,
                 connectionCount,
@@ -70,11 +72,13 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         Uri endpoint,
         int connectionCount,
         ResoniteLinkSendDiagnostics diagnostics,
+        PlateauImportMemoryProfile memoryProfile,
         Action<string>? progressReporter = null)
         : this(
             endpoint,
             connectionCount,
             diagnostics,
+            memoryProfile,
             CreateDefaultDependencies(
                 endpoint,
                 connectionCount,
@@ -90,12 +94,14 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         Uri endpoint,
         int connectionCount,
         ResoniteLinkSendDiagnostics diagnostics,
+        PlateauImportMemoryProfile memoryProfile,
         bool enableMeshBake,
         Action<string>? progressReporter = null)
         : this(
             endpoint,
             connectionCount,
             diagnostics,
+            memoryProfile,
             CreateDefaultDependencies(
                 endpoint,
                 connectionCount,
@@ -114,6 +120,25 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         ResoniteLiveSceneImportDependencies dependencies,
         bool enableMeshBake = true,
         Action<string>? progressReporter = null)
+        : this(
+            endpoint,
+            connectionCount,
+            diagnostics,
+            PlateauImportMemoryProfile.Large,
+            dependencies,
+            enableMeshBake,
+            progressReporter)
+    {
+    }
+
+    internal ResoniteLiveSceneImportTarget(
+        Uri endpoint,
+        int connectionCount,
+        ResoniteLinkSendDiagnostics diagnostics,
+        PlateauImportMemoryProfile memoryProfile,
+        ResoniteLiveSceneImportDependencies dependencies,
+        bool enableMeshBake = true,
+        Action<string>? progressReporter = null)
     {
         ArgumentNullException.ThrowIfNull(dependencies);
         ArgumentNullException.ThrowIfNull(dependencies.ClientSession);
@@ -121,6 +146,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
 
         this.endpoint = endpoint;
         this.connectionCount = connectionCount;
+        MemoryProfile = memoryProfile;
         this.diagnostics = diagnostics;
         this.terrainTextureAssetGenerator = dependencies.TerrainTextureAssetGenerator;
         MeshBakeEnabled = enableMeshBake;
@@ -152,6 +178,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
     }
 
     internal bool MeshBakeEnabled { get; }
+
+    internal PlateauImportMemoryProfile MemoryProfile { get; }
 
     public async Task<SceneImportExecutionResult> ExecuteAsync(
         SceneImportExecutionPlan plan,
@@ -321,9 +349,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 $"Starting routed send workers (connection_pool={connectionCount})."));
         LiveSendExecutionRuntime runtime = new(runtimePlan, cancellationToken);
         progress.Reset();
+        ResoniteImportBudgetProfile resourceBudget = runPlan.ResourceBudget;
         CompositeCityObjectBaker? cityObjectBaker = runPlan.MeshBakeEnabled
             ? new CompositeCityObjectBaker(
-                new Lod2AtlasCityObjectBaker(textureImageLoader),
+                new Lod2AtlasCityObjectBaker(textureImageLoader, resourceBudget: resourceBudget),
                 new FixedCellCityObjectMeshBaker())
             : null;
         LiveSendRunContext context = new(
@@ -347,7 +376,9 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 "live",
                 $"Send lane tasks launched (connection budget={connectionCount}, "
                 + $"queue_capacity_total={runtimePlan.QueueCapacity}, "
-                + $"memory_budget_bytes={runtimePlan.MemoryBudgetBytes})."));
+                + $"memory_budget_bytes={runtimePlan.MemoryBudgetBytes}, "
+                + $"memory_profile={resourceBudget.Name.ToString().ToLowerInvariant()}, "
+                + $"runtime_vram_budget_bytes={resourceBudget.RuntimeVramBudgetBytes})."));
         laneStartStopwatch.Stop();
         ReportProgress(
             PlateauLog.Info(
@@ -389,17 +420,20 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         string resolvedWorkRoot,
         ResoniteLocalOrigin requestLocalOrigin)
     {
+        ResoniteImportBudgetProfile resourceBudget = ResoniteImportBudgetProfiles.ForProfile(MemoryProfile);
         return new LiveSendRunPlan(
             bootstrapInfo,
             resolvedWorkRoot,
             requestLocalOrigin,
             ResonitePlacementPolicy.CreateCityGmlSlotNamesByRelativePath(bootstrapInfo.SourceFiles),
+            resourceBudget,
             new LiveSendQueuePlan(
                 connectionCount,
                 Math.Max(MaxQueuedCityObjects * connectionCount, connectionCount),
-                Math.Max(
-                    MaxInFlightCityObjectWorkingSetBytesFloor,
-                    connectionCount * MaxInFlightCityObjectWorkingSetBytesPerLane)),
+                Math.Max(resourceBudget.ImportWorkingSetBytes,
+                    Math.Max(
+                        MaxInFlightCityObjectWorkingSetBytesFloor,
+                        connectionCount * MaxInFlightCityObjectWorkingSetBytesPerLane))),
             MeshBakeEnabled);
     }
 

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -1084,7 +1084,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         Dictionary<TerrainTextureOverlay, ResoniteTextureImport> preparedTerrainTextureDataByOverlay = CreatePreparedTerrainTextureDataByOverlay(preparedCityObject);
         Stopwatch materialStopwatch = Stopwatch.StartNew();
         Stopwatch geometryStopwatch = new();
-        Task<IReadOnlyList<PlannedMaterialAsset>> materialPlanningTask = PlanMaterialAssetsAsync(
+        Task<PlannedSceneMaterialPlan> materialPlanningTask = PlanSceneMaterialPlanAsync(
             state,
             routedClient,
             cityObject,
@@ -1096,11 +1096,11 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             cityObject,
             preparedCityObject,
             buildStepCancellation.Token);
-        IReadOnlyList<PlannedMaterialAsset> plannedMaterialAssets;
+        PlannedSceneMaterialPlan plannedMaterials;
         PlannedGeometryAsset plannedGeometryAsset;
         try
         {
-            plannedMaterialAssets = await materialPlanningTask;
+            plannedMaterials = await materialPlanningTask;
             materialStopwatch.Stop();
 
             ReportBuildStep(cityObject, $"Preparing geometry assets ({DescribePreparedGeometry(preparedCityObject.Geometry)}).");
@@ -1117,10 +1117,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
 
         PlannedSceneObjectEmission emissionPlan = new(
             plannedGeometryAsset,
-            plannedMaterialAssets,
+            plannedMaterials.MaterialAssets,
             new PlannedRenderer(
                 plannedGeometryAsset.Identity,
-                plannedMaterialAssets.Select(static asset => asset.Identity).ToArray()),
+                plannedMaterials.RendererMaterialBindings),
             new PlannedCollider(
                 plannedGeometryAsset.Identity,
                 cityObject.CollisionEnabled));
@@ -1311,7 +1311,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             + $"material_bindings=[{materialSummary}]");
     }
 
-    private async Task<IReadOnlyList<PlannedMaterialAsset>> PlanMaterialAssetsAsync(
+    private async Task<PlannedSceneMaterialPlan> PlanSceneMaterialPlanAsync(
         LiveSendRunState state,
         IResoniteLinkClient importClient,
         ResoniteConstructionCityObject cityObject,
@@ -1319,7 +1319,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         Dictionary<TerrainTextureOverlay, ResoniteTextureImport> preparedTerrainTextureDataByOverlay,
         CancellationToken cancellationToken)
     {
-        Task<PlannedMaterialAsset>[] plannedMaterialTasks = new Task<PlannedMaterialAsset>[cityObject.Materials.Count];
+        Task<(PlannedMaterialAsset MaterialAsset, PlannedRendererMaterialBinding RendererBinding)>[] materialPlanTasks
+            = new Task<(PlannedMaterialAsset MaterialAsset, PlannedRendererMaterialBinding RendererBinding)>[cityObject.Materials.Count];
         for (int materialIndex = 0; materialIndex < cityObject.Materials.Count; materialIndex++)
         {
             ResoniteMaterialBinding material = cityObject.Materials[materialIndex];
@@ -1328,65 +1329,112 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 $"Creating material {materialIndex + 1}/{cityObject.Materials.Count} ({material.MaterialKey}).");
             if (material.AssetScope == ResoniteMaterialAssetScope.Common)
             {
-                material = ResoniteSceneMaterialConventions.NormalizeCommonMaterialBinding(material);
-                if (material.AssetScope != ResoniteMaterialAssetScope.Common)
-                {
-                    plannedMaterialTasks[materialIndex] = WrapDedicatedMaterialPlanningTask(
-                        ResoniteMaterialPlanning.PlanDedicatedMaterialAssetAsync(
-                            importClient,
-                            material,
-                            materialIndex,
-                            cityObject.PackageName,
-                            preparedTextureDataByIdentity,
-                            preparedTerrainTextureDataByOverlay,
-                            preserveDedicatedMaterialSlot: IsDemPackage(cityObject.PackageName),
-                            cancellationToken));
-                    continue;
-                }
-
-                string family = material.Family ?? BundledDefaultMaterialFamilies.Other;
-                if (state.Materials.CommonMaterialFamilyWarmupTasks.TryGetValue(family, out Task? familyWarmupTask))
-                {
-                    await familyWarmupTask.WaitAsync(cancellationToken);
-                }
-
-                string materialKey = ResoniteSceneMaterialConventions.CreateCanonicalCommonMaterialKey(
-                    family,
-                    material.BundledVariantIndex ?? 0,
-                    material.Projection,
-                    material.TextureScale);
-                if (!state.Materials.CommonMaterialCreationTasks.TryGetValue(materialKey, out Task<CreatedMaterialAsset>? materialCreationTask))
-                {
-                    throw new InvalidOperationException(
-                        $"Bootstrap did not produce common material '{materialKey}'.");
-                }
-
-                CreatedMaterialAsset existingMaterialAsset = await materialCreationTask.WaitAsync(cancellationToken);
-                plannedMaterialTasks[materialIndex] = Task.FromResult<PlannedMaterialAsset>(
-                    new PlannedReusableMaterialAsset(
-                        new MaterialIdentity(materialKey),
-                        existingMaterialAsset.MaterialComponentId));
-            }
-            else
-            {
-                plannedMaterialTasks[materialIndex] = WrapDedicatedMaterialPlanningTask(
-                    ResoniteMaterialPlanning.PlanDedicatedMaterialAssetAsync(
+                if (TryCreateSharedCommonRendererMaterialPlanTask(
+                        state,
                         importClient,
                         material,
-                        materialIndex,
-                        cityObject.PackageName,
                         preparedTextureDataByIdentity,
                         preparedTerrainTextureDataByOverlay,
-                        preserveDedicatedMaterialSlot: IsDemPackage(cityObject.PackageName),
-                        cancellationToken));
+                        cancellationToken,
+                        out Task<(PlannedMaterialAsset MaterialAsset, PlannedRendererMaterialBinding RendererBinding)>? sharedCommonPlanTask))
+                {
+                    materialPlanTasks[materialIndex] = sharedCommonPlanTask
+                        ?? throw new InvalidOperationException("Shared common renderer material planning task was not created.");
+                    continue;
+                }
             }
+
+            materialPlanTasks[materialIndex] = WrapDedicatedMaterialPlanningTask(
+                ResoniteMaterialPlanning.PlanDedicatedMaterialAssetAsync(
+                    importClient,
+                    material,
+                    materialIndex,
+                    cityObject.PackageName,
+                    preparedTextureDataByIdentity,
+                    preparedTerrainTextureDataByOverlay,
+                    preserveDedicatedMaterialSlot: IsDemPackage(cityObject.PackageName),
+                    cancellationToken));
         }
 
-        return await Task.WhenAll(plannedMaterialTasks);
+        (PlannedMaterialAsset MaterialAsset, PlannedRendererMaterialBinding RendererBinding)[] materialPlans = await Task.WhenAll(materialPlanTasks);
+        return new PlannedSceneMaterialPlan(
+            materialPlans.Select(static plan => plan.MaterialAsset).ToArray(),
+            materialPlans.Select(static plan => plan.RendererBinding).ToArray());
 
-        static async Task<PlannedMaterialAsset> WrapDedicatedMaterialPlanningTask(Task<PlannedDedicatedMaterialAsset> task)
+        bool TryCreateSharedCommonRendererMaterialPlanTask(
+            LiveSendRunState runState,
+            IResoniteLinkClient client,
+            ResoniteMaterialBinding sourceMaterial,
+            IReadOnlyDictionary<string, ResoniteTextureImport> preparedTexturesByIdentity,
+            IReadOnlyDictionary<TerrainTextureOverlay, ResoniteTextureImport> preparedTexturesByOverlay,
+            CancellationToken ct,
+            out Task<(PlannedMaterialAsset MaterialAsset, PlannedRendererMaterialBinding RendererBinding)>? sharedPlanTask)
         {
-            return await task;
+            sharedPlanTask = null;
+            if (!ResoniteSceneMaterialConventions.TryNormalizeCommonBaseMaterialBinding(
+                    sourceMaterial,
+                    out ResoniteMaterialBinding normalizedCommonMaterial))
+            {
+                return false;
+            }
+
+            string family = normalizedCommonMaterial.Family ?? BundledDefaultMaterialFamilies.Other;
+            string materialKey = normalizedCommonMaterial.MaterialKey;
+            sharedPlanTask = PlanSharedCommonRendererMaterialAsync(
+                runState,
+                client,
+                sourceMaterial,
+                normalizedCommonMaterial,
+                family,
+                materialKey,
+                preparedTexturesByIdentity,
+                preparedTexturesByOverlay,
+                ct);
+            return true;
+        }
+
+        async Task<(PlannedMaterialAsset MaterialAsset, PlannedRendererMaterialBinding RendererBinding)> PlanSharedCommonRendererMaterialAsync(
+            LiveSendRunState runState,
+            IResoniteLinkClient client,
+            ResoniteMaterialBinding sourceMaterial,
+            ResoniteMaterialBinding normalizedCommonMaterial,
+            string family,
+            string materialKey,
+            IReadOnlyDictionary<string, ResoniteTextureImport> preparedTexturesByIdentity,
+            IReadOnlyDictionary<TerrainTextureOverlay, ResoniteTextureImport> preparedTexturesByOverlay,
+            CancellationToken ct)
+        {
+            if (runState.Materials.CommonMaterialFamilyWarmupTasks.TryGetValue(family, out Task? familyWarmupTask))
+            {
+                await familyWarmupTask.WaitAsync(ct);
+            }
+
+            if (!runState.Materials.CommonMaterialCreationTasks.TryGetValue(materialKey, out Task<CreatedMaterialAsset>? materialCreationTask))
+            {
+                throw new InvalidOperationException(
+                    $"Bootstrap did not produce common material '{materialKey}'.");
+            }
+
+            CreatedMaterialAsset existingMaterialAsset = await materialCreationTask.WaitAsync(ct);
+            PlannedReusableMaterialAsset sharedMaterialAsset = new(
+                new MaterialIdentity(materialKey),
+                existingMaterialAsset.MaterialComponentId);
+            PlannedTextureAsset? mainTextureOverride = await ResoniteMaterialPlanning.PlanMainTextureOverrideAsync(
+                client,
+                sourceMaterial,
+                preparedTexturesByIdentity,
+                preparedTexturesByOverlay,
+                ct);
+            PlannedRendererMaterialBinding rendererBinding = mainTextureOverride is null
+                ? new PlannedDirectRendererMaterialBinding(sharedMaterialAsset.Identity)
+                : new PlannedMainTextureOverrideRendererMaterialBinding(sharedMaterialAsset.Identity, mainTextureOverride);
+            return (sharedMaterialAsset, rendererBinding);
+        }
+
+        static async Task<(PlannedMaterialAsset MaterialAsset, PlannedRendererMaterialBinding RendererBinding)> WrapDedicatedMaterialPlanningTask(Task<PlannedDedicatedMaterialAsset> task)
+        {
+            PlannedDedicatedMaterialAsset plannedMaterial = await task;
+            return (plannedMaterial, new PlannedDirectRendererMaterialBinding(plannedMaterial.Identity));
         }
     }
 
@@ -1603,6 +1651,36 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             objectSlots.CityObjectRotation));
         slotResolutionTargets.Add(presentationSlotId);
 
+        SyncList rendererMaterials = new()
+        {
+            Elements = emissionPlan.Renderer.MaterialBindings
+                .Select(binding => (Member)new Reference
+                {
+                    TargetID = emittedMaterialTargets[binding.MaterialIdentity],
+                })
+                .ToList(),
+        };
+        SyncList rendererMaterialPropertyBlocks = new()
+        {
+            Elements = [],
+        };
+        bool hasMaterialPropertyBlockOverride = false;
+        foreach (PlannedRendererMaterialBinding materialBinding in emissionPlan.Renderer.MaterialBindings)
+        {
+            if (materialBinding is PlannedMainTextureOverrideRendererMaterialBinding mainTextureOverrideBinding)
+            {
+                hasMaterialPropertyBlockOverride = true;
+                rendererMaterialPropertyBlocks.Elements.Add(
+                    CreateMainTexturePropertyBlockReference(componentEmissions, presentationSlotId.Value, mainTextureOverrideBinding));
+                continue;
+            }
+
+            rendererMaterialPropertyBlocks.Elements.Add(new Reference
+            {
+                TargetID = null,
+            });
+        }
+
         componentEmissions.Add(new PlannedBatchComponentEmission(
             CreateBatchPlanEntityId("mesh-renderer-component"),
             presentationSlotId.Value,
@@ -1613,15 +1691,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 {
                     TargetID = geometryComponentId.Value,
                 },
-                ["Materials"] = new SyncList
-                {
-                    Elements = emissionPlan.Renderer.MaterialIdentities
-                        .Select(materialIdentity => (Member)new Reference
-                        {
-                            TargetID = emittedMaterialTargets[materialIdentity],
-                        })
-                        .ToList(),
-                },
+                ["Materials"] = rendererMaterials,
+                ["MaterialPropertyBlocks"] = hasMaterialPropertyBlockOverride
+                    ? rendererMaterialPropertyBlocks
+                    : new SyncList { Elements = [] },
             }));
         componentEmissions.Add(new PlannedBatchComponentEmission(
             CreateBatchPlanEntityId("mesh-collider-component"),
@@ -1648,6 +1721,37 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             componentEmissions,
             slotResolutionTargets,
             componentResolutionTargets);
+    }
+
+    private static Reference CreateMainTexturePropertyBlockReference(
+        List<PlannedBatchComponentEmission> componentEmissions,
+        string presentationSlotId,
+        PlannedMainTextureOverrideRendererMaterialBinding binding)
+    {
+        BatchPlanEntityId textureId = CreateBatchPlanEntityId($"renderer-texture:{binding.MaterialIdentity.Value}");
+        componentEmissions.Add(new PlannedBatchComponentEmission(
+            textureId,
+            presentationSlotId,
+            "[FrooxEngine]FrooxEngine.StaticTexture2D",
+            ResoniteSceneMaterialConventions.CreateTextureMembers(binding.MainTexture.AssetUri)));
+
+        BatchPlanEntityId propertyBlockId = CreateBatchPlanEntityId($"renderer-main-texture-property-block:{binding.MaterialIdentity.Value}");
+        componentEmissions.Add(new PlannedBatchComponentEmission(
+            propertyBlockId,
+            presentationSlotId,
+            "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
+            new Dictionary<string, Member>(StringComparer.Ordinal)
+            {
+                ["Texture"] = new Reference
+                {
+                    TargetID = textureId.Value,
+                },
+            }));
+
+        return new Reference
+        {
+            TargetID = propertyBlockId.Value,
+        };
     }
 
     private static long EstimateBatchPayloadBytes(int operationCount)

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialPlanning.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialPlanning.cs
@@ -91,6 +91,37 @@ internal static class ResoniteMaterialPlanning
         return textures.FirstOrDefault(texture => string.Equals(texture.Identity.Value, role, StringComparison.Ordinal))?.AssetUri;
     }
 
+    public static async Task<PlannedTextureAsset?> PlanMainTextureOverrideAsync(
+        IResoniteLinkClient importClient,
+        ResoniteMaterialBinding material,
+        IReadOnlyDictionary<string, ResoniteTextureImport> preparedTextureDataByIdentity,
+        IReadOnlyDictionary<TerrainTextureOverlay, ResoniteTextureImport> preparedTerrainTextureDataByOverlay,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(importClient);
+        ArgumentNullException.ThrowIfNull(material);
+        ArgumentNullException.ThrowIfNull(preparedTextureDataByIdentity);
+        ArgumentNullException.ThrowIfNull(preparedTerrainTextureDataByOverlay);
+
+        ResoniteTextureImport? textureImport = material.TexturePayload is not null
+            && !string.IsNullOrWhiteSpace(material.TexturePayload.Identity)
+            && preparedTextureDataByIdentity.TryGetValue(material.TexturePayload.Identity, out ResoniteTextureImport? directTextureImport)
+                ? directTextureImport
+            : material.TerrainOverlay is not null
+            && preparedTerrainTextureDataByOverlay.TryGetValue(material.TerrainOverlay, out ResoniteTextureImport? terrainOverlayTextureImport)
+                ? terrainOverlayTextureImport
+            : null;
+        if (textureImport is null)
+        {
+            return null;
+        }
+
+        Uri? textureUri = await ImportOptionalTextureAsync(importClient, textureImport, cancellationToken);
+        return textureUri is null
+            ? null
+            : new PlannedTextureAsset(new TextureIdentity($"main-texture-override:{material.MaterialKey}"), textureUri);
+    }
+
     public static async Task<CreatedMaterialAsset> EmitCommonMaterialAsync(
         IResoniteLinkClient client,
         PlannedDedicatedMaterialAsset plannedMaterial,

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResonitePlannedBatchEmissionInterpreter.cs
@@ -99,6 +99,11 @@ internal sealed class PlannedBatchEmissionInterpreter(Action<string> reportProgr
         IReadOnlyDictionary<string, PendingBatchSlot> pendingSlotsByPlanId,
         IReadOnlyDictionary<string, PendingBatchComponent> pendingComponentsByPlanId)
     {
+        if (string.IsNullOrWhiteSpace(targetId))
+        {
+            return targetId;
+        }
+
         if (pendingSlotsByPlanId.TryGetValue(targetId, out PendingBatchSlot pendingSlot))
         {
             return pendingSlot.LocalId;

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapInterpreter.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapInterpreter.cs
@@ -10,6 +10,8 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
 {
     private const string LicenseComponentType = "[FrooxEngine]FrooxEngine.License";
     private const string StaticTextureComponentType = "[FrooxEngine]FrooxEngine.StaticTexture2D";
+    private const string SharedAssetsRootName = "PLATEAU Shared Assets";
+    private const string SharedCommonMaterialsRootName = "Common Materials";
     private const float DefaultNormalScale = 1.0f;
     private const float DefaultBundledHeightScale = 0.002f;
     private const string GsiLicenseName = "GSI Maps Terms";
@@ -38,6 +40,13 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
 
         string completionMeshCode = ResoniteSourceMeshCodeAnchor.ResolveCompletionMeshCode(setupInfo);
         string datasetRootName = $"PLATEAU {setupInfo.Dataset}";
+        Slot rootSnapshot = await setupClient.GetSlotAsync("Root", 4, cancellationToken)
+            ?? throw new InvalidOperationException("ResoniteLink did not surface the Root slot during bootstrap.");
+        ResoniteSceneSlotSnapshot rootSlotSnapshot = new(rootSnapshot);
+        Slot? sharedAssetsSlot = GetReusableChildSlot(rootSlotSnapshot, SharedAssetsRootName, "Root");
+        Slot? sharedCommonMaterialsSlot = sharedAssetsSlot is null
+            ? null
+            : GetReusableChildSlot(new ResoniteSceneSlotSnapshot(sharedAssetsSlot), SharedCommonMaterialsRootName, sharedAssetsSlot.ID!);
         CreatedSlot? existingDatasetRoot = await tryGetDatasetRootAsync(
             setupClient,
             datasetRootName,
@@ -51,6 +60,8 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
                 completionMeshCode,
                 CreateDatasetLicensePlan(setupInfo),
                 commonMaterials,
+                sharedAssetsSlot,
+                sharedCommonMaterialsSlot,
                 cancellationToken);
         }
 
@@ -63,15 +74,13 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
         Slot? assetsSlot = assetsLookup.State == ResoniteSceneChildLookupState.FoundWithId
             ? assetsLookup.Slot
             : null;
-        Slot? commonSlot = assetsSlot is null
-            ? null
-            : GetReusableChildSlot(new ResoniteSceneSlotSnapshot(assetsSlot), "Common", assetsSlot.ID!);
         DatasetLicenseDefinition[] datasetLicenses = CreateDatasetLicensePlan(setupInfo);
         HashSet<DatasetLicenseRole> matchedExistingLicenseRoles = MatchExistingLicenseRoles(datasetRootSnapshot, datasetLicenses);
 
         List<DataModelOperation> operations = [];
         ResoniteBatchOperations.PendingBatchSlot? pendingAssets = null;
-        ResoniteBatchOperations.PendingBatchSlot? pendingCommon = null;
+        ResoniteBatchOperations.PendingBatchSlot? pendingSharedAssets = null;
+        ResoniteBatchOperations.PendingBatchSlot? pendingSharedCommon = null;
         string batchScopeToken = CreateBatchScopeToken();
 
         string assetsParentId = existingDatasetRoot.Value.SlotId;
@@ -86,15 +95,23 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             assetsParentId = assetsSlot.ID ?? throw new InvalidOperationException("Existing Assets slot did not expose an ID.");
         }
 
-        if (commonSlot is null)
+        string sharedAssetsParentId = sharedAssetsSlot?.ID ?? "Root";
+        if (sharedAssetsSlot is null)
         {
-            pendingCommon = CreatePendingBatchSlot("bootstrap_common_assets_root", "Common", batchScopeToken);
-            operations.Add(ResoniteBatchOperations.CreateAddSlotOperation(assetsParentId, "Common", null, null, pendingCommon.Value));
+            pendingSharedAssets = CreatePendingBatchSlot("bootstrap_shared_assets_root", SharedAssetsRootName, batchScopeToken);
+            operations.Add(ResoniteBatchOperations.CreateAddSlotOperation("Root", SharedAssetsRootName, null, null, pendingSharedAssets.Value));
+            sharedAssetsParentId = pendingSharedAssets.Value.LocalId;
         }
 
-        string commonParentId = commonSlot?.ID
-            ?? pendingCommon?.LocalId
-            ?? throw new InvalidOperationException("Bootstrap could not determine the Common parent slot.");
+        if (sharedCommonMaterialsSlot is null)
+        {
+            pendingSharedCommon = CreatePendingBatchSlot("bootstrap_shared_common_materials_root", SharedCommonMaterialsRootName, batchScopeToken);
+            operations.Add(ResoniteBatchOperations.CreateAddSlotOperation(sharedAssetsParentId, SharedCommonMaterialsRootName, null, null, pendingSharedCommon.Value));
+        }
+
+        string commonParentId = sharedCommonMaterialsSlot?.ID
+            ?? pendingSharedCommon?.LocalId
+            ?? throw new InvalidOperationException("Bootstrap could not determine the shared Common Materials parent slot.");
 
         SceneAnchor sceneAnchor = await sceneAnchorResolver.ResolveAsync(
             setupClient,
@@ -125,7 +142,7 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             = await PlanCommonMaterialOperationsAsync(
                 setupClient,
                 commonMaterials,
-                commonSlot,
+                sharedCommonMaterialsSlot,
                 commonParentId,
                 batchScopeToken,
                 operations,
@@ -140,9 +157,9 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
                 assetsSlot = CreateSlot(entityMap.ResolveSlot(pendingAssets.Value));
             }
 
-            if (pendingCommon is not null)
+            if (pendingSharedCommon is not null)
             {
-                commonSlot = CreateSlot(entityMap.ResolveSlot(pendingCommon.Value));
+                sharedCommonMaterialsSlot = CreateSlot(entityMap.ResolveSlot(pendingSharedCommon.Value));
             }
 
             foreach (PlannedCommonMaterialBatchEntry plannedMaterial in plannedCommonMaterials)
@@ -153,7 +170,7 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             }
         }
 
-        if (assetsSlot is null || commonSlot is null)
+        if (assetsSlot is null || sharedCommonMaterialsSlot is null)
         {
             throw new InvalidOperationException("Bootstrap did not resolve required shared slots.");
         }
@@ -161,7 +178,7 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
         return new ResoniteSceneBootstrapState(
             existingDatasetRoot.Value,
             new CreatedSlot(assetsSlot.ID!, assetsSlot.Name?.Value ?? "Assets"),
-            new CreatedSlot(commonSlot.ID!, commonSlot.Name?.Value ?? "Common"),
+            new CreatedSlot(sharedCommonMaterialsSlot.ID!, sharedCommonMaterialsSlot.Name?.Value ?? SharedCommonMaterialsRootName),
             DatasetRootExisted: true,
             sceneAnchor,
             datasetRootSnapshot,
@@ -186,6 +203,8 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
         string completionMeshCode,
         IReadOnlyList<DatasetLicenseDefinition> datasetLicenses,
         IReadOnlyList<ResoniteMaterialBinding> commonMaterials,
+        Slot? existingSharedAssetsSlot,
+        Slot? existingSharedCommonMaterialsSlot,
         CancellationToken cancellationToken)
     {
         string datasetRootName = $"PLATEAU {datasetName}";
@@ -193,13 +212,27 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
         string batchScopeToken = CreateBatchScopeToken();
         ResoniteBatchOperations.PendingBatchSlot pendingDatasetRootSlot = CreatePendingBatchSlot("bootstrap_dataset_root", datasetRootName, batchScopeToken);
         ResoniteBatchOperations.PendingBatchSlot pendingDatasetAssetsRootSlot = CreatePendingBatchSlot("bootstrap_assets_root", "Assets", batchScopeToken);
-        ResoniteBatchOperations.PendingBatchSlot pendingCommonAssetsRootSlot = CreatePendingBatchSlot("bootstrap_common_assets_root", "Common", batchScopeToken);
         List<DataModelOperation> operations =
         [
             ResoniteBatchOperations.CreateAddSlotOperation("Root", datasetRootName, null, null, pendingDatasetRootSlot),
             ResoniteBatchOperations.CreateAddSlotOperation(pendingDatasetRootSlot.LocalId, "Assets", null, null, pendingDatasetAssetsRootSlot),
-            ResoniteBatchOperations.CreateAddSlotOperation(pendingDatasetAssetsRootSlot.LocalId, "Common", null, null, pendingCommonAssetsRootSlot),
         ];
+        ResoniteBatchOperations.PendingBatchSlot? pendingSharedAssetsRootSlot = null;
+        ResoniteBatchOperations.PendingBatchSlot? pendingSharedCommonMaterialsRootSlot = null;
+        string sharedAssetsParentId = existingSharedAssetsSlot?.ID ?? "Root";
+        if (existingSharedAssetsSlot is null)
+        {
+            pendingSharedAssetsRootSlot = CreatePendingBatchSlot("bootstrap_shared_assets_root", SharedAssetsRootName, batchScopeToken);
+            operations.Add(ResoniteBatchOperations.CreateAddSlotOperation("Root", SharedAssetsRootName, null, null, pendingSharedAssetsRootSlot.Value));
+            sharedAssetsParentId = pendingSharedAssetsRootSlot.Value.LocalId;
+        }
+
+        if (existingSharedCommonMaterialsSlot is null)
+        {
+            pendingSharedCommonMaterialsRootSlot = CreatePendingBatchSlot("bootstrap_shared_common_materials_root", SharedCommonMaterialsRootName, batchScopeToken);
+            operations.Add(ResoniteBatchOperations.CreateAddSlotOperation(sharedAssetsParentId, SharedCommonMaterialsRootName, null, null, pendingSharedCommonMaterialsRootSlot.Value));
+        }
+
         foreach (DatasetLicenseDefinition datasetLicense in datasetLicenses)
         {
             ResoniteBatchOperations.PendingBatchComponent pendingLicense = CreatePendingBatchComponent(
@@ -217,8 +250,8 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             = await PlanCommonMaterialOperationsAsync(
                 setupClient,
                 commonMaterials,
-                commonSlot: null,
-                commonParentId: pendingCommonAssetsRootSlot.LocalId,
+                commonSlot: existingSharedCommonMaterialsSlot,
+                commonParentId: existingSharedCommonMaterialsSlot?.ID ?? pendingSharedCommonMaterialsRootSlot?.LocalId ?? throw new InvalidOperationException("Bootstrap could not determine the shared Common Materials parent slot."),
                 batchScopeToken,
                 operations,
                 cancellationToken);
@@ -228,7 +261,9 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
         CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response);
         CreatedSlot datasetRootSlot = entityMap.ResolveSlot(pendingDatasetRootSlot);
         CreatedSlot datasetAssetsRootSlot = entityMap.ResolveSlot(pendingDatasetAssetsRootSlot);
-        CreatedSlot commonAssetsRootSlot = entityMap.ResolveSlot(pendingCommonAssetsRootSlot);
+        CreatedSlot commonAssetsRootSlot = existingSharedCommonMaterialsSlot is null
+            ? entityMap.ResolveSlot(pendingSharedCommonMaterialsRootSlot ?? throw new InvalidOperationException("Shared Common Materials slot was not planned."))
+            : new CreatedSlot(existingSharedCommonMaterialsSlot.ID!, existingSharedCommonMaterialsSlot.Name?.Value ?? SharedCommonMaterialsRootName);
         foreach (PlannedCommonMaterialBatchEntry plannedMaterial in plannedCommonMaterials)
         {
             commonMaterialAssetsByKey[plannedMaterial.MaterialKey] = new CreatedMaterialAsset(
@@ -333,15 +368,54 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
         List<PlannedCommonMaterialBatchEntry> plannedCommonMaterials = [];
         Dictionary<string, ResoniteMaterialBinding> canonicalMaterialsByKey = CollectCanonicalCommonMaterials(commonMaterials);
         ResoniteSceneSlotSnapshot? commonSlotSnapshot = commonSlot is null ? null : new ResoniteSceneSlotSnapshot(commonSlot);
+        string? commonSlotId = commonSlot?.ID;
+        Dictionary<string, string> familyParentIds = new(StringComparer.Ordinal);
 
         foreach (ResoniteMaterialBinding material in canonicalMaterialsByKey.Values.OrderBy(static material => material.MaterialKey, StringComparer.Ordinal))
         {
             string family = material.Family ?? BundledDefaultMaterialFamilies.Other;
             commonMaterialFamilies.Add(family);
+            string familySlotName = family;
+            if (!familyParentIds.TryGetValue(family, out string? familyParentId))
+            {
+                Slot? existingFamilySlot = commonSlotSnapshot is null
+                    ? null
+                    : GetReusableChildSlot(
+                        commonSlotSnapshot,
+                        familySlotName,
+                        commonSlotId ?? throw new InvalidOperationException("Existing shared Common Materials slot did not expose an ID."));
+                if (existingFamilySlot is null)
+                {
+                    ResoniteBatchOperations.PendingBatchSlot pendingFamilySlot = CreatePendingBatchSlot(
+                        $"bootstrap_common_material_family_{plannedCommonMaterials.Count}",
+                        familySlotName,
+                        batchScopeToken);
+                    operations.Add(ResoniteBatchOperations.CreateAddSlotOperation(commonParentId, familySlotName, null, null, pendingFamilySlot));
+                    familyParentId = pendingFamilySlot.LocalId;
+                }
+                else
+                {
+                    familyParentId = existingFamilySlot.ID ?? throw new InvalidOperationException("Existing common material family slot did not expose an ID.");
+                }
+
+                familyParentIds[family] = familyParentId;
+            }
+
             string materialSlotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
-            Slot? existingMaterialSlot = commonSlotSnapshot is null
+            Slot? familySnapshotSlot = commonSlotSnapshot is null
                 ? null
-                : GetReusableChildSlot(commonSlotSnapshot, materialSlotName, commonSlot!.ID!);
+                : GetReusableChildSlot(
+                    commonSlotSnapshot,
+                    familySlotName,
+                    commonSlotId ?? throw new InvalidOperationException("Existing shared Common Materials slot did not expose an ID."));
+            ResoniteSceneSlotSnapshot? familySlotSnapshot = familySnapshotSlot is null ? null : new ResoniteSceneSlotSnapshot(familySnapshotSlot);
+            string? familySnapshotSlotId = familySnapshotSlot?.ID;
+            Slot? existingMaterialSlot = familySlotSnapshot is null
+                ? null
+                : GetReusableChildSlot(
+                    familySlotSnapshot,
+                    materialSlotName,
+                    familySnapshotSlotId ?? throw new InvalidOperationException("Existing common material family slot did not expose an ID."));
             string materialComponentType = ResoniteMaterialComponentPolicy.GetComponentType(material);
             string? existingMaterialComponentId = existingMaterialSlot?.Components?
                 .Where(component => string.Equals(component.ComponentType, materialComponentType, StringComparison.Ordinal))
@@ -368,7 +442,7 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
                     materialSlotName,
                     batchScopeToken);
                 materialContainerId = pendingMaterialSlot.Value.LocalId;
-                operations.Add(ResoniteBatchOperations.CreateAddSlotOperation(commonParentId, materialSlotName, null, null, pendingMaterialSlot.Value));
+                operations.Add(ResoniteBatchOperations.CreateAddSlotOperation(familyParentId, materialSlotName, null, null, pendingMaterialSlot.Value));
             }
 
             ResoniteBatchOperations.PendingBatchComponent pendingMaterialComponent = AddCommonMaterialComponentOperations(

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -44,9 +44,23 @@ internal sealed record PlannedDedicatedMaterialAsset(
     bool PreserveDedicatedMaterialSlot)
     : PlannedMaterialAsset(Identity);
 
+internal abstract record PlannedRendererMaterialBinding(MaterialIdentity MaterialIdentity);
+
+internal sealed record PlannedDirectRendererMaterialBinding(MaterialIdentity MaterialIdentity)
+    : PlannedRendererMaterialBinding(MaterialIdentity);
+
+internal sealed record PlannedMainTextureOverrideRendererMaterialBinding(
+    MaterialIdentity MaterialIdentity,
+    PlannedTextureAsset MainTexture)
+    : PlannedRendererMaterialBinding(MaterialIdentity);
+
 internal sealed record PlannedRenderer(
     GeometryIdentity GeometryIdentity,
-    IReadOnlyList<MaterialIdentity> MaterialIdentities);
+    IReadOnlyList<PlannedRendererMaterialBinding> MaterialBindings);
+
+internal sealed record PlannedSceneMaterialPlan(
+    IReadOnlyList<PlannedMaterialAsset> MaterialAssets,
+    IReadOnlyList<PlannedRendererMaterialBinding> RendererMaterialBindings);
 
 internal sealed record PlannedCollider(
     GeometryIdentity GeometryIdentity,

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneImportTargetFactory.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneImportTargetFactory.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 
 using Plateau.ResoniteLink.Application.Importing;
+using Plateau.ResoniteLink.Domain.Importing;
 
 namespace Plateau.ResoniteLink.Targets.Resonite;
 
@@ -11,6 +12,7 @@ public static class ResoniteSceneImportTargetFactory
         Uri endpoint,
         int connectionCount,
         bool enableSendMetrics,
+        PlateauImportMemoryProfile memoryProfile,
         bool enableMeshBake,
         string? terrainTileCacheRoot,
         bool disableTerrainTileCache,
@@ -28,6 +30,7 @@ public static class ResoniteSceneImportTargetFactory
             endpoint,
             connectionCount,
             diagnostics,
+            memoryProfile,
             new ResoniteLiveSceneImportDependencies(
                 Transport.ResoniteLink.ResoniteLinkTransportSessionFactory.Create(
                     endpoint,

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -14,6 +14,11 @@ internal static class ResoniteSceneMaterialConventions
     {
         ArgumentNullException.ThrowIfNull(material);
 
+        if (useCommonMaterialAssets)
+        {
+            return CreateCommonMaterialSlotName(material);
+        }
+
         string componentKind = material.MaterialType switch
         {
             ResoniteMaterialType.Standard => material.Projection switch
@@ -112,6 +117,34 @@ internal static class ResoniteSceneMaterialConventions
         };
     }
 
+    public static bool TryNormalizeCommonBaseMaterialBinding(
+        ResoniteMaterialBinding material,
+        out ResoniteMaterialBinding normalizedMaterial)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+
+        normalizedMaterial = material;
+        if (material.AssetScope != ResoniteMaterialAssetScope.Common
+            || material.MaterialType != ResoniteMaterialType.Standard
+            || material.Projection != ResoniteMaterialProjection.Uv
+            || material.DepthOffset is not null
+            || material.TextureOffset is not null
+            || !IsWhiteBaseColor(material.BaseColor))
+        {
+            return false;
+        }
+
+        ResoniteMaterialBinding commonBaseCandidate = material with
+        {
+            BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            TexturePayload = null,
+            TerrainOverlay = null,
+            TextureSourceKind = ResoniteTextureSourceKind.Bundled,
+        };
+        normalizedMaterial = NormalizeCommonMaterialBinding(commonBaseCandidate);
+        return normalizedMaterial.AssetScope == ResoniteMaterialAssetScope.Common;
+    }
+
     public static string CreateCanonicalCommonMaterialKey(
         string family,
         int bundledVariantIndex,
@@ -154,6 +187,32 @@ internal static class ResoniteSceneMaterialConventions
             $"{color.R:0.###}-{color.G:0.###}-{color.B:0.###}-{color.A:0.###}");
     }
 
+    private static string CreateCommonMaterialSlotName(ResoniteMaterialBinding material)
+    {
+        string projectionName = material.Projection switch
+        {
+            ResoniteMaterialProjection.Uv => "uv",
+            ResoniteMaterialProjection.Triplanar => "triplanar",
+            _ => material.Projection.ToString().ToLowerInvariant(),
+        };
+        int variantIndex = material.BundledVariantIndex ?? 0;
+        ResoniteFloat2? defaultTextureScale = TryGetBundledDefaultScale(material);
+        ResoniteFloat2? materialTextureScale = material.TextureScale;
+        bool hasNonDefaultScale = materialTextureScale is not null
+            && (defaultTextureScale is null
+                || Math.Abs(materialTextureScale.X - defaultTextureScale.X) > 1e-9
+                || Math.Abs(materialTextureScale.Y - defaultTextureScale.Y) > 1e-9);
+        string scaleToken = hasNonDefaultScale
+            ? string.Create(
+                CultureInfo.InvariantCulture,
+                $"_scale_{materialTextureScale!.X:0.######}x{materialTextureScale.Y:0.######}")
+            : string.Empty;
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"shared_{projectionName}_variant_{variantIndex}{scaleToken}");
+    }
+
     private static string CreateTerrainOverlayToken(TerrainTextureOverlay terrainTextureOverlay)
     {
         ArgumentNullException.ThrowIfNull(terrainTextureOverlay);
@@ -171,5 +230,24 @@ internal static class ResoniteSceneMaterialConventions
     {
         byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(text));
         return Convert.ToHexString(hash.AsSpan(0, 4)).ToLowerInvariant();
+    }
+
+    private static ResoniteFloat2? TryGetBundledDefaultScale(ResoniteMaterialBinding material)
+    {
+        if (string.IsNullOrWhiteSpace(material.Family))
+        {
+            return null;
+        }
+
+        string bundledVariantPath = BundledDefaultMaterialFamilies.GetVariant(material.Family!, material.BundledVariantIndex ?? 0);
+        return BundledDefaultMaterialProfiles.GetTilesPerMeter(bundledVariantPath);
+    }
+
+    private static bool IsWhiteBaseColor(ResoniteColor color)
+    {
+        return Math.Abs(color.R - 1.0) < 1e-9
+            && Math.Abs(color.G - 1.0) < 1e-9
+            && Math.Abs(color.B - 1.0) < 1e-9
+            && Math.Abs(color.A - 1.0) < 1e-9;
     }
 }

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -36,7 +36,6 @@ internal sealed class ResoniteSharedSlotIndex(
         }
 
         IndexCreatedSharedSlot(bootstrapState.DatasetRootSlot.SlotId, bootstrapState.DatasetAssetsRootSlot);
-        IndexCreatedSharedSlot(bootstrapState.DatasetAssetsRootSlot.SlotId, bootstrapState.CommonAssetsRootSlot);
     }
 
     public Task<ObjectSlotHierarchy> CreateObjectHierarchyTask(

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliApplicationTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliApplicationTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 
 using Plateau.ResoniteLink.Application.Importing;
 using Plateau.ResoniteLink.Cli;
+using Plateau.ResoniteLink.Domain.Importing;
 
 namespace Plateau.ResoniteLink.Tests.Cli;
 
@@ -102,6 +103,7 @@ public sealed class CliApplicationTests
         Assert.Equal(0, exitCode);
         BuildCommandOptions capturedOptions = Assert.Single(importServiceFactory.CapturedOptions);
         Assert.Equal(CliTestData.DocumentedDefaultPackageNames, capturedOptions.Request.PackageNames);
+        Assert.Equal(PlateauImportMemoryProfile.Large, capturedOptions.MemoryProfile);
         Assert.Equal(string.Empty, standardError.ToString());
         Assert.Contains("Resonite import completed.", standardOutput.ToString());
     }

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -33,6 +33,7 @@ public sealed class CliArgumentsParserTests
         Assert.Equal("local", result.Options.WorkRoot);
         Assert.Equal(new Uri("ws://localhost:12345/"), result.Options.ResoniteLinkUri);
         Assert.Equal(4, result.Options.ResoniteLinkConnectionCount);
+        Assert.Equal(PlateauImportMemoryProfile.Large, result.Options.MemoryProfile);
         Assert.True(result.Options.EnableMeshBake);
         Assert.Null(result.Options.TerrainTileCacheRoot);
         Assert.False(result.Options.DisableTerrainTileCache);
@@ -540,6 +541,51 @@ public sealed class CliArgumentsParserTests
 
         Assert.Null(result.Error);
         Assert.True(result.Options!.EnableSendMetrics);
+    }
+
+    [Fact]
+    public void ParseParsesMemoryProfile()
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "build",
+                "--dataset",
+                "tokyo23ku",
+                "--mesh-code",
+                "53394525",
+                "--local-source-path",
+                "/data/plateau",
+                "--resonitelink-port",
+                "12345",
+                "--memory-profile",
+                "small",
+            ]);
+
+        Assert.Null(result.Error);
+        Assert.Equal(PlateauImportMemoryProfile.Small, result.Options!.MemoryProfile);
+    }
+
+    [Fact]
+    public void ParseRejectsInvalidMemoryProfile()
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "build",
+                "--dataset",
+                "tokyo23ku",
+                "--mesh-code",
+                "53394525",
+                "--local-source-path",
+                "/data/plateau",
+                "--resonitelink-port",
+                "12345",
+                "--memory-profile",
+                "tiny",
+            ]);
+
+        Assert.Equal(
+            "The value 'tiny' is not a valid memory profile. Use 'small' or 'large'.",
+            result.Error);
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
@@ -54,6 +54,7 @@ public sealed class ImportServiceFactoryTests
             "local",
             new Uri("ws://localhost:12345/"),
             4,
+            PlateauImportMemoryProfile.Large,
             enableMeshBake,
             TerrainTileCacheRoot: null,
             DisableTerrainTileCache: false,

--- a/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -145,6 +145,44 @@ public sealed class Lod2AtlasCityObjectBakerTests
         Assert.Contains(baked, static cityObject => cityObject.SourceUnitKey == "unit-b" && cityObject.SourceFileRelativePath == "unit-b.gml");
     }
 
+    [Fact]
+    public async Task FlushAllAsyncPacksMixedSizeTexturesIntoSingleAtlasBatch()
+    {
+        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 10, tilePaddingPixels: 0);
+
+        await AssertBufferedAsync(baker, CreateLod2Building("building-a", CreatePayload("textures/a.png", new Rgba32(255, 0, 0, 255), 7, 7), 0, "unit-a"));
+        await AssertBufferedAsync(baker, CreateLod2Building("building-b", CreatePayload("textures/b.png", new Rgba32(0, 255, 0, 255), 1, 7), 2, "unit-a"));
+        await AssertBufferedAsync(baker, CreateLod2Building("building-c", CreatePayload("textures/c.png", new Rgba32(0, 0, 255, 255), 3, 3), 4, "unit-a"));
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        Assert.Equal(8, atlasPayload.Width);
+        Assert.Equal(10, atlasPayload.Height);
+    }
+
+    [Fact]
+    public async Task FlushAllAsyncCapsAtlasTileSizeForSmallMemoryProfile()
+    {
+        Lod2AtlasCityObjectBaker baker = new(
+            new ResoniteTextureImageLoader(),
+            maxAtlasSize: 2048,
+            tilePaddingPixels: 0,
+            resourceBudget: ResoniteImportBudgetProfiles.Small);
+
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-large",
+                CreatePayload("textures/large.png", new Rgba32(255, 0, 0, 255), 1024, 1024),
+                0,
+                "unit-a"));
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        Assert.Equal(512, atlasPayload.Width);
+        Assert.Equal(512, atlasPayload.Height);
+    }
+
     private static async Task AssertBufferedAsync(Lod2AtlasCityObjectBaker baker, ResoniteConstructionCityObject cityObject)
     {
         BufferedCityObjectBufferResult result = await baker.TryBufferAsync(cityObject);

--- a/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -74,6 +74,35 @@ public sealed class Lod2AtlasCityObjectBakerTests
     }
 
     [Fact]
+    public async Task FlushAllAsyncPreservesDetectedBackgroundColorInTransparentTilePixels()
+    {
+        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 0);
+
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-transparent",
+                CreatePayload(
+                    "textures/transparent-edge.png",
+                    [
+                        new Rgba32(255, 0, 0, 255),
+                        new Rgba32(0, 0, 0, 0),
+                    ],
+                    2,
+                    1),
+                0,
+                "unit-a"));
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+
+        Assert.Equal(2, atlasPayload.Width);
+        Assert.Equal(1, atlasPayload.Height);
+        Assert.Equal(new Rgba32(255, 0, 0, 255), ReadPixel(atlasPayload, 0, 0));
+        Assert.Equal(new Rgba32(255, 0, 0, 0), ReadPixel(atlasPayload, 1, 0));
+    }
+
+    [Fact]
     public async Task FlushAllAsyncKeepsCommonMaterialsAsSeparateSubmeshesWhileAtlasingDedicatedMaterials()
     {
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 1);
@@ -193,6 +222,21 @@ public sealed class Lod2AtlasCityObjectBakerTests
     private static ResoniteTexturePayload CreatePayload(string identity, Rgba32 color, int width, int height)
     {
         using Image<Rgba32> image = new(width, height, color);
+        return ResoniteTextureImportFactory.CreatePayloadFromImage(image, identity: identity);
+    }
+
+    private static ResoniteTexturePayload CreatePayload(string identity, IReadOnlyList<Rgba32> pixels, int width, int height)
+    {
+        Assert.Equal(width * height, pixels.Count);
+        using Image<Rgba32> image = new(width, height);
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                image[x, y] = pixels[(y * width) + x];
+            }
+        }
+
         return ResoniteTextureImportFactory.CreatePayloadFromImage(image, identity: identity);
     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -43,7 +43,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
 
         Assert.Equal(firstMaterialId, secondMaterialId);
         Assert.StartsWith(
-            $"PLATEAU {DatasetName}/Assets/Common/",
+            "PLATEAU Shared Assets/Common Materials/",
             client.SlotPaths[commonMaterialContainerSlotId],
             StringComparison.Ordinal);
     }
@@ -91,7 +91,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
         string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject dataset-texture-two");
         HashSet<string> commonMaterialIds = client.AddedComponents
             .Where(request => client.SlotPaths.TryGetValue(request.ContainerSlotId, out string? path)
-                && path.Contains("/Assets/Common/", StringComparison.Ordinal))
+                && path.Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal))
             .Select(static request => request.Data.ID)
             .Where(static id => !string.IsNullOrWhiteSpace(id))
             .ToHashSet(StringComparer.Ordinal);
@@ -123,7 +123,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
         Assert.Equal(2, materialIds.Length);
         HashSet<string> commonMaterialIds = client.AddedComponents
             .Where(request => client.SlotPaths.TryGetValue(request.ContainerSlotId, out string? path)
-                && path.Contains("/Assets/Common/", StringComparison.Ordinal))
+                && path.Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal))
             .Select(static request => request.Data.ID)
             .Where(static id => !string.IsNullOrWhiteSpace(id))
             .ToHashSet(StringComparer.Ordinal);
@@ -149,14 +149,16 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
 
         Slot datasetRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, $"PLATEAU {DatasetName}");
         Slot assetsRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(client, $"PLATEAU {DatasetName}/Assets");
-        Slot commonRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(client, $"PLATEAU {DatasetName}/Assets/Common");
+        Slot sharedAssetsRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(client, "PLATEAU Shared Assets");
+        Slot commonRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(client, "PLATEAU Shared Assets/Common Materials");
 
         Assert.Equal(1, client.SlotsById.Values.Count(slot => string.Equals(slot.Name?.Value, $"PLATEAU {DatasetName}", StringComparison.Ordinal)));
         Assert.Equal(1, client.SlotsById.Values.Count(slot => string.Equals(slot.Name?.Value, "Assets", StringComparison.Ordinal)
             && string.Equals(slot.Parent?.TargetID, datasetRoot.ID, StringComparison.Ordinal)));
-        Assert.Equal(1, client.SlotsById.Values.Count(slot => string.Equals(slot.Name?.Value, "Common", StringComparison.Ordinal)
-            && string.Equals(slot.Parent?.TargetID, assetsRoot.ID, StringComparison.Ordinal)));
-        Assert.True(ResoniteLiveSceneImportTargetTestSupport.IsDescendantOf(client, commonRoot.ID, assetsRoot.ID));
+        Assert.Equal(1, client.SlotsById.Values.Count(slot => string.Equals(slot.Name?.Value, "PLATEAU Shared Assets", StringComparison.Ordinal)));
+        Assert.Equal(1, client.SlotsById.Values.Count(slot => string.Equals(slot.Name?.Value, "Common Materials", StringComparison.Ordinal)
+            && string.Equals(slot.Parent?.TargetID, sharedAssetsRoot.ID, StringComparison.Ordinal)));
+        Assert.True(ResoniteLiveSceneImportTargetTestSupport.IsDescendantOf(client, commonRoot.ID, sharedAssetsRoot.ID));
         Assert.True(client.ImportedMeshes.Count >= 2);
     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -69,7 +69,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
-    public async Task BuildAsyncDemotesPayloadTexturesToDedicatedMaterials()
+    public async Task BuildAsyncReusesSharedCommonMaterialForPayloadAlbedoOverrides()
     {
         using TemporaryDirectory datasetDirectory = new();
         ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
@@ -95,16 +95,18 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             .Select(static request => request.Data.ID)
             .Where(static id => !string.IsNullOrWhiteSpace(id))
             .ToHashSet(StringComparer.Ordinal);
+        string firstPropertyBlockId = GetRendererMaterialPropertyBlockReferenceTarget(client, "CityObject dataset-texture-one");
+        string secondPropertyBlockId = GetRendererMaterialPropertyBlockReferenceTarget(client, "CityObject dataset-texture-two");
 
-        Assert.NotEqual(firstMaterialId, secondMaterialId);
-        Assert.DoesNotContain(firstMaterialId, commonMaterialIds);
-        Assert.DoesNotContain(secondMaterialId, commonMaterialIds);
+        Assert.Equal(firstMaterialId, secondMaterialId);
+        Assert.Contains(firstMaterialId, commonMaterialIds);
+        Assert.NotEqual(firstPropertyBlockId, secondPropertyBlockId);
         Assert.Contains(client.ImportedRawTextures, static texture => texture.Identity == "textures/albedo-one.png");
         Assert.Contains(client.ImportedRawTextures, static texture => texture.Identity == "textures/albedo-two.png");
     }
 
     [Fact]
-    public async Task BuildAsyncPreservesMixedCommonAndDedicatedMaterialOrder()
+    public async Task BuildAsyncPreservesMixedCommonAndOverrideMaterialOrder()
     {
         using TemporaryDirectory datasetDirectory = new();
         ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
@@ -127,10 +129,12 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             .Select(static request => request.Data.ID)
             .Where(static id => !string.IsNullOrWhiteSpace(id))
             .ToHashSet(StringComparer.Ordinal);
+        string?[] propertyBlockIds = GetRendererMaterialPropertyBlockReferenceTargets(client, "CityObject mixed-material-order");
 
-        Assert.NotEqual(materialIds[0], materialIds[1]);
         Assert.Contains(materialIds[0], commonMaterialIds);
-        Assert.DoesNotContain(materialIds[1], commonMaterialIds);
+        Assert.Contains(materialIds[1], commonMaterialIds);
+        Assert.Null(propertyBlockIds[0]);
+        Assert.NotNull(propertyBlockIds[1]);
         Assert.Contains(client.ImportedRawTextures, static texture => texture.Identity == "textures/mixed-albedo.png");
     }
 
@@ -884,6 +888,30 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                 .Select(static request => request.Data));
         SyncList materials = Assert.IsType<SyncList>(renderer.Members["Materials"]);
         return materials.Elements
+            .Select(Assert.IsType<Reference>)
+            .Select(static reference => reference.TargetID)
+            .ToArray();
+    }
+
+    private static string GetRendererMaterialPropertyBlockReferenceTarget(
+        SceneBuilderRecordingClient client,
+        string slotName)
+    {
+        string? targetId = Assert.Single(GetRendererMaterialPropertyBlockReferenceTargets(client, slotName));
+        return Assert.IsType<string>(targetId);
+    }
+
+    private static string?[] GetRendererMaterialPropertyBlockReferenceTargets(
+        SceneBuilderRecordingClient client,
+        string slotName)
+    {
+        Component renderer = Assert.Single(
+            client.AddedComponents.Where(request =>
+                    string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal)
+                    && string.Equals(client.SlotsById[request.ContainerSlotId].Name?.Value, slotName, StringComparison.Ordinal))
+                .Select(static request => request.Data));
+        SyncList propertyBlocks = Assert.IsType<SyncList>(renderer.Members["MaterialPropertyBlocks"]);
+        return propertyBlocks.Elements
             .Select(Assert.IsType<Reference>)
             .Select(static reference => reference.TargetID)
             .ToArray();

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -1,4 +1,6 @@
 
+using Plateau.ResoniteLink.Domain.Importing;
+
 namespace Plateau.ResoniteLink.Tests.Targets;
 
 public sealed class ResoniteLiveSceneImportTargetConfigurationTests
@@ -19,12 +21,21 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         Assert.False(builder.MeshBakeEnabled);
     }
 
+    [Fact]
+    public async Task ConstructorUsesLargeMemoryProfileByDefault()
+    {
+        await using ResoniteLiveSceneImportTarget builder = CreateBuilder();
+
+        Assert.Equal(PlateauImportMemoryProfile.Large, builder.MemoryProfile);
+    }
+
     private static ResoniteLiveSceneImportTarget CreateBuilder(bool enableMeshBake = true)
     {
         return new ResoniteLiveSceneImportTarget(
             new Uri("ws://localhost:12345/"),
             1,
             ResoniteLinkSendDiagnostics.Disabled,
+            PlateauImportMemoryProfile.Large,
             new ResoniteLiveSceneImportDependencies(
                 new DelegatingClientSession(),
                 new TerrainTextureAssetGenerator()),

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -193,6 +193,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             new Uri("ws://localhost:12345/"),
             1,
             ResoniteLinkSendDiagnostics.Disabled,
+            PlateauImportMemoryProfile.Large,
             new ResoniteLiveSceneImportDependencies(
                 session ?? new DelegatingClientSession(routedClient),
                 terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator()),

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -91,7 +91,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             ],
             new PlannedRenderer(
                 new GeometryIdentity("geom"),
-                [new MaterialIdentity("reusable"), dedicatedMaterial.Identity]),
+                [
+                    new PlannedDirectRendererMaterialBinding(new MaterialIdentity("reusable")),
+                    new PlannedDirectRendererMaterialBinding(dedicatedMaterial.Identity),
+                ]),
             new PlannedCollider(
                 new GeometryIdentity("geom"),
                 false));
@@ -161,7 +164,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             [dedicatedMaterial],
             new PlannedRenderer(
                 new GeometryIdentity("geom"),
-                [dedicatedMaterial.Identity]),
+                [new PlannedDirectRendererMaterialBinding(dedicatedMaterial.Identity)]),
             new PlannedCollider(
                 new GeometryIdentity("geom"),
                 true));
@@ -205,5 +208,55 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.Equal(texturesByUri["resdb:///texture/metallic"].Identity.Value, Assert.IsType<Reference>(materialComponent.Members["MetallicMap"]).TargetID);
         Assert.Equal(texturesByUri["resdb:///texture/metallic"].Identity.Value, Assert.IsType<Reference>(materialComponent.Members["OcclusionMap"]).TargetID);
         Assert.Equal(texturesByUri["resdb:///texture/emission"].Identity.Value, Assert.IsType<Reference>(materialComponent.Members["EmissiveMap"]).TargetID);
+    }
+
+    [Fact]
+    public void CreatePlannedBatchEmission_UsesMainTexturePropertyBlockForRendererOverride()
+    {
+        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
+            new CreatedSlot("asset-lod-slot", "Asset LOD"),
+            new CreatedSlot("lod-slot", "LOD"),
+            "Triangle Object",
+            new Plateau.ResoniteLink.Domain.Importing.ResoniteFloat3(0.0, 0.0, 0.0),
+            null);
+        PlannedReusableMaterialAsset reusableMaterial = new(new MaterialIdentity("reusable"), "shared-material-id");
+        PlannedSceneObjectEmission emissionPlan = new(
+            new PlannedTriangleMeshGeometryAsset(
+                new GeometryIdentity("geom"),
+                "Triangle Object",
+                new Uri("resdb:///mesh/triangle")),
+            [reusableMaterial],
+            new PlannedRenderer(
+                new GeometryIdentity("geom"),
+                [
+                    new PlannedMainTextureOverrideRendererMaterialBinding(
+                        reusableMaterial.Identity,
+                        new PlannedTextureAsset(new TextureIdentity("override"), new Uri("resdb:///texture/override"))),
+                ]),
+            new PlannedCollider(
+                new GeometryIdentity("geom"),
+                false));
+
+        PlannedBatchEmission batchPlan = ResoniteLiveSceneImportTarget.CreatePlannedBatchEmission(objectSlots, emissionPlan);
+
+        PlannedBatchComponentEmission meshRenderer = Assert.Single(
+            batchPlan.ComponentEmissions,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal));
+        SyncList rendererMaterials = Assert.IsType<SyncList>(meshRenderer.Members["Materials"]);
+        SyncList rendererPropertyBlocks = Assert.IsType<SyncList>(meshRenderer.Members["MaterialPropertyBlocks"]);
+        Reference materialReference = Assert.IsType<Reference>(Assert.Single(rendererMaterials.Elements));
+        Reference propertyBlockReference = Assert.IsType<Reference>(Assert.Single(rendererPropertyBlocks.Elements));
+        PlannedBatchComponentEmission propertyBlockComponent = Assert.Single(
+            batchPlan.ComponentEmissions,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));
+        PlannedBatchComponentEmission overrideTexture = Assert.Single(
+            batchPlan.ComponentEmissions,
+            component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
+                && string.Equals(component.ContainerId, meshRenderer.ContainerId, StringComparison.Ordinal));
+
+        Assert.Equal("shared-material-id", materialReference.TargetID);
+        Assert.Equal(propertyBlockComponent.Identity.Value, propertyBlockReference.TargetID);
+        Assert.Equal(propertyBlockComponent.ContainerId, meshRenderer.ContainerId);
+        Assert.Equal(overrideTexture.Identity.Value, Assert.IsType<Reference>(propertyBlockComponent.Members["Texture"]).TargetID);
     }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -1,0 +1,77 @@
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Tests.Targets;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test names describe contract cases.")]
+public sealed class ResoniteSceneMaterialConventionsTests
+{
+    [Fact]
+    public void CreateMaterialSlotName_ForCommonMaterial_UsesClassifiedName()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "common|facade|variant:0|Uv|scale:13x13",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter,
+            Family: BundledDefaultMaterialFamilies.Facade,
+            BundledVariantIndex: 0,
+            AssetScope: ResoniteMaterialAssetScope.Common);
+
+        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
+
+        Assert.Equal("shared_uv_variant_0", slotName);
+    }
+
+    [Fact]
+    public void CreateMaterialSlotName_ForCommonMaterialWithNonDefaultScale_KeepsOnlyScaleDiscriminator()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "common|facade|variant:0|Uv|scale:0.5x0.5",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: new ResoniteFloat2(0.5, 0.5),
+            Family: BundledDefaultMaterialFamilies.Facade,
+            BundledVariantIndex: 0,
+            AssetScope: ResoniteMaterialAssetScope.Common);
+
+        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
+
+        Assert.Equal("shared_uv_variant_0_scale_0.5x0.5", slotName);
+    }
+
+    [Fact]
+    public void CreateMaterialSlotName_ForDedicatedMaterial_KeepsDetailedIdentity()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "dedicated-material",
+            BaseColor: new ResoniteColor(0.1, 0.2, 0.3, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: new ResoniteMaterialDepthOffset(2.0, 3.0),
+            SubmeshIndices: [0],
+            TextureScale: new ResoniteFloat2(0.5, 0.25),
+            TextureOffset: new ResoniteFloat2(0.125, 0.75),
+            Family: BundledDefaultMaterialFamilies.Facade,
+            BundledVariantIndex: 0,
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: false);
+
+        Assert.Contains("pbs-uv_uv_", slotName, StringComparison.Ordinal);
+        Assert.Contains("_0.5x0.25_", slotName, StringComparison.Ordinal);
+        Assert.Contains("_0.125x0.75_", slotName, StringComparison.Ordinal);
+        Assert.Contains("_2x3_", slotName, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add budgeted atlas memory profiles and deterministic mixed-size atlas packing
- move shared common materials to root-level shared assets and detect atlas background colors for gap fill
- plan renderer material bindings explicitly so shared common materials can be reused with per-renderer main-texture overrides
- simplify common material slot names to classification-oriented names instead of serializing nearly all properties

## Verification
- `dotnet restore Plateau.ResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet test Plateau.ResoniteLink.sln --filter "FullyQualifiedName~ResoniteSceneMaterialConventionsTests|FullyQualifiedName~ResoniteSceneBatchEmissionPlanningTests|FullyQualifiedName~ResoniteLiveSceneImportTargetAssetReuseTests|FullyQualifiedName~ResoniteLiveSceneImportTargetConfigurationTests"`
- live resend to port 19001 completed with `attempted=6 sent=6 failed=0`

## Notes
- full `dotnet build/test` against the solution currently hits intermittent `NU1301` repository-signature fetch failures in `.agents/skills/resonite-live-send-debug/tools/ResoniteSessionTool`, so the targeted test slice above is the current code-change verification evidence.
- Related to #66 without closing it.

Closes #67
Closes #73
Closes #75
Closes #83
Closes #86
