### PR TITLE
refactor(citygml): extract appearance store and lod selector

### DIFF
--- a/src/Plateau.ResoniteLink/Formats/CityGml/CityGmlAppearanceModels.cs
+++ b/src/Plateau.ResoniteLink/Formats/CityGml/CityGmlAppearanceModels.cs
@@ -1,0 +1,42 @@
+using System.Xml.Linq;
+
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Application.Importing;
+
+internal sealed record CityGmlMaterialAttributes(
+    ResoniteColor DiffuseColor,
+    double? AmbientIntensity,
+    ResoniteColor? EmissiveColor,
+    ResoniteColor? SpecularColor,
+    double? Shininess,
+    double? Transparency);
+
+internal sealed record CityGmlParameterizedTexture(
+    string ResolvedTexturePath,
+    string? MimeType,
+    string? TextureType,
+    string? WrapMode,
+    ResoniteColor? BorderColor,
+    IReadOnlyDictionary<string, IReadOnlyList<ResoniteFloat2>> RingCoordinates);
+
+internal sealed record CityGmlGeoreferencedTexture(
+    string? ResolvedTexturePath,
+    string? MimeType,
+    string? TextureType,
+    string? WrapMode,
+    ResoniteColor? BorderColor,
+    string? ReferencePoint,
+    string? Orientation);
+
+internal sealed record CityGmlResolvedAppearance(
+    ResoniteColor BaseColor,
+    ResoniteTexturePayload? TexturePayload,
+    IReadOnlyDictionary<string, IReadOnlyList<ResoniteFloat2>>? RingUvsByRingId,
+    CityGmlMaterialAttributes? MaterialAttributes = null,
+    CityGmlParameterizedTexture? ParameterizedTexture = null,
+    CityGmlGeoreferencedTexture? GeoreferencedTexture = null);
+
+internal sealed record CityGmlLodSelection(
+    XElement[] SurfaceElements,
+    int? LodLevel);

--- a/src/Plateau.ResoniteLink/Formats/CityGml/CityGmlAppearanceStore.cs
+++ b/src/Plateau.ResoniteLink/Formats/CityGml/CityGmlAppearanceStore.cs
@@ -1,0 +1,293 @@
+using System.Xml.Linq;
+
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Application.Importing;
+
+internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
+{
+    private static readonly ResoniteColor DefaultMaterialColor = new(1.0, 1.0, 1.0, 1.0);
+    private static readonly XNamespace App = "http://www.opengis.net/citygml/appearance/2.0";
+
+    private readonly Dictionary<string, CityGmlMaterialAttributes> materialAttributesByPolygonId = new(StringComparer.Ordinal);
+    private readonly IPlateauDatasetContentSource datasetSource;
+    private readonly string sourceFileRelativePath;
+    private readonly Dictionary<string, ResoniteTexturePayload> texturePayloadsByResolvedPath = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, CityGmlParameterizedTexture> parameterizedTexturesByPolygonId = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, CityGmlGeoreferencedTexture> georeferencedTexturesByPolygonId = new(StringComparer.Ordinal);
+
+    internal CityGmlAppearanceStore(
+        string sourceFileRelativePath,
+        IPlateauDatasetContentSource datasetSource)
+    {
+        this.sourceFileRelativePath = sourceFileRelativePath;
+        this.datasetSource = datasetSource;
+    }
+
+    public void LoadFromDocument(XDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        foreach (XElement appearanceElement in document.Descendants()
+                     .Where(element => string.Equals(element.Name.NamespaceName, App.NamespaceName, StringComparison.Ordinal)))
+        {
+            if (IsSupportedAppearanceElement(appearanceElement))
+            {
+                ApplyAppearanceElement(appearanceElement);
+            }
+        }
+    }
+
+    public void ApplyAppearanceElement(XElement appearanceElement)
+    {
+        ArgumentNullException.ThrowIfNull(appearanceElement);
+
+        if (!string.Equals(appearanceElement.Name.NamespaceName, App.NamespaceName, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        switch (appearanceElement.Name.LocalName)
+        {
+            case "ParameterizedTexture":
+                ApplyParameterizedTexture(appearanceElement);
+                break;
+            case "X3DMaterial":
+                ApplyX3DMaterial(appearanceElement);
+                break;
+            case "GeoreferencedTexture":
+                ApplyGeoreferencedTexture(appearanceElement);
+                break;
+        }
+    }
+
+    public CityGmlResolvedAppearance Resolve(string polygonId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(polygonId);
+
+        CityGmlMaterialAttributes? materialAttributes = materialAttributesByPolygonId.GetValueOrDefault(polygonId);
+        ResoniteColor baseColor = materialAttributes?.DiffuseColor ?? DefaultMaterialColor;
+
+        CityGmlParameterizedTexture? parameterizedTexture = parameterizedTexturesByPolygonId.GetValueOrDefault(polygonId);
+        ResoniteTexturePayload? texturePayload = null;
+        if (parameterizedTexture is not null)
+        {
+            texturePayload = LoadTexturePayload(parameterizedTexture.ResolvedTexturePath);
+        }
+
+        return new CityGmlResolvedAppearance(
+            BaseColor: baseColor,
+            TexturePayload: texturePayload,
+            RingUvsByRingId: parameterizedTexture?.RingCoordinates,
+            MaterialAttributes: materialAttributes,
+            ParameterizedTexture: parameterizedTexture,
+            GeoreferencedTexture: georeferencedTexturesByPolygonId.GetValueOrDefault(polygonId));
+    }
+
+    private void ApplyParameterizedTexture(XElement textureElement)
+    {
+        string? imageUri = textureElement.Element(App + "imageURI")?.Value.Trim();
+        string? resolvedTexturePath = ResolveTexturePath(imageUri);
+        if (resolvedTexturePath is null)
+        {
+            return;
+        }
+
+        string? mimeType = textureElement.Element(App + "mimeType")?.Value.Trim();
+        string? textureType = textureElement.Element(App + "textureType")?.Value.Trim();
+        string? wrapMode = textureElement.Element(App + "wrapMode")?.Value.Trim();
+        ResoniteColor? borderColor = TryParseColor(textureElement.Element(App + "borderColor")?.Value);
+
+        foreach (XElement targetElement in textureElement.Elements(App + "target"))
+        {
+            string? polygonId = StripReferencePrefix(targetElement.Attribute("uri")?.Value);
+            if (string.IsNullOrWhiteSpace(polygonId))
+            {
+                continue;
+            }
+
+            Dictionary<string, IReadOnlyList<ResoniteFloat2>> ringCoordinates = new(StringComparer.Ordinal);
+            foreach (XElement textureCoordinatesElement in targetElement.Descendants(App + "textureCoordinates"))
+            {
+                string? ringId = StripReferencePrefix(textureCoordinatesElement.Attribute("ring")?.Value);
+                if (string.IsNullOrWhiteSpace(ringId))
+                {
+                    continue;
+                }
+
+                List<ResoniteFloat2> coordinates = LocalCityGmlObjectProjection.ParseTextureCoordinates(textureCoordinatesElement.Value);
+                if (coordinates.Count > 0)
+                {
+                    ringCoordinates[ringId] = coordinates;
+                }
+            }
+
+            parameterizedTexturesByPolygonId[polygonId] = new CityGmlParameterizedTexture(
+                resolvedTexturePath,
+                mimeType,
+                textureType,
+                wrapMode,
+                borderColor,
+                ringCoordinates);
+        }
+    }
+
+    private void ApplyX3DMaterial(XElement materialElement)
+    {
+        CityGmlMaterialAttributes materialAttributes = new(
+            DiffuseColor: ParseColor(materialElement.Element(App + "diffuseColor")?.Value, DefaultMaterialColor),
+            AmbientIntensity: TryParseDouble(materialElement.Element(App + "ambientIntensity")?.Value),
+            EmissiveColor: TryParseColor(materialElement.Element(App + "emissiveColor")?.Value),
+            SpecularColor: TryParseColor(materialElement.Element(App + "specularColor")?.Value),
+            Shininess: TryParseDouble(materialElement.Element(App + "shininess")?.Value),
+            Transparency: TryParseDouble(materialElement.Element(App + "transparency")?.Value));
+
+        foreach (XElement targetElement in materialElement.Elements(App + "target"))
+        {
+            string? polygonId = StripReferencePrefix(targetElement.Attribute("uri")?.Value);
+            if (!string.IsNullOrWhiteSpace(polygonId))
+            {
+                materialAttributesByPolygonId[polygonId] = materialAttributes;
+            }
+        }
+    }
+
+    private void ApplyGeoreferencedTexture(XElement textureElement)
+    {
+        string? imageUri = textureElement.Element(App + "imageURI")?.Value.Trim();
+        string? resolvedTexturePath = ResolveTexturePath(imageUri);
+        string? mimeType = textureElement.Element(App + "mimeType")?.Value.Trim();
+        string? textureType = textureElement.Element(App + "textureType")?.Value.Trim();
+        string? wrapMode = textureElement.Element(App + "wrapMode")?.Value.Trim();
+        ResoniteColor? borderColor = TryParseColor(textureElement.Element(App + "borderColor")?.Value);
+        string? referencePoint = textureElement.Element(App + "referencePoint")?.Value.Trim();
+        string? orientation = textureElement.Element(App + "orientation")?.Value.Trim();
+
+        foreach (XElement targetElement in textureElement.Elements(App + "target"))
+        {
+            string? polygonId = StripReferencePrefix(targetElement.Attribute("uri")?.Value);
+            if (!string.IsNullOrWhiteSpace(polygonId))
+            {
+                georeferencedTexturesByPolygonId[polygonId] = new CityGmlGeoreferencedTexture(
+                    resolvedTexturePath,
+                    mimeType,
+                    textureType,
+                    wrapMode,
+                    borderColor,
+                    referencePoint,
+                    orientation);
+            }
+        }
+    }
+
+    private ResoniteTexturePayload? LoadTexturePayload(string resolvedTexturePath)
+    {
+        if (!texturePayloadsByResolvedPath.TryGetValue(resolvedTexturePath, out ResoniteTexturePayload? texturePayload))
+        {
+            using Stream stream = datasetSource.OpenReadAsync(resolvedTexturePath, CancellationToken.None)
+                .AsTask()
+                .GetAwaiter()
+                .GetResult();
+            using MemoryStream encodedPayloadStream = new();
+            stream.CopyTo(encodedPayloadStream);
+            texturePayload = new ResoniteTexturePayload(
+                Width: null,
+                Height: null,
+                "sRGB",
+                encodedPayloadStream.ToArray(),
+                $"dataset:{resolvedTexturePath}",
+                ResoniteTexturePayloadFormat.EncodedImage);
+            texturePayloadsByResolvedPath[resolvedTexturePath] = texturePayload;
+        }
+
+        return texturePayload;
+    }
+
+    private string? ResolveTexturePath(string? imageUri)
+    {
+        if (string.IsNullOrWhiteSpace(imageUri))
+        {
+            return null;
+        }
+
+        string? resolvedTexturePath = PlateauDatasetContentSourceFactory.ResolveRelativePath(
+            sourceFileRelativePath,
+            imageUri);
+        if (resolvedTexturePath is null || !datasetSource.FileExists(resolvedTexturePath))
+        {
+            return null;
+        }
+
+        return resolvedTexturePath;
+    }
+
+    private static bool IsSupportedAppearanceElement(XElement appearanceElement)
+    {
+        return appearanceElement.Name == App + "ParameterizedTexture"
+            || appearanceElement.Name == App + "X3DMaterial"
+            || appearanceElement.Name == App + "GeoreferencedTexture";
+    }
+
+    private static string? StripReferencePrefix(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.StartsWith('#')
+            ? value[1..]
+            : value;
+    }
+
+    private static double? TryParseDouble(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        double[] values = LocalCityGmlObjectProjection.ParseDoubles(value);
+        return values.Length == 0 ? null : values[0];
+    }
+
+    private static ResoniteColor ParseColor(string? value, ResoniteColor fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        double[] values = LocalCityGmlObjectProjection.ParseDoubles(value);
+        if (values.Length < 3)
+        {
+            return fallback;
+        }
+
+        return new ResoniteColor(
+            R: values[0],
+            G: values[1],
+            B: values[2],
+            A: values.Length >= 4 ? values[3] : 1.0);
+    }
+
+    private static ResoniteColor? TryParseColor(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        double[] values = LocalCityGmlObjectProjection.ParseDoubles(value);
+        if (values.Length < 3)
+        {
+            return null;
+        }
+
+        return new ResoniteColor(
+            R: values[0],
+            G: values[1],
+            B: values[2],
+            A: values.Length >= 4 ? values[3] : 1.0);
+    }
+}

--- a/src/Plateau.ResoniteLink/Formats/CityGml/CityGmlAppearanceStore.cs
+++ b/src/Plateau.ResoniteLink/Formats/CityGml/CityGmlAppearanceStore.cs
@@ -247,7 +247,12 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
             return null;
         }
 
-        double[] values = LocalCityGmlObjectProjection.ParseDoubles(value);
+        double[]? values = TryParseDoubles(value);
+        if (values is null)
+        {
+            return null;
+        }
+
         return values.Length == 0 ? null : values[0];
     }
 
