### PR TITLE
feat(import): switch texture payload contracts to Stream

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -198,13 +198,11 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
                 .AsTask()
                 .GetAwaiter()
                 .GetResult();
-            using MemoryStream encodedPayloadStream = new();
-            stream.CopyTo(encodedPayloadStream);
             texturePayload = new TexturePayload(
                 Width: null,
                 Height: null,
                 "sRGB",
-                encodedPayloadStream.ToArray(),
+                stream,
                 $"dataset:{resolvedTexturePath}",
                 TexturePayloadFormat.EncodedImage);
             texturePayloadsByResolvedPath[resolvedTexturePath] = texturePayload;

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -198,13 +198,15 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
                 .AsTask()
                 .GetAwaiter()
                 .GetResult();
+            using MemoryStream encodedPayloadStream = new();
+            stream.CopyTo(encodedPayloadStream);
             texturePayload = new TexturePayload(
-                Width: null,
-                Height: null,
-                "sRGB",
-                stream,
-                $"dataset:{resolvedTexturePath}",
-                TexturePayloadFormat.EncodedImage);
+                width: null,
+                height: null,
+                colorProfile: "sRGB",
+                binaryPayload: encodedPayloadStream.ToArray(),
+                identity: $"dataset:{resolvedTexturePath}",
+                format: TexturePayloadFormat.EncodedImage);
             texturePayloadsByResolvedPath[resolvedTexturePath] = texturePayload;
         }
 

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 
 using PlateauResoniteLink.Domain.Importing;
 
@@ -94,13 +96,87 @@ public enum TexturePayloadFormat
     EncodedImage = 1,
 }
 
-public sealed record TexturePayload(
-    int? Width,
-    int? Height,
-    string? ColorProfile,
-    byte[] BinaryPayload,
-    string? Identity = null,
-    TexturePayloadFormat Format = TexturePayloadFormat.RawRgba32);
+public sealed record TexturePayload
+{
+    private readonly byte[] binaryPayloadBytes;
+
+    public TexturePayload(
+        int? Width,
+        int? Height,
+        string? ColorProfile,
+        Stream BinaryPayload,
+        string? Identity = null,
+        TexturePayloadFormat Format = TexturePayloadFormat.RawRgba32)
+    {
+        this.Width = Width;
+        this.Height = Height;
+        this.ColorProfile = ColorProfile;
+        binaryPayloadBytes = CopyBinaryPayload(BinaryPayload);
+        this.Identity = Identity;
+        this.Format = Format;
+    }
+
+    public TexturePayload(
+        int? Width,
+        int? Height,
+        string? ColorProfile,
+        byte[] BinaryPayload,
+        string? Identity = null,
+        TexturePayloadFormat Format = TexturePayloadFormat.RawRgba32)
+        : this(Width, Height, ColorProfile, CreateBinaryPayloadStream(BinaryPayload), Identity, Format)
+    {
+    }
+
+    public int? Width { get; }
+
+    public int? Height { get; }
+
+    public string? ColorProfile { get; }
+
+    public Stream BinaryPayload => CreateBinaryPayloadStream(binaryPayloadBytes);
+
+    public string? Identity { get; }
+
+    public TexturePayloadFormat Format { get; }
+
+    internal byte[] CopyBinaryPayloadToArray() => (byte[])binaryPayloadBytes.Clone();
+
+    private static MemoryStream CreateBinaryPayloadStream(byte[] binaryPayload)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        return new MemoryStream(binaryPayload, writable: false);
+    }
+
+    private static byte[] CopyBinaryPayload(Stream binaryPayload)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        if (!binaryPayload.CanRead)
+        {
+            throw new ArgumentException("Texture payload stream must be readable.", nameof(binaryPayload));
+        }
+
+        long originalPosition = 0;
+        bool restorePosition = binaryPayload.CanSeek;
+        if (restorePosition)
+        {
+            originalPosition = binaryPayload.Position;
+        }
+
+        try
+        {
+            using MemoryStream copy = new();
+            binaryPayload.CopyTo(copy);
+            return copy.ToArray();
+        }
+        finally
+        {
+            if (restorePosition)
+            {
+                binaryPayload.Position = originalPosition;
+            }
+        }
+    }
+}
 
 public enum TextureSourceKind
 {

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.Linq;
 
 using PlateauResoniteLink.Domain.Importing;
 
@@ -98,84 +98,34 @@ public enum TexturePayloadFormat
 
 public sealed record TexturePayload
 {
-    private readonly byte[] binaryPayloadBytes;
-
     public TexturePayload(
-        int? Width,
-        int? Height,
-        string? ColorProfile,
-        Stream BinaryPayload,
-        string? Identity = null,
-        TexturePayloadFormat Format = TexturePayloadFormat.RawRgba32)
+        int? width,
+        int? height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        string? identity = null,
+        TexturePayloadFormat format = TexturePayloadFormat.RawRgba32)
     {
-        this.Width = Width;
-        this.Height = Height;
-        this.ColorProfile = ColorProfile;
-        binaryPayloadBytes = CopyBinaryPayload(BinaryPayload);
-        this.Identity = Identity;
-        this.Format = Format;
-    }
-
-    public TexturePayload(
-        int? Width,
-        int? Height,
-        string? ColorProfile,
-        byte[] BinaryPayload,
-        string? Identity = null,
-        TexturePayloadFormat Format = TexturePayloadFormat.RawRgba32)
-        : this(Width, Height, ColorProfile, CreateBinaryPayloadStream(BinaryPayload), Identity, Format)
-    {
-    }
-
-    public int? Width { get; }
-
-    public int? Height { get; }
-
-    public string? ColorProfile { get; }
-
-    public Stream BinaryPayload => CreateBinaryPayloadStream(binaryPayloadBytes);
-
-    public string? Identity { get; }
-
-    public TexturePayloadFormat Format { get; }
-
-    internal byte[] CopyBinaryPayloadToArray() => (byte[])binaryPayloadBytes.Clone();
-
-    private static MemoryStream CreateBinaryPayloadStream(byte[] binaryPayload)
-    {
+        Width = width;
+        Height = height;
+        ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(binaryPayload);
-        return new MemoryStream(binaryPayload, writable: false);
+        BinaryPayload = binaryPayload.ToArray();
+        Identity = identity;
+        Format = format;
     }
 
-    private static byte[] CopyBinaryPayload(Stream binaryPayload)
-    {
-        ArgumentNullException.ThrowIfNull(binaryPayload);
-        if (!binaryPayload.CanRead)
-        {
-            throw new ArgumentException("Texture payload stream must be readable.", nameof(binaryPayload));
-        }
+    public int? Width { get; init; }
 
-        long originalPosition = 0;
-        bool restorePosition = binaryPayload.CanSeek;
-        if (restorePosition)
-        {
-            originalPosition = binaryPayload.Position;
-        }
+    public int? Height { get; init; }
 
-        try
-        {
-            using MemoryStream copy = new();
-            binaryPayload.CopyTo(copy);
-            return copy.ToArray();
-        }
-        finally
-        {
-            if (restorePosition)
-            {
-                binaryPayload.Position = originalPosition;
-            }
-        }
-    }
+    public string? ColorProfile { get; init; }
+
+    public byte[] BinaryPayload { get; init; }
+
+    public string? Identity { get; init; }
+
+    public TexturePayloadFormat Format { get; init; }
 }
 
 public enum TextureSourceKind

--- a/src/PlateauResoniteLink/Domain/Importing/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/ResoniteTexturePayload.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+
 namespace PlateauResoniteLink.Domain.Importing;
 
 public enum ResoniteTexturePayloadFormat
@@ -6,10 +9,84 @@ public enum ResoniteTexturePayloadFormat
     EncodedImage,
 }
 
-public sealed record ResoniteTexturePayload(
-    int? Width,
-    int? Height,
-    string? ColorProfile,
-    byte[] BinaryPayload,
-    string? Identity = null,
-    ResoniteTexturePayloadFormat Format = ResoniteTexturePayloadFormat.RawRgba32);
+public sealed record ResoniteTexturePayload
+{
+    private readonly byte[] binaryPayloadBytes;
+
+    public ResoniteTexturePayload(
+        int? Width,
+        int? Height,
+        string? ColorProfile,
+        Stream BinaryPayload,
+        string? Identity = null,
+        ResoniteTexturePayloadFormat Format = ResoniteTexturePayloadFormat.RawRgba32)
+    {
+        this.Width = Width;
+        this.Height = Height;
+        this.ColorProfile = ColorProfile;
+        binaryPayloadBytes = CopyBinaryPayload(BinaryPayload);
+        this.Identity = Identity;
+        this.Format = Format;
+    }
+
+    public ResoniteTexturePayload(
+        int? Width,
+        int? Height,
+        string? ColorProfile,
+        byte[] BinaryPayload,
+        string? Identity = null,
+        ResoniteTexturePayloadFormat Format = ResoniteTexturePayloadFormat.RawRgba32)
+        : this(Width, Height, ColorProfile, CreateBinaryPayloadStream(BinaryPayload), Identity, Format)
+    {
+    }
+
+    public int? Width { get; }
+
+    public int? Height { get; }
+
+    public string? ColorProfile { get; }
+
+    public Stream BinaryPayload => CreateBinaryPayloadStream(binaryPayloadBytes);
+
+    public string? Identity { get; }
+
+    public ResoniteTexturePayloadFormat Format { get; }
+
+    internal byte[] CopyBinaryPayloadToArray() => (byte[])binaryPayloadBytes.Clone();
+
+    private static MemoryStream CreateBinaryPayloadStream(byte[] binaryPayload)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        return new MemoryStream(binaryPayload, writable: false);
+    }
+
+    private static byte[] CopyBinaryPayload(Stream binaryPayload)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        if (!binaryPayload.CanRead)
+        {
+            throw new ArgumentException("Texture payload stream must be readable.", nameof(binaryPayload));
+        }
+
+        long originalPosition = 0;
+        bool restorePosition = binaryPayload.CanSeek;
+        if (restorePosition)
+        {
+            originalPosition = binaryPayload.Position;
+        }
+
+        try
+        {
+            using MemoryStream copy = new();
+            binaryPayload.CopyTo(copy);
+            return copy.ToArray();
+        }
+        finally
+        {
+            if (restorePosition)
+            {
+                binaryPayload.Position = originalPosition;
+            }
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Domain/Importing/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/ResoniteTexturePayload.cs
@@ -1,5 +1,5 @@
 using System;
-using System.IO;
+using System.Linq;
 
 namespace PlateauResoniteLink.Domain.Importing;
 
@@ -11,82 +11,32 @@ public enum ResoniteTexturePayloadFormat
 
 public sealed record ResoniteTexturePayload
 {
-    private readonly byte[] binaryPayloadBytes;
-
     public ResoniteTexturePayload(
-        int? Width,
-        int? Height,
-        string? ColorProfile,
-        Stream BinaryPayload,
-        string? Identity = null,
-        ResoniteTexturePayloadFormat Format = ResoniteTexturePayloadFormat.RawRgba32)
+        int? width,
+        int? height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        string? identity = null,
+        ResoniteTexturePayloadFormat format = ResoniteTexturePayloadFormat.RawRgba32)
     {
-        this.Width = Width;
-        this.Height = Height;
-        this.ColorProfile = ColorProfile;
-        binaryPayloadBytes = CopyBinaryPayload(BinaryPayload);
-        this.Identity = Identity;
-        this.Format = Format;
-    }
-
-    public ResoniteTexturePayload(
-        int? Width,
-        int? Height,
-        string? ColorProfile,
-        byte[] BinaryPayload,
-        string? Identity = null,
-        ResoniteTexturePayloadFormat Format = ResoniteTexturePayloadFormat.RawRgba32)
-        : this(Width, Height, ColorProfile, CreateBinaryPayloadStream(BinaryPayload), Identity, Format)
-    {
-    }
-
-    public int? Width { get; }
-
-    public int? Height { get; }
-
-    public string? ColorProfile { get; }
-
-    public Stream BinaryPayload => CreateBinaryPayloadStream(binaryPayloadBytes);
-
-    public string? Identity { get; }
-
-    public ResoniteTexturePayloadFormat Format { get; }
-
-    internal byte[] CopyBinaryPayloadToArray() => (byte[])binaryPayloadBytes.Clone();
-
-    private static MemoryStream CreateBinaryPayloadStream(byte[] binaryPayload)
-    {
+        Width = width;
+        Height = height;
+        ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(binaryPayload);
-        return new MemoryStream(binaryPayload, writable: false);
+        BinaryPayload = binaryPayload.ToArray();
+        Identity = identity;
+        Format = format;
     }
 
-    private static byte[] CopyBinaryPayload(Stream binaryPayload)
-    {
-        ArgumentNullException.ThrowIfNull(binaryPayload);
-        if (!binaryPayload.CanRead)
-        {
-            throw new ArgumentException("Texture payload stream must be readable.", nameof(binaryPayload));
-        }
+    public int? Width { get; init; }
 
-        long originalPosition = 0;
-        bool restorePosition = binaryPayload.CanSeek;
-        if (restorePosition)
-        {
-            originalPosition = binaryPayload.Position;
-        }
+    public int? Height { get; init; }
 
-        try
-        {
-            using MemoryStream copy = new();
-            binaryPayload.CopyTo(copy);
-            return copy.ToArray();
-        }
-        finally
-        {
-            if (restorePosition)
-            {
-                binaryPayload.Position = originalPosition;
-            }
-        }
-    }
+    public string? ColorProfile { get; init; }
+
+    public byte[] BinaryPayload { get; init; }
+
+    public string? Identity { get; init; }
+
+    public ResoniteTexturePayloadFormat Format { get; init; }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -390,7 +390,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
 
     private static bool TryGetUniformPixel(ResoniteTexturePayload payload, out Rgba32 pixel)
     {
-        byte[] bytes = payload.BinaryPayload;
+        byte[] bytes = payload.CopyBinaryPayloadToArray();
         if (bytes.Length < 4 || (bytes.Length % 4) != 0)
         {
             pixel = default;

--- a/src/PlateauResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -390,7 +390,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
 
     private static bool TryGetUniformPixel(ResoniteTexturePayload payload, out Rgba32 pixel)
     {
-        byte[] bytes = payload.CopyBinaryPayloadToArray();
+        byte[] bytes = payload.BinaryPayload;
         if (bytes.Length < 4 || (bytes.Length % 4) != 0)
         {
             pixel = default;

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImport.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImport.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -119,13 +120,13 @@ internal static class ResoniteTextureImportFactory
             payload.Width.Value,
             payload.Height.Value,
             payload.ColorProfile,
-            payload.CopyBinaryPayloadToArray(),
+            payload.BinaryPayload.ToArray(),
             payload.Identity);
     }
 
     private static ResoniteRawTextureImport CreateRawFromEncodedPayload(ResoniteTexturePayload payload)
     {
-        using Stream stream = payload.BinaryPayload;
+        using MemoryStream stream = new(payload.BinaryPayload, writable: false);
         using Image<Rgba32> image = Image.Load<Rgba32>(stream);
         return CreateRawFromImageCore(
             image,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImport.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImport.cs
@@ -119,13 +119,13 @@ internal static class ResoniteTextureImportFactory
             payload.Width.Value,
             payload.Height.Value,
             payload.ColorProfile,
-            payload.BinaryPayload,
+            payload.CopyBinaryPayloadToArray(),
             payload.Identity);
     }
 
     private static ResoniteRawTextureImport CreateRawFromEncodedPayload(ResoniteTexturePayload payload)
     {
-        using MemoryStream stream = new(payload.BinaryPayload, writable: false);
+        using Stream stream = payload.BinaryPayload;
         using Image<Rgba32> image = Image.Load<Rgba32>(stream);
         return CreateRawFromImageCore(
             image,

--- a/tests/PlateauResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -409,14 +410,15 @@ public sealed class Lod2AtlasCityObjectBakerTests
 
         HashSet<Rgba32> atlasColors = [];
         int pixelCount = atlasPayload.Width.Value * atlasPayload.Height.Value;
+        byte[] atlasBytes = ReadAllBytes(atlasPayload.BinaryPayload);
         for (int pixelIndex = 0; pixelIndex < pixelCount; pixelIndex++)
         {
             int offset = pixelIndex * 4;
             atlasColors.Add(new Rgba32(
-                atlasPayload.BinaryPayload[offset],
-                atlasPayload.BinaryPayload[offset + 1],
-                atlasPayload.BinaryPayload[offset + 2],
-                atlasPayload.BinaryPayload[offset + 3]));
+                atlasBytes[offset],
+                atlasBytes[offset + 1],
+                atlasBytes[offset + 2],
+                atlasBytes[offset + 3]));
         }
 
         Assert.Contains(new Rgba32(255, 0, 0, 255), atlasColors);
@@ -673,11 +675,22 @@ public sealed class Lod2AtlasCityObjectBakerTests
         Assert.NotNull(payload.Width);
         int width = payload.Width.Value;
         int offset = ((y * width) + x) * 4;
+        byte[] bytes = ReadAllBytes(payload.BinaryPayload);
         return new Rgba32(
-            payload.BinaryPayload[offset],
-            payload.BinaryPayload[offset + 1],
-            payload.BinaryPayload[offset + 2],
-            payload.BinaryPayload[offset + 3]);
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3]);
+    }
+
+    private static byte[] ReadAllBytes(Stream stream)
+    {
+        using (stream)
+        {
+            using MemoryStream copy = new();
+            stream.CopyTo(copy);
+            return copy.ToArray();
+        }
     }
 
     private static ResoniteConstructionCityObject CreateLod2Building(

--- a/tests/PlateauResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -410,7 +409,7 @@ public sealed class Lod2AtlasCityObjectBakerTests
 
         HashSet<Rgba32> atlasColors = [];
         int pixelCount = atlasPayload.Width.Value * atlasPayload.Height.Value;
-        byte[] atlasBytes = ReadAllBytes(atlasPayload.BinaryPayload);
+        byte[] atlasBytes = atlasPayload.BinaryPayload;
         for (int pixelIndex = 0; pixelIndex < pixelCount; pixelIndex++)
         {
             int offset = pixelIndex * 4;
@@ -675,22 +674,12 @@ public sealed class Lod2AtlasCityObjectBakerTests
         Assert.NotNull(payload.Width);
         int width = payload.Width.Value;
         int offset = ((y * width) + x) * 4;
-        byte[] bytes = ReadAllBytes(payload.BinaryPayload);
+        byte[] bytes = payload.BinaryPayload;
         return new Rgba32(
             bytes[offset],
             bytes[offset + 1],
             bytes[offset + 2],
             bytes[offset + 3]);
-    }
-
-    private static byte[] ReadAllBytes(Stream stream)
-    {
-        using (stream)
-        {
-            using MemoryStream copy = new();
-            stream.CopyTo(copy);
-            return copy.ToArray();
-        }
     }
 
     private static ResoniteConstructionCityObject CreateLod2Building(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteTextureImportFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteTextureImportFactoryTests.cs
@@ -1,0 +1,25 @@
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class ResoniteTextureImportFactoryTests
+{
+    [Fact]
+    public void CreateRawFromPayloadCopiesRawRgbaBytes()
+    {
+        byte[] sourcePayloadBytes = [1, 2, 3, 4];
+        ResoniteTexturePayload payload = new(
+            1,
+            1,
+            ResoniteTextureColorProfiles.Srgb,
+            sourcePayloadBytes,
+            "dataset:texture",
+            ResoniteTexturePayloadFormat.RawRgba32);
+
+        ResoniteRawTextureImport import = ResoniteTextureImportFactory.CreateRawFromPayload(payload);
+        sourcePayloadBytes[0] = 99;
+
+        Assert.Equal<byte>([1, 2, 3, 4], import.RawRgba32Bytes);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -1,5 +1,3 @@
-using System.IO;
-
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
@@ -11,13 +9,14 @@ public sealed class SceneImportContractMapperTests
     [Fact]
     public void ToInternalMaterialBindingsPreservesNeutralContractFields()
     {
+        byte[] sourcePayloadBytes = [1, 2, 3, 4];
         MaterialBinding[] bindings =
         [
             new(
                 MaterialKey: "shared",
                 BaseColor: new ColorRgba(0.1, 0.2, 0.3, 0.4),
                 MaterialType: MaterialType.Standard,
-                TexturePayload: new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
+                TexturePayload: new TexturePayload(2, 2, "sRGB", sourcePayloadBytes, "dataset:texture", TexturePayloadFormat.EncodedImage),
                 TextureSourceKind: TextureSourceKind.Dataset,
                 Projection: MaterialProjection.Uv,
                 DepthOffset: new MaterialDepthOffset(-1.5, 2.5),
@@ -30,13 +29,14 @@ public sealed class SceneImportContractMapperTests
         ];
 
         ResoniteMaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToInternal(bindings));
+        sourcePayloadBytes[0] = 99;
 
         Assert.Equal("shared", mapped.MaterialKey);
         Assert.Equal(0.1, mapped.BaseColor.R, 9);
         Assert.Equal(0.2, mapped.BaseColor.G, 9);
         Assert.Equal("dataset:texture", mapped.TexturePayload!.Identity);
         Assert.Equal(ResoniteTexturePayloadFormat.EncodedImage, mapped.TexturePayload.Format);
-        Assert.Equal([1, 2, 3, 4], ReadAllBytes(mapped.TexturePayload.BinaryPayload));
+        Assert.Equal<byte>([1, 2, 3, 4], mapped.TexturePayload.BinaryPayload);
         Assert.Equal(-1.5, mapped.DepthOffset!.Factor, 9);
         Assert.Equal(2.5, mapped.DepthOffset.Units, 9);
         Assert.Equal(0.25, mapped.TextureScale!.X, 9);
@@ -97,7 +97,7 @@ public sealed class SceneImportContractMapperTests
     }
 
     [Fact]
-    public void ToContractMaterialBindingsExposesFreshReadablePayloadStream()
+    public void ToContractMaterialBindingsCopiesTexturePayloadBytes()
     {
         ResoniteMaterialBinding[] bindings =
         [
@@ -113,18 +113,8 @@ public sealed class SceneImportContractMapperTests
         ];
 
         MaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToContract(bindings));
+        bindings[0].TexturePayload!.BinaryPayload[0] = 42;
 
-        Assert.Equal([9, 8, 7, 6], ReadAllBytes(mapped.TexturePayload!.BinaryPayload));
-        Assert.Equal([9, 8, 7, 6], ReadAllBytes(mapped.TexturePayload.BinaryPayload));
-    }
-
-    private static byte[] ReadAllBytes(Stream stream)
-    {
-        using (stream)
-        {
-            using MemoryStream copy = new();
-            stream.CopyTo(copy);
-            return copy.ToArray();
-        }
+        Assert.Equal<byte>([9, 8, 7, 6], mapped.TexturePayload!.BinaryPayload);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
@@ -34,6 +36,7 @@ public sealed class SceneImportContractMapperTests
         Assert.Equal(0.2, mapped.BaseColor.G, 9);
         Assert.Equal("dataset:texture", mapped.TexturePayload!.Identity);
         Assert.Equal(ResoniteTexturePayloadFormat.EncodedImage, mapped.TexturePayload.Format);
+        Assert.Equal([1, 2, 3, 4], ReadAllBytes(mapped.TexturePayload.BinaryPayload));
         Assert.Equal(-1.5, mapped.DepthOffset!.Factor, 9);
         Assert.Equal(2.5, mapped.DepthOffset.Units, 9);
         Assert.Equal(0.25, mapped.TextureScale!.X, 9);
@@ -91,5 +94,37 @@ public sealed class SceneImportContractMapperTests
         Assert.Equal(3, geometry.Mesh.Vertices.Count);
         Assert.Equal("shared", Assert.Single(geometry.Mesh.Submeshes).MaterialKey);
         Assert.Equal("shared", Assert.Single(mapped.Materials).MaterialKey);
+    }
+
+    [Fact]
+    public void ToContractMaterialBindingsExposesFreshReadablePayloadStream()
+    {
+        ResoniteMaterialBinding[] bindings =
+        [
+            new(
+                MaterialKey: "shared",
+                BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                MaterialType: ResoniteMaterialType.Standard,
+                TexturePayload: new ResoniteTexturePayload(1, 1, "sRGB", [9, 8, 7, 6], "dataset:texture"),
+                TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                Projection: ResoniteMaterialProjection.Uv,
+                DepthOffset: null,
+                SubmeshIndices: [0]),
+        ];
+
+        MaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToContract(bindings));
+
+        Assert.Equal([9, 8, 7, 6], ReadAllBytes(mapped.TexturePayload!.BinaryPayload));
+        Assert.Equal([9, 8, 7, 6], ReadAllBytes(mapped.TexturePayload.BinaryPayload));
+    }
+
+    private static byte[] ReadAllBytes(Stream stream)
+    {
+        using (stream)
+        {
+            using MemoryStream copy = new();
+            stream.CopyTo(copy);
+            return copy.ToArray();
+        }
     }
 }


### PR DESCRIPTION
Implements #112 by changing texture payload interface contracts from byte arrays to readable streams while keeping target-edge decoding explicit.

- switch contract payload types to Stream-backed snapshots
- preserve fresh readable payload streams on each access
- adapt texture import and atlas bake callers
- add mapper and baker regression coverage