### PR TITLE
fix: role-aware StaticTexture2D members for texture payloads

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -217,7 +217,9 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 albedoTextureId,
                 materialContainerId,
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(albedoTextureUri)));
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    albedoTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Albedo)));
             materialMembers["AlbedoTexture"] = new Reference
             {
                 TargetID = albedoTextureId.Value,
@@ -232,7 +234,9 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 normalTextureId,
                 materialContainerId,
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(normalTextureUri)));
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    normalTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Normal)));
             materialMembers["NormalMap"] = new Reference
             {
                 TargetID = normalTextureId.Value,
@@ -251,7 +255,9 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 heightTextureId,
                 materialContainerId,
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(heightTextureUri)));
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    heightTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Height)));
             materialMembers["HeightMap"] = new Reference
             {
                 TargetID = heightTextureId.Value,
@@ -270,7 +276,9 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 metallicTextureId,
                 materialContainerId,
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(metallicTextureUri)));
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    metallicTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Metallic)));
             materialMembers["MetallicMap"] = new Reference
             {
                 TargetID = metallicTextureId.Value,
@@ -289,7 +297,9 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 emissionTextureId,
                 materialContainerId,
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(emissionTextureUri)));
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    emissionTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Emission)));
             materialMembers["EmissiveMap"] = new Reference
             {
                 TargetID = emissionTextureId.Value,
@@ -371,7 +381,9 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             textureId,
             assetSlotId,
             "[FrooxEngine]FrooxEngine.StaticTexture2D",
-            ResoniteSceneMaterialConventions.CreateTextureMembers(binding.MainTexture.AssetUri)));
+            ResoniteSceneMaterialConventions.CreateTextureMembers(
+                binding.MainTexture.AssetUri,
+                ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride)));
 
         BatchPlanEntityId propertyBlockId = CreateBatchPlanEntityId($"renderer-main-texture-property-block:{overrideIdentity}");
         componentEmissions.Add(new PlannedBatchComponentEmission(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -377,13 +377,16 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
     {
         string overrideIdentity = $"{binding.MaterialIdentity.Value}:{binding.MainTexture.Identity.Value}";
         BatchPlanEntityId textureId = CreateBatchPlanEntityId($"renderer-texture:{overrideIdentity}");
+        ResoniteSceneMaterialConventions.TextureMemberRole textureRole = binding.ClampWrapMode
+            ? ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride
+            : ResoniteSceneMaterialConventions.TextureMemberRole.Albedo;
         componentEmissions.Add(new PlannedBatchComponentEmission(
             textureId,
             assetSlotId,
             "[FrooxEngine]FrooxEngine.StaticTexture2D",
             ResoniteSceneMaterialConventions.CreateTextureMembers(
                 binding.MainTexture.AssetUri,
-                ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride)));
+                textureRole)));
 
         BatchPlanEntityId propertyBlockId = CreateBatchPlanEntityId($"renderer-main-texture-property-block:{overrideIdentity}");
         componentEmissions.Add(new PlannedBatchComponentEmission(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -185,7 +185,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
                 client,
                 materialContainerSlotId,
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(albedoTextureUri),
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    albedoTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
                 cancellationToken);
             materialMembers["AlbedoTexture"] = new Reference
             {
@@ -200,7 +202,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
                 client,
                 materialContainerSlotId,
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(normalTextureUri),
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    normalTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Normal),
                 cancellationToken);
             materialMembers["NormalMap"] = new Reference
             {
@@ -219,7 +223,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
                 client,
                 materialContainerSlotId,
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(heightTextureUri),
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    heightTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Height),
                 cancellationToken);
             materialMembers["HeightMap"] = new Reference
             {
@@ -238,7 +244,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
                 client,
                 materialContainerSlotId,
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(metallicTextureUri),
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    metallicTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Metallic),
                 cancellationToken);
             materialMembers["MetallicMap"] = new Reference
             {
@@ -257,7 +265,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
                 client,
                 materialContainerSlotId,
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(emissionTextureUri),
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    emissionTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Emission),
                 cancellationToken);
             materialMembers["EmissiveMap"] = new Reference
             {

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneBootstrapInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneBootstrapInterpreter.cs
@@ -519,7 +519,9 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             operations.Add(ResoniteBatchOperations.CreateAddComponentOperation(
                 materialContainerId,
                 StaticTextureComponentType,
-                ResoniteSceneMaterialConventions.CreateTextureMembers(albedoTextureUri),
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    albedoTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
                 albedoTexture));
             materialMembers["AlbedoTexture"] = new Reference
             {
@@ -537,7 +539,9 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             operations.Add(ResoniteBatchOperations.CreateAddComponentOperation(
                 materialContainerId,
                 StaticTextureComponentType,
-                ResoniteSceneMaterialConventions.CreateTextureMembers(normalTextureUri),
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    normalTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Normal),
                 normalTexture));
             materialMembers["NormalMap"] = new Reference
             {
@@ -559,7 +563,9 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             operations.Add(ResoniteBatchOperations.CreateAddComponentOperation(
                 materialContainerId,
                 StaticTextureComponentType,
-                ResoniteSceneMaterialConventions.CreateTextureMembers(heightTextureUri),
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    heightTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Height),
                 heightTexture));
             materialMembers["HeightMap"] = new Reference
             {
@@ -581,7 +587,9 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             operations.Add(ResoniteBatchOperations.CreateAddComponentOperation(
                 materialContainerId,
                 StaticTextureComponentType,
-                ResoniteSceneMaterialConventions.CreateTextureMembers(metallicTextureUri),
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    metallicTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Metallic),
                 metallicTexture));
             materialMembers["MetallicMap"] = new Reference
             {
@@ -603,7 +611,9 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             operations.Add(ResoniteBatchOperations.CreateAddComponentOperation(
                 materialContainerId,
                 StaticTextureComponentType,
-                ResoniteSceneMaterialConventions.CreateTextureMembers(emissionTextureUri),
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    emissionTextureUri,
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Emission),
                 emissionTexture));
             materialMembers["EmissiveMap"] = new Reference
             {

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -1491,7 +1491,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneImportTarget
                 ct);
             PlannedRendererMaterialBinding rendererBinding = mainTextureOverride is null
                 ? new PlannedDirectRendererMaterialBinding(sharedMaterialAsset.Identity)
-                : new PlannedMainTextureOverrideRendererMaterialBinding(sharedMaterialAsset.Identity, mainTextureOverride);
+                : new PlannedMainTextureOverrideRendererMaterialBinding(
+                    sharedMaterialAsset.Identity,
+                    mainTextureOverride,
+                    ClampWrapMode: sourceMaterial.TerrainOverlay is not null);
             return (sharedMaterialAsset, rendererBinding);
         }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -54,7 +54,8 @@ internal sealed record PlannedDirectRendererMaterialBinding(MaterialIdentity Mat
 
 internal sealed record PlannedMainTextureOverrideRendererMaterialBinding(
     MaterialIdentity MaterialIdentity,
-    PlannedTextureAsset MainTexture)
+    PlannedTextureAsset MainTexture,
+    bool ClampWrapMode = false)
     : PlannedRendererMaterialBinding(MaterialIdentity);
 
 internal sealed record PlannedRenderer(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -15,6 +15,16 @@ internal static class ResoniteSceneMaterialConventions
 {
     private static readonly IReadOnlyList<string> EmptyLookupNames = [];
 
+    internal enum TextureMemberRole
+    {
+        Albedo,
+        Normal,
+        Height,
+        Metallic,
+        Emission,
+        TerrainMainTextureOverride,
+    }
+
     public static string CreateMaterialSlotName(ResoniteMaterialBinding material, bool useCommonMaterialAssets)
     {
         ArgumentNullException.ThrowIfNull(material);
@@ -301,15 +311,37 @@ internal static class ResoniteSceneMaterialConventions
         return ResoniteMaterialSharing.CreateCanonicalVertexColorCommonMaterialKey(projection, depthOffset);
     }
 
-    public static Dictionary<string, Member> CreateTextureMembers(Uri assetUri)
+    public static Dictionary<string, Member> CreateTextureMembers(Uri assetUri, TextureMemberRole role)
     {
-        return new Dictionary<string, Member>(StringComparer.Ordinal)
+        ArgumentNullException.ThrowIfNull(assetUri);
+
+        Dictionary<string, Member> members = new(StringComparer.Ordinal)
         {
             ["URL"] = new Field_Uri
             {
                 Value = assetUri,
             },
         };
+
+        switch (role)
+        {
+            case TextureMemberRole.Normal:
+            case TextureMemberRole.Height:
+            case TextureMemberRole.Metallic:
+                members["PreferredProfile"] = CreateNullableEnumMember(ResoniteTextureColorProfiles.Linear);
+                break;
+            case TextureMemberRole.TerrainMainTextureOverride:
+                members["WrapModeU"] = CreateEnumMember("Clamp");
+                members["WrapModeV"] = CreateEnumMember("Clamp");
+                break;
+            case TextureMemberRole.Albedo:
+            case TextureMemberRole.Emission:
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported texture member role '{role}'.");
+        }
+
+        return members;
     }
 
     private static bool IsBundledCommonMaterialCandidate(ResoniteMaterialBinding material)
@@ -552,5 +584,21 @@ internal static class ResoniteSceneMaterialConventions
         return textureOffset is null
             || (Math.Abs(textureOffset.X) < 1e-9
                 && Math.Abs(textureOffset.Y) < 1e-9);
+    }
+
+    private static Field_Enum CreateEnumMember(string value)
+    {
+        return new Field_Enum
+        {
+            Value = value,
+        };
+    }
+
+    private static Field_Nullable_Enum CreateNullableEnumMember(string value)
+    {
+        return new Field_Nullable_Enum
+        {
+            Value = value,
+        };
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -136,6 +136,9 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 && string.Equals(operation.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
         Field_Uri textureUrl = Assert.IsType<Field_Uri>(overrideTextureComponent.Members["URL"]);
         Assert.StartsWith("resdb:///texture/", textureUrl.Value.ToString(), StringComparison.Ordinal);
+        Assert.Equal("Clamp", Assert.IsType<Field_Enum>(overrideTextureComponent.Members["WrapModeU"]).Value);
+        Assert.Equal("Clamp", Assert.IsType<Field_Enum>(overrideTextureComponent.Members["WrapModeV"]).Value);
+        Assert.DoesNotContain("PreferredProfile", overrideTextureComponent.Members.Keys);
     }
 
     [Fact]
@@ -278,6 +281,10 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Reference displacementTextureReference = Assert.IsType<Reference>(gridMesh.Members["DisplacementTexture"]);
         Component displacementTexture = client.ComponentsById[displacementTextureReference.TargetID];
         Assert.Equal("[FrooxEngine]FrooxEngine.StaticTexture2D", displacementTexture.ComponentType);
+        Assert.Equal("Clamp", Assert.IsType<Field_Enum>(displacementTexture.Members["WrapModeU"]).Value);
+        Assert.Equal("Clamp", Assert.IsType<Field_Enum>(displacementTexture.Members["WrapModeV"]).Value);
+        Assert.Equal("Point", Assert.IsType<Field_Nullable_Enum>(displacementTexture.Members["FilterMode"]).Value);
+        Assert.False(Assert.IsType<Field_bool>(displacementTexture.Members["MipMaps"]).Value);
         Assert.DoesNotContain(
             client.ComponentsById.Values,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -278,6 +278,46 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.Equal(propertyBlockComponent.Identity.Value, propertyBlockReference.TargetID);
         Assert.Equal(propertyBlockComponent.ContainerId, meshRenderer.ContainerId);
         Assert.Equal(overrideTexture.Identity.Value, Assert.IsType<Reference>(propertyBlockComponent.Members["Texture"]).TargetID);
+        Assert.DoesNotContain("WrapModeU", overrideTexture.Members.Keys);
+        Assert.DoesNotContain("WrapModeV", overrideTexture.Members.Keys);
+        Assert.DoesNotContain("PreferredProfile", overrideTexture.Members.Keys);
+    }
+
+    [Fact]
+    public void CreatePlannedBatchEmission_ClampsTerrainMainTextureOverride()
+    {
+        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
+            new CreatedSlot("asset-lod-slot", "Asset LOD"),
+            new CreatedSlot("lod-slot", "LOD"),
+            "Triangle Object",
+            new PlateauResoniteLink.Domain.Importing.ResoniteFloat3(0.0, 0.0, 0.0),
+            null);
+        PlannedReusableMaterialAsset reusableMaterial = new(new MaterialIdentity("reusable"), "shared-material-id");
+        PlannedSceneObjectEmission emissionPlan = new(
+            new PlannedTriangleMeshGeometryAsset(
+                new GeometryIdentity("geom"),
+                "Triangle Object",
+                new Uri("resdb:///mesh/triangle")),
+            [reusableMaterial],
+            new PlannedRenderer(
+                new GeometryIdentity("geom"),
+                [
+                    new PlannedMainTextureOverrideRendererMaterialBinding(
+                        reusableMaterial.Identity,
+                        new PlannedTextureAsset(new TextureIdentity("override"), new Uri("resdb:///texture/override")),
+                        ClampWrapMode: true),
+                ]),
+            new PlannedCollider(
+                new GeometryIdentity("geom"),
+                false));
+
+        PlannedBatchEmission batchPlan = Planner.Create(objectSlots, emissionPlan);
+
+        PlannedBatchComponentEmission overrideTexture = Assert.Single(
+            batchPlan.ComponentEmissions,
+            component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
+                && string.Equals(component.ContainerId, "plan:mesh-asset-slot", StringComparison.Ordinal));
+
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(overrideTexture.Members["WrapModeU"]).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(overrideTexture.Members["WrapModeV"]).Value);
         Assert.DoesNotContain("PreferredProfile", overrideTexture.Members.Keys);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -63,6 +63,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.Equal("asset-lod-slot", meshAssetSlot.ParentId);
         Assert.Equal("asset-lod-slot", heightMapSlot.ParentId);
         Assert.Equal(heightMapSlot.Identity.Value, heightTexture.ContainerId);
+        Assert.Equal("Clamp", Assert.IsType<Field_Enum>(heightTexture.Members["WrapModeU"]).Value);
+        Assert.Equal("Clamp", Assert.IsType<Field_Enum>(heightTexture.Members["WrapModeV"]).Value);
+        Assert.Equal("Point", Assert.IsType<Field_Nullable_Enum>(heightTexture.Members["FilterMode"]).Value);
+        Assert.False(Assert.IsType<Field_bool>(heightTexture.Members["MipMaps"]).Value);
         Reference displacementTexture = Assert.IsType<Reference>(gridMesh.Members["DisplacementTexture"]);
         Assert.Equal(heightTexture.Identity.Value, displacementTexture.TargetID);
     }
