### PR TITLE
Recover shared common material normalization

### DIFF
--- a/src/Plateau.ResoniteLink/Model3d/ResoniteDynamicMaterialUvNormalizer.cs
+++ b/src/Plateau.ResoniteLink/Model3d/ResoniteDynamicMaterialUvNormalizer.cs
@@ -12,7 +12,7 @@ public static class ResoniteDynamicMaterialUvNormalizer
             && material.AssetScope != ResoniteMaterialAssetScope.Common
             && !(material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
                 && !string.IsNullOrWhiteSpace(material.Family))
-            && (material.TextureScale is not null || material.TextureOffset is not null);
+            && HasEffectiveTextureTransform(material);
     }
 
     public static ResoniteConstructionCityObject Normalize(ResoniteConstructionCityObject cityObject)
@@ -61,6 +61,15 @@ public static class ResoniteDynamicMaterialUvNormalizer
     {
         ArgumentNullException.ThrowIfNull(material);
 
+        if (!HasEffectiveTextureTransform(material))
+        {
+            return material with
+            {
+                TextureScale = null,
+                TextureOffset = null,
+            };
+        }
+
         return ShouldBakeTextureTransform(material)
             ? material with
             {
@@ -84,5 +93,25 @@ public static class ResoniteDynamicMaterialUvNormalizer
         return new ResoniteFloat2(
             (sourceUv.X * scaleX) + offsetX,
             (sourceUv.Y * scaleY) + offsetY);
+    }
+
+    private static bool HasEffectiveTextureTransform(ResoniteMaterialBinding material)
+    {
+        return !IsIdentityTextureScale(material.TextureScale)
+            || !IsZeroTextureOffset(material.TextureOffset);
+    }
+
+    private static bool IsIdentityTextureScale(ResoniteFloat2? textureScale)
+    {
+        return textureScale is null
+            || (Math.Abs(textureScale.X - 1.0) < 1e-9
+                && Math.Abs(textureScale.Y - 1.0) < 1e-9);
+    }
+
+    private static bool IsZeroTextureOffset(ResoniteFloat2? textureOffset)
+    {
+        return textureOffset is null
+            || (Math.Abs(textureOffset.X) < 1e-9
+                && Math.Abs(textureOffset.Y) < 1e-9);
     }
 }

--- a/src/Plateau.ResoniteLink/Model3d/ResoniteDynamicMaterialUvNormalizer.cs
+++ b/src/Plateau.ResoniteLink/Model3d/ResoniteDynamicMaterialUvNormalizer.cs
@@ -63,6 +63,14 @@ public static class ResoniteDynamicMaterialUvNormalizer
 
         if (!HasEffectiveTextureTransform(material))
         {
+            if (IsBundledFamilyMaterial(material) && material.TextureScale is not null)
+            {
+                return material with
+                {
+                    TextureOffset = null,
+                };
+            }
+
             return material with
             {
                 TextureScale = null,
@@ -99,6 +107,12 @@ public static class ResoniteDynamicMaterialUvNormalizer
     {
         return !IsIdentityTextureScale(material.TextureScale)
             || !IsZeroTextureOffset(material.TextureOffset);
+    }
+
+    private static bool IsBundledFamilyMaterial(ResoniteMaterialBinding material)
+    {
+        return material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
+            && !string.IsNullOrWhiteSpace(material.Family);
     }
 
     private static bool IsIdentityTextureScale(ResoniteFloat2? textureScale)

--- a/src/Plateau.ResoniteLink/Model3d/ResoniteDynamicMaterialUvNormalizer.cs
+++ b/src/Plateau.ResoniteLink/Model3d/ResoniteDynamicMaterialUvNormalizer.cs
@@ -1,0 +1,85 @@
+namespace Plateau.ResoniteLink.Domain.Importing;
+
+public static class ResoniteDynamicMaterialUvNormalizer
+{
+    public static bool ShouldBakeTextureTransform(ResoniteMaterialBinding material)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+
+        return material.MaterialType == ResoniteMaterialType.Standard
+            && material.Projection == ResoniteMaterialProjection.Uv
+            && material.AssetScope != ResoniteMaterialAssetScope.Common
+            && (material.TextureScale is not null || material.TextureOffset is not null);
+    }
+
+    public static ResoniteConstructionCityObject Normalize(ResoniteConstructionCityObject cityObject)
+    {
+        ArgumentNullException.ThrowIfNull(cityObject);
+
+        if (cityObject.Geometry is not ResoniteTriangleMeshGeometry triangleMesh
+            || !cityObject.Materials.Any(ShouldBakeTextureTransform))
+        {
+            return cityObject;
+        }
+
+        Dictionary<int, ResoniteMaterialBinding> materialBySubmeshIndex = cityObject.Materials
+            .SelectMany(material => material.SubmeshIndices.Select(submeshIndex => (submeshIndex, material)))
+            .ToDictionary(static pair => pair.submeshIndex, static pair => pair.material);
+
+        List<ResoniteMeshVertex> normalizedVertices = [];
+        List<ResoniteMeshSubmesh> normalizedSubmeshes = [];
+        foreach (ResoniteMeshSubmesh submesh in triangleMesh.Mesh.Submeshes)
+        {
+            materialBySubmeshIndex.TryGetValue(submesh.Index, out ResoniteMaterialBinding? material);
+            List<int> normalizedTriangleVertexIndices = new(submesh.TriangleVertexIndices.Count);
+            foreach (int sourceIndex in submesh.TriangleVertexIndices)
+            {
+                ResoniteMeshVertex sourceVertex = triangleMesh.Mesh.Vertices[sourceIndex];
+                ResoniteFloat2 normalizedUv = material is not null && ShouldBakeTextureTransform(material)
+                    ? ApplyTextureTransform(sourceVertex.UV0, material)
+                    : sourceVertex.UV0;
+                normalizedVertices.Add(sourceVertex with { UV0 = normalizedUv });
+                normalizedTriangleVertexIndices.Add(normalizedVertices.Count - 1);
+            }
+
+            normalizedSubmeshes.Add(submesh with { TriangleVertexIndices = normalizedTriangleVertexIndices });
+        }
+
+        return cityObject with
+        {
+            Geometry = new ResoniteTriangleMeshGeometry(new ResoniteImportedMesh(normalizedVertices, normalizedSubmeshes)),
+            Materials = cityObject.Materials
+                .Select(NormalizeMaterialBinding)
+                .ToArray(),
+        };
+    }
+
+    public static ResoniteMaterialBinding NormalizeMaterialBinding(ResoniteMaterialBinding material)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+
+        return ShouldBakeTextureTransform(material)
+            ? material with
+            {
+                TextureScale = null,
+                TextureOffset = null,
+            }
+            : material;
+    }
+
+    public static ResoniteFloat2 ApplyTextureTransform(
+        ResoniteFloat2 sourceUv,
+        ResoniteMaterialBinding material)
+    {
+        ArgumentNullException.ThrowIfNull(sourceUv);
+        ArgumentNullException.ThrowIfNull(material);
+
+        double scaleX = material.TextureScale?.X ?? 1.0;
+        double scaleY = material.TextureScale?.Y ?? 1.0;
+        double offsetX = material.TextureOffset?.X ?? 0.0;
+        double offsetY = material.TextureOffset?.Y ?? 0.0;
+        return new ResoniteFloat2(
+            (sourceUv.X * scaleX) + offsetX,
+            (sourceUv.Y * scaleY) + offsetY);
+    }
+}

--- a/src/Plateau.ResoniteLink/Model3d/ResoniteDynamicMaterialUvNormalizer.cs
+++ b/src/Plateau.ResoniteLink/Model3d/ResoniteDynamicMaterialUvNormalizer.cs
@@ -8,6 +8,7 @@ public static class ResoniteDynamicMaterialUvNormalizer
 
         return material.MaterialType == ResoniteMaterialType.Standard
             && material.Projection == ResoniteMaterialProjection.Uv
+            && material.TerrainOverlay is null
             && material.AssetScope != ResoniteMaterialAssetScope.Common
             && (material.TextureScale is not null || material.TextureOffset is not null);
     }

--- a/src/Plateau.ResoniteLink/Model3d/ResoniteDynamicMaterialUvNormalizer.cs
+++ b/src/Plateau.ResoniteLink/Model3d/ResoniteDynamicMaterialUvNormalizer.cs
@@ -10,6 +10,8 @@ public static class ResoniteDynamicMaterialUvNormalizer
             && material.Projection == ResoniteMaterialProjection.Uv
             && material.TerrainOverlay is null
             && material.AssetScope != ResoniteMaterialAssetScope.Common
+            && !(material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
+                && !string.IsNullOrWhiteSpace(material.Family))
             && (material.TextureScale is not null || material.TextureOffset is not null);
     }
 

--- a/src/Plateau.ResoniteLink/Model3d/ResoniteDynamicMaterialUvNormalizer.cs
+++ b/src/Plateau.ResoniteLink/Model3d/ResoniteDynamicMaterialUvNormalizer.cs
@@ -61,6 +61,12 @@ public static class ResoniteDynamicMaterialUvNormalizer
     {
         ArgumentNullException.ThrowIfNull(material);
 
+        if (material.MaterialType != ResoniteMaterialType.Standard
+            || material.Projection != ResoniteMaterialProjection.Uv)
+        {
+            return material;
+        }
+
         if (!HasEffectiveTextureTransform(material))
         {
             if (IsBundledFamilyMaterial(material) && material.TextureScale is not null)

--- a/src/Plateau.ResoniteLink/Model3d/ResoniteMaterialSharing.cs
+++ b/src/Plateau.ResoniteLink/Model3d/ResoniteMaterialSharing.cs
@@ -4,13 +4,6 @@ public static class ResoniteMaterialSharing
 {
     private static readonly ResoniteColor SharedBaseColor = new(1.0, 1.0, 1.0, 1.0);
 
-    public static IReadOnlyList<ResoniteFloat2> FixedSharedAlbedoOffsets { get; } =
-    [
-        new ResoniteFloat2(0.5, 0.0),
-        new ResoniteFloat2(0.0, 0.5),
-        new ResoniteFloat2(0.5, 0.5),
-    ];
-
     public static bool CanUseSharedAlbedoOnlyMaterial(ResoniteMaterialBinding material)
     {
         ArgumentNullException.ThrowIfNull(material);
@@ -40,16 +33,11 @@ public static class ResoniteMaterialSharing
 
     public static ResoniteMaterialBinding CreateSharedAlbedoCommonMaterial()
     {
-        return CreateSharedAlbedoCommonMaterial(textureOffset: null);
-    }
-
-    public static ResoniteMaterialBinding CreateSharedAlbedoCommonMaterial(ResoniteFloat2? textureOffset)
-    {
         return new ResoniteMaterialBinding(
             MaterialKey: CreateCanonicalGenericSharedMaterialKey(
                 ResoniteMaterialProjection.Uv,
                 textureScale: null,
-                textureOffset,
+                textureOffset: null,
                 depthOffset: null),
             BaseColor: SharedBaseColor,
             MaterialType: ResoniteMaterialType.Standard,
@@ -60,7 +48,7 @@ public static class ResoniteMaterialSharing
             SubmeshIndices: [0],
             TextureScale: null,
             Family: null,
-            TextureOffset: textureOffset,
+            TextureOffset: null,
             AssetScope: ResoniteMaterialAssetScope.Common);
     }
 
@@ -88,7 +76,8 @@ public static class ResoniteMaterialSharing
         ResoniteFloat2? textureOffset,
         ResoniteMaterialDepthOffset? depthOffset)
     {
-        string scaleToken = CreateFloat2Token(textureScale);
+        ResoniteFloat2? normalizedTextureScale = IsIdentityTextureScale(textureScale) ? null : textureScale;
+        string scaleToken = CreateFloat2Token(normalizedTextureScale);
         string offsetToken = CreateFloat2Token(textureOffset);
         string depthToken = CreateDepthToken(depthOffset);
         return $"generic|{projection}|scale:{scaleToken}|offset:{offsetToken}|depth:{depthToken}";
@@ -125,5 +114,12 @@ public static class ResoniteMaterialSharing
             : string.Create(
                 System.Globalization.CultureInfo.InvariantCulture,
                 $"{value.Factor:0.######}x{value.Units:0.######}");
+    }
+
+    private static bool IsIdentityTextureScale(ResoniteFloat2? textureScale)
+    {
+        return textureScale is not null
+            && Math.Abs(textureScale.X - 1.0) < 1e-9
+            && Math.Abs(textureScale.Y - 1.0) < 1e-9;
     }
 }

--- a/src/Plateau.ResoniteLink/Model3d/ResoniteMaterialSharing.cs
+++ b/src/Plateau.ResoniteLink/Model3d/ResoniteMaterialSharing.cs
@@ -2,7 +2,14 @@ namespace Plateau.ResoniteLink.Domain.Importing;
 
 public static class ResoniteMaterialSharing
 {
-    private static readonly ResoniteColor SharedAlbedoOnlyBaseColor = new(1.0, 1.0, 1.0, 1.0);
+    private static readonly ResoniteColor SharedBaseColor = new(1.0, 1.0, 1.0, 1.0);
+
+    public static IReadOnlyList<ResoniteFloat2> FixedSharedAlbedoOffsets { get; } =
+    [
+        new ResoniteFloat2(0.5, 0.0),
+        new ResoniteFloat2(0.0, 0.5),
+        new ResoniteFloat2(0.5, 0.5),
+    ];
 
     public static bool CanUseSharedAlbedoOnlyMaterial(ResoniteMaterialBinding material)
     {
@@ -15,6 +22,108 @@ public static class ResoniteMaterialSharing
             && material.DepthOffset is null
             && material.TextureScale is null
             && material.TextureOffset is null
-            && material.BaseColor == SharedAlbedoOnlyBaseColor;
+            && material.BaseColor == SharedBaseColor;
+    }
+
+    public static bool CanUseSharedVertexColorMaterial(ResoniteMaterialBinding material)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+
+        return material.MaterialType == ResoniteMaterialType.VertexColor
+            && material.Projection == ResoniteMaterialProjection.Uv
+            && IsWhiteBaseColor(material.BaseColor)
+            && material.TexturePayload is null
+            && material.TerrainOverlay is null
+            && material.TextureScale is null
+            && material.TextureOffset is null;
+    }
+
+    public static ResoniteMaterialBinding CreateSharedAlbedoCommonMaterial()
+    {
+        return CreateSharedAlbedoCommonMaterial(textureOffset: null);
+    }
+
+    public static ResoniteMaterialBinding CreateSharedAlbedoCommonMaterial(ResoniteFloat2? textureOffset)
+    {
+        return new ResoniteMaterialBinding(
+            MaterialKey: CreateCanonicalGenericSharedMaterialKey(
+                ResoniteMaterialProjection.Uv,
+                textureScale: null,
+                textureOffset,
+                depthOffset: null),
+            BaseColor: SharedBaseColor,
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: null,
+            Family: null,
+            TextureOffset: textureOffset,
+            AssetScope: ResoniteMaterialAssetScope.Common);
+    }
+
+    public static ResoniteMaterialBinding CreateSharedVertexColorCommonMaterial(
+        ResoniteMaterialDepthOffset? depthOffset = null)
+    {
+        return new ResoniteMaterialBinding(
+            MaterialKey: CreateCanonicalVertexColorCommonMaterialKey(ResoniteMaterialProjection.Uv, depthOffset),
+            BaseColor: SharedBaseColor,
+            MaterialType: ResoniteMaterialType.VertexColor,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: depthOffset,
+            SubmeshIndices: [0],
+            TextureScale: null,
+            Family: null,
+            TextureOffset: null,
+            AssetScope: ResoniteMaterialAssetScope.Common);
+    }
+
+    public static string CreateCanonicalGenericSharedMaterialKey(
+        ResoniteMaterialProjection projection,
+        ResoniteFloat2? textureScale,
+        ResoniteFloat2? textureOffset,
+        ResoniteMaterialDepthOffset? depthOffset)
+    {
+        string scaleToken = CreateFloat2Token(textureScale);
+        string offsetToken = CreateFloat2Token(textureOffset);
+        string depthToken = CreateDepthToken(depthOffset);
+        return $"generic|{projection}|scale:{scaleToken}|offset:{offsetToken}|depth:{depthToken}";
+    }
+
+    public static string CreateCanonicalVertexColorCommonMaterialKey(
+        ResoniteMaterialProjection projection,
+        ResoniteMaterialDepthOffset? depthOffset)
+    {
+        return $"vertex-color|{projection}|depth:{CreateDepthToken(depthOffset)}";
+    }
+
+    public static bool IsWhiteBaseColor(ResoniteColor color)
+    {
+        return Math.Abs(color.R - 1.0) < 1e-9
+            && Math.Abs(color.G - 1.0) < 1e-9
+            && Math.Abs(color.B - 1.0) < 1e-9
+            && Math.Abs(color.A - 1.0) < 1e-9;
+    }
+
+    private static string CreateFloat2Token(ResoniteFloat2? value)
+    {
+        return value is null
+            ? "none"
+            : string.Create(
+                System.Globalization.CultureInfo.InvariantCulture,
+                $"{value.X:0.######}x{value.Y:0.######}");
+    }
+
+    private static string CreateDepthToken(ResoniteMaterialDepthOffset? value)
+    {
+        return value is null
+            ? "none"
+            : string.Create(
+                System.Globalization.CultureInfo.InvariantCulture,
+                $"{value.Factor:0.######}x{value.Units:0.######}");
     }
 }

--- a/src/Plateau.ResoniteLink/Model3d/ResoniteMaterialSharing.cs
+++ b/src/Plateau.ResoniteLink/Model3d/ResoniteMaterialSharing.cs
@@ -13,8 +13,8 @@ public static class ResoniteMaterialSharing
             && material.TextureSourceKind == ResoniteTextureSourceKind.Dataset
             && material.TexturePayload is not null
             && material.DepthOffset is null
-            && material.TextureScale is null
-            && material.TextureOffset is null
+            && IsIdentityTextureScale(material.TextureScale)
+            && IsZeroTextureOffset(material.TextureOffset)
             && material.BaseColor == SharedBaseColor;
     }
 
@@ -27,8 +27,8 @@ public static class ResoniteMaterialSharing
             && IsWhiteBaseColor(material.BaseColor)
             && material.TexturePayload is null
             && material.TerrainOverlay is null
-            && material.TextureScale is null
-            && material.TextureOffset is null;
+            && IsIdentityTextureScale(material.TextureScale)
+            && IsZeroTextureOffset(material.TextureOffset);
     }
 
     public static ResoniteMaterialBinding CreateSharedAlbedoCommonMaterial()
@@ -77,8 +77,9 @@ public static class ResoniteMaterialSharing
         ResoniteMaterialDepthOffset? depthOffset)
     {
         ResoniteFloat2? normalizedTextureScale = IsIdentityTextureScale(textureScale) ? null : textureScale;
+        ResoniteFloat2? normalizedTextureOffset = IsZeroTextureOffset(textureOffset) ? null : textureOffset;
         string scaleToken = CreateFloat2Token(normalizedTextureScale);
-        string offsetToken = CreateFloat2Token(textureOffset);
+        string offsetToken = CreateFloat2Token(normalizedTextureOffset);
         string depthToken = CreateDepthToken(depthOffset);
         return $"generic|{projection}|scale:{scaleToken}|offset:{offsetToken}|depth:{depthToken}";
     }
@@ -118,8 +119,15 @@ public static class ResoniteMaterialSharing
 
     private static bool IsIdentityTextureScale(ResoniteFloat2? textureScale)
     {
-        return textureScale is not null
-            && Math.Abs(textureScale.X - 1.0) < 1e-9
-            && Math.Abs(textureScale.Y - 1.0) < 1e-9;
+        return textureScale is null
+            || (Math.Abs(textureScale.X - 1.0) < 1e-9
+                && Math.Abs(textureScale.Y - 1.0) < 1e-9);
+    }
+
+    private static bool IsZeroTextureOffset(ResoniteFloat2? textureOffset)
+    {
+        return textureOffset is null
+            || (Math.Abs(textureOffset.X) < 1e-9
+                && Math.Abs(textureOffset.Y) < 1e-9);
     }
 }

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/CommonMaterialCatalog.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/CommonMaterialCatalog.cs
@@ -55,6 +55,13 @@ public static class CommonMaterialCatalog
             }
         }
 
+        materials.Add(ResoniteMaterialSharing.CreateSharedAlbedoCommonMaterial());
+        materials.Add(ResoniteMaterialSharing.CreateSharedVertexColorCommonMaterial());
+        foreach (ResoniteFloat2 offset in ResoniteMaterialSharing.FixedSharedAlbedoOffsets)
+        {
+            materials.Add(ResoniteMaterialSharing.CreateSharedAlbedoCommonMaterial(offset));
+        }
+
         return materials;
     }
 

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/CommonMaterialCatalog.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/CommonMaterialCatalog.cs
@@ -57,10 +57,6 @@ public static class CommonMaterialCatalog
 
         materials.Add(ResoniteMaterialSharing.CreateSharedAlbedoCommonMaterial());
         materials.Add(ResoniteMaterialSharing.CreateSharedVertexColorCommonMaterial());
