### PR TITLE
feat(import): abstract DEM texture sources

### DIFF
--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.cs
@@ -20,7 +20,8 @@ public static partial class LocalCityGmlObjectProjection
     public const string DefaultDemTerrainTexturePath = "dem/plateau-ortho";
     public const string DefaultDemTerrainTextureUrlTemplate = "https://api.plateauview.mlit.go.jp/tiles/plateau-ortho-2023/{z}/{x}/{y}.png";
     public const string DefaultDemTerrainTextureFallbackUrlTemplate = "https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/{z}/{x}/{y}.jpg";
-    public const int DefaultDemTerrainTextureZoomLevel = 18;
+    public const int DefaultDemTerrainTextureZoomLevel = 19;
+    public const int DefaultDemTerrainTextureFallbackZoomLevel = 18;
     public const int DefaultDemTerrainTextureMaxSize = 4096;
     public const double DefaultGeneratedRoadMarkingWidthMeters = 0.15;
     public const double DefaultGeneratedRoadMarkingSegmentLengthMeters = 5.0;
@@ -2441,7 +2442,7 @@ public static partial class LocalCityGmlObjectProjection
     {
         return string.Create(
             CultureInfo.InvariantCulture,
-            $"{terrainOverlay.PackageName.ToLowerInvariant()}|{terrainOverlay.ZoomLevel}|"
+            $"{terrainOverlay.PackageName.ToLowerInvariant()}|{terrainOverlay.SourceIdentityKey}|"
             + $"{terrainOverlay.GeographicBounds.MinLatitude:0.######},"
             + $"{terrainOverlay.GeographicBounds.MaxLatitude:0.######},"
             + $"{terrainOverlay.GeographicBounds.MinLongitude:0.######},"

--- a/src/Plateau.ResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -44,42 +44,120 @@ internal sealed class TerrainTextureAssetGenerator(
         TerrainTextureOverlay terrainTextureOverlay,
         CancellationToken cancellationToken)
     {
-        TerrainTextureLayoutPlan layoutPlan = TerrainTextureLayoutPlanner.Create(terrainTextureOverlay);
-        int usedTerrainTiles = 0;
-        int fallbackTerrainTiles = 0;
+        for (int sourceIndex = 0; sourceIndex < terrainTextureOverlay.Sources.Count; sourceIndex++)
+        {
+            TerrainTextureSource source = terrainTextureOverlay.Sources[sourceIndex];
+            Image<Rgba32>? image = source switch
+            {
+                TerrainTextureTileSource tileSource => await TryCreateTextureFromTileSourceAsync(
+                    terrainTextureOverlay,
+                    tileSource,
+                    cancellationToken),
+                TerrainTextureGeoReferencedRasterSource rasterSource => await TryCreateTextureFromGeoReferencedRasterSourceAsync(
+                    terrainTextureOverlay,
+                    rasterSource,
+                    cancellationToken),
+                _ => null,
+            };
 
-        using Image<Rgba32> stitchedImage = new(
-            layoutPlan.StitchedWidth,
-            layoutPlan.StitchedHeight);
+            if (image is null)
+            {
+                continue;
+            }
+
+            using (image)
+            using (Image<Rgba32> outputImage = ResizeToMaxTextureSize(image, terrainTextureOverlay.MaxTextureSize))
+            {
+                return new CachedTerrainTexture(
+                    CreateRawTextureImport(outputImage, CreateOverlayIdentity(terrainTextureOverlay, source)),
+                    source);
+            }
+        }
+
+        throw new HttpRequestException(
+            $"Terrain texture generation failed for '{terrainTextureOverlay.SourceIdentityKey}'.");
+    }
+
+    private async Task<Image<Rgba32>?> TryCreateTextureFromTileSourceAsync(
+        TerrainTextureOverlay terrainTextureOverlay,
+        TerrainTextureTileSource tileSource,
+        CancellationToken cancellationToken)
+    {
+        TerrainTextureLayoutPlan layoutPlan = TerrainTextureLayoutPlanner.Create(
+            terrainTextureOverlay.GeographicBounds,
+            tileSource.ZoomLevel);
+        using Image<Rgba32> stitchedImage = new(layoutPlan.StitchedWidth, layoutPlan.StitchedHeight);
 
         for (int tileY = layoutPlan.MinTileY; tileY <= layoutPlan.MaxTileY; tileY++)
         {
             for (int tileX = layoutPlan.MinTileX; tileX <= layoutPlan.MaxTileX; tileX++)
             {
-                DownloadedTerrainTile tile = await DownloadTileAsync(terrainTextureOverlay, tileX, tileY, cancellationToken);
-                usedTerrainTiles += tile.UsedTerrainTileCount;
-                fallbackTerrainTiles += tile.FallbackTileUseCount;
-                using Image<Rgba32> tileImage = tile.Image;
-                stitchedImage.Mutate(context => context.DrawImage(
-                    tileImage,
-                    new Point(
-                        (tileX - layoutPlan.MinTileX) * WebMercatorTileMath.TileSizePixels,
-                        (tileY - layoutPlan.MinTileY) * WebMercatorTileMath.TileSizePixels),
-                    1.0f));
+                Image<Rgba32>? tileImage = await TryDownloadTileAsync(
+                    tileSource,
+                    tileX,
+                    tileY,
+                    cancellationToken);
+                if (tileImage is null)
+                {
+                    return null;
+                }
+
+                using (tileImage)
+                {
+                    stitchedImage.Mutate(context => context.DrawImage(
+                        tileImage,
+                        new Point(
+                            (tileX - layoutPlan.MinTileX) * WebMercatorTileMath.TileSizePixels,
+                            (tileY - layoutPlan.MinTileY) * WebMercatorTileMath.TileSizePixels),
+                        1.0f));
+                }
             }
         }
 
-        using Image<Rgba32> croppedImage = stitchedImage.Clone(context => context.Crop(new Rectangle(
+        return stitchedImage.Clone(context => context.Crop(new Rectangle(
             layoutPlan.CropLeft,
             layoutPlan.CropTop,
             layoutPlan.CropWidth,
             layoutPlan.CropHeight)));
+    }
 
-        using Image<Rgba32> outputImage = ResizeToMaxTextureSize(croppedImage, terrainTextureOverlay.MaxTextureSize);
-        return new CachedTerrainTexture(
-            CreateRawTextureImport(outputImage, CreateOverlayIdentity(terrainTextureOverlay)),
-            usedTerrainTiles,
-            fallbackTerrainTiles);
+    private static async Task<Image<Rgba32>?> TryCreateTextureFromGeoReferencedRasterSourceAsync(
+        TerrainTextureOverlay terrainTextureOverlay,
+        TerrainTextureGeoReferencedRasterSource rasterSource,
+        CancellationToken cancellationToken)
+    {
+        string sourcePath = Path.GetFullPath(rasterSource.SourcePath);
+        GeoReferencedRasterMetadata? metadata = rasterSource.Metadata
+            ?? await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(sourcePath, cancellationToken);
+        if (metadata is null || !metadata.IsUsable)
+        {
+            return null;
+        }
+
+        try
+        {
+            using Image<Rgba32> sourceImage = await Image.LoadAsync<Rgba32>(sourcePath, cancellationToken);
+            return TerrainTextureGeoReferencedRasterCropper.TryCrop(
+                sourceImage,
+                metadata,
+                terrainTextureOverlay.GeographicBounds);
+        }
+        catch (UnknownImageFormatException)
+        {
+            return null;
+        }
+        catch (InvalidImageContentException)
+        {
+            return null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
     }
 
     private static Image<Rgba32> ResizeToMaxTextureSize(Image<Rgba32> image, int maxTextureSize)
@@ -99,58 +177,13 @@ internal sealed class TerrainTextureAssetGenerator(
         }));
     }
 
-    private async Task<DownloadedTerrainTile> DownloadTileAsync(
+    private static string CreateOverlayIdentity(
         TerrainTextureOverlay terrainTextureOverlay,
-        int tileX,
-        int tileY,
-        CancellationToken cancellationToken)
-    {
-        Image<Rgba32>? primaryImage = await TryDownloadTileAsync(
-            terrainTextureOverlay.UrlTemplate,
-            tileX,
-            tileY,
-            terrainTextureOverlay.ZoomLevel,
-            cancellationToken);
-        if (primaryImage is not null)
-        {
-            return new DownloadedTerrainTile(primaryImage, UsedTerrainTileCount: 1, FallbackTileUseCount: 0);
-        }
-
-        return await DownloadFallbackTileAsync(terrainTextureOverlay, tileX, tileY, cancellationToken);
-    }
-
-    private async Task<DownloadedTerrainTile> DownloadFallbackTileAsync(
-        TerrainTextureOverlay terrainTextureOverlay,
-        int tileX,
-        int tileY,
-        CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(terrainTextureOverlay.FallbackUrlTemplate))
-        {
-            throw new HttpRequestException(
-                $"Terrain texture tile download failed for '{CreateOverlayIdentity(terrainTextureOverlay)}' at {terrainTextureOverlay.ZoomLevel}/{tileX}/{tileY}.");
-        }
-
-        Image<Rgba32>? image = await TryDownloadTileAsync(
-            terrainTextureOverlay.FallbackUrlTemplate,
-            tileX,
-            tileY,
-            terrainTextureOverlay.ZoomLevel,
-            cancellationToken);
-        if (image is null)
-        {
-            throw new HttpRequestException(
-                $"Terrain texture tile download failed for both primary and fallback sources at {terrainTextureOverlay.ZoomLevel}/{tileX}/{tileY}.");
-        }
-
-        return new DownloadedTerrainTile(image, UsedTerrainTileCount: 1, FallbackTileUseCount: 1);
-    }
-
-    private static string CreateOverlayIdentity(TerrainTextureOverlay terrainTextureOverlay)
+        TerrainTextureSource usedSource)
     {
         return string.Create(
             System.Globalization.CultureInfo.InvariantCulture,
-            $"terrain-overlay/{terrainTextureOverlay.PackageName}/{terrainTextureOverlay.ZoomLevel}/"
+            $"terrain-overlay/{terrainTextureOverlay.PackageName}/{usedSource.IdentityKey}/"
             + $"{terrainTextureOverlay.GeographicBounds.MinLatitude:0.######},"
             + $"{terrainTextureOverlay.GeographicBounds.MaxLatitude:0.######},"
             + $"{terrainTextureOverlay.GeographicBounds.MinLongitude:0.######},"
@@ -158,18 +191,17 @@ internal sealed class TerrainTextureAssetGenerator(
     }
 
     private async Task<Image<Rgba32>?> TryDownloadTileAsync(
-        string urlTemplate,
+        TerrainTextureTileSource tileSource,
         int tileX,
         int tileY,
-        int zoomLevel,
         CancellationToken cancellationToken)
     {
-        string tileUrl = WebMercatorTileMath.FormatTileUrl(urlTemplate, zoomLevel, tileX, tileY);
+        string tileUrl = WebMercatorTileMath.FormatTileUrl(tileSource.UrlTemplate, tileSource.ZoomLevel, tileX, tileY);
         if (persistentTileCache is not null)
         {
             byte[]? cachedBytes = await persistentTileCache.TryReadTileBytesAsync(
-                urlTemplate,
-                zoomLevel,
+                tileSource.UrlTemplate,
+                tileSource.ZoomLevel,
                 tileX,
                 tileY,
                 cancellationToken);
@@ -179,13 +211,11 @@ internal sealed class TerrainTextureAssetGenerator(
                 {
                     return await LoadTileImageAsync(cachedBytes, cancellationToken);
                 }
-                catch (SixLabors.ImageSharp.UnknownImageFormatException)
+                catch (UnknownImageFormatException)
                 {
-                    // Corrupt persistent cache entries should behave like a cache miss.
                 }
-                catch (SixLabors.ImageSharp.InvalidImageContentException)
+                catch (InvalidImageContentException)
                 {
-                    // Corrupt persistent cache entries should behave like a cache miss.
                 }
             }
         }
@@ -205,8 +235,8 @@ internal sealed class TerrainTextureAssetGenerator(
             if (persistentTileCache is not null)
             {
                 await TryWritePersistentTileBytesAsync(
-                    urlTemplate,
-                    zoomLevel,
+                    tileSource.UrlTemplate,
+                    tileSource.ZoomLevel,
                     tileX,
                     tileY,
                     encodedBytes,
@@ -246,13 +276,9 @@ internal sealed class TerrainTextureAssetGenerator(
         }
         catch (IOException)
         {
-            // Persistent tile caching is an optimization. A local cache write failure
-            // must not discard a tile that was already downloaded successfully.
         }
         catch (UnauthorizedAccessException)
         {
-            // Persistent tile caching is an optimization. A local cache write failure
-            // must not discard a tile that was already downloaded successfully.
         }
     }
 
@@ -278,13 +304,7 @@ internal sealed class TerrainTextureAssetGenerator(
 
     private sealed record CachedTerrainTexture(
         ResoniteRawTextureImport TextureImport,
-        int UsedTerrainTileCount,
-        int FallbackTileUseCount);
-
-    private sealed record DownloadedTerrainTile(
-        Image<Rgba32> Image,
-        int UsedTerrainTileCount,
-        int FallbackTileUseCount);
+        TerrainTextureSource UsedSource);
 }
 
 internal sealed class PersistentTerrainTileCache

--- a/src/Plateau.ResoniteLink/Targets/Resonite/TerrainTextureGeoReferencedRasterSupport.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/TerrainTextureGeoReferencedRasterSupport.cs
@@ -1,0 +1,484 @@
+using GeographicLib;
+using GeographicLib.Projections;
+
+using Plateau.ResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace Plateau.ResoniteLink.Targets.Resonite;
+
+internal static class TerrainTextureGeoReferencedRasterMetadataReader
+{
+    private const int GeographicTypeGeoKey = 2048;
+    private const int ProjectedCSTypeGeoKey = 3072;
+    public static async Task<GeoReferencedRasterMetadata?> TryReadMetadataAsync(
+        string sourcePath,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(sourcePath) || !File.Exists(sourcePath))
+        {
+            return null;
+        }
+
+        ImageInfo imageInfo;
+        try
+        {
+            imageInfo = await Image.IdentifyAsync(sourcePath, cancellationToken)
+                ?? throw new InvalidOperationException($"Failed to identify raster '{sourcePath}'.");
+        }
+        catch (UnknownImageFormatException)
+        {
+            return null;
+        }
+
+        ExifProfile? exifProfile = imageInfo.Metadata.ExifProfile;
+        if (exifProfile is null)
+        {
+            return null;
+        }
+
+        double[]? tiePoints = TryGetDoubleArray(exifProfile, ExifTag.ModelTiePoint);
+        double[]? pixelScale = TryGetDoubleArray(exifProfile, ExifTag.PixelScale);
+        double[]? modelTransform = TryGetDoubleArray(exifProfile, ExifTag.ModelTransform);
+        ushort[]? geoKeyDirectory = TryGetUnsignedShortArray(exifProfile, "GeoKeyDirectoryTag");
+        double[]? geoDoubleParams = TryGetNamedDoubleArray(exifProfile, "GeoDoubleParamsTag");
+        string? geoAsciiParams = TryGetNamedString(exifProfile, "GeoAsciiParamsTag");
+
+        return TryCreateMetadata(
+            imageInfo.Width,
+            imageInfo.Height,
+            tiePoints,
+            pixelScale,
+            modelTransform,
+            geoKeyDirectory,
+            geoDoubleParams,
+            geoAsciiParams);
+    }
+
+    internal static GeoReferencedRasterMetadata? TryCreateMetadata(
+        int pixelWidth,
+        int pixelHeight,
+        double[]? modelTiePoint,
+        double[]? pixelScale,
+        double[]? modelTransform,
+        ushort[]? geoKeyDirectory,
+        double[]? geoDoubleParams,
+        string? geoAsciiParams)
+    {
+        if (pixelWidth <= 0 || pixelHeight <= 0)
+        {
+            return null;
+        }
+
+        if (!TryCreateModelBounds(
+                pixelWidth,
+                pixelHeight,
+                modelTiePoint,
+                pixelScale,
+                modelTransform,
+                out ModelSpaceRectangle modelBounds,
+                out double pixelWidthInModelUnits,
+                out double pixelHeightInModelUnits))
+        {
+            return null;
+        }
+
+        string? coordinateSystemIdentifier = TryResolveCoordinateSystemIdentifier(
+            geoKeyDirectory,
+            geoDoubleParams,
+            geoAsciiParams);
+        GeographicRectangle? geographicBounds = TryConvertToGeographicBounds(
+            coordinateSystemIdentifier,
+            modelBounds);
+        if (geographicBounds is null)
+        {
+            return new GeoReferencedRasterMetadata(
+                modelBounds.ToFallbackGeographicRectangle(),
+                coordinateSystemIdentifier,
+                PixelWidthMeters: 0.0,
+                PixelHeightMeters: 0.0);
+        }
+
+        return new GeoReferencedRasterMetadata(
+            geographicBounds,
+            coordinateSystemIdentifier,
+            GetPixelWidthMeters(coordinateSystemIdentifier, geographicBounds, pixelWidthInModelUnits),
+            GetPixelHeightMeters(coordinateSystemIdentifier, geographicBounds, pixelHeightInModelUnits));
+    }
+
+    private static bool TryCreateModelBounds(
+        int pixelWidth,
+        int pixelHeight,
+        double[]? modelTiePoint,
+        double[]? pixelScale,
+        double[]? modelTransform,
+        out ModelSpaceRectangle bounds,
+        out double pixelWidthInModelUnits,
+        out double pixelHeightInModelUnits)
+    {
+        if (TryCreateBoundsFromTiePointAndScale(
+                pixelWidth,
+                pixelHeight,
+                modelTiePoint,
+                pixelScale,
+                out bounds,
+                out pixelWidthInModelUnits,
+                out pixelHeightInModelUnits))
+        {
+            return true;
+        }
+
+        return TryCreateBoundsFromTransform(
+            pixelWidth,
+            pixelHeight,
+            modelTransform,
+            out bounds,
+            out pixelWidthInModelUnits,
+            out pixelHeightInModelUnits);
+    }
+
+    private static bool TryCreateBoundsFromTiePointAndScale(
+        int pixelWidth,
+        int pixelHeight,
+        double[]? modelTiePoint,
+        double[]? pixelScale,
+        out ModelSpaceRectangle bounds,
+        out double pixelWidthInModelUnits,
+        out double pixelHeightInModelUnits)
+    {
+        bounds = default;
+        pixelWidthInModelUnits = 0.0;
+        pixelHeightInModelUnits = 0.0;
+        if (modelTiePoint is null || pixelScale is null || modelTiePoint.Length < 6 || pixelScale.Length < 2)
+        {
+            return false;
+        }
+
+        double rasterX = modelTiePoint[0];
+        double rasterY = modelTiePoint[1];
+        double modelX = modelTiePoint[3];
+        double modelY = modelTiePoint[4];
+        double scaleX = Math.Abs(pixelScale[0]);
+        double scaleY = Math.Abs(pixelScale[1]);
+        if (scaleX <= 0.0 || scaleY <= 0.0)
+        {
+            return false;
+        }
+
+        double west = modelX - (rasterX * scaleX);
+        double north = modelY + (rasterY * scaleY);
+        double east = west + (pixelWidth * scaleX);
+        double south = north - (pixelHeight * scaleY);
+        bounds = new ModelSpaceRectangle(west, south, east, north);
+        pixelWidthInModelUnits = scaleX;
+        pixelHeightInModelUnits = scaleY;
+        return true;
+    }
+
+    private static bool TryCreateBoundsFromTransform(
+        int pixelWidth,
+        int pixelHeight,
+        double[]? modelTransform,
+        out ModelSpaceRectangle bounds,
+        out double pixelWidthInModelUnits,
+        out double pixelHeightInModelUnits)
+    {
+        bounds = default;
+        pixelWidthInModelUnits = 0.0;
+        pixelHeightInModelUnits = 0.0;
+        if (modelTransform is null || modelTransform.Length < 16)
+        {
+            return false;
+        }
+
+        double scaleX = modelTransform[0];
+        double shearX = modelTransform[1];
+        double shearY = modelTransform[4];
+        double scaleY = modelTransform[5];
+        if (Math.Abs(shearX) > 1e-9 || Math.Abs(shearY) > 1e-9 || scaleX <= 0.0 || scaleY >= 0.0)
+        {
+            return false;
+        }
+
+        double translateX = modelTransform[3];
+        double translateY = modelTransform[7];
+        double west = translateX;
+        double north = translateY;
+        double east = west + (pixelWidth * scaleX);
+        double south = north + (pixelHeight * scaleY);
+        bounds = new ModelSpaceRectangle(west, south, east, north);
+        pixelWidthInModelUnits = Math.Abs(scaleX);
+        pixelHeightInModelUnits = Math.Abs(scaleY);
+        return true;
+    }
+
+    private static string? TryResolveCoordinateSystemIdentifier(
+        ushort[]? geoKeyDirectory,
+        double[]? geoDoubleParams,
+        string? geoAsciiParams)
+    {
+        if (geoKeyDirectory is null || geoKeyDirectory.Length < 8)
+        {
+            return null;
+        }
+
+        _ = geoDoubleParams;
+        _ = geoAsciiParams;
+
+        int keyCount = geoKeyDirectory[3];
+        for (int index = 0; index < keyCount; index++)
+        {
+            int entryOffset = 4 + (index * 4);
+            if (entryOffset + 3 >= geoKeyDirectory.Length)
+            {
+                break;
+            }
+
+            int keyId = geoKeyDirectory[entryOffset];
+            int tiffTagLocation = geoKeyDirectory[entryOffset + 1];
+            int valueCount = geoKeyDirectory[entryOffset + 2];
+            int valueOffset = geoKeyDirectory[entryOffset + 3];
+            if (valueCount != 1 || tiffTagLocation != 0)
+            {
+                continue;
+            }
+
+            if (keyId == GeographicTypeGeoKey || keyId == ProjectedCSTypeGeoKey)
+            {
+                return $"EPSG:{valueOffset}";
+            }
+        }
+
+        return null;
+    }
+
+    private static GeographicRectangle? TryConvertToGeographicBounds(
+        string? coordinateSystemIdentifier,
+        ModelSpaceRectangle modelBounds)
+    {
+        if (string.IsNullOrWhiteSpace(coordinateSystemIdentifier))
+        {
+            return null;
+        }
+
+        if (string.Equals(coordinateSystemIdentifier, "EPSG:4326", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(coordinateSystemIdentifier, "EPSG:6668", StringComparison.OrdinalIgnoreCase))
+        {
+            return new GeographicRectangle(
+                modelBounds.MinY,
+                modelBounds.MaxY,
+                modelBounds.MinX,
+                modelBounds.MaxX);
+        }
+
+        if (!TryParseJapanPlaneRectangularZone(coordinateSystemIdentifier, out int zone))
+        {
+            return null;
+        }
+
+        (double originLatitude, double originLongitude) = JapanPlaneRectangularZoneOrigins[zone - 1];
+        TransverseMercator projection = new(Ellipsoid.GRS80, JapanPlaneRectangularCentralScale);
+        (_, double originNorthing) = projection.Forward(originLongitude, originLatitude, originLongitude);
+
+        (double minLatitude, double minLongitude) = ReverseProjected(projection, originLongitude, originNorthing, modelBounds.MinX, modelBounds.MinY);
+        (double maxLatitude, double maxLongitude) = ReverseProjected(projection, originLongitude, originNorthing, modelBounds.MaxX, modelBounds.MaxY);
+        return new GeographicRectangle(
+            MinLatitude: Math.Min(minLatitude, maxLatitude),
+            MaxLatitude: Math.Max(minLatitude, maxLatitude),
+            MinLongitude: Math.Min(minLongitude, maxLongitude),
+            MaxLongitude: Math.Max(minLongitude, maxLongitude));
+    }
+
+    private static double GetPixelWidthMeters(
+        string? coordinateSystemIdentifier,
+        GeographicRectangle geographicBounds,
+        double pixelWidthInModelUnits)
+    {
+        if (pixelWidthInModelUnits <= 0.0)
+        {
+            return 0.0;
+        }
+
+        return IsGeographicCoordinateSystem(coordinateSystemIdentifier)
+            ? DegreesLongitudeToMeters((geographicBounds.MinLatitude + geographicBounds.MaxLatitude) * 0.5, pixelWidthInModelUnits)
+            : pixelWidthInModelUnits;
+    }
+
+    private static double GetPixelHeightMeters(
+        string? coordinateSystemIdentifier,
+        GeographicRectangle geographicBounds,
+        double pixelHeightInModelUnits)
+    {
+        if (pixelHeightInModelUnits <= 0.0)
+        {
+            return 0.0;
+        }
+
+        return IsGeographicCoordinateSystem(coordinateSystemIdentifier)
+            ? DegreesLatitudeToMeters(pixelHeightInModelUnits)
+            : pixelHeightInModelUnits;
+    }
+
+    private static bool IsGeographicCoordinateSystem(string? coordinateSystemIdentifier)
+    {
+        return string.Equals(coordinateSystemIdentifier, "EPSG:4326", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(coordinateSystemIdentifier, "EPSG:6668", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static (double Latitude, double Longitude) ReverseProjected(
+        TransverseMercator projection,
+        double centralMeridian,
+        double originNorthing,
+        double x,
+        double y)
+    {
+        (double latitude, double longitude) = projection.Reverse(centralMeridian, x, y + originNorthing);
+        return (latitude, longitude);
+    }
+
+    private static bool TryParseJapanPlaneRectangularZone(
+        string coordinateSystemIdentifier,
+        out int zone)
+    {
+        zone = 0;
+        if (!coordinateSystemIdentifier.StartsWith("EPSG:", StringComparison.OrdinalIgnoreCase)
+            || !int.TryParse(coordinateSystemIdentifier["EPSG:".Length..], out int epsgCode))
+        {
+            return false;
+        }
+
+        zone = epsgCode - 6668;
+        return zone is >= 1 and <= 19;
+    }
+
+    private static double DegreesLatitudeToMeters(double degrees)
+    {
+        return Math.Abs(degrees) * 111_320.0;
+    }
+
+    private static double DegreesLongitudeToMeters(double latitude, double degrees)
+    {
+        return Math.Abs(degrees) * 111_320.0 * Math.Cos(latitude * (Math.PI / 180.0));
+    }
+
+    private static double[]? TryGetDoubleArray(ExifProfile exifProfile, ExifTag<double[]> tag)
+    {
+        return exifProfile.TryGetValue(tag, out IExifValue<double[]>? exifValue)
+            ? exifValue.Value
+            : null;
+    }
+
+    private static ushort[]? TryGetUnsignedShortArray(ExifProfile exifProfile, string tagName)
+    {
+        object? value = TryGetNamedValue(exifProfile, tagName);
+        return value switch
+        {
+            ushort[] ushortArray => ushortArray,
+            short[] shortArray => shortArray.Select(static item => unchecked((ushort)item)).ToArray(),
+            _ => null,
+        };
+    }
+
+    private static double[]? TryGetNamedDoubleArray(ExifProfile exifProfile, string tagName)
+    {
+        return TryGetNamedValue(exifProfile, tagName) as double[];
+    }
+
+    private static string? TryGetNamedString(ExifProfile exifProfile, string tagName)
+    {
+        return TryGetNamedValue(exifProfile, tagName) as string;
+    }
+
+    private static object? TryGetNamedValue(ExifProfile exifProfile, string tagName)
+    {
+        foreach (IExifValue value in exifProfile.Values)
+        {
+            if (!string.Equals(value.Tag.ToString(), tagName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            return value.GetType().GetProperty("Value")?.GetValue(value);
+        }
+
+        return null;
+    }
+
+    private const double JapanPlaneRectangularCentralScale = 0.9999;
+
+    private static readonly (double Latitude, double Longitude)[] JapanPlaneRectangularZoneOrigins =
+    [
+        (33.0, 129.5),
+        (33.0, 131.0),
+        (36.0, 132.16666666666666),
+        (33.0, 133.5),
+        (36.0, 134.33333333333334),
+        (36.0, 136.0),
+        (36.0, 137.16666666666666),
+        (36.0, 138.5),
+        (36.0, 139.83333333333334),
+        (40.0, 140.83333333333334),
+        (44.0, 140.25),
+        (44.0, 142.25),
+        (44.0, 144.25),
+        (26.0, 142.0),
+        (26.0, 127.5),
+        (26.0, 124.0),
+        (26.0, 131.0),
+        (20.0, 136.0),
+        (26.0, 154.0),
+    ];
+
+    private readonly record struct ModelSpaceRectangle(
+        double MinX,
+        double MinY,
+        double MaxX,
+        double MaxY)
+    {
+        public GeographicRectangle ToFallbackGeographicRectangle()
+        {
+            return new GeographicRectangle(MinY, MaxY, MinX, MaxX);
+        }
+    }
+}
+
+internal static class TerrainTextureGeoReferencedRasterCropper
+{
+    public static Image<Rgba32>? TryCrop(
+        Image<Rgba32> sourceImage,
+        GeoReferencedRasterMetadata metadata,
+        GeographicRectangle requestedBounds)
+    {
+        if (!metadata.IsUsable)
+        {
+            return null;
+        }
+
+        GeographicRectangle rasterBounds = metadata.GeographicBounds;
+        GeographicRectangle intersection = new(
+            Math.Max(requestedBounds.MinLatitude, rasterBounds.MinLatitude),
+            Math.Min(requestedBounds.MaxLatitude, rasterBounds.MaxLatitude),
+            Math.Max(requestedBounds.MinLongitude, rasterBounds.MinLongitude),
+            Math.Min(requestedBounds.MaxLongitude, rasterBounds.MaxLongitude));
+        if (intersection.MaxLatitude <= intersection.MinLatitude
+            || intersection.MaxLongitude <= intersection.MinLongitude)
+        {
+            return null;
+        }
+
+        double u0 = (intersection.MinLongitude - rasterBounds.MinLongitude) / (rasterBounds.MaxLongitude - rasterBounds.MinLongitude);
+        double u1 = (intersection.MaxLongitude - rasterBounds.MinLongitude) / (rasterBounds.MaxLongitude - rasterBounds.MinLongitude);
+        double v0 = (rasterBounds.MaxLatitude - intersection.MaxLatitude) / (rasterBounds.MaxLatitude - rasterBounds.MinLatitude);
+        double v1 = (rasterBounds.MaxLatitude - intersection.MinLatitude) / (rasterBounds.MaxLatitude - rasterBounds.MinLatitude);
+
+        int left = Math.Clamp((int)Math.Floor(u0 * sourceImage.Width), 0, sourceImage.Width - 1);
+        int top = Math.Clamp((int)Math.Floor(v0 * sourceImage.Height), 0, sourceImage.Height - 1);
+        int right = Math.Clamp((int)Math.Ceiling(u1 * sourceImage.Width), left + 1, sourceImage.Width);
+        int bottom = Math.Clamp((int)Math.Ceiling(v1 * sourceImage.Height), top + 1, sourceImage.Height);
+
+        return sourceImage.Clone(context => context.Crop(new Rectangle(left, top, right - left, bottom - top)));
+    }
+}

--- a/src/Plateau.ResoniteLink/Targets/Resonite/TerrainTextureLayoutPlanner.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/TerrainTextureLayoutPlanner.cs
@@ -10,11 +10,17 @@ internal static class TerrainTextureLayoutPlanner
     {
         ArgumentNullException.ThrowIfNull(terrainTextureOverlay);
 
-        GeographicRectangle bounds = terrainTextureOverlay.GeographicBounds;
-        double leftPixel = WebMercatorTileMath.LongitudeToPixelX(bounds.MinLongitude, terrainTextureOverlay.ZoomLevel);
-        double rightPixel = WebMercatorTileMath.LongitudeToPixelX(bounds.MaxLongitude, terrainTextureOverlay.ZoomLevel);
-        double topPixel = WebMercatorTileMath.LatitudeToPixelY(bounds.MaxLatitude, terrainTextureOverlay.ZoomLevel);
-        double bottomPixel = WebMercatorTileMath.LatitudeToPixelY(bounds.MinLatitude, terrainTextureOverlay.ZoomLevel);
+        return Create(terrainTextureOverlay.GeographicBounds, terrainTextureOverlay.ZoomLevel);
+    }
+
+    public static TerrainTextureLayoutPlan Create(
+        GeographicRectangle bounds,
+        int zoomLevel)
+    {
+        double leftPixel = WebMercatorTileMath.LongitudeToPixelX(bounds.MinLongitude, zoomLevel);
+        double rightPixel = WebMercatorTileMath.LongitudeToPixelX(bounds.MaxLongitude, zoomLevel);
+        double topPixel = WebMercatorTileMath.LatitudeToPixelY(bounds.MaxLatitude, zoomLevel);
+        double bottomPixel = WebMercatorTileMath.LatitudeToPixelY(bounds.MinLatitude, zoomLevel);
 
         if (rightPixel - leftPixel <= PixelEpsilon || bottomPixel - topPixel <= PixelEpsilon)
         {

--- a/tests/Plateau.ResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -23,7 +23,7 @@ public sealed class TerrainTextureAssetGeneratorTests
         ResoniteRawTextureImport secondTexture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
         Assert.Same(firstTexture, secondTexture);
-        Assert.Contains("terrain-overlay/dem/1/", firstTexture.Identity, StringComparison.Ordinal);
+        Assert.Contains("terrain-overlay/dem/tile|1|https://tiles.example/{z}/{x}/{y}.png/", firstTexture.Identity, StringComparison.Ordinal);
 
         using Image<Rgba32> image = Image.LoadPixelData<Rgba32>(firstTexture.RawRgba32Bytes, firstTexture.Width, firstTexture.Height);
         Assert.Equal(512, image.Width);
@@ -122,7 +122,7 @@ public sealed class TerrainTextureAssetGeneratorTests
         ResoniteRawTextureImport texture = await secondGenerator.EnsureTextureAsync(overlay, CancellationToken.None);
 
         Assert.Equal(0, secondHandler.RequestCount);
-        Assert.Contains("terrain-overlay/dem/1/", texture.Identity, StringComparison.Ordinal);
+        Assert.Contains("terrain-overlay/dem/tile|1|https://tiles.example/{z}/{x}/{y}.png/", texture.Identity, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -244,6 +244,34 @@ public sealed class TerrainTextureAssetGeneratorTests
         using Image<Rgba32> image = Image.LoadPixelData<Rgba32>(texture.RawRgba32Bytes, texture.Width, texture.Height);
         AssertColor(image[128, 128], 255, 0, 0);
         AssertColor(image[384, 128], 0, 255, 0);
+    }
+
+    [Fact]
+    public async Task EnsureTextureAsyncUsesFallbackSourceZoomLevelIndependently()
+    {
+        using ZoomAwareFallbackMapTileHandler handler = new();
+        using HttpClient httpClient = new(handler);
+        TerrainTextureAssetGenerator generator = new(httpClient, disablePersistentCache: true);
+        const int primaryZoomLevel = 2;
+        GeographicRectangle bounds = new(
+            MinLatitude: WebMercatorTileMath.PixelYToLatitude(WebMercatorTileMath.TileSizePixels, primaryZoomLevel),
+            MaxLatitude: WebMercatorTileMath.PixelYToLatitude(0, primaryZoomLevel),
+            MinLongitude: WebMercatorTileMath.PixelXToLongitude(0, primaryZoomLevel),
+            MaxLongitude: WebMercatorTileMath.PixelXToLongitude(WebMercatorTileMath.TileSizePixels, primaryZoomLevel));
+        TerrainTextureOverlay overlay = new(
+            PackageName: "dem",
+            GeographicBounds: bounds,
+            MaxTextureSize: 4096,
+            PrimarySource: new TerrainTextureTileSource("https://primary.example/{z}/{x}/{y}.png", primaryZoomLevel),
+            FallbackSource: new TerrainTextureTileSource("https://fallback.example/{z}/{x}/{y}.png", 1));
+
+        _ = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
+
+        string[] requestedSources = handler.Requests
+            .Select(static request => $"{request.Host}|{request.ZoomLevel}")
+            .ToArray();
+        Assert.Contains($"primary.example|{primaryZoomLevel}", requestedSources);
+        Assert.Contains("fallback.example|1", requestedSources);
     }
 
     private static TerrainTextureOverlay CreateFullCoverageOverlay(string urlTemplate, string? fallbackUrlTemplate = null)
@@ -371,6 +399,32 @@ public sealed class TerrainTextureAssetGeneratorTests
             string[] segments = request.RequestUri!.AbsolutePath.Trim('/').Split('/');
             int tileX = int.Parse(segments[^2], CultureInfo.InvariantCulture);
             int tileY = int.Parse(Path.GetFileNameWithoutExtension(segments[^1]), CultureInfo.InvariantCulture);
+
+            using Image<Rgba32> image = new(WebMercatorTileMath.TileSizePixels, WebMercatorTileMath.TileSizePixels, FakeMapTileHandler.GetTileColorForTests(tileX, tileY));
+            MemoryStream stream = new();
+            await image.SaveAsPngAsync(stream, cancellationToken);
+            stream.Position = 0;
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(stream) };
+        }
+    }
+
+    private sealed class ZoomAwareFallbackMapTileHandler : HttpMessageHandler
+    {
+        public List<(string Host, int ZoomLevel, int TileX, int TileY)> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string[] segments = request.RequestUri!.AbsolutePath.Trim('/').Split('/');
+            int zoomLevel = int.Parse(segments[^3], CultureInfo.InvariantCulture);
+            int tileX = int.Parse(segments[^2], CultureInfo.InvariantCulture);
+            int tileY = int.Parse(Path.GetFileNameWithoutExtension(segments[^1]), CultureInfo.InvariantCulture);
+            Requests.Add((request.RequestUri.Host, zoomLevel, tileX, tileY));
+
+            if (string.Equals(request.RequestUri.Host, "primary.example", StringComparison.Ordinal))
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
 
             using Image<Rgba32> image = new(WebMercatorTileMath.TileSizePixels, WebMercatorTileMath.TileSizePixels, FakeMapTileHandler.GetTileColorForTests(tileX, tileY));
             MemoryStream stream = new();

--- a/tests/Plateau.ResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+
+using Plateau.ResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Plateau.ResoniteLink.Tests.Targets;
+
+public sealed class TerrainTextureGeoReferencedRasterSupportTests
+{
+    [Fact]
+    public void TryCreateMetadataResolvesJapanPlaneRectangularBounds()
+    {
+        ushort[] geoKeyDirectory =
+        [
+            1, 1, 0, 1,
+            3072, 0, 1, 6676,
+        ];
+
+        GeoReferencedRasterMetadata? metadata = TerrainTextureGeoReferencedRasterMetadataReader.TryCreateMetadata(
+            pixelWidth: 100,
+            pixelHeight: 50,
+            modelTiePoint: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            pixelScale: [1.0, 1.0, 0.0],
+            modelTransform: null,
+            geoKeyDirectory: geoKeyDirectory,
+            geoDoubleParams: null,
+            geoAsciiParams: null);
+
+        Assert.NotNull(metadata);
+        Assert.True(metadata.IsUsable);
+        Assert.Equal("EPSG:6676", metadata.CoordinateSystemIdentifier);
+        Assert.Equal(1.0, metadata.PixelWidthMeters);
+        Assert.Equal(1.0, metadata.PixelHeightMeters);
+        Assert.InRange(metadata.GeographicBounds.MaxLatitude, 35.99, 36.01);
+        Assert.InRange(metadata.GeographicBounds.MinLongitude, 138.49, 138.51);
+        Assert.True(metadata.GeographicBounds.MaxLongitude > metadata.GeographicBounds.MinLongitude);
+        Assert.True(metadata.GeographicBounds.MaxLatitude > metadata.GeographicBounds.MinLatitude);
+    }
+
+    [Fact]
+    public void TryCreateMetadataReturnsUnusableMetadataWhenCoordinateSystemIsMissing()
+    {
+        GeoReferencedRasterMetadata? metadata = TerrainTextureGeoReferencedRasterMetadataReader.TryCreateMetadata(
+            pixelWidth: 10,
+            pixelHeight: 10,
+            modelTiePoint: [0.0, 0.0, 0.0, 139.0, 35.0, 0.0],
+            pixelScale: [0.00001, 0.00001, 0.0],
+            modelTransform: null,
+            geoKeyDirectory: null,
+            geoDoubleParams: null,
+            geoAsciiParams: null);
+
+        Assert.NotNull(metadata);
+        Assert.False(metadata.IsUsable);
+        Assert.Null(metadata.CoordinateSystemIdentifier);
+    }
+
+    [Fact]
+    public async Task EnsureTextureAsyncUsesGeoReferencedRasterSourceBeforeTileFallback()
+    {
+        using TemporaryDirectory workDirectory = new();
+        string rasterPath = Path.Combine(workDirectory.Path, "terrain.png");
+        using (Image<Rgba32> rasterImage = new(4, 4, new Rgba32(12, 34, 56, 255)))
+        {
+            await rasterImage.SaveAsPngAsync(rasterPath);
+        }
+
+        GeographicRectangle bounds = new(35.0, 35.001, 139.0, 139.001);
+        TerrainTextureOverlay overlay = new(
+            PackageName: "dem",
+            GeographicBounds: bounds,
+            MaxTextureSize: 1024,
+            Sources:
+            [
+                new TerrainTextureGeoReferencedRasterSource(
+                    rasterPath,
+                    new GeoReferencedRasterMetadata(bounds, "EPSG:4326", 10.0, 10.0)),
+                new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", 18),
+            ]);
+
+        using NeverCalledMapTileHandler handler = new();
+        using HttpClient httpClient = new(handler);
+        TerrainTextureAssetGenerator generator = new(httpClient, disablePersistentCache: true);
+
+        ResoniteRawTextureImport texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
+
+        Assert.Equal(0, handler.RequestCount);
+        using Image<Rgba32> outputImage = Image.LoadPixelData<Rgba32>(texture.RawRgba32Bytes, texture.Width, texture.Height);
+        Assert.Equal(new Rgba32(12, 34, 56, 255), outputImage[0, 0]);
+        Assert.Contains("georaster|", texture.Identity, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task EnsureTextureAsyncSkipsUnsupportedGeoReferencedRasterSource()
+    {
+        GeographicRectangle bounds = new(0.0, WebMercatorTileMath.MaxLatitude, -180.0, 180.0);
+        TerrainTextureOverlay overlay = new(
+            PackageName: "dem",
+            GeographicBounds: bounds,
+            MaxTextureSize: 1024,
+            Sources:
+            [
+                new TerrainTextureGeoReferencedRasterSource("missing.tif"),
+                new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", 1),
+            ]);
+
+        using TerrainTextureAssetGeneratorTestsProxyMapTileHandler handler = new();
+        using HttpClient httpClient = new(handler);
+        TerrainTextureAssetGenerator generator = new(httpClient, disablePersistentCache: true);
+
+        ResoniteRawTextureImport texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
+
+        Assert.Equal(4, handler.RequestCount);
+        Assert.Contains("tile|1|https://tiles.example/{z}/{x}/{y}.png", texture.Identity, StringComparison.Ordinal);
+    }
+
+    private sealed class NeverCalledMapTileHandler : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            throw new InvalidOperationException($"Unexpected tile request to '{request.RequestUri}'.");
+        }
+    }
+
+    private sealed class TerrainTextureAssetGeneratorTestsProxyMapTileHandler : HttpMessageHandler
+    {
+        private int requestCount;
+
+        public int RequestCount => requestCount;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Interlocked.Increment(ref requestCount);
+
+            string[] segments = request.RequestUri!.AbsolutePath.Trim('/').Split('/');
+            int tileX = int.Parse(segments[^2], System.Globalization.CultureInfo.InvariantCulture);
+            int tileY = int.Parse(Path.GetFileNameWithoutExtension(segments[^1]), System.Globalization.CultureInfo.InvariantCulture);
+            using Image<Rgba32> image = new(WebMercatorTileMath.TileSizePixels, WebMercatorTileMath.TileSizePixels, GetTileColor(tileX, tileY));
+            MemoryStream stream = new();
+            await image.SaveAsPngAsync(stream, cancellationToken);
+            stream.Position = 0;
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(stream) };
+        }
+
+        private static Rgba32 GetTileColor(int tileX, int tileY)
+        {
+            return (tileX, tileY) switch
+            {
+                (0, 0) => new Rgba32(255, 0, 0, 255),
+                (1, 0) => new Rgba32(0, 255, 0, 255),
+                (0, 1) => new Rgba32(0, 0, 255, 255),
+                (1, 1) => new Rgba32(255, 255, 0, 255),
+                _ => new Rgba32(255, 0, 255, 255),
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- abstract DEM texture overlays over ordered texture source candidates
- prefer PLATEAU ortho z=19 with z=18 and GSI fallback while keeping current behavior
- add a GeoTIFF-backed georeferenced raster foundation and focused tests

## Verification
- dotnet build Plateau.ResoniteLink.sln --no-restore -v minimal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- dotnet test tests/Plateau.ResoniteLink.Tests/Plateau.ResoniteLink.Tests.csproj --no-build --filter "FullyQualifiedName~TerrainTextureAssetGeneratorTests|FullyQualifiedName~LocalCityGmlDemBootstrapSupportTests|FullyQualifiedName~TerrainTextureLayoutPlannerTests|FullyQualifiedName~TerrainTextureGeoReferencedRasterSupportTests" -v minimal -m:1 --disable-build-servers -p:UseSharedCompilation=false