### PR TITLE
[codex] Refactor Resonite / ResoniteLink execution boundary

### DIFF
--- a/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
@@ -211,7 +211,10 @@ public static class CliArgumentsParser
                         {
                             string memoryProfileValue = ReadValue(args, ref index, token);
                             if (!Enum.TryParse(memoryProfileValue, ignoreCase: true, out memoryProfile)
-                                || !Enum.IsDefined(memoryProfile))
+                                || !string.Equals(
+                                    Enum.GetName(memoryProfile),
+                                    memoryProfileValue,
+                                    StringComparison.OrdinalIgnoreCase))
                             {
                                 return CliParseResult.Failure(
                                     $"The value '{memoryProfileValue}' is not a valid memory profile. Use 'small' or 'large'.");

--- a/src/Plateau.ResoniteLink.Cli/CliHostFactory.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliHostFactory.cs
@@ -36,6 +36,7 @@ internal static class CliServiceCollectionExtensions
         services.AddHttpClient(CliHostFactory.TerrainTextureAssetsHttpClientName);
 
         services.AddPlateauCityGmlImportServices();
+        services.AddResoniteLiveSendTargetServices();
 
         services.AddSingleton<DatasetInspectionService>();
         services.AddSingleton<IImportServiceFactory, DefaultImportServiceFactory>();
@@ -99,22 +100,63 @@ internal sealed class DefaultPlateauDatasetSourceResolverFactory(IHttpClientFact
     }
 }
 
-internal sealed class DefaultSceneImportTargetFactory(IHttpClientFactory httpClientFactory)
+internal sealed class DefaultSceneImportTargetFactory(
+    IHttpClientFactory httpClientFactory,
+    IServiceScopeFactory serviceScopeFactory)
     : ISceneImportTargetFactory
 {
     public ISceneImportTarget Create(BuildCommandOptions options, Action<string>? progressReporter)
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        return ResoniteSceneImportTargetFactory.Create(
-            options.ResoniteLinkUri!,
-            options.ResoniteLinkConnectionCount,
-            options.EnableSendMetrics,
-            options.MemoryProfile,
-            options.EnableMeshBake,
-            options.TerrainTileCacheRoot,
-            options.DisableTerrainTileCache,
-            httpClientFactory.CreateClient(CliHostFactory.TerrainTextureAssetsHttpClientName),
-            progressReporter);
+        AsyncServiceScope scope = serviceScopeFactory.CreateAsyncScope();
+        try
+        {
+            ResoniteLiveSceneImportTargetOptions targetOptions = new(
+                options.ResoniteLinkUri!,
+                options.ResoniteLinkConnectionCount,
+                options.EnableSendMetrics,
+                options.MemoryProfile,
+                options.EnableMeshBake,
+                options.TerrainTileCacheRoot,
+                options.DisableTerrainTileCache,
+                progressReporter);
+            IResoniteLiveSceneImportFactory targetFactory =
+                scope.ServiceProvider.GetRequiredService<IResoniteLiveSceneImportFactory>();
+            ResoniteLiveSceneImportTarget target = targetFactory.CreateTarget(
+                targetOptions,
+                httpClientFactory.CreateClient(CliHostFactory.TerrainTextureAssetsHttpClientName));
+            return new ScopedSceneImportTarget(scope, target);
+        }
+        catch
+        {
+            scope.Dispose();
+            throw;
+        }
+    }
+}
+
+internal sealed class ScopedSceneImportTarget(
+    AsyncServiceScope scope,
+    ISceneImportTarget inner) : ISceneImportTarget
+{
+    public Task<SceneImportExecutionResult> ExecuteAsync(
+        SceneImportExecutionPlan plan,
+        IAsyncEnumerable<ImportedCityObject> cityObjects,
+        CancellationToken cancellationToken = default)
+    {
+        return inner.ExecuteAsync(plan, cityObjects, cancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await inner.DisposeAsync();
+        }
+        finally
+        {
+            await scope.DisposeAsync();
+        }
     }
 }

--- a/src/Plateau.ResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -1,0 +1,314 @@
+using Plateau.ResoniteLink.Domain.Importing;
+
+using ResoniteLink;
+
+namespace Plateau.ResoniteLink.Targets.Resonite.Execution;
+
+internal interface IResoniteBatchEmissionPlanner
+{
+    PlannedBatchEmission Create(
+        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots,
+        PlannedSceneObjectEmission emissionPlan);
+}
+
+internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlanner
+{
+    private const float DefaultNormalScale = 1.0f;
+    private const float DefaultBundledHeightScale = 0.002f;
+
+    public PlannedBatchEmission Create(
+        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots,
+        PlannedSceneObjectEmission emissionPlan)
+    {
+        ArgumentNullException.ThrowIfNull(objectSlots);
+        ArgumentNullException.ThrowIfNull(emissionPlan);
+
+        List<PlannedBatchSlotEmission> slotEmissions = [];
+        List<PlannedBatchComponentEmission> componentEmissions = [];
+        List<BatchPlanEntityId> slotResolutionTargets = [];
+        List<BatchPlanEntityId> componentResolutionTargets = [];
+
+        BatchPlanEntityId meshAssetSlotId = CreateBatchPlanEntityId("mesh-asset-slot");
+        slotEmissions.Add(new PlannedBatchSlotEmission(
+            meshAssetSlotId,
+            objectSlots.AssetLodSlot.SlotId,
+            emissionPlan.GeometryAsset.MeshAssetSlotName,
+            null,
+            null));
+        slotResolutionTargets.Add(meshAssetSlotId);
+
+        BatchPlanEntityId geometryComponentId = CreateBatchPlanEntityId("geometry-component");
+        switch (emissionPlan.GeometryAsset)
+        {
+            case PlannedTriangleMeshGeometryAsset triangleMesh:
+                componentEmissions.Add(new PlannedBatchComponentEmission(
+                    geometryComponentId,
+                    meshAssetSlotId.Value,
+                    "[FrooxEngine]FrooxEngine.StaticMesh",
+                    new Dictionary<string, Member>(StringComparer.Ordinal)
+                    {
+                        ["URL"] = new Field_Uri
+                        {
+                            Value = triangleMesh.MeshUri,
+                        },
+                    }));
+                break;
+            case PlannedHeightMapGridGeometryAsset heightMap:
+                BatchPlanEntityId heightMapAssetSlotId = CreateBatchPlanEntityId("heightmap-asset-slot");
+                BatchPlanEntityId heightTextureComponentId = CreateBatchPlanEntityId("height-texture-component");
+                slotEmissions.Add(new PlannedBatchSlotEmission(
+                    heightMapAssetSlotId,
+                    objectSlots.AssetLodSlot.SlotId,
+                    heightMap.HeightMapAssetSlotName,
+                    null,
+                    null));
+                slotResolutionTargets.Add(heightMapAssetSlotId);
+                componentEmissions.Add(new PlannedBatchComponentEmission(
+                    heightTextureComponentId,
+                    heightMapAssetSlotId.Value,
+                    "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                    ResoniteGeometryAssetAssembler.CreateHeightMapTextureMembers(heightMap.HeightTextureUri)));
+                double displacementMagnitude = Math.Max(heightMap.Geometry.MaxHeight - heightMap.Geometry.MinHeight, 0.0);
+                componentEmissions.Add(new PlannedBatchComponentEmission(
+                    geometryComponentId,
+                    meshAssetSlotId.Value,
+                    "[FrooxEngine]FrooxEngine.GridMesh",
+                    new Dictionary<string, Member>(StringComparer.Ordinal)
+                    {
+                        ["Points"] = new Field_int2
+                        {
+                            Value = new int2
+                            {
+                                x = heightMap.Geometry.Width,
+                                y = heightMap.Geometry.Height,
+                            },
+                        },
+                        ["Size"] = new Field_float2
+                        {
+                            Value = new float2
+                            {
+                                x = (float)heightMap.Geometry.Size.X,
+                                y = (float)heightMap.Geometry.Size.Y,
+                            },
+                        },
+                        ["DisplacementMagnitude"] = new Field_float
+                        {
+                            Value = (float)displacementMagnitude,
+                        },
+                        ["DisplacementTexture"] = new Reference
+                        {
+                            TargetID = heightTextureComponentId.Value,
+                        },
+                    }));
+                break;
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported planned geometry asset type '{emissionPlan.GeometryAsset.GetType().Name}'.");
+        }
+        componentResolutionTargets.Add(geometryComponentId);
+
+        Dictionary<MaterialIdentity, string> emittedMaterialTargets = new();
+        foreach (PlannedMaterialAsset materialAsset in emissionPlan.MaterialAssets)
+        {
+            switch (materialAsset)
+            {
+                case PlannedReusableMaterialAsset reusableMaterial:
+                    emittedMaterialTargets[reusableMaterial.Identity] = reusableMaterial.TargetId;
+                    break;
+                case PlannedDedicatedMaterialAsset dedicatedMaterial:
+                    string emittedMaterialTarget = AddPlannedDedicatedMaterialEmissions(
+                        slotEmissions,
+                        componentEmissions,
+                        meshAssetSlotId.Value,
+                        dedicatedMaterial);
+                    emittedMaterialTargets[dedicatedMaterial.Identity] = emittedMaterialTarget;
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unsupported planned material asset type '{materialAsset.GetType().Name}'.");
+            }
+        }
+
+        BatchPlanEntityId presentationSlotId = CreateBatchPlanEntityId("presentation-slot");
+        slotEmissions.Add(new PlannedBatchSlotEmission(
+            presentationSlotId,
+            objectSlots.LodSlot.SlotId,
+            objectSlots.CityObjectSlotName,
+            objectSlots.CityObjectLocalPosition,
+            objectSlots.CityObjectRotation));
+        slotResolutionTargets.Add(presentationSlotId);
+
+        componentEmissions.Add(new PlannedBatchComponentEmission(
+            CreateBatchPlanEntityId("mesh-renderer-component"),
+            presentationSlotId.Value,
+            "[FrooxEngine]FrooxEngine.MeshRenderer",
+            new Dictionary<string, Member>(StringComparer.Ordinal)
+            {
+                ["Mesh"] = new Reference
+                {
+                    TargetID = geometryComponentId.Value,
+                },
+                ["Materials"] = new SyncList
+                {
+                    Elements = emissionPlan.Renderer.MaterialIdentities
+                        .Select(materialIdentity => (Member)new Reference
+                        {
+                            TargetID = emittedMaterialTargets[materialIdentity],
+                        })
+                        .ToList(),
+                },
+            }));
+        componentEmissions.Add(new PlannedBatchComponentEmission(
+            CreateBatchPlanEntityId("mesh-collider-component"),
+            presentationSlotId.Value,
+            "[FrooxEngine]FrooxEngine.MeshCollider",
+            new Dictionary<string, Member>(StringComparer.Ordinal)
+            {
+                ["Type"] = new Field_Enum
+                {
+                    Value = emissionPlan.Collider.CollisionEnabled ? "Static" : "NoCollision",
+                },
+                ["CharacterCollider"] = new Field_bool
+                {
+                    Value = emissionPlan.Collider.CollisionEnabled,
+                },
+                ["Mesh"] = new Reference
+                {
+                    TargetID = geometryComponentId.Value,
+                },
+            }));
+
+        return new PlannedBatchEmission(
+            slotEmissions,
+            componentEmissions,
+            slotResolutionTargets,
+            componentResolutionTargets);
+    }
+
+    private static string AddPlannedDedicatedMaterialEmissions(
+        List<PlannedBatchSlotEmission> slotEmissions,
+        List<PlannedBatchComponentEmission> componentEmissions,
+        string meshAssetSlotTargetId,
+        PlannedDedicatedMaterialAsset plannedMaterial)
+    {
+        ResoniteMaterialBinding material = plannedMaterial.Material;
+        string materialContainerId = meshAssetSlotTargetId;
+        if (plannedMaterial.PreserveDedicatedMaterialSlot)
+        {
+            BatchPlanEntityId materialSlotId = CreateBatchPlanEntityId($"material-slot:{plannedMaterial.Identity.Value}");
+            string materialSlotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: false);
+            slotEmissions.Add(new PlannedBatchSlotEmission(
+                materialSlotId,
+                meshAssetSlotTargetId,
+                materialSlotName,
+                null,
+                null));
+            materialContainerId = materialSlotId.Value;
+        }
+
+        Dictionary<string, Member> materialMembers = ResoniteMaterialComponentPolicy.CreateMembers(material);
+
+        Uri? albedoTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "albedo");
+        if (albedoTextureUri is not null)
+        {
+            BatchPlanEntityId albedoTextureId = CreateBatchPlanEntityId($"material-texture:{plannedMaterial.Identity.Value}:albedo");
+            componentEmissions.Add(new PlannedBatchComponentEmission(
+                albedoTextureId,
+                materialContainerId,
+                "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                ResoniteSceneMaterialConventions.CreateTextureMembers(albedoTextureUri)));
+            materialMembers["AlbedoTexture"] = new Reference
+            {
+                TargetID = albedoTextureId.Value,
+            };
+        }
+
+        Uri? normalTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "normal");
+        if (normalTextureUri is not null)
+        {
+            BatchPlanEntityId normalTextureId = CreateBatchPlanEntityId($"material-texture:{plannedMaterial.Identity.Value}:normal");
+            componentEmissions.Add(new PlannedBatchComponentEmission(
+                normalTextureId,
+                materialContainerId,
+                "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                ResoniteSceneMaterialConventions.CreateTextureMembers(normalTextureUri)));
+            materialMembers["NormalMap"] = new Reference
+            {
+                TargetID = normalTextureId.Value,
+            };
+            materialMembers["NormalScale"] = new Field_float
+            {
+                Value = DefaultNormalScale,
+            };
+        }
+
+        Uri? heightTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "height");
+        if (heightTextureUri is not null)
+        {
+            BatchPlanEntityId heightTextureId = CreateBatchPlanEntityId($"material-texture:{plannedMaterial.Identity.Value}:height");
+            componentEmissions.Add(new PlannedBatchComponentEmission(
+                heightTextureId,
+                materialContainerId,
+                "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                ResoniteSceneMaterialConventions.CreateTextureMembers(heightTextureUri)));
+            materialMembers["HeightMap"] = new Reference
+            {
+                TargetID = heightTextureId.Value,
+            };
+            materialMembers["HeightScale"] = new Field_float
+            {
+                Value = DefaultBundledHeightScale,
+            };
+        }
+
+        Uri? metallicTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "metallic");
+        if (metallicTextureUri is not null)
+        {
+            BatchPlanEntityId metallicTextureId = CreateBatchPlanEntityId($"material-texture:{plannedMaterial.Identity.Value}:metallic");
+            componentEmissions.Add(new PlannedBatchComponentEmission(
+                metallicTextureId,
+                materialContainerId,
+                "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                ResoniteSceneMaterialConventions.CreateTextureMembers(metallicTextureUri)));
+            materialMembers["MetallicMap"] = new Reference
+            {
+                TargetID = metallicTextureId.Value,
+            };
+            materialMembers["OcclusionMap"] = new Reference
+            {
+                TargetID = metallicTextureId.Value,
+            };
+        }
+
+        Uri? emissionTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "emission");
+        if (emissionTextureUri is not null)
+        {
+            BatchPlanEntityId emissionTextureId = CreateBatchPlanEntityId($"material-texture:{plannedMaterial.Identity.Value}:emission");
+            componentEmissions.Add(new PlannedBatchComponentEmission(
+                emissionTextureId,
+                materialContainerId,
+                "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                ResoniteSceneMaterialConventions.CreateTextureMembers(emissionTextureUri)));
+            materialMembers["EmissiveMap"] = new Reference
+            {
+                TargetID = emissionTextureId.Value,
+            };
+            materialMembers["EmissiveColor"] = ResoniteMaterialComponentPolicy.CreateColorMember(
+                new ResoniteColor(1.0, 1.0, 1.0, 1.0));
+        }
+
+        BatchPlanEntityId materialComponentId = CreateBatchPlanEntityId($"material-component:{plannedMaterial.Identity.Value}");
+        componentEmissions.Add(new PlannedBatchComponentEmission(
+            materialComponentId,
+            materialContainerId,
+            ResoniteMaterialComponentPolicy.GetComponentType(material),
+            materialMembers));
+        return materialComponentId.Value;
+    }
+
+    private static BatchPlanEntityId CreateBatchPlanEntityId(string suffix)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(suffix);
+        return new BatchPlanEntityId($"plan:{suffix}");
+    }
+}

--- a/src/Plateau.ResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -148,15 +148,12 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 {
                     TargetID = geometryComponentId.Value,
                 },
-                ["Materials"] = new SyncList
-                {
-                    Elements = emissionPlan.Renderer.MaterialIdentities
-                        .Select(materialIdentity => (Member)new Reference
-                        {
-                            TargetID = emittedMaterialTargets[materialIdentity],
-                        })
-                        .ToList(),
-                },
+                ["Materials"] = CreateRendererMaterials(emissionPlan.Renderer.MaterialBindings, emittedMaterialTargets),
+                ["MaterialPropertyBlocks"] = CreateRendererMaterialPropertyBlocks(
+                    componentEmissions,
+                    meshAssetSlotId.Value,
+                    presentationSlotId.Value,
+                    emissionPlan.Renderer.MaterialBindings),
             }));
         componentEmissions.Add(new PlannedBatchComponentEmission(
             CreateBatchPlanEntityId("mesh-collider-component"),
@@ -304,6 +301,91 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             ResoniteMaterialComponentPolicy.GetComponentType(material),
             materialMembers));
         return materialComponentId.Value;
+    }
+
+    private static SyncList CreateRendererMaterials(
+        IReadOnlyList<PlannedRendererMaterialBinding> materialBindings,
+        Dictionary<MaterialIdentity, string> emittedMaterialTargets)
+    {
+        return new SyncList
+        {
+            Elements = materialBindings
+                .Select(binding => (Member)new Reference
+                {
+                    TargetID = emittedMaterialTargets[binding.MaterialIdentity],
+                })
+                .ToList(),
+        };
+    }
+
+    private static SyncList CreateRendererMaterialPropertyBlocks(
+        List<PlannedBatchComponentEmission> componentEmissions,
+        string assetSlotId,
+        string presentationSlotId,
+        IReadOnlyList<PlannedRendererMaterialBinding> materialBindings)
+    {
+        SyncList propertyBlocks = new()
+        {
+            Elements = [],
+        };
+
+        bool hasMaterialPropertyBlockOverride = false;
+        foreach (PlannedRendererMaterialBinding materialBinding in materialBindings)
+        {
+            if (materialBinding is PlannedMainTextureOverrideRendererMaterialBinding mainTextureOverrideBinding)
+            {
+                hasMaterialPropertyBlockOverride = true;
+                propertyBlocks.Elements.Add(
+                    CreateMainTexturePropertyBlockReference(
+                        componentEmissions,
+                        assetSlotId,
+                        presentationSlotId,
+                        mainTextureOverrideBinding));
+                continue;
+            }
+
+            propertyBlocks.Elements.Add(new Reference
+            {
+                TargetID = null,
+            });
+        }
+
+        return hasMaterialPropertyBlockOverride
+            ? propertyBlocks
+            : new SyncList { Elements = [] };
+    }
+
+    private static Reference CreateMainTexturePropertyBlockReference(
+        List<PlannedBatchComponentEmission> componentEmissions,
+        string assetSlotId,
+        string presentationSlotId,
+        PlannedMainTextureOverrideRendererMaterialBinding binding)
+    {
+        string overrideIdentity = $"{binding.MaterialIdentity.Value}:{binding.MainTexture.Identity.Value}";
+        BatchPlanEntityId textureId = CreateBatchPlanEntityId($"renderer-texture:{overrideIdentity}");
+        componentEmissions.Add(new PlannedBatchComponentEmission(
+            textureId,
+            assetSlotId,
+            "[FrooxEngine]FrooxEngine.StaticTexture2D",
+            ResoniteSceneMaterialConventions.CreateTextureMembers(binding.MainTexture.AssetUri)));
+
+        BatchPlanEntityId propertyBlockId = CreateBatchPlanEntityId($"renderer-main-texture-property-block:{overrideIdentity}");
+        componentEmissions.Add(new PlannedBatchComponentEmission(
+            propertyBlockId,
+            presentationSlotId,
+            "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
+            new Dictionary<string, Member>(StringComparer.Ordinal)
+            {
+                ["Texture"] = new Reference
+                {
+                    TargetID = textureId.Value,
+                },
+            }));
+
+        return new Reference
+        {
+            TargetID = propertyBlockId.Value,
+        };
     }
 
     private static BatchPlanEntityId CreateBatchPlanEntityId(string suffix)

--- a/src/Plateau.ResoniteLink/Targets/Resonite/Execution/IResoniteSceneSlotLocator.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/Execution/IResoniteSceneSlotLocator.cs
@@ -1,0 +1,30 @@
+namespace Plateau.ResoniteLink.Targets.Resonite.Execution;
+
+internal interface IResoniteSceneSlotLocator
+{
+    Task<CreatedSlot?> TryGetDatasetRootAsync(
+        IResoniteLinkClient client,
+        string slotName,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteSceneSlotLocator : IResoniteSceneSlotLocator
+{
+    private const string RootSlotId = "Root";
+
+    public async Task<CreatedSlot?> TryGetDatasetRootAsync(
+        IResoniteLinkClient client,
+        string slotName,
+        CancellationToken cancellationToken)
+    {
+        ResoniteSceneSlotSnapshot snapshot = await ResoniteSceneSlotSnapshot.CreateAsync(
+            client,
+            RootSlotId,
+            1,
+            cancellationToken);
+        ResoniteSceneChildLookupResult lookup = snapshot.GetUniqueChildLookupResult(slotName, RootSlotId);
+        return lookup.State == ResoniteSceneChildLookupState.FoundWithId
+            ? new CreatedSlot(lookup.SlotId!, slotName)
+            : null;
+    }
+}

--- a/src/Plateau.ResoniteLink/Targets/Resonite/Execution/IResoniteSlotCreator.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/Execution/IResoniteSlotCreator.cs
@@ -1,0 +1,37 @@
+using Plateau.ResoniteLink.Domain.Importing;
+
+using ResoniteLink;
+
+namespace Plateau.ResoniteLink.Targets.Resonite.Execution;
+
+internal interface IResoniteSlotCreator
+{
+    Task<CreatedSlot> CreateAsync(
+        IResoniteLinkClient client,
+        string parentId,
+        string slotName,
+        ResoniteFloat3? position,
+        ResoniteFloatQ? rotation,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteSlotCreator : IResoniteSlotCreator
+{
+    public async Task<CreatedSlot> CreateAsync(
+        IResoniteLinkClient client,
+        string parentId,
+        string slotName,
+        ResoniteFloat3? position,
+        ResoniteFloatQ? rotation,
+        CancellationToken cancellationToken)
+    {
+        ResoniteBatchOperations.PendingBatchSlot pendingSlot = new(
+            LocalId: $"single_slot_{Guid.NewGuid():N}",
+            MessageId: $"single_slot_message_{Guid.NewGuid():N}",
+            SlotName: slotName);
+        BatchResponse response = await client.RunDataModelOperationBatchAsync(
+            [ResoniteBatchOperations.CreateAddSlotOperation(parentId, slotName, position, rotation, requestedSlotId: pendingSlot.LocalId, messageId: pendingSlot.MessageId)],
+            cancellationToken);
+        return CanonicalBatchEntityMap.Create(response).ResolveSlot(pendingSlot);
+    }
+}

--- a/src/Plateau.ResoniteLink/Targets/Resonite/IResoniteSceneBootstrapInterpreter.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/IResoniteSceneBootstrapInterpreter.cs
@@ -1,6 +1,6 @@
 using Plateau.ResoniteLink.Domain.Importing;
 
-namespace Plateau.ResoniteLink.Targets.Resonite;
+namespace Plateau.ResoniteLink.Targets.Resonite.Execution;
 
 internal interface IResoniteSceneBootstrapInterpreter
 {

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteBatchOperations.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteBatchOperations.cs
@@ -2,7 +2,7 @@ using Plateau.ResoniteLink.Domain.Importing;
 
 using ResoniteLink;
 
-namespace Plateau.ResoniteLink.Targets.Resonite;
+namespace Plateau.ResoniteLink.Targets.Resonite.Execution;
 
 internal static class ResoniteBatchOperations
 {

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
@@ -1,0 +1,26 @@
+namespace Plateau.ResoniteLink.Targets.Resonite;
+
+internal interface IResoniteBufferedCityObjectBakerFactory
+{
+    CompositeCityObjectBaker? Create(
+        bool enableMeshBake,
+        ResoniteTextureImageLoader textureImageLoader,
+        ResoniteImportBudgetProfile resourceBudget);
+}
+
+internal sealed class ResoniteBufferedCityObjectBakerFactory : IResoniteBufferedCityObjectBakerFactory
+{
+    public CompositeCityObjectBaker? Create(
+        bool enableMeshBake,
+        ResoniteTextureImageLoader textureImageLoader,
+        ResoniteImportBudgetProfile resourceBudget)
+    {
+        ArgumentNullException.ThrowIfNull(textureImageLoader);
+
+        return enableMeshBake
+            ? new CompositeCityObjectBaker(
+                new Lod2AtlasCityObjectBaker(textureImageLoader, resourceBudget: resourceBudget),
+                new FixedCellCityObjectMeshBaker())
+            : null;
+    }
+}

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteComponentUpdateInterpreter.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteComponentUpdateInterpreter.cs
@@ -1,6 +1,6 @@
 using ResoniteLink;
 
-namespace Plateau.ResoniteLink.Targets.Resonite;
+namespace Plateau.ResoniteLink.Targets.Resonite.Execution;
 
 internal sealed class ResoniteComponentUpdateInterpreter
 {

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteGeometryAssetAssembler.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteGeometryAssetAssembler.cs
@@ -2,22 +2,44 @@ using Plateau.ResoniteLink.Domain.Importing;
 
 using ResoniteLink;
 
-namespace Plateau.ResoniteLink.Targets.Resonite;
+namespace Plateau.ResoniteLink.Targets.Resonite.Execution;
 
-internal sealed class ResoniteGeometryAssetAssembler(Action<string>? progressReporter = null)
+internal interface IResoniteGeometryAssetAssembler
+{
+    Task<PreparedGeometryAssetBatch> PrepareTriangleMeshAsync(
+        IResoniteLinkClient importClient,
+        string meshAssetSlotName,
+        string displayName,
+        ImportMeshRawData meshImport,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken);
+
+    Task<PreparedGeometryAssetBatch> PrepareHeightMapGridAsync(
+        IResoniteLinkClient importClient,
+        string meshAssetSlotName,
+        string heightMapAssetSlotName,
+        string displayName,
+        ResoniteHeightMapGridGeometry geometry,
+        ResoniteRawHdrTextureImport heightTextureImport,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAssembler
 {
     public async Task<PreparedGeometryAssetBatch> PrepareTriangleMeshAsync(
         IResoniteLinkClient importClient,
         string meshAssetSlotName,
         string displayName,
         ImportMeshRawData meshImport,
+        Action<string>? progressReporter,
         CancellationToken cancellationToken)
     {
-        ReportProgress(
+        progressReporter?.Invoke(
             $"[live] Mesh '{displayName}' importing triangle mesh "
             + $"(vertices={meshImport.VertexCount}, submeshes={meshImport.Submeshes.Count}).");
         Uri assetUri = await importClient.ImportMeshAsync(meshImport, cancellationToken);
-        ReportProgress($"[live] Mesh '{displayName}' mesh import completed -> '{assetUri}'.");
+        progressReporter?.Invoke($"[live] Mesh '{displayName}' mesh import completed -> '{assetUri}'.");
         return new PreparedTriangleMeshAssetBatch(meshAssetSlotName, assetUri);
     }
 
@@ -28,12 +50,13 @@ internal sealed class ResoniteGeometryAssetAssembler(Action<string>? progressRep
         string displayName,
         ResoniteHeightMapGridGeometry geometry,
         ResoniteRawHdrTextureImport heightTextureImport,
+        Action<string>? progressReporter,
         CancellationToken cancellationToken)
     {
-        ReportProgress(
+        progressReporter?.Invoke(
             $"[live] HeightMap '{geometry.Width}x{geometry.Height}' importing displacement texture via raw payload.");
         Uri textureUri = await importClient.ImportTextureAsync(heightTextureImport, cancellationToken);
-        ReportProgress($"[live] HeightMap '{displayName}' displacement texture import completed -> '{textureUri}'.");
+        progressReporter?.Invoke($"[live] HeightMap '{displayName}' displacement texture import completed -> '{textureUri}'.");
         return new PreparedHeightMapGridAssetBatch(
             meshAssetSlotName,
             heightMapAssetSlotName,
@@ -57,11 +80,6 @@ internal sealed class ResoniteGeometryAssetAssembler(Action<string>? progressRep
             ["WrapModeV"] = new Field_Enum { Value = "Clamp" },
             ["FilterMode"] = new Field_Nullable_Enum { Value = "Point" },
         };
-    }
-
-    private void ReportProgress(string message)
-    {
-        progressReporter?.Invoke(message);
     }
 }
 

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
@@ -2,6 +2,7 @@ namespace Plateau.ResoniteLink.Targets.Resonite;
 
 internal sealed record ResoniteLiveSceneImportDependencies(
     ILiveSendClientSession ClientSession,
+    ResoniteLinkSendDiagnostics Diagnostics,
     ITerrainTextureAssetGenerator TerrainTextureAssetGenerator,
     Execution.IResoniteSceneBootstrapInterpreter SceneBootstrapInterpreter,
     Execution.IResoniteGeometryAssetAssembler GeometryAssetAssembler,
@@ -16,6 +17,7 @@ internal sealed record ResoniteLiveSceneImportDependencies(
         ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
         : this(
             clientSession,
+            ResoniteLinkSendDiagnostics.Disabled,
             terrainTextureAssetGenerator,
             new Execution.ResoniteSceneBootstrapInterpreter(new Execution.ResoniteSceneSlotLocator()),
             new Execution.ResoniteGeometryAssetAssembler(),

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
@@ -2,6 +2,28 @@ namespace Plateau.ResoniteLink.Targets.Resonite;
 
 internal sealed record ResoniteLiveSceneImportDependencies(
     ILiveSendClientSession ClientSession,
-    ITerrainTextureAssetGenerator TerrainTextureAssetGenerator)
+    ITerrainTextureAssetGenerator TerrainTextureAssetGenerator,
+    Execution.IResoniteSceneBootstrapInterpreter SceneBootstrapInterpreter,
+    Execution.IResoniteGeometryAssetAssembler GeometryAssetAssembler,
+    Execution.IResoniteMaterialPlanning MaterialPlanning,
+    Execution.IResoniteBatchEmissionPlanner BatchEmissionPlanner,
+    Execution.IResoniteSceneBatchEmitter BatchEmitter,
+    Execution.IResoniteSlotCreator SlotCreator,
+    IResoniteBufferedCityObjectBakerFactory CityObjectBakerFactory)
 {
+    internal ResoniteLiveSceneImportDependencies(
+        ILiveSendClientSession clientSession,
+        ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
+        : this(
+            clientSession,
+            terrainTextureAssetGenerator,
+            new Execution.ResoniteSceneBootstrapInterpreter(new Execution.ResoniteSceneSlotLocator()),
+            new Execution.ResoniteGeometryAssetAssembler(),
+            new Execution.ResoniteMaterialPlanning(),
+            new Execution.ResoniteBatchEmissionPlanner(),
+            new Execution.PlannedBatchEmissionInterpreter(),
+            new Execution.ResoniteSlotCreator(),
+            new ResoniteBufferedCityObjectBakerFactory())
+    {
+    }
 }

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -7,6 +7,7 @@ using ResoniteLink;
 using Plateau.ResoniteLink.Application.Importing;
 using Plateau.ResoniteLink.Application.Logging;
 using Plateau.ResoniteLink.Domain.Importing;
+using Plateau.ResoniteLink.Targets.Resonite.Execution;
 
 namespace Plateau.ResoniteLink.Targets.Resonite;
 
@@ -15,16 +16,18 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
     private const int MaxQueuedCityObjects = 4;
     private const long MaxInFlightCityObjectWorkingSetBytesPerLane = 256L * 1024L * 1024L;
     private const long MaxInFlightCityObjectWorkingSetBytesFloor = 512L * 1024L * 1024L;
-    private const string RootSlotId = "Root";
     private const string DemPackageName = "dem";
     private const string HeightMapAssetSlotSuffix = "_heightmap";
-    private const float DefaultNormalScale = 1.0f;
-    private const float DefaultBundledHeightScale = 0.002f;
     private readonly Uri endpoint;
     private readonly int connectionCount;
     private readonly ResoniteLinkSendDiagnostics diagnostics;
     private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator;
-    private readonly ResoniteGeometryAssetAssembler geometryAssetAssembler;
+    private readonly IResoniteGeometryAssetAssembler geometryAssetAssembler;
+    private readonly IResoniteMaterialPlanning materialPlanning;
+    private readonly IResoniteBatchEmissionPlanner batchEmissionPlanner;
+    private readonly IResoniteSceneBatchEmitter batchEmitter;
+    private readonly IResoniteSlotCreator slotCreator;
+    private readonly IResoniteBufferedCityObjectBakerFactory cityObjectBakerFactory;
 #pragma warning disable CA1859
     private readonly ILiveSendClientSession clientSession;
 #pragma warning restore CA1859
@@ -36,35 +39,41 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
 
     public ResoniteLiveSceneImportTarget(Uri endpoint, Action<string>? progressReporter = null)
         : this(
-            endpoint,
-            4,
-            ResoniteLinkSendDiagnostics.Disabled,
-            PlateauImportMemoryProfile.Large,
+            new ResoniteLiveSceneImportTargetOptions(
+                endpoint,
+                4,
+                EnableSendMetrics: false,
+                PlateauImportMemoryProfile.Large,
+                EnableMeshBake: true,
+                TerrainTileCacheRoot: null,
+                DisableTerrainTileCache: false,
+                ProgressReporter: progressReporter),
             CreateDefaultDependencies(
                 endpoint,
                 4,
                 ResoniteLinkSendDiagnostics.Disabled,
                 new TerrainTextureAssetGenerator(),
-                progressReporter),
-            enableMeshBake: true,
-            progressReporter)
+                progressReporter))
     {
     }
 
     public ResoniteLiveSceneImportTarget(Uri endpoint, int connectionCount, Action<string>? progressReporter = null)
         : this(
-            endpoint,
-            connectionCount,
-            ResoniteLinkSendDiagnostics.Disabled,
-            PlateauImportMemoryProfile.Large,
+            new ResoniteLiveSceneImportTargetOptions(
+                endpoint,
+                connectionCount,
+                EnableSendMetrics: false,
+                PlateauImportMemoryProfile.Large,
+                EnableMeshBake: true,
+                TerrainTileCacheRoot: null,
+                DisableTerrainTileCache: false,
+                ProgressReporter: progressReporter),
             CreateDefaultDependencies(
                 endpoint,
                 connectionCount,
                 ResoniteLinkSendDiagnostics.Disabled,
                 new TerrainTextureAssetGenerator(),
-                progressReporter),
-            enableMeshBake: true,
-            progressReporter)
+                progressReporter))
     {
     }
 
@@ -75,18 +84,21 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         PlateauImportMemoryProfile memoryProfile,
         Action<string>? progressReporter = null)
         : this(
-            endpoint,
-            connectionCount,
-            diagnostics,
-            memoryProfile,
+            new ResoniteLiveSceneImportTargetOptions(
+                endpoint,
+                connectionCount,
+                EnableSendMetrics: diagnostics != ResoniteLinkSendDiagnostics.Disabled,
+                memoryProfile,
+                EnableMeshBake: true,
+                TerrainTileCacheRoot: null,
+                DisableTerrainTileCache: false,
+                ProgressReporter: progressReporter),
             CreateDefaultDependencies(
                 endpoint,
                 connectionCount,
                 diagnostics,
                 new TerrainTextureAssetGenerator(),
-                progressReporter),
-            enableMeshBake: true,
-            progressReporter)
+                progressReporter))
     {
     }
 
@@ -98,18 +110,21 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         bool enableMeshBake,
         Action<string>? progressReporter = null)
         : this(
-            endpoint,
-            connectionCount,
-            diagnostics,
-            memoryProfile,
+            new ResoniteLiveSceneImportTargetOptions(
+                endpoint,
+                connectionCount,
+                EnableSendMetrics: diagnostics != ResoniteLinkSendDiagnostics.Disabled,
+                memoryProfile,
+                enableMeshBake,
+                TerrainTileCacheRoot: null,
+                DisableTerrainTileCache: false,
+                ProgressReporter: progressReporter),
             CreateDefaultDependencies(
                 endpoint,
                 connectionCount,
                 diagnostics,
                 new TerrainTextureAssetGenerator(),
-                progressReporter),
-            enableMeshBake,
-            progressReporter)
+                progressReporter))
     {
     }
 
@@ -121,13 +136,16 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         bool enableMeshBake = true,
         Action<string>? progressReporter = null)
         : this(
-            endpoint,
-            connectionCount,
-            diagnostics,
-            PlateauImportMemoryProfile.Large,
-            dependencies,
-            enableMeshBake,
-            progressReporter)
+            new ResoniteLiveSceneImportTargetOptions(
+                endpoint,
+                connectionCount,
+                EnableSendMetrics: diagnostics != ResoniteLinkSendDiagnostics.Disabled,
+                PlateauImportMemoryProfile.Large,
+                enableMeshBake,
+                TerrainTileCacheRoot: null,
+                DisableTerrainTileCache: false,
+                ProgressReporter: progressReporter),
+            dependencies)
     {
     }
 
@@ -139,21 +157,45 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         ResoniteLiveSceneImportDependencies dependencies,
         bool enableMeshBake = true,
         Action<string>? progressReporter = null)
+        : this(
+            new ResoniteLiveSceneImportTargetOptions(
+                endpoint,
+                connectionCount,
+                EnableSendMetrics: diagnostics != ResoniteLinkSendDiagnostics.Disabled,
+                memoryProfile,
+                enableMeshBake,
+                TerrainTileCacheRoot: null,
+                DisableTerrainTileCache: false,
+                ProgressReporter: progressReporter),
+            dependencies)
     {
+    }
+
+    internal ResoniteLiveSceneImportTarget(
+        ResoniteLiveSceneImportTargetOptions options,
+        ResoniteLiveSceneImportDependencies dependencies)
+    {
+        ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(dependencies);
         ArgumentNullException.ThrowIfNull(dependencies.ClientSession);
         ArgumentNullException.ThrowIfNull(dependencies.TerrainTextureAssetGenerator);
 
-        this.endpoint = endpoint;
-        this.connectionCount = connectionCount;
-        MemoryProfile = memoryProfile;
-        this.diagnostics = diagnostics;
+        endpoint = options.Endpoint;
+        connectionCount = options.ConnectionCount;
+        MemoryProfile = options.MemoryProfile;
+        diagnostics = options.EnableSendMetrics
+            ? ResoniteLinkSendDiagnostics.CreateEnabled(options.ProgressReporter)
+            : ResoniteLinkSendDiagnostics.Disabled;
         this.terrainTextureAssetGenerator = dependencies.TerrainTextureAssetGenerator;
-        MeshBakeEnabled = enableMeshBake;
-        this.progressReporter = progressReporter;
-        sceneBootstrapInterpreter = new ResoniteSceneBootstrapInterpreter(
-            TryGetDatasetRootAsync);
-        geometryAssetAssembler = new ResoniteGeometryAssetAssembler(ReportProgress);
+        MeshBakeEnabled = options.EnableMeshBake;
+        progressReporter = options.ProgressReporter;
+        sceneBootstrapInterpreter = dependencies.SceneBootstrapInterpreter;
+        geometryAssetAssembler = dependencies.GeometryAssetAssembler;
+        materialPlanning = dependencies.MaterialPlanning;
+        batchEmissionPlanner = dependencies.BatchEmissionPlanner;
+        batchEmitter = dependencies.BatchEmitter;
+        slotCreator = dependencies.SlotCreator;
+        cityObjectBakerFactory = dependencies.CityObjectBakerFactory;
         clientSession = dependencies.ClientSession;
     }
 
@@ -174,7 +216,14 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 diagnostics,
                 progressReporter,
                 baseClientFactory),
-            terrainTextureAssetGenerator);
+            terrainTextureAssetGenerator,
+            new ResoniteSceneBootstrapInterpreter(new ResoniteSceneSlotLocator()),
+            new ResoniteGeometryAssetAssembler(),
+            new ResoniteMaterialPlanning(),
+            new ResoniteBatchEmissionPlanner(),
+            new PlannedBatchEmissionInterpreter(),
+            new ResoniteSlotCreator(),
+            new ResoniteBufferedCityObjectBakerFactory());
     }
 
     internal bool MeshBakeEnabled { get; }