@@ -258,7 +263,12 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
             return fallback;
         }
 
-        double[] values = LocalCityGmlObjectProjection.ParseDoubles(value);
+        double[]? values = TryParseDoubles(value);
+        if (values is null)
+        {
+            return fallback;
+        }
+
         if (values.Length < 3)
         {
             return fallback;
@@ -278,7 +288,12 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
             return null;
         }
 
-        double[] values = LocalCityGmlObjectProjection.ParseDoubles(value);
+        double[]? values = TryParseDoubles(value);
+        if (values is null)
+        {
+            return null;
+        }
+
         if (values.Length < 3)
         {
             return null;
@@ -289,5 +304,21 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
             G: values[1],
             B: values[2],
             A: values.Length >= 4 ? values[3] : 1.0);
+    }
+
+    private static double[]? TryParseDoubles(string value)
+    {
+        try
+        {
+            return LocalCityGmlObjectProjection.ParseDoubles(value);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+        catch (OverflowException)
+        {
+            return null;
+        }
     }
 }

--- a/src/Plateau.ResoniteLink/Formats/CityGml/CityGmlAppearanceStoreFactory.cs
+++ b/src/Plateau.ResoniteLink/Formats/CityGml/CityGmlAppearanceStoreFactory.cs
@@ -1,0 +1,13 @@
+namespace Plateau.ResoniteLink.Application.Importing;
+
+internal sealed class CityGmlAppearanceStoreFactory : ICityGmlAppearanceStoreFactory
+{
+    public ICityGmlAppearanceStore Create(
+        string sourceFileRelativePath,
+        IPlateauDatasetContentSource datasetSource)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceFileRelativePath);
+        ArgumentNullException.ThrowIfNull(datasetSource);
+        return new CityGmlAppearanceStore(sourceFileRelativePath, datasetSource);
+    }
+}

