### PR TITLE
fix(import): serialize lazy shared material creation

### DIFF
--- a/src/Plateau.ResoniteLink/Targets/Resonite/AsyncInFlightResultCache.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/AsyncInFlightResultCache.cs
@@ -1,0 +1,108 @@
+using System.Collections.Concurrent;
+
+namespace Plateau.ResoniteLink.Targets.Resonite;
+
+internal sealed class AsyncInFlightResultCache<TKey, TValue>
+    where TKey : notnull
+{
+    private readonly ConcurrentDictionary<TKey, TValue> completedValues = [];
+    private readonly ConcurrentDictionary<TKey, Task<TValue>> inFlightTasks = [];
+    private readonly ConcurrentDictionary<TKey, SemaphoreSlim> gates = [];
+
+    public async Task<TValue> GetOrCreateAsync(
+        TKey key,
+        Func<Task<TValue>> factory,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
+        if (completedValues.TryGetValue(key, out TValue? existingValue))
+        {
+            return existingValue;
+        }
+
+        Task<TValue> task = await GetOrCreateTaskAsync(key, factory, cancellationToken);
+        return await task.WaitAsync(cancellationToken);
+    }
+
+    public void Clear()
+    {
+        completedValues.Clear();
+        inFlightTasks.Clear();
+        foreach ((_, SemaphoreSlim gate) in gates)
+        {
+            gate.Dispose();
+        }
+
+        gates.Clear();
+    }
+
+    public void Remember(TKey key, TValue value)
+    {
+        completedValues[key] = value;
+        inFlightTasks.TryRemove(key, out _);
+    }
+
+    public void Remove(TKey key)
+    {
+        completedValues.TryRemove(key, out _);
+        inFlightTasks.TryRemove(key, out _);
+    }
+
+    private async Task<Task<TValue>> GetOrCreateTaskAsync(
+        TKey key,
+        Func<Task<TValue>> factory,
+        CancellationToken cancellationToken)
+    {
+        SemaphoreSlim gate = gates.GetOrAdd(key, static _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (completedValues.TryGetValue(key, out TValue? existingValue))
+            {
+                return Task.FromResult(existingValue);
+            }
+
+            if (inFlightTasks.TryGetValue(key, out Task<TValue>? existingTask))
+            {
+                return existingTask;
+            }
+
+            Task<TValue> createdTask = factory();
+            inFlightTasks[key] = createdTask;
+            ObserveCompletion(key, createdTask);
+            return createdTask;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private void ObserveCompletion(TKey key, Task<TValue> task)
+    {
+        _ = task.ContinueWith(
+            static (completedTask, state) =>
+            {
+                CompletionState completionState = (CompletionState)state!;
+                if (completedTask.Status == TaskStatus.RanToCompletion)
+                {
+                    completionState.Cache.completedValues[completionState.Key] = completedTask.Result;
+                }
+
+                if (completionState.Cache.inFlightTasks.TryGetValue(completionState.Key, out Task<TValue>? currentTask)
+                    && ReferenceEquals(currentTask, completedTask))
+                {
+                    completionState.Cache.inFlightTasks.TryRemove(completionState.Key, out _);
+                }
+            },
+            new CompletionState(this, key),
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private readonly record struct CompletionState(
+        AsyncInFlightResultCache<TKey, TValue> Cache,
+        TKey Key);
+}

--- a/src/Plateau.ResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
@@ -50,7 +50,7 @@ internal sealed class CommonMaterialAssetCache
 {
     public ConcurrentDictionary<string, Task> CommonMaterialFamilyWarmupTasks { get; } = new(StringComparer.Ordinal);
 
-    public AsyncCompletedResultCache<string, CreatedMaterialAsset> CommonMaterialCreationTasks { get; } = new();
+    public AsyncInFlightResultCache<string, CreatedMaterialAsset> CommonMaterialCreationTasks { get; } = new();
 }
 
 internal sealed record LiveSendRunPlan(

--- a/src/Plateau.ResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
@@ -50,7 +50,7 @@ internal sealed class CommonMaterialAssetCache
 {
     public ConcurrentDictionary<string, Task> CommonMaterialFamilyWarmupTasks { get; } = new(StringComparer.Ordinal);
 
-    public ConcurrentDictionary<string, Task<CreatedMaterialAsset>> CommonMaterialCreationTasks { get; } = new(StringComparer.Ordinal);
+    public AsyncCompletedResultCache<string, CreatedMaterialAsset> CommonMaterialCreationTasks { get; } = new();
 }
 
 internal sealed record LiveSendRunPlan(

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -311,7 +311,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 + $"anchor_source_file_root='{bootstrapState.SceneAnchor.ReferenceSourceFileRootId ?? "<pending>"}')."));
         foreach ((string materialKey, CreatedMaterialAsset materialAsset) in bootstrapState.CommonMaterialAssetsByKey)
         {
-            materials.CommonMaterialCreationTasks[materialKey] = Task.FromResult(materialAsset);
+            materials.CommonMaterialCreationTasks.Remember(materialKey, materialAsset);
         }
 
         foreach (string family in bootstrapState.CommonMaterialFamilies)
@@ -1406,17 +1406,15 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 await familyWarmupTask.WaitAsync(ct);
             }
 
-            Task<CreatedMaterialAsset> materialCreationTask = runState.Materials.CommonMaterialCreationTasks.GetOrAdd(
+            CreatedMaterialAsset existingMaterialAsset = await runState.Materials.CommonMaterialCreationTasks.GetOrCreateAsync(
                 materialKey,
-                static (key, state) => state.CreateLazySharedMaterialTask(key),
-                new LazySharedMaterialTaskFactory(
+                _ => new LazySharedMaterialTaskFactory(
                     runState,
                     client,
                     normalizedSharedMaterial,
                     familySlotName,
-                    CreateComponentAsync));
-
-            CreatedMaterialAsset existingMaterialAsset = await materialCreationTask.WaitAsync(ct);
+                    CreateComponentAsync).CreateLazySharedMaterialTask(materialKey),
+                ct);
             PlannedReusableMaterialAsset sharedMaterialAsset = new(
                 new MaterialIdentity(materialKey),
                 existingMaterialAsset.MaterialComponentId);

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -1408,7 +1408,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
 
             CreatedMaterialAsset existingMaterialAsset = await runState.Materials.CommonMaterialCreationTasks.GetOrCreateAsync(
                 materialKey,
-                _ => new LazySharedMaterialTaskFactory(
+                () => new LazySharedMaterialTaskFactory(
                     runState,
                     client,
                     normalizedSharedMaterial,

--- a/tests/Plateau.ResoniteLink.Tests/Targets/AsyncCompletedResultCacheTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/AsyncCompletedResultCacheTests.cs
@@ -1,0 +1,34 @@
+namespace Plateau.ResoniteLink.Tests.Targets;
+
+public sealed class AsyncCompletedResultCacheTests
+{
+    [Fact]
+    public async Task GetOrCreateAsyncInvokesFactoryOnlyOnceForConcurrentRequests()
+    {
+        Plateau.ResoniteLink.Targets.Resonite.AsyncCompletedResultCache<string, int> cache = new();
+        int invocationCount = 0;
+        TaskCompletionSource releaseFactory = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<int>[] requests =
+        [
+            cache.GetOrCreateAsync("shared", async _ =>
+            {
+                int currentCount = Interlocked.Increment(ref invocationCount);
+                await releaseFactory.Task;
+                return currentCount;
+            }, CancellationToken.None),
+            cache.GetOrCreateAsync("shared", async _ =>
+            {
+                int currentCount = Interlocked.Increment(ref invocationCount);
+                await releaseFactory.Task;
+                return currentCount;
+            }, CancellationToken.None),
+        ];
+
+        releaseFactory.SetResult();
+        int[] results = await Task.WhenAll(requests);
+
+        Assert.Equal(1, Volatile.Read(ref invocationCount));
+        Assert.Equal([1, 1], results);
+    }
+}

--- a/tests/Plateau.ResoniteLink.Tests/Targets/AsyncInFlightResultCacheTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/AsyncInFlightResultCacheTests.cs
@@ -1,0 +1,66 @@
+namespace Plateau.ResoniteLink.Tests.Targets;
+
+public sealed class AsyncInFlightResultCacheTests
+{
+    [Fact]
+    public async Task GetOrCreateAsyncInvokesFactoryOnlyOnceForConcurrentRequests()
+    {
+        Plateau.ResoniteLink.Targets.Resonite.AsyncInFlightResultCache<string, int> cache = new();
+        int invocationCount = 0;
+        TaskCompletionSource releaseFactory = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<int>[] requests =
+        [
+            cache.GetOrCreateAsync("shared", async () =>
+            {
+                int currentCount = Interlocked.Increment(ref invocationCount);
+                await releaseFactory.Task;
+                return currentCount;
+            }, CancellationToken.None),
+            cache.GetOrCreateAsync("shared", async () =>
+            {
+                int currentCount = Interlocked.Increment(ref invocationCount);
+                await releaseFactory.Task;
+                return currentCount;
+            }, CancellationToken.None),
+        ];
+
+        releaseFactory.SetResult();
+        int[] results = await Task.WhenAll(requests);
+
+        Assert.Equal(1, Volatile.Read(ref invocationCount));
+        Assert.Equal([1, 1], results);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsyncKeepsInFlightTaskWhenFirstWaiterIsCanceled()
+    {
+        Plateau.ResoniteLink.Targets.Resonite.AsyncInFlightResultCache<string, int> cache = new();
+        int invocationCount = 0;
+        TaskCompletionSource releaseFactory = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        using CancellationTokenSource firstWaiterCancellation = new();
+
+        Task<int> canceledRequest = cache.GetOrCreateAsync("shared", async () =>
+        {
+            Interlocked.Increment(ref invocationCount);
+            await releaseFactory.Task;
+            return 42;
+        }, firstWaiterCancellation.Token);
+
+        await firstWaiterCancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await canceledRequest);
+
+        Task<int> reusedRequest = cache.GetOrCreateAsync("shared", async () =>
+        {
+            Interlocked.Increment(ref invocationCount);
+            await Task.Yield();
+            return 99;
+        }, CancellationToken.None);
+
+        releaseFactory.SetResult();
+        int result = await reusedRequest;
+
+        Assert.Equal(1, Volatile.Read(ref invocationCount));
+        Assert.Equal(42, result);
+    }
+}


### PR DESCRIPTION
## Summary
- serialize lazy shared-material creation through `AsyncCompletedResultCache` so a shared material key emits at most once even under concurrent planning
- seed the same cache from bootstrap-discovered shared materials so repeated imports still reuse the preexisting common assets
- add a concurrency regression test for the cache behavior that now protects shared-material emission

## Verification
- `dotnet restore Plateau.ResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`

## Context
Follow-up to merged PR #88 for the new review thread about concurrent `GetOrAdd` side effects in lazy shared material creation.