-        foreach (ResoniteFloat2 offset in ResoniteMaterialSharing.FixedSharedAlbedoOffsets)
-        {
-            materials.Add(ResoniteMaterialSharing.CreateSharedAlbedoCommonMaterial(offset));
-        }
 
         return materials;
     }

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.cs
@@ -1492,7 +1492,7 @@ public static partial class LocalCityGmlObjectProjection
                     BundledVariantIndex: representativeSurface.Material.BundledVariantIndex));
         }
 
-        return new ResoniteConstructionCityObject(
+        return ResoniteDynamicMaterialUvNormalizer.Normalize(new ResoniteConstructionCityObject(
             SlotKey: cityObject.SlotKey,
             DisplayName: cityObject.DisplayName,
             PackageName: cityObject.PackageName,
@@ -1503,7 +1503,7 @@ public static partial class LocalCityGmlObjectProjection
             Materials: materials,
             SourceObjectKey: cityObject.SourceIdentity,
             SourceUnitKey: cityObject.SourceUnitIdentity,
-            SourceFileRelativePath: cityObject.SourceFileRelativePath);
+            SourceFileRelativePath: cityObject.SourceFileRelativePath));
     }
 
     private static GeodeticPoint GetCityObjectOrigin(ParsedCityObject cityObject)

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.cs
@@ -22,7 +22,7 @@ public static partial class LocalCityGmlObjectProjection
     public const string DefaultDemTerrainTextureFallbackUrlTemplate = "https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/{z}/{x}/{y}.jpg";
     public const int DefaultDemTerrainTextureZoomLevel = 19;
     public const int DefaultDemTerrainTextureFallbackZoomLevel = 18;
-    public const int DefaultDemTerrainTextureMaxSize = 4096;
+    public const int DefaultDemTerrainTextureMaxSize = 8192;
     public const double DefaultGeneratedRoadMarkingWidthMeters = 0.15;
     public const double DefaultGeneratedRoadMarkingSegmentLengthMeters = 5.0;
     public const double DefaultTerrainAlignedTransportationSegmentLengthMeters = 5.0;

--- a/src/Plateau.ResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
@@ -59,6 +59,7 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
         out ResoniteConstructionCityObject? bakedCityObject)
     {
         ArgumentNullException.ThrowIfNull(cityObject);
+        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
 
         bakedCityObject = null;
         if (!CanBake(cityObject))
@@ -85,6 +86,7 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
 
         if (!CanBake(cityObject))
         {

--- a/src/Plateau.ResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
@@ -66,6 +66,7 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
             return false;
         }
 
+        EnsureUniqueMaterialAssignments(cityObject);
         cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         CellKey cellKey = CreateCellKey(cityObject);
         bool createdBuffer = false;
@@ -92,6 +93,7 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
             return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: false, []));
         }
 
+        EnsureUniqueMaterialAssignments(cityObject);
         cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         CellKey cellKey = CreateCellKey(cityObject);
         bool createdBuffer = false;
@@ -210,6 +212,22 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
             scopeIdentity,
             CellX: 0,
             CellZ: 0);
+    }
+
+    private static void EnsureUniqueMaterialAssignments(ResoniteConstructionCityObject cityObject)
+    {
+        HashSet<int> assignedSubmeshIndices = [];
+        foreach (ResoniteMaterialBinding material in cityObject.Materials)
+        {
+            foreach (int submeshIndex in material.SubmeshIndices)
+            {
+                if (!assignedSubmeshIndices.Add(submeshIndex))
+                {
+                    throw new InvalidOperationException(
+                        $"Buffered mesh bake city object '{cityObject.DisplayName}' contained duplicate material assignments for submesh index {submeshIndex}.");
+                }
+            }
+        }
     }
 
     private ResoniteConstructionCityObject FlushCell(CellKey cellKey)

--- a/src/Plateau.ResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
@@ -59,7 +59,6 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
         out ResoniteConstructionCityObject? bakedCityObject)
     {
         ArgumentNullException.ThrowIfNull(cityObject);
-        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
 
         bakedCityObject = null;
         if (!CanBake(cityObject))
@@ -67,6 +66,7 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
             return false;
         }
 
+        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         CellKey cellKey = CreateCellKey(cityObject);
         bool createdBuffer = false;
         if (!buffers.TryGetValue(cellKey, out CellBuffer? buffer))
@@ -86,13 +86,13 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
 
         if (!CanBake(cityObject))
         {
             return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: false, []));
         }
 
+        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         CellKey cellKey = CreateCellKey(cityObject);
         bool createdBuffer = false;
         if (!buffers.TryGetValue(cellKey, out CellBuffer? buffer))

--- a/src/Plateau.ResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
@@ -86,6 +86,7 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
         ResoniteConstructionCityObject cityObject,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(cityObject);
         cancellationToken.ThrowIfCancellationRequested();
 
         if (!CanBake(cityObject))

--- a/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -298,16 +298,16 @@ internal sealed class Lod2AtlasCityObjectBaker(
                 case Lod2AtlasMaterialBakeCategory.PreservedTextureless when policy.PreserveTexturelessMaterials:
                 case Lod2AtlasMaterialBakeCategory.PreservedVertexColor when policy.PreserveVertexColorMaterials:
                 case Lod2AtlasMaterialBakeCategory.PreservedOther:
-                    ResoniteMeshSubmesh originalSubmesh = cityObject.Mesh.Submeshes.Single(candidate => candidate.Index == submesh.Index);
-                    ResoniteMaterialBinding originalMaterial = cityObject.Materials.Single(candidate => candidate.SubmeshIndices.Contains(submesh.Index));
-                    preservedEntries.Add(new PreservedSubmeshEntry(cityObject, originalSubmesh, originalMaterial));
+                    ResoniteMeshSubmesh normalizedSubmesh = normalizedCityObject.Mesh.Submeshes.Single(candidate => candidate.Index == submesh.Index);
+                    ResoniteMaterialBinding normalizedMaterial = normalizedCityObject.Materials.Single(candidate => candidate.SubmeshIndices.Contains(submesh.Index));
+                    preservedEntries.Add(new PreservedSubmeshEntry(normalizedCityObject, normalizedSubmesh, normalizedMaterial));
                     break;
             }
         }
 
         if (policy.RequireAtlasCandidateMaterial && atlasEntries.Count == 0)
         {
-            DisposeCandidateImages(new CityObjectBakeCandidate(cityObject, atlasEntries, preservedEntries));
+            DisposeCandidateImages(new CityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries));
             return null;
         }
 
@@ -317,7 +317,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
                 $"LOD2 atlas bake city object '{cityObject.DisplayName}' produced no atlas or preserved submesh candidate.");
         }
 
-        return new CityObjectBakeCandidate(cityObject, atlasEntries, preservedEntries);
+        return new CityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries);
     }
 
     private async Task<MaterialAtlasTile> CreateAtlasTileAsync(

--- a/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -61,7 +61,6 @@ internal sealed class Lod2AtlasCityObjectBaker(
             return new BufferedCityObjectBufferResult(Buffered: false, []);
         }
 
-        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         SourceUnitBatchKey sourceUnitKey = CreateSourceUnitKey(cityObject, policy);
         List<ResoniteConstructionCityObject> readyCityObjects = [];
         BufferedCityObject bufferedCityObject = new(cityObject, policy);
@@ -262,8 +261,9 @@ internal sealed class Lod2AtlasCityObjectBaker(
         CancellationToken cancellationToken)
     {
         ResoniteConstructionCityObject cityObject = bufferedCityObject.CityObject;
+        ResoniteConstructionCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         Lod2AtlasCityObjectBakePolicy policy = bufferedCityObject.Policy;
-        if (!TryCreateMaterialBySubmeshIndex(cityObject, out Dictionary<int, ResoniteMaterialBinding>? materialBySubmeshIndex))
+        if (!TryCreateMaterialBySubmeshIndex(normalizedCityObject, out Dictionary<int, ResoniteMaterialBinding>? materialBySubmeshIndex))
         {
             throw new InvalidOperationException(
                 $"LOD2 atlas bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
@@ -271,7 +271,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
 
         List<AtlasBatchEntry> atlasEntries = [];
         List<PreservedSubmeshEntry> preservedEntries = [];
-        foreach (ResoniteMeshSubmesh submesh in cityObject.Mesh.Submeshes.OrderBy(static candidate => candidate.Index))
+        foreach (ResoniteMeshSubmesh submesh in normalizedCityObject.Mesh.Submeshes.OrderBy(static candidate => candidate.Index))
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (!materialBySubmeshIndex.TryGetValue(submesh.Index, out ResoniteMaterialBinding? material))
@@ -284,15 +284,17 @@ internal sealed class Lod2AtlasCityObjectBaker(
             switch (category)
             {
                 case Lod2AtlasMaterialBakeCategory.AtlasCandidate:
-                    UvBounds uvBounds = ComputeUvBounds(cityObject.Mesh.Vertices, submesh, material);
+                    UvBounds uvBounds = ComputeUvBounds(normalizedCityObject.Mesh.Vertices, submesh, material);
                     MaterialAtlasTile tile = await CreateAtlasTileAsync(material, uvBounds, cancellationToken);
-                    atlasEntries.Add(new AtlasBatchEntry(cityObject, submesh, material, tile, uvBounds));
+                    atlasEntries.Add(new AtlasBatchEntry(normalizedCityObject, submesh, material, tile, uvBounds));
                     break;
                 case Lod2AtlasMaterialBakeCategory.PreservedCommonMaterial when policy.PreserveCommonMaterials:
                 case Lod2AtlasMaterialBakeCategory.PreservedTextureless when policy.PreserveTexturelessMaterials:
                 case Lod2AtlasMaterialBakeCategory.PreservedVertexColor when policy.PreserveVertexColorMaterials:
                 case Lod2AtlasMaterialBakeCategory.PreservedOther:
-                    preservedEntries.Add(new PreservedSubmeshEntry(cityObject, submesh, material));
+                    ResoniteMeshSubmesh originalSubmesh = cityObject.Mesh.Submeshes.Single(candidate => candidate.Index == submesh.Index);
+                    ResoniteMaterialBinding originalMaterial = cityObject.Materials.Single(candidate => candidate.SubmeshIndices.Contains(submesh.Index));
+                    preservedEntries.Add(new PreservedSubmeshEntry(cityObject, originalSubmesh, originalMaterial));
                     break;
             }
         }

--- a/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -52,7 +52,6 @@ internal sealed class Lod2AtlasCityObjectBaker(
     {
         ArgumentNullException.ThrowIfNull(cityObject);
         cancellationToken.ThrowIfCancellationRequested();
-        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         _ = maxBufferedSourceUnitsForCompatibility;
         _ = maxBufferedCityObjectsPerSourceUnitForCompatibility;
 
@@ -62,6 +61,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
             return new BufferedCityObjectBufferResult(Buffered: false, []);
         }
 
+        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         SourceUnitBatchKey sourceUnitKey = CreateSourceUnitKey(cityObject, policy);
         List<ResoniteConstructionCityObject> readyCityObjects = [];
         BufferedCityObject bufferedCityObject = new(cityObject, policy);

--- a/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -441,7 +441,9 @@ internal sealed class Lod2AtlasCityObjectBaker(
         if (material.AssetScope == ResoniteMaterialAssetScope.Common
             || !string.IsNullOrWhiteSpace(material.Family))
         {
-            return Lod2AtlasMaterialBakeCategory.PreservedCommonMaterial;
+            return CanPreserveAsCommonMaterial(material)
+                ? Lod2AtlasMaterialBakeCategory.PreservedCommonMaterial
+                : Lod2AtlasMaterialBakeCategory.PreservedOther;
         }
 
         if (IsAtlasBakeCandidate(material))
@@ -455,6 +457,16 @@ internal sealed class Lod2AtlasCityObjectBaker(
         }
 
         return Lod2AtlasMaterialBakeCategory.PreservedOther;
+    }
+
+    private static bool CanPreserveAsCommonMaterial(ResoniteMaterialBinding material)
+    {
+        ResoniteMaterialBinding commonCandidate = material with
+        {
+            AssetScope = ResoniteMaterialAssetScope.Common,
+        };
+        return ResoniteSceneMaterialConventions.NormalizeCommonMaterialBinding(commonCandidate).AssetScope
+            == ResoniteMaterialAssetScope.Common;
     }
 
     private AtlasBatchPlan BuildAtlasCandidateBatches(
@@ -1475,7 +1487,10 @@ internal sealed class Lod2AtlasCityObjectBaker(
             || normalizedMaterial.TexturePayload is not null
             || normalizedMaterial.TerrainOverlay is not null
             || string.IsNullOrWhiteSpace(normalizedMaterial.Family)
-            || normalizedMaterial.TextureSourceKind != ResoniteTextureSourceKind.Bundled)
+            || normalizedMaterial.TextureSourceKind != ResoniteTextureSourceKind.Bundled
+            || !ResoniteMaterialSharing.IsWhiteBaseColor(normalizedMaterial.BaseColor)
+            || normalizedMaterial.TextureOffset is not null
+            || normalizedMaterial.DepthOffset is not null)
         {
             return normalizedMaterial;
         }

--- a/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -261,8 +261,14 @@ internal sealed class Lod2AtlasCityObjectBaker(
         CancellationToken cancellationToken)
     {
         ResoniteConstructionCityObject cityObject = bufferedCityObject.CityObject;
-        ResoniteConstructionCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         Lod2AtlasCityObjectBakePolicy policy = bufferedCityObject.Policy;
+        if (!TryCreateMaterialBySubmeshIndex(cityObject, out _))
+        {
+            throw new InvalidOperationException(
+                $"LOD2 atlas bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
+        }
+
+        ResoniteConstructionCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         if (!TryCreateMaterialBySubmeshIndex(normalizedCityObject, out Dictionary<int, ResoniteMaterialBinding>? materialBySubmeshIndex))
         {
             throw new InvalidOperationException(

--- a/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -52,6 +52,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
     {
         ArgumentNullException.ThrowIfNull(cityObject);
         cancellationToken.ThrowIfCancellationRequested();
+        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         _ = maxBufferedSourceUnitsForCompatibility;
         _ = maxBufferedCityObjectsPerSourceUnitForCompatibility;
 
@@ -626,7 +627,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
         foreach (int sourceIndex in placement.Entry.Submesh.TriangleVertexIndices)
         {
             ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
-            ResoniteFloat2 sourceUv = ApplyMaterialUvTransform(sourceVertex.UV0, placement.Entry.Material);
+            ResoniteFloat2 sourceUv = sourceVertex.UV0;
             ResoniteFloat2 atlasUv = MapUvToAtlas(sourceUv, placement.Entry.UvBounds, innerRect, atlasWidth, atlasHeight);
             vertices.Add(sourceVertex with
             {
@@ -668,19 +669,6 @@ internal sealed class Lod2AtlasCityObjectBaker(
         return new ResoniteFloat2(
             (atlasRect.X + (normalizedU * atlasRect.Width)) / atlasWidth,
             (atlasHeight - atlasRect.Y - atlasRect.Height + (normalizedV * atlasRect.Height)) / atlasHeight);
-    }
-
-    private static ResoniteFloat2 ApplyMaterialUvTransform(
-        ResoniteFloat2 sourceUv,
-        ResoniteMaterialBinding material)
-    {
-        double scaleX = material.TextureScale?.X ?? 1.0;
-        double scaleY = material.TextureScale?.Y ?? 1.0;
-        double offsetX = material.TextureOffset?.X ?? 0.0;
-        double offsetY = material.TextureOffset?.Y ?? 0.0;
-        return new ResoniteFloat2(
-            (sourceUv.X * scaleX) + offsetX,
-            (sourceUv.Y * scaleY) + offsetY);
     }
 
     private static ResoniteFloat3 ComputeBakeOrigin(IReadOnlyList<CityObjectBakeCandidate> candidates)
@@ -1152,7 +1140,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
 
         foreach (int sourceIndex in submesh.TriangleVertexIndices)
         {
-            ResoniteFloat2 transformedUv = ApplyMaterialUvTransform(vertices[sourceIndex].UV0, material);
+            ResoniteFloat2 transformedUv = vertices[sourceIndex].UV0;
             minU = Math.Min(minU, transformedUv.X);
             minV = Math.Min(minV, transformedUv.Y);
             maxU = Math.Max(maxU, transformedUv.X);

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -910,7 +910,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         long geometryWeightBytes = cityObject.Geometry switch
         {
             ResoniteTriangleMeshGeometry triangleMesh => checked(
-                EstimateTriangleMeshWorkingSetBytes(triangleMesh.Mesh) * triangleMeshExpansionFactor),
+                EstimateTriangleMeshWorkingSetBytes(triangleMesh.Mesh, cityObject.Materials) * triangleMeshExpansionFactor),
             ResoniteHeightMapGridGeometry heightMap => checked(
                 (heightMap.HeightSamples.Count * heightSampleWeightBytes)
                 + ((long)heightMap.Width * heightMap.Height * hdrHeightTextureWeightBytes)
@@ -939,9 +939,15 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             + terrainOverlayCanvasWeightBytes);
         return Math.Max(minimumWeightBytes, geometryWeightBytes + materialWeightBytes);
 
-        static long EstimateTriangleMeshWorkingSetBytes(ResoniteImportedMesh mesh)
+        static long EstimateTriangleMeshWorkingSetBytes(
+            ResoniteImportedMesh mesh,
+            IReadOnlyList<ResoniteMaterialBinding> materials)
         {
-            long vertexBytes = mesh.Vertices.Count * vertexWeightBytes;
+            bool requiresUvBake = materials.Any(ResoniteDynamicMaterialUvNormalizer.ShouldBakeTextureTransform);
+            long normalizedVertexCount = requiresUvBake
+                ? mesh.Submeshes.Sum(static submesh => (long)submesh.TriangleVertexIndices.Count)
+                : mesh.Vertices.Count;
+            long vertexBytes = normalizedVertexCount * vertexWeightBytes;
             long indexBytes = mesh.Submeshes.Sum(static submesh => (long)submesh.TriangleVertexIndices.Count * indexWeightBytes);
             long submeshBytes = mesh.Submeshes.Count * perSubmeshWeightBytes;
             return checked(vertexBytes + indexBytes + submeshBytes);

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -1018,6 +1018,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         ResoniteConstructionCityObject cityObject,
         CancellationToken cancellationToken)
     {
+        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
+
         if (cityObject.Geometry is ResoniteTriangleMeshGeometry triangleGeometry)
         {
             try

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -947,7 +947,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             long normalizedVertexCount = requiresUvBake
                 ? mesh.Submeshes.Sum(static submesh => (long)submesh.TriangleVertexIndices.Count)
                 : mesh.Vertices.Count;
-            long vertexBytes = normalizedVertexCount * vertexWeightBytes;
+            long sourceVertexCount = mesh.Vertices.Count;
+            long vertexBytes = requiresUvBake
+                ? checked((sourceVertexCount + normalizedVertexCount) * vertexWeightBytes)
+                : sourceVertexCount * vertexWeightBytes;
             long indexBytes = mesh.Submeshes.Sum(static submesh => (long)submesh.TriangleVertexIndices.Count * indexWeightBytes);
             long submeshBytes = mesh.Submeshes.Count * perSubmeshWeightBytes;
             return checked(vertexBytes + indexBytes + submeshBytes);

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -1629,11 +1629,12 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 Material,
                 RunState.Runtime.ProcessingCancellationToken);
             string materialSlotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(Material, useCommonMaterialAssets: true);
+            IReadOnlyList<string> materialSlotLookupNames = ResoniteSceneMaterialConventions.CreateCommonMaterialSlotLookupNames(Material);
             string materialComponentType = ResoniteMaterialComponentPolicy.GetComponentType(Material);
             string? existingMaterialComponentId = await ResoniteMaterialPlanning.TryGetExistingCommonMaterialComponentIdAsync(
                 Client,
                 familySlot.SlotId,
-                materialSlotName,
+                materialSlotLookupNames,
                 materialComponentType,
                 RunState.Runtime.ProcessingCancellationToken);
             if (!string.IsNullOrWhiteSpace(existingMaterialComponentId))

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -1024,8 +1024,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
         ResoniteConstructionCityObject cityObject,
         CancellationToken cancellationToken)
     {
-        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
-
         if (cityObject.Geometry is ResoniteTriangleMeshGeometry triangleGeometry)
         {
             try
@@ -1042,6 +1040,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
             }
 
         }
+
+        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
 
         TerrainTextureOverlay[] distinctTerrainOverlays = cityObject.Materials
             .Where(static material => material.TerrainOverlay is not null)

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialComponentPolicy.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialComponentPolicy.cs
@@ -54,9 +54,9 @@ internal static class ResoniteMaterialComponentPolicy
 
         if (material.MaterialType == ResoniteMaterialType.Standard
             && material.Projection == ResoniteMaterialProjection.Uv
-            && material.TextureScale is not null)
+            && (material.TextureScale is not null || material.TextureOffset is not null))
         {
-            AddTextureTransformMembers(materialMembers, material.TextureScale, material.TextureOffset);
+            AddTextureTransformMembers(materialMembers, material.TextureScale ?? new ResoniteFloat2(1.0, 1.0), material.TextureOffset);
         }
 
         if (material.MaterialType == ResoniteMaterialType.Standard

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialComponentPolicy.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialComponentPolicy.cs
@@ -53,7 +53,9 @@ internal static class ResoniteMaterialComponentPolicy
         }
 
         if (material.MaterialType == ResoniteMaterialType.Standard
-            && material.TextureScale is not null)
+            && material.Projection == ResoniteMaterialProjection.Uv
+            && material.TextureScale is not null
+            && !ResoniteDynamicMaterialUvNormalizer.ShouldBakeTextureTransform(material))
         {
             AddTextureTransformMembers(materialMembers, material.TextureScale, material.TextureOffset);
         }

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialComponentPolicy.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialComponentPolicy.cs
@@ -54,8 +54,7 @@ internal static class ResoniteMaterialComponentPolicy
 
         if (material.MaterialType == ResoniteMaterialType.Standard
             && material.Projection == ResoniteMaterialProjection.Uv
-            && material.TextureScale is not null
-            && !ResoniteDynamicMaterialUvNormalizer.ShouldBakeTextureTransform(material))
+            && material.TextureScale is not null)
         {
             AddTextureTransformMembers(materialMembers, material.TextureScale, material.TextureOffset);
         }

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialPlanning.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteMaterialPlanning.cs
@@ -290,23 +290,42 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
     public static async Task<string?> TryGetExistingCommonMaterialComponentIdAsync(
         IResoniteLinkClient client,
         string familySlotId,
-        string materialSlotName,
+        IReadOnlyList<string> materialSlotNames,
         string materialComponentType,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(client);
         ArgumentException.ThrowIfNullOrWhiteSpace(familySlotId);
-        ArgumentException.ThrowIfNullOrWhiteSpace(materialSlotName);
+        ArgumentNullException.ThrowIfNull(materialSlotNames);
+        if (materialSlotNames.Count == 0 || materialSlotNames.All(string.IsNullOrWhiteSpace))
+        {
+            throw new ArgumentException("At least one material slot lookup name is required.", nameof(materialSlotNames));
+        }
+
         ArgumentException.ThrowIfNullOrWhiteSpace(materialComponentType);
 
         Slot? familySlotSnapshot = await client.GetSlotAsync(familySlotId, 1, cancellationToken);
-        ResoniteSceneChildLookupResult materialLookup = new ResoniteSceneSlotSnapshot(familySlotSnapshot)
-            .GetUniqueChildLookupResult(materialSlotName, familySlotId);
-        return materialLookup.Slot?.Components?
-            .Where(component => string.Equals(component.ComponentType, materialComponentType, StringComparison.Ordinal))
-            .OrderBy(static component => component.ID, StringComparer.Ordinal)
-            .Select(static component => component.ID)
-            .FirstOrDefault(static id => !string.IsNullOrWhiteSpace(id));
+        if (familySlotSnapshot is null)
+        {
+            return null;
+        }
+
+        ResoniteSceneSlotSnapshot familySlot = new(familySlotSnapshot);
+        foreach (string materialSlotName in materialSlotNames.Where(static name => !string.IsNullOrWhiteSpace(name)))
+        {
+            ResoniteSceneChildLookupResult materialLookup = familySlot.GetUniqueChildLookupResult(materialSlotName, familySlotId);
+            string? existingMaterialComponentId = materialLookup.Slot?.Components?
+                .Where(component => string.Equals(component.ComponentType, materialComponentType, StringComparison.Ordinal))
+                .OrderBy(static component => component.ID, StringComparer.Ordinal)
+                .Select(static component => component.ID)
+                .FirstOrDefault(static id => !string.IsNullOrWhiteSpace(id));
+            if (!string.IsNullOrWhiteSpace(existingMaterialComponentId))
+            {
+                return existingMaterialComponentId;
+            }
+        }
+
+        return null;
     }
 
     public static async Task<CreatedComponent> CreateComponentAsync(

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapInterpreter.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapInterpreter.cs
@@ -389,6 +389,7 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             }
 
             string materialSlotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
+            IReadOnlyList<string> materialSlotLookupNames = ResoniteSceneMaterialConventions.CreateCommonMaterialSlotLookupNames(material);
             Slot? familySnapshotSlot = commonSlotSnapshot is null
                 ? null
                 : GetReusableChildSlot(
@@ -397,12 +398,20 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
                     commonSlotId ?? throw new InvalidOperationException("Existing shared Common Materials slot did not expose an ID."));
             ResoniteSceneSlotSnapshot? familySlotSnapshot = familySnapshotSlot is null ? null : new ResoniteSceneSlotSnapshot(familySnapshotSlot);
             string? familySnapshotSlotId = familySnapshotSlot?.ID;
-            Slot? existingMaterialSlot = familySlotSnapshot is null
-                ? null
-                : GetReusableChildSlot(
-                    familySlotSnapshot,
-                    materialSlotName,
-                    familySnapshotSlotId ?? throw new InvalidOperationException("Existing common material family slot did not expose an ID."));
+            Slot? existingMaterialSlot = null;
+            if (familySlotSnapshot is not null)
+            {
+                string requiredFamilySlotId = familySnapshotSlotId
+                    ?? throw new InvalidOperationException("Existing common material family slot did not expose an ID.");
+                foreach (string lookupSlotName in materialSlotLookupNames)
+                {
+                    existingMaterialSlot = GetReusableChildSlot(familySlotSnapshot, lookupSlotName, requiredFamilySlotId);
+                    if (existingMaterialSlot is not null)
+                    {
+                        break;
+                    }
+                }
+            }
             string materialComponentType = ResoniteMaterialComponentPolicy.GetComponentType(material);
             string? existingMaterialComponentId = existingMaterialSlot?.Components?
                 .Where(component => string.Equals(component.ComponentType, materialComponentType, StringComparison.Ordinal))

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapInterpreter.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapInterpreter.cs
@@ -360,7 +360,7 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
 
         foreach (ResoniteMaterialBinding material in canonicalMaterialsByKey.Values.OrderBy(static material => material.MaterialKey, StringComparer.Ordinal))
         {
-            string family = material.Family ?? BundledDefaultMaterialFamilies.Other;
+            string family = ResoniteSceneMaterialConventions.GetCommonMaterialFamilySlotName(material);
             commonMaterialFamilies.Add(family);
             string familySlotName = family;
             if (!familyParentIds.TryGetValue(family, out string? familyParentId))

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapInterpreter.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapInterpreter.cs
@@ -399,6 +399,7 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             ResoniteSceneSlotSnapshot? familySlotSnapshot = familySnapshotSlot is null ? null : new ResoniteSceneSlotSnapshot(familySnapshotSlot);
             string? familySnapshotSlotId = familySnapshotSlot?.ID;
             Slot? existingMaterialSlot = null;
+            Slot? reusableEmptyMaterialSlot = null;
             if (familySlotSnapshot is not null)
             {
                 string requiredFamilySlotId = familySnapshotSlotId
@@ -406,7 +407,13 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
                 foreach (string lookupSlotName in materialSlotLookupNames)
                 {
                     Slot? candidateMaterialSlot = GetReusableChildSlot(familySlotSnapshot, lookupSlotName, requiredFamilySlotId);
-                    if (candidateMaterialSlot?.Components?.Any(component =>
+                    if (candidateMaterialSlot is null)
+                    {
+                        continue;
+                    }
+
+                    reusableEmptyMaterialSlot ??= candidateMaterialSlot;
+                    if (candidateMaterialSlot.Components?.Any(component =>
                             string.Equals(component.ComponentType, ResoniteMaterialComponentPolicy.GetComponentType(material), StringComparison.Ordinal)) == true)
                     {
                         existingMaterialSlot = candidateMaterialSlot;
@@ -414,6 +421,7 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
                     }
                 }
             }
+            existingMaterialSlot ??= reusableEmptyMaterialSlot;
             string materialComponentType = ResoniteMaterialComponentPolicy.GetComponentType(material);
             string? existingMaterialComponentId = existingMaterialSlot?.Components?
                 .Where(component => string.Equals(component.ComponentType, materialComponentType, StringComparison.Ordinal))

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapInterpreter.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneBootstrapInterpreter.cs
@@ -405,9 +405,11 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
                     ?? throw new InvalidOperationException("Existing common material family slot did not expose an ID.");
                 foreach (string lookupSlotName in materialSlotLookupNames)
                 {
-                    existingMaterialSlot = GetReusableChildSlot(familySlotSnapshot, lookupSlotName, requiredFamilySlotId);
-                    if (existingMaterialSlot is not null)
+                    Slot? candidateMaterialSlot = GetReusableChildSlot(familySlotSnapshot, lookupSlotName, requiredFamilySlotId);
+                    if (candidateMaterialSlot?.Components?.Any(component =>
+                            string.Equals(component.ComponentType, ResoniteMaterialComponentPolicy.GetComponentType(material), StringComparison.Ordinal)) == true)
                     {
+                        existingMaterialSlot = candidateMaterialSlot;
                         break;
                     }
                 }

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -10,6 +10,8 @@ namespace Plateau.ResoniteLink.Targets.Resonite;
 
 internal static class ResoniteSceneMaterialConventions
 {
+    private static readonly IReadOnlyList<string> EmptyLookupNames = [];
+
     public static string CreateMaterialSlotName(ResoniteMaterialBinding material, bool useCommonMaterialAssets)
     {
         ArgumentNullException.ThrowIfNull(material);
@@ -71,6 +73,26 @@ internal static class ResoniteSceneMaterialConventions
         return string.Create(
             CultureInfo.InvariantCulture,
             $"{componentKind}_{projectionName}_{sourceName}_{familyName}_{scaleName}_{offsetName}_{depthName}_{colorName}");
+    }
+
+    public static IReadOnlyList<string> CreateCommonMaterialSlotLookupNames(ResoniteMaterialBinding material)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+        material = NormalizeCommonMaterialBinding(material);
+        if (material.AssetScope != ResoniteMaterialAssetScope.Common)
+        {
+            return EmptyLookupNames;
+        }
+
+        string currentSlotName = CreateMaterialSlotName(material, useCommonMaterialAssets: true);
+        string? legacySlotName = TryCreateLegacyCommonMaterialSlotName(material);
+        if (string.IsNullOrWhiteSpace(legacySlotName)
+            || string.Equals(currentSlotName, legacySlotName, StringComparison.Ordinal))
+        {
+            return [currentSlotName];
+        }
+
+        return [currentSlotName, legacySlotName];
     }
 
     public static ResoniteMaterialBinding NormalizeCommonMaterialBinding(ResoniteMaterialBinding material)
@@ -423,6 +445,20 @@ internal static class ResoniteSceneMaterialConventions
         }
 
         return builder.ToString().Trim('-');
+    }
+
+    private static string? TryCreateLegacyCommonMaterialSlotName(ResoniteMaterialBinding material)
+    {
+        if (!IsGenericSharedCommonMaterialCandidate(material)
+            || material.Projection != ResoniteMaterialProjection.Uv
+            || material.TextureOffset is not null
+            || material.DepthOffset is not null
+            || material.TextureScale is not null)
+        {
+            return null;
+        }
+
+        return "shared_uv_generic_scale_1x1";
     }
 
     private static ResoniteMaterialBinding NormalizeGenericSharedMaterialBinding(ResoniteMaterialBinding material)

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -179,7 +179,8 @@ internal static class ResoniteSceneMaterialConventions
             && !string.IsNullOrWhiteSpace(material.Family)
             && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
             && material.DepthOffset is null
-            && material.TextureOffset is null)
+            && material.TextureOffset is null
+            && IsWhiteBaseColor(material.BaseColor))
         {
             ResoniteMaterialBinding commonBaseCandidate = material with
             {
@@ -228,6 +229,22 @@ internal static class ResoniteSceneMaterialConventions
     public static ResoniteMaterialBinding NormalizeBatchGroupedMaterialBinding(ResoniteMaterialBinding material)
     {
         ArgumentNullException.ThrowIfNull(material);
+
+        if (material.AssetScope == ResoniteMaterialAssetScope.Common
+            && material.MaterialType == ResoniteMaterialType.Standard
+            && material.TexturePayload is null
+            && material.TerrainOverlay is null
+            && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
+            && !string.IsNullOrWhiteSpace(material.Family)
+            && (!IsWhiteBaseColor(material.BaseColor)
+                || material.TextureOffset is not null
+                || material.DepthOffset is not null))
+        {
+            return material with
+            {
+                AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped,
+            };
+        }
 
         if (TryNormalizeSharedMaterialBinding(material, out ResoniteMaterialBinding normalizedSharedMaterial, out _)
             && material.TexturePayload is null
@@ -305,7 +322,10 @@ internal static class ResoniteSceneMaterialConventions
         return material.TerrainOverlay is null
             && material.TexturePayload is null
             && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
-            && !string.IsNullOrWhiteSpace(material.Family);
+            && !string.IsNullOrWhiteSpace(material.Family)
+            && material.TextureOffset is null
+            && material.DepthOffset is null
+            && IsWhiteBaseColor(material.BaseColor);
     }
 
     private static bool IsGenericSharedCommonMaterialCandidate(ResoniteMaterialBinding material)

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -454,14 +454,26 @@ internal static class ResoniteSceneMaterialConventions
     {
         if (!IsGenericSharedCommonMaterialCandidate(material)
             || material.Projection != ResoniteMaterialProjection.Uv
-            || material.TextureOffset is not null
-            || material.DepthOffset is not null
-            || material.TextureScale is not null)
+            || (material.TextureScale is not null
+                && (Math.Abs(material.TextureScale.X - 1.0) > 1e-9
+                    || Math.Abs(material.TextureScale.Y - 1.0) > 1e-9)))
         {
             return null;
         }
 
-        return "shared_uv_generic_scale_1x1";
+        string offsetToken = material.TextureOffset is null
+            ? string.Empty
+            : string.Create(
+                CultureInfo.InvariantCulture,
+                $"_offset_{material.TextureOffset.X:0.######}x{material.TextureOffset.Y:0.######}");
+        string depthToken = material.DepthOffset is null
+            ? string.Empty
+            : string.Create(
+                CultureInfo.InvariantCulture,
+                $"_depth_{material.DepthOffset.Factor:0.######}x{material.DepthOffset.Units:0.######}");
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"shared_uv_generic_scale_1x1{offsetToken}{depthToken}");
     }
 
     private static ResoniteMaterialBinding NormalizeGenericSharedMaterialBinding(ResoniteMaterialBinding material)

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -15,7 +15,6 @@ internal static class ResoniteSceneMaterialConventions
     public static string CreateMaterialSlotName(ResoniteMaterialBinding material, bool useCommonMaterialAssets)
     {
         ArgumentNullException.ThrowIfNull(material);
-        material = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
 
         if (useCommonMaterialAssets)
         {
@@ -160,7 +159,6 @@ internal static class ResoniteSceneMaterialConventions
         out string familySlotName)
     {
         ArgumentNullException.ThrowIfNull(material);
-        material = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
 
         normalizedMaterial = material;
         familySlotName = string.Empty;
@@ -216,6 +214,12 @@ internal static class ResoniteSceneMaterialConventions
             return false;
         }
 
+        if ((material.TextureScale is not null || material.TextureOffset is not null)
+            && material.TerrainOverlay is null)
+        {
+            return false;
+        }
+
         normalizedMaterial = NormalizeGenericSharedMaterialBinding(material);
         familySlotName = GetCommonMaterialFamilySlotName(normalizedMaterial);
         return true;
@@ -224,7 +228,6 @@ internal static class ResoniteSceneMaterialConventions
     public static ResoniteMaterialBinding NormalizeBatchGroupedMaterialBinding(ResoniteMaterialBinding material)
     {
         ArgumentNullException.ThrowIfNull(material);
-        material = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
 
         if (TryNormalizeSharedMaterialBinding(material, out ResoniteMaterialBinding normalizedSharedMaterial, out _)
             && material.TexturePayload is null

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -214,7 +214,7 @@ internal static class ResoniteSceneMaterialConventions
             return false;
         }
 
-        if ((material.TextureScale is not null || material.TextureOffset is not null)
+        if (HasEffectiveGenericTextureTransform(material)
             && material.TerrainOverlay is null)
         {
             return false;
@@ -355,11 +355,11 @@ internal static class ResoniteSceneMaterialConventions
                 : string.Create(
                     CultureInfo.InvariantCulture,
                     $"_scale_{material.TextureScale!.X:0.######}x{material.TextureScale.Y:0.######}");
-            string offsetToken = material.TextureOffset is null
+            string offsetToken = IsZeroTextureOffset(material.TextureOffset)
                 ? string.Empty
                 : string.Create(
                     CultureInfo.InvariantCulture,
-                    $"_offset_{material.TextureOffset.X:0.######}x{material.TextureOffset.Y:0.######}");
+                    $"_offset_{material.TextureOffset!.X:0.######}x{material.TextureOffset.Y:0.######}");
             string depthToken = material.DepthOffset is null
                 ? string.Empty
                 : string.Create(
@@ -461,11 +461,11 @@ internal static class ResoniteSceneMaterialConventions
             return null;
         }
 
-        string offsetToken = material.TextureOffset is null
+        string offsetToken = IsZeroTextureOffset(material.TextureOffset)
             ? string.Empty
             : string.Create(
                 CultureInfo.InvariantCulture,
-                $"_offset_{material.TextureOffset.X:0.######}x{material.TextureOffset.Y:0.######}");
+                $"_offset_{material.TextureOffset!.X:0.######}x{material.TextureOffset.Y:0.######}");
         string depthToken = material.DepthOffset is null
             ? string.Empty
             : string.Create(
@@ -478,17 +478,28 @@ internal static class ResoniteSceneMaterialConventions
 
     private static ResoniteMaterialBinding NormalizeGenericSharedMaterialBinding(ResoniteMaterialBinding material)
     {
+        ResoniteFloat2? normalizedTextureScale = material.TextureScale is not null
+            && Math.Abs(material.TextureScale.X - 1.0) < 1e-9
+            && Math.Abs(material.TextureScale.Y - 1.0) < 1e-9
+            ? null
+            : material.TextureScale;
+        ResoniteFloat2? normalizedTextureOffset = IsZeroTextureOffset(material.TextureOffset)
+            ? null
+            : material.TextureOffset;
+
         return material with
         {
             MaterialKey = CreateCanonicalGenericSharedMaterialKey(
                 material.Projection,
-                material.TextureScale,
-                material.TextureOffset,
+                normalizedTextureScale,
+                normalizedTextureOffset,
                 material.DepthOffset),
             BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             TexturePayload = null,
             TerrainOverlay = null,
             TextureSourceKind = ResoniteTextureSourceKind.Dataset,
+            TextureScale = normalizedTextureScale,
+            TextureOffset = normalizedTextureOffset,
             AssetScope = ResoniteMaterialAssetScope.Common,
             BundledVariantIndex = null,
         };
@@ -511,5 +522,20 @@ internal static class ResoniteSceneMaterialConventions
             AssetScope = ResoniteMaterialAssetScope.Common,
             BundledVariantIndex = null,
         };
+    }
+
+    private static bool HasEffectiveGenericTextureTransform(ResoniteMaterialBinding material)
+    {
+        bool hasNonIdentityScale = material.TextureScale is not null
+            && (Math.Abs(material.TextureScale.X - 1.0) > 1e-9
+                || Math.Abs(material.TextureScale.Y - 1.0) > 1e-9);
+        return hasNonIdentityScale || !IsZeroTextureOffset(material.TextureOffset);
+    }
+
+    private static bool IsZeroTextureOffset(ResoniteFloat2? textureOffset)
+    {
+        return textureOffset is null
+            || (Math.Abs(textureOffset.X) < 1e-9
+                && Math.Abs(textureOffset.Y) < 1e-9);
     }
 }

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -13,6 +13,7 @@ internal static class ResoniteSceneMaterialConventions
     public static string CreateMaterialSlotName(ResoniteMaterialBinding material, bool useCommonMaterialAssets)
     {
         ArgumentNullException.ThrowIfNull(material);
+        material = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
 
         if (useCommonMaterialAssets)
         {
@@ -80,34 +81,55 @@ internal static class ResoniteSceneMaterialConventions
             return material;
         }
 
-        if (!IsBundledCommonMaterialCandidate(material))
+        if (IsBundledCommonMaterialCandidate(material))
         {
-            return material with { AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped };
+            string canonicalFamily = string.IsNullOrWhiteSpace(material.Family)
+                ? BundledDefaultMaterialFamilies.Other
+                : material.Family!;
+            int canonicalVariantIndex = material.BundledVariantIndex ?? 0;
+            ResoniteFloat2 defaultTextureScale = BundledDefaultMaterialProfiles.GetTilesPerMeter(
+                BundledDefaultMaterialFamilies.GetVariant(canonicalFamily, canonicalVariantIndex));
+            ResoniteFloat2 canonicalTextureScale = material.TextureScale ?? defaultTextureScale;
+            return material with
+            {
+                MaterialKey = CreateCanonicalCommonMaterialKey(
+                    canonicalFamily,
+                    canonicalVariantIndex,
+                    material.Projection,
+                    canonicalTextureScale),
+                BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                MaterialType = ResoniteMaterialType.Standard,
+                TextureSourceKind = ResoniteTextureSourceKind.Bundled,
+                TextureScale = canonicalTextureScale,
+                Family = canonicalFamily,
+                TextureOffset = null,
+                DepthOffset = null,
+                BundledVariantIndex = canonicalVariantIndex,
+            };
         }
 
-        string canonicalFamily = string.IsNullOrWhiteSpace(material.Family)
-            ? BundledDefaultMaterialFamilies.Other
-            : material.Family!;
-        int canonicalVariantIndex = material.BundledVariantIndex ?? 0;
-        ResoniteFloat2 defaultTextureScale = BundledDefaultMaterialProfiles.GetTilesPerMeter(
-            BundledDefaultMaterialFamilies.GetVariant(canonicalFamily, canonicalVariantIndex));
-        ResoniteFloat2 canonicalTextureScale = material.TextureScale ?? defaultTextureScale;
-        return material with
+        if (IsGenericSharedCommonMaterialCandidate(material))
         {
-            MaterialKey = CreateCanonicalCommonMaterialKey(
-                canonicalFamily,
-                canonicalVariantIndex,
-                material.Projection,
-                canonicalTextureScale),
-            BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-            MaterialType = ResoniteMaterialType.Standard,
-            TextureSourceKind = ResoniteTextureSourceKind.Bundled,
-            TextureScale = canonicalTextureScale,
-            Family = canonicalFamily,
-            TextureOffset = null,
-            DepthOffset = null,
-            BundledVariantIndex = canonicalVariantIndex,
-        };
+            return NormalizeGenericSharedMaterialBinding(material);
+        }
+
+        if (ResoniteMaterialSharing.CanUseSharedVertexColorMaterial(material))
+        {
+            return NormalizeVertexColorSharedMaterialBinding(material);
+        }
+
+        return material with { AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped };
+    }
+
+    public static string GetCommonMaterialFamilySlotName(ResoniteMaterialBinding material)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+
+        return material.MaterialType == ResoniteMaterialType.VertexColor
+            ? "vertex-color"
+            : string.IsNullOrWhiteSpace(material.Family)
+                ? "generic"
+                : material.Family!;
     }
 
     public static bool TryNormalizeSharedMaterialBinding(
@@ -116,9 +138,17 @@ internal static class ResoniteSceneMaterialConventions
         out string familySlotName)
     {
         ArgumentNullException.ThrowIfNull(material);
+        material = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
 
         normalizedMaterial = material;
         familySlotName = string.Empty;
+        if (ResoniteMaterialSharing.CanUseSharedVertexColorMaterial(material))
+        {
+            normalizedMaterial = NormalizeVertexColorSharedMaterialBinding(material);
+            familySlotName = GetCommonMaterialFamilySlotName(normalizedMaterial);
+            return true;
+        }
+
         if (material.MaterialType != ResoniteMaterialType.Standard)
         {
             return false;
@@ -145,7 +175,7 @@ internal static class ResoniteSceneMaterialConventions
                 return false;
             }
 
-            familySlotName = normalizedMaterial.Family ?? BundledDefaultMaterialFamilies.Other;
+            familySlotName = GetCommonMaterialFamilySlotName(normalizedMaterial);
             return true;
         }
 
@@ -165,30 +195,22 @@ internal static class ResoniteSceneMaterialConventions
         }
 
         normalizedMaterial = NormalizeGenericSharedMaterialBinding(material);
-        familySlotName = "generic";
+        familySlotName = GetCommonMaterialFamilySlotName(normalizedMaterial);
         return true;
     }
 
     public static ResoniteMaterialBinding NormalizeBatchGroupedMaterialBinding(ResoniteMaterialBinding material)
     {
         ArgumentNullException.ThrowIfNull(material);
+        material = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
 
         if (TryNormalizeSharedMaterialBinding(material, out ResoniteMaterialBinding normalizedSharedMaterial, out _)
-            && !string.IsNullOrWhiteSpace(normalizedSharedMaterial.Family)
             && material.TexturePayload is null
             && material.TerrainOverlay is null)
         {
             return normalizedSharedMaterial with
             {
                 SubmeshIndices = material.SubmeshIndices,
-            };
-        }
-
-        if (material.MaterialType == ResoniteMaterialType.VertexColor)
-        {
-            return material with
-            {
-                MaterialKey = "preserved-vertex-color",
             };
         }
 
@@ -228,24 +250,18 @@ internal static class ResoniteSceneMaterialConventions
         ResoniteFloat2? textureOffset,
         ResoniteMaterialDepthOffset? depthOffset)
     {
-        string scaleToken = textureScale is null
-            ? "none"
-            : string.Create(
-                CultureInfo.InvariantCulture,
-                $"{textureScale.X:0.######}x{textureScale.Y:0.######}");
-        string offsetToken = textureOffset is null
-            ? "none"
-            : string.Create(
-                CultureInfo.InvariantCulture,
-                $"{textureOffset.X:0.######}x{textureOffset.Y:0.######}");
-        string depthToken = depthOffset is null
-            ? "none"
-            : string.Create(
-                CultureInfo.InvariantCulture,
-                $"{depthOffset.Factor:0.######}x{depthOffset.Units:0.######}");
-        return string.Create(
-            CultureInfo.InvariantCulture,
-            $"generic|{projection}|scale:{scaleToken}|offset:{offsetToken}|depth:{depthToken}");
+        return ResoniteMaterialSharing.CreateCanonicalGenericSharedMaterialKey(
+            projection,
+            textureScale,
+            textureOffset,
+            depthOffset);
+    }
+
+    public static string CreateCanonicalVertexColorCommonMaterialKey(
+        ResoniteMaterialProjection projection,
+        ResoniteMaterialDepthOffset? depthOffset)
+    {
+        return ResoniteMaterialSharing.CreateCanonicalVertexColorCommonMaterialKey(projection, depthOffset);
     }
 
     public static Dictionary<string, Member> CreateTextureMembers(Uri assetUri)
@@ -267,6 +283,16 @@ internal static class ResoniteSceneMaterialConventions
             && !string.IsNullOrWhiteSpace(material.Family);
     }
 
+    private static bool IsGenericSharedCommonMaterialCandidate(ResoniteMaterialBinding material)
+    {
+        return material.MaterialType == ResoniteMaterialType.Standard
+            && material.Projection == ResoniteMaterialProjection.Uv
+            && ResoniteMaterialSharing.IsWhiteBaseColor(material.BaseColor)
+            && string.IsNullOrWhiteSpace(material.Family)
+            && material.TexturePayload is null
+            && material.TerrainOverlay is null;
+    }
+
     private static string CreateCompactColorSuffix(ResoniteColor color)
     {
         return string.Create(
@@ -282,6 +308,18 @@ internal static class ResoniteSceneMaterialConventions
             ResoniteMaterialProjection.Triplanar => "triplanar",
             _ => material.Projection.ToString().ToLowerInvariant(),
         };
+        if (material.MaterialType == ResoniteMaterialType.VertexColor)
+        {
+            string depthToken = material.DepthOffset is null
+                ? string.Empty
+                : string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"_depth_{material.DepthOffset.Factor:0.######}x{material.DepthOffset.Units:0.######}");
+            return string.Create(
+                CultureInfo.InvariantCulture,
+                $"shared_{projectionName}_vertex-color{depthToken}");
+        }
+
         if (string.IsNullOrWhiteSpace(material.Family))
         {
             string genericScaleToken = material.TextureScale is null
@@ -347,10 +385,7 @@ internal static class ResoniteSceneMaterialConventions
 
     private static bool IsWhiteBaseColor(ResoniteColor color)
     {
-        return Math.Abs(color.R - 1.0) < 1e-9
-            && Math.Abs(color.G - 1.0) < 1e-9
-            && Math.Abs(color.B - 1.0) < 1e-9
-            && Math.Abs(color.A - 1.0) < 1e-9;
+        return ResoniteMaterialSharing.IsWhiteBaseColor(color);
     }
 
     private static ResoniteFloat2? TryGetBundledDefaultScale(ResoniteMaterialBinding material)
@@ -400,6 +435,25 @@ internal static class ResoniteSceneMaterialConventions
             TexturePayload = null,
             TerrainOverlay = null,
             TextureSourceKind = ResoniteTextureSourceKind.Dataset,
+            AssetScope = ResoniteMaterialAssetScope.Common,
+            BundledVariantIndex = null,
+        };
+    }
+
+    private static ResoniteMaterialBinding NormalizeVertexColorSharedMaterialBinding(ResoniteMaterialBinding material)
+    {
+        return material with
+        {
+            MaterialKey = CreateCanonicalVertexColorCommonMaterialKey(
+                material.Projection,
+                material.DepthOffset),
+            BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            TexturePayload = null,
+            TerrainOverlay = null,
+            TextureSourceKind = ResoniteTextureSourceKind.Bundled,
+            Family = null,
+            TextureScale = null,
+            TextureOffset = null,
             AssetScope = ResoniteMaterialAssetScope.Common,
             BundledVariantIndex = null,
         };

--- a/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/Plateau.ResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -322,11 +322,14 @@ internal static class ResoniteSceneMaterialConventions
 
         if (string.IsNullOrWhiteSpace(material.Family))
         {
-            string genericScaleToken = material.TextureScale is null
+            bool hasNonIdentityScale = material.TextureScale is not null
+                && (Math.Abs(material.TextureScale.X - 1.0) > 1e-9
+                    || Math.Abs(material.TextureScale.Y - 1.0) > 1e-9);
+            string genericScaleToken = !hasNonIdentityScale
                 ? string.Empty
                 : string.Create(
                     CultureInfo.InvariantCulture,
-                    $"_scale_{material.TextureScale.X:0.######}x{material.TextureScale.Y:0.######}");
+                    $"_scale_{material.TextureScale!.X:0.######}x{material.TextureScale.Y:0.######}");
             string offsetToken = material.TextureOffset is null
                 ? string.Empty
                 : string.Create(

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/CommonMaterialCatalogTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/CommonMaterialCatalogTests.cs
@@ -25,20 +25,4 @@ public sealed class CommonMaterialCatalogTests
                 depthOffset: null));
     }
 
-    [Fact]
-    public void CreateForPackages_IncludesFixedSharedAlbedoOffsetVariants()
-    {
-        IReadOnlyList<ResoniteMaterialBinding> materials = CommonMaterialCatalog.CreateForPackages(["bldg"]);
-
-        foreach (ResoniteFloat2 offset in ResoniteMaterialSharing.FixedSharedAlbedoOffsets)
-        {
-            Assert.Contains(
-                materials,
-                material => material.MaterialKey == ResoniteMaterialSharing.CreateCanonicalGenericSharedMaterialKey(
-                    ResoniteMaterialProjection.Uv,
-                    textureScale: null,
-                    textureOffset: offset,
-                    depthOffset: null));
-        }
-    }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/CommonMaterialCatalogTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/CommonMaterialCatalogTests.cs
@@ -1,0 +1,44 @@
+using Plateau.ResoniteLink.Application.Importing;
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Tests.Profiles;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test names describe contract cases.")]
+public sealed class CommonMaterialCatalogTests
+{
+    [Fact]
+    public void CreateForPackages_IncludesSharedAlbedoAndVertexColorCommonMaterials()
+    {
+        IReadOnlyList<ResoniteMaterialBinding> materials = CommonMaterialCatalog.CreateForPackages(["bldg"]);
+
+        Assert.Contains(
+            materials,
+            material => material.MaterialKey == ResoniteMaterialSharing.CreateCanonicalGenericSharedMaterialKey(
+                ResoniteMaterialProjection.Uv,
+                textureScale: null,
+                textureOffset: null,
+                depthOffset: null));
+        Assert.Contains(
+            materials,
+            material => material.MaterialKey == ResoniteMaterialSharing.CreateCanonicalVertexColorCommonMaterialKey(
+                ResoniteMaterialProjection.Uv,
+                depthOffset: null));
+    }
+
+    [Fact]
+    public void CreateForPackages_IncludesFixedSharedAlbedoOffsetVariants()
+    {
+        IReadOnlyList<ResoniteMaterialBinding> materials = CommonMaterialCatalog.CreateForPackages(["bldg"]);
+
+        foreach (ResoniteFloat2 offset in ResoniteMaterialSharing.FixedSharedAlbedoOffsets)
+        {
+            Assert.Contains(
+                materials,
+                material => material.MaterialKey == ResoniteMaterialSharing.CreateCanonicalGenericSharedMaterialKey(
+                    ResoniteMaterialProjection.Uv,
+                    textureScale: null,
+                    textureOffset: offset,
+                    depthOffset: null));
+        }
+    }
+}

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlConstructionSourceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlConstructionSourceTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 using Plateau.ResoniteLink.Application.Importing;
 using Plateau.ResoniteLink.Domain.Importing;
 
@@ -236,7 +238,7 @@ public sealed class LocalCityGmlConstructionSourceTests
 
     private sealed class OverlayRecordingGeometryProjector : ICityGmlGeometryProjector
     {
-        public Dictionary<string, int> OverlayCountsByPackage { get; } = new(StringComparer.Ordinal);
+        public ConcurrentDictionary<string, int> OverlayCountsByPackage { get; } = new(StringComparer.Ordinal);
 
         public IEnumerable<ResoniteConstructionCityObject> MaterializeCityObjects(
             CachedSourceFileDescriptor sourceFile,

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlDemBootstrapSupportTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlDemBootstrapSupportTests.cs
@@ -87,6 +87,7 @@ public sealed class LocalCityGmlDemBootstrapSupportTests
                 Assert.Equal(LocalCityGmlObjectProjection.DefaultDemTerrainTextureFallbackUrlTemplate, tileSource.UrlTemplate);
                 Assert.Equal(LocalCityGmlObjectProjection.DefaultDemTerrainTextureFallbackZoomLevel, tileSource.ZoomLevel);
             });
+        Assert.Equal(LocalCityGmlObjectProjection.DefaultDemTerrainTextureMaxSize, overlay.MaxTextureSize);
         Assert.Equal(TerrainTextureLicenseMode.PlateauOrthoOnly, overlay.LicenseMode);
     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -149,8 +149,8 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.True(maxV - minV > 0.49);
         Assert.InRange(minU, 0.0, 0.1);
         Assert.InRange(minV, 0.0, 0.11);
-        Assert.InRange(maxU, 0.89, 0.91);
-        Assert.InRange(maxV, 0.89, 0.91);
+        Assert.InRange(maxU, 0.89, 1.0);
+        Assert.InRange(maxV, 0.89, 1.0);
         Assert.Single(demCityObject.Mesh.Submeshes);
         Assert.InRange(demCityObject.Mesh.Vertices.Count, 4, 6);
     }
@@ -277,12 +277,12 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.Null(material.TexturePayload);
         Assert.Single(materialized.Mesh.Submeshes);
         Assert.NotEmpty(materialized.Mesh.Vertices);
-        Assert.Null(material.TextureScale);
-        Assert.Null(material.TextureOffset);
-        double minU = materialized.Mesh.Vertices.Min(static vertex => vertex.UV0.X);
-        double maxU = materialized.Mesh.Vertices.Max(static vertex => vertex.UV0.X);
-        Assert.InRange(minU, 0.0, 0.01);
-        Assert.InRange(maxU, 0.49, 0.51);
+        ResoniteFloat2? textureScale = material.TextureScale;
+        ResoniteFloat2? textureOffset = material.TextureOffset;
+        Assert.NotNull(textureScale);
+        Assert.NotNull(textureOffset);
+        Assert.InRange(textureScale!.X, 0.49, 0.51);
+        Assert.InRange(textureOffset!.X, 0.0, 0.01);
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -145,12 +145,12 @@ public sealed class LocalCityGmlObjectProjectionTests
         double maxU = demCityObject.Mesh.Vertices.Max(static vertex => vertex.UV0.X);
         double minV = demCityObject.Mesh.Vertices.Min(static vertex => vertex.UV0.Y);
         double maxV = demCityObject.Mesh.Vertices.Max(static vertex => vertex.UV0.Y);
-        Assert.True(maxU - minU > 0.9);
-        Assert.True(maxV - minV > 0.9);
+        Assert.True(maxU - minU > 0.79);
+        Assert.True(maxV - minV > 0.49);
         Assert.InRange(minU, 0.0, 0.1);
-        Assert.InRange(minV, 0.0, 0.1);
-        Assert.InRange(maxU, 0.9, 1.0);
-        Assert.InRange(maxV, 0.9, 1.0);
+        Assert.InRange(minV, 0.0, 0.11);
+        Assert.InRange(maxU, 0.89, 0.91);
+        Assert.InRange(maxV, 0.89, 0.91);
         Assert.Single(demCityObject.Mesh.Submeshes);
         Assert.InRange(demCityObject.Mesh.Vertices.Count, 4, 6);
     }
@@ -277,12 +277,12 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.Null(material.TexturePayload);
         Assert.Single(materialized.Mesh.Submeshes);
         Assert.NotEmpty(materialized.Mesh.Vertices);
-        ResoniteFloat2? textureScale = material.TextureScale;
-        ResoniteFloat2? textureOffset = material.TextureOffset;
-        Assert.NotNull(textureScale);
-        Assert.NotNull(textureOffset);
-        Assert.InRange(textureScale!.X, 0.49, 0.51);
-        Assert.InRange(textureOffset!.X, 0.0, 0.01);
+        Assert.Null(material.TextureScale);
+        Assert.Null(material.TextureOffset);
+        double minU = materialized.Mesh.Vertices.Min(static vertex => vertex.UV0.X);
+        double maxU = materialized.Mesh.Vertices.Max(static vertex => vertex.UV0.X);
+        Assert.InRange(minU, 0.0, 0.01);
+        Assert.InRange(maxU, 0.49, 0.51);
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
@@ -220,6 +220,33 @@ public sealed class FixedCellCityObjectMeshBakerTests
     }
 
     [Fact]
+    public void FlushAllBakesDynamicUvTransformIntoMeshAndClearsMaterialTransform()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "dynamic-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic.png"),
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: new ResoniteFloat2(2.0, 0.5),
+            TextureOffset: new ResoniteFloat2(0.25, 0.75));
+        Assert.True(baker.TryBuffer(CreateTriangleBuilding("dynamic", 10.0, 12.0, "unit-a", null, material), out _));
+
+        ResoniteConstructionCityObject baked = Assert.Single(baker.FlushAll());
+
+        ResoniteMaterialBinding bakedMaterial = Assert.Single(baked.Materials);
+        Assert.Null(bakedMaterial.TextureScale);
+        Assert.Null(bakedMaterial.TextureOffset);
+        Assert.Equal(new ResoniteFloat2(0.25, 0.75), baked.Mesh.Vertices[0].UV0);
+        Assert.Equal(new ResoniteFloat2(2.25, 0.75), baked.Mesh.Vertices[1].UV0);
+        Assert.Equal(new ResoniteFloat2(0.25, 1.25), baked.Mesh.Vertices[2].UV0);
+    }
+
+    [Fact]
     public void FlushAllMergesEquivalentBundledFamilyMaterialsAcrossObjects()
     {
         FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);

--- a/tests/Plateau.ResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
@@ -226,6 +226,42 @@ public sealed class FixedCellCityObjectMeshBakerTests
     }
 
     [Fact]
+    public void TryBufferThrowsControlledErrorForDuplicateMaterialAssignmentsBeforeUvNormalization()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
+        ResoniteConstructionCityObject invalid = CreateTriangleBuilding("duplicate-material-assignment", x: 10.0, z: 12.0, sourceUnitKey: "unit-a", sourceFileRelativePath: "common.gml") with
+        {
+            Materials =
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "shared-material-a",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(255, 0, 0, "textures/fixedcell-duplicate-a.png"),
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    TextureScale: new ResoniteFloat2(2.0, 0.5),
+                    TextureOffset: new ResoniteFloat2(0.25, 0.75)),
+                new ResoniteMaterialBinding(
+                    MaterialKey: "shared-material-b",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(0, 255, 0, "textures/fixedcell-duplicate-b.png"),
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0]),
+            ],
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => baker.TryBuffer(invalid, out _));
+
+        Assert.Contains("contained duplicate material assignments for submesh index 0", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FlushAllProducesDeterministicMeshForEquivalentBufferedOrderings()
     {
         FixedCellCityObjectMeshBaker forward = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);

--- a/tests/Plateau.ResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
@@ -262,6 +262,43 @@ public sealed class FixedCellCityObjectMeshBakerTests
     }
 
     [Fact]
+    public async Task TryBufferAsyncThrowsControlledErrorForDuplicateMaterialAssignmentsBeforeUvNormalization()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
+        ResoniteConstructionCityObject invalid = CreateTriangleBuilding("duplicate-material-assignment-async", x: 10.0, z: 12.0, sourceUnitKey: "unit-a", sourceFileRelativePath: "common.gml") with
+        {
+            Materials =
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "shared-material-a",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(255, 0, 0, "textures/fixedcell-duplicate-async-a.png"),
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    TextureScale: new ResoniteFloat2(2.0, 0.5),
+                    TextureOffset: new ResoniteFloat2(0.25, 0.75)),
+                new ResoniteMaterialBinding(
+                    MaterialKey: "shared-material-b",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(0, 255, 0, "textures/fixedcell-duplicate-async-b.png"),
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0]),
+            ],
+        };
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await baker.TryBufferAsync(invalid));
+
+        Assert.Contains("contained duplicate material assignments for submesh index 0", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FlushAllProducesDeterministicMeshForEquivalentBufferedOrderings()
     {
         FixedCellCityObjectMeshBaker forward = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);

--- a/tests/Plateau.ResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
@@ -110,6 +110,78 @@ public sealed class FixedCellCityObjectMeshBakerTests
     }
 
     [Fact]
+    public void TryBufferSkipsNonTargetCityObjectsWithoutNormalizingDynamicUvTransform()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 2, maxVerticesPerBatch: 1000);
+        ResoniteMaterialBinding dynamicMaterial = new(
+            MaterialKey: "lod2-dynamic-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic.png"),
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: new ResoniteFloat2(2.0, 0.5),
+            TextureOffset: new ResoniteFloat2(0.25, 0.75));
+        ResoniteConstructionCityObject lod2Building = CreateTriangleBuilding(
+            "lod2-dynamic",
+            x: 10.0,
+            z: 10.0,
+            sourceUnitKey: "unit-a",
+            sourceFileRelativePath: null,
+            material: dynamicMaterial) with
+        {
+            LodLevel = 2,
+        };
+
+        bool buffered = baker.TryBuffer(lod2Building, out ResoniteConstructionCityObject? baked);
+
+        Assert.False(buffered);
+        Assert.Null(baked);
+        Assert.Equal(new ResoniteFloat2(2.0, 0.5), Assert.Single(lod2Building.Materials).TextureScale);
+        Assert.Equal(new ResoniteFloat2(0.25, 0.75), Assert.Single(lod2Building.Materials).TextureOffset);
+        Assert.Equal(3, lod2Building.Mesh.Vertices.Count);
+        Assert.Empty(baker.FlushAll());
+    }
+
+    [Fact]
+    public async Task TryBufferAsyncSkipsNonTargetCityObjectsWithoutNormalizingDynamicUvTransform()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 2, maxVerticesPerBatch: 1000);
+        ResoniteMaterialBinding dynamicMaterial = new(
+            MaterialKey: "lod2-dynamic-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic.png"),
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: new ResoniteFloat2(2.0, 0.5),
+            TextureOffset: new ResoniteFloat2(0.25, 0.75));
+        ResoniteConstructionCityObject lod2Building = CreateTriangleBuilding(
+            "lod2-dynamic-async",
+            x: 10.0,
+            z: 10.0,
+            sourceUnitKey: "unit-a",
+            sourceFileRelativePath: null,
+            material: dynamicMaterial) with
+        {
+            LodLevel = 2,
+        };
+
+        BufferedCityObjectBufferResult result = await baker.TryBufferAsync(lod2Building);
+
+        Assert.False(result.Buffered);
+        Assert.Empty(result.ReadyCityObjects);
+        Assert.Equal(new ResoniteFloat2(2.0, 0.5), Assert.Single(lod2Building.Materials).TextureScale);
+        Assert.Equal(new ResoniteFloat2(0.25, 0.75), Assert.Single(lod2Building.Materials).TextureOffset);
+        Assert.Equal(3, lod2Building.Mesh.Vertices.Count);
+        Assert.Empty(await baker.FlushAllAsync());
+    }
+
+    [Fact]
     public void FlushAllRejectsBufferedMeshBakeWhenSubmeshMaterialAssignmentIsMissing()
     {
         FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);

--- a/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -234,6 +234,30 @@ public sealed class Lod2AtlasCityObjectBakerTests
     }
 
     [Fact]
+    public async Task TryBufferAsyncSkipsNonTargetCityObjectsWithoutNormalizingDynamicUvTransform()
+    {
+        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 1);
+        ResoniteConstructionCityObject nonTargetCityObject = CreateUvScaledLod2Building(
+            "lod1-dynamic",
+            CreatePayload("textures/lod1-dynamic.png", new Rgba32(255, 0, 0, 255), 4, 4),
+            "unit-a",
+            new ResoniteFloat2(2.0, 0.5),
+            new ResoniteFloat2(0.25, 0.75)) with
+        {
+            LodLevel = 1,
+        };
+
+        BufferedCityObjectBufferResult result = await baker.TryBufferAsync(nonTargetCityObject);
+
+        Assert.False(result.Buffered);
+        Assert.Empty(result.ReadyCityObjects);
+        Assert.Equal(new ResoniteFloat2(2.0, 0.5), Assert.Single(nonTargetCityObject.Materials).TextureScale);
+        Assert.Equal(new ResoniteFloat2(0.25, 0.75), Assert.Single(nonTargetCityObject.Materials).TextureOffset);
+        Assert.Equal(3, nonTargetCityObject.Mesh.Vertices.Count);
+        Assert.Empty(await baker.FlushAllAsync());
+    }
+
+    [Fact]
     public async Task FlushAllAsyncCapsAtlasTileSizeForSmallMemoryProfile()
     {
         Lod2AtlasCityObjectBaker baker = new(

--- a/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -114,12 +114,15 @@ public sealed class Lod2AtlasCityObjectBakerTests
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         Assert.Equal(2, cityObject.Materials.Count);
         Assert.Equal(2, cityObject.Mesh.Submeshes.Count);
-        Assert.Contains(cityObject.Materials, static material => material.AssetScope == ResoniteMaterialAssetScope.Common);
+        Assert.Contains(
+            cityObject.Materials,
+            static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.Facade, StringComparison.Ordinal)
+                && material.AssetScope == ResoniteMaterialAssetScope.PresentationSlotScoped);
         Assert.Contains(cityObject.Materials, static material => material.TexturePayload is not null);
     }
 
     [Fact]
-    public async Task FlushAllAsyncUnifiesPreservedCommonMaterialVariantsByFamily()
+    public async Task FlushAllAsyncKeepsTintedPrescopedCommonMaterialVariantsDedicated()
     {
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 1);
 
@@ -131,18 +134,20 @@ public sealed class Lod2AtlasCityObjectBakerTests
                 "unit-a"));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteMaterialBinding commonMaterial = Assert.Single(
-            cityObject.Materials,
-            static material => material.AssetScope == ResoniteMaterialAssetScope.Common);
+        ResoniteMaterialBinding[] preservedFacadeMaterials = cityObject.Materials
+            .Where(static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.Facade, StringComparison.Ordinal))
+            .ToArray();
 
-        Assert.Equal(2, cityObject.Materials.Count);
-        Assert.Equal(2, cityObject.Mesh.Submeshes.Count);
-        Assert.Equal(BundledDefaultMaterialFamilies.Facade, commonMaterial.Family);
-        Assert.Equal(0, commonMaterial.BundledVariantIndex);
+        Assert.Equal(3, cityObject.Materials.Count);
+        Assert.Equal(3, cityObject.Mesh.Submeshes.Count);
+        Assert.Equal(2, preservedFacadeMaterials.Length);
+        Assert.All(preservedFacadeMaterials, static material => Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, material.AssetScope));
+        Assert.Contains(preservedFacadeMaterials, static material => material.BundledVariantIndex == 0 && material.BaseColor == new ResoniteColor(0.5, 0.5, 0.5, 1.0));
+        Assert.Contains(preservedFacadeMaterials, static material => material.BundledVariantIndex == 1 && material.BaseColor == new ResoniteColor(0.5, 0.5, 0.5, 1.0));
     }
 
     [Fact]
-    public async Task FlushAllAsyncUnifiesPreservedBundledFamilyMaterialsEvenWhenNotPreScopedAsCommon()
+    public async Task FlushAllAsyncKeepsTintedPreservedBundledFamilyMaterialsDedicated()
     {
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 1);
 
@@ -154,15 +159,179 @@ public sealed class Lod2AtlasCityObjectBakerTests
                 "unit-a"));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteMaterialBinding commonMaterial = Assert.Single(
-            cityObject.Materials,
-            static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.Roof, StringComparison.Ordinal));
+        ResoniteMaterialBinding[] preservedRoofMaterials = cityObject.Materials
+            .Where(static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.Roof, StringComparison.Ordinal))
+            .ToArray();
 
-        Assert.Equal(2, cityObject.Materials.Count);
-        Assert.Equal(2, cityObject.Mesh.Submeshes.Count);
-        Assert.Equal(ResoniteMaterialAssetScope.Common, commonMaterial.AssetScope);
-        Assert.Equal(0, commonMaterial.BundledVariantIndex);
-        Assert.Null(commonMaterial.TexturePayload);
+        Assert.Equal(3, cityObject.Materials.Count);
+        Assert.Equal(3, cityObject.Mesh.Submeshes.Count);
+        Assert.Equal(2, preservedRoofMaterials.Length);
+        Assert.All(preservedRoofMaterials, static material => Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, material.AssetScope));
+        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 0 && material.BaseColor == new ResoniteColor(0.85, 0.85, 0.85, 1.0));
+        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 1 && material.BaseColor == new ResoniteColor(0.75, 0.75, 0.75, 1.0));
+        Assert.All(preservedRoofMaterials, static material => Assert.Null(material.TexturePayload));
+    }
+
+    [Fact]
+    public async Task FlushAllAsyncKeepsWhitePreservedBundledFamilyMaterialsDedicatedWhenOffsetOrDepthExists()
+    {
+        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 1);
+        ResoniteConstructionCityObject source = CreateBundledFamilyPreservedLod2Building(
+            "building-transform",
+            CreatePayload("textures/transform.png", new Rgba32(255, 0, 0, 255), 4, 4),
+            "unit-a") with
+        {
+            Materials =
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "building-transform-atlas",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: CreatePayload("textures/transform.png", new Rgba32(255, 0, 0, 255), 4, 4),
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0]),
+                new ResoniteMaterialBinding(
+                    MaterialKey: "building-transform-roof-0",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: new ResoniteMaterialDepthOffset(1.0, 1.0),
+                    SubmeshIndices: [1],
+                    Family: BundledDefaultMaterialFamilies.Roof,
+                    TextureOffset: new ResoniteFloat2(0.125, 0.25),
+                    BundledVariantIndex: 0),
+                new ResoniteMaterialBinding(
+                    MaterialKey: "building-transform-roof-1",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: new ResoniteMaterialDepthOffset(2.0, 2.0),
+                    SubmeshIndices: [2],
+                    Family: BundledDefaultMaterialFamilies.Roof,
+                    TextureOffset: new ResoniteFloat2(0.25, 0.5),
+                    BundledVariantIndex: 1),
+            ],
+        };
+
+        await AssertBufferedAsync(baker, source);
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+        ResoniteMaterialBinding[] preservedRoofMaterials = cityObject.Materials
+            .Where(static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.Roof, StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Equal(3, cityObject.Materials.Count);
+        Assert.Equal(3, cityObject.Mesh.Submeshes.Count);
+        Assert.Equal(2, preservedRoofMaterials.Length);
+        Assert.All(preservedRoofMaterials, static material => Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, material.AssetScope));
+        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 0 && material.TextureOffset == new ResoniteFloat2(0.125, 0.25));
+        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 1 && material.TextureOffset == new ResoniteFloat2(0.25, 0.5));
+    }
+
+    [Fact]
+    public async Task FlushAllAsyncAllowsTintedPreservedBundledFamilyMaterialsWhenCommonPreservationIsDisabled()
+    {
+        Lod2AtlasCityObjectBaker baker = new(
+            new ResoniteTextureImageLoader(),
+            maxAtlasSize: 32,
+            tilePaddingPixels: 1,
+            bakePolicies:
+            [
+                new Lod2AtlasCityObjectBakePolicy(
+                    Name: "dedicated-bundled-check",
+                    CanBufferCityObject: static _ => true,
+                    RequireAtlasCandidateMaterial: true,
+                    PreserveVertexColorMaterials: true,
+                    PreserveTexturelessMaterials: false,
+                    PreserveCommonMaterials: false,
+                    EnableGridPassThrough: false,
+                    PassThroughGridCellSizeMeters: 0),
+            ]);
+
+        await AssertBufferedAsync(
+            baker,
+            CreateBundledFamilyPreservedLod2Building(
+                "building-policy-check",
+                CreatePayload("textures/policy-check.png", new Rgba32(255, 0, 0, 255), 4, 4),
+                "unit-a"));
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+        ResoniteMaterialBinding[] preservedRoofMaterials = cityObject.Materials
+            .Where(static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.Roof, StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Equal(3, cityObject.Materials.Count);
+        Assert.Equal(2, preservedRoofMaterials.Length);
+        Assert.All(preservedRoofMaterials, static material => Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, material.AssetScope));
+    }
+
+    [Fact]
+    public async Task FlushAllAsyncDemotesPrescopedWhiteBundledFamilyMaterialsWhenOffsetOrDepthExists()
+    {
+        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 1);
+        ResoniteConstructionCityObject source = CreateBundledFamilyPreservedLod2Building(
+            "building-prescoped-transform",
+            CreatePayload("textures/prescoped-transform.png", new Rgba32(255, 0, 0, 255), 4, 4),
+            "unit-a") with
+        {
+            Materials =
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "building-prescoped-transform-atlas",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: CreatePayload("textures/prescoped-transform.png", new Rgba32(255, 0, 0, 255), 4, 4),
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0]),
+                new ResoniteMaterialBinding(
+                    MaterialKey: "building-prescoped-transform-roof-0",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: new ResoniteMaterialDepthOffset(1.0, 1.0),
+                    SubmeshIndices: [1],
+                    Family: BundledDefaultMaterialFamilies.Roof,
+                    TextureOffset: new ResoniteFloat2(0.125, 0.25),
+                    BundledVariantIndex: 0,
+                    AssetScope: ResoniteMaterialAssetScope.Common),
+                new ResoniteMaterialBinding(
+                    MaterialKey: "building-prescoped-transform-roof-1",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: new ResoniteMaterialDepthOffset(2.0, 2.0),
+                    SubmeshIndices: [2],
+                    Family: BundledDefaultMaterialFamilies.Roof,
+                    TextureOffset: new ResoniteFloat2(0.25, 0.5),
+                    BundledVariantIndex: 1,
+                    AssetScope: ResoniteMaterialAssetScope.Common),
+            ],
+        };
+
+        await AssertBufferedAsync(baker, source);
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+        ResoniteMaterialBinding[] preservedRoofMaterials = cityObject.Materials
+            .Where(static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.Roof, StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Equal(3, cityObject.Materials.Count);
+        Assert.Equal(2, preservedRoofMaterials.Length);
+        Assert.All(preservedRoofMaterials, static material => Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, material.AssetScope));
+        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 0 && material.TextureOffset == new ResoniteFloat2(0.125, 0.25));
+        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 1 && material.TextureOffset == new ResoniteFloat2(0.25, 0.5));
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -186,6 +186,28 @@ public sealed class Lod2AtlasCityObjectBakerTests
     }
 
     [Fact]
+    public async Task FlushAllAsyncFallsBackToOriginalCityObjectWithoutNormalizingDynamicUvTransform()
+    {
+        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 10, tilePaddingPixels: 0);
+        ResoniteConstructionCityObject oversizedCandidate = CreateUvScaledLod2Building(
+            "building-dynamic-fallback",
+            CreatePayload("textures/dynamic-fallback.png", new Rgba32(255, 0, 0, 255), 9, 3),
+            "unit-a",
+            new ResoniteFloat2(2.0, 0.5),
+            new ResoniteFloat2(0.25, 0.75));
+
+        await AssertBufferedAsync(baker, oversizedCandidate);
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+        ResoniteMaterialBinding material = Assert.Single(cityObject.Materials);
+        Assert.Equal(oversizedCandidate.SlotKey, cityObject.SlotKey);
+        Assert.Equal(new ResoniteFloat2(2.0, 0.5), material.TextureScale);
+        Assert.Equal(new ResoniteFloat2(0.25, 0.75), material.TextureOffset);
+        Assert.Equal(3, cityObject.Mesh.Vertices.Count);
+        Assert.DoesNotContain(cityObject.Materials, static candidate => candidate.TexturePayload?.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
+    }
+
+    [Fact]
     public async Task FlushAllAsyncKeepsDistinctSourceUnitsInSeparateAtlasBatches()
     {
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 1);

--- a/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -47,6 +47,8 @@ public sealed class Lod2AtlasCityObjectBakerTests
         Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, atlasPayload.Format);
         Assert.Equal(1, atlasPayload.Width);
         Assert.Equal(1, atlasPayload.Height);
+        Assert.Null(cityObject.Materials[0].TextureScale);
+        Assert.Null(cityObject.Materials[0].TextureOffset);
         Assert.Equal(new Rgba32(0, 0, 255, 255), ReadPixel(atlasPayload, 0, 0));
     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -355,7 +355,7 @@ public sealed class Lod2AtlasCityObjectBakerTests
     }
 
     [Fact]
-    public async Task FlushAllAsyncFallsBackToOriginalCityObjectWithoutNormalizingDynamicUvTransform()
+    public async Task FlushAllAsyncFallsBackToNormalizedCityObjectWhenSingleCandidateCannotFitAtlasBudget()
     {
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 10, tilePaddingPixels: 0);
         ResoniteConstructionCityObject oversizedCandidate = CreateUvScaledLod2Building(
@@ -370,9 +370,12 @@ public sealed class Lod2AtlasCityObjectBakerTests
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         ResoniteMaterialBinding material = Assert.Single(cityObject.Materials);
         Assert.Equal(oversizedCandidate.SlotKey, cityObject.SlotKey);
-        Assert.Equal(new ResoniteFloat2(2.0, 0.5), material.TextureScale);
-        Assert.Equal(new ResoniteFloat2(0.25, 0.75), material.TextureOffset);
+        Assert.Null(material.TextureScale);
+        Assert.Null(material.TextureOffset);
         Assert.Equal(3, cityObject.Mesh.Vertices.Count);
+        Assert.Equal(new ResoniteFloat2(0.25, 0.75), cityObject.Mesh.Vertices[0].UV0);
+        Assert.Equal(new ResoniteFloat2(2.25, 0.75), cityObject.Mesh.Vertices[1].UV0);
+        Assert.Equal(new ResoniteFloat2(0.25, 1.25), cityObject.Mesh.Vertices[2].UV0);
         Assert.DoesNotContain(cityObject.Materials, static candidate => candidate.TexturePayload?.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
@@ -34,6 +34,88 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
         Assert.Equal(new ResoniteFloat2(1.0, 0.0), normalized.Mesh.Vertices[1].UV0);
     }
 
+    [Fact]
+    public void NormalizeMaterialBinding_PreservesExplicitIdentityScaleForBundledFamilyMaterial()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "bundled-identity-override",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: new ResoniteFloat2(1.0, 1.0),
+            TextureOffset: new ResoniteFloat2(0.0, 0.0),
+            Family: BundledDefaultMaterialFamilies.Facade,
+            BundledVariantIndex: 0,
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        ResoniteMaterialBinding normalized = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
+
+        Assert.Equal(new ResoniteFloat2(1.0, 1.0), normalized.TextureScale);
+        Assert.Null(normalized.TextureOffset);
+    }
+
+    [Fact]
+    public void Normalize_PreservesBundledIdentityScaleOverrideWhenAnotherMaterialBakes()
+    {
+        ResoniteConstructionCityObject cityObject = new(
+            SlotKey: "mixed-material-city-object",
+            DisplayName: "Mixed Material CityObject",
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 2,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Mesh: new ResoniteImportedMesh(
+                [
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(1.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 1.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(2.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(3.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(2.0, 1.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 1.0)),
+                ],
+                [
+                    new ResoniteMeshSubmesh(0, "dynamic-uv-material", [0, 1, 2]),
+                    new ResoniteMeshSubmesh(1, "bundled-identity-override", [3, 4, 5]),
+                ]),
+            Materials:
+            [
+                CreateDynamicUvMaterial(new ResoniteFloat2(0.5, 0.25), new ResoniteFloat2(0.125, 0.75)) with
+                {
+                    SubmeshIndices = [0],
+                },
+                new ResoniteMaterialBinding(
+                    MaterialKey: "bundled-identity-override",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [1],
+                    TextureScale: new ResoniteFloat2(1.0, 1.0),
+                    TextureOffset: new ResoniteFloat2(0.0, 0.0),
+                    Family: BundledDefaultMaterialFamilies.Facade,
+                    BundledVariantIndex: 0,
+                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
+            ],
+            SourceObjectKey: "unit-a:mixed-material-city-object",
+            SourceUnitKey: "unit-a",
+            SourceFileRelativePath: "unit-a.gml");
+
+        ResoniteConstructionCityObject normalized = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
+        ResoniteMaterialBinding bundledMaterial = Assert.Single(
+            normalized.Materials,
+            static material => string.Equals(material.MaterialKey, "bundled-identity-override", StringComparison.Ordinal));
+
+        Assert.NotSame(cityObject, normalized);
+        Assert.Equal(new ResoniteFloat2(1.0, 1.0), bundledMaterial.TextureScale);
+        Assert.Null(bundledMaterial.TextureOffset);
+    }
+
     private static ResoniteConstructionCityObject CreateTriangleCityObject(
         ResoniteFloat2? textureScale,
         ResoniteFloat2? textureOffset)

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
@@ -1,0 +1,83 @@
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Tests.Targets;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test names describe contract cases.")]
+public sealed class ResoniteDynamicMaterialUvNormalizerTests
+{
+    [Fact]
+    public void ShouldBakeTextureTransform_ReturnsFalseForIdentityScaleWithoutOffset()
+    {
+        ResoniteMaterialBinding material = CreateDynamicUvMaterial(
+            textureScale: new ResoniteFloat2(1.0, 1.0),
+            textureOffset: null);
+
+        bool shouldBake = ResoniteDynamicMaterialUvNormalizer.ShouldBakeTextureTransform(material);
+        ResoniteMaterialBinding normalized = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
+
+        Assert.False(shouldBake);
+        Assert.Null(normalized.TextureScale);
+        Assert.Null(normalized.TextureOffset);
+    }
+
+    [Fact]
+    public void Normalize_DoesNotExpandTriangleMeshForIdentityTransformOnlyMaterial()
+    {
+        ResoniteConstructionCityObject cityObject = CreateTriangleCityObject(
+            textureScale: new ResoniteFloat2(1.0, 1.0),
+            textureOffset: null);
+
+        ResoniteConstructionCityObject normalized = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
+
+        Assert.Same(cityObject, normalized);
+        Assert.Equal(3, normalized.Mesh.Vertices.Count);
+        Assert.Equal(new ResoniteFloat2(1.0, 0.0), normalized.Mesh.Vertices[1].UV0);
+    }
+
+    private static ResoniteConstructionCityObject CreateTriangleCityObject(
+        ResoniteFloat2? textureScale,
+        ResoniteFloat2? textureOffset)
+    {
+        return new ResoniteConstructionCityObject(
+            SlotKey: "dynamic-uv-city-object",
+            DisplayName: "Dynamic UV CityObject",
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 2,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Mesh: new ResoniteImportedMesh(
+                [
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(1.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 1.0)),
+                ],
+                [
+                    new ResoniteMeshSubmesh(0, "dynamic-uv-material", [0, 1, 2]),
+                ]),
+            Materials:
+            [
+                CreateDynamicUvMaterial(textureScale, textureOffset),
+            ],
+            SourceObjectKey: "unit-a:dynamic-uv-city-object",
+            SourceUnitKey: "unit-a",
+            SourceFileRelativePath: "unit-a.gml");
+    }
+
+    private static ResoniteMaterialBinding CreateDynamicUvMaterial(
+        ResoniteFloat2? textureScale,
+        ResoniteFloat2? textureOffset)
+    {
+        return new ResoniteMaterialBinding(
+            MaterialKey: "dynamic-uv-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: textureScale,
+            TextureOffset: textureOffset,
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+    }
+}

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
@@ -116,6 +116,65 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
         Assert.Null(bundledMaterial.TextureOffset);
     }
 
+    [Fact]
+    public void Normalize_PreservesExplicitIdentityScaleForUnrelatedTriplanarMaterial()
+    {
+        ResoniteConstructionCityObject cityObject = new(
+            SlotKey: "mixed-triplanar-city-object",
+            DisplayName: "Mixed Triplanar CityObject",
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 2,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Mesh: new ResoniteImportedMesh(
+                [
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(1.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 1.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(2.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(3.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(2.0, 1.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 1.0)),
+                ],
+                [
+                    new ResoniteMeshSubmesh(0, "dynamic-uv-material", [0, 1, 2]),
+                    new ResoniteMeshSubmesh(1, "triplanar-identity-override", [3, 4, 5]),
+                ]),
+            Materials:
+            [
+                CreateDynamicUvMaterial(new ResoniteFloat2(0.5, 0.25), new ResoniteFloat2(0.125, 0.75)) with
+                {
+                    SubmeshIndices = [0],
+                },
+                new ResoniteMaterialBinding(
+                    MaterialKey: "triplanar-identity-override",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Triplanar,
+                    DepthOffset: null,
+                    SubmeshIndices: [1],
+                    TextureScale: new ResoniteFloat2(1.0, 1.0),
+                    TextureOffset: new ResoniteFloat2(0.0, 0.0),
+                    Family: null,
+                    BundledVariantIndex: null,
+                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
+            ],
+            SourceObjectKey: "unit-a:mixed-triplanar-city-object",
+            SourceUnitKey: "unit-a",
+            SourceFileRelativePath: "unit-a.gml");
+
+        ResoniteConstructionCityObject normalized = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
+        ResoniteMaterialBinding triplanarMaterial = Assert.Single(
+            normalized.Materials,
+            static material => string.Equals(material.MaterialKey, "triplanar-identity-override", StringComparison.Ordinal));
+
+        Assert.NotSame(cityObject, normalized);
+        Assert.Equal(ResoniteMaterialProjection.Triplanar, triplanarMaterial.Projection);
+        Assert.Equal(new ResoniteFloat2(1.0, 1.0), triplanarMaterial.TextureScale);
+        Assert.Equal(new ResoniteFloat2(0.0, 0.0), triplanarMaterial.TextureOffset);
+    }
+
     private static ResoniteConstructionCityObject CreateTriangleCityObject(
         ResoniteFloat2? textureScale,
         ResoniteFloat2? textureOffset)

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -140,6 +140,34 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
+    public async Task BuildAsyncReusesSharedCommonMaterialForPayloadAlbedoOverridesWithExplicitNoOpTransform()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        using SceneBuilderRecordingClient client = new();
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [
+                CreatePayloadTriangleCityObject(
+                    "dataset-texture-noop-transform-one",
+                    ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(255, 0, 0, "textures/albedo-noop-one.png"),
+                    textureScale: new ResoniteFloat2(1.0, 1.0),
+                    textureOffset: new ResoniteFloat2(0.0, 0.0)),
+                CreatePayloadTriangleCityObject(
+                    "dataset-texture-noop-transform-two",
+                    ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(0, 255, 0, "textures/albedo-noop-two.png")),
+            ],
+            client);
+
+        string firstMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject dataset-texture-noop-transform-one");
+        string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject dataset-texture-noop-transform-two");
+
+        Assert.Equal(firstMaterialId, secondMaterialId);
+        Assert.Equal(1, CountCommonMaterialComponents(client, firstMaterialId));
+    }
+
+    [Fact]
     public async Task BuildAsyncReusesSharedCommonMaterialForPayloadAlbedoOverridesWithDifferentUvTransforms()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -312,6 +340,39 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
 
         Assert.Equal(legacyMaterialComponentId, rendererMaterialId);
         Assert.Equal(1, CountCommonMaterialComponents(client, legacyMaterialComponentId));
+    }
+
+    [Fact]
+    public async Task BuildAsyncReusesExistingEmptyCurrentGenericCommonMaterialSlot()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        using SceneBuilderRecordingClient client = new();
+
+        string emptyCurrentMaterialSlotId = await SeedEmptyCurrentGenericSharedMaterialSlotAsync(client);
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [
+                CreatePayloadTriangleCityObject(
+                    "empty-current-generic-slot-reuse",
+                    ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(255, 0, 0, "textures/empty-current-generic-slot.png")),
+            ],
+            client);
+
+        string rendererMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject empty-current-generic-slot-reuse");
+        string currentGenericPath = Assert.Single(
+            client.SlotPaths,
+            static pair => pair.Value.EndsWith("/generic/shared_uv_generic", StringComparison.Ordinal)).Key;
+        AddComponent materialComponentRequest = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, rendererMaterialId, StringComparison.Ordinal));
+
+        Assert.Equal(emptyCurrentMaterialSlotId, currentGenericPath);
+        Assert.Equal(emptyCurrentMaterialSlotId, materialComponentRequest.ContainerSlotId);
+        Assert.Equal(
+            1,
+            client.SlotPaths.Values.Count(static path => path.EndsWith("/generic/shared_uv_generic", StringComparison.Ordinal)));
     }
 
     [Fact]
@@ -1460,6 +1521,51 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                 {
                     ComponentType = "[FrooxEngine]FrooxEngine.PBS_Metallic",
                     Members = new Dictionary<string, Member>(StringComparer.Ordinal),
+                },
+            },
+                CancellationToken.None);
+    }
+
+    private static async Task<string> SeedEmptyCurrentGenericSharedMaterialSlotAsync(SceneBuilderRecordingClient client)
+    {
+        string sharedAssetsRootId = await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    Parent = new Reference { TargetID = "Root" },
+                    Name = new Field_string { Value = "PLATEAU Shared Assets" },
+                },
+            },
+            CancellationToken.None);
+        string commonMaterialsRootId = await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    Parent = new Reference { TargetID = sharedAssetsRootId },
+                    Name = new Field_string { Value = "Common Materials" },
+                },
+            },
+            CancellationToken.None);
+        string genericFamilySlotId = await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    Parent = new Reference { TargetID = commonMaterialsRootId },
+                    Name = new Field_string { Value = "generic" },
+                },
+            },
+            CancellationToken.None);
+
+        return await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    Parent = new Reference { TargetID = genericFamilySlotId },
+                    Name = new Field_string { Value = "shared_uv_generic" },
                 },
             },
             CancellationToken.None);

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -140,6 +140,104 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
+    public async Task BuildAsyncReusesSharedCommonMaterialForPayloadAlbedoOverridesWithDifferentUvTransforms()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        using SceneBuilderRecordingClient client = new();
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [
+                CreatePayloadTriangleCityObject(
+                    "dataset-texture-scaled-one",
+                    ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(255, 0, 0, "textures/albedo-scaled-one.png"),
+                    textureScale: new ResoniteFloat2(0.5, 0.25),
+                    textureOffset: new ResoniteFloat2(0.125, 0.75)),
+                CreatePayloadTriangleCityObject(
+                    "dataset-texture-scaled-two",
+                    ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(0, 255, 0, "textures/albedo-scaled-two.png"),
+                    textureScale: new ResoniteFloat2(2.0, 1.5),
+                    textureOffset: new ResoniteFloat2(0.25, 0.5)),
+            ],
+            client);
+
+        string firstMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject dataset-texture-scaled-one");
+        string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject dataset-texture-scaled-two");
+        HashSet<string> commonMaterialIds = client.AddedComponents
+            .Where(request => client.SlotPaths.TryGetValue(request.ContainerSlotId, out string? path)
+                && path.Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal))
+            .Select(static request => request.Data.ID)
+            .Where(static id => !string.IsNullOrWhiteSpace(id))
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(firstMaterialId, secondMaterialId);
+        Assert.Contains(firstMaterialId, commonMaterialIds);
+    }
+
+    [Fact]
+    public async Task BuildAsyncBootstrapsFixedGenericAndVertexColorCommonMaterials()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        using SceneBuilderRecordingClient client = new();
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [CreateBundledTriangleCityObject("bootstrap-common-check")],
+            client);
+
+        Slot commonRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(client, "PLATEAU Shared Assets/Common Materials");
+
+        Assert.Contains(
+            client.SlotPaths.Values,
+            path => string.Equals(
+                path,
+                $"{client.SlotPaths[commonRoot.ID!]}/generic/shared_uv_generic",
+                StringComparison.Ordinal));
+        Assert.Contains(
+            client.SlotPaths.Values,
+            path => string.Equals(
+                path,
+                $"{client.SlotPaths[commonRoot.ID!]}/vertex-color/shared_uv_vertex-color",
+                StringComparison.Ordinal));
+        Assert.Contains(
+            client.SlotPaths.Values,
+            path => path.EndsWith("/generic/shared_uv_generic_offset_0.5x0", StringComparison.Ordinal));
+        Assert.Contains(
+            client.SlotPaths.Values,
+            path => path.EndsWith("/generic/shared_uv_generic_offset_0x0.5", StringComparison.Ordinal));
+        Assert.Contains(
+            client.SlotPaths.Values,
+            path => path.EndsWith("/generic/shared_uv_generic_offset_0.5x0.5", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task BuildAsyncReusesSharedCommonMaterialForVertexColor()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        using SceneBuilderRecordingClient client = new();
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [
+                CreateVertexColorTriangleCityObject("vertex-color-one"),
+                CreateVertexColorTriangleCityObject("vertex-color-two"),
+            ],
+            client);
+
+        string firstMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject vertex-color-one");
+        string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject vertex-color-two");
+        string commonMaterialContainerSlotId = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, firstMaterialId, StringComparison.Ordinal)).ContainerSlotId;
+
+        Assert.Equal(firstMaterialId, secondMaterialId);
+        Assert.Contains("/vertex-color/", client.SlotPaths[commonMaterialContainerSlotId], StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task BuildAsyncUsesDistinctPropertyBlocksForSameMaterialKeyWithDifferentPayloadOverrides()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -770,6 +868,8 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     private static ResoniteConstructionCityObject CreatePayloadTriangleCityObject(
         string objectIdentity,
         ResoniteTexturePayload payload,
+        ResoniteFloat2? textureScale = null,
+        ResoniteFloat2? textureOffset = null,
         string sourceFileRelativePath = PrimarySourceFile)
     {
         return new ResoniteConstructionCityObject(
@@ -791,7 +891,9 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                    TextureScale: textureScale,
                     Family: null,
+                    TextureOffset: textureOffset,
                     AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
             ],
             SourceObjectKey: objectIdentity,
@@ -872,6 +974,35 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0]),
+            ],
+            SourceObjectKey: objectIdentity,
+            SourceFileRelativePath: sourceFileRelativePath);
+    }
+
+    private static ResoniteConstructionCityObject CreateVertexColorTriangleCityObject(
+        string objectIdentity,
+        string sourceFileRelativePath = PrimarySourceFile)
+    {
+        return new ResoniteConstructionCityObject(
+            SlotKey: $"slot-{objectIdentity}",
+            DisplayName: $"CityObject {objectIdentity}",
+            PackageName: "bldg",
+            ActualMeshCode: MeshCode,
+            LodLevel: 0,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Mesh: ResoniteLiveSceneImportTargetTestSupport.CreateTriangleMesh("vertex-color-material"),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "vertex-color-material",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.VertexColor,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
             ],
             SourceObjectKey: objectIdentity,
             SourceFileRelativePath: sourceFileRelativePath);

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -173,6 +173,22 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
 
         Assert.Equal(firstMaterialId, secondMaterialId);
         Assert.Contains(firstMaterialId, commonMaterialIds);
+        Assert.True(client.ImportedMeshes.Count >= 2);
+        HashSet<string> importedUvSignatures = client.ImportedMeshes
+            .Select(CreateMeshUvSignature)
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.Contains(
+            CreateMeshUvSignature(
+                new ResoniteFloat2(0.125, 0.75),
+                new ResoniteFloat2(0.625, 0.75),
+                new ResoniteFloat2(0.125, 1.0)),
+            importedUvSignatures);
+        Assert.Contains(
+            CreateMeshUvSignature(
+                new ResoniteFloat2(0.25, 0.5),
+                new ResoniteFloat2(2.25, 0.5),
+                new ResoniteFloat2(0.25, 2.0)),
+            importedUvSignatures);
     }
 
     [Fact]
@@ -226,6 +242,52 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
 
         Assert.Equal(firstMaterialId, secondMaterialId);
         Assert.Contains("/vertex-color/", client.SlotPaths[commonMaterialContainerSlotId], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BuildAsyncReusesExistingSharedVertexColorCommonMaterialAssetsAcrossRuns()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        using SceneBuilderRecordingClient client = new();
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneTwiceAsync(
+            metadata,
+            [CreateVertexColorTriangleCityObject("vertex-color-run-one")],
+            [CreateVertexColorTriangleCityObject("vertex-color-run-two")],
+            client);
+
+        string firstMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject vertex-color-run-one");
+        string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject vertex-color-run-two");
+
+        Assert.Equal(firstMaterialId, secondMaterialId);
+        Assert.Equal(1, CountCommonMaterialComponents(client, firstMaterialId));
+    }
+
+    [Fact]
+    public async Task BuildAsyncReusesLegacyGenericScaleOneCommonMaterialSlotAcrossRuns()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        using SceneBuilderRecordingClient client = new();
+
+        string legacyMaterialComponentId = await SeedLegacyGenericSharedMaterialAsync(client);
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [
+                CreatePayloadTriangleCityObject(
+                    "legacy-generic-reuse",
+                    ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(255, 0, 0, "textures/legacy-reuse.png")),
+            ],
+            client);
+
+        string rendererMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject legacy-generic-reuse");
+
+        Assert.Equal(legacyMaterialComponentId, rendererMaterialId);
+        Assert.DoesNotContain(
+            client.SlotPaths.Values,
+            static path => path.EndsWith("/generic/shared_uv_generic", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -1196,6 +1258,82 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             string.Equals(request.Data.ID, materialComponentId, StringComparison.Ordinal)
             && client.SlotPaths.TryGetValue(request.ContainerSlotId, out string? path)
             && path.Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal));
+    }
+
+    private static string CreateMeshUvSignature(
+        ImportMeshRawData mesh)
+    {
+        Assert.Equal(3, mesh.VertexCount);
+        return CreateMeshUvSignature(
+            new ResoniteFloat2(mesh.AccessUV_2D(0)[0].x, mesh.AccessUV_2D(0)[0].y),
+            new ResoniteFloat2(mesh.AccessUV_2D(0)[1].x, mesh.AccessUV_2D(0)[1].y),
+            new ResoniteFloat2(mesh.AccessUV_2D(0)[2].x, mesh.AccessUV_2D(0)[2].y));
+    }
+
+    private static string CreateMeshUvSignature(
+        ResoniteFloat2 firstUv,
+        ResoniteFloat2 secondUv,
+        ResoniteFloat2 thirdUv)
+    {
+        return string.Create(
+            System.Globalization.CultureInfo.InvariantCulture,
+            $"{firstUv.X:0.######},{firstUv.Y:0.######}|{secondUv.X:0.######},{secondUv.Y:0.######}|{thirdUv.X:0.######},{thirdUv.Y:0.######}");
+    }
+
+    private static async Task<string> SeedLegacyGenericSharedMaterialAsync(SceneBuilderRecordingClient client)
+    {
+        string sharedAssetsRootId = await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    Parent = new Reference { TargetID = "Root" },
+                    Name = new Field_string { Value = "PLATEAU Shared Assets" },
+                },
+            },
+            CancellationToken.None);
+        string commonMaterialsRootId = await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    Parent = new Reference { TargetID = sharedAssetsRootId },
+                    Name = new Field_string { Value = "Common Materials" },
+                },
+            },
+            CancellationToken.None);
+        string genericFamilySlotId = await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    Parent = new Reference { TargetID = commonMaterialsRootId },
+                    Name = new Field_string { Value = "generic" },
+                },
+            },
+            CancellationToken.None);
+        string materialSlotId = await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    Parent = new Reference { TargetID = genericFamilySlotId },
+                    Name = new Field_string { Value = "shared_uv_generic_scale_1x1" },
+                },
+            },
+            CancellationToken.None);
+
+        return await client.AddComponentAsync(
+            new AddComponent
+            {
+                ContainerSlotId = materialSlotId,
+                Data = new Component
+                {
+                    ComponentType = "[FrooxEngine]FrooxEngine.PBS_Metallic",
+                    Members = new Dictionary<string, Member>(StringComparer.Ordinal),
+                },
+            },
+            CancellationToken.None);
     }
 
 }

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -201,15 +201,6 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                 path,
                 $"{client.SlotPaths[commonRoot.ID!]}/vertex-color/shared_uv_vertex-color",
                 StringComparison.Ordinal));
-        Assert.Contains(
-            client.SlotPaths.Values,
-            path => path.EndsWith("/generic/shared_uv_generic_offset_0.5x0", StringComparison.Ordinal));
-        Assert.Contains(
-            client.SlotPaths.Values,
-            path => path.EndsWith("/generic/shared_uv_generic_offset_0x0.5", StringComparison.Ordinal));
-        Assert.Contains(
-            client.SlotPaths.Values,
-            path => path.EndsWith("/generic/shared_uv_generic_offset_0.5x0.5", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -291,6 +291,119 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
+    public async Task BuildAsyncReusesLegacyGenericScaleOneCommonMaterialWhenCurrentSlotExistsWithoutComponent()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        using SceneBuilderRecordingClient client = new();
+
+        string legacyMaterialComponentId = await SeedLegacyGenericSharedMaterialAsync(client, includeEmptyCurrentSlot: true);
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [
+                CreatePayloadTriangleCityObject(
+                    "legacy-generic-coexistence-reuse",
+                    ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(255, 0, 0, "textures/legacy-coexistence.png")),
+            ],
+            client);
+
+        string rendererMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject legacy-generic-coexistence-reuse");
+
+        Assert.Equal(legacyMaterialComponentId, rendererMaterialId);
+        Assert.Equal(1, CountCommonMaterialComponents(client, legacyMaterialComponentId));
+    }
+
+    [Fact]
+    public async Task BuildAsyncReusesSharedCommonMaterialAcrossRunsForPayloadAlbedoOverridesWithDifferentUvTransforms()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        using SceneBuilderRecordingClient client = new();
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneTwiceAsync(
+            metadata,
+            [
+                CreatePayloadTriangleCityObject(
+                    "dataset-texture-scaled-run-one",
+                    ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(255, 0, 0, "textures/albedo-scaled-run-one.png"),
+                    textureScale: new ResoniteFloat2(0.5, 0.25),
+                    textureOffset: new ResoniteFloat2(0.125, 0.75)),
+            ],
+            [
+                CreatePayloadTriangleCityObject(
+                    "dataset-texture-scaled-run-two",
+                    ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(0, 255, 0, "textures/albedo-scaled-run-two.png"),
+                    textureScale: new ResoniteFloat2(2.0, 1.5),
+                    textureOffset: new ResoniteFloat2(0.25, 0.5)),
+            ],
+            client);
+
+        string firstMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject dataset-texture-scaled-run-one");
+        string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject dataset-texture-scaled-run-two");
+        HashSet<string> importedUvSignatures = client.ImportedMeshes
+            .Select(CreateMeshUvSignature)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(firstMaterialId, secondMaterialId);
+        Assert.Equal(1, CountCommonMaterialComponents(client, firstMaterialId));
+        Assert.Contains(
+            CreateMeshUvSignature(
+                new ResoniteFloat2(0.125, 0.75),
+                new ResoniteFloat2(0.625, 0.75),
+                new ResoniteFloat2(0.125, 1.0)),
+            importedUvSignatures);
+        Assert.Contains(
+            CreateMeshUvSignature(
+                new ResoniteFloat2(0.25, 0.5),
+                new ResoniteFloat2(2.25, 0.5),
+                new ResoniteFloat2(0.25, 2.0)),
+            importedUvSignatures);
+    }
+
+    [Fact]
+    public async Task BuildAsyncReusesLegacySharedGenericMaterialAcrossRunsWhenSecondRunNeedsUvBake()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteConstructionMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        using SceneBuilderRecordingClient client = new();
+
+        string legacyMaterialComponentId = await SeedLegacyGenericSharedMaterialAsync(client);
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneTwiceAsync(
+            metadata,
+            [
+                CreatePayloadTriangleCityObject(
+                    "legacy-run-one",
+                    ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(255, 0, 0, "textures/legacy-run-one.png")),
+            ],
+            [
+                CreatePayloadTriangleCityObject(
+                    "legacy-run-two",
+                    ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(0, 255, 0, "textures/legacy-run-two.png"),
+                    textureScale: new ResoniteFloat2(2.0, 1.5),
+                    textureOffset: new ResoniteFloat2(0.25, 0.5)),
+            ],
+            client);
+
+        string firstMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject legacy-run-one");
+        string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject legacy-run-two");
+        HashSet<string> importedUvSignatures = client.ImportedMeshes
+            .Select(CreateMeshUvSignature)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(legacyMaterialComponentId, firstMaterialId);
+        Assert.Equal(legacyMaterialComponentId, secondMaterialId);
+        Assert.Equal(1, CountCommonMaterialComponents(client, legacyMaterialComponentId));
+        Assert.Contains(
+            CreateMeshUvSignature(
+                new ResoniteFloat2(0.25, 0.5),
+                new ResoniteFloat2(2.25, 0.5),
+                new ResoniteFloat2(0.25, 2.0)),
+            importedUvSignatures);
+    }
+
+    [Fact]
     public async Task BuildAsyncUsesDistinctPropertyBlocksForSameMaterialKeyWithDifferentPayloadOverrides()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -1280,7 +1393,9 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             $"{firstUv.X:0.######},{firstUv.Y:0.######}|{secondUv.X:0.######},{secondUv.Y:0.######}|{thirdUv.X:0.######},{thirdUv.Y:0.######}");
     }
 
-    private static async Task<string> SeedLegacyGenericSharedMaterialAsync(SceneBuilderRecordingClient client)
+    private static async Task<string> SeedLegacyGenericSharedMaterialAsync(
+        SceneBuilderRecordingClient client,
+        bool includeEmptyCurrentSlot = false)
     {
         string sharedAssetsRootId = await client.AddSlotAsync(
             new AddSlot
@@ -1312,6 +1427,20 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                 },
             },
             CancellationToken.None);
+        if (includeEmptyCurrentSlot)
+        {
+            _ = await client.AddSlotAsync(
+                new AddSlot
+                {
+                    Data = new Slot
+                    {
+                        Parent = new Reference { TargetID = genericFamilySlotId },
+                        Name = new Field_string { Value = "shared_uv_generic" },
+                    },
+                },
+                CancellationToken.None);
+        }
+
         string materialSlotId = await client.AddSlotAsync(
             new AddSlot
             {

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -753,6 +753,61 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
+    public async Task BuildAsyncFailsFastOnDuplicateMaterialSubmeshAssignmentBeforeDynamicUvNormalization()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using SceneBuilderRecordingClient client = new();
+        ResoniteConstructionMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            LocalOrigin,
+            packageNames: ["bldg"],
+            sourceFiles:
+            [
+                $"udx/bldg/{MeshCode}/plateau_{DatasetName}_bldg_{MeshCode}.gml",
+            ]);
+        ResoniteConstructionCityObject cityObject = new(
+            SlotKey: "invalid-submesh-duplicate-dynamic",
+            DisplayName: "Invalid Submesh Duplicate Dynamic",
+            PackageName: "bldg",
+            ActualMeshCode: MeshCode,
+            LodLevel: 0,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Mesh: CreateTwoSubmeshMesh(),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "first-material",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(255, 0, 0, "textures/duplicate-a.png"),
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    TextureScale: new ResoniteFloat2(2.0, 0.5),
+                    TextureOffset: new ResoniteFloat2(0.25, 0.75)),
+                new ResoniteMaterialBinding(
+                    MaterialKey: "second-material",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(0, 255, 0, "textures/duplicate-b.png"),
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0, 1]),
+            ],
+            SourceObjectKey: "invalid-submesh-duplicate-dynamic");
+
+        ResoniteMeshValidationException exception = await Assert.ThrowsAsync<ResoniteMeshValidationException>(
+            () => ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(metadata, [cityObject], client, enableMeshBake: false));
+
+        Assert.Contains("assigned submesh index 0", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("materials=2", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task BuildAsyncFailsFastOnUnassignedMeshSubmesh()
     {
         using TemporaryDirectory datasetDirectory = new();

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -136,6 +136,85 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
+    public async Task BuildAsyncReusesLegacyTerrainOverlayGenericCommonMaterialSlotWithIdentityScaleOffset()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using SceneBuilderRecordingClient client = new();
+        TerrainTextureOverlay overlay = new(
+            PackageName: "dem",
+            UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
+            ZoomLevel: 17,
+            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+            MaxTextureSize: 512);
+        RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
+            requestedOverlay => new GeneratedTerrainTexture(
+                new ResoniteRawTextureImport(
+                    2,
+                    2,
+                    ResoniteTextureColorProfiles.Srgb,
+                    new byte[16],
+                    $"terrain-overlay/{requestedOverlay.PackageName}/{requestedOverlay.ZoomLevel}/generated"),
+                new ResoniteFloat2(1.0, 1.0),
+                new ResoniteFloat2(0.125, 0.375)));
+        ResoniteConstructionMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            LocalOrigin,
+            packageNames: ["dem"],
+            sourceFiles:
+            [
+                $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml",
+            ],
+            terrainTextureOverlays: [overlay]);
+        string legacyMaterialComponentId = await SeedCommonMaterialComponentAsync(
+            client,
+            familySlotName: "generic",
+            materialSlotName: "shared_uv_generic_scale_1x1_offset_0.125x0.375",
+            componentType: "[FrooxEngine]FrooxEngine.PBS_Metallic");
+        ResoniteConstructionCityObject cityObject = new(
+            SlotKey: "dem-overlay-legacy-object",
+            DisplayName: "DEM Overlay Legacy Object",
+            PackageName: "dem",
+            ActualMeshCode: MeshCode,
+            LodLevel: 0,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Mesh: ResoniteLiveSceneImportTargetTestSupport.CreateTriangleMesh("dem-overlay-legacy-material"),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "dem-overlay-legacy-material",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    TerrainOverlay: overlay),
+            ],
+            SourceObjectKey: "dem-overlay-legacy-source");
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [cityObject],
+            client,
+            terrainTextureGenerator);
+
+        Component meshRenderer = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal)
+                && string.Equals(client.SlotsById[request.ContainerSlotId].Name?.Value, "DEM Overlay Legacy Object", StringComparison.Ordinal))
+            .Data;
+        string sharedMaterialId = Assert.IsType<Reference>(Assert.Single(Assert.IsType<SyncList>(meshRenderer.Members["Materials"]).Elements)).TargetID;
+
+        Assert.Equal(legacyMaterialComponentId, sharedMaterialId);
+        Assert.DoesNotContain(
+            client.SlotPaths.Values,
+            static path => path.EndsWith("/generic/shared_uv_generic_offset_0.125x0.375", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task BuildAsyncSendsHeightMapAsHdrRawTextureAndCreatesGridMesh()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -935,6 +1014,66 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.False((slot.ID ?? string.Empty).StartsWith("plan:", StringComparison.Ordinal));
         Assert.False((slot.Parent?.TargetID ?? string.Empty).StartsWith("plan:", StringComparison.Ordinal));
         Assert.False((slot.Tag?.Value ?? string.Empty).StartsWith("plan:", StringComparison.Ordinal));
+    }
+
+    private static async Task<string> SeedCommonMaterialComponentAsync(
+        SceneBuilderRecordingClient client,
+        string familySlotName,
+        string materialSlotName,
+        string componentType)
+    {
+        string sharedAssetsRootId = await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    Parent = new Reference { TargetID = "Root" },
+                    Name = new Field_string { Value = "PLATEAU Shared Assets" },
+                },
+            },
+            CancellationToken.None);
+        string commonMaterialsRootId = await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    Parent = new Reference { TargetID = sharedAssetsRootId },
+                    Name = new Field_string { Value = "Common Materials" },
+                },
+            },
+            CancellationToken.None);
+        string familySlotId = await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    Parent = new Reference { TargetID = commonMaterialsRootId },
+                    Name = new Field_string { Value = familySlotName },
+                },
+            },
+            CancellationToken.None);
+        string materialSlotId = await client.AddSlotAsync(
+            new AddSlot
+            {
+                Data = new Slot
+                {
+                    Parent = new Reference { TargetID = familySlotId },
+                    Name = new Field_string { Value = materialSlotName },
+                },
+            },
+            CancellationToken.None);
+
+        return await client.AddComponentAsync(
+            new AddComponent
+            {
+                ContainerSlotId = materialSlotId,
+                Data = new Component
+                {
+                    ComponentType = componentType,
+                    Members = new Dictionary<string, Member>(StringComparer.Ordinal),
+                },
+            },
+            CancellationToken.None);
     }
 
     private static void AssertNoPlannedReferences(IEnumerable<Member> members)

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -103,12 +103,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
             "PLATEAU Shared Assets/Common Materials/",
             client.SlotPaths[commonMaterialContainerSlotId],
             StringComparison.Ordinal);
-        Field_float2 textureScale = Assert.IsType<Field_float2>(sharedMaterial.Members["TextureScale"]);
-        Field_float2 textureOffset = Assert.IsType<Field_float2>(sharedMaterial.Members["TextureOffset"]);
-        Assert.Equal(0.4f, textureScale.Value.x, 6);
-        Assert.Equal(0.1f, textureScale.Value.y, 6);
-        Assert.Equal(0.25f, textureOffset.Value.x, 6);
-        Assert.Equal(0.5f, textureOffset.Value.y, 6);
+        Assert.DoesNotContain("TextureScale", sharedMaterial.Members.Keys);
+        Assert.DoesNotContain("TextureOffset", sharedMaterial.Members.Keys);
         Assert.Equal("[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", propertyBlock.ComponentType);
         string propertyBlockReferenceId = Assert.IsType<Reference>(Assert.Single(propertyBlocks.Elements)).TargetID;
         AddComponent plannedPropertyBlock = Assert.Single(

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -378,6 +378,66 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.True(overlayEstimate - baselineEstimate > 0);
     }
 
+    [Fact]
+    public void EstimateCityObjectWorkingSetBytesKeepsOriginalVertexFootprintForUvBake()
+    {
+        ResoniteImportedMesh sparseMesh = new(
+            [
+                new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+                new ResoniteMeshVertex(new ResoniteFloat3(1.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 0.0)),
+                new ResoniteMeshVertex(new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 1.0)),
+                new ResoniteMeshVertex(new ResoniteFloat3(5.0, 5.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+                new ResoniteMeshVertex(new ResoniteFloat3(6.0, 5.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+                new ResoniteMeshVertex(new ResoniteFloat3(7.0, 5.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+            ],
+            [
+                new ResoniteMeshSubmesh(0, "uv-bake-budget", [0, 1, 2]),
+            ]);
+        ResoniteConstructionCityObject baseline = new(
+            SlotKey: "uv-bake-budget-baseline",
+            DisplayName: "UV Bake Budget Baseline",
+            PackageName: "bldg",
+            ActualMeshCode: MeshCode,
+            LodLevel: 2,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Mesh: sparseMesh,
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "uv-bake-budget",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/uv-bake-budget.png"),
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    TextureScale: null,
+                    TextureOffset: null,
+                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
+            ],
+            SourceObjectKey: "uv-bake-budget-baseline");
+        ResoniteConstructionCityObject withBake = baseline with
+        {
+            SlotKey = "uv-bake-budget-baked",
+            DisplayName = "UV Bake Budget Baked",
+            Materials =
+            [
+                baseline.Materials[0] with
+                {
+                    TextureScale = new ResoniteFloat2(2.0, 0.5),
+                    TextureOffset = new ResoniteFloat2(0.25, 0.75),
+                },
+            ],
+            SourceObjectKey = "uv-bake-budget-baked",
+        };
+
+        long baselineEstimate = InvokeEstimatedWorkingSetBytes(baseline);
+        long bakedEstimate = InvokeEstimatedWorkingSetBytes(withBake);
+
+        Assert.True(bakedEstimate > baselineEstimate);
+    }
+
     private static long InvokeEstimatedWorkingSetBytes(ResoniteConstructionCityObject cityObject)
     {
         MethodInfo method = typeof(ResoniteLiveSceneImportTarget)

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -516,6 +516,146 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
+    public async Task BuildAsyncPreservesBundledFamilyUvScaleForPresentationScopedInputs()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using SceneBuilderRecordingClient client = new();
+        string sourceFile = $"udx/bldg/{MeshCode}/plateau_{DatasetName}_bldg_{MeshCode}.gml";
+        ResoniteConstructionMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            LocalOrigin,
+            packageNames: ["bldg"],
+            sourceFiles: [sourceFile]);
+        ResoniteConstructionCityObject cityObject = new(
+            SlotKey: "bundled-family-scale-check",
+            DisplayName: "Bundled Family Scale Check",
+            PackageName: "bldg",
+            ActualMeshCode: MeshCode,
+            LodLevel: 0,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Mesh: ResoniteLiveSceneImportTargetTestSupport.CreateTriangleMesh("bundled-family-scale-material"),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "bundled-family-scale-material",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    TextureScale: new ResoniteFloat2(0.5, 0.5),
+                    Family: BundledDefaultMaterialFamilies.Facade,
+                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
+                    BundledVariantIndex: 0),
+            ],
+            SourceObjectKey: "bundled-family-scale-source",
+            SourceFileRelativePath: sourceFile);
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [cityObject],
+            client,
+            enableMeshBake: false);
+
+        Component meshRenderer = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal)
+                && string.Equals(client.SlotsById[request.ContainerSlotId].Name?.Value, "Bundled Family Scale Check", StringComparison.Ordinal))
+            .Data;
+        SyncList materials = Assert.IsType<SyncList>(meshRenderer.Members["Materials"]);
+        string materialId = Assert.IsType<Reference>(Assert.Single(materials.Elements)).TargetID;
+        Component sharedMaterial = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, materialId, StringComparison.Ordinal)).Data;
+        string commonMaterialContainerSlotId = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, materialId, StringComparison.Ordinal)).ContainerSlotId;
+        Field_float2 textureScale = Assert.IsType<Field_float2>(sharedMaterial.Members["TextureScale"]);
+
+        Assert.Contains(
+            "PLATEAU Shared Assets/Common Materials/",
+            client.SlotPaths[commonMaterialContainerSlotId],
+            StringComparison.Ordinal);
+        Assert.Equal(0.5f, textureScale.Value.x, 6);
+        Assert.Equal(0.5f, textureScale.Value.y, 6);
+    }
+
+    [Fact]
+    public async Task BuildAsyncPreservesBundledFamilyUvTransformForDedicatedPresentationScopedInputs()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using SceneBuilderRecordingClient client = new();
+        string sourceFile = $"udx/bldg/{MeshCode}/plateau_{DatasetName}_bldg_{MeshCode}.gml";
+        ResoniteConstructionMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            LocalOrigin,
+            packageNames: ["bldg"],
+            sourceFiles: [sourceFile]);
+        ResoniteConstructionCityObject cityObject = new(
+            SlotKey: "bundled-family-transform-check",
+            DisplayName: "Bundled Family Transform Check",
+            PackageName: "bldg",
+            ActualMeshCode: MeshCode,
+            LodLevel: 0,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Mesh: ResoniteLiveSceneImportTargetTestSupport.CreateTriangleMesh("bundled-family-transform-material"),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "bundled-family-transform-material",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    TextureScale: new ResoniteFloat2(0.5, 0.5),
+                    TextureOffset: new ResoniteFloat2(0.125, 0.25),
+                    Family: BundledDefaultMaterialFamilies.Facade,
+                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
+                    BundledVariantIndex: 0),
+            ],
+            SourceObjectKey: "bundled-family-transform-source",
+            SourceFileRelativePath: sourceFile);
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [cityObject],
+            client,
+            enableMeshBake: false);
+
+        AddComponent materialRequest = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal)
+                && request.Data.Members.TryGetValue("TextureScale", out Member? rawTextureScale)
+                && request.Data.Members.TryGetValue("TextureOffset", out Member? rawTextureOffset)
+                && rawTextureScale is Field_float2 textureScaleField
+                && rawTextureOffset is Field_float2 textureOffsetField
+                && Math.Abs(textureScaleField.Value.x - 0.5f) < 1e-6f
+                && Math.Abs(textureScaleField.Value.y - 0.5f) < 1e-6f
+                && Math.Abs(textureOffsetField.Value.x - 0.125f) < 1e-6f
+                && Math.Abs(textureOffsetField.Value.y - 0.25f) < 1e-6f);
+        Field_float2 textureScale = Assert.IsType<Field_float2>(materialRequest.Data.Members["TextureScale"]);
+        Field_float2 textureOffset = Assert.IsType<Field_float2>(materialRequest.Data.Members["TextureOffset"]);
+
+        Assert.DoesNotContain(
+            "PLATEAU Shared Assets/Common Materials/",
+            client.SlotPaths[materialRequest.ContainerSlotId],
+            StringComparison.Ordinal);
+        Assert.Equal(0.5f, textureScale.Value.x, 6);
+        Assert.Equal(0.5f, textureScale.Value.y, 6);
+        Assert.Equal(0.125f, textureOffset.Value.x, 6);
+        Assert.Equal(0.25f, textureOffset.Value.y, 6);
+    }
+
+    [Fact]
     public async Task BuildAsyncFailsFastOnOutOfRangeMaterialSubmeshAssignment()
     {
         using TemporaryDirectory datasetDirectory = new();

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -103,8 +103,12 @@ public sealed class ResoniteLiveSceneImportTargetTests
             "PLATEAU Shared Assets/Common Materials/",
             client.SlotPaths[commonMaterialContainerSlotId],
             StringComparison.Ordinal);
-        Assert.DoesNotContain("TextureScale", sharedMaterial.Members.Keys);
-        Assert.DoesNotContain("TextureOffset", sharedMaterial.Members.Keys);
+        Field_float2 textureScale = Assert.IsType<Field_float2>(sharedMaterial.Members["TextureScale"]);
+        Field_float2 textureOffset = Assert.IsType<Field_float2>(sharedMaterial.Members["TextureOffset"]);
+        Assert.Equal(0.4f, textureScale.Value.x, 6);
+        Assert.Equal(0.1f, textureScale.Value.y, 6);
+        Assert.Equal(0.25f, textureOffset.Value.x, 6);
+        Assert.Equal(0.5f, textureOffset.Value.y, 6);
         Assert.Equal("[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", propertyBlock.ComponentType);
         string propertyBlockReferenceId = Assert.IsType<Reference>(Assert.Single(propertyBlocks.Elements)).TargetID;
         AddComponent plannedPropertyBlock = Assert.Single(

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
@@ -145,6 +145,37 @@ public sealed class ResoniteMaterialComponentPolicyTests
     }
 
     [Fact]
+    public void CreateMembersPreservesOffsetOnlyUvTransformUsingIdentityScale()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "offset-only-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureOffset: new ResoniteFloat2(0.125, 0.75),
+            TerrainOverlay: new TerrainTextureOverlay(
+                PackageName: "dem",
+                UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
+                ZoomLevel: 17,
+                GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+                MaxTextureSize: 512),
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        Dictionary<string, Member> members = ResoniteMaterialComponentPolicy.CreateMembers(material);
+
+        Field_float2 textureScale = Assert.IsType<Field_float2>(members["TextureScale"]);
+        Field_float2 textureOffset = Assert.IsType<Field_float2>(members["TextureOffset"]);
+        Assert.Equal(1.0f, textureScale.Value.x, 6);
+        Assert.Equal(1.0f, textureScale.Value.y, 6);
+        Assert.Equal(0.125f, textureOffset.Value.x, 6);
+        Assert.Equal(0.75f, textureOffset.Value.y, 6);
+    }
+
+    [Fact]
     public void TryGetBundledCompanionTextureSetResolvesSiblingTextures()
     {
         ResoniteMaterialBinding material = new(

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
@@ -24,6 +24,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
             TextureScale: new ResoniteFloat2(0.5, 0.25),
             TextureOffset: new ResoniteFloat2(0.125, 0.75),
             Family: BundledDefaultMaterialFamilies.Facade,
+            AssetScope: ResoniteMaterialAssetScope.Common,
             BundledVariantIndex: 0);
 
         string componentType = ResoniteMaterialComponentPolicy.GetComponentType(material);
@@ -92,6 +93,28 @@ public sealed class ResoniteMaterialComponentPolicyTests
         Field_colorX fillColor = Assert.IsType<Field_colorX>(wireframeMembers["FillColor"]);
         Assert.Equal(0.01f, thickness.Value, 6);
         Assert.Equal(0.04f, fillColor.Value.a, 6);
+    }
+
+    [Fact]
+    public void CreateMembersOmitsUvTransformForDynamicMaterialsThatBakeIntoMesh()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "dynamic-overlay",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic.png"),
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: new ResoniteFloat2(0.5, 0.25),
+            TextureOffset: new ResoniteFloat2(0.125, 0.75),
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        Dictionary<string, Member> members = ResoniteMaterialComponentPolicy.CreateMembers(material);
+
+        Assert.DoesNotContain("TextureScale", members.Keys);
+        Assert.DoesNotContain("TextureOffset", members.Keys);
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
@@ -111,10 +111,37 @@ public sealed class ResoniteMaterialComponentPolicyTests
             TextureOffset: new ResoniteFloat2(0.125, 0.75),
             AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
 
-        Dictionary<string, Member> members = ResoniteMaterialComponentPolicy.CreateMembers(material);
+        Dictionary<string, Member> members = ResoniteMaterialComponentPolicy.CreateMembers(
+            ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material));
 
         Assert.DoesNotContain("TextureScale", members.Keys);
         Assert.DoesNotContain("TextureOffset", members.Keys);
+    }
+
+    [Fact]
+    public void CreateMembersPreservesUvTransformForUnbakedDirectInputMaterial()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "direct-heightmap-style-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/direct-heightmap-style.png"),
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: new ResoniteFloat2(1.0, 1.0),
+            TextureOffset: new ResoniteFloat2(0.125, 0.75),
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        Dictionary<string, Member> members = ResoniteMaterialComponentPolicy.CreateMembers(material);
+
+        Field_float2 textureScale = Assert.IsType<Field_float2>(members["TextureScale"]);
+        Field_float2 textureOffset = Assert.IsType<Field_float2>(members["TextureOffset"]);
+        Assert.Equal(1.0f, textureScale.Value.x, 6);
+        Assert.Equal(1.0f, textureScale.Value.y, 6);
+        Assert.Equal(0.125f, textureOffset.Value.x, 6);
+        Assert.Equal(0.75f, textureOffset.Value.y, 6);
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -1,4 +1,5 @@
 using Plateau.ResoniteLink.Domain.Importing;
+
 namespace Plateau.ResoniteLink.Tests.Targets;
 
 public sealed class ResoniteMaterialPlanningTests

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -95,7 +95,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
 
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
 
-        Assert.Equal("shared_uv_generic_scale_1x1_offset_0.25x0.75", slotName);
+        Assert.Equal("shared_uv_generic_offset_0.25x0.75", slotName);
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -119,6 +119,29 @@ public sealed class ResoniteSceneMaterialConventionsTests
     }
 
     [Fact]
+    public void CreateCommonMaterialSlotLookupNames_ForIdentityScaleGenericOffsetMaterial_IncludesLegacyScaleOneName()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "generic|Uv|scale:none|offset:0.25x0.75|depth:2x3",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: new ResoniteMaterialDepthOffset(2.0, 3.0),
+            SubmeshIndices: [0],
+            TextureScale: null,
+            TextureOffset: new ResoniteFloat2(0.25, 0.75),
+            AssetScope: ResoniteMaterialAssetScope.Common);
+
+        IReadOnlyList<string> slotLookupNames = ResoniteSceneMaterialConventions.CreateCommonMaterialSlotLookupNames(material);
+
+        Assert.Equal(
+            ["shared_uv_generic_offset_0.25x0.75_depth_2x3", "shared_uv_generic_scale_1x1_offset_0.25x0.75_depth_2x3"],
+            slotLookupNames);
+    }
+
+    [Fact]
     public void TryNormalizeSharedMaterialBinding_AllowsTerrainOverlayAsMainTextureOverride()
     {
         TerrainTextureOverlay overlay = new(

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -109,6 +109,16 @@ public sealed class ResoniteSceneMaterialConventionsTests
     }
 
     [Fact]
+    public void CreateCommonMaterialSlotLookupNames_ForIdentityGenericCommonMaterial_IncludesLegacyScaleOneName()
+    {
+        ResoniteMaterialBinding material = ResoniteMaterialSharing.CreateSharedAlbedoCommonMaterial();
+
+        IReadOnlyList<string> slotLookupNames = ResoniteSceneMaterialConventions.CreateCommonMaterialSlotLookupNames(material);
+
+        Assert.Equal(["shared_uv_generic", "shared_uv_generic_scale_1x1"], slotLookupNames);
+    }
+
+    [Fact]
     public void TryNormalizeSharedMaterialBinding_AllowsTerrainOverlayAsMainTextureOverride()
     {
         TerrainTextureOverlay overlay = new(
@@ -167,5 +177,50 @@ public sealed class ResoniteSceneMaterialConventionsTests
         Assert.Equal(ResoniteMaterialAssetScope.Common, normalizedMaterial.AssetScope);
         Assert.Equal("vertex-color|Uv|depth:none", normalizedMaterial.MaterialKey);
         Assert.Equal(ResoniteMaterialType.VertexColor, normalizedMaterial.MaterialType);
+    }
+
+    [Fact]
+    public void TryNormalizeSharedMaterialBinding_RejectsTintedVertexColorMaterial()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "vertex-color-tinted-material",
+            BaseColor: new ResoniteColor(0.8, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.VertexColor,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        bool normalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
+            material,
+            out _,
+            out _);
+
+        Assert.False(normalized);
+    }
+
+    [Fact]
+    public void TryNormalizeSharedMaterialBinding_RejectsTransformedVertexColorMaterial()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "vertex-color-transformed-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.VertexColor,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: new ResoniteFloat2(2.0, 1.0),
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        bool normalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
+            material,
+            out _,
+            out _);
+
+        Assert.False(normalized);
     }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -70,8 +70,8 @@ public sealed class ResoniteSceneMaterialConventionsTests
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: false);
 
         Assert.Contains("pbs-uv_uv_", slotName, StringComparison.Ordinal);
-        Assert.Contains("_0.5x0.25_", slotName, StringComparison.Ordinal);
-        Assert.Contains("_0.125x0.75_", slotName, StringComparison.Ordinal);
+        Assert.DoesNotContain("_0.5x0.25_", slotName, StringComparison.Ordinal);
+        Assert.DoesNotContain("_0.125x0.75_", slotName, StringComparison.Ordinal);
         Assert.Contains("_2x3_", slotName, StringComparison.Ordinal);
     }
 
@@ -96,6 +96,16 @@ public sealed class ResoniteSceneMaterialConventionsTests
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
 
         Assert.Equal("shared_uv_generic_scale_1x1_offset_0.25x0.75", slotName);
+    }
+
+    [Fact]
+    public void CreateMaterialSlotName_ForVertexColorCommonMaterial_UsesVertexColorName()
+    {
+        ResoniteMaterialBinding material = ResoniteMaterialSharing.CreateSharedVertexColorCommonMaterial();
+
+        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
+
+        Assert.Equal("shared_uv_vertex-color", slotName);
     }
 
     [Fact]
@@ -131,5 +141,31 @@ public sealed class ResoniteSceneMaterialConventionsTests
         Assert.Equal("generic|Uv|scale:none|offset:none|depth:none", normalizedMaterial.MaterialKey);
         Assert.Null(normalizedMaterial.TerrainOverlay);
         Assert.Equal(new ResoniteColor(1.0, 1.0, 1.0, 1.0), normalizedMaterial.BaseColor);
+    }
+
+    [Fact]
+    public void TryNormalizeSharedMaterialBinding_AllowsVertexColorSharedCommonMaterial()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "vertex-color-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.VertexColor,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        bool normalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
+            material,
+            out ResoniteMaterialBinding normalizedMaterial,
+            out string familySlotName);
+
+        Assert.True(normalized);
+        Assert.Equal("vertex-color", familySlotName);
+        Assert.Equal(ResoniteMaterialAssetScope.Common, normalizedMaterial.AssetScope);
+        Assert.Equal("vertex-color|Uv|depth:none", normalizedMaterial.MaterialKey);
+        Assert.Equal(ResoniteMaterialType.VertexColor, normalizedMaterial.MaterialType);
     }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -324,6 +324,178 @@ public sealed class ResoniteSceneMaterialConventionsTests
     }
 
     [Fact]
+    public void TryNormalizeSharedMaterialBinding_RejectsTransformedGenericCommonMaterialWithoutTerrainOverlay()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "generic-shared-transformed-common-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: new ResoniteFloat2(1.0, 1.0),
+            TextureOffset: new ResoniteFloat2(0.25, 0.75),
+            AssetScope: ResoniteMaterialAssetScope.Common);
+
+        bool normalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
+            material,
+            out _,
+            out _);
+
+        Assert.False(normalized);
+    }
+
+    [Fact]
+    public void TryNormalizeSharedMaterialBinding_RejectsTintedBundledFamilySharedMaterial()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "bundled-family-tinted-material",
+            BaseColor: new ResoniteColor(0.8, 0.7, 0.6, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter,
+            Family: BundledDefaultMaterialFamilies.Facade,
+            BundledVariantIndex: 0,
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        bool normalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
+            material,
+            out _,
+            out _);
+
+        Assert.False(normalized);
+    }
+
+    [Fact]
+    public void TryNormalizeSharedMaterialBinding_RejectsBundledFamilySharedMaterialWithUvOrDepthTransform()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "bundled-family-transformed-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: new ResoniteMaterialDepthOffset(1.0, 1.0),
+            SubmeshIndices: [0],
+            TextureScale: BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter,
+            TextureOffset: new ResoniteFloat2(0.125, 0.25),
+            Family: BundledDefaultMaterialFamilies.Facade,
+            BundledVariantIndex: 0,
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        bool normalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
+            material,
+            out _,
+            out _);
+
+        Assert.False(normalized);
+    }
+
+    [Fact]
+    public void NormalizeCommonMaterialBinding_DemotesTintedBundledFamilyCommonMaterial()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "bundled-family-tinted-common-material",
+            BaseColor: new ResoniteColor(0.8, 0.7, 0.6, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter,
+            Family: BundledDefaultMaterialFamilies.Facade,
+            BundledVariantIndex: 0,
+            AssetScope: ResoniteMaterialAssetScope.Common);
+
+        ResoniteMaterialBinding normalized = ResoniteSceneMaterialConventions.NormalizeCommonMaterialBinding(material);
+
+        Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, normalized.AssetScope);
+        Assert.Equal(new ResoniteColor(0.8, 0.7, 0.6, 1.0), normalized.BaseColor);
+        Assert.Equal(BundledDefaultMaterialFamilies.Facade, normalized.Family);
+    }
+
+    [Fact]
+    public void NormalizeCommonMaterialBinding_DemotesWhiteBundledFamilyCommonMaterialWithUvOrDepthTransform()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "bundled-family-white-transformed-common-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: new ResoniteMaterialDepthOffset(1.0, 1.0),
+            SubmeshIndices: [0],
+            TextureScale: BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter,
+            TextureOffset: new ResoniteFloat2(0.125, 0.25),
+            Family: BundledDefaultMaterialFamilies.Facade,
+            BundledVariantIndex: 0,
+            AssetScope: ResoniteMaterialAssetScope.Common);
+
+        ResoniteMaterialBinding normalized = ResoniteSceneMaterialConventions.NormalizeCommonMaterialBinding(material);
+
+        Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, normalized.AssetScope);
+        Assert.Equal(new ResoniteMaterialDepthOffset(1.0, 1.0), normalized.DepthOffset);
+        Assert.Equal(new ResoniteFloat2(0.125, 0.25), normalized.TextureOffset);
+    }
+
+    [Fact]
+    public void NormalizeBatchGroupedMaterialBinding_DemotesTintedBundledFamilyCommonMaterial()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "bundled-family-tinted-batch-material",
+            BaseColor: new ResoniteColor(0.8, 0.7, 0.6, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter,
+            Family: BundledDefaultMaterialFamilies.Facade,
+            BundledVariantIndex: 0,
+            AssetScope: ResoniteMaterialAssetScope.Common);
+
+        ResoniteMaterialBinding normalized = ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
+
+        Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, normalized.AssetScope);
+        Assert.Equal(new ResoniteColor(0.8, 0.7, 0.6, 1.0), normalized.BaseColor);
+    }
+
+    [Fact]
+    public void NormalizeBatchGroupedMaterialBinding_DemotesWhiteBundledFamilyCommonMaterialWithUvOrDepthTransform()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "bundled-family-white-transformed-batch-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: new ResoniteMaterialDepthOffset(1.0, 1.0),
+            SubmeshIndices: [0],
+            TextureScale: BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter,
+            TextureOffset: new ResoniteFloat2(0.125, 0.25),
+            Family: BundledDefaultMaterialFamilies.Facade,
+            BundledVariantIndex: 0,
+            AssetScope: ResoniteMaterialAssetScope.Common);
+
+        ResoniteMaterialBinding normalized = ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
+
+        Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, normalized.AssetScope);
+        Assert.Equal(new ResoniteMaterialDepthOffset(1.0, 1.0), normalized.DepthOffset);
+        Assert.Equal(new ResoniteFloat2(0.125, 0.25), normalized.TextureOffset);
+    }
+
+    [Fact]
     public void TryNormalizeSharedMaterialBinding_AllowsTransformedTerrainOverlaySharedMaterial()
     {
         TerrainTextureOverlay overlay = new(

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -99,6 +99,29 @@ public sealed class ResoniteSceneMaterialConventionsTests
     }
 
     [Fact]
+    public void CreateMaterialSlotName_ForGenericSharedMaterial_OmitsExplicitZeroOffset()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "generic|Uv|scale:none|offset:0x0|depth:none",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: null,
+            TextureOffset: new ResoniteFloat2(0.0, 0.0),
+            Family: null,
+            BundledVariantIndex: null,
+            AssetScope: ResoniteMaterialAssetScope.Common);
+
+        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
+
+        Assert.Equal("shared_uv_generic", slotName);
+    }
+
+    [Fact]
     public void CreateMaterialSlotName_ForVertexColorCommonMaterial_UsesVertexColorName()
     {
         ResoniteMaterialBinding material = ResoniteMaterialSharing.CreateSharedVertexColorCommonMaterial();
@@ -174,6 +197,35 @@ public sealed class ResoniteSceneMaterialConventionsTests
         Assert.Equal("generic|Uv|scale:none|offset:none|depth:none", normalizedMaterial.MaterialKey);
         Assert.Null(normalizedMaterial.TerrainOverlay);
         Assert.Equal(new ResoniteColor(1.0, 1.0, 1.0, 1.0), normalizedMaterial.BaseColor);
+    }
+
+    [Fact]
+    public void TryNormalizeSharedMaterialBinding_AllowsPayloadMaterialWithExplicitNoOpTextureTransform()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "payload-noop-transform",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/noop-transform.png"),
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: new ResoniteFloat2(1.0, 1.0),
+            TextureOffset: new ResoniteFloat2(0.0, 0.0),
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        bool normalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
+            material,
+            out ResoniteMaterialBinding normalizedMaterial,
+            out string familySlotName);
+
+        Assert.True(normalized);
+        Assert.Equal("generic", familySlotName);
+        Assert.Equal(ResoniteMaterialAssetScope.Common, normalizedMaterial.AssetScope);
+        Assert.Null(normalizedMaterial.TextureScale);
+        Assert.Null(normalizedMaterial.TextureOffset);
+        Assert.Equal("generic|Uv|scale:none|offset:none|depth:none", normalizedMaterial.MaterialKey);
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -70,8 +70,8 @@ public sealed class ResoniteSceneMaterialConventionsTests
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: false);
 
         Assert.Contains("pbs-uv_uv_", slotName, StringComparison.Ordinal);
-        Assert.DoesNotContain("_0.5x0.25_", slotName, StringComparison.Ordinal);
-        Assert.DoesNotContain("_0.125x0.75_", slotName, StringComparison.Ordinal);
+        Assert.Contains("_0.5x0.25_", slotName, StringComparison.Ordinal);
+        Assert.Contains("_0.125x0.75_", slotName, StringComparison.Ordinal);
         Assert.Contains("_2x3_", slotName, StringComparison.Ordinal);
     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -223,4 +223,64 @@ public sealed class ResoniteSceneMaterialConventionsTests
 
         Assert.False(normalized);
     }
+
+    [Fact]
+    public void TryNormalizeSharedMaterialBinding_RejectsTransformedGenericSharedMaterial()
+    {
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "generic-shared-transformed-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/transformed-generic.png"),
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: new ResoniteFloat2(1.0, 1.0),
+            TextureOffset: new ResoniteFloat2(0.25, 0.75),
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        bool normalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
+            material,
+            out _,
+            out _);
+
+        Assert.False(normalized);
+    }
+
+    [Fact]
+    public void TryNormalizeSharedMaterialBinding_AllowsTransformedTerrainOverlaySharedMaterial()
+    {
+        TerrainTextureOverlay overlay = new(
+            PackageName: "dem",
+            UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
+            ZoomLevel: 17,
+            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+            MaxTextureSize: 512);
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "dem-overlay-transformed-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TextureScale: new ResoniteFloat2(0.5, 0.25),
+            TextureOffset: new ResoniteFloat2(0.125, 0.375),
+            TerrainOverlay: overlay,
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        bool normalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
+            material,
+            out ResoniteMaterialBinding normalizedMaterial,
+            out string familySlotName);
+
+        Assert.True(normalized);
+        Assert.Equal("generic", familySlotName);
+        Assert.Equal(ResoniteMaterialAssetScope.Common, normalizedMaterial.AssetScope);
+        Assert.Equal(new ResoniteFloat2(0.5, 0.25), normalizedMaterial.TextureScale);
+        Assert.Equal(new ResoniteFloat2(0.125, 0.375), normalizedMaterial.TextureOffset);
+        Assert.Equal("generic|Uv|scale:0.5x0.25|offset:0.125x0.375|depth:none", normalizedMaterial.MaterialKey);
+    }
 }


### PR DESCRIPTION
## Summary
- restore dynamic UV transform baking for non-common UV materials
- recover fixed shared common material bootstrap for shared albedo, vertex color, and fixed-offset generic bases
- stop dynamic TextureScale/TextureOffset from reappearing in common material identity and component emission

## Verification
- dotnet restore Plateau.ResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --verbosity minimal -m:1 --disable-build-servers -p:UseSharedCompilation=false