### PR TITLE
Restore discovery-only DEM bootstrap

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,6 @@ Shipped:
 - `--resonitelink-connections` は shipped な live-send option として扱い、既定の live-send pool size は 4 とする。
 - `ParameterizedTexture` appearance を保持しつつ、mesh / material 順序を決定的に保ち、source texture がない場合は bundled default material に fallback する。
 - source bootstrap の完了後は、dataset / mesh-code branch を段階的に構築し、full live send 完了前から Resonite 側に取り込み結果を出し始める。
-- LOD1 mesh bake と LOD2 atlas bake は CityGML scope、package、LOD、bake policy をキーにまとめ、emit される bake payload が cityObject の到着順に依存しないように保つ。
 - DEM terrain imagery tile は既定で local cache に永続化し、再実行時に PLATEAU Ortho や fallback の GSI tile を再利用できるようにする。
 
 Pending:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Shipped:
 - Treat `--resonitelink-connections` as a shipped live-send option, with a default live-send pool size of 4.
 - Preserve deterministic mesh/material ordering, keep `ParameterizedTexture` appearance data where present, and fall back to bundled default materials when source textures are missing.
 - After source bootstrap completes, build dataset and mesh-code branches incrementally so imported content can begin appearing in Resonite before the full live send completes.
-- Keep LOD1 mesh bake and LOD2 atlas bake keyed by CityGML scope, package, LOD, and bake policy so emitted bake payloads do not depend on cityObject arrival order.
 - Persist terrain imagery tiles under a local cache by default so repeated DEM imports can reuse already downloaded PLATEAU Ortho or fallback GSI tiles.
 
 Pending:

--- a/src/Plateau.ResoniteLink/Formats/CityGml/LocalCityGmlDocumentSet.cs
+++ b/src/Plateau.ResoniteLink/Formats/CityGml/LocalCityGmlDocumentSet.cs
@@ -14,7 +14,8 @@ public sealed class LocalCityGmlDocumentSet
         IReadOnlyList<CachedSourceFileDescriptor> cachedDemSourceFiles,
         CoordinateReferenceSystem? referenceSystem,
         GeodeticPoint globalOriginPoint,
-        TerrainHeightSampler? terrainHeightSampler)
+        TerrainHeightSampler? terrainHeightSampler,
+        DemTerrainGeoReferencedRasterCatalog? demRasterCatalog = null)
         : this(
             datasetSource,
             relativeSourceFiles,
@@ -22,7 +23,8 @@ public sealed class LocalCityGmlDocumentSet
             terrainTextureOverlays,
             requestedMeshCodes,
             sourceFilePipelines,
-            globalOriginPoint)
+            globalOriginPoint,
+            demRasterCatalog)
     {
         BootstrapCachedDemSourceFiles = cachedDemSourceFiles;
         BootstrapReferenceSystem = referenceSystem;
@@ -36,7 +38,8 @@ public sealed class LocalCityGmlDocumentSet
         IReadOnlyList<TerrainTextureOverlay> terrainTextureOverlays,
         IReadOnlyList<string> requestedMeshCodes,
         IReadOnlyList<SourceFilePipeline> sourceFilePipelines,
-        GeodeticPoint globalOriginPoint)
+        GeodeticPoint globalOriginPoint,
+        DemTerrainGeoReferencedRasterCatalog? demRasterCatalog = null)
     {
         DatasetSource = datasetSource;
         RelativeSourceFiles = relativeSourceFiles;
@@ -45,6 +48,7 @@ public sealed class LocalCityGmlDocumentSet
         RequestedMeshCodes = requestedMeshCodes;
         BootstrapSourceFilePipelines = sourceFilePipelines;
         BootstrapGlobalOriginPoint = globalOriginPoint;
+        BootstrapDemRasterCatalog = demRasterCatalog;
     }
 
     public IPlateauDatasetContentSource DatasetSource { get; }
@@ -66,4 +70,6 @@ public sealed class LocalCityGmlDocumentSet
     internal GeodeticPoint BootstrapGlobalOriginPoint { get; }
 
     internal TerrainHeightSampler? BootstrapTerrainHeightSampler { get; }
+
+    internal DemTerrainGeoReferencedRasterCatalog? BootstrapDemRasterCatalog { get; }
 }

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/DemTerrainGeoReferencedRasterCatalog.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/DemTerrainGeoReferencedRasterCatalog.cs
@@ -124,6 +124,11 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog
                 throw;
             }
 