@@ -215,6 +219,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.Equal(texturesByUri["resdb:///texture/metallic"].Identity.Value, Assert.IsType<Reference>(materialComponent.Members["MetallicMap"]).TargetID);
         Assert.Equal(texturesByUri["resdb:///texture/metallic"].Identity.Value, Assert.IsType<Reference>(materialComponent.Members["OcclusionMap"]).TargetID);
         Assert.Equal(texturesByUri["resdb:///texture/emission"].Identity.Value, Assert.IsType<Reference>(materialComponent.Members["EmissiveMap"]).TargetID);
+        Assert.DoesNotContain("PreferredProfile", texturesByUri["resdb:///texture/albedo"].Members.Keys);
+        Assert.Equal("Linear", Assert.IsType<Field_Nullable_Enum>(texturesByUri["resdb:///texture/normal"].Members["PreferredProfile"]).Value);
+        Assert.Equal("Linear", Assert.IsType<Field_Nullable_Enum>(texturesByUri["resdb:///texture/height"].Members["PreferredProfile"]).Value);
+        Assert.Equal("Linear", Assert.IsType<Field_Nullable_Enum>(texturesByUri["resdb:///texture/metallic"].Members["PreferredProfile"]).Value);
+        Assert.DoesNotContain("PreferredProfile", texturesByUri["resdb:///texture/emission"].Members.Keys);
     }
 
     [Fact]
