### PR TITLE
refactor(cli): unify citygml and geotiff source options

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,6 +10,7 @@ Plateau.ResoniteLink は、[PLATEAU](https://www.mlit.go.jp/plateau/) の CityGM
 
 Shipped:
 - ローカルの PLATEAU dataset または explicit な remote CityGML ZIP/7z archive を、起動中の ResoniteLink listener へ送る。
+- `--citygml-source` と `--geotiff-source` は path-or-URL 入力として扱い、`http` / `https` は remote URL、それ以外は local filesystem path として解釈する。
 - import 前に、ローカルの dataset directory またはローカル ZIP/7z archive を組み込みの `search` / `stats` command で inspection できる。
 - `--resonitelink-connections` は shipped な live-send option として扱い、既定の live-send pool size は 4 とする。
 - `ParameterizedTexture` appearance を保持しつつ、mesh / material 順序を決定的に保ち、source texture がない場合は bundled default material に fallback する。
@@ -51,8 +52,7 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   build \
   --dataset plateau-20202-matsumoto-shi-2020 \
   --mesh-code 54372778 \
-  --source local \
-  --local-source-path /path/to/plateau \
+  --citygml-source /path/to/plateau \
   --resonitelink-port <port>
 ```
 
@@ -63,26 +63,26 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   build \
   --dataset plateau-20202-matsumoto-shi-2020 \
   --mesh-code 54372788 \
-  --source remote \
-  --server-url https://example.invalid/plateau-20202-matsumoto-shi-2020_citygml.zip \
+  --citygml-source https://example.invalid/plateau-20202-matsumoto-shi-2020_citygml.zip \
+  --geotiff-source https://example.invalid/53394525.tif \
   --resonitelink-port <port>
 ```
 
-`--resonitelink-port` または `--resonitelink-url` は必須です。`--source remote` では direct な `.zip` / `.7z` CityGML archive URL が必要です。
+`--resonitelink-port` または `--resonitelink-url` は必須です。`--citygml-source` には extracted dataset directory、local の `.zip` / `.7z` archive、または direct な `.zip` / `.7z` CityGML archive URL を指定できます。`--geotiff-source` には local の `.tif` / `.tiff` file、local の `.zip` / `.7z` archive、または direct な `.tif` / `.tiff` / `.zip` / `.7z` URL を指定できます。remote URL に対する built-in dataset search は行いません。
 
 ローカル inspection の例:
 
 ```bash
 dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   search \
-  --local-source-path /path/to/plateau-or-archive.zip \
+  --citygml-source /path/to/plateau-or-archive.zip \
   --mesh-code 5437277.
 ```
 
 ```bash
 dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   stats \
-  --local-source-path /path/to/plateau-or-archive.zip
+  --citygml-source /path/to/plateau-or-archive.zip
 ```
 
 `search` と `stats` は、ローカルの dataset directory とローカル `.zip` / `.7z` archive を inspection します。remote import 自体は引き続き explicit な direct archive URL が必要です。

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This README is the canonical human-readable scope statement for the current `bet
 
 Shipped:
 - Stream local PLATEAU datasets or explicit remote CityGML ZIP/7z archives into a running ResoniteLink listener.
+- Accept `--citygml-source` and `--geotiff-source` as path-or-URL inputs, with `http`/`https` treated as remote URLs and other values treated as local filesystem paths.
 - Inspect local dataset directories or local ZIP/7z archives with built-in `search` and `stats` commands before import.
 - Treat `--resonitelink-connections` as a shipped live-send option, with a default live-send pool size of 4.
 - Preserve deterministic mesh/material ordering, keep `ParameterizedTexture` appearance data where present, and fall back to bundled default materials when source textures are missing.
@@ -51,8 +52,7 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   build \
   --dataset plateau-20202-matsumoto-shi-2020 \
   --mesh-code 54372778 \
-  --source local \
-  --local-source-path /path/to/plateau \
+  --citygml-source /path/to/plateau \
   --resonitelink-port <port>
 ```
 
@@ -63,26 +63,26 @@ dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   build \
   --dataset plateau-20202-matsumoto-shi-2020 \
   --mesh-code 54372788 \
-  --source remote \
-  --server-url https://example.invalid/plateau-20202-matsumoto-shi-2020_citygml.zip \
+  --citygml-source https://example.invalid/plateau-20202-matsumoto-shi-2020_citygml.zip \
+  --geotiff-source https://example.invalid/53394525.tif \
   --resonitelink-port <port>
 ```
 
-`--resonitelink-port` or `--resonitelink-url` is required. `--source remote` requires a direct `.zip` or `.7z` CityGML archive URL and does not perform built-in dataset search.
+`--resonitelink-port` or `--resonitelink-url` is required. `--citygml-source` accepts an extracted dataset directory, a local `.zip` / `.7z` archive, or a direct `.zip` / `.7z` CityGML archive URL. `--geotiff-source` accepts a local `.tif` / `.tiff` file, a local `.zip` / `.7z` archive, or a direct `.tif` / `.tiff` / `.zip` / `.7z` URL. Built-in dataset search is not performed for remote URLs.
 
 Local inspection examples:
 
 ```bash
 dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   search \
-  --local-source-path /path/to/plateau-or-archive.zip \
+  --citygml-source /path/to/plateau-or-archive.zip \
   --mesh-code 5437277.
 ```
 
 ```bash
 dotnet run --project src/Plateau.ResoniteLink.Cli -- \
   stats \
-  --local-source-path /path/to/plateau-or-archive.zip
+  --citygml-source /path/to/plateau-or-archive.zip
 ```
 
 `search` and `stats` inspect local dataset directories and local `.zip` / `.7z` archives. Remote import still requires an explicit direct archive URL.

--- a/src/Plateau.ResoniteLink.Cli/CliApplication.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliApplication.cs
@@ -92,7 +92,7 @@ public sealed class CliApplication
                 case SearchCommandOptions options:
                     {
                         DatasetSearchResult result = await datasetInspectionService.SearchAsync(
-                            options.LocalSourcePath,
+                            options.CityGmlSourcePath,
                             options.MeshCode,
                             options.PackageNames,
                             cancellationToken);
@@ -102,7 +102,7 @@ public sealed class CliApplication
                 case StatsCommandOptions options:
                     {
                         DatasetStatsResult result = await datasetInspectionService.GetStatsAsync(
-                            options.LocalSourcePath,
+                            options.CityGmlSourcePath,
                             options.PackageNames,
                             cancellationToken);
                         await WriteStatsResultAsync(result, options.OutputFormat, cancellationToken);

--- a/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/Plateau.ResoniteLink.Cli/CliArgumentsParser.cs
@@ -12,8 +12,8 @@ public static class CliArgumentsParser
 
         Usage:
           plateau-resonitelink build --dataset <dataset> --mesh-code <mesh-code> [options]
-          plateau-resonitelink search --local-source-path <path> --mesh-code <mesh-code> [options]
-          plateau-resonitelink stats --local-source-path <path> [options]
+          plateau-resonitelink search --citygml-source <path> --mesh-code <mesh-code> [options]
+          plateau-resonitelink stats --citygml-source <path> [options]
 
         Build options:
           --dataset <value>      Required. PLATEAU dataset identifier.
@@ -30,8 +30,8 @@ public static class CliArgumentsParser
                                 Supports: "*suffix", "prefix*", "*middle*", "exact".
           --citygml-source <path-or-url>
                                 Required. Local dataset directory/archive path or absolute direct .zip/.7z CityGML archive URL.
-          --ortho-source <path-or-url>
-                                Optional. Local GeoTIFF file/directory/archive path or absolute .tif/.tiff/.zip/.7z orthophoto URL.
+          --geotiff-source <path-or-url>
+                                Optional. Local GeoTIFF file/archive path or absolute .tif/.tiff/.zip/.7z GeoTIFF URL.
           --dem-terrain-mode <mesh|heightmap>
                                 Optional. DEM import mode. Default: mesh.
           --dem-heightmap-meters-per-vertex <value>
@@ -54,7 +54,7 @@ public static class CliArgumentsParser
           --verbose              Optional. Include debug-level progress logs.
 
         Search/stats options:
-          --local-source-path <path>
+          --citygml-source <path>
                                 Required. Local dataset directory or .zip/.7z archive to inspect.
           --mesh-code <value>    Required for search. PLATEAU mesh code or regex to search within the dataset source.
           --packages <csv>       Optional. Restrict inspection to specific PLATEAU packages.
@@ -140,7 +140,7 @@ public static class CliArgumentsParser
                     case "--citygml-source":
                         cityGmlSourceInput = ReadValue(args, ref index, token);
                         break;
-                    case "--ortho-source":
+                    case "--geotiff-source":
                         orthoSourceInput = ReadValue(args, ref index, token);
                         break;
                     case "--work-root":
@@ -385,7 +385,7 @@ public static class CliArgumentsParser
 
     private static CliParseResult ParseSearch(string[] args)
     {
-        string? localSourcePath = null;
+        string? cityGmlSourcePath = null;
         string? meshCode = null;
         IReadOnlyList<string>? packageNames = null;
         CliOutputFormat outputFormat = CliOutputFormat.Text;
@@ -400,8 +400,8 @@ public static class CliArgumentsParser
                     case "-h":
                     case "--help":
                         return CliParseResult.Help();
-                    case "--local-source-path":
-                        localSourcePath = ReadValue(args, ref index, token);
+                    case "--citygml-source":
+                        cityGmlSourcePath = ReadValue(args, ref index, token);
                         break;
                     case "--mesh-code":
                         meshCode = ReadValue(args, ref index, token);
@@ -438,9 +438,9 @@ public static class CliArgumentsParser
             return CliParseResult.Failure(exception.Message);
         }
 
-        if (string.IsNullOrWhiteSpace(localSourcePath))
+        if (string.IsNullOrWhiteSpace(cityGmlSourcePath))
         {
-            return CliParseResult.Failure("Specify --local-source-path.");
+            return CliParseResult.Failure("Specify --citygml-source.");
         }
 
         if (string.IsNullOrWhiteSpace(meshCode))
@@ -449,7 +449,7 @@ public static class CliArgumentsParser
         }
 
         return CliParseResult.Success(
-            new SearchCommandOptions(localSourcePath, meshCode, packageNames, outputFormat));
+            new SearchCommandOptions(cityGmlSourcePath, meshCode, packageNames, outputFormat));
     }
 
     private static PlateauImportSource ParseImportSourceInput(string sourceInput)
@@ -466,7 +466,7 @@ public static class CliArgumentsParser
 
     private static CliParseResult ParseStats(string[] args)
     {
-        string? localSourcePath = null;
+        string? cityGmlSourcePath = null;
         IReadOnlyList<string>? packageNames = null;
         CliOutputFormat outputFormat = CliOutputFormat.Text;
 
@@ -480,8 +480,8 @@ public static class CliArgumentsParser
                     case "-h":
                     case "--help":
                         return CliParseResult.Help();
-                    case "--local-source-path":
-                        localSourcePath = ReadValue(args, ref index, token);
+                    case "--citygml-source":
+                        cityGmlSourcePath = ReadValue(args, ref index, token);
                         break;
                     case "--packages":
                         {
@@ -515,13 +515,13 @@ public static class CliArgumentsParser
             return CliParseResult.Failure(exception.Message);
         }
 
-        if (string.IsNullOrWhiteSpace(localSourcePath))
+        if (string.IsNullOrWhiteSpace(cityGmlSourcePath))
         {
-            return CliParseResult.Failure("Specify --local-source-path.");
+            return CliParseResult.Failure("Specify --citygml-source.");
         }
 
         return CliParseResult.Success(
-            new StatsCommandOptions(localSourcePath, packageNames, outputFormat));
+            new StatsCommandOptions(cityGmlSourcePath, packageNames, outputFormat));
     }
 
     private static bool TryParseOutputFormat(string value, out CliOutputFormat outputFormat)

--- a/src/Plateau.ResoniteLink.Cli/SearchCommandOptions.cs
+++ b/src/Plateau.ResoniteLink.Cli/SearchCommandOptions.cs
@@ -1,7 +1,7 @@
 namespace Plateau.ResoniteLink.Cli;
 
 public sealed record SearchCommandOptions(
-    string LocalSourcePath,
+    string CityGmlSourcePath,
     string MeshCode,
     IReadOnlyList<string>? PackageNames,
     CliOutputFormat OutputFormat) : CliCommandOptions;

--- a/src/Plateau.ResoniteLink.Cli/StatsCommandOptions.cs
+++ b/src/Plateau.ResoniteLink.Cli/StatsCommandOptions.cs
@@ -1,6 +1,6 @@
 namespace Plateau.ResoniteLink.Cli;
 
 public sealed record StatsCommandOptions(
-    string LocalSourcePath,
+    string CityGmlSourcePath,
     IReadOnlyList<string>? PackageNames,
     CliOutputFormat OutputFormat) : CliCommandOptions;

--- a/src/Plateau.ResoniteLink/Formats/CityGml/LocalCityGmlImportErrorMessages.cs
+++ b/src/Plateau.ResoniteLink/Formats/CityGml/LocalCityGmlImportErrorMessages.cs
@@ -38,11 +38,11 @@ internal static class LocalCityGmlImportErrorMessages
         return demTextureSource switch
         {
             PlateauLocalImportSource localSource =>
-                $"The ortho source '{localSource.LocalSourcePath}' did not resolve any usable GeoTIFF raster covering the requested DEM bounds.",
+                $"The GeoTIFF source '{localSource.LocalSourcePath}' did not resolve any usable GeoTIFF raster covering the requested DEM bounds.",
             PlateauRemoteImportSource remoteSource =>
-                $"The ortho source '{remoteSource.ServerUri}' did not resolve any usable GeoTIFF raster covering the requested DEM bounds.",
+                $"The GeoTIFF source '{remoteSource.ServerUri}' did not resolve any usable GeoTIFF raster covering the requested DEM bounds.",
             _ =>
-                "The ortho source did not resolve any usable GeoTIFF raster covering the requested DEM bounds.",
+                "The GeoTIFF source did not resolve any usable GeoTIFF raster covering the requested DEM bounds.",
         };
     }
 

--- a/src/Plateau.ResoniteLink/UseCases/Importing/PlateauImportRequestValidator.cs
+++ b/src/Plateau.ResoniteLink/UseCases/Importing/PlateauImportRequestValidator.cs
@@ -192,22 +192,20 @@ public static class PlateauImportRequestValidator
                 case PlateauLocalImportSource localSource:
                     if (string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
                     {
-                        validationErrors.Add("The --ortho-source value must not be empty.");
+                        validationErrors.Add("The --geotiff-source value must not be empty.");
                         break;
                     }
 
-                    if (!Directory.Exists(localSource.LocalSourcePath)
-                        && !File.Exists(localSource.LocalSourcePath))
+                    if (!File.Exists(localSource.LocalSourcePath))
                     {
-                        validationErrors.Add($"The ortho source path '{localSource.LocalSourcePath}' does not exist.");
+                        validationErrors.Add($"The GeoTIFF source path '{localSource.LocalSourcePath}' must point to an existing file.");
                         break;
                     }
 
-                    if (File.Exists(localSource.LocalSourcePath)
-                        && !LooksLikeSupportedLocalTerrainTextureSourcePath(localSource.LocalSourcePath))
+                    if (!LooksLikeSupportedLocalTerrainTextureSourcePath(localSource.LocalSourcePath))
                     {
                         validationErrors.Add(
-                            $"The ortho source path '{localSource.LocalSourcePath}' must be a directory, .tif/.tiff file, or .zip/.7z archive.");
+                            $"The GeoTIFF source path '{localSource.LocalSourcePath}' must be a .tif/.tiff file or a .zip/.7z archive.");
                         break;
                     }
 
@@ -216,19 +214,19 @@ public static class PlateauImportRequestValidator
                 case PlateauRemoteImportSource remoteSource:
                     if (remoteSource.ServerUri is null)
                     {
-                        validationErrors.Add("The --ortho-source value must not be empty.");
+                        validationErrors.Add("The --geotiff-source value must not be empty.");
                         break;
                     }
 
                     if (!remoteSource.ServerUri.IsAbsoluteUri)
                     {
-                        validationErrors.Add("The --ortho-source value must be an absolute URI.");
+                        validationErrors.Add("The --geotiff-source value must be an absolute URI.");
                         break;
                     }
 
                     if (!LooksLikeSupportedTerrainTextureUri(remoteSource.ServerUri))
                     {
-                        validationErrors.Add("The --ortho-source value must point directly to a .tif, .tiff, .zip, or .7z resource over http or https.");
+                        validationErrors.Add("The --geotiff-source value must point directly to a .tif, .tiff, .zip, or .7z resource over http or https.");
                         break;
                     }
 

--- a/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -30,7 +30,7 @@ public sealed class CliArgumentsParserTests
     }
 
     [Fact]
-    public void ParseParsesRemoteBuildCommandAndOptionalOrthoSource()
+    public void ParseParsesRemoteBuildCommandAndOptionalGeoTiffSource()
     {
         CliParseResult result = CliArgumentsParser.Parse(
             [
@@ -41,7 +41,7 @@ public sealed class CliArgumentsParserTests
                 "53394525",
                 "--citygml-source",
                 "https://example.invalid/plateau.zip",
-                "--ortho-source",
+                "--geotiff-source",
                 "https://example.invalid/53394525.tif",
                 "--resonitelink-url",
                 "ws://localhost:12345/",
@@ -77,7 +77,7 @@ public sealed class CliArgumentsParserTests
         CliParseResult result = CliArgumentsParser.Parse(
             [
                 "search",
-                "--local-source-path",
+                "--citygml-source",
                 "/data/plateau.zip",
                 "--mesh-code",
                 "5339452[56]",
@@ -89,7 +89,7 @@ public sealed class CliArgumentsParserTests
 
         Assert.Null(result.Error);
         SearchCommandOptions command = Assert.IsType<SearchCommandOptions>(result.Command);
-        Assert.Equal("/data/plateau.zip", command.LocalSourcePath);
+        Assert.Equal("/data/plateau.zip", command.CityGmlSourcePath);
         Assert.Equal("5339452[56]", command.MeshCode);
         Assert.Equal(["bldg", "tran"], command.PackageNames);
         Assert.Equal(CliOutputFormat.Json, command.OutputFormat);
@@ -101,7 +101,7 @@ public sealed class CliArgumentsParserTests
         CliParseResult result = CliArgumentsParser.Parse(
             [
                 "stats",
-                "--local-source-path",
+                "--citygml-source",
                 "/data/plateau",
                 "--packages",
                 "dem,bldg",
@@ -109,7 +109,7 @@ public sealed class CliArgumentsParserTests
 
         Assert.Null(result.Error);
         StatsCommandOptions command = Assert.IsType<StatsCommandOptions>(result.Command);
-        Assert.Equal("/data/plateau", command.LocalSourcePath);
+        Assert.Equal("/data/plateau", command.CityGmlSourcePath);
         Assert.Equal(["dem", "bldg"], command.PackageNames);
     }
 
@@ -117,9 +117,10 @@ public sealed class CliArgumentsParserTests
     public void HelpTextDocumentsUnifiedSourceOptions()
     {
         Assert.Contains("--citygml-source <path-or-url>", CliArgumentsParser.HelpText, StringComparison.Ordinal);
-        Assert.Contains("--ortho-source <path-or-url>", CliArgumentsParser.HelpText, StringComparison.Ordinal);
+        Assert.Contains("--geotiff-source <path-or-url>", CliArgumentsParser.HelpText, StringComparison.Ordinal);
         Assert.DoesNotContain("--source <value>", CliArgumentsParser.HelpText, StringComparison.Ordinal);
         Assert.DoesNotContain("--server-url <url>", CliArgumentsParser.HelpText, StringComparison.Ordinal);
+        Assert.DoesNotContain("--local-source-path <path>", CliArgumentsParser.HelpText, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Plateau.ResoniteLink.Tests/UseCases/PlateauImportRequestValidatorTests.cs
+++ b/tests/Plateau.ResoniteLink.Tests/UseCases/PlateauImportRequestValidatorTests.cs
@@ -110,7 +110,7 @@ public sealed class PlateauImportRequestValidatorTests
     }
 
     [Fact]
-    public void ValidateAcceptsRemoteOrthoGeoTiffUrl()
+    public void ValidateAcceptsRemoteGeoTiffUrl()
     {
         using TemporaryDirectory sourceRoot = new();
 
@@ -126,7 +126,7 @@ public sealed class PlateauImportRequestValidatorTests
     }
 
     [Fact]
-    public void ValidateRejectsUnsupportedRemoteOrthoSource()
+    public void ValidateRejectsUnsupportedRemoteGeoTiffSource()
     {
         using TemporaryDirectory sourceRoot = new();
 
@@ -139,7 +139,44 @@ public sealed class PlateauImportRequestValidatorTests
         IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
 
         Assert.Contains(
-            "The --ortho-source value must point directly to a .tif, .tiff, .zip, or .7z resource over http or https.",
+            "The --geotiff-source value must point directly to a .tif, .tiff, .zip, or .7z resource over http or https.",
+            errors);
+    }
+
+    [Fact]
+    public void ValidateAcceptsExistingLocalGeoTiffFile()
+    {
+        using TemporaryDirectory sourceRoot = new();
+        string geoTiffPath = Path.Combine(sourceRoot.Path, "53394525.tif");
+        File.WriteAllText(geoTiffPath, "dummy");
+
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            Source: PlateauImportSource.Local(sourceRoot.Path),
+            DemTextureSource: PlateauImportSource.Local(geoTiffPath));
+
+        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ValidateRejectsGeoTiffSourceDirectory()
+    {
+        using TemporaryDirectory sourceRoot = new();
+        using TemporaryDirectory geoTiffRoot = new();
+
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            Source: PlateauImportSource.Local(sourceRoot.Path),
+            DemTextureSource: PlateauImportSource.Local(geoTiffRoot.Path));
+
+        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
+
+        Assert.Contains(
+            $"The GeoTIFF source path '{geoTiffRoot.Path}' must point to an existing file.",
             errors);
     }
 


### PR DESCRIPTION
## Summary
- rename the public orthophoto input to --geotiff-source
- rename search/stats local source input to --citygml-source
- keep --citygml-source and --geotiff-source on a path-or-URL contract and tighten local GeoTIFF validation to file/archive inputs only

## Verification
- dotnet restore Plateau.ResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build Plateau.ResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test Plateau.ResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false