### PR TITLE
fix(resonite): pack atlas into power-of-two canvases

### DIFF
--- a/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -777,41 +777,126 @@ internal sealed class Lod2AtlasCityObjectBaker(
         out AtlasLayout? layout)
     {
         int atlasMaxSize = EffectiveMaxAtlasSize;
+        AtlasSizeRequirements requirements = ComputeAtlasSizeRequirements(entries, atlasMaxSize);
+        if (!requirements.IsValid)
+        {
+            layout = null;
+            return false;
+        }
+
+        foreach (AtlasCanvasCandidate candidate in EnumerateAtlasCanvasCandidates(requirements, atlasMaxSize))
+        {
+            if (TryCreateAtlasLayoutForCanvas(entries, candidate.Width, candidate.Height, out layout))
+            {
+                return true;
+            }
+        }
+
+        layout = null;
+        return false;
+    }
+
+    private bool TryCreateAtlasLayoutForCanvas(
+        IReadOnlyList<AtlasBatchEntry> entries,
+        int atlasWidth,
+        int atlasHeight,
+        out AtlasLayout? layout)
+    {
         List<AtlasPlacement> placements = [];
-        List<Rect> freeRectangles = [new Rect(0, 0, atlasMaxSize, atlasMaxSize)];
-        int usedWidth = 0;
-        int usedHeight = 0;
+        List<Rect> freeRectangles = [new Rect(0, 0, atlasWidth, atlasHeight)];
 
         foreach (AtlasBatchEntry entry in entries)
         {
-            int paddedWidth = entry.Tile.Image.Width + (tilePaddingPixels * 2);
-            int paddedHeight = entry.Tile.Image.Height + (tilePaddingPixels * 2);
-            if (paddedWidth > atlasMaxSize || paddedHeight > atlasMaxSize)
+            AtlasEntrySize entrySize = GetAtlasEntrySize(entry);
+            if (entrySize.PaddedWidth > atlasWidth || entrySize.PaddedHeight > atlasHeight)
             {
                 layout = null;
                 return false;
             }
 
-            if (!TryChooseFreeRectangle(freeRectangles, paddedWidth, paddedHeight, out Rect selectedRect))
+            if (!TryChooseFreeRectangle(freeRectangles, entrySize.PaddedWidth, entrySize.PaddedHeight, out Rect selectedRect))
             {
                 layout = null;
                 return false;
             }
 
-            Rect outerRect = new(selectedRect.X, selectedRect.Y, paddedWidth, paddedHeight);
+            Rect outerRect = new(selectedRect.X, selectedRect.Y, entrySize.PaddedWidth, entrySize.PaddedHeight);
             Rect innerRect = new(selectedRect.X + tilePaddingPixels, selectedRect.Y + tilePaddingPixels, entry.Tile.Image.Width, entry.Tile.Image.Height);
             placements.Add(new AtlasPlacement(entry, outerRect, innerRect));
             SplitFreeRectangles(freeRectangles, outerRect);
             PruneFreeRectangles(freeRectangles);
-            usedWidth = Math.Max(usedWidth, outerRect.X + outerRect.Width);
-            usedHeight = Math.Max(usedHeight, outerRect.Y + outerRect.Height);
         }
 
         layout = new AtlasLayout(
-            Math.Max(1, usedWidth),
-            Math.Max(1, usedHeight),
+            atlasWidth,
+            atlasHeight,
             placements);
         return true;
+    }
+
+    private AtlasSizeRequirements ComputeAtlasSizeRequirements(
+        IReadOnlyList<AtlasBatchEntry> entries,
+        int atlasMaxSize)
+    {
+        long requiredArea = 0;
+        int minWidth = 1;
+        int minHeight = 1;
+
+        foreach (AtlasBatchEntry entry in entries)
+        {
+            AtlasEntrySize entrySize = GetAtlasEntrySize(entry);
+            if (entrySize.PaddedWidth > atlasMaxSize || entrySize.PaddedHeight > atlasMaxSize)
+            {
+                return AtlasSizeRequirements.Invalid;
+            }
+
+            minWidth = Math.Max(minWidth, entrySize.PaddedWidth);
+            minHeight = Math.Max(minHeight, entrySize.PaddedHeight);
+            requiredArea += (long)entrySize.PaddedWidth * entrySize.PaddedHeight;
+        }
+
+        return new AtlasSizeRequirements(minWidth, minHeight, requiredArea);
+    }
+
+    private static IEnumerable<AtlasCanvasCandidate> EnumerateAtlasCanvasCandidates(
+        AtlasSizeRequirements requirements,
+        int atlasMaxSize)
+    {
+        List<int> widthCandidates = EnumeratePowerOfTwoEdges(requirements.MinWidth, atlasMaxSize).ToList();
+        List<int> heightCandidates = EnumeratePowerOfTwoEdges(requirements.MinHeight, atlasMaxSize).ToList();
+
+        return widthCandidates
+            .SelectMany(
+                width => heightCandidates,
+                (width, height) => new AtlasCanvasCandidate(width, height, requirements))
+            .OrderBy(static candidate => candidate.Area)
+            .ThenBy(static candidate => candidate.AreaSlack)
+            .ThenBy(static candidate => candidate.DimensionSlack)
+            .ThenBy(static candidate => candidate.Height)
+            .ThenBy(static candidate => candidate.Width);
+    }
+
+    private static IEnumerable<int> EnumeratePowerOfTwoEdges(int minimumEdge, int maxEdge)
+    {
+        if (minimumEdge > maxEdge)
+        {
+            yield break;
+        }
+
+        for (int edge = 1; edge > 0 && edge <= maxEdge; edge <<= 1)
+        {
+            if (edge >= minimumEdge)
+            {
+                yield return edge;
+            }
+        }
+    }
+
+    private AtlasEntrySize GetAtlasEntrySize(AtlasBatchEntry entry)
+    {
+        return new AtlasEntrySize(
+            entry.Tile.Image.Width + (tilePaddingPixels * 2),
+            entry.Tile.Image.Height + (tilePaddingPixels * 2));
     }
 
     private static bool TryChooseFreeRectangle(
@@ -1515,6 +1600,32 @@ internal sealed class Lod2AtlasCityObjectBaker(
         int Width,
         int Height,
         IReadOnlyList<AtlasPlacement> Placements);
+
+    private readonly record struct AtlasSizeRequirements(
+        int MinWidth,
+        int MinHeight,
+        long RequiredArea)
+    {
+        internal static AtlasSizeRequirements Invalid => new(0, 0, 0);
+
+        internal bool IsValid => MinWidth > 0 && MinHeight > 0;
+    }
+
+    private readonly record struct AtlasCanvasCandidate(
+        int Width,
+        int Height,
+        AtlasSizeRequirements Requirements)
+    {
+        internal long Area => (long)Width * Height;
+
+        internal long AreaSlack => Area - Requirements.RequiredArea;
+
+        internal int DimensionSlack => (Width - Requirements.MinWidth) + (Height - Requirements.MinHeight);
+    }
+
+    private readonly record struct AtlasEntrySize(
+        int PaddedWidth,
+        int PaddedHeight);
 
     private sealed record AtlasPlacement(
         AtlasBatchEntry Entry,

--- a/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -201,7 +201,7 @@ public sealed class Lod2AtlasCityObjectBakerTests
     [Fact]
     public async Task FlushAllAsyncPacksMixedSizeTexturesIntoSingleAtlasBatch()
     {
-        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 10, tilePaddingPixels: 0);
+        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 16, tilePaddingPixels: 0);
 
         await AssertBufferedAsync(baker, CreateLod2Building("building-a", CreatePayload("textures/a.png", new Rgba32(255, 0, 0, 255), 7, 7), 0, "unit-a"));
         await AssertBufferedAsync(baker, CreateLod2Building("building-b", CreatePayload("textures/b.png", new Rgba32(0, 255, 0, 255), 1, 7), 2, "unit-a"));
@@ -209,8 +209,26 @@ public sealed class Lod2AtlasCityObjectBakerTests
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
-        Assert.Equal(8, atlasPayload.Width);
-        Assert.Equal(10, atlasPayload.Height);
+        Assert.Equal(16, atlasPayload.Width);
+        Assert.Equal(8, atlasPayload.Height);
+    }
+
+    [Fact]
+    public async Task FlushAllAsyncFallsBackWhenSingleCandidateNeedsNonPowerOfTwoEdgeBeyondBudget()
+    {
+        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 10, tilePaddingPixels: 0);
+
+        ResoniteConstructionCityObject oversizedCandidate = CreateLod2Building(
+            "building-a",
+            CreatePayload("textures/a.png", new Rgba32(255, 0, 0, 255), 9, 3),
+            0,
+            "unit-a");
+
+        await AssertBufferedAsync(baker, oversizedCandidate);
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+        Assert.Equal(oversizedCandidate.SlotKey, cityObject.SlotKey);
+        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- make atlas packing choose a fixed power-of-two canvas before layout succeeds
- keep width and height independent so non-square power-of-two atlases remain valid
- update atlas baker tests for the new contract and budget fallback behavior

## Verification
- dotnet restore Plateau.ResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