--- a/src/Plateau.ResoniteLink/Formats/CityGml/CityGmlLodSelector.cs
+++ b/src/Plateau.ResoniteLink/Formats/CityGml/CityGmlLodSelector.cs
@@ -1,0 +1,89 @@
+using System.Globalization;
+using System.Xml.Linq;
+
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Application.Importing;
+
+internal sealed class CityGmlLodSelector : ICityGmlLodSelector
+{
+    private static readonly XNamespace Gml = "http://www.opengis.net/gml";
+
+    public CityGmlLodSelection SelectPreferredSurfaceElements(
+        XElement cityObjectElement,
+        string packageName,
+        bool isMarking,
+        LodFilteringStrategy lodFilteringStrategy)
+    {
+        ArgumentNullException.ThrowIfNull(cityObjectElement);
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageName);
+        ArgumentNullException.ThrowIfNull(lodFilteringStrategy);
+
+        (XElement SurfaceElement, int? LodLevel)[] surfaces = cityObjectElement
+            .Descendants()
+            .Where(element => element.Name == Gml + "Polygon" || element.Name == Gml + "Triangle")
+            .Select(surfaceElement => (surfaceElement, GetSurfaceLodLevel(surfaceElement, cityObjectElement)))
+            .ToArray();
+
+        int[] explicitLodLevels = surfaces
+            .Where(static surface => surface.LodLevel.HasValue)
+            .Select(static surface => surface.LodLevel!.Value)
+            .ToArray();
+        int[] validLodLevels = explicitLodLevels
+            .Where(lod => !lodFilteringStrategy.ShouldExcludeLod(packageName, lod, isMarking))
+            .ToArray();
+
+        int? highestLod = validLodLevels.Length > 0
+            ? validLodLevels.Max()
+            : null;
+
+        XElement[] selectedSurfaces = highestLod.HasValue
+            ? surfaces
+                .Where(surface => surface.LodLevel == highestLod.Value)
+                .Select(static surface => surface.SurfaceElement)
+                .ToArray()
+            : surfaces
+                .Where(surface => !lodFilteringStrategy.ShouldExcludeLod(packageName, surface.LodLevel, isMarking))
+                .Select(static surface => surface.SurfaceElement)
+                .ToArray();
+
+        return new CityGmlLodSelection(selectedSurfaces, highestLod);
+    }
+
+    private static int? GetSurfaceLodLevel(XElement surfaceElement, XElement cityObjectElement)
+    {
+        for (XElement? ancestor = surfaceElement.Parent; ancestor is not null && ancestor != cityObjectElement; ancestor = ancestor.Parent)
+        {
+            if (TryParseLodLevel(ancestor.Name.LocalName, out int lodLevel))
+            {
+                return lodLevel;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryParseLodLevel(string localName, out int lodLevel)
+    {
+        lodLevel = 0;
+        if (!localName.StartsWith("lod", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        int digitStart = 3;
+        int digitLength = 0;
+        while (digitStart + digitLength < localName.Length
+            && char.IsDigit(localName[digitStart + digitLength]))
+        {
+            digitLength++;
+        }
+
+        return digitLength > 0
+            && int.TryParse(
+                localName.AsSpan(digitStart, digitLength),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out lodLevel);
+    }
+}

--- a/src/Plateau.ResoniteLink/Formats/CityGml/ICityGmlAppearanceStore.cs
+++ b/src/Plateau.ResoniteLink/Formats/CityGml/ICityGmlAppearanceStore.cs
@@ -1,0 +1,12 @@
+using System.Xml.Linq;
+
+namespace Plateau.ResoniteLink.Application.Importing;
+
+internal interface ICityGmlAppearanceStore
+{
+    void LoadFromDocument(XDocument document);
+
+    void ApplyAppearanceElement(XElement appearanceElement);
+
+    CityGmlResolvedAppearance Resolve(string polygonId);
+}

--- a/src/Plateau.ResoniteLink/Formats/CityGml/ICityGmlAppearanceStoreFactory.cs
+++ b/src/Plateau.ResoniteLink/Formats/CityGml/ICityGmlAppearanceStoreFactory.cs
@@ -1,0 +1,8 @@
+namespace Plateau.ResoniteLink.Application.Importing;
+
+internal interface ICityGmlAppearanceStoreFactory
+{
+    ICityGmlAppearanceStore Create(
+        string sourceFileRelativePath,
+        IPlateauDatasetContentSource datasetSource);
+}

--- a/src/Plateau.ResoniteLink/Formats/CityGml/ICityGmlLodSelector.cs
+++ b/src/Plateau.ResoniteLink/Formats/CityGml/ICityGmlLodSelector.cs
@@ -1,0 +1,14 @@
+using System.Xml.Linq;
+
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Application.Importing;
+
+internal interface ICityGmlLodSelector
+{
+    CityGmlLodSelection SelectPreferredSurfaceElements(
+        XElement cityObjectElement,
+        string packageName,
+        bool isMarking,
+        LodFilteringStrategy lodFilteringStrategy);
+}

--- a/src/Plateau.ResoniteLink/Formats/CityGml/LocalCityGmlDocumentReader.cs
+++ b/src/Plateau.ResoniteLink/Formats/CityGml/LocalCityGmlDocumentReader.cs
@@ -4,6 +4,22 @@ namespace Plateau.ResoniteLink.Application.Importing;
 
 public sealed class LocalCityGmlDocumentReader : ICityGmlDocumentReader
 {
+    private readonly ICityGmlAppearanceStoreFactory appearanceStoreFactory;
+    private readonly ICityGmlLodSelector lodSelector;
+
+    public LocalCityGmlDocumentReader()
+        : this(new CityGmlAppearanceStoreFactory(), new CityGmlLodSelector())
+    {
+    }
+
+    internal LocalCityGmlDocumentReader(
+        ICityGmlAppearanceStoreFactory appearanceStoreFactory,
+        ICityGmlLodSelector lodSelector)
+    {
+        this.appearanceStoreFactory = appearanceStoreFactory;
+        this.lodSelector = lodSelector;
+    }
+
     public async Task<LocalCityGmlDocumentSet> ReadAsync(
         PlateauImportRequest request,
         Action<string>? progressReporter = null,
@@ -11,6 +27,8 @@ public sealed class LocalCityGmlDocumentReader : ICityGmlDocumentReader
     {
         return await LocalCityGmlBootstrapPipeline.ReadAsync(
             request,
+            appearanceStoreFactory,
+            lodSelector,
             progressReporter,
             cancellationToken);
     }

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlBootstrapParsedObjectModels.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlBootstrapParsedObjectModels.cs
@@ -85,7 +85,9 @@ internal sealed record BootstrapParsedCityObject(
     string SourceIdentity,
     bool SharedAcrossMeshCodes,
     bool TerrainAligned = false,
-    GeodeticPoint? OriginOverride = null)
+    GeodeticPoint? OriginOverride = null,
+    int? FloorsAboveGround = null,
+    double? MeasuredHeightMeters = null)
 {
     internal LocalCityGmlObjectProjection.ParsedCityObject ToLegacy()
     {
@@ -102,7 +104,9 @@ internal sealed record BootstrapParsedCityObject(
             SourceIdentity,
             SharedAcrossMeshCodes,
             TerrainAligned,
-            OriginOverride?.ToLegacy());
+            OriginOverride?.ToLegacy(),
+            FloorsAboveGround,
+            MeasuredHeightMeters);
     }
 
     internal static BootstrapParsedCityObject FromLegacy(LocalCityGmlObjectProjection.ParsedCityObject cityObject)
@@ -120,6 +124,8 @@ internal sealed record BootstrapParsedCityObject(
             cityObject.SourceIdentity,
             cityObject.SharedAcrossMeshCodes,
             cityObject.TerrainAligned,
-            cityObject.OriginOverride is null ? null : GeodeticPoint.FromLegacy(cityObject.OriginOverride));
+            cityObject.OriginOverride is null ? null : GeodeticPoint.FromLegacy(cityObject.OriginOverride),
+            cityObject.FloorsAboveGround,
+            cityObject.MeasuredHeightMeters);
     }
 }

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlBootstrapPipeline.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlBootstrapPipeline.cs
@@ -9,18 +9,24 @@ internal static class LocalCityGmlBootstrapPipeline
 {
     public static async Task<LocalCityGmlDocumentSet> ReadAsync(
         PlateauImportRequest request,
+        ICityGmlAppearanceStoreFactory? appearanceStoreFactory = null,
+        ICityGmlLodSelector? lodSelector = null,
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default)
     {
-        return await ReadDocumentSetCoreAsync(request, progressReporter, cancellationToken);
+        return await ReadDocumentSetCoreAsync(request, progressReporter, appearanceStoreFactory, lodSelector, cancellationToken);
     }
 
     internal static async Task<LocalCityGmlDocumentSet> ReadDocumentSetCoreAsync(
         PlateauImportRequest request,
         Action<string>? progressReporter = null,
+        ICityGmlAppearanceStoreFactory? appearanceStoreFactory = null,
+        ICityGmlLodSelector? lodSelector = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+        appearanceStoreFactory ??= new CityGmlAppearanceStoreFactory();
+        lodSelector ??= new CityGmlLodSelector();
 
         if (request.Source is not PlateauLocalImportSource localSource || string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
         {
@@ -75,6 +81,8 @@ internal static class LocalCityGmlBootstrapPipeline
                 requestedMeshAreas,
                 progressReporter,
                 lodFilteringStrategy,
+                appearanceStoreFactory,
+                lodSelector,
                 cancellationToken);
         ParsedSourceFileResult[] demParsedSourceFiles = (await Task.WhenAll(
             sourceFilePipelines

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.Bootstrap.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.Bootstrap.cs
@@ -10,6 +10,8 @@ public static partial class LocalCityGmlObjectProjection
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         Action<string>? progressReporter,
         LodFilteringStrategy lodFilteringStrategy,
+        ICityGmlAppearanceStoreFactory appearanceStoreFactory,
+        ICityGmlLodSelector lodSelector,
         CancellationToken cancellationToken)
     {
         global::Plateau.ResoniteLink.Application.Importing.SourceFilePipeline[] pipelines = await CreateSourceFilePipelinesCoreAsync(
@@ -18,6 +20,8 @@ public static partial class LocalCityGmlObjectProjection
             requestedMeshAreas,
             progressReporter,
             lodFilteringStrategy,
+            appearanceStoreFactory,
+            lodSelector,
             cancellationToken);
 
         return pipelines.Select(static pipeline => pipeline.ToLegacy()).ToArray();
@@ -29,6 +33,8 @@ public static partial class LocalCityGmlObjectProjection
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         Action<string>? progressReporter,
         LodFilteringStrategy lodFilteringStrategy,
+        ICityGmlAppearanceStoreFactory appearanceStoreFactory,
+        ICityGmlLodSelector lodSelector,
         CancellationToken cancellationToken)
     {
         return ParseSourceFileCoreAsync(
@@ -37,6 +43,8 @@ public static partial class LocalCityGmlObjectProjection
                 requestedMeshAreas,
                 progressReporter,
                 lodFilteringStrategy,
+                appearanceStoreFactory,
+                lodSelector,
                 cancellationToken)
             .ContinueWith(
                 static task => task.GetAwaiter().GetResult().ToLegacy(),
@@ -50,6 +58,8 @@ public static partial class LocalCityGmlObjectProjection
         IPlateauDatasetContentSource datasetSource,
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         LodFilteringStrategy? lodFilteringStrategy,
+        ICityGmlAppearanceStoreFactory appearanceStoreFactory,
+        ICityGmlLodSelector lodSelector,
         CancellationToken cancellationToken = default)
     {
         return StreamParsedCityObjectsCoreAsync(
@@ -57,6 +67,8 @@ public static partial class LocalCityGmlObjectProjection
             datasetSource,
             requestedMeshAreas,
             lodFilteringStrategy,
+            appearanceStoreFactory,
+            lodSelector,
             parsedReferenceSystem: null,
             cancellationToken);
     }

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.SourceFileParser.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.SourceFileParser.cs
@@ -23,6 +23,8 @@ public static partial class LocalCityGmlObjectProjection
         return await LocalCityGmlBootstrapPipeline.ReadDocumentSetCoreAsync(
             request,
             progressReporter,
+            appearanceStoreFactory: null,
+            lodSelector: null,
             cancellationToken);
     }
 
@@ -32,6 +34,8 @@ public static partial class LocalCityGmlObjectProjection
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         Action<string>? progressReporter,
         LodFilteringStrategy lodFilteringStrategy,
+        ICityGmlAppearanceStoreFactory appearanceStoreFactory,
+        ICityGmlLodSelector lodSelector,
         CancellationToken cancellationToken)
     {
         return Task.FromResult(
@@ -45,12 +49,16 @@ public static partial class LocalCityGmlObjectProjection
                             requestedMeshAreas,
                             progressReporter,
                             lodFilteringStrategy,
+                            appearanceStoreFactory,
+                            lodSelector,
                             cancellationToken),
                         streamFactory: cancellationToken => StreamBootstrapParsedCityObjectsCoreAsync(
                             sourceFile,
                             datasetSource,
                             requestedMeshAreas,
                             lodFilteringStrategy,
+                            appearanceStoreFactory,
+                            lodSelector,
                             cancellationToken)))
                 .ToArray());
     }
@@ -61,6 +69,8 @@ public static partial class LocalCityGmlObjectProjection
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         Action<string>? progressReporter,
         LodFilteringStrategy lodFilteringStrategy,
+        ICityGmlAppearanceStoreFactory appearanceStoreFactory,
+        ICityGmlLodSelector lodSelector,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -73,6 +83,8 @@ public static partial class LocalCityGmlObjectProjection
                            datasetSource,
                            requestedMeshAreas,
                            lodFilteringStrategy,
+                           appearanceStoreFactory,
+                           lodSelector,
                            parsedReferenceSystem: parsedReferenceSystem => coordinateReferenceSystem ??= parsedReferenceSystem,
                            cancellationToken))
         {
@@ -113,6 +125,8 @@ public static partial class LocalCityGmlObjectProjection
         IPlateauDatasetContentSource datasetSource,
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         LodFilteringStrategy? lodFilteringStrategy,
+        ICityGmlAppearanceStoreFactory appearanceStoreFactory,
+        ICityGmlLodSelector lodSelector,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         await foreach (ParsedCityObject cityObject in StreamParsedCityObjectsCoreAsync(
@@ -120,6 +134,8 @@ public static partial class LocalCityGmlObjectProjection
                            datasetSource,
                            requestedMeshAreas,
                            lodFilteringStrategy,
+                           appearanceStoreFactory,
+                           lodSelector,
                            parsedReferenceSystem: null,
                            cancellationToken))
         {
@@ -132,6 +148,8 @@ public static partial class LocalCityGmlObjectProjection
         IPlateauDatasetContentSource datasetSource,
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         LodFilteringStrategy? lodFilteringStrategy,
+        ICityGmlAppearanceStoreFactory appearanceStoreFactory,
+        ICityGmlLodSelector lodSelector,
         Action<CoordinateReferenceSystem>? parsedReferenceSystem = null,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
@@ -144,6 +162,8 @@ public static partial class LocalCityGmlObjectProjection
                                datasetSource,
                                requestedMeshAreas,
                                lodFilteringStrategy,
+                               appearanceStoreFactory,
+                               lodSelector,
                                parsedReferenceSystem,
                                cancellationToken))
             {
@@ -160,6 +180,8 @@ public static partial class LocalCityGmlObjectProjection
             datasetSource,
             requestedMeshAreas,
             lodFilteringStrategy,
+            appearanceStoreFactory,
+            lodSelector,
             parsedReferenceSystem,
             cancellationToken))
         {
@@ -225,13 +247,13 @@ public static partial class LocalCityGmlObjectProjection
         IPlateauDatasetContentSource datasetSource,
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         LodFilteringStrategy? lodFilteringStrategy,
+        ICityGmlAppearanceStoreFactory appearanceStoreFactory,
+        ICityGmlLodSelector lodSelector,
         Action<CoordinateReferenceSystem>? parsedReferenceSystem,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
     {
         lodFilteringStrategy ??= new LodFilteringStrategy();
-        Dictionary<string, ResoniteColor> colorsByPolygonId = new(StringComparer.Ordinal);
-        Dictionary<string, TextureAssignment> texturesByPolygonId = new(StringComparer.Ordinal);
-        AppearanceLibrary appearanceLibrary = new(colorsByPolygonId, datasetSource, texturesByPolygonId);
+        ICityGmlAppearanceStore appearanceStore = appearanceStoreFactory.Create(sourceFile.RelativePath, datasetSource);
         CoordinateReferenceSystem coordinateReferenceSystem = CoordinateReferenceSystem.Parse((string?)null);
 
         using XmlReader reader = XmlReader.Create(stream, CreateStreamingReaderSettings());
@@ -265,11 +287,7 @@ public static partial class LocalCityGmlObjectProjection
                         using (XmlReader textureSubtreeReader = reader.ReadSubtree())
                         {
                             XElement textureElement = await XElement.LoadAsync(textureSubtreeReader, LoadOptions.None, cancellationToken);
-                            AppearanceLibrary.ParseParameterizedTexture(
-                                textureElement,
-                                sourceFile.RelativePath,
-                                datasetSource,
-                                texturesByPolygonId);
+                            appearanceStore.ApplyAppearanceElement(textureElement);
                         }
 
                         continue;
@@ -277,7 +295,15 @@ public static partial class LocalCityGmlObjectProjection
                         using (XmlReader materialSubtreeReader = reader.ReadSubtree())
                         {
                             XElement materialElement = await XElement.LoadAsync(materialSubtreeReader, LoadOptions.None, cancellationToken);
-                            AppearanceLibrary.ParseX3DMaterial(materialElement, colorsByPolygonId);
+                            appearanceStore.ApplyAppearanceElement(materialElement);
+                        }
+
+                        continue;
+                    case "GeoreferencedTexture":
+                        using (XmlReader textureSubtreeReader = reader.ReadSubtree())
+                        {
+                            XElement textureElement = await XElement.LoadAsync(textureSubtreeReader, LoadOptions.None, cancellationToken);
+                            appearanceStore.ApplyAppearanceElement(textureElement);
                         }
 
                         continue;
@@ -304,7 +330,8 @@ public static partial class LocalCityGmlObjectProjection
                 sourceFile.RelativePath,
                 sourceFile.MatchedMeshCode,
                 sourceFile.RequiresMeshAreaFilter,
-                appearanceLibrary,
+                appearanceStore,
+                lodSelector,
                 coordinateReferenceSystem,
                 sourceFile.RequiresMeshAreaFilter ? requestedMeshAreas : null,
                 lodFilteringStrategy);
@@ -322,6 +349,8 @@ public static partial class LocalCityGmlObjectProjection
         IPlateauDatasetContentSource datasetSource,
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         LodFilteringStrategy? lodFilteringStrategy,
+        ICityGmlAppearanceStoreFactory appearanceStoreFactory,
+        ICityGmlLodSelector lodSelector,
         Action<CoordinateReferenceSystem>? parsedReferenceSystem,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
     {
@@ -330,10 +359,8 @@ public static partial class LocalCityGmlObjectProjection
         XDocument cityModel = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken);
         CoordinateReferenceSystem coordinateReferenceSystem = CoordinateReferenceSystem.Parse(cityModel);
         parsedReferenceSystem?.Invoke(coordinateReferenceSystem);
-        AppearanceLibrary appearanceLibrary = AppearanceLibrary.Parse(
-            cityModel,
-            sourceFile.RelativePath,
-            datasetSource);
+        ICityGmlAppearanceStore appearanceStore = appearanceStoreFactory.Create(sourceFile.RelativePath, datasetSource);
+        appearanceStore.LoadFromDocument(cityModel);
 
         if (cityModel.Root is null)
         {
@@ -355,7 +382,8 @@ public static partial class LocalCityGmlObjectProjection
                 sourceFile.RelativePath,
                 sourceFile.MatchedMeshCode,
                 sourceFile.RequiresMeshAreaFilter,
-                appearanceLibrary,
+                appearanceStore,
+                lodSelector,
                 coordinateReferenceSystem,
                 sourceFile.RequiresMeshAreaFilter ? requestedMeshAreas : null,
                 lodFilteringStrategy);

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.cs
@@ -476,6 +476,13 @@ public static partial class LocalCityGmlObjectProjection
             return null;
         }
 