@@ -269,6 +278,9 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.Equal(propertyBlockComponent.Identity.Value, propertyBlockReference.TargetID);
         Assert.Equal(propertyBlockComponent.ContainerId, meshRenderer.ContainerId);
         Assert.Equal(overrideTexture.Identity.Value, Assert.IsType<Reference>(propertyBlockComponent.Members["Texture"]).TargetID);
+        Assert.Equal("Clamp", Assert.IsType<Field_Enum>(overrideTexture.Members["WrapModeU"]).Value);
+        Assert.Equal("Clamp", Assert.IsType<Field_Enum>(overrideTexture.Members["WrapModeV"]).Value);
+        Assert.DoesNotContain("PreferredProfile", overrideTexture.Members.Keys);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -4,11 +4,52 @@ using System.Collections.Generic;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
+using ResoniteLink;
+
 namespace PlateauResoniteLink.Tests.Targets;
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test names describe contract cases.")]
 public sealed class ResoniteSceneMaterialConventionsTests
 {
+    [Fact]
+    public void CreateTextureMembers_ForAlbedo_UsesUrlOnly()
+    {
+        Dictionary<string, Member> members = ResoniteSceneMaterialConventions.CreateTextureMembers(
+            new Uri("resdb:///texture/albedo"),
+            ResoniteSceneMaterialConventions.TextureMemberRole.Albedo);
+
+        Field_Uri url = Assert.IsType<Field_Uri>(members["URL"]);
+
+        Assert.Equal("resdb:///texture/albedo", url.Value.ToString());
+        Assert.DoesNotContain("PreferredProfile", members.Keys);
+        Assert.DoesNotContain("WrapModeU", members.Keys);
+        Assert.DoesNotContain("WrapModeV", members.Keys);
+    }
+
+    [Fact]
+    public void CreateTextureMembers_ForMetallic_PrefersLinearProfileWithoutExplicitWrap()
+    {
+        Dictionary<string, Member> members = ResoniteSceneMaterialConventions.CreateTextureMembers(
+            new Uri("resdb:///texture/metallic"),
+            ResoniteSceneMaterialConventions.TextureMemberRole.Metallic);
+
+        Assert.Equal("Linear", Assert.IsType<Field_Nullable_Enum>(members["PreferredProfile"]).Value);
+        Assert.DoesNotContain("WrapModeU", members.Keys);
+        Assert.DoesNotContain("WrapModeV", members.Keys);
+    }
+
+    [Fact]
+    public void CreateTextureMembers_ForTerrainMainTextureOverride_ClampsWithoutPreferredProfile()
+    {
+        Dictionary<string, Member> members = ResoniteSceneMaterialConventions.CreateTextureMembers(
+            new Uri("resdb:///texture/override"),
+            ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride);
+
+        Assert.Equal("Clamp", Assert.IsType<Field_Enum>(members["WrapModeU"]).Value);
+        Assert.Equal("Clamp", Assert.IsType<Field_Enum>(members["WrapModeV"]).Value);
+        Assert.DoesNotContain("PreferredProfile", members.Keys);
+    }
+
     [Fact]
     public void CreateMaterialSlotName_ForCommonMaterial_UsesStableSharedDiscriminators()
     {


### PR DESCRIPTION
## Summary
- centralize StaticTexture2D member emission behind role-aware texture policy
- send PreferredProfile=Linear only for non-color companion maps such as MetallicMap
- clamp DEM main-texture overrides explicitly while omitting default texture members elsewhere

## Testing
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false