+            if (resolveTask.IsCompletedSuccessfully)
+            {
+                throw;
+            }
+
             lock (cachedRasterSourceTaskGate)
             {
                 if (cachedRasterSourceTasksByMeshCode.TryGetValue(cacheKey, out Task<TerrainTextureGeoReferencedRasterSource?>? cachedTask)

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/DemTerrainGeoReferencedRasterCatalog.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/DemTerrainGeoReferencedRasterCatalog.cs
@@ -10,7 +10,8 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog
     private readonly string outputRoot;
     private readonly IReadOnlyList<string> orderedRelativeRasterPaths;
     private readonly IReadOnlyDictionary<string, string> relativeRasterPathsByStem;
-    private readonly Dictionary<string, TerrainTextureGeoReferencedRasterSource?> cachedRasterSourcesByMeshCode =
+    private readonly object cachedRasterSourceTaskGate = new();
+    private readonly Dictionary<string, Task<TerrainTextureGeoReferencedRasterSource?>> cachedRasterSourceTasksByMeshCode =
         new(StringComparer.OrdinalIgnoreCase);
 
     private DemTerrainGeoReferencedRasterCatalog(
@@ -95,11 +96,40 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(meshCode);
 
-        if (cachedRasterSourcesByMeshCode.TryGetValue(meshCode, out TerrainTextureGeoReferencedRasterSource? cachedRasterSource))
+        Task<TerrainTextureGeoReferencedRasterSource?> resolveTask;
+        lock (cachedRasterSourceTaskGate)
         {
-            return cachedRasterSource;
+            if (!cachedRasterSourceTasksByMeshCode.TryGetValue(meshCode, out resolveTask!))
+            {
+                resolveTask = ResolveRasterSourceCoreAsync(meshCode, overlayBounds, cancellationToken);
+                cachedRasterSourceTasksByMeshCode[meshCode] = resolveTask;
+            }
         }
 
+        try
+        {
+            return await resolveTask.WaitAsync(cancellationToken);
+        }
+        catch
+        {
+            lock (cachedRasterSourceTaskGate)
+            {
+                if (cachedRasterSourceTasksByMeshCode.TryGetValue(meshCode, out Task<TerrainTextureGeoReferencedRasterSource?>? cachedTask)
+                    && ReferenceEquals(cachedTask, resolveTask))
+                {
+                    cachedRasterSourceTasksByMeshCode.Remove(meshCode);
+                }
+            }
+
+            throw;
+        }
+    }
+
+    private async Task<TerrainTextureGeoReferencedRasterSource?> ResolveRasterSourceCoreAsync(
+        string meshCode,
+        GeographicRectangle overlayBounds,
+        CancellationToken cancellationToken)
+    {
         foreach (string rasterPath in await ResolveCandidateRasterPathsAsync(meshCode, cancellationToken))
         {
             GeoReferencedRasterMetadata? metadata = await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(
@@ -113,11 +143,9 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog
             }
 
             TerrainTextureGeoReferencedRasterSource rasterSource = new(rasterPath, metadata);
-            cachedRasterSourcesByMeshCode[meshCode] = rasterSource;
             return rasterSource;
         }
 
-        cachedRasterSourcesByMeshCode[meshCode] = null;
         return null;
     }
 

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/DemTerrainGeoReferencedRasterCatalog.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/DemTerrainGeoReferencedRasterCatalog.cs
@@ -90,19 +90,21 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog
     }
 
     public async Task<TerrainTextureGeoReferencedRasterSource?> TryResolveRasterSourceAsync(
+        string cacheKey,
         string meshCode,
         GeographicRectangle overlayBounds,
         CancellationToken cancellationToken)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(cacheKey);
         ArgumentException.ThrowIfNullOrWhiteSpace(meshCode);
 
         Task<TerrainTextureGeoReferencedRasterSource?> resolveTask;
         lock (cachedRasterSourceTaskGate)
         {
-            if (!cachedRasterSourceTasksByMeshCode.TryGetValue(meshCode, out resolveTask!))
+            if (!cachedRasterSourceTasksByMeshCode.TryGetValue(cacheKey, out resolveTask!))
             {
                 resolveTask = ResolveRasterSourceCoreAsync(meshCode, overlayBounds, cancellationToken);
-                cachedRasterSourceTasksByMeshCode[meshCode] = resolveTask;
+                cachedRasterSourceTasksByMeshCode[cacheKey] = resolveTask;
             }
         }
 
@@ -114,10 +116,10 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog
         {
             lock (cachedRasterSourceTaskGate)
             {
-                if (cachedRasterSourceTasksByMeshCode.TryGetValue(meshCode, out Task<TerrainTextureGeoReferencedRasterSource?>? cachedTask)
+                if (cachedRasterSourceTasksByMeshCode.TryGetValue(cacheKey, out Task<TerrainTextureGeoReferencedRasterSource?>? cachedTask)
                     && ReferenceEquals(cachedTask, resolveTask))
                 {
-                    cachedRasterSourceTasksByMeshCode.Remove(meshCode);
+                    cachedRasterSourceTasksByMeshCode.Remove(cacheKey);
                 }
             }
 

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/DemTerrainGeoReferencedRasterCatalog.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/DemTerrainGeoReferencedRasterCatalog.cs
@@ -103,8 +103,13 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog
         {
             if (!cachedRasterSourceTasksByMeshCode.TryGetValue(cacheKey, out resolveTask!))
             {
-                resolveTask = ResolveRasterSourceCoreAsync(meshCode, overlayBounds, cancellationToken);
+                resolveTask = ResolveRasterSourceCoreAsync(meshCode, overlayBounds, CancellationToken.None);
                 cachedRasterSourceTasksByMeshCode[cacheKey] = resolveTask;
+                _ = resolveTask.ContinueWith(
+                    completedTask => RemoveFaultedResolveTask(cacheKey, completedTask),
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
             }
         }
 
@@ -114,6 +119,11 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog
         }
         catch
         {
+            if (!resolveTask.IsCompleted)
+            {
+                throw;
+            }
+
             lock (cachedRasterSourceTaskGate)
             {
                 if (cachedRasterSourceTasksByMeshCode.TryGetValue(cacheKey, out Task<TerrainTextureGeoReferencedRasterSource?>? cachedTask)
@@ -149,6 +159,25 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog
         }
 
         return null;
+    }
+
+    private void RemoveFaultedResolveTask(
+        string cacheKey,
+        Task<TerrainTextureGeoReferencedRasterSource?> completedTask)
+    {
+        if (!completedTask.IsFaulted && !completedTask.IsCanceled)
+        {
+            return;
+        }
+
+        lock (cachedRasterSourceTaskGate)
+        {
+            if (cachedRasterSourceTasksByMeshCode.TryGetValue(cacheKey, out Task<TerrainTextureGeoReferencedRasterSource?>? cachedTask)
+                && ReferenceEquals(cachedTask, completedTask))
+            {
+                cachedRasterSourceTasksByMeshCode.Remove(cacheKey);
+            }
+        }
     }
 
     private async Task<IReadOnlyList<string>> ResolveCandidateRasterPathsAsync(

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlBootstrapPipeline.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlBootstrapPipeline.cs
@@ -142,36 +142,9 @@ internal static class LocalCityGmlBootstrapPipeline
                 appearanceStoreFactory,
                 lodSelector,
                 cancellationToken);
-        ParsedSourceFileResult[] demParsedSourceFiles = (await Task.WhenAll(
-            sourceFilePipelines
-                .Where(static pipeline => string.Equals(pipeline.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
-                .Select(static pipeline => pipeline.GetParseTask())))
-            .ToArray();
         List<string> relativeSourceFiles = sourceFilePipelines
             .Select(static pipeline => pipeline.SourceFile.RelativePath)
             .ToList();
-        DemTerrainGeoReferencedRasterCatalog? demRasterCatalog = await DemTerrainGeoReferencedRasterCatalog.CreateAsync(
-            request.DemTextureSource,
-            datasetContentSourceFactory,
-            cancellationToken);
-        if (request.DemTextureSource is not null && demRasterCatalog is null)
-        {
-            throw new PlateauImportValidationException(
-                [LocalCityGmlImportErrorMessages.InvalidDemTextureSource(request.DemTextureSource)]);
-        }
-
-        TerrainTextureOverlay[] terrainTextureOverlays = await CreateBootstrapTerrainTextureOverlaysAsync(
-            demParsedSourceFiles,
-            discoveryResult.RequestedMeshCodes,
-            demRasterCatalog,
-            cancellationToken);
-        if (request.DemTextureSource is not null
-            && terrainTextureOverlays.Any(static overlay => !overlay.EnumerateGeoReferencedRasterSources().Any()))
-        {
-            throw new PlateauImportValidationException(
-                [LocalCityGmlImportErrorMessages.InvalidDemTextureSource(request.DemTextureSource)]);
-        }
-
         ResoniteLocalOrigin? resolvedLocalOrigin =
             LocalCityGmlObjectProjection.ResolveLocalOrigin(effectiveRequestedMeshArea);
         if (resolvedLocalOrigin is null)
@@ -197,39 +170,13 @@ internal static class LocalCityGmlBootstrapPipeline
                 .Distinct(StringComparer.Ordinal)
                 .OrderBy(static packageName => packageName, StringComparer.Ordinal)
                 .ToArray(),
-            terrainTextureOverlays,
+            [],
             discoveryResult.RequestedMeshCodes,
             sourceFilePipelines.Select(static pipeline => new SourceFilePipeline(pipeline.SourceFile, pipeline.GetParseTask, pipeline.StreamParsedCityObjectsAsync)).ToArray(),
             [],
             referenceSystem: null,
             GeodeticPoint.FromLegacy(globalOriginPoint),
             terrainHeightSampler: null);
-    }
-
-    private static async Task<TerrainTextureOverlay[]> CreateBootstrapTerrainTextureOverlaysAsync(
-        ParsedSourceFileResult[] demParsedSourceFiles,
-        IReadOnlyList<string> requestedMeshCodes,
-        DemTerrainGeoReferencedRasterCatalog? demRasterCatalog,
-        CancellationToken cancellationToken)
-    {
-        if (demParsedSourceFiles.Length == 0)
-        {
-            return [];
-        }
-
-        DemTerrainBounds? demBounds = LocalCityGmlDemBootstrapSupport.ResolveDemTerrainBounds(
-            demParsedSourceFiles,
-            fallbackBounds: null);
-        if (demBounds is null)
-        {
-            return [];
-        }
-
-        return await LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlaysAsync(
-            demBounds,
-            requestedMeshCodes,
-            demRasterCatalog,
-            cancellationToken);
     }
 
     private static void ValidateCompatibleReferenceSystem(

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSource.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSource.cs
@@ -53,10 +53,12 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
         {
             CoordinateReferenceSystem? resolvedReferenceSystem = null;
             LocalCartesian? globalCartesian = null;
-            IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays = CreateDemTerrainTextureOverlays(sourceFile.SourceFile.PackageName);
 
             await foreach (BootstrapParsedCityObject parsedCityObject in sourceFile.StreamParsedCityObjectsAsync(cancellationToken))
             {
+                IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays = CreateDemTerrainTextureOverlays(
+                    sourceFile.SourceFile,
+                    parsedCityObject);
                 foreach (ResoniteMaterialBinding material in commonMaterialEnumerator.Enumerate(
                              new CachedSourceFileDescriptor(sourceFile.SourceFile, [parsedCityObject]),
                              resolvedReferenceSystem ??= ResolveReferenceSystem(parsedCityObject.ReferenceSystem),
@@ -232,7 +234,6 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
         Stopwatch fileStopwatch = Stopwatch.StartNew();
         CoordinateReferenceSystem? resolvedReferenceSystem = null;
         LocalCartesian? globalCartesian = null;
-        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays = CreateDemTerrainTextureOverlays(sourceFile.SourceFile.PackageName);
         int parsedCount = 0;
         int yieldedCount = 0;
 
@@ -242,6 +243,9 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
             parsedCount++;
             resolvedReferenceSystem ??= ResolveReferenceSystem(parsedCityObject.ReferenceSystem);
             globalCartesian ??= CreateGlobalCartesian(resolvedReferenceSystem);
+            IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays = CreateDemTerrainTextureOverlays(
+                sourceFile.SourceFile,
+                parsedCityObject);
 
             foreach (ResoniteConstructionCityObject cityObject in geometryProjector.MaterializeCityObjects(
                          new CachedSourceFileDescriptor(sourceFile.SourceFile, [parsedCityObject]),
@@ -295,7 +299,36 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
 
     private TerrainTextureOverlay[] CreateDemTerrainTextureOverlays(ParsedSourceFileResult parsedSourceFile)
     {
-        return CreateDemTerrainTextureOverlays(parsedSourceFile.SourceFile.PackageName);
+        if (!string.Equals(parsedSourceFile.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
+        {
+            return [];
+        }
+
+        TerrainTextureOverlay[] bootstrapOverlays = CreateDemTerrainTextureOverlays(parsedSourceFile.SourceFile.PackageName);
+        if (bootstrapOverlays.Length == 0)
+        {
+            return CreateDemTerrainTextureOverlaysFromParsedSourceFile(parsedSourceFile, preferRequestedMeshCodeSplit: true);
+        }
+
+        if (HasOverlayCoverage(parsedSourceFile, bootstrapOverlays))
+        {
+            return bootstrapOverlays;
+        }
+
+        return CreateDemTerrainTextureOverlaysFromParsedSourceFile(parsedSourceFile, preferRequestedMeshCodeSplit: false);
+    }
+
+    private TerrainTextureOverlay[] CreateDemTerrainTextureOverlays(
+        SourceFileDescriptor sourceFile,
+        BootstrapParsedCityObject parsedCityObject)
+    {
+        return CreateDemTerrainTextureOverlays(
+            new ParsedSourceFileResult(
+                sourceFile,
+                [parsedCityObject],
+                parsedCityObject.ReferenceSystem,
+                [],
+                TimeSpan.Zero));
     }
 
     private TerrainTextureOverlay[] CreateDemTerrainTextureOverlays(string packageName)
@@ -307,6 +340,74 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
         }
 
         return Metadata.SourceDataset.TerrainTextureOverlays.ToArray();
+    }
+
+    private TerrainTextureOverlay[] CreateDemTerrainTextureOverlaysFromParsedSourceFile(
+        ParsedSourceFileResult parsedSourceFile,
+        bool preferRequestedMeshCodeSplit)
+    {
+        DemTerrainBounds? fallbackBounds = MeshCodeBounds.TryMerge(requestedMeshAreas) is { } requestedMeshBounds
+            ? new DemTerrainBounds(
+                requestedMeshBounds.SouthLatitude,
+                requestedMeshBounds.NorthLatitude,
+                requestedMeshBounds.WestLongitude,
+                requestedMeshBounds.EastLongitude)
+            : null;
+        IReadOnlyList<string> requestedMeshCodes =
+            preferRequestedMeshCodeSplit && Metadata.SourceDataset.RequestedMeshCodes is { Count: > 0 }
+                ? Metadata.SourceDataset.RequestedMeshCodes
+                : [];
+        if (!HasAnyVertices(parsedSourceFile.CityObjects))
+        {
+            if (fallbackBounds is null)
+            {
+                return [];
+            }
+
+            return LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlays(
+                fallbackBounds,
+                requestedMeshCodes);
+        }
+
+        DemTerrainBounds? demBounds = LocalCityGmlDemBootstrapSupport.ResolveDemTerrainBounds(
+            [parsedSourceFile],
+            fallbackBounds);
+        if (demBounds is null)
+        {
+            return [];
+        }
+
+        return LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlays(
+            demBounds,
+            requestedMeshCodes);
+    }
+
+    private bool HasOverlayCoverage(
+        ParsedSourceFileResult parsedSourceFile,
+        IReadOnlyList<TerrainTextureOverlay> overlays)
+    {
+        try
+        {
+            foreach (BootstrapParsedCityObject parsedCityObject in parsedSourceFile.CityObjects)
+            {
+                _ = DemTerrainOverlayAssignment.SplitParsedCityObject(
+                        parsedCityObject.ToLegacy(),
+                        overlays,
+                        requestedMeshAreas)
+                    .ToArray();
+            }
+
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private static bool HasAnyVertices(IEnumerable<BootstrapParsedCityObject> cityObjects)
+    {
+        return cityObjects.Any(static cityObject => cityObject.Surfaces.Any(static surface => surface.Vertices.Any()));
     }
 
     private static void ValidateCompatibleReferenceSystem(

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSource.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSource.cs
@@ -58,9 +58,10 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
 
             await foreach (BootstrapParsedCityObject parsedCityObject in sourceFile.StreamParsedCityObjectsAsync(cancellationToken))
             {
-                IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays = CreateDemTerrainTextureOverlays(
+                IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays = await CreateDemTerrainTextureOverlaysAsync(
                     sourceFile.SourceFile,
-                    parsedCityObject);
+                    parsedCityObject,
+                    cancellationToken);
                 foreach (ResoniteMaterialBinding material in commonMaterialEnumerator.Enumerate(
                              new CachedSourceFileDescriptor(sourceFile.SourceFile, [parsedCityObject]),
                              resolvedReferenceSystem ??= ResolveReferenceSystem(parsedCityObject.ReferenceSystem),
@@ -245,9 +246,10 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
             parsedCount++;
             resolvedReferenceSystem ??= ResolveReferenceSystem(parsedCityObject.ReferenceSystem);
             globalCartesian ??= CreateGlobalCartesian(resolvedReferenceSystem);
-            IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays = CreateDemTerrainTextureOverlays(
+            IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays = await CreateDemTerrainTextureOverlaysAsync(
                 sourceFile.SourceFile,
-                parsedCityObject);
+                parsedCityObject,
+                cancellationToken);
 
             foreach (ResoniteConstructionCityObject cityObject in geometryProjector.MaterializeCityObjects(
                          new CachedSourceFileDescriptor(sourceFile.SourceFile, [parsedCityObject]),
@@ -333,6 +335,21 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
                 TimeSpan.Zero));
     }
 
+    private Task<TerrainTextureOverlay[]> CreateDemTerrainTextureOverlaysAsync(
+        SourceFileDescriptor sourceFile,
+        BootstrapParsedCityObject parsedCityObject,
+        CancellationToken cancellationToken)
+    {
+        return CreateDemTerrainTextureOverlaysAsync(
+            new ParsedSourceFileResult(
+                sourceFile,
+                [parsedCityObject],
+                parsedCityObject.ReferenceSystem,
+                [],
+                TimeSpan.Zero),
+            cancellationToken);
+    }
+
     private TerrainTextureOverlay[] CreateDemTerrainTextureOverlays(string packageName)
     {
         if (!string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase)
@@ -342,6 +359,35 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
         }
 
         return Metadata.SourceDataset.TerrainTextureOverlays.ToArray();
+    }
+
+    private async Task<TerrainTextureOverlay[]> CreateDemTerrainTextureOverlaysAsync(
+        ParsedSourceFileResult parsedSourceFile,
+        CancellationToken cancellationToken)
+    {
+        if (!string.Equals(parsedSourceFile.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
+        {
+            return [];
+        }
+
+        TerrainTextureOverlay[] bootstrapOverlays = CreateDemTerrainTextureOverlays(parsedSourceFile.SourceFile.PackageName);
+        if (bootstrapOverlays.Length == 0)
+        {
+            return await CreateDemTerrainTextureOverlaysFromParsedSourceFileAsync(
+                parsedSourceFile,
+                preferRequestedMeshCodeSplit: true,
+                cancellationToken);
+        }
+
+        if (HasOverlayCoverage(parsedSourceFile, bootstrapOverlays))
+        {
+            return bootstrapOverlays;
+        }
+
+        return await CreateDemTerrainTextureOverlaysFromParsedSourceFileAsync(
+            parsedSourceFile,
+            preferRequestedMeshCodeSplit: false,
+            cancellationToken);
     }
 
     private TerrainTextureOverlay[] CreateDemTerrainTextureOverlaysFromParsedSourceFile(
@@ -384,6 +430,51 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
             demBounds,
             requestedMeshCodes,
             demRasterCatalog);
+    }
+
+    private async Task<TerrainTextureOverlay[]> CreateDemTerrainTextureOverlaysFromParsedSourceFileAsync(
+        ParsedSourceFileResult parsedSourceFile,
+        bool preferRequestedMeshCodeSplit,
+        CancellationToken cancellationToken)
+    {
+        DemTerrainBounds? fallbackBounds = MeshCodeBounds.TryMerge(requestedMeshAreas) is { } requestedMeshBounds
+            ? new DemTerrainBounds(
+                requestedMeshBounds.SouthLatitude,
+                requestedMeshBounds.NorthLatitude,
+                requestedMeshBounds.WestLongitude,
+                requestedMeshBounds.EastLongitude)
+            : null;
+        IReadOnlyList<string> requestedMeshCodes =
+            preferRequestedMeshCodeSplit && Metadata.SourceDataset.RequestedMeshCodes is { Count: > 0 }
+                ? Metadata.SourceDataset.RequestedMeshCodes
+                : [];
+        if (!HasAnyVertices(parsedSourceFile.CityObjects))
+        {
+            if (fallbackBounds is null)
+            {
+                return [];
+            }
+
+            return await LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlaysAsync(
+                fallbackBounds,
+                requestedMeshCodes,
+                demRasterCatalog,
+                cancellationToken);
+        }
+
+        DemTerrainBounds? demBounds = LocalCityGmlDemBootstrapSupport.ResolveDemTerrainBounds(
+            [parsedSourceFile],
+            fallbackBounds);
+        if (demBounds is null)
+        {
+            return [];
+        }
+
+        return await LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlaysAsync(
+            demBounds,
+            requestedMeshCodes,
+            demRasterCatalog,
+            cancellationToken);
     }
 
     private bool HasOverlayCoverage(

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSource.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSource.cs
@@ -21,6 +21,7 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
     private readonly Action<string>? progressReporter;
     private readonly object referenceSystemGate = new();
     private readonly MeshCodeBounds[] requestedMeshAreas;
+    private readonly DemTerrainGeoReferencedRasterCatalog? demRasterCatalog;
     private CoordinateReferenceSystem? referenceSystem;
 
     public LocalCityGmlConstructionSource(
@@ -38,6 +39,7 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
         this.geometryProjector = geometryProjector;
         this.commonMaterialEnumerator = commonMaterialEnumerator;
         this.progressReporter = progressReporter;
+        demRasterCatalog = documentSet.BootstrapDemRasterCatalog;
         requestedMeshAreas = MeshCodeBounds.CreateManyFromRequestedMeshCodes(
             Metadata.SourceDataset.RequestedMeshCodes ?? [request.MeshCode]);
     }
@@ -366,7 +368,8 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
 
             return LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlays(
                 fallbackBounds,
-                requestedMeshCodes);
+                requestedMeshCodes,
+                demRasterCatalog);
         }
 
         DemTerrainBounds? demBounds = LocalCityGmlDemBootstrapSupport.ResolveDemTerrainBounds(
@@ -379,7 +382,8 @@ internal sealed class LocalCityGmlConstructionSource : IResoniteConstructionSour
 
         return LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlays(
             demBounds,
-            requestedMeshCodes);
+            requestedMeshCodes,
+            demRasterCatalog);
     }
 
     private bool HasOverlayCoverage(

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSourceFactory.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSourceFactory.cs
@@ -91,6 +91,8 @@ internal sealed class LocalCityGmlConstructionSourceFactory : IResoniteConstruct
 
         (TerrainTextureOverlay[] overlays, DemTerrainGeoReferencedRasterCatalog? demRasterCatalog) = await CreateDemTerrainTextureOverlaysAsync(
             request,
+            documentSet,
+            demSourceFiles,
             demRequestedMeshCodes.Length > 0
                 ? demRequestedMeshCodes
                 : documentSet.RequestedMeshCodes.Count > 0
@@ -118,6 +120,8 @@ internal sealed class LocalCityGmlConstructionSourceFactory : IResoniteConstruct
 
     private async Task<(TerrainTextureOverlay[] Overlays, DemTerrainGeoReferencedRasterCatalog? RasterCatalog)> CreateDemTerrainTextureOverlaysAsync(
         PlateauImportRequest request,
+        LocalCityGmlDocumentSet documentSet,
+        IReadOnlyList<SourceFileDescriptor> demSourceFiles,
         IReadOnlyList<string> requestedMeshCodes,
         CancellationToken cancellationToken)
     {
@@ -131,10 +135,17 @@ internal sealed class LocalCityGmlConstructionSourceFactory : IResoniteConstruct
                 [LocalCityGmlImportErrorMessages.InvalidDemTextureSource(request.DemTextureSource)]);
         }
 
-        TerrainTextureOverlay[] overlays = await LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlaysAsync(
-            requestedMeshCodes,
-            demRasterCatalog,
-            cancellationToken);
+        TerrainTextureOverlay[] overlays = request.DemTextureSource is null
+            ? await LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlaysAsync(
+                requestedMeshCodes,
+                demRasterCatalog,
+                cancellationToken)
+            : await CreateExplicitDemTerrainTextureOverlaysAsync(
+                documentSet,
+                demSourceFiles,
+                requestedMeshCodes,
+                demRasterCatalog,
+                cancellationToken);
         if (request.DemTextureSource is not null
             && overlays.Any(static overlay => !overlay.EnumerateGeoReferencedRasterSources().Any()))
         {
@@ -143,6 +154,55 @@ internal sealed class LocalCityGmlConstructionSourceFactory : IResoniteConstruct
         }
 
         return (overlays, demRasterCatalog);
+    }
+
+    internal static async Task<TerrainTextureOverlay[]> CreateExplicitDemTerrainTextureOverlaysAsync(
+        LocalCityGmlDocumentSet documentSet,
+        IReadOnlyList<SourceFileDescriptor> demSourceFiles,
+        IReadOnlyList<string> requestedMeshCodes,
+        DemTerrainGeoReferencedRasterCatalog? demRasterCatalog,
+        CancellationToken cancellationToken)
+    {
+        TerrainTextureOverlay[] requestScopedFallbackOverlays = await LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlaysAsync(
+            requestedMeshCodes,
+            demRasterCatalog,
+            cancellationToken);
+        if (demSourceFiles.Count == 0)
+        {
+            return requestScopedFallbackOverlays;
+        }
+
+        List<TerrainTextureOverlay> geometryScopedOverlays = [];
+        foreach (SourceFilePipeline pipeline in documentSet.BootstrapSourceFilePipelines
+                     .Where(pipeline => demSourceFiles.Contains(pipeline.SourceFile)))
+        {
+            BootstrapParsedCityObject[] parsedCityObjects = await pipeline.StreamParsedCityObjectsAsync(cancellationToken)
+                .ToArrayAsync(cancellationToken);
+            DemTerrainBounds? demBounds = LocalCityGmlDemBootstrapSupport.ResolveDemTerrainBounds(
+                [new ParsedSourceFileResult(pipeline.SourceFile, parsedCityObjects, null, [], TimeSpan.Zero)],
+                fallbackBounds: null);
+            if (demBounds is null)
+            {
+                continue;
+            }
+
+            geometryScopedOverlays.AddRange(
+                await LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlaysAsync(
+                    demBounds,
+                    requestedMeshCodes,
+                    demRasterCatalog,
+                    cancellationToken));
+        }
+
+        return geometryScopedOverlays.Count > 0
+            ? geometryScopedOverlays
+                .Distinct()
+                .OrderBy(static overlay => overlay.GeographicBounds.MinLatitude)
+                .ThenBy(static overlay => overlay.GeographicBounds.MinLongitude)
+                .ThenBy(static overlay => overlay.GeographicBounds.MaxLatitude)
+                .ThenBy(static overlay => overlay.GeographicBounds.MaxLongitude)
+                .ToArray()
+            : requestScopedFallbackOverlays;
     }
 
     private static bool MatchesDemRequestedMeshCode(

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSourceFactory.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSourceFactory.cs
@@ -79,11 +79,23 @@ internal sealed class LocalCityGmlConstructionSourceFactory : IResoniteConstruct
             return documentSet;
         }
 
+        SourceFileDescriptor[] demSourceFiles = documentSet.BootstrapSourceFilePipelines
+            .Where(static pipeline => string.Equals(pipeline.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
+            .Select(static pipeline => pipeline.SourceFile)
+            .ToArray();
+        string[] demRequestedMeshCodes = documentSet.RequestedMeshCodes
+            .Where(requestedMeshCode => demSourceFiles.Any(sourceFile => MatchesDemRequestedMeshCode(sourceFile, requestedMeshCode)))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static meshCode => meshCode, StringComparer.Ordinal)
+            .ToArray();
+
         (TerrainTextureOverlay[] overlays, DemTerrainGeoReferencedRasterCatalog? demRasterCatalog) = await CreateDemTerrainTextureOverlaysAsync(
             request,
-            documentSet.RequestedMeshCodes.Count > 0
-                ? documentSet.RequestedMeshCodes
-                : [request.MeshCode],
+            demRequestedMeshCodes.Length > 0
+                ? demRequestedMeshCodes
+                : documentSet.RequestedMeshCodes.Count > 0
+                    ? documentSet.RequestedMeshCodes
+                    : [request.MeshCode],
             cancellationToken);
         if (overlays.Length == 0)
         {
@@ -131,5 +143,19 @@ internal sealed class LocalCityGmlConstructionSourceFactory : IResoniteConstruct
         }
 
         return (overlays, demRasterCatalog);
+    }
+
+    private static bool MatchesDemRequestedMeshCode(
+        SourceFileDescriptor sourceFile,
+        string requestedMeshCode)
+    {
+        if (string.Equals(sourceFile.MatchedMeshCode, requestedMeshCode, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return sourceFile.MatchedMeshCode.Length == 6
+            && requestedMeshCode.Length >= 6
+            && requestedMeshCode.StartsWith(sourceFile.MatchedMeshCode, StringComparison.Ordinal);
     }
 }

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSourceFactory.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSourceFactory.cs
@@ -6,13 +6,19 @@ internal sealed class LocalCityGmlConstructionSourceFactory : IResoniteConstruct
 {
     private readonly ICityGmlDocumentReader documentReader;
     private readonly IResoniteConstructionComposer constructionComposer;
+    private readonly IPlateauDatasetContentSourceFactory datasetContentSourceFactory;
 
     internal LocalCityGmlConstructionSourceFactory(
         ICityGmlDocumentReader documentReader,
-        IResoniteConstructionComposer constructionComposer)
+        IResoniteConstructionComposer constructionComposer,
+        IPlateauDatasetContentSourceFactory? datasetContentSourceFactory = null)
     {
         this.documentReader = documentReader;
         this.constructionComposer = constructionComposer;
+        this.datasetContentSourceFactory = datasetContentSourceFactory
+            ?? new DefaultPlateauDatasetContentSourceFactory(
+                new RemoteArchiveDistributionPolicy(),
+                new ArchiveFileLayoutPolicy());
     }
 
     public Task<IResoniteConstructionSource> CreateAsync(
@@ -42,16 +48,73 @@ internal sealed class LocalCityGmlConstructionSourceFactory : IResoniteConstruct
             request,
             progressReporter,
             cancellationToken);
-        return constructionComposer.Compose(request, documentSet, progressReporter);
+        return await CreateCoreAsync(request, documentSet, progressReporter, cancellationToken);
     }
 
-    private Task<IResoniteConstructionSource> CreateCoreAsync(
+    private async Task<IResoniteConstructionSource> CreateCoreAsync(
         PlateauImportRequest request,
         LocalCityGmlDocumentSet documentSet,
         Action<string>? progressReporter,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
-        return Task.FromResult(constructionComposer.Compose(request, documentSet, progressReporter));
+        LocalCityGmlDocumentSet resolvedDocumentSet = await ResolveDocumentSetAsync(
+            request,
+            documentSet,
+            cancellationToken);
+        return constructionComposer.Compose(request, resolvedDocumentSet, progressReporter);
+    }
+
+    private async Task<LocalCityGmlDocumentSet> ResolveDocumentSetAsync(
+        PlateauImportRequest request,
+        LocalCityGmlDocumentSet documentSet,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(documentSet);
+
+        if (documentSet.TerrainTextureOverlays.Count > 0
+            || !documentSet.PackageNames.Contains("dem", StringComparer.Ordinal))
+        {
+            return documentSet;
+        }
+
+        TerrainTextureOverlay[] overlays = await CreateDemTerrainTextureOverlaysAsync(
+            request,
+            documentSet.RequestedMeshCodes.Count > 0
+                ? documentSet.RequestedMeshCodes
+                : [request.MeshCode],
+            cancellationToken);
+        if (overlays.Length == 0)
+        {
+            return documentSet;
+        }
+
+        return new LocalCityGmlDocumentSet(
+            documentSet.DatasetSource,
+            documentSet.RelativeSourceFiles,
+            documentSet.PackageNames,
+            overlays,
+            documentSet.RequestedMeshCodes,
+            documentSet.BootstrapSourceFilePipelines,
+            documentSet.BootstrapCachedDemSourceFiles,
+            documentSet.BootstrapReferenceSystem,
+            documentSet.BootstrapGlobalOriginPoint,
+            documentSet.BootstrapTerrainHeightSampler);
+    }
+
+    private async Task<TerrainTextureOverlay[]> CreateDemTerrainTextureOverlaysAsync(
+        PlateauImportRequest request,
+        IReadOnlyList<string> requestedMeshCodes,
+        CancellationToken cancellationToken)
+    {
+        DemTerrainGeoReferencedRasterCatalog? demRasterCatalog = await DemTerrainGeoReferencedRasterCatalog.CreateAsync(
+            request.DemTextureSource,
+            datasetContentSourceFactory,
+            cancellationToken);
+        return await LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlaysAsync(
+            requestedMeshCodes,
+            demRasterCatalog,
+            cancellationToken);
     }
 }

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSourceFactory.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlConstructionSourceFactory.cs
@@ -79,7 +79,7 @@ internal sealed class LocalCityGmlConstructionSourceFactory : IResoniteConstruct
             return documentSet;
         }
 
-        TerrainTextureOverlay[] overlays = await CreateDemTerrainTextureOverlaysAsync(
+        (TerrainTextureOverlay[] overlays, DemTerrainGeoReferencedRasterCatalog? demRasterCatalog) = await CreateDemTerrainTextureOverlaysAsync(
             request,
             documentSet.RequestedMeshCodes.Count > 0
                 ? documentSet.RequestedMeshCodes
@@ -100,10 +100,11 @@ internal sealed class LocalCityGmlConstructionSourceFactory : IResoniteConstruct
             documentSet.BootstrapCachedDemSourceFiles,
             documentSet.BootstrapReferenceSystem,
             documentSet.BootstrapGlobalOriginPoint,
-            documentSet.BootstrapTerrainHeightSampler);
+            documentSet.BootstrapTerrainHeightSampler,
+            demRasterCatalog);
     }
 
-    private async Task<TerrainTextureOverlay[]> CreateDemTerrainTextureOverlaysAsync(
+    private async Task<(TerrainTextureOverlay[] Overlays, DemTerrainGeoReferencedRasterCatalog? RasterCatalog)> CreateDemTerrainTextureOverlaysAsync(
         PlateauImportRequest request,
         IReadOnlyList<string> requestedMeshCodes,
         CancellationToken cancellationToken)
@@ -112,9 +113,23 @@ internal sealed class LocalCityGmlConstructionSourceFactory : IResoniteConstruct
             request.DemTextureSource,
             datasetContentSourceFactory,
             cancellationToken);
-        return await LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlaysAsync(
+        if (request.DemTextureSource is not null && demRasterCatalog is null)
+        {
+            throw new PlateauImportValidationException(
+                [LocalCityGmlImportErrorMessages.InvalidDemTextureSource(request.DemTextureSource)]);
+        }
+
+        TerrainTextureOverlay[] overlays = await LocalCityGmlDemBootstrapSupport.CreateDemTerrainTextureOverlaysAsync(
             requestedMeshCodes,
             demRasterCatalog,
             cancellationToken);
+        if (request.DemTextureSource is not null
+            && overlays.Any(static overlay => !overlay.EnumerateGeoReferencedRasterSources().Any()))
+        {
+            throw new PlateauImportValidationException(
+                [LocalCityGmlImportErrorMessages.InvalidDemTextureSource(request.DemTextureSource)]);
+        }
+
+        return (overlays, demRasterCatalog);
     }
 }

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlDemBootstrapSupport.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlDemBootstrapSupport.cs
@@ -247,7 +247,9 @@ internal static class LocalCityGmlDemBootstrapSupport
         ];
         if (demRasterCatalog is not null)
         {
+            string rasterLookupCacheKey = CreateRasterLookupCacheKey(meshCode, geographicBounds);
             TerrainTextureGeoReferencedRasterSource? rasterSource = await demRasterCatalog.TryResolveRasterSourceAsync(
+                rasterLookupCacheKey,
                 meshCode,
                 geographicBounds,
                 cancellationToken);
@@ -305,6 +307,20 @@ internal static class LocalCityGmlDemBootstrapSupport
             IsAvailable: true,
             IsExplicit: false,
             effectiveResolutionMeters);
+    }
+
+    private static string CreateRasterLookupCacheKey(
+        string meshCode,
+        GeographicRectangle geographicBounds)
+    {
+        if (PlateauMeshCode.TryGetBounds(meshCode, out _))
+        {
+            return meshCode;
+        }
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{meshCode}|{geographicBounds.MinLatitude:F6}|{geographicBounds.MaxLatitude:F6}|{geographicBounds.MinLongitude:F6}|{geographicBounds.MaxLongitude:F6}");
     }
 
     private static IEnumerable<string> ExpandToThirdMeshCodes(IEnumerable<string> requestedMeshCodes)

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlDemBootstrapSupport.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlDemBootstrapSupport.cs
@@ -170,6 +170,32 @@ internal static class LocalCityGmlDemBootstrapSupport
             .GetResult();
     }
 
+    internal static TerrainTextureOverlay[] CreateDemTerrainTextureOverlays(
+        DemTerrainBounds demBounds,
+        IReadOnlyList<string> requestedMeshCodes,
+        DemTerrainGeoReferencedRasterCatalog? demRasterCatalog)
+    {
+        return CreateDemTerrainTextureOverlaysAsync(
+                demBounds,
+                requestedMeshCodes,
+                demRasterCatalog,
+                CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    internal static TerrainTextureOverlay[] CreateDemTerrainTextureOverlays(
+        IReadOnlyList<string> requestedMeshCodes,
+        DemTerrainGeoReferencedRasterCatalog? demRasterCatalog)
+    {
+        return CreateDemTerrainTextureOverlaysAsync(
+                requestedMeshCodes,
+                demRasterCatalog,
+                CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+    }
+
     internal static TerrainHeightSampler? CreateTerrainHeightSampler(
         bool isGeographicReferenceSystem,
         IReadOnlyCollection<TerrainHeightTriangle> terrainTriangles,

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlDemBootstrapSupport.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlDemBootstrapSupport.cs
@@ -127,6 +127,36 @@ internal static class LocalCityGmlDemBootstrapSupport
         ];
     }
 
+    internal static async Task<TerrainTextureOverlay[]> CreateDemTerrainTextureOverlaysAsync(
+        IReadOnlyList<string> requestedMeshCodes,
+        DemTerrainGeoReferencedRasterCatalog? demRasterCatalog,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(requestedMeshCodes);
+
+        List<TerrainTextureOverlay> overlays = [];
+        foreach (string meshCode in ExpandToThirdMeshCodes(requestedMeshCodes))
+        {
+            if (!PlateauMeshCode.TryGetBounds(meshCode, out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds))
+            {
+                continue;
+            }
+
+            overlays.Add(await CreateDemTerrainTextureOverlayAsync(
+                meshCode,
+                bounds,
+                demRasterCatalog,
+                cancellationToken));
+        }
+
+        return overlays
+            .OrderBy(static overlay => overlay.GeographicBounds.MinLatitude)
+            .ThenBy(static overlay => overlay.GeographicBounds.MinLongitude)
+            .ThenBy(static overlay => overlay.GeographicBounds.MaxLatitude)
+            .ThenBy(static overlay => overlay.GeographicBounds.MaxLongitude)
+            .ToArray();
+    }
+
     internal static TerrainTextureOverlay[] CreateDemTerrainTextureOverlays(
         DemTerrainBounds demBounds,
         IReadOnlyList<string> requestedMeshCodes)

--- a/tests/Plateau.ResoniteLink.Tests/Formats/LocalCityGmlDocumentReaderTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Formats/LocalCityGmlDocumentReaderTests.cs
@@ -28,4 +28,76 @@ public sealed class LocalCityGmlDocumentReaderTests
         Assert.Empty(documentSet.TerrainTextureOverlays);
         Assert.Equal(["53394525"], documentSet.RequestedMeshCodes);
     }
+
+    [Fact]
+    public async Task ReadAsyncDoesNotOpenDemFilesDuringBootstrapDiscovery()
+    {
+        CountingDatasetContentSource datasetSource = new(
+            "C:\\fixtures\\plateau",
+            ["udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml"]);
+        LocalCityGmlDocumentReader reader = new(
+            new StubDatasetContentSourceFactory(datasetSource),
+            new CityGmlAppearanceStoreFactory(),
+            new CityGmlLodSelector());
+
+        LocalCityGmlDocumentSet documentSet = await reader.ReadAsync(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: datasetSource.SourcePath,
+                PackageNames: ["dem"],
+                ServerUri: null));
+
+        Assert.Equal(["udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml"], documentSet.RelativeSourceFiles);
+        Assert.Equal(["dem"], documentSet.PackageNames);
+        Assert.Empty(documentSet.TerrainTextureOverlays);
+        Assert.Equal(0, datasetSource.OpenReadCallCount);
+    }
+
+    private sealed class StubDatasetContentSourceFactory(IPlateauDatasetContentSource datasetSource) : IPlateauDatasetContentSourceFactory
+    {
+        public Task<IPlateauDatasetContentSource> CreateAsync(
+            string sourcePath,
+            CancellationToken cancellationToken = default)
+        {
+            Assert.Equal(datasetSource.SourcePath, sourcePath);
+            return Task.FromResult(datasetSource);
+        }
+    }
+
+    private sealed class CountingDatasetContentSource(
+        string sourcePath,
+        IReadOnlyList<string> files) : IPlateauDatasetContentSource
+    {
+        public int OpenReadCallCount { get; private set; }
+
+        public string SourcePath => sourcePath;
+
+        public IReadOnlyList<string> EnumerateFiles()
+        {
+            return files;
+        }
+
+        public bool FileExists(string relativePath)
+        {
+            return files.Contains(relativePath, StringComparer.Ordinal);
+        }
+
+        public ValueTask<Stream> OpenReadAsync(
+            string relativePath,
+            CancellationToken cancellationToken = default)
+        {
+            OpenReadCallCount++;
+            throw new InvalidOperationException($"Bootstrap discovery should not open '{relativePath}'.");
+        }
+
+        public Task<string> MaterializeFileAsync(
+            string relativePath,
+            string outputRoot,
+            CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("Bootstrap discovery should not materialize files.");
+        }
+    }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
@@ -1,0 +1,109 @@
+using Plateau.ResoniteLink.Application.Importing;
+using Plateau.ResoniteLink.Domain.Importing;
+
+namespace Plateau.ResoniteLink.Tests.Application;
+
+public sealed class DemTerrainGeoReferencedRasterCatalogTests
+{
+    [Fact]
+    public async Task TryResolveRasterSourceAsyncReusesMaterializedCandidatesForSameCacheKey()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        RecordingDatasetContentSource datasetSource = CreateDatasetSource(datasetRoot.Path);
+        DemTerrainGeoReferencedRasterCatalog catalog = await CreateCatalogAsync(datasetSource);
+        GeographicRectangle bounds = new(35.0, 35.1, 139.0, 139.1);
+
+        _ = await catalog.TryResolveRasterSourceAsync("dem-fallback", "dem-fallback", bounds, CancellationToken.None);
+        _ = await catalog.TryResolveRasterSourceAsync("dem-fallback", "dem-fallback", bounds, CancellationToken.None);
+
+        Assert.Equal(2, datasetSource.MaterializeCallCount);
+    }
+
+    [Fact]
+    public async Task TryResolveRasterSourceAsyncDoesNotReuseFallbackMaterializationAcrossDistinctBoundsKeys()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        RecordingDatasetContentSource datasetSource = CreateDatasetSource(datasetRoot.Path);
+        DemTerrainGeoReferencedRasterCatalog catalog = await CreateCatalogAsync(datasetSource);
+
+        _ = await catalog.TryResolveRasterSourceAsync(
+            "dem-fallback|35.000000|35.100000|139.000000|139.100000",
+            "dem-fallback",
+            new GeographicRectangle(35.0, 35.1, 139.0, 139.1),
+            CancellationToken.None);
+        _ = await catalog.TryResolveRasterSourceAsync(
+            "dem-fallback|35.100000|35.200000|139.100000|139.200000",
+            "dem-fallback",
+            new GeographicRectangle(35.1, 35.2, 139.1, 139.2),
+            CancellationToken.None);
+
+        Assert.Equal(4, datasetSource.MaterializeCallCount);
+    }
+
+    private static RecordingDatasetContentSource CreateDatasetSource(string datasetRoot)
+    {
+        string westRasterPath = Path.Combine(datasetRoot, "west.tif");
+        string eastRasterPath = Path.Combine(datasetRoot, "east.tif");
+        File.WriteAllText(westRasterPath, "dummy");
+        File.WriteAllText(eastRasterPath, "dummy");
+        return new RecordingDatasetContentSource(
+            datasetRoot,
+            [Path.GetFileName(westRasterPath), Path.GetFileName(eastRasterPath)]);
+    }
+
+    private static async Task<DemTerrainGeoReferencedRasterCatalog> CreateCatalogAsync(RecordingDatasetContentSource datasetSource)
+    {
+        DemTerrainGeoReferencedRasterCatalog? catalog = await DemTerrainGeoReferencedRasterCatalog.CreateAsync(
+            PlateauImportSource.Local(datasetSource.SourcePath),
+            new StubDatasetContentSourceFactory(datasetSource),
+            CancellationToken.None);
+
+        return Assert.IsType<DemTerrainGeoReferencedRasterCatalog>(catalog);
+    }
+
+    private sealed class StubDatasetContentSourceFactory(IPlateauDatasetContentSource datasetSource) : IPlateauDatasetContentSourceFactory
+    {
+        public Task<IPlateauDatasetContentSource> CreateAsync(
+            string sourcePath,
+            CancellationToken cancellationToken = default)
+        {
+            Assert.Equal(datasetSource.SourcePath, sourcePath);
+            return Task.FromResult(datasetSource);
+        }
+    }
+
+    private sealed class RecordingDatasetContentSource(
+        string sourcePath,
+        IReadOnlyList<string> files) : IPlateauDatasetContentSource
+    {
+        public string SourcePath { get; } = sourcePath;
+
+        public int MaterializeCallCount { get; private set; }
+
+        public IReadOnlyList<string> EnumerateFiles()
+        {
+            return files;
+        }
+
+        public bool FileExists(string relativePath)
+        {
+            return files.Contains(relativePath, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public ValueTask<Stream> OpenReadAsync(
+            string relativePath,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<string> MaterializeFileAsync(
+            string relativePath,
+            string outputRoot,
+            CancellationToken cancellationToken = default)
+        {
+            MaterializeCallCount++;
+            return Task.FromResult(Path.Combine(SourcePath, relativePath));
+        }
+    }
+}

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
@@ -132,6 +132,43 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         Assert.Equal(2, datasetSource.MaterializeCallCount);
     }
 
+    [Fact]
+    public async Task TryResolveRasterSourceAsyncKeepsSuccessfulCachedTaskAfterCanceledWaiter()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        SucceedingGateableDatasetContentSource datasetSource = CreateSucceedingGateableDatasetSource(datasetRoot.Path);
+        DemTerrainGeoReferencedRasterCatalog catalog = await CreateCatalogAsync(datasetSource);
+        GeographicRectangle bounds = new(35.0, 35.1, 139.0, 139.1);
+        using CancellationTokenSource firstCallerCancellation = new();
+
+        Task<TerrainTextureGeoReferencedRasterSource?> firstCall = catalog.TryResolveRasterSourceAsync(
+            "dem-fallback",
+            "dem-fallback",
+            bounds,
+            firstCallerCancellation.Token);
+        await datasetSource.MaterializeStarted.Task.WaitAsync(CancellationToken.None);
+        Task<TerrainTextureGeoReferencedRasterSource?> secondCall = catalog.TryResolveRasterSourceAsync(
+            "dem-fallback",
+            "dem-fallback",
+            bounds,
+            CancellationToken.None);
+
+        await firstCallerCancellation.CancelAsync();
+        datasetSource.ReleaseMaterialize.TrySetResult();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await firstCall);
+        TerrainTextureGeoReferencedRasterSource? secondResult = await secondCall;
+        Assert.Null(secondResult);
+
+        TerrainTextureGeoReferencedRasterSource? thirdResult = await catalog.TryResolveRasterSourceAsync(
+            "dem-fallback",
+            "dem-fallback",
+            bounds,
+            CancellationToken.None);
+        Assert.Null(thirdResult);
+        Assert.Equal(1, datasetSource.MaterializeCallCount);
+    }
+
     private static RecordingDatasetContentSource CreateDatasetSource(string datasetRoot)
     {
         string westRasterPath = Path.Combine(datasetRoot, "west.tif");
@@ -157,6 +194,15 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         string rasterPath = Path.Combine(datasetRoot, "faulting.tif");
         File.WriteAllText(rasterPath, "dummy");
         return new FaultingGateableDatasetContentSource(
+            datasetRoot,
+            [Path.GetFileName(rasterPath)]);
+    }
+
+    private static SucceedingGateableDatasetContentSource CreateSucceedingGateableDatasetSource(string datasetRoot)
+    {
+        string rasterPath = Path.Combine(datasetRoot, "succeeding.tif");
+        File.WriteAllText(rasterPath, "dummy");
+        return new SucceedingGateableDatasetContentSource(
             datasetRoot,
             [Path.GetFileName(rasterPath)]);
     }
@@ -305,6 +351,47 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
             {
                 BackgroundCompletion.TrySetResult();
             }
+        }
+    }
+
+    private sealed class SucceedingGateableDatasetContentSource(
+        string sourcePath,
+        IReadOnlyList<string> files) : IPlateauDatasetContentSource
+    {
+        public string SourcePath { get; } = sourcePath;
+
+        public int MaterializeCallCount { get; private set; }
+
+        public TaskCompletionSource MaterializeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseMaterialize { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public IReadOnlyList<string> EnumerateFiles()
+        {
+            return files;
+        }
+
+        public bool FileExists(string relativePath)
+        {
+            return files.Contains(relativePath, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public ValueTask<Stream> OpenReadAsync(
+            string relativePath,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public async Task<string> MaterializeFileAsync(
+            string relativePath,
+            string outputRoot,
+            CancellationToken cancellationToken = default)
+        {
+            MaterializeCallCount++;
+            MaterializeStarted.TrySetResult();
+            await ReleaseMaterialize.Task.WaitAsync(cancellationToken);
+            return Path.Combine(SourcePath, relativePath);
         }
     }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
@@ -40,6 +40,98 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         Assert.Equal(4, datasetSource.MaterializeCallCount);
     }
 
+    [Fact]
+    public async Task TryResolveRasterSourceAsyncAllowsLaterWaiterToCompleteAfterFirstCallerCancels()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        GateableDatasetContentSource datasetSource = CreateGateableDatasetSource(datasetRoot.Path);
+        DemTerrainGeoReferencedRasterCatalog catalog = await CreateCatalogAsync(datasetSource);
+        GeographicRectangle bounds = new(35.0, 35.1, 139.0, 139.1);
+        using CancellationTokenSource firstCallerCancellation = new();
+
+        Task<TerrainTextureGeoReferencedRasterSource?> firstCall = catalog.TryResolveRasterSourceAsync(
+            "dem-fallback",
+            "dem-fallback",
+            bounds,
+            firstCallerCancellation.Token);
+        await datasetSource.MaterializeStarted.Task.WaitAsync(CancellationToken.None);
+        Task<TerrainTextureGeoReferencedRasterSource?> secondCall = catalog.TryResolveRasterSourceAsync(
+            "dem-fallback",
+            "dem-fallback",
+            bounds,
+            CancellationToken.None);
+
+        await firstCallerCancellation.CancelAsync();
+        datasetSource.ReleaseMaterialize.TrySetResult();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await firstCall);
+        TerrainTextureGeoReferencedRasterSource? secondResult = await secondCall;
+        Assert.Null(secondResult);
+    }
+
+    [Fact]
+    public async Task TryResolveRasterSourceAsyncKeepsInFlightTaskCachedWhenFirstWaiterCancels()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        GateableDatasetContentSource datasetSource = CreateGateableDatasetSource(datasetRoot.Path);
+        DemTerrainGeoReferencedRasterCatalog catalog = await CreateCatalogAsync(datasetSource);
+        GeographicRectangle bounds = new(35.0, 35.1, 139.0, 139.1);
+        using CancellationTokenSource firstCallerCancellation = new();
+
+        Task<TerrainTextureGeoReferencedRasterSource?> firstCall = catalog.TryResolveRasterSourceAsync(
+            "dem-fallback",
+            "dem-fallback",
+            bounds,
+            firstCallerCancellation.Token);
+        await datasetSource.MaterializeStarted.Task.WaitAsync(CancellationToken.None);
+
+        await firstCallerCancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await firstCall);
+
+        Task<TerrainTextureGeoReferencedRasterSource?> secondCall = catalog.TryResolveRasterSourceAsync(
+            "dem-fallback",
+            "dem-fallback",
+            bounds,
+            CancellationToken.None);
+        datasetSource.ReleaseMaterialize.TrySetResult();
+
+        TerrainTextureGeoReferencedRasterSource? secondResult = await secondCall;
+        Assert.Null(secondResult);
+        Assert.Equal(1, datasetSource.MaterializeCallCount);
+    }
+
+    [Fact]
+    public async Task TryResolveRasterSourceAsyncEvictsBackgroundFaultAfterCanceledWaiterAbandonsIt()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        FaultingGateableDatasetContentSource datasetSource = CreateFaultingGateableDatasetSource(datasetRoot.Path);
+        DemTerrainGeoReferencedRasterCatalog catalog = await CreateCatalogAsync(datasetSource);
+        GeographicRectangle bounds = new(35.0, 35.1, 139.0, 139.1);
+        using CancellationTokenSource firstCallerCancellation = new();
+
+        Task<TerrainTextureGeoReferencedRasterSource?> firstCall = catalog.TryResolveRasterSourceAsync(
+            "dem-fallback",
+            "dem-fallback",
+            bounds,
+            firstCallerCancellation.Token);
+        await datasetSource.MaterializeStarted.Task.WaitAsync(CancellationToken.None);
+
+        await firstCallerCancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await firstCall);
+        datasetSource.ReleaseMaterialize.TrySetResult();
+        await datasetSource.BackgroundCompletion.Task.WaitAsync(CancellationToken.None);
+        await Task.Yield();
+        await Task.Delay(10);
+
+        await Assert.ThrowsAnyAsync<IOException>(
+            async () => await catalog.TryResolveRasterSourceAsync(
+                "dem-fallback",
+                "dem-fallback",
+                bounds,
+                CancellationToken.None));
+        Assert.Equal(2, datasetSource.MaterializeCallCount);
+    }
+
     private static RecordingDatasetContentSource CreateDatasetSource(string datasetRoot)
     {
         string westRasterPath = Path.Combine(datasetRoot, "west.tif");
@@ -51,7 +143,25 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
             [Path.GetFileName(westRasterPath), Path.GetFileName(eastRasterPath)]);
     }
 
-    private static async Task<DemTerrainGeoReferencedRasterCatalog> CreateCatalogAsync(RecordingDatasetContentSource datasetSource)
+    private static GateableDatasetContentSource CreateGateableDatasetSource(string datasetRoot)
+    {
+        string rasterPath = Path.Combine(datasetRoot, "gateable.tif");
+        File.WriteAllText(rasterPath, "dummy");
+        return new GateableDatasetContentSource(
+            datasetRoot,
+            [Path.GetFileName(rasterPath)]);
+    }
+
+    private static FaultingGateableDatasetContentSource CreateFaultingGateableDatasetSource(string datasetRoot)
+    {
+        string rasterPath = Path.Combine(datasetRoot, "faulting.tif");
+        File.WriteAllText(rasterPath, "dummy");
+        return new FaultingGateableDatasetContentSource(
+            datasetRoot,
+            [Path.GetFileName(rasterPath)]);
+    }
+
+    private static async Task<DemTerrainGeoReferencedRasterCatalog> CreateCatalogAsync(IPlateauDatasetContentSource datasetSource)
     {
         DemTerrainGeoReferencedRasterCatalog? catalog = await DemTerrainGeoReferencedRasterCatalog.CreateAsync(
             PlateauImportSource.Local(datasetSource.SourcePath),
@@ -104,6 +214,97 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         {
             MaterializeCallCount++;
             return Task.FromResult(Path.Combine(SourcePath, relativePath));
+        }
+    }
+
+    private sealed class GateableDatasetContentSource(
+        string sourcePath,
+        IReadOnlyList<string> files) : IPlateauDatasetContentSource
+    {
+        public string SourcePath { get; } = sourcePath;
+
+        public int MaterializeCallCount { get; private set; }
+
+        public TaskCompletionSource MaterializeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseMaterialize { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public IReadOnlyList<string> EnumerateFiles()
+        {
+            return files;
+        }
+
+        public bool FileExists(string relativePath)
+        {
+            return files.Contains(relativePath, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public ValueTask<Stream> OpenReadAsync(
+            string relativePath,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public async Task<string> MaterializeFileAsync(
+            string relativePath,
+            string outputRoot,
+            CancellationToken cancellationToken = default)
+        {
+            MaterializeCallCount++;
+            MaterializeStarted.TrySetResult();
+            await ReleaseMaterialize.Task.WaitAsync(cancellationToken);
+            return Path.Combine(SourcePath, relativePath);
+        }
+    }
+
+    private sealed class FaultingGateableDatasetContentSource(
+        string sourcePath,
+        IReadOnlyList<string> files) : IPlateauDatasetContentSource
+    {
+        public string SourcePath { get; } = sourcePath;
+
+        public int MaterializeCallCount { get; private set; }
+
+        public TaskCompletionSource MaterializeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseMaterialize { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource BackgroundCompletion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public IReadOnlyList<string> EnumerateFiles()
+        {
+            return files;
+        }
+
+        public bool FileExists(string relativePath)
+        {
+            return files.Contains(relativePath, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public ValueTask<Stream> OpenReadAsync(
+            string relativePath,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public async Task<string> MaterializeFileAsync(
+            string relativePath,
+            string outputRoot,
+            CancellationToken cancellationToken = default)
+        {
+            MaterializeCallCount++;
+            MaterializeStarted.TrySetResult();
+            try
+            {
+                await ReleaseMaterialize.Task.WaitAsync(cancellationToken);
+                throw new IOException("Simulated materialization failure.");
+            }
+            finally
+            {
+                BackgroundCompletion.TrySetResult();
+            }
         }
     }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlConstructionSourceFactoryTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlConstructionSourceFactoryTests.cs
@@ -31,23 +31,61 @@ public sealed class LocalCityGmlConstructionSourceFactoryTests
         Assert.Same(progressReporter, composer.LastProgressReporter);
     }
 
+    [Fact]
+    public async Task CreateAsyncAddsDemOverlaysDuringConstructionWhenBootstrapDocumentSetIsDiscoveryOnly()
+    {
+        RecordingDocumentReader reader = new(
+            new LocalCityGmlDocumentSet(
+                new EmptyDatasetContentSource(),
+                ["udx/dem/53394525/terrain.gml"],
+                ["dem"],
+                [],
+                ["53394525"],
+                [],
+                [],
+                CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697"),
+                new GeodeticPoint(35.0, 139.0, 0.0),
+                terrainHeightSampler: null));
+        RecordingComposer composer = new(new StubConstructionSource());
+        LocalCityGmlConstructionSourceFactory factory = new(reader, composer);
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "/tmp/plateau",
+            PackageNames: ["dem"],
+            ServerUri: null);
+
+        _ = await factory.CreateAsync(request);
+
+        Assert.NotSame(reader.DocumentSet, composer.LastDocumentSet);
+        Assert.Empty(reader.DocumentSet.TerrainTextureOverlays);
+        TerrainTextureOverlay overlay = Assert.Single(composer.LastDocumentSet!.TerrainTextureOverlays);
+        Assert.Equal("dem", overlay.PackageName);
+    }
+
     private sealed class RecordingDocumentReader : ICityGmlDocumentReader
     {
+        public RecordingDocumentReader(LocalCityGmlDocumentSet? documentSet = null)
+        {
+            DocumentSet = documentSet ?? new LocalCityGmlDocumentSet(
+                new EmptyDatasetContentSource(),
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697"),
+                new GeodeticPoint(35.0, 139.0, 0.0),
+                terrainHeightSampler: null);
+        }
+
         public PlateauImportRequest? LastRequest { get; private set; }
 
         public Action<string>? LastProgressReporter { get; private set; }
 
-        public LocalCityGmlDocumentSet DocumentSet { get; } = new(
-            new EmptyDatasetContentSource(),
-            [],
-            [],
-            [],
-            [],
-            [],
-            [],
-            CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697"),
-            new GeodeticPoint(35.0, 139.0, 0.0),
-            terrainHeightSampler: null);
+        public LocalCityGmlDocumentSet DocumentSet { get; }
 
         public Task<LocalCityGmlDocumentSet> ReadAsync(
             PlateauImportRequest request,

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlConstructionSourceFactoryTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlConstructionSourceFactoryTests.cs
@@ -100,6 +100,57 @@ public sealed class LocalCityGmlConstructionSourceFactoryTests
             static error => error.Contains("GeoTIFF", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public async Task CreateExplicitDemTerrainTextureOverlaysAsyncLimitsCoverageToActualDemGeometry()
+    {
+        Assert.True(
+            PlateauMeshCode.TryGetBounds(
+                "53394525",
+                out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) meshBounds));
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        SourceFileDescriptor demSourceFile = new("udx/dem/533945/sample.gml", "dem", "533945", RequiresMeshAreaFilter: false);
+        BootstrapParsedCityObject demCityObject = CreateDemParsedCityObject(
+            demSourceFile,
+            referenceSystem,
+            meshBounds.SouthLatitude + 0.0001,
+            meshBounds.WestLongitude + 0.0001);
+        SourceFilePipeline demPipeline = new(
+            demSourceFile,
+            () => Task.FromResult(
+                new ParsedSourceFileResult(
+                    demSourceFile,
+                    [demCityObject],
+                    referenceSystem,
+                    [],
+                    TimeSpan.Zero)));
+        RecordingDocumentReader reader = new(
+            new LocalCityGmlDocumentSet(
+                new EmptyDatasetContentSource(),
+                [demSourceFile.RelativePath],
+                ["dem"],
+                [],
+                ["533945"],
+                [demPipeline],
+                [],
+                referenceSystem,
+                new GeodeticPoint(35.0, 139.0, 0.0),
+                terrainHeightSampler: null));
+        TerrainTextureOverlay[] overlays = await LocalCityGmlConstructionSourceFactory.CreateExplicitDemTerrainTextureOverlaysAsync(
+            reader.DocumentSet,
+            [demSourceFile],
+            ["533945"],
+            demRasterCatalog: null,
+            CancellationToken.None);
+
+        TerrainTextureOverlay overlay = Assert.Single(overlays);
+        Assert.Empty(overlay.EnumerateGeoReferencedRasterSources());
+        Assert.True(
+            overlay.GeographicBounds.MinLatitude >= meshBounds.SouthLatitude
+            && overlay.GeographicBounds.MaxLatitude <= meshBounds.NorthLatitude
+            && overlay.GeographicBounds.MinLongitude >= meshBounds.WestLongitude
+            && overlay.GeographicBounds.MaxLongitude <= meshBounds.EastLongitude);
+    }
+
     private sealed class RecordingDocumentReader : ICityGmlDocumentReader
     {
         public RecordingDocumentReader(LocalCityGmlDocumentSet? documentSet = null)
@@ -242,4 +293,45 @@ public sealed class LocalCityGmlConstructionSourceFactoryTests
             return Task.FromResult(datasetSource);
         }
     }
+
+    private static BootstrapParsedCityObject CreateDemParsedCityObject(
+        SourceFileDescriptor sourceFile,
+        CoordinateReferenceSystem referenceSystem,
+        double southLatitude,
+        double westLongitude)
+    {
+        GeodeticPoint[] vertices =
+        [
+            new(southLatitude, westLongitude, 10.0),
+            new(southLatitude, westLongitude + 0.001, 10.0),
+            new(southLatitude + 0.001, westLongitude + 0.001, 10.0),
+            new(southLatitude + 0.001, westLongitude, 10.0),
+        ];
+
+        return new BootstrapParsedCityObject(
+            SlotKey: "dem",
+            DisplayName: "dem",
+            PackageName: "dem",
+            ActualMeshCode: "53394525",
+            LodLevel: 1,
+            Surfaces:
+            [
+                new BootstrapParsedSurface(
+                    PolygonId: "surface",
+                    Semantic: BootstrapParsedSurfaceSemantic.Ground,
+                    ExteriorRing: new BootstrapParsedRing("ring", vertices, null),
+                    InteriorRings: [],
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    TexturePayload: null,
+                    UsesGeneratedDemTexture: false),
+            ],
+            ReferenceSystem: referenceSystem,
+            SourceFileRelativePath: sourceFile.RelativePath,
+            SourceUnitIdentity: sourceFile.RelativePath,
+            SourceIdentity: $"{sourceFile.RelativePath}:dem",
+            SharedAcrossMeshCodes: false,
+            TerrainAligned: false,
+            OriginOverride: null);
+    }
+
 }

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlConstructionSourceFactoryTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlConstructionSourceFactoryTests.cs
@@ -64,6 +64,42 @@ public sealed class LocalCityGmlConstructionSourceFactoryTests
         Assert.Equal("dem", overlay.PackageName);
     }
 
+    [Fact]
+    public async Task CreateAsyncRejectsInvalidExplicitDemTextureSourceWhenRecoveredConstructionOverlayHasNoGeoTiffCoverage()
+    {
+        RecordingDocumentReader reader = new(
+            new LocalCityGmlDocumentSet(
+                new EmptyDatasetContentSource(),
+                ["udx/dem/53394525/terrain.gml"],
+                ["dem"],
+                [],
+                ["53394525"],
+                [],
+                [],
+                CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697"),
+                new GeodeticPoint(35.0, 139.0, 0.0),
+                terrainHeightSampler: null));
+        RecordingComposer composer = new(new StubConstructionSource());
+        LocalCityGmlConstructionSourceFactory factory = new(
+            reader,
+            composer,
+            new StubDatasetContentSourceFactory(
+                new EmptyDatasetContentSource("C:\\ortho")));
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            Source: PlateauImportSource.Local("/tmp/plateau"),
+            PackageNames: ["dem"],
+            DemTextureSource: PlateauImportSource.Local("C:\\ortho"));
+
+        PlateauImportValidationException exception = await Assert.ThrowsAsync<PlateauImportValidationException>(
+            () => factory.CreateAsync(request));
+
+        Assert.Contains(
+            exception.Errors,
+            static error => error.Contains("GeoTIFF", StringComparison.OrdinalIgnoreCase));
+    }
+
     private sealed class RecordingDocumentReader : ICityGmlDocumentReader
     {
         public RecordingDocumentReader(LocalCityGmlDocumentSet? documentSet = null)
@@ -163,7 +199,12 @@ public sealed class LocalCityGmlConstructionSourceFactoryTests
 
     private sealed class EmptyDatasetContentSource : IPlateauDatasetContentSource
     {
-        public string SourcePath => "/tmp/plateau";
+        public EmptyDatasetContentSource(string sourcePath = "/tmp/plateau")
+        {
+            SourcePath = sourcePath;
+        }
+
+        public string SourcePath { get; }
 
         public IReadOnlyList<string> EnumerateFiles()
         {
@@ -188,6 +229,17 @@ public sealed class LocalCityGmlConstructionSourceFactoryTests
             CancellationToken cancellationToken = default)
         {
             throw new FileNotFoundException(relativePath);
+        }
+    }
+
+    private sealed class StubDatasetContentSourceFactory(IPlateauDatasetContentSource datasetSource) : IPlateauDatasetContentSourceFactory
+    {
+        public Task<IPlateauDatasetContentSource> CreateAsync(
+            string sourcePath,
+            CancellationToken cancellationToken = default)
+        {
+            Assert.Equal(datasetSource.SourcePath, sourcePath);
+            return Task.FromResult(datasetSource);
         }
     }
 }

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlConstructionSourceTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlConstructionSourceTests.cs
@@ -43,7 +43,7 @@ public sealed class LocalCityGmlConstructionSourceTests
     }
 
     [Fact]
-    public async Task ReadCityObjectsAsyncPassesBootstrapDemOverlaysOnlyToDemSourceFiles()
+    public async Task ReadCityObjectsAsyncDoesNotPassDemOverlaysToNonDemSourceFiles()
     {
         PlateauImportRequest request = new(
             Dataset: "plateau-04100-sendai-shi-2024",
@@ -79,7 +79,38 @@ public sealed class LocalCityGmlConstructionSourceTests
 
         Assert.Equal(2, cityObjects.Count);
         Assert.Equal(0, geometryProjector.OverlayCountsByPackage["bldg"]);
-        Assert.Equal(1, geometryProjector.OverlayCountsByPackage["dem"]);
+        Assert.True(geometryProjector.OverlayCountsByPackage.ContainsKey("dem"));
+    }
+
+    [Fact]
+    public async Task ReadCityObjectsAsyncAllowsDemSourceFilesWhenBootstrapMetadataIsEmpty()
+    {
+        PlateauImportRequest request = new(
+            Dataset: "plateau-04100-sendai-shi-2024",
+            MeshCode: "57402736",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "/tmp/source.zip",
+            ServerUri: null,
+            PackageNames: ["dem"]);
+        OverlayRecordingGeometryProjector geometryProjector = new();
+        LocalCityGmlConstructionSource source = new(
+            CreateMetadata(request),
+            request,
+            CreateDocumentSet(
+                [
+                    new SourceFileDescriptor("udx/dem/file-001.gml", "dem", "57402736", RequiresMeshAreaFilter: false),
+                ]),
+            geometryProjector,
+            CommonMaterialEnumerator);
+
+        List<ResoniteConstructionCityObject> cityObjects = [];
+        await foreach (ResoniteConstructionCityObject cityObject in source.ReadCityObjectsAsync())
+        {
+            cityObjects.Add(cityObject);
+        }
+
+        Assert.Single(cityObjects);
+        Assert.Equal(0, geometryProjector.OverlayCountsByPackage["dem"]);
     }
 
     private static ResoniteConstructionMetadata CreateMetadata(


### PR DESCRIPTION
## Summary
- remove DEM eager parse and terrain overlay resolution from bootstrap document reading
- restore DEM overlay resolution as a construction-side concern with parsed-file fallback when requested-mesh overlays are insufficient
- add tests that pin bootstrap discovery-only behavior and construction-side DEM overlay recovery

## Verification
- dotnet restore Plateau.ResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false