### PR TITLE
fix(dem): restore default DEM terrain texture max size

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,6 @@ Shipped:
 - `--resonitelink-connections` は shipped な live-send option として扱い、既定の live-send pool size は 4 とする。
 - `ParameterizedTexture` appearance を保持しつつ、mesh / material 順序を決定的に保ち、source texture がない場合は bundled default material に fallback する。
 - source bootstrap の完了後は、dataset / mesh-code branch を段階的に構築し、full live send 完了前から Resonite 側に取り込み結果を出し始める。
-- LOD1 mesh bake と LOD2 atlas bake は CityGML scope、package、LOD、bake policy をキーにまとめ、emit される bake payload が cityObject の到着順に依存しないように保つ。
 - DEM terrain imagery tile は既定で local cache に永続化し、再実行時に PLATEAU Ortho や fallback の GSI tile を再利用できるようにする。
 
 Pending:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Shipped:
 - Treat `--resonitelink-connections` as a shipped live-send option, with a default live-send pool size of 4.
 - Preserve deterministic mesh/material ordering, keep `ParameterizedTexture` appearance data where present, and fall back to bundled default materials when source textures are missing.
 - After source bootstrap completes, build dataset and mesh-code branches incrementally so imported content can begin appearing in Resonite before the full live send completes.
-- Keep LOD1 mesh bake and LOD2 atlas bake keyed by CityGML scope, package, LOD, and bake policy so emitted bake payloads do not depend on cityObject arrival order.
 - Persist terrain imagery tiles under a local cache by default so repeated DEM imports can reuse already downloaded PLATEAU Ortho or fallback GSI tiles.
 
 Pending:

--- a/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.cs
+++ b/src/Plateau.ResoniteLink/Profiles/PlateauCityGml/LocalCityGmlObjectProjection.cs
@@ -22,7 +22,7 @@ public static partial class LocalCityGmlObjectProjection
     public const string DefaultDemTerrainTextureFallbackUrlTemplate = "https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/{z}/{x}/{y}.jpg";
     public const int DefaultDemTerrainTextureZoomLevel = 19;
     public const int DefaultDemTerrainTextureFallbackZoomLevel = 18;
-    public const int DefaultDemTerrainTextureMaxSize = 4096;
+    public const int DefaultDemTerrainTextureMaxSize = 8192;
     public const double DefaultGeneratedRoadMarkingWidthMeters = 0.15;
     public const double DefaultGeneratedRoadMarkingSegmentLengthMeters = 5.0;
     public const double DefaultTerrainAlignedTransportationSegmentLengthMeters = 5.0;

--- a/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlDemBootstrapSupportTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Profiles/LocalCityGmlDemBootstrapSupportTests.cs
@@ -87,6 +87,7 @@ public sealed class LocalCityGmlDemBootstrapSupportTests
                 Assert.Equal(LocalCityGmlObjectProjection.DefaultDemTerrainTextureFallbackUrlTemplate, tileSource.UrlTemplate);
                 Assert.Equal(LocalCityGmlObjectProjection.DefaultDemTerrainTextureFallbackZoomLevel, tileSource.ZoomLevel);
             });
+        Assert.Equal(LocalCityGmlObjectProjection.DefaultDemTerrainTextureMaxSize, overlay.MaxTextureSize);
         Assert.Equal(TerrainTextureLicenseMode.PlateauOrthoOnly, overlay.LicenseMode);
     }
 


### PR DESCRIPTION
## Summary
- restore the default DEM terrain texture max size to 8192
- keep the default overlay generation path wired through the shared constant
- add a regression assertion that default DEM overlays carry the restored max size

## Verification
- dotnet restore Plateau.ResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false