@@ -297,7 +346,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             runPlan.RequestLocalOrigin,
             runPlan.SourceFileSlotNamesByRelativePath,
             bootstrapState.SceneAnchor,
-            CreateSlotAsync);
+            slotCreator.CreateAsync);
         placement.IndexBootstrapHierarchy(bootstrapState);
         ReportProgress(
             PlateauLog.Info(
@@ -350,11 +399,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         LiveSendExecutionRuntime runtime = new(runtimePlan, cancellationToken);
         progress.Reset();
         ResoniteImportBudgetProfile resourceBudget = runPlan.ResourceBudget;
-        CompositeCityObjectBaker? cityObjectBaker = runPlan.MeshBakeEnabled
-            ? new CompositeCityObjectBaker(
-                new Lod2AtlasCityObjectBaker(textureImageLoader, resourceBudget: resourceBudget),
-                new FixedCellCityObjectMeshBaker())
-            : null;
+        CompositeCityObjectBaker? cityObjectBaker = cityObjectBakerFactory.Create(
+            runPlan.MeshBakeEnabled,
+            textureImageLoader,
+            resourceBudget);
         LiveSendRunContext context = new(
             runPlan,
             bootstrapState.DatasetRootSlot,
@@ -390,30 +438,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 "live",
                 $"Send lane startup phase complete in {laneStartStopwatch.Elapsed.TotalSeconds:F2}s."));
         return state;
-    }
-
-    private Task<CreatedSlot?> TryGetDatasetRootAsync(
-        IResoniteLinkClient client,
-        string slotName,
-        CancellationToken cancellationToken)
-    {
-        return TryGetDatasetRootCoreAsync(client, slotName, cancellationToken);
-    }
-
-    private static async Task<CreatedSlot?> TryGetDatasetRootCoreAsync(
-        IResoniteLinkClient client,
-        string slotName,
-        CancellationToken cancellationToken)
-    {
-        ResoniteSceneSlotSnapshot snapshot = await ResoniteSceneSlotSnapshot.CreateAsync(
-            client,
-            RootSlotId,
-            1,
-            cancellationToken);
-        ResoniteSceneChildLookupResult lookup = snapshot.GetUniqueChildLookupResult(slotName, RootSlotId);
-        return lookup.State == ResoniteSceneChildLookupState.FoundWithId
-            ? new CreatedSlot(lookup.SlotId!, slotName)
-            : null;
     }
 
     private LiveSendRunPlan CreateRunPlan(
@@ -1125,14 +1149,15 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             new PlannedCollider(
                 plannedGeometryAsset.Identity,
                 cityObject.CollisionEnabled));
-        PlannedBatchEmission batchEmission = CreatePlannedBatchEmission(objectSlots, emissionPlan);
+        PlannedBatchEmission batchEmission = batchEmissionPlanner.Create(objectSlots, emissionPlan);
 
         ReportBuildStep(cityObject, "Creating object-scoped DataModel batch.");
         Stopwatch batchStopwatch = Stopwatch.StartNew();
-        await new PlannedBatchEmissionInterpreter(ReportProgress).ExecuteAsync(
+        await batchEmitter.ExecuteAsync(
             routedClient,
             cityObject,
             batchEmission,
+            progressReporter,
             cancellationToken);
         batchStopwatch.Stop();
 
@@ -1553,6 +1578,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                     CreateMeshAssetSlotName(cityObject),
                     cityObject.DisplayName,
                     triangleMesh.MeshImport,
+                    progressReporter,
                     cancellationToken)),
             PreparedHeightMapGridGeometry heightMap => CreatePlannedGeometryAsset(
                 cityObject,
@@ -1563,6 +1589,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                     cityObject.DisplayName,
                     heightMap.Geometry,
                     heightMap.HeightTextureImport,
+                    progressReporter,
                     cancellationToken)),
             _ => throw new InvalidOperationException(
                 $"Unsupported prepared geometry type '{preparedCityObject.Geometry.GetType().Name}'."),
@@ -1624,366 +1651,9 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         };
     }
 
-    internal static PlannedBatchEmission CreatePlannedBatchEmission(
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots,
-        PlannedSceneObjectEmission emissionPlan)
-    {
-        ArgumentNullException.ThrowIfNull(objectSlots);
-        ArgumentNullException.ThrowIfNull(emissionPlan);
-
-        List<PlannedBatchSlotEmission> slotEmissions = [];
-        List<PlannedBatchComponentEmission> componentEmissions = [];
-        List<BatchPlanEntityId> slotResolutionTargets = [];
-        List<BatchPlanEntityId> componentResolutionTargets = [];
-
-        BatchPlanEntityId meshAssetSlotId = CreateBatchPlanEntityId("mesh-asset-slot");
-        slotEmissions.Add(new PlannedBatchSlotEmission(
-            meshAssetSlotId,
-            objectSlots.AssetLodSlot.SlotId,
-            emissionPlan.GeometryAsset.MeshAssetSlotName,
-            null,
-            null));
-        slotResolutionTargets.Add(meshAssetSlotId);
-
-        BatchPlanEntityId geometryComponentId = CreateBatchPlanEntityId("geometry-component");
-        switch (emissionPlan.GeometryAsset)
-        {
-            case PlannedTriangleMeshGeometryAsset triangleMesh:
-                componentEmissions.Add(new PlannedBatchComponentEmission(
-                    geometryComponentId,
-                    meshAssetSlotId.Value,
-                    "[FrooxEngine]FrooxEngine.StaticMesh",
-                    new Dictionary<string, Member>(StringComparer.Ordinal)
-                    {
-                        ["URL"] = new Field_Uri
-                        {
-                            Value = triangleMesh.MeshUri,
-                        },
-                    }));
-                break;
-            case PlannedHeightMapGridGeometryAsset heightMap:
-                BatchPlanEntityId heightMapAssetSlotId = CreateBatchPlanEntityId("heightmap-asset-slot");
-                BatchPlanEntityId heightTextureComponentId = CreateBatchPlanEntityId("height-texture-component");
-                slotEmissions.Add(new PlannedBatchSlotEmission(
-                    heightMapAssetSlotId,
-                    objectSlots.AssetLodSlot.SlotId,
-                    heightMap.HeightMapAssetSlotName,
-                    null,
-                    null));
-                slotResolutionTargets.Add(heightMapAssetSlotId);
-                componentEmissions.Add(new PlannedBatchComponentEmission(
-                    heightTextureComponentId,
-                    heightMapAssetSlotId.Value,
-                    "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                    ResoniteGeometryAssetAssembler.CreateHeightMapTextureMembers(heightMap.HeightTextureUri)));
-                double displacementMagnitude = Math.Max(heightMap.Geometry.MaxHeight - heightMap.Geometry.MinHeight, 0.0);
-                componentEmissions.Add(new PlannedBatchComponentEmission(
-                    geometryComponentId,
-                    meshAssetSlotId.Value,
-                    "[FrooxEngine]FrooxEngine.GridMesh",
-                    new Dictionary<string, Member>(StringComparer.Ordinal)
-                    {
-                        ["Points"] = new Field_int2
-                        {
-                            Value = new int2
-                            {
-                                x = heightMap.Geometry.Width,
-                                y = heightMap.Geometry.Height,
-                            },
-                        },
-                        ["Size"] = new Field_float2
-                        {
-                            Value = new float2
-                            {
-                                x = (float)heightMap.Geometry.Size.X,
-                                y = (float)heightMap.Geometry.Size.Y,
-                            },
-                        },
-                        ["DisplacementMagnitude"] = new Field_float
-                        {
-                            Value = (float)displacementMagnitude,
-                        },
-                        ["DisplacementTexture"] = new Reference
-                        {
-                            TargetID = heightTextureComponentId.Value,
-                        },
-                    }));
-                break;
-            default:
-                throw new InvalidOperationException(
-                    $"Unsupported planned geometry asset type '{emissionPlan.GeometryAsset.GetType().Name}'.");
-        }
-        componentResolutionTargets.Add(geometryComponentId);
-
-        Dictionary<MaterialIdentity, string> emittedMaterialTargets = new();
-        foreach (PlannedMaterialAsset materialAsset in emissionPlan.MaterialAssets)
-        {
-            switch (materialAsset)
-            {
-                case PlannedReusableMaterialAsset reusableMaterial:
-                    emittedMaterialTargets[reusableMaterial.Identity] = reusableMaterial.TargetId;
-                    break;
-                case PlannedDedicatedMaterialAsset dedicatedMaterial:
-                    string emittedMaterialTarget = AddPlannedDedicatedMaterialEmissions(
-                        slotEmissions,
-                        componentEmissions,
-                        meshAssetSlotId.Value,
-                        dedicatedMaterial);
-                    emittedMaterialTargets[dedicatedMaterial.Identity] = emittedMaterialTarget;
-                    break;
-                default:
-                    throw new InvalidOperationException(
-                        $"Unsupported planned material asset type '{materialAsset.GetType().Name}'.");
-            }
-        }
-
-        BatchPlanEntityId presentationSlotId = CreateBatchPlanEntityId("presentation-slot");
-        slotEmissions.Add(new PlannedBatchSlotEmission(
-            presentationSlotId,
-            objectSlots.LodSlot.SlotId,
-            objectSlots.CityObjectSlotName,
-            objectSlots.CityObjectLocalPosition,
-            objectSlots.CityObjectRotation));
-        slotResolutionTargets.Add(presentationSlotId);
-
-        SyncList rendererMaterials = new()
-        {
-            Elements = emissionPlan.Renderer.MaterialBindings
-                .Select(binding => (Member)new Reference
-                {
-                    TargetID = emittedMaterialTargets[binding.MaterialIdentity],
-                })
-                .ToList(),
-        };
-        SyncList rendererMaterialPropertyBlocks = new()
-        {
-            Elements = [],
-        };
-        bool hasMaterialPropertyBlockOverride = false;
-        foreach (PlannedRendererMaterialBinding materialBinding in emissionPlan.Renderer.MaterialBindings)
-        {
-            if (materialBinding is PlannedMainTextureOverrideRendererMaterialBinding mainTextureOverrideBinding)
-            {
-                hasMaterialPropertyBlockOverride = true;
-                rendererMaterialPropertyBlocks.Elements.Add(
-                    CreateMainTexturePropertyBlockReference(
-                        componentEmissions,
-                        meshAssetSlotId.Value,
-                        presentationSlotId.Value,
-                        mainTextureOverrideBinding));
-                continue;
-            }
-
-            rendererMaterialPropertyBlocks.Elements.Add(new Reference
-            {
-                TargetID = null,
-            });
-        }
-
-        componentEmissions.Add(new PlannedBatchComponentEmission(
-            CreateBatchPlanEntityId("mesh-renderer-component"),
-            presentationSlotId.Value,
-            "[FrooxEngine]FrooxEngine.MeshRenderer",
-            new Dictionary<string, Member>(StringComparer.Ordinal)
-            {
-                ["Mesh"] = new Reference
-                {
-                    TargetID = geometryComponentId.Value,
-                },
-                ["Materials"] = rendererMaterials,
-                ["MaterialPropertyBlocks"] = hasMaterialPropertyBlockOverride
-                    ? rendererMaterialPropertyBlocks
-                    : new SyncList { Elements = [] },
-            }));
-        componentEmissions.Add(new PlannedBatchComponentEmission(
-            CreateBatchPlanEntityId("mesh-collider-component"),
-            presentationSlotId.Value,
-            "[FrooxEngine]FrooxEngine.MeshCollider",
-            new Dictionary<string, Member>(StringComparer.Ordinal)
-            {
-                ["Type"] = new Field_Enum
-                {
-                    Value = emissionPlan.Collider.CollisionEnabled ? "Static" : "NoCollision",
-                },
-                ["CharacterCollider"] = new Field_bool
-                {
-                    Value = emissionPlan.Collider.CollisionEnabled,
-                },
-                ["Mesh"] = new Reference
-                {
-                    TargetID = geometryComponentId.Value,
-                },
-            }));
-
-        return new PlannedBatchEmission(
-            slotEmissions,
-            componentEmissions,
-            slotResolutionTargets,
-            componentResolutionTargets);
-    }
-
-    private static Reference CreateMainTexturePropertyBlockReference(
-        List<PlannedBatchComponentEmission> componentEmissions,
-        string assetSlotId,
-        string presentationSlotId,
-        PlannedMainTextureOverrideRendererMaterialBinding binding)
-    {
-        string overrideIdentity = $"{binding.MaterialIdentity.Value}:{binding.MainTexture.Identity.Value}";
-        BatchPlanEntityId textureId = CreateBatchPlanEntityId($"renderer-texture:{overrideIdentity}");
-        componentEmissions.Add(new PlannedBatchComponentEmission(
-            textureId,
-            assetSlotId,
-            "[FrooxEngine]FrooxEngine.StaticTexture2D",
-            ResoniteSceneMaterialConventions.CreateTextureMembers(binding.MainTexture.AssetUri)));
-
-        BatchPlanEntityId propertyBlockId = CreateBatchPlanEntityId($"renderer-main-texture-property-block:{overrideIdentity}");
-        componentEmissions.Add(new PlannedBatchComponentEmission(
-            propertyBlockId,
-            presentationSlotId,
-            "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
-            new Dictionary<string, Member>(StringComparer.Ordinal)
-            {
-                ["Texture"] = new Reference
-                {
-                    TargetID = textureId.Value,
-                },
-            }));
-
-        return new Reference
-        {
-            TargetID = propertyBlockId.Value,
-        };
-    }
-
     private static long EstimateBatchPayloadBytes(int operationCount)
     {
         return Math.Max(1L, operationCount) * 1024L;
-    }
-
-    private static string AddPlannedDedicatedMaterialEmissions(
-        List<PlannedBatchSlotEmission> slotEmissions,
-        List<PlannedBatchComponentEmission> componentEmissions,
-        string meshAssetSlotTargetId,
-        PlannedDedicatedMaterialAsset plannedMaterial)
-    {
-        ResoniteMaterialBinding material = plannedMaterial.Material;
-        string materialContainerId = meshAssetSlotTargetId;
-        if (plannedMaterial.PreserveDedicatedMaterialSlot)
-        {
-            BatchPlanEntityId materialSlotId = CreateBatchPlanEntityId($"material-slot:{plannedMaterial.Identity.Value}");
-            string materialSlotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: false);
-            slotEmissions.Add(new PlannedBatchSlotEmission(
-                materialSlotId,
-                meshAssetSlotTargetId,
-                materialSlotName,
-                null,
-                null));
-            materialContainerId = materialSlotId.Value;
-        }
-
-        Dictionary<string, Member> materialMembers = ResoniteMaterialComponentPolicy.CreateMembers(material);
-
-        Uri? albedoTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "albedo");
-        if (albedoTextureUri is not null)
-        {
-            BatchPlanEntityId albedoTextureId = CreateBatchPlanEntityId($"material-texture:{plannedMaterial.Identity.Value}:albedo");
-            componentEmissions.Add(new PlannedBatchComponentEmission(
-                albedoTextureId,
-                materialContainerId,
-                "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(albedoTextureUri)));
-            materialMembers["AlbedoTexture"] = new Reference
-            {
-                TargetID = albedoTextureId.Value,
-            };
-        }
-
-        Uri? normalTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "normal");
-        if (normalTextureUri is not null)
-        {
-            BatchPlanEntityId normalTextureId = CreateBatchPlanEntityId($"material-texture:{plannedMaterial.Identity.Value}:normal");
-            componentEmissions.Add(new PlannedBatchComponentEmission(
-                normalTextureId,
-                materialContainerId,
-                "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(normalTextureUri)));
-            materialMembers["NormalMap"] = new Reference
-            {
-                TargetID = normalTextureId.Value,
-            };
-            materialMembers["NormalScale"] = new Field_float
-            {
-                Value = DefaultNormalScale,
-            };
-        }
-
-        Uri? heightTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "height");
-        if (heightTextureUri is not null)
-        {
-            BatchPlanEntityId heightTextureId = CreateBatchPlanEntityId($"material-texture:{plannedMaterial.Identity.Value}:height");
-            componentEmissions.Add(new PlannedBatchComponentEmission(
-                heightTextureId,
-                materialContainerId,
-                "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(heightTextureUri)));
-            materialMembers["HeightMap"] = new Reference
-            {
-                TargetID = heightTextureId.Value,
-            };
-            materialMembers["HeightScale"] = new Field_float
-            {
-                Value = DefaultBundledHeightScale,
-            };
-        }
-
-        Uri? metallicTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "metallic");
-        if (metallicTextureUri is not null)
-        {
-            BatchPlanEntityId metallicTextureId = CreateBatchPlanEntityId($"material-texture:{plannedMaterial.Identity.Value}:metallic");
-            componentEmissions.Add(new PlannedBatchComponentEmission(
-                metallicTextureId,
-                materialContainerId,
-                "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(metallicTextureUri)));
-            materialMembers["MetallicMap"] = new Reference
-            {
-                TargetID = metallicTextureId.Value,
-            };
-            materialMembers["OcclusionMap"] = new Reference
-            {
-                TargetID = metallicTextureId.Value,
-            };
-        }
-
-        Uri? emissionTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "emission");
-        if (emissionTextureUri is not null)
-        {
-            BatchPlanEntityId emissionTextureId = CreateBatchPlanEntityId($"material-texture:{plannedMaterial.Identity.Value}:emission");
-            componentEmissions.Add(new PlannedBatchComponentEmission(
-                emissionTextureId,
-                materialContainerId,
-                "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(emissionTextureUri)));
-            materialMembers["EmissiveMap"] = new Reference
-            {
-                TargetID = emissionTextureId.Value,
-            };
-            materialMembers["EmissiveColor"] = ResoniteMaterialComponentPolicy.CreateColorMember(
-                new ResoniteColor(1.0, 1.0, 1.0, 1.0));
-        }
-
-        BatchPlanEntityId materialComponentId = CreateBatchPlanEntityId($"material-component:{plannedMaterial.Identity.Value}");
-        componentEmissions.Add(new PlannedBatchComponentEmission(
-            materialComponentId,
-            materialContainerId,
-            ResoniteMaterialComponentPolicy.GetComponentType(material),
-            materialMembers));
-        return materialComponentId.Value;
-    }
-
-    internal static Dictionary<string, Member> CreateTextureMembers(Uri assetUri)
-    {
-        return ResoniteSceneMaterialConventions.CreateTextureMembers(assetUri);
     }
 
     private void ReportBuildStep(ResoniteConstructionCityObject cityObject, string step)
@@ -2019,51 +1689,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         state.Runtime.Cancel();
     }
 
-    private Task<CreatedSlot> CreateSlotAsync(
-        IResoniteLinkClient client,
-        string parentId,
-        string slotName,
-        ResoniteFloat3? position,
-        ResoniteFloatQ? rotation,
-        CancellationToken cancellationToken)
-    {
-        return CreateSlotCoreAsync(client, parentId, slotName, position, rotation, cancellationToken);
-    }
-
-    private static async Task<CreatedComponent> CreateComponentAsync(
-        IResoniteLinkClient client,
-        string containerSlotId,
-        string componentType,
-        IReadOnlyDictionary<string, Member> members,
-        CancellationToken cancellationToken)
-    {
-        ResoniteBatchOperations.PendingBatchComponent pendingComponent = new(
-            LocalId: $"single_component_{Guid.NewGuid():N}",
-            MessageId: $"single_component_message_{Guid.NewGuid():N}",
-            ComponentType: componentType);
-        BatchResponse response = await client.RunDataModelOperationBatchAsync(
-            [ResoniteBatchOperations.CreateAddComponentOperation(containerSlotId, componentType, members, pendingComponent.LocalId, pendingComponent.MessageId)],
-            cancellationToken);
-        return CanonicalBatchEntityMap.Create(response).ResolveComponent(pendingComponent);
-    }
-
-    private static async Task<CreatedSlot> CreateSlotCoreAsync(
-        IResoniteLinkClient client,
-        string parentId,
-        string slotName,
-        ResoniteFloat3? position,
-        ResoniteFloatQ? rotation,
-        CancellationToken cancellationToken)
-    {
-        ResoniteBatchOperations.PendingBatchSlot pendingSlot = new(
-            LocalId: $"single_slot_{Guid.NewGuid():N}",
-            MessageId: $"single_slot_message_{Guid.NewGuid():N}",
-            SlotName: slotName);
-        BatchResponse response = await client.RunDataModelOperationBatchAsync(
-            [ResoniteBatchOperations.CreateAddSlotOperation(parentId, slotName, position, rotation, requestedSlotId: pendingSlot.LocalId, messageId: pendingSlot.MessageId)],
-            cancellationToken);
-        return CanonicalBatchEntityMap.Create(response).ResolveSlot(pendingSlot);
-    }
 
     private static string CreateMeshAssetSlotName(ResoniteConstructionCityObject cityObject)
     {

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -1438,9 +1438,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 () => new LazySharedMaterialTaskFactory(
                     runState,
                     client,
+                    materialPlanning,
                     normalizedSharedMaterial,
                     familySlotName,
-                    CreateComponentAsync).CreateLazySharedMaterialTask(materialKey),
+                    ResoniteMaterialPlanning.CreateComponentAsync).CreateLazySharedMaterialTask(materialKey),
                 ct);
             PlannedReusableMaterialAsset sharedMaterialAsset = new(
                 new MaterialIdentity(materialKey),
@@ -1467,7 +1468,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             bool preserveDedicatedMaterialSlot,
             CancellationToken ct)
         {
-            PlannedDedicatedMaterialAsset plannedMaterial = await ResoniteMaterialPlanning.PlanDedicatedMaterialAssetAsync(
+            PlannedDedicatedMaterialAsset plannedMaterial = await materialPlanning.PlanDedicatedMaterialAssetAsync(
                 client,
                 sourceMaterial,
                 materialIndex,
@@ -1483,6 +1484,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
     private readonly record struct LazySharedMaterialTaskFactory(
         LiveSendRunState RunState,
         IResoniteLinkClient Client,
+        IResoniteMaterialPlanning MaterialPlanning,
         ResoniteMaterialBinding Material,
         string FamilySlotName,
         Func<IResoniteLinkClient, string, string, IReadOnlyDictionary<string, Member>, CancellationToken, Task<CreatedComponent>> CreateComponentAsync)
@@ -1494,7 +1496,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
 
         private async Task<CreatedMaterialAsset> CreateAsync(string materialKey)
         {
-            CreatedSlot familySlot = await TryGetExistingSharedChildSlotAsync(
+            CreatedSlot familySlot = await ResoniteMaterialPlanning.TryGetExistingSharedChildSlotAsync(
+                Client,
                 RunState.Context.CommonAssetsRootSlot.SlotId,
                 FamilySlotName,
                 RunState.Runtime.ProcessingCancellationToken)
@@ -1503,13 +1506,14 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                     RunState.Context.CommonAssetsRootSlot.SlotId,
                     FamilySlotName,
                     RunState.Runtime.ProcessingCancellationToken);
-            PlannedDedicatedMaterialAsset plannedMaterial = await ResoniteMaterialPlanning.PlanCommonMaterialAssetAsync(
+            PlannedDedicatedMaterialAsset plannedMaterial = await MaterialPlanning.PlanCommonMaterialAssetAsync(
                 Client,
                 Material,
                 RunState.Runtime.ProcessingCancellationToken);
             string materialSlotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(Material, useCommonMaterialAssets: true);
             string materialComponentType = ResoniteMaterialComponentPolicy.GetComponentType(Material);
-            string? existingMaterialComponentId = await TryGetExistingCommonMaterialComponentIdAsync(
+            string? existingMaterialComponentId = await ResoniteMaterialPlanning.TryGetExistingCommonMaterialComponentIdAsync(
+                Client,
                 familySlot.SlotId,
                 materialSlotName,
                 materialComponentType,
@@ -1528,35 +1532,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 CreateComponentAsync,
                 RunState.Runtime.ProcessingCancellationToken);
             return createdMaterial;
-        }
-
-        private async Task<CreatedSlot?> TryGetExistingSharedChildSlotAsync(
-            string parentSlotId,
-            string childSlotName,
-            CancellationToken cancellationToken)
-        {
-            Slot? parentSlotSnapshot = await Client.GetSlotAsync(parentSlotId, 1, cancellationToken);
-            ResoniteSceneChildLookupResult childLookup = new ResoniteSceneSlotSnapshot(parentSlotSnapshot)
-                .GetUniqueChildLookupResult(childSlotName, parentSlotId);
-            return childLookup.State == ResoniteSceneChildLookupState.FoundWithId
-                ? new CreatedSlot(childLookup.SlotId!, childSlotName)
-                : null;
-        }
-
-        private async Task<string?> TryGetExistingCommonMaterialComponentIdAsync(
-            string familySlotId,
-            string materialSlotName,
-            string materialComponentType,
-            CancellationToken cancellationToken)
-        {
-            Slot? familySlotSnapshot = await Client.GetSlotAsync(familySlotId, 1, cancellationToken);
-            ResoniteSceneChildLookupResult materialLookup = new ResoniteSceneSlotSnapshot(familySlotSnapshot)
-                .GetUniqueChildLookupResult(materialSlotName, familySlotId);
-            return materialLookup.Slot?.Components?
-                .Where(component => string.Equals(component.ComponentType, materialComponentType, StringComparison.Ordinal))
-                .OrderBy(static component => component.ID, StringComparer.Ordinal)
-                .Select(static component => component.ID)
-                .FirstOrDefault(static id => !string.IsNullOrWhiteSpace(id));
         }
     }
 

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -20,7 +20,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
     private const string HeightMapAssetSlotSuffix = "_heightmap";
     private readonly Uri endpoint;
     private readonly int connectionCount;
-    private readonly ResoniteLinkSendDiagnostics diagnostics;
     private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator;
     private readonly IResoniteGeometryAssetAssembler geometryAssetAssembler;
     private readonly IResoniteMaterialPlanning materialPlanning;
@@ -29,7 +28,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
     private readonly IResoniteSlotCreator slotCreator;
     private readonly IResoniteBufferedCityObjectBakerFactory cityObjectBakerFactory;
 #pragma warning disable CA1859
-    private readonly ILiveSendClientSession clientSession;
+    private ILiveSendClientSession ClientSessionInternal { get; }
 #pragma warning restore CA1859
     private readonly Action<string>? progressReporter;
 #pragma warning disable CA1859
@@ -183,9 +182,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         endpoint = options.Endpoint;
         connectionCount = options.ConnectionCount;
         MemoryProfile = options.MemoryProfile;
-        diagnostics = options.EnableSendMetrics
-            ? ResoniteLinkSendDiagnostics.CreateEnabled(options.ProgressReporter)
-            : ResoniteLinkSendDiagnostics.Disabled;
+        Diagnostics = dependencies.Diagnostics;
         this.terrainTextureAssetGenerator = dependencies.TerrainTextureAssetGenerator;
         MeshBakeEnabled = options.EnableMeshBake;
         progressReporter = options.ProgressReporter;
@@ -196,7 +193,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         batchEmitter = dependencies.BatchEmitter;
         slotCreator = dependencies.SlotCreator;
         cityObjectBakerFactory = dependencies.CityObjectBakerFactory;
-        clientSession = dependencies.ClientSession;
+        ClientSessionInternal = dependencies.ClientSession;
     }
 
     internal static ResoniteLiveSceneImportDependencies CreateDefaultDependencies(
@@ -216,6 +213,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 diagnostics,
                 progressReporter,
                 baseClientFactory),
+            diagnostics,
             terrainTextureAssetGenerator,
             new ResoniteSceneBootstrapInterpreter(new ResoniteSceneSlotLocator()),
             new ResoniteGeometryAssetAssembler(),
@@ -227,6 +225,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
     }
 
     internal bool MeshBakeEnabled { get; }
+
+    internal ResoniteLinkSendDiagnostics Diagnostics { get; }
+
+    internal ILiveSendClientSession ClientSession => ClientSessionInternal;
 
     internal PlateauImportMemoryProfile MemoryProfile { get; }
 
@@ -312,7 +314,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 "live",
                 $"Connecting ResoniteLink connection pool to {endpoint} "
                 + $"with {connectionCount} available routed connection(s)."));
-        await clientSession.EnsureConnectedAsync(normalizedRequest, cancellationToken);
+        await ClientSessionInternal.EnsureConnectedAsync(normalizedRequest, cancellationToken);
         connectionStopwatch.Stop();
         ReportProgress(
             PlateauLog.Info(
@@ -390,7 +392,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 "live",
                 $"Dataset metadata/license phase complete during bootstrap. "
                 + $"Dataset root existed={bootstrapState.DatasetRootExisted}."));
-        clientSession.BeginWorkerClientTracking();
+        ClientSessionInternal.BeginWorkerClientTracking();
         LiveSendQueuePlan runtimePlan = runPlan.Queue;
         ReportProgress(
             PlateauLog.Info(
@@ -418,7 +420,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             Runtime = runtime,
         };
         Stopwatch laneStartStopwatch = Stopwatch.StartNew();
-        diagnostics.StartSendWindow(connectionCount);
+        Diagnostics.StartSendWindow(connectionCount);
         runtime.Start(CreateProcessingTasks(state, runtime));
         ReportProgress(
             PlateauLog.Info(
@@ -693,7 +695,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 $"Awaiting {runtime.ProcessingTaskCount} send lane task(s) to drain after queue close."));
         await runtime.AwaitCompletionAsync(cancellationToken);
         ReportProgress(PlateauLog.Info("live", "All send lanes drained and completion barrier passed."));
-        diagnostics.CompleteSendWindow();
+        Diagnostics.CompleteSendWindow();
         ReportProgress(
             PlateauLog.Info(
                 "live",
@@ -727,11 +729,11 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
 
         if (disposeClients)
         {
-            clientSession.DisposeClients();
+            ClientSessionInternal.DisposeClients();
         }
         else if (resetClients)
         {
-            await clientSession.ResetClientsAsync();
+            await ClientSessionInternal.ResetClientsAsync();
         }
     }
 
@@ -926,7 +928,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
 
     private IResoniteLinkClient GetRoutedClient()
     {
-        return clientSession.RoutedClient
+        return ClientSessionInternal.RoutedClient
             ?? throw new ObjectDisposedException(nameof(ILiveSendClientSession), "Routed ResoniteLink client is not connected.");
     }
 
@@ -1040,7 +1042,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                     .ToArray()));
         PreparedConstructionGeometry preparedGeometry = await geometryPreparationTask;
         stopwatch.Stop();
-        diagnostics.RecordPrepare(cityObject.PackageName, stopwatch.Elapsed.TotalSeconds);
+        Diagnostics.RecordPrepare(cityObject.PackageName, stopwatch.Elapsed.TotalSeconds);
 
         if (Interlocked.CompareExchange(ref state.Progress.FirstPreparedCityObjectLogged, 1, 0) == 0)
         {
@@ -1096,7 +1098,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
     {
         IResoniteLinkClient routedClient = GetRoutedClient();
         ResoniteConstructionCityObject cityObject = preparedCityObject.CityObject;
-        using ResoniteLinkSendDiagnostics.CityObjectSendScope sendScope = diagnostics.BeginCityObjectSend(cityObject.PackageName);
+        using ResoniteLinkSendDiagnostics.CityObjectSendScope sendScope = Diagnostics.BeginCityObjectSend(cityObject.PackageName);
         Stopwatch cityObjectStopwatch = Stopwatch.StartNew();
         ReportBuildStep(cityObject, "Creating object slot hierarchy.");
         Stopwatch slotHierarchyStopwatch = Stopwatch.StartNew();

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTargetOptions.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTargetOptions.cs
@@ -1,0 +1,13 @@
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Targets.Resonite;
+
+public sealed record ResoniteLiveSceneImportTargetOptions(
+    Uri Endpoint,
+    int ConnectionCount,
+    bool EnableSendMetrics,
+    PlateauImportMemoryProfile MemoryProfile,
+    bool EnableMeshBake,
+    string? TerrainTileCacheRoot,
+    bool DisableTerrainTileCache,
+    Action<string>? ProgressReporter);

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using Plateau.ResoniteLink.Targets.Resonite.Execution;
+
+namespace Plateau.ResoniteLink.Targets.Resonite;
+
+public static class ResoniteLiveSendTargetServiceCollectionExtensions
+{
+    public static IServiceCollection AddResoniteLiveSendTargetServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddScoped<IResoniteBatchEmissionPlanner, ResoniteBatchEmissionPlanner>();
+        services.AddScoped<IResoniteBufferedCityObjectBakerFactory, ResoniteBufferedCityObjectBakerFactory>();
+        services.AddScoped<IResoniteGeometryAssetAssembler, ResoniteGeometryAssetAssembler>();
+        services.AddScoped<IResoniteMaterialPlanning, ResoniteMaterialPlanning>();
+        services.AddScoped<IResoniteSceneBatchEmitter, PlannedBatchEmissionInterpreter>();
+        services.AddScoped<IResoniteSceneBootstrapInterpreter, ResoniteSceneBootstrapInterpreter>();
+        services.AddScoped<IResoniteSlotCreator, ResoniteSlotCreator>();
+        services.AddScoped<IResoniteSceneSlotLocator, ResoniteSceneSlotLocator>();
+        services.AddScoped<IResoniteLiveSceneImportDependencyFactory, ResoniteLiveSceneImportDependencyFactory>();
+        services.AddScoped<IResoniteLiveSceneImportFactory, ResoniteLiveSceneImportFactory>();
+
+        return services;
+    }
+}
+
+public interface IResoniteLiveSceneImportFactory
+{
+    ResoniteLiveSceneImportTarget CreateTarget(
+        ResoniteLiveSceneImportTargetOptions options,
+        HttpClient terrainTextureAssetHttpClient);
+}
+
+internal sealed class ResoniteLiveSceneImportFactory(
+    IServiceProvider serviceProvider,
+    IResoniteLiveSceneImportDependencyFactory dependencyFactory) : IResoniteLiveSceneImportFactory
+{
+    public ResoniteLiveSceneImportTarget CreateTarget(
+        ResoniteLiveSceneImportTargetOptions options,
+        HttpClient terrainTextureAssetHttpClient)
+    {
+        ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
+            options,
+            terrainTextureAssetHttpClient);
+        return ActivatorUtilities.CreateInstance<ResoniteLiveSceneImportTarget>(
+            serviceProvider,
+            options,
+            dependencies);
+    }
+}
+
+internal interface IResoniteLiveSceneImportDependencyFactory
+{
+    ResoniteLiveSceneImportDependencies Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        HttpClient terrainTextureAssetHttpClient);
+}
+
+internal sealed class ResoniteLiveSceneImportDependencyFactory(IServiceProvider serviceProvider)
+    : IResoniteLiveSceneImportDependencyFactory
+{
+    public ResoniteLiveSceneImportDependencies Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        HttpClient terrainTextureAssetHttpClient)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+
+        return new ResoniteLiveSceneImportDependencies(
+            ResoniteLinkTransportSessionFactory.Create(
+                options.Endpoint,
+                options.ConnectionCount,
+                options.EnableSendMetrics
+                    ? ResoniteLinkSendDiagnostics.CreateEnabled(options.ProgressReporter)
+                    : ResoniteLinkSendDiagnostics.Disabled,
+                options.ProgressReporter),
+            new TerrainTextureAssetGenerator(
+                terrainTextureAssetHttpClient,
+                options.TerrainTileCacheRoot,
+                options.DisableTerrainTileCache),
+            serviceProvider.GetRequiredService<IResoniteSceneBootstrapInterpreter>(),
+            serviceProvider.GetRequiredService<IResoniteGeometryAssetAssembler>(),
+            serviceProvider.GetRequiredService<IResoniteMaterialPlanning>(),
+            serviceProvider.GetRequiredService<IResoniteBatchEmissionPlanner>(),
+            serviceProvider.GetRequiredService<IResoniteSceneBatchEmitter>(),
+            serviceProvider.GetRequiredService<IResoniteSlotCreator>(),
+            serviceProvider.GetRequiredService<IResoniteBufferedCityObjectBakerFactory>());
+    }
+}

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -15,9 +15,12 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.AddScoped<IResoniteGeometryAssetAssembler, ResoniteGeometryAssetAssembler>();
         services.AddScoped<IResoniteMaterialPlanning, ResoniteMaterialPlanning>();
         services.AddScoped<IResoniteSceneBatchEmitter, PlannedBatchEmissionInterpreter>();
-        services.AddScoped<IResoniteSceneBootstrapInterpreter, ResoniteSceneBootstrapInterpreter>();
         services.AddScoped<IResoniteSlotCreator, ResoniteSlotCreator>();
         services.AddScoped<IResoniteSceneSlotLocator, ResoniteSceneSlotLocator>();
+        services.AddScoped<IResoniteSceneBootstrapInterpreter>(
+            static serviceProvider => new ResoniteSceneBootstrapInterpreter(
+                serviceProvider.GetRequiredService<IResoniteSceneSlotLocator>(),
+                serviceProvider.GetRequiredService<IResoniteMaterialPlanning>()));
         services.AddScoped<IResoniteLiveSceneImportDependencyFactory, ResoniteLiveSceneImportDependencyFactory>();
         services.AddScoped<IResoniteLiveSceneImportFactory, ResoniteLiveSceneImportFactory>();
 
@@ -33,7 +36,6 @@ public interface IResoniteLiveSceneImportFactory
 }
 
 internal sealed class ResoniteLiveSceneImportFactory(
-    IServiceProvider serviceProvider,
     IResoniteLiveSceneImportDependencyFactory dependencyFactory) : IResoniteLiveSceneImportFactory
 {
     public ResoniteLiveSceneImportTarget CreateTarget(
@@ -43,10 +45,7 @@ internal sealed class ResoniteLiveSceneImportFactory(
         ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
             options,
             terrainTextureAssetHttpClient);
-        return ActivatorUtilities.CreateInstance<ResoniteLiveSceneImportTarget>(
-            serviceProvider,
-            options,
-            dependencies);
+        return new ResoniteLiveSceneImportTarget(options, dependencies);
     }
 }
 
@@ -66,15 +65,17 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(IServiceProvider 
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ResoniteLinkSendDiagnostics diagnostics = options.EnableSendMetrics
+            ? ResoniteLinkSendDiagnostics.CreateEnabled(options.ProgressReporter)
+            : ResoniteLinkSendDiagnostics.Disabled;
 
         return new ResoniteLiveSceneImportDependencies(
             ResoniteLinkTransportSessionFactory.Create(
                 options.Endpoint,
                 options.ConnectionCount,
-                options.EnableSendMetrics
-                    ? ResoniteLinkSendDiagnostics.CreateEnabled(options.ProgressReporter)
-                    : ResoniteLinkSendDiagnostics.Disabled,
+                diagnostics,
                 options.ProgressReporter),
+            diagnostics,
             new TerrainTextureAssetGenerator(
                 terrainTextureAssetHttpClient,
                 options.TerrainTileCacheRoot,

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialPlanning.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialPlanning.cs
@@ -2,14 +2,32 @@ using Plateau.ResoniteLink.Domain.Importing;
 
 using ResoniteLink;
 
-namespace Plateau.ResoniteLink.Targets.Resonite;
+namespace Plateau.ResoniteLink.Targets.Resonite.Execution;
 
-internal static class ResoniteMaterialPlanning
+internal interface IResoniteMaterialPlanning
+{
+    Task<PlannedDedicatedMaterialAsset> PlanCommonMaterialAssetAsync(
+        IResoniteLinkClient importClient,
+        ResoniteMaterialBinding material,
+        CancellationToken cancellationToken);
+
+    Task<PlannedDedicatedMaterialAsset> PlanDedicatedMaterialAssetAsync(
+        IResoniteLinkClient importClient,
+        ResoniteMaterialBinding material,
+        int materialIndex,
+        string packageName,
+        IReadOnlyDictionary<string, ResoniteTextureImport> preparedTextureDataByIdentity,
+        IReadOnlyDictionary<TerrainTextureOverlay, ResoniteTextureImport> preparedTerrainTextureDataByOverlay,
+        bool preserveDedicatedMaterialSlot,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
 {
     private const float DefaultNormalScale = 1.0f;
     private const float DefaultBundledHeightScale = 0.002f;
 
-    public static async Task<PlannedDedicatedMaterialAsset> PlanCommonMaterialAssetAsync(
+    public async Task<PlannedDedicatedMaterialAsset> PlanCommonMaterialAssetAsync(
         IResoniteLinkClient importClient,
         ResoniteMaterialBinding material,
         CancellationToken cancellationToken)
@@ -41,7 +59,7 @@ internal static class ResoniteMaterialPlanning
             PreserveDedicatedMaterialSlot: false);
     }
 
-    public static async Task<PlannedDedicatedMaterialAsset> PlanDedicatedMaterialAssetAsync(
+    public async Task<PlannedDedicatedMaterialAsset> PlanDedicatedMaterialAssetAsync(
         IResoniteLinkClient importClient,
         ResoniteMaterialBinding material,
         int materialIndex,

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialPlanning.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialPlanning.cs
@@ -269,6 +269,68 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         return new CreatedMaterialAsset(materialComponent.ComponentId, null);
     }
 
+    public static async Task<CreatedSlot?> TryGetExistingSharedChildSlotAsync(
+        IResoniteLinkClient client,
+        string parentSlotId,
+        string childSlotName,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentException.ThrowIfNullOrWhiteSpace(parentSlotId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(childSlotName);
+
+        Slot? parentSlotSnapshot = await client.GetSlotAsync(parentSlotId, 1, cancellationToken);
+        ResoniteSceneChildLookupResult childLookup = new ResoniteSceneSlotSnapshot(parentSlotSnapshot)
+            .GetUniqueChildLookupResult(childSlotName, parentSlotId);
+        return childLookup.State == ResoniteSceneChildLookupState.FoundWithId
+            ? new CreatedSlot(childLookup.SlotId!, childSlotName)
+            : null;
+    }
+
+    public static async Task<string?> TryGetExistingCommonMaterialComponentIdAsync(
+        IResoniteLinkClient client,
+        string familySlotId,
+        string materialSlotName,
+        string materialComponentType,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentException.ThrowIfNullOrWhiteSpace(familySlotId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(materialSlotName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(materialComponentType);
+
+        Slot? familySlotSnapshot = await client.GetSlotAsync(familySlotId, 1, cancellationToken);
+        ResoniteSceneChildLookupResult materialLookup = new ResoniteSceneSlotSnapshot(familySlotSnapshot)
+            .GetUniqueChildLookupResult(materialSlotName, familySlotId);
+        return materialLookup.Slot?.Components?
+            .Where(component => string.Equals(component.ComponentType, materialComponentType, StringComparison.Ordinal))
+            .OrderBy(static component => component.ID, StringComparer.Ordinal)
+            .Select(static component => component.ID)
+            .FirstOrDefault(static id => !string.IsNullOrWhiteSpace(id));
+    }
+
+    public static async Task<CreatedComponent> CreateComponentAsync(
+        IResoniteLinkClient client,
+        string containerSlotId,
+        string componentType,
+        IReadOnlyDictionary<string, Member> members,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentException.ThrowIfNullOrWhiteSpace(containerSlotId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(componentType);
+        ArgumentNullException.ThrowIfNull(members);
+
+        ResoniteBatchOperations.PendingBatchComponent pendingComponent = new(
+            LocalId: $"single_component_{Guid.NewGuid():N}",
+            MessageId: $"single_component_message_{Guid.NewGuid():N}",
+            ComponentType: componentType);
+        BatchResponse response = await client.RunDataModelOperationBatchAsync(
+            [ResoniteBatchOperations.CreateAddComponentOperation(containerSlotId, componentType, members, pendingComponent.LocalId, pendingComponent.MessageId)],
+            cancellationToken);
+        return CanonicalBatchEntityMap.Create(response).ResolveComponent(pendingComponent);
+    }
+
     public static MaterialIdentity CreateDedicatedMaterialIdentity(
         string packageName,
         int materialIndex,

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResonitePlannedBatchEmissionInterpreter.cs
@@ -5,27 +5,39 @@ using System.Security.Cryptography;
 using Plateau.ResoniteLink.Application.Logging;
 using Plateau.ResoniteLink.Domain.Importing;
 
-using static Plateau.ResoniteLink.Targets.Resonite.ResoniteBatchOperations;
+using static Plateau.ResoniteLink.Targets.Resonite.Execution.ResoniteBatchOperations;
 
 using ResoniteLink;
 
-namespace Plateau.ResoniteLink.Targets.Resonite;
+namespace Plateau.ResoniteLink.Targets.Resonite.Execution;
 
-internal sealed class PlannedBatchEmissionInterpreter(Action<string> reportProgress)
+internal interface IResoniteSceneBatchEmitter
+{
+    Task ExecuteAsync(
+        IResoniteLinkClient client,
+        ResoniteConstructionCityObject cityObject,
+        PlannedBatchEmission batchEmission,
+        Action<string>? reportProgress,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitter
 {
     public Task ExecuteAsync(
         IResoniteLinkClient client,
         ResoniteConstructionCityObject cityObject,
         PlannedBatchEmission batchEmission,
+        Action<string>? reportProgress,
         CancellationToken cancellationToken)
     {
-        return ExecuteCoreAsync(client, cityObject, batchEmission, cancellationToken);
+        return ExecuteCoreAsync(client, cityObject, batchEmission, reportProgress, cancellationToken);
     }
 
-    private async Task ExecuteCoreAsync(
+    private static async Task ExecuteCoreAsync(
         IResoniteLinkClient client,
         ResoniteConstructionCityObject cityObject,
         PlannedBatchEmission batchEmission,
+        Action<string>? reportProgress,
         CancellationToken cancellationToken)
     {
         BatchOperationAccumulator batchBuilder = new();
@@ -54,7 +66,7 @@ internal sealed class PlannedBatchEmissionInterpreter(Action<string> reportProgr
                 && pointsMember is Field_int2 points
                 && displacementMember is Field_float displacement)
             {
-                reportProgress(
+                reportProgress?.Invoke(
                     $"[live] HeightMap texture ready. Creating GridMesh "
                     + $"({points.Value.x}x{points.Value.y}, displacement={displacement.Value:F3}).");
             }
@@ -70,7 +82,7 @@ internal sealed class PlannedBatchEmissionInterpreter(Action<string> reportProgr
         Stopwatch batchStopwatch = Stopwatch.StartNew();
         BatchResponse batchResponse = await client.RunDataModelOperationBatchAsync(batchBuilder.Operations, cancellationToken);
         batchStopwatch.Stop();
-        reportProgress(
+        reportProgress?.Invoke(
             PlateauLog.Debug(
                 "live",
                 $"City object '{cityObject.DisplayName}' batch completed in {batchStopwatch.Elapsed.TotalSeconds:F3}s "

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneAnchorResolver.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneAnchorResolver.cs
@@ -4,7 +4,7 @@ using Plateau.ResoniteLink.Domain.Importing;
 
 using ResoniteLink;
 
-namespace Plateau.ResoniteLink.Targets.Resonite;
+namespace Plateau.ResoniteLink.Targets.Resonite.Execution;
 
 internal interface IResoniteSceneAnchorResolver
 {

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapInterpreter.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapInterpreter.cs
@@ -4,7 +4,7 @@ using Plateau.ResoniteLink.Domain.Importing;
 
 using ResoniteLink;
 
-namespace Plateau.ResoniteLink.Targets.Resonite;
+namespace Plateau.ResoniteLink.Targets.Resonite.Execution;
 
 internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstrapInterpreter
 {
@@ -17,14 +17,17 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
     private const string GsiLicenseName = "GSI Maps Terms";
     private const string GsiLicenseUrl = "https://maps.gsi.go.jp/help/termsofuse.html";
 
-    private readonly Func<IResoniteLinkClient, string, CancellationToken, Task<CreatedSlot?>> tryGetDatasetRootAsync;
+    private readonly IResoniteSceneSlotLocator sceneSlotLocator;
     private readonly IResoniteSceneAnchorResolver sceneAnchorResolver;
+    private readonly IResoniteMaterialPlanning materialPlanning;
 
     internal ResoniteSceneBootstrapInterpreter(
-        Func<IResoniteLinkClient, string, CancellationToken, Task<CreatedSlot?>> tryGetDatasetRootAsync,
+        IResoniteSceneSlotLocator sceneSlotLocator,
+        IResoniteMaterialPlanning? materialPlanning = null,
         IResoniteSceneAnchorResolver? sceneAnchorResolver = null)
     {
-        this.tryGetDatasetRootAsync = tryGetDatasetRootAsync;
+        this.sceneSlotLocator = sceneSlotLocator ?? throw new ArgumentNullException(nameof(sceneSlotLocator));
+        this.materialPlanning = materialPlanning ?? new ResoniteMaterialPlanning();
         this.sceneAnchorResolver = sceneAnchorResolver ?? new ResoniteSceneAnchorResolver();
     }
 
@@ -47,7 +50,7 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
         Slot? sharedCommonMaterialsSlot = sharedAssetsSlot is null
             ? null
             : GetReusableChildSlot(new ResoniteSceneSlotSnapshot(sharedAssetsSlot), SharedCommonMaterialsRootName, sharedAssetsSlot.ID!);
-        CreatedSlot? existingDatasetRoot = await tryGetDatasetRootAsync(
+        CreatedSlot? existingDatasetRoot = await sceneSlotLocator.TryGetDatasetRootAsync(
             setupClient,
             datasetRootName,
             cancellationToken);
@@ -197,7 +200,7 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             : null;
     }
 
-    private static async Task<ResoniteSceneBootstrapState> CreateInitialBootstrapStateAsync(
+    private async Task<ResoniteSceneBootstrapState> CreateInitialBootstrapStateAsync(
         IResoniteLinkClient setupClient,
         string datasetName,
         string completionMeshCode,
@@ -354,7 +357,7 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
         return string.Equals(existingCreditString.Value, expectedCreditString.Value, StringComparison.Ordinal);
     }
 
-    private static async Task<(Dictionary<string, CreatedMaterialAsset> CommonMaterialAssetsByKey, HashSet<string> CommonMaterialFamilies, List<PlannedCommonMaterialBatchEntry> PlannedCommonMaterials)> PlanCommonMaterialOperationsAsync(
+    private async Task<(Dictionary<string, CreatedMaterialAsset> CommonMaterialAssetsByKey, HashSet<string> CommonMaterialFamilies, List<PlannedCommonMaterialBatchEntry> PlannedCommonMaterials)> PlanCommonMaterialOperationsAsync(
         IResoniteLinkClient setupClient,
         IReadOnlyList<ResoniteMaterialBinding> commonMaterials,
         Slot? commonSlot,
@@ -428,7 +431,7 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
                 continue;
             }
 
-            PlannedDedicatedMaterialAsset plannedMaterial = await ResoniteMaterialPlanning.PlanCommonMaterialAssetAsync(
+            PlannedDedicatedMaterialAsset plannedMaterial = await this.materialPlanning.PlanCommonMaterialAssetAsync(
                 setupClient,
                 material,
                 cancellationToken);

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapState.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapState.cs
@@ -1,3 +1,5 @@
+using Plateau.ResoniteLink.Targets.Resonite.Execution;
+
 using ResoniteLink;
 
 namespace Plateau.ResoniteLink.Targets.Resonite;

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneImportTargetFactory.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneImportTargetFactory.cs
@@ -42,6 +42,7 @@ public static class ResoniteSceneImportTargetFactory
                     connectionCount,
                     diagnostics,
                     progressReporter),
+                diagnostics,
                 new TerrainTextureAssetGenerator(
                     terrainTextureAssetHttpClient,
                     terrainTileCacheRoot,

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneImportTargetFactory.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneImportTargetFactory.cs
@@ -27,10 +27,15 @@ public static class ResoniteSceneImportTargetFactory
             : ResoniteLinkSendDiagnostics.Disabled;
 
         return new ResoniteLiveSceneImportTarget(
-            endpoint,
-            connectionCount,
-            diagnostics,
-            memoryProfile,
+            new ResoniteLiveSceneImportTargetOptions(
+                endpoint,
+                connectionCount,
+                diagnostics != ResoniteLinkSendDiagnostics.Disabled,
+                memoryProfile,
+                enableMeshBake,
+                terrainTileCacheRoot,
+                disableTerrainTileCache,
+                progressReporter),
             new ResoniteLiveSceneImportDependencies(
                 Transport.ResoniteLink.ResoniteLinkTransportSessionFactory.Create(
                     endpoint,
@@ -40,8 +45,13 @@ public static class ResoniteSceneImportTargetFactory
                 new TerrainTextureAssetGenerator(
                     terrainTextureAssetHttpClient,
                     terrainTileCacheRoot,
-                    disableTerrainTileCache)),
-            enableMeshBake,
-            progressReporter);
+                    disableTerrainTileCache),
+                new Execution.ResoniteSceneBootstrapInterpreter(new Execution.ResoniteSceneSlotLocator()),
+                new Execution.ResoniteGeometryAssetAssembler(),
+                new Execution.ResoniteMaterialPlanning(),
+                new Execution.ResoniteBatchEmissionPlanner(),
+                new Execution.PlannedBatchEmissionInterpreter(),
+                new Execution.ResoniteSlotCreator(),
+                new ResoniteBufferedCityObjectBakerFactory()));
     }
 }

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneSlotSnapshot.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneSlotSnapshot.cs
@@ -1,6 +1,6 @@
 using ResoniteLink;
 
-namespace Plateau.ResoniteLink.Targets.Resonite;
+namespace Plateau.ResoniteLink.Targets.Resonite.Execution;
 
 internal enum ResoniteSceneChildLookupState
 {

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Globalization;
 
 using Plateau.ResoniteLink.Domain.Importing;
+using Plateau.ResoniteLink.Targets.Resonite.Execution;
 
 using ResoniteLink;
 

--- a/src/Plateau.ResoniteLink/Transport/ResoniteLink/ILiveSendClientSession.cs
+++ b/src/Plateau.ResoniteLink/Transport/ResoniteLink/ILiveSendClientSession.cs
@@ -6,6 +6,8 @@ internal interface ILiveSendClientSession
 {
     IResoniteLinkClient? RoutedClient { get; }
 
+    ResoniteLinkSendDiagnostics Diagnostics { get; }
+
     void BeginWorkerClientTracking();
 
     Task EnsureConnectedAsync(

--- a/src/Plateau.ResoniteLink/Transport/ResoniteLink/LiveSendClientSession.cs
+++ b/src/Plateau.ResoniteLink/Transport/ResoniteLink/LiveSendClientSession.cs
@@ -18,15 +18,19 @@ internal sealed class LiveSendClientSession : ILiveSendClientSession, IDisposabl
         Func<IResoniteLinkClient> createConfiguredClient,
         Uri endpoint,
         int connectionCount,
+        ResoniteLinkSendDiagnostics diagnostics,
         Action<string>? progressReporter)
     {
         this.createConfiguredClient = createConfiguredClient;
         this.endpoint = endpoint;
         this.connectionCount = connectionCount;
+        Diagnostics = diagnostics;
         reportProgress = progressReporter;
     }
 
     public IResoniteLinkClient? RoutedClient { get; private set; }
+
+    public ResoniteLinkSendDiagnostics Diagnostics { get; }
 
     private IResoniteLinkClient[]? ConnectedClients { get; set; }
 

--- a/src/Plateau.ResoniteLink/Transport/ResoniteLink/ResoniteLinkTransportSessionFactory.cs
+++ b/src/Plateau.ResoniteLink/Transport/ResoniteLink/ResoniteLinkTransportSessionFactory.cs
@@ -24,6 +24,7 @@ internal static class ResoniteLinkTransportSessionFactory
             CreateConfiguredClient,
             endpoint,
             connectionCount,
+            diagnostics,
             progressReporter);
     }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Architecture/Issue80ArchitectureContractTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Architecture/Issue80ArchitectureContractTests.cs
@@ -53,6 +53,37 @@ public sealed partial class Issue80ArchitectureContractTests
     }
 
     [Fact]
+    public void ResoniteTargets_RpcExecutionCalls_AppearOnlyInsideExecutionAdapters()
+    {
+        string executionRoot = TestData.GetRepositoryPath("src", "Plateau.ResoniteLink", "Targets", "Resonite");
+        string[] allowedFiles =
+        [
+            "ResoniteSceneBootstrapInterpreter.cs",
+            "ResoniteSceneAnchorResolver.cs",
+            "ResoniteSceneSlotSnapshot.cs",
+            "IResoniteSlotCreator.cs",
+            "ResonitePlannedBatchEmissionInterpreter.cs",
+            "ResoniteGeometryAssetAssembler.cs",
+            "ResoniteMaterialPlanning.cs",
+        ];
+
+        string[] offendingFiles = Directory
+            .EnumerateFiles(executionRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path =>
+            {
+                string content = File.ReadAllText(path);
+                return content.Contains("RunDataModelOperationBatchAsync(", StringComparison.Ordinal)
+                    || content.Contains("GetSlotAsync(", StringComparison.Ordinal)
+                    || content.Contains("ImportTextureAsync(", StringComparison.Ordinal)
+                    || content.Contains("ImportMeshAsync(", StringComparison.Ordinal);
+            })
+            .Where(path => allowedFiles.All(allowed => !path.EndsWith(allowed, StringComparison.Ordinal)))
+            .ToArray();
+
+        Assert.Empty(offendingFiles);
+    }
+
+    [Fact]
     public void SourceTree_NoLongerReferencesRemovedIssue80Names()
     {
         string[] files =

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -615,29 +615,6 @@ public sealed class CliArgumentsParserTests
     }
 
     [Fact]
-    public void ParseRejectsNumericMemoryProfile()
-    {
-        CliParseResult result = CliArgumentsParser.Parse(
-            [
-                "build",
-                "--dataset",
-                "tokyo23ku",
-                "--mesh-code",
-                "53394525",
-                "--local-source-path",
-                "/data/plateau",
-                "--resonitelink-port",
-                "12345",
-                "--memory-profile",
-                "2",
-            ]);
-
-        Assert.Equal(
-            "The value '2' is not a valid memory profile. Use 'small' or 'large'.",
-            result.Error);
-    }
-
-    [Fact]
     public void ParseDisablesMeshBakeWhenRequested()
     {
         CliParseResult result = CliArgumentsParser.Parse(

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -588,6 +588,32 @@ public sealed class CliArgumentsParserTests
             result.Error);
     }
 
+    [Theory]
+    [InlineData("0")]
+    [InlineData("1")]
+    [InlineData("2")]
+    public void ParseRejectsNumericMemoryProfile(string memoryProfileValue)
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "build",
+                "--dataset",
+                "tokyo23ku",
+                "--mesh-code",
+                "53394525",
+                "--local-source-path",
+                "/data/plateau",
+                "--resonitelink-port",
+                "12345",
+                "--memory-profile",
+                memoryProfileValue,
+            ]);
+
+        Assert.Equal(
+            $"The value '{memoryProfileValue}' is not a valid memory profile. Use 'small' or 'large'.",
+            result.Error);
+    }
+
     [Fact]
     public void ParseRejectsNumericMemoryProfile()
     {

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliHostFactoryTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliHostFactoryTests.cs
@@ -30,4 +30,16 @@ public sealed class CliHostFactoryTests
         Assert.NotNull(host.Services.GetRequiredService<IResoniteConstructionComposer>());
         Assert.NotNull(host.Services.GetRequiredService<IResoniteConstructionSourceFactory>());
     }
+
+    [Fact]
+    public void CreateResolvesResoniteLiveSendFactoryServices()
+    {
+        using IHost host = CliHostFactory.Create([]);
+
+        Assert.NotNull(host.Services.GetRequiredService<IResoniteLiveSceneImportFactory>());
+        Assert.NotNull(host.Services.GetRequiredService<IResoniteBatchEmissionPlanner>());
+        Assert.NotNull(host.Services.GetRequiredService<IResoniteSceneBatchEmitter>());
+        Assert.NotNull(host.Services.GetRequiredService<IResoniteGeometryAssetAssembler>());
+        Assert.NotNull(host.Services.GetRequiredService<IResoniteMaterialPlanning>());
+    }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliHostFactoryTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliHostFactoryTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Hosting;
 
 using Plateau.ResoniteLink.Application.Importing;
 using Plateau.ResoniteLink.Cli;
+using Plateau.ResoniteLink.Domain.Importing;
 
 namespace Plateau.ResoniteLink.Tests.Cli;
 
@@ -41,5 +42,27 @@ public sealed class CliHostFactoryTests
         Assert.NotNull(host.Services.GetRequiredService<IResoniteSceneBatchEmitter>());
         Assert.NotNull(host.Services.GetRequiredService<IResoniteGeometryAssetAssembler>());
         Assert.NotNull(host.Services.GetRequiredService<IResoniteMaterialPlanning>());
+    }
+
+    [Fact]
+    public async Task CreateResoniteLiveSendFactoryReusesTransportDiagnostics()
+    {
+        using IHost host = CliHostFactory.Create([]);
+        using IServiceScope scope = host.Services.CreateScope();
+        IResoniteLiveSceneImportFactory factory = scope.ServiceProvider.GetRequiredService<IResoniteLiveSceneImportFactory>();
+        using HttpClient terrainTextureAssetHttpClient = new();
+        await using ResoniteLiveSceneImportTarget builder = factory.CreateTarget(
+            new ResoniteLiveSceneImportTargetOptions(
+                new Uri("ws://localhost:12345/"),
+                ConnectionCount: 1,
+                EnableSendMetrics: true,
+                MemoryProfile: PlateauImportMemoryProfile.Large,
+                EnableMeshBake: true,
+                TerrainTileCacheRoot: null,
+                DisableTerrainTileCache: false,
+                ProgressReporter: null),
+            terrainTextureAssetHttpClient);
+
+        Assert.Same(builder.Diagnostics, builder.ClientSession.Diagnostics);
     }
 }

--- a/tests/Plateau.ResoniteLink.Tests/GlobalUsings.Architecture.cs
+++ b/tests/Plateau.ResoniteLink.Tests/GlobalUsings.Architecture.cs
@@ -1,2 +1,3 @@
 global using Plateau.ResoniteLink.Targets.Resonite;
+global using Plateau.ResoniteLink.Targets.Resonite.Execution;
 global using Plateau.ResoniteLink.Transport.ResoniteLink;

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -1,4 +1,7 @@
 
+using System.Diagnostics.CodeAnalysis;
+
+using Plateau.ResoniteLink.Application.Importing;
 using Plateau.ResoniteLink.Domain.Importing;
 
 namespace Plateau.ResoniteLink.Tests.Targets;
@@ -27,6 +30,52 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         await using ResoniteLiveSceneImportTarget builder = CreateBuilder();
 
         Assert.Equal(PlateauImportMemoryProfile.Large, builder.MemoryProfile);
+    }
+
+    [Fact]
+    public async Task ConstructorReusesDependencyDiagnostics()
+    {
+        ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.CreateEnabled();
+        await using ResoniteLiveSceneImportTarget builder = new(
+            new Uri("ws://localhost:12345/"),
+            1,
+            diagnostics,
+            PlateauImportMemoryProfile.Large,
+            new ResoniteLiveSceneImportDependencies(
+                new DelegatingClientSession(),
+                diagnostics,
+                new TerrainTextureAssetGenerator(),
+                new ResoniteSceneBootstrapInterpreter(new ResoniteSceneSlotLocator()),
+                new ResoniteGeometryAssetAssembler(),
+                new ResoniteMaterialPlanning(),
+                new ResoniteBatchEmissionPlanner(),
+                new PlannedBatchEmissionInterpreter(),
+                new ResoniteSlotCreator(),
+                new ResoniteBufferedCityObjectBakerFactory()),
+            enableMeshBake: true,
+            progressReporter: null);
+
+        Assert.Same(diagnostics, builder.Diagnostics);
+    }
+
+    [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The created target is disposed via await using in this test.")]
+    public async Task FactoryCreateReusesTransportDiagnostics()
+    {
+        using HttpClient terrainTextureAssetHttpClient = new();
+        ISceneImportTarget target = ResoniteSceneImportTargetFactory.Create(
+            new Uri("ws://localhost:12345/"),
+            connectionCount: 1,
+            enableSendMetrics: true,
+            memoryProfile: PlateauImportMemoryProfile.Large,
+            enableMeshBake: true,
+            terrainTileCacheRoot: null,
+            disableTerrainTileCache: false,
+            terrainTextureAssetHttpClient,
+            progressReporter: null);
+        await using ResoniteLiveSceneImportTarget builder = Assert.IsType<ResoniteLiveSceneImportTarget>(target);
+
+        Assert.Same(builder.Diagnostics, builder.ClientSession.Diagnostics);
     }
 
     private static ResoniteLiveSceneImportTarget CreateBuilder(bool enableMeshBake = true)

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -613,6 +613,8 @@ internal sealed class DelegatingClientSession(
 
     public IResoniteLinkClient? RoutedClient { get; set; } = routedClient;
 
+    public ResoniteLinkSendDiagnostics Diagnostics { get; } = ResoniteLinkSendDiagnostics.Disabled;
+
     public int BeginWorkerClientTrackingCallCount { get; private set; }
 
     public int EnsureConnectedCallCount { get; private set; }

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -239,7 +239,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 new GeometryIdentity("geom"),
                 false));
 
-        PlannedBatchEmission batchPlan = ResoniteLiveSceneImportTarget.CreatePlannedBatchEmission(objectSlots, emissionPlan);
+        PlannedBatchEmission batchPlan = Planner.Create(objectSlots, emissionPlan);
 
         PlannedBatchComponentEmission meshRenderer = Assert.Single(
             batchPlan.ComponentEmissions,
@@ -295,7 +295,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 new GeometryIdentity("geom"),
                 false));
 
-        PlannedBatchEmission batchPlan = ResoniteLiveSceneImportTarget.CreatePlannedBatchEmission(objectSlots, emissionPlan);
+        PlannedBatchEmission batchPlan = Planner.Create(objectSlots, emissionPlan);
 
         PlannedBatchComponentEmission[] propertyBlocks = batchPlan.ComponentEmissions
             .Where(static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal))

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -5,6 +5,8 @@ namespace Plateau.ResoniteLink.Tests.Targets;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test names describe contract cases.")]
 public sealed class ResoniteSceneBatchEmissionPlanningTests
 {
+    private static readonly IResoniteBatchEmissionPlanner Planner = new ResoniteBatchEmissionPlanner();
+
     [Fact]
     public void CreatePlannedBatchEmission_CreatesHeightMapGridPlanWithPlannedTextureReference()
     {
@@ -35,7 +37,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 new GeometryIdentity("geom"),
                 true));
 
-        PlannedBatchEmission batchPlan = ResoniteLiveSceneImportTarget.CreatePlannedBatchEmission(objectSlots, emissionPlan);
+        PlannedBatchEmission batchPlan = Planner.Create(objectSlots, emissionPlan);
 
         PlannedBatchSlotEmission meshAssetSlot = Assert.Single(
             batchPlan.SlotEmissions,
@@ -99,7 +101,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 new GeometryIdentity("geom"),
                 false));
 
-        PlannedBatchEmission batchPlan = ResoniteLiveSceneImportTarget.CreatePlannedBatchEmission(objectSlots, emissionPlan);
+        PlannedBatchEmission batchPlan = Planner.Create(objectSlots, emissionPlan);
 
         PlannedBatchComponentEmission meshRenderer = Assert.Single(
             batchPlan.ComponentEmissions,
@@ -169,7 +171,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 new GeometryIdentity("geom"),
                 true));
 
-        PlannedBatchEmission batchPlan = ResoniteLiveSceneImportTarget.CreatePlannedBatchEmission(objectSlots, emissionPlan);
+        PlannedBatchEmission batchPlan = Planner.Create(objectSlots, emissionPlan);
 
         PlannedBatchSlotEmission meshAssetSlot = Assert.Single(
             batchPlan.SlotEmissions,

--- a/tests/Plateau.ResoniteLink.Tests/Transport/LiveSendClientSessionTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Transport/LiveSendClientSessionTests.cs
@@ -14,6 +14,7 @@ public sealed class LiveSendClientSessionTests
             clientFactory.Create,
             new Uri("ws://localhost:12345/"),
             connectionCount: 3,
+            ResoniteLinkSendDiagnostics.Disabled,
             progressReporter: null);
 
         PlateauImportRequest request = CreateRequest();
@@ -35,6 +36,7 @@ public sealed class LiveSendClientSessionTests
             clientFactory.Create,
             new Uri("ws://localhost:12345/"),
             connectionCount: 3,
+            ResoniteLinkSendDiagnostics.Disabled,
             progressReporter: null);
 
         PlateauImportRequest request = CreateRequest();
@@ -59,6 +61,7 @@ public sealed class LiveSendClientSessionTests
             clientFactory.Create,
             new Uri("ws://localhost:12345/"),
             connectionCount: 3,
+            ResoniteLinkSendDiagnostics.Disabled,
             progressReporter: null);
 
         PlateauImportRequest request = CreateRequest();
@@ -103,6 +106,7 @@ public sealed class LiveSendClientSessionTests
             clientFactory.Create,
             new Uri("ws://localhost:12345/"),
             connectionCount: 2,
+            ResoniteLinkSendDiagnostics.Disabled,
             progressReporter: null);
 
         PlateauImportRequest request = CreateRequest();
@@ -126,6 +130,7 @@ public sealed class LiveSendClientSessionTests
             clientFactory.Create,
             new Uri("ws://localhost:12345/"),
             connectionCount,
+            ResoniteLinkSendDiagnostics.Disabled,
             progressReporter: null);
 
         PlateauImportRequest request = CreateRequest();
@@ -142,6 +147,7 @@ public sealed class LiveSendClientSessionTests
             clientFactory.Create,
             new Uri("ws://localhost:12345/"),
             connectionCount: 2,
+            ResoniteLinkSendDiagnostics.Disabled,
             progressReporter: null);
 
         PlateauImportRequest request = CreateRequest();


### PR DESCRIPTION
## Summary
- split Resonite scene expression concerns from ResoniteLink execution collaborators
- move live-send target construction to DI-owned scoped services and target options
- add architecture and CLI coverage for the new execution boundary and service resolution

## Why
`ResoniteLiveSceneImportTarget` was directly constructing and owning ResoniteLink-specific execution details. That mixed scene expression policy with transport execution, made the target hard to compose through DI, and let package-specific RPC concerns leak across the target layer.

## Impact
- `ResoniteLiveSceneImportTarget` is reduced to orchestration and delegates bootstrap, batch emission, slot creation, geometry, and material execution to injected collaborators
- library-side `AddResoniteLiveSendTargetServices(...)` now owns the Resonite live-send graph and CLI resolves targets from a scoped provider instead of hand-built `new` chains
- execution-oriented collaborators live under the `Execution` boundary and tests now enforce where ResoniteLink RPC/import calls may appear

## Validation
- `dotnet restore --locked-mode`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build`
- `dotnet test Plateau.ResoniteLink.sln --configuration Debug --no-build`