+        string? unitOfMeasure = element.Attribute("uom")?.Value.Trim();
+        if (!string.IsNullOrWhiteSpace(unitOfMeasure)
+            && !string.Equals(unitOfMeasure, "m", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
         return double.TryParse(element.Value.Trim(), CultureInfo.InvariantCulture, out double value) && value > 0.0
             ? value
             : null;

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.cs
@@ -137,6 +137,102 @@ public static partial class LocalCityGmlObjectProjection
             SharedAcrossMeshCodes: sharedAcrossMeshCodes);
     }
 
+    private static ParsedCityObject? ParseCityObject(
+        XElement cityObjectElement,
+        string packageName,
+        string relativeSourceFile,
+        string actualMeshCode,
+        bool sharedAcrossMeshCodes,
+        ICityGmlAppearanceStore appearanceStore,
+        ICityGmlLodSelector lodSelector,
+        CoordinateReferenceSystem coordinateReferenceSystem,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshAreas,
+        LodFilteringStrategy lodFilteringStrategy)
+    {
+        string objectTypeName = cityObjectElement.Name.LocalName;
+        string objectId = GetAttribute(cityObjectElement, Gml + "id") ?? objectTypeName;
+        string? displayName = cityObjectElement.Elements(Gml + "name").FirstOrDefault()?.Value.Trim();
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = objectId;
+        }
+
+        string resolvedActualMeshCode =
+            sharedAcrossMeshCodes && string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase)
+                ? ResolveConcreteActualMeshCode(displayName!, objectId, actualMeshCode)
+                : actualMeshCode;
+        int? floorsAboveGround = TryParseStoreysAboveGround(cityObjectElement);
+        double? measuredHeightMeters = TryParseMeasuredHeightMeters(cityObjectElement);
+
+        bool isMarking = displayName.Contains("Marking", StringComparison.OrdinalIgnoreCase)
+            || objectId.Contains("Marking", StringComparison.OrdinalIgnoreCase)
+            || objectId.Contains("_road_marking", StringComparison.Ordinal);
+
+        CityGmlLodSelection lodSelection = lodSelector.SelectPreferredSurfaceElements(
+            cityObjectElement,
+            packageName,
+            isMarking,
+            lodFilteringStrategy);
+        XElement[] preferredSurfaceElements = lodSelection.SurfaceElements;
+        int? lodLevel = lodSelection.LodLevel;
+
+        if (!lodFilteringStrategy.ShouldIncludeByPattern(packageName, objectId, isMarking))
+        {
+            return null;
+        }
+
+        if (preferredSurfaceElements.Length == 0 && lodFilteringStrategy.ShouldExcludeLod(packageName, lodLevel, isMarking))
+        {
+            return null;
+        }
+
+        ParsedSurface[] surfaces = preferredSurfaceElements
+            .Select(surfaceElement => ParseSurface(surfaceElement, appearanceStore))
+            .Where(static surface => surface is not null)
+            .Select(static surface => surface!)
+            .Select(surface => ApplyPackageSurfaceDefaults(packageName, surface))
+            .OrderBy(static surface => CreateStableSurfaceSortKey(surface), StringComparer.Ordinal)
+            .ToArray();
+
+        if (surfaces.Length == 0)
+        {
+            return null;
+        }
+
+        if (requestedMeshAreas is not null
+            && requestedMeshAreas.Count > 0
+            && coordinateReferenceSystem.IsGeographic)
+        {
+            bool intersectsRequestedMeshArea = sharedAcrossMeshCodes
+                && TryCreateMeshCodeBounds(resolvedActualMeshCode, out MeshCodeBounds? resolvedActualMeshArea)
+                    ? IntersectsMeshCodeBounds(resolvedActualMeshArea!, requestedMeshAreas)
+                    : IntersectsMeshCodeBounds(surfaces, requestedMeshAreas);
+            if (!intersectsRequestedMeshArea)
+            {
+                return null;
+            }
+        }
+
+        string fileStem = Path.GetFileNameWithoutExtension(relativeSourceFile);
+        string slotKey = SanitizeIdentifier($"{packageName}_{fileStem}_{objectId}");
+        string sourceUnitIdentity = SanitizeIdentifier(relativeSourceFile);
+        string sourceIdentity = SanitizeIdentifier($"{relativeSourceFile}_{objectId}");
+        return new ParsedCityObject(
+            slotKey,
+            displayName!,
+            packageName,
+            resolvedActualMeshCode,
+            lodLevel,
+            surfaces,
+            coordinateReferenceSystem,
+            relativeSourceFile,
+            sourceUnitIdentity,
+            sourceIdentity,
+            SharedAcrossMeshCodes: sharedAcrossMeshCodes,
+            FloorsAboveGround: floorsAboveGround,
+            MeasuredHeightMeters: measuredHeightMeters);
+    }
+
     internal static TerrainTextureOverlay[] CreateDemTerrainTextureOverlays(
         MeshCodeBounds demBounds,
         IReadOnlyList<string> requestedMeshCodes)
@@ -355,6 +451,34 @@ public static partial class LocalCityGmlObjectProjection
     {
         meshCodeArea = MeshCodeBounds.TryParse(meshCode);
         return meshCodeArea is not null;
+    }
+
+    private static int? TryParseStoreysAboveGround(XElement cityObjectElement)
+    {
+        XElement? element = cityObjectElement.Elements()
+            .FirstOrDefault(static child => string.Equals(child.Name.LocalName, "storeysAboveGround", StringComparison.Ordinal));
+        if (element is null)
+        {
+            return null;
+        }
+
+        return int.TryParse(element.Value.Trim(), CultureInfo.InvariantCulture, out int value) && value >= 0
+            ? value
+            : null;
+    }
+
+    private static double? TryParseMeasuredHeightMeters(XElement cityObjectElement)
+    {
+        XElement? element = cityObjectElement.Elements()
+            .FirstOrDefault(static child => string.Equals(child.Name.LocalName, "measuredHeight", StringComparison.Ordinal));
+        if (element is null)
+        {
+            return null;
+        }
+
+        return double.TryParse(element.Value.Trim(), CultureInfo.InvariantCulture, out double value) && value > 0.0
+            ? value
+            : null;
     }
 
     private static string CreateStableElementId(string prefix, XElement element)
@@ -1086,6 +1210,46 @@ public static partial class LocalCityGmlObjectProjection
 
         string polygonId = GetAttribute(polygonElement, Gml + "id") ?? CreateStableElementId("polygon", polygonElement);
         SurfaceAppearance appearance = appearanceLibrary.Resolve(polygonId);
+        ParsedRing? exteriorParsedRing = ParseRing(
+            exteriorRing,
+            appearance.RingUvsByRingId,
+            fallbackRingId: polygonId);
+        if (exteriorParsedRing is null)
+        {
+            return null;
+        }
+
+        ParsedRing[] interiorRings = polygonElement
+            .Elements(Gml + "interior")
+            .Select(interiorElement => ParseRing(
+                interiorElement.Element(Gml + "LinearRing"),
+                appearance.RingUvsByRingId,
+                fallbackRingId: null))
+            .Where(static ring => ring is not null)
+            .Select(static ring => ring!)
+            .ToArray();
+
+        return new ParsedSurface(
+            PolygonId: polygonId,
+            Semantic: ParseSurfaceSemantic(polygonElement),
+            ExteriorRing: exteriorParsedRing,
+            InteriorRings: interiorRings,
+            BaseColor: appearance.BaseColor,
+            TexturePayload: appearance.TexturePayload);
+    }
+
+    private static ParsedSurface? ParseSurface(XElement polygonElement, ICityGmlAppearanceStore appearanceStore)
+    {
+        XElement? exteriorRing = polygonElement
+            .Element(Gml + "exterior")
+            ?.Element(Gml + "LinearRing");
+        if (exteriorRing is null)
+        {
+            return null;
+        }
+
+        string polygonId = GetAttribute(polygonElement, Gml + "id") ?? CreateStableElementId("polygon", polygonElement);
+        CityGmlResolvedAppearance appearance = appearanceStore.Resolve(polygonId);
         ParsedRing? exteriorParsedRing = ParseRing(
             exteriorRing,
             appearance.RingUvsByRingId,
@@ -2553,7 +2717,7 @@ public static partial class LocalCityGmlObjectProjection
         return element.Attribute(attributeName)?.Value;
     }
 
-    private static double[] ParseDoubles(string value)
+    internal static double[] ParseDoubles(string value)
     {
         return value
             .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
@@ -2561,7 +2725,7 @@ public static partial class LocalCityGmlObjectProjection
             .ToArray();
     }
 
-    private static List<ResoniteFloat2> ParseTextureCoordinates(string value)
+    internal static List<ResoniteFloat2> ParseTextureCoordinates(string value)
     {
         double[] ordinates = ParseDoubles(value);
         List<ResoniteFloat2> coordinates = [];
@@ -3718,7 +3882,9 @@ public static partial class LocalCityGmlObjectProjection
         string SourceIdentity,
         bool SharedAcrossMeshCodes,
         bool TerrainAligned = false,
-        GeodeticPoint? OriginOverride = null);
+        GeodeticPoint? OriginOverride = null,
+        int? FloorsAboveGround = null,
+        double? MeasuredHeightMeters = null);
 
     internal sealed record SourceFileDescriptor(
         string RelativePath,

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/PlateauCityGmlImportComposition.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/PlateauCityGmlImportComposition.cs
@@ -6,7 +6,18 @@ internal static class PlateauCityGmlImportComposition
 {
     public static ICityGmlDocumentReader CreateDocumentReader()
     {
-        return new LocalCityGmlDocumentReader();
+        return new LocalCityGmlDocumentReader(
+            new CityGmlAppearanceStoreFactory(),
+            new CityGmlLodSelector());
+    }
+
+    public static ICityGmlDocumentReader CreateDocumentReader(
+        ICityGmlAppearanceStoreFactory appearanceStoreFactory,
+        ICityGmlLodSelector lodSelector)
+    {
+        ArgumentNullException.ThrowIfNull(appearanceStoreFactory);
+        ArgumentNullException.ThrowIfNull(lodSelector);
+        return new LocalCityGmlDocumentReader(appearanceStoreFactory, lodSelector);
     }
 
     public static IDefaultMaterialResolver CreateMaterialResolver()

--- a/src/Plateau.ResoniteLink/UseCases/Importing/PlateauImportServiceCollectionExtensions.cs
+++ b/src/Plateau.ResoniteLink/UseCases/Importing/PlateauImportServiceCollectionExtensions.cs
@@ -10,7 +10,12 @@ public static class PlateauImportServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.AddSingleton<ICityGmlDocumentReader>(_ => PlateauCityGmlImportComposition.CreateDocumentReader());
+        services.AddSingleton<ICityGmlAppearanceStoreFactory, CityGmlAppearanceStoreFactory>();
+        services.AddSingleton<ICityGmlLodSelector, CityGmlLodSelector>();
+        services.AddSingleton<ICityGmlDocumentReader>(provider =>
+            PlateauCityGmlImportComposition.CreateDocumentReader(
+                provider.GetRequiredService<ICityGmlAppearanceStoreFactory>(),
+                provider.GetRequiredService<ICityGmlLodSelector>()));
         services.AddSingleton<IDefaultMaterialResolver>(_ => PlateauCityGmlImportComposition.CreateMaterialResolver());
         services.AddSingleton<ICityGmlGeometryProjector>(provider =>
             PlateauCityGmlImportComposition.CreateGeometryProjector(

--- a/tests/Plateau.ResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
@@ -1,0 +1,125 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Xml.Linq;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+using Plateau.ResoniteLink.Application.Importing;
+
+namespace Plateau.ResoniteLink.Tests.Formats;
+
+[SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test names describe contract cases.")]
+public sealed class CityGmlAppearanceStoreTests
+{
+    [Fact]
+    public async Task Resolve_PreservesParameterizedTextureAndX3dMaterialAttributes()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        string packageDirectory = Path.Combine(datasetRoot.Path, "udx", "bldg", "53394525");
+        string appearanceDirectory = Path.Combine(packageDirectory, "appearance");
+        Directory.CreateDirectory(appearanceDirectory);
+
+        using (Image<Rgba32> image = new(1, 1, new Rgba32(255, 255, 255, 255)))
+        {
+            await image.SaveAsPngAsync(Path.Combine(appearanceDirectory, "roof.png"));
+        }
+
+        IPlateauDatasetContentSource datasetSource = await PlateauDatasetContentSourceFactory.CreateAsync(datasetRoot.Path);
+        ICityGmlAppearanceStore store = new CityGmlAppearanceStoreFactory().Create(
+            "udx/bldg/53394525/example.gml",
+            datasetSource);
+        XDocument document = XDocument.Parse(
+            """
+            <core:CityModel xmlns:app="http://www.opengis.net/citygml/appearance/2.0" xmlns:core="http://www.opengis.net/citygml/2.0">
+              <app:appearanceMember>
+                <app:Appearance>
+                  <app:surfaceDataMember>
+                    <app:ParameterizedTexture>
+                      <app:imageURI>appearance/roof.png</app:imageURI>
+                      <app:mimeType>image/png</app:mimeType>
+                      <app:target uri="#poly-1">
+                        <app:TexCoordList>
+                          <app:textureCoordinates ring="#ring-1">0 0 1 0 1 1 0 1</app:textureCoordinates>
+                        </app:TexCoordList>
+                      </app:target>
+                    </app:ParameterizedTexture>
+                  </app:surfaceDataMember>
+                  <app:surfaceDataMember>
+                    <app:X3DMaterial>
+                      <app:ambientIntensity>0.25</app:ambientIntensity>
+                      <app:diffuseColor>0.2 0.4 0.6</app:diffuseColor>
+                      <app:emissiveColor>0.1 0.2 0.3</app:emissiveColor>
+                      <app:specularColor>0.7 0.8 0.9</app:specularColor>
+                      <app:shininess>0.5</app:shininess>
+                      <app:transparency>0.15</app:transparency>
+                      <app:target uri="#poly-1" />
+                    </app:X3DMaterial>
+                  </app:surfaceDataMember>
+                </app:Appearance>
+              </app:appearanceMember>
+            </core:CityModel>
+            """);
+
+        store.LoadFromDocument(document);
+        CityGmlResolvedAppearance appearance = store.Resolve("poly-1");
+
+        Assert.Equal(0.2, appearance.BaseColor.R, 6);
+        Assert.NotNull(appearance.TexturePayload);
+        Assert.NotNull(appearance.ParameterizedTexture);
+        Assert.Equal("image/png", appearance.ParameterizedTexture!.MimeType);
+        Assert.NotNull(appearance.MaterialAttributes);
+        Assert.Equal(0.25, appearance.MaterialAttributes!.AmbientIntensity!.Value, 6);
+        Assert.Equal(0.5, appearance.MaterialAttributes.Shininess!.Value, 6);
+        Assert.Equal(0.15, appearance.MaterialAttributes.Transparency!.Value, 6);
+        Assert.NotNull(appearance.MaterialAttributes.EmissiveColor);
+        Assert.NotNull(appearance.MaterialAttributes.SpecularColor);
+        Assert.True(appearance.RingUvsByRingId!.ContainsKey("ring-1"));
+    }
+
+    [Fact]
+    public async Task Resolve_ExposesGeoreferencedTextureMetadataWithoutDatasetPayload()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        string packageDirectory = Path.Combine(datasetRoot.Path, "udx", "bldg", "53394525");
+        string appearanceDirectory = Path.Combine(packageDirectory, "appearance");
+        Directory.CreateDirectory(appearanceDirectory);
+
+        using (Image<Rgba32> image = new(1, 1, new Rgba32(255, 255, 255, 255)))
+        {
+            await image.SaveAsPngAsync(Path.Combine(appearanceDirectory, "ortho.png"));
+        }
+
+        IPlateauDatasetContentSource datasetSource = await PlateauDatasetContentSourceFactory.CreateAsync(datasetRoot.Path);
+        ICityGmlAppearanceStore store = new CityGmlAppearanceStoreFactory().Create(
+            "udx/bldg/53394525/example.gml",
+            datasetSource);
+        XDocument document = XDocument.Parse(
+            """
+            <core:CityModel xmlns:app="http://www.opengis.net/citygml/appearance/2.0" xmlns:core="http://www.opengis.net/citygml/2.0">
+              <app:appearanceMember>
+                <app:Appearance>
+                  <app:surfaceDataMember>
+                    <app:GeoreferencedTexture>
+                      <app:imageURI>appearance/ortho.png</app:imageURI>
+                      <app:mimeType>image/png</app:mimeType>
+                      <app:referencePoint>35.0 139.0 10.0</app:referencePoint>
+                      <app:orientation>0 1</app:orientation>
+                      <app:target uri="#poly-geo" />
+                    </app:GeoreferencedTexture>
+                  </app:surfaceDataMember>
+                </app:Appearance>
+              </app:appearanceMember>
+            </core:CityModel>
+            """);
+
+        store.LoadFromDocument(document);
+        CityGmlResolvedAppearance appearance = store.Resolve("poly-geo");
+
+        Assert.Equal(1.0, appearance.BaseColor.R, 6);
+        Assert.Null(appearance.TexturePayload);
+        Assert.NotNull(appearance.GeoreferencedTexture);
+        Assert.Equal("image/png", appearance.GeoreferencedTexture!.MimeType);
+        Assert.Equal("35.0 139.0 10.0", appearance.GeoreferencedTexture.ReferencePoint);
+        Assert.Equal("0 1", appearance.GeoreferencedTexture.Orientation);
+    }
+}

--- a/tests/Plateau.ResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
@@ -122,4 +122,94 @@ public sealed class CityGmlAppearanceStoreTests
         Assert.Equal("35.0 139.0 10.0", appearance.GeoreferencedTexture.ReferencePoint);
         Assert.Equal("0 1", appearance.GeoreferencedTexture.Orientation);
     }
+
+    [Fact]
+    public async Task Resolve_IgnoresMalformedOptionalBorderColor()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        string packageDirectory = Path.Combine(datasetRoot.Path, "udx", "bldg", "53394525");
+        string appearanceDirectory = Path.Combine(packageDirectory, "appearance");
+        Directory.CreateDirectory(appearanceDirectory);
+
+        using (Image<Rgba32> image = new(1, 1, new Rgba32(255, 255, 255, 255)))
+        {
+            await image.SaveAsPngAsync(Path.Combine(appearanceDirectory, "roof.png"));
+        }
+
+        IPlateauDatasetContentSource datasetSource = await PlateauDatasetContentSourceFactory.CreateAsync(datasetRoot.Path);
+        ICityGmlAppearanceStore store = new CityGmlAppearanceStoreFactory().Create(
+            "udx/bldg/53394525/example.gml",
+            datasetSource);
+        XDocument document = XDocument.Parse(
+            """
+            <core:CityModel xmlns:app="http://www.opengis.net/citygml/appearance/2.0" xmlns:core="http://www.opengis.net/citygml/2.0">
+              <app:appearanceMember>
+                <app:Appearance>
+                  <app:surfaceDataMember>
+                    <app:ParameterizedTexture>
+                      <app:imageURI>appearance/roof.png</app:imageURI>
+                      <app:borderColor>broken value</app:borderColor>
+                      <app:target uri="#poly-1">
+                        <app:TexCoordList>
+                          <app:textureCoordinates ring="#ring-1">0 0 1 0 1 1 0 1</app:textureCoordinates>
+                        </app:TexCoordList>
+                      </app:target>
+                    </app:ParameterizedTexture>
+                  </app:surfaceDataMember>
+                </app:Appearance>
+              </app:appearanceMember>
+            </core:CityModel>
+            """);
+
+        store.LoadFromDocument(document);
+        CityGmlResolvedAppearance appearance = store.Resolve("poly-1");
+
+        Assert.NotNull(appearance.ParameterizedTexture);
+        Assert.Null(appearance.ParameterizedTexture!.BorderColor);
+        Assert.NotNull(appearance.TexturePayload);
+    }
+
+    [Fact]
+    public async Task Resolve_IgnoresMalformedOptionalX3dMaterialFields()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        string packageDirectory = Path.Combine(datasetRoot.Path, "udx", "bldg", "53394525");
+        Directory.CreateDirectory(packageDirectory);
+
+        IPlateauDatasetContentSource datasetSource = await PlateauDatasetContentSourceFactory.CreateAsync(datasetRoot.Path);
+        ICityGmlAppearanceStore store = new CityGmlAppearanceStoreFactory().Create(
+            "udx/bldg/53394525/example.gml",
+            datasetSource);
+        XDocument document = XDocument.Parse(
+            """
+            <core:CityModel xmlns:app="http://www.opengis.net/citygml/appearance/2.0" xmlns:core="http://www.opengis.net/citygml/2.0">
+              <app:appearanceMember>
+                <app:Appearance>
+                  <app:surfaceDataMember>
+                    <app:X3DMaterial>
+                      <app:diffuseColor>0.2 0.4 0.6</app:diffuseColor>
+                      <app:ambientIntensity>broken</app:ambientIntensity>
+                      <app:emissiveColor>bad color</app:emissiveColor>
+                      <app:specularColor>still bad</app:specularColor>
+                      <app:shininess>oops</app:shininess>
+                      <app:transparency>nope</app:transparency>
+                      <app:target uri="#poly-1" />
+                    </app:X3DMaterial>
+                  </app:surfaceDataMember>
+                </app:Appearance>
+              </app:appearanceMember>
+            </core:CityModel>
+            """);
+
+        store.LoadFromDocument(document);
+        CityGmlResolvedAppearance appearance = store.Resolve("poly-1");
+
+        Assert.NotNull(appearance.MaterialAttributes);
+        Assert.Equal(0.2, appearance.MaterialAttributes!.DiffuseColor.R, 6);
+        Assert.Null(appearance.MaterialAttributes.AmbientIntensity);
+        Assert.Null(appearance.MaterialAttributes.EmissiveColor);
+        Assert.Null(appearance.MaterialAttributes.SpecularColor);
+        Assert.Null(appearance.MaterialAttributes.Shininess);
+        Assert.Null(appearance.MaterialAttributes.Transparency);
+    }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Formats/CityGmlLodSelectorTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Formats/CityGmlLodSelectorTests.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Xml.Linq;
+
+using Plateau.ResoniteLink.Application.Importing;
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Tests.Formats;
+
+[SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test names describe contract cases.")]
+public sealed class CityGmlLodSelectorTests
+{
+    [Fact]
+    public void SelectPreferredSurfaceElements_PicksHighestNonExcludedLod()
+    {
+        XElement cityObject = XElement.Parse(
+            """
+            <bldg:Building xmlns:bldg="http://www.opengis.net/citygml/building/2.0" xmlns:gml="http://www.opengis.net/gml">
+              <bldg:lod1MultiSurface>
+                <gml:MultiSurface>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="poly-lod1" />
+                  </gml:surfaceMember>
+                </gml:MultiSurface>
+              </bldg:lod1MultiSurface>
+              <bldg:lod2MultiSurface>
+                <gml:MultiSurface>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="poly-lod2" />
+                  </gml:surfaceMember>
+                </gml:MultiSurface>
+              </bldg:lod2MultiSurface>
+            </bldg:Building>
+            """);
+
+        CityGmlLodSelector selector = new();
+        CityGmlLodSelection selection = selector.SelectPreferredSurfaceElements(
+            cityObject,
+            "bldg",
+            isMarking: false,
+            new LodFilteringStrategy(globalExcludeLodLevels: new HashSet<int> { 2 }));
+
+        Assert.Equal(1, selection.LodLevel);
+        Assert.Single(selection.SurfaceElements);
+        Assert.Equal("poly-lod1", selection.SurfaceElements[0].Attribute(XName.Get("id", "http://www.opengis.net/gml"))?.Value);
+    }
+}

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
@@ -164,6 +164,72 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
         Assert.InRange(parsedCityObject.MeasuredHeightMeters!.Value, 11.799999, 11.800001);
     }
 
+    [Fact]
+    public async Task SourceFilePipeline_StreamParsedCityObjectsAsync_IgnoresMeasuredHeightWithNonMeterUnit()
+    {
+        string xml =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <core:CityModel xmlns:core="http://www.opengis.net/citygml/2.0" xmlns:gml="http://www.opengis.net/gml" xmlns:bldg="http://www.opengis.net/citygml/building/2.0">
+              <gml:boundedBy>
+                <gml:Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/6697" srsDimension="3">
+                  <gml:lowerCorner>35.0000 139.0000 0</gml:lowerCorner>
+                  <gml:upperCorner>35.0100 139.0100 12</gml:upperCorner>
+                </gml:Envelope>
+              </gml:boundedBy>
+              <core:cityObjectMember>
+                <bldg:Building gml:id="bldg-1">
+                  <gml:name>Building One</gml:name>
+                  <bldg:measuredHeight uom="ft">11.8</bldg:measuredHeight>
+                  <bldg:storeysAboveGround>4</bldg:storeysAboveGround>
+                  <bldg:lod2MultiSurface>
+                    <gml:MultiSurface>
+                      <gml:surfaceMember>
+                        <bldg:WallSurface>
+                          <gml:Polygon gml:id="poly-1">
+                            <gml:exterior>
+                              <gml:LinearRing gml:id="ring-1">
+                                <gml:posList>35.0000 139.0000 0 35.0000 139.0010 0 35.0000 139.0010 12 35.0000 139.0000 12 35.0000 139.0000 0</gml:posList>
+                              </gml:LinearRing>
+                            </gml:exterior>
+                          </gml:Polygon>
+                        </bldg:WallSurface>
+                      </gml:surfaceMember>
+                    </gml:MultiSurface>
+                  </bldg:lod2MultiSurface>
+                </bldg:Building>
+              </core:cityObjectMember>
+            </core:CityModel>
+            """;
+        InMemoryDatasetContentSource datasetSource = new(Encoding.UTF8.GetBytes(xml));
+        SourceFileDescriptor sourceFile = new(
+            "udx/bldg/53394525/metadata.gml",
+            "bldg",
+            "53394525",
+            RequiresMeshAreaFilter: false);
+
+        SourceFilePipeline[] pipelines = await LocalCityGmlObjectProjection.CreateSourceFilePipelinesCoreAsync(
+            [sourceFile],
+            datasetSource,
+            [],
+            progressReporter: null,
+            new LodFilteringStrategy(),
+            new CityGmlAppearanceStoreFactory(),
+            new CityGmlLodSelector(),
+            CancellationToken.None);
+
+        BootstrapParsedCityObject? parsedCityObject = null;
+        await foreach (BootstrapParsedCityObject cityObject in pipelines.Single().StreamParsedCityObjectsAsync())
+        {
+            parsedCityObject = cityObject;
+            break;
+        }
+
+        Assert.NotNull(parsedCityObject);
+        Assert.Equal(4, parsedCityObject!.FloorsAboveGround);
+        Assert.Null(parsedCityObject.MeasuredHeightMeters);
+    }
+
     private sealed class GateableDatasetContentSource(byte[] payload, int gateOffset) : IPlateauDatasetContentSource
     {
         private readonly TaskCompletionSource releaseSignal = new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
@@ -76,6 +76,8 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
             [],
             progressReporter: null,
             new LodFilteringStrategy(),
+            new CityGmlAppearanceStoreFactory(),
+            new CityGmlLodSelector(),
             CancellationToken.None);
 
         await using IAsyncEnumerator<BootstrapParsedCityObject> enumerator =
@@ -93,6 +95,73 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
 
         Assert.True(await secondMoveTask);
         Assert.Equal("Building Two", enumerator.Current.DisplayName);
+    }
+
+    [Fact]
+    public async Task SourceFilePipeline_StreamParsedCityObjectsAsync_PreservesFloorMetadata()
+    {
+        string xml =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <core:CityModel xmlns:core="http://www.opengis.net/citygml/2.0" xmlns:gml="http://www.opengis.net/gml" xmlns:bldg="http://www.opengis.net/citygml/building/2.0">
+              <gml:boundedBy>
+                <gml:Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/6697" srsDimension="3">
+                  <gml:lowerCorner>35.0000 139.0000 0</gml:lowerCorner>
+                  <gml:upperCorner>35.0100 139.0100 12</gml:upperCorner>
+                </gml:Envelope>
+              </gml:boundedBy>
+              <core:cityObjectMember>
+                <bldg:Building gml:id="bldg-1">
+                  <gml:name>Building One</gml:name>
+                  <bldg:measuredHeight uom="m">11.8</bldg:measuredHeight>
+                  <bldg:storeysAboveGround>4</bldg:storeysAboveGround>
+                  <bldg:lod2MultiSurface>
+                    <gml:MultiSurface>
+                      <gml:surfaceMember>
+                        <bldg:WallSurface>
+                          <gml:Polygon gml:id="poly-1">
+                            <gml:exterior>
+                              <gml:LinearRing gml:id="ring-1">
+                                <gml:posList>35.0000 139.0000 0 35.0000 139.0010 0 35.0000 139.0010 12 35.0000 139.0000 12 35.0000 139.0000 0</gml:posList>
+                              </gml:LinearRing>
+                            </gml:exterior>
+                          </gml:Polygon>
+                        </bldg:WallSurface>
+                      </gml:surfaceMember>
+                    </gml:MultiSurface>
+                  </bldg:lod2MultiSurface>
+                </bldg:Building>
+              </core:cityObjectMember>
+            </core:CityModel>
+            """;
+        InMemoryDatasetContentSource datasetSource = new(Encoding.UTF8.GetBytes(xml));
+        SourceFileDescriptor sourceFile = new(
+            "udx/bldg/53394525/metadata.gml",
+            "bldg",
+            "53394525",
+            RequiresMeshAreaFilter: false);
+
+        SourceFilePipeline[] pipelines = await LocalCityGmlObjectProjection.CreateSourceFilePipelinesCoreAsync(
+            [sourceFile],
+            datasetSource,
+            [],
+            progressReporter: null,
+            new LodFilteringStrategy(),
+            new CityGmlAppearanceStoreFactory(),
+            new CityGmlLodSelector(),
+            CancellationToken.None);
+
+        BootstrapParsedCityObject? parsedCityObject = null;
+        await foreach (BootstrapParsedCityObject cityObject in pipelines.Single().StreamParsedCityObjectsAsync())
+        {
+            parsedCityObject = cityObject;
+            break;
+        }
+
+        Assert.NotNull(parsedCityObject);
+        Assert.Equal(4, parsedCityObject.FloorsAboveGround);
+        Assert.NotNull(parsedCityObject.MeasuredHeightMeters);
+        Assert.InRange(parsedCityObject.MeasuredHeightMeters!.Value, 11.799999, 11.800001);
     }
 
     private sealed class GateableDatasetContentSource(byte[] payload, int gateOffset) : IPlateauDatasetContentSource
@@ -134,6 +203,40 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
         public void Release()
         {
             releaseSignal.TrySetResult();
+        }
+    }
+
+    private sealed class InMemoryDatasetContentSource(byte[] payload) : IPlateauDatasetContentSource
+    {
+        public string SourcePath => "/tmp/streaming";
+
+        public IReadOnlyList<string> EnumerateFiles()
+        {
+            return ["udx/bldg/53394525/metadata.gml"];
+        }
+
+        public bool FileExists(string relativePath)
+        {
+            return true;
+        }
+
+        [SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "Ownership is transferred to the caller as a Stream result.")]
+        public ValueTask<Stream> OpenReadAsync(
+            string relativePath,
+            CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult<Stream>(new MemoryStream(payload, writable: false));
+        }
+
+        public Task<string> MaterializeFileAsync(
+            string relativePath,
+            string outputRoot,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
         }
     }
 


### PR DESCRIPTION
## Summary
- extract generic CityGML appearance parsing into dedicated raw appearance store types
- extract LOD surface selection into a dedicated selector and thread both through the CityGML import pipeline
- add focused tests for the new appearance store, LOD selector, and streaming parser call-site updates

## Verification
- built Plateau.ResoniteLink.Tests with msbuild restore disabled after single-node restore
- ran focused vstest coverage for the new appearance store, LOD selector, and streaming parser tests

## Follow-up
- headless validation will be handled separately