### PR TITLE
fix: harden live-send import budgeting

### DIFF
--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
@@ -19,14 +19,33 @@ internal sealed class ResoniteBufferedCityObjectBakerFactory : IResoniteBuffered
     {
         ArgumentNullException.ThrowIfNull(textureImageLoader);
 
+        int maxVerticesPerBatch = resourceBudget.Name switch
+        {
+            PlateauImportMemoryProfile.Small => 32_768,
+            PlateauImportMemoryProfile.Large => 65_535,
+            _ => throw new ArgumentOutOfRangeException(nameof(resourceBudget), resourceBudget.Name, "Unsupported memory profile."),
+        };
+        int maxCityObjectsPerBatch = resourceBudget.Name switch
+        {
+            PlateauImportMemoryProfile.Small => 512,
+            PlateauImportMemoryProfile.Large => 4096,
+            _ => throw new ArgumentOutOfRangeException(nameof(resourceBudget), resourceBudget.Name, "Unsupported memory profile."),
+        };
+        int maxBufferedCells = resourceBudget.Name switch
+        {
+            PlateauImportMemoryProfile.Small => 256,
+            PlateauImportMemoryProfile.Large => 1024,
+            _ => throw new ArgumentOutOfRangeException(nameof(resourceBudget), resourceBudget.Name, "Unsupported memory profile."),
+        };
+
         return enableMeshBake
             ? new CompositeCityObjectBaker(
                 new Lod2AtlasCityObjectBaker(textureImageLoader, resourceBudget: resourceBudget),
                 new FixedCellCityObjectMeshBaker(
                     FixedCellCityObjectMeshBaker.DefaultCellSizeMeters,
-                    FixedCellCityObjectMeshBaker.DefaultMaxCityObjectsPerBatch,
-                    FixedCellCityObjectMeshBaker.DefaultMaxVerticesPerBatch,
-                    resourceBudget.Name == PlateauImportMemoryProfile.Small ? 256 : 1024))
+                    maxCityObjectsPerBatch,
+                    maxVerticesPerBatch,
+                    maxBufferedCells))
             : null;
     }
 }

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -723,21 +723,25 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
 
     private static long EstimateCityObjectWorkingSetBytes(ResoniteConstructionCityObject cityObject)
     {
-        const long minimumWeightBytes = 256L * 1024L;
-        const long textureReferenceWeightBytes = 4L * 1024L * 1024L;
+        const long minimumWeightBytes = 16L * 1024L * 1024L;
+        const long textureReferenceWeightBytes = 16L * 1024L * 1024L;
         const long heightSampleWeightBytes = sizeof(double);
         const long hdrHeightTextureWeightBytes = 4L * sizeof(float);
-        const long materialBindingWeightBytes = 512L;
-        const long vertexWeightBytes = 64L;
-        const long indexWeightBytes = sizeof(int);
-        const long perSubmeshWeightBytes = 256L;
+        const long materialBindingWeightBytes = 4096L;
+        const long vertexWeightBytes = 256L;
+        const long indexWeightBytes = 16L;
+        const long perSubmeshWeightBytes = 4096L;
+        const long triangleMeshExpansionFactor = 4L;
+        const long heightMapExpansionFactor = 2L;
 
         long geometryWeightBytes = cityObject.Geometry switch
         {
-            ResoniteTriangleMeshGeometry triangleMesh => EstimateTriangleMeshWorkingSetBytes(triangleMesh.Mesh),
+            ResoniteTriangleMeshGeometry triangleMesh => checked(
+                EstimateTriangleMeshWorkingSetBytes(triangleMesh.Mesh) * triangleMeshExpansionFactor),
             ResoniteHeightMapGridGeometry heightMap => checked(
                 (heightMap.HeightSamples.Count * heightSampleWeightBytes)
-                + ((long)heightMap.Width * heightMap.Height * hdrHeightTextureWeightBytes)),
+                + ((long)heightMap.Width * heightMap.Height * hdrHeightTextureWeightBytes)
+                * heightMapExpansionFactor),
             _ => minimumWeightBytes,
         };
 
@@ -909,10 +913,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             .ThenBy(static overlay => overlay.GeographicBounds.MinLongitude)
             .ToArray();
 
-        Task<PreparedTextureReference>[] terrainOverlayTexturePreparationTasks = distinctTerrainOverlays
+        Task<PreparedTextureReference?>[] terrainOverlayTexturePreparationTasks = distinctTerrainOverlays
             .Select(terrainTextureOverlay => PrepareTerrainOverlayTextureReferenceAsync(terrainTextureOverlay, cancellationToken))
             .ToArray();
-        Task<PreparedTextureReference>[] texturePreparationTasks = [];
+        Task<PreparedTextureReference?>[] texturePreparationTasks = [];
 
         Task<PreparedConstructionGeometry> geometryPreparationTask = cityObject.Geometry switch
         {
@@ -925,13 +929,16 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
         };
         Stopwatch stopwatch = Stopwatch.StartNew();
-        PreparedTextureReference[] preparedTextures = await Task.WhenAll(
+        PreparedTextureReference?[] preparedTextureResults = await Task.WhenAll(
             texturePreparationTasks
                 .Concat(terrainOverlayTexturePreparationTasks)
                 .Concat(cityObject.Materials
                     .Where(static material => material.TexturePayload is not null)
                     .Select(PrepareDirectMaterialTextureReferenceAsync)
                     .ToArray()));
+        PreparedTextureReference[] preparedTextures = preparedTextureResults
+            .OfType<PreparedTextureReference>()
+            .ToArray();
         PreparedConstructionGeometry preparedGeometry = await geometryPreparationTask;
         stopwatch.Stop();
         Diagnostics.RecordPrepare(cityObject.PackageName, stopwatch.Elapsed.TotalSeconds);
@@ -953,29 +960,40 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             preparedTextures);
     }
 
-    private async Task<PreparedTextureReference> PrepareTerrainOverlayTextureReferenceAsync(
+    private async Task<PreparedTextureReference?> PrepareTerrainOverlayTextureReferenceAsync(
         TerrainTextureOverlay terrainTextureOverlay,
         CancellationToken cancellationToken)
     {
-        GeneratedTerrainTexture terrainTexture = await terrainTextureAssetGenerator.EnsureTextureAsync(
-            terrainTextureOverlay,
-            cancellationToken);
+        try
+        {
+            GeneratedTerrainTexture terrainTexture = await terrainTextureAssetGenerator.EnsureTextureAsync(
+                terrainTextureOverlay,
+                cancellationToken);
 
-        return new PreparedTextureReference(
-            TextureIdentity: null,
-            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-            TextureImport: terrainTexture.TextureImport,
-            TerrainOverlay: terrainTextureOverlay,
-            GeneratedTerrainTexture: terrainTexture);
+            return new PreparedTextureReference(
+                TextureIdentity: null,
+                TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                TextureImport: terrainTexture.TextureImport,
+                TerrainOverlay: terrainTextureOverlay,
+                GeneratedTerrainTexture: terrainTexture);
+        }
+        catch (HttpRequestException)
+        {
+            ReportProgress(
+                PlateauLog.Warning(
+                    "live",
+                    $"Skipping terrain overlay texture for '{terrainTextureOverlay.SourceIdentityKey}' after texture generation failure."));
+            return null;
+        }
     }
 
-    private Task<PreparedTextureReference> PrepareDirectMaterialTextureReferenceAsync(
+    private Task<PreparedTextureReference?> PrepareDirectMaterialTextureReferenceAsync(
         ResoniteMaterialBinding material)
     {
         ArgumentNullException.ThrowIfNull(material);
         ArgumentNullException.ThrowIfNull(material.TexturePayload);
 
-        return Task.FromResult(
+        return Task.FromResult<PreparedTextureReference?>(
             new PreparedTextureReference(
                 TextureIdentity: material.TexturePayload.Identity,
                 TextureSourceKind: material.TextureSourceKind,

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -1,5 +1,6 @@
 
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -152,6 +153,32 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         Assert.True(terrainTextureFactory.LastOptions.DisableTerrainTileCache);
     }
 
+    [Theory]
+    [InlineData(PlateauImportMemoryProfile.Small, 512, 32768, 256)]
+    [InlineData(PlateauImportMemoryProfile.Large, 4096, 65535, 1024)]
+    public void BufferedCityObjectBakerFactoryScalesMeshBakeBudgetsByMemoryProfile(
+        PlateauImportMemoryProfile memoryProfile,
+        int expectedMaxCityObjectsPerBatch,
+        int expectedMaxVerticesPerBatch,
+        int expectedMaxBufferedCells)
+    {
+        ResoniteBufferedCityObjectBakerFactory factory = new();
+
+        CompositeCityObjectBaker baker = factory.Create(
+                enableMeshBake: true,
+                new ResoniteTextureImageLoader(),
+                ResoniteImportBudgetProfiles.ForProfile(memoryProfile))
+            ?? throw new InvalidOperationException("Expected mesh bake composite baker.");
+
+        IResoniteBufferedCityObjectBaker fixedCellBaker = Assert.Single(
+            GetPrivateField<IResoniteBufferedCityObjectBaker[]>(baker, "bakers"),
+            static candidate => candidate is FixedCellCityObjectMeshBaker);
+
+        Assert.Equal(expectedMaxCityObjectsPerBatch, GetPrivateField<int>(fixedCellBaker, "maxCityObjectsPerBatch"));
+        Assert.Equal(expectedMaxVerticesPerBatch, GetPrivateField<int>(fixedCellBaker, "maxVerticesPerBatch"));
+        Assert.Equal(expectedMaxBufferedCells, GetPrivateField<int>(fixedCellBaker, "maxBufferedCells"));
+    }
+
     private static ResoniteLiveSceneImportTarget CreateBuilder(bool enableMeshBake = true)
     {
         ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
@@ -219,5 +246,13 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             cancellationToken.ThrowIfCancellationRequested();
             throw new NotSupportedException("This test only verifies DI override preservation during target creation.");
         }
+    }
+
+    private static T GetPrivateField<T>(object instance, string fieldName)
+    {
+        FieldInfo field = instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"Field '{fieldName}' was not found on '{instance.GetType().Name}'.");
+        return (T)(field.GetValue(instance)
+            ?? throw new InvalidOperationException($"Field '{fieldName}' was null."));
     }
 }


### PR DESCRIPTION
## Summary
- scale fixed-cell mesh bake budgets by import memory profile
- increase live-send working-set estimates to better reflect real geometry and texture cost
- degrade missing terrain overlay texture fetches to warnings so a full-area send can continue

## Verification
- dotnet restore Plateau.ResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

Stacked on top of #102 (base branch: codex/import-intent-unified).