### PR TITLE
fix(skill): avoid login-shell headless launch

### DIFF
--- a/.agents/skills/resonite-live-send-debug/tools/session-tool.cs
+++ b/.agents/skills/resonite-live-send-debug/tools/session-tool.cs
@@ -879,7 +879,7 @@ StartedProcess StartProcess(HeadlessLaunch launch, string stdoutPath, string std
         RedirectStandardError = false,
         CreateNoWindow = true,
     };
-    startInfo.ArgumentList.Add("-lc");
+    startInfo.ArgumentList.Add("-c");
     startInfo.ArgumentList.Add(shellCommand);
 
     Process process = new()

--- a/tests/Plateau.ResoniteLink.Tests/Tools/ResoniteSessionToolCommandLineParserTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Tools/ResoniteSessionToolCommandLineParserTests.cs
@@ -398,6 +398,15 @@ public sealed class ResoniteSessionToolCommandLineParserTests
     }
 
     [Fact]
+    public void SessionToolSourceUsesNonLoginShellForPosixLaunch()
+    {
+        string source = File.ReadAllText(ScriptPath);
+
+        Assert.Contains("startInfo.ArgumentList.Add(\"-c\");", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("startInfo.ArgumentList.Add(\"-lc\");", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task StopHeadlessRejectsMissingLocator()
     {
         ProcessResult result = await RunSessionToolAsync("stop-headless");


### PR DESCRIPTION
## Summary
- switch POSIX headless launch from /bin/sh -lc to /bin/sh -c to avoid profile-dependent startup failures
- add a source contract test that guards the non-login shell launch path

## Verification
- dotnet restore .agents/skills/resonite-live-send-debug/tools/tests/ResoniteLiveSendDebug.ToolTests.csproj --locked-mode --disable-build-servers
- dotnet test .agents/skills/resonite-live-send-debug/tools/tests/ResoniteLiveSendDebug.ToolTests.csproj --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- dotnet restore Plateau.ResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false