### PR TITLE
feat(bake): batch frn and tran atlases by grid cell

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -614,8 +614,12 @@ internal sealed class Lod2AtlasCityObjectBaker(
         string? sourceObjectKey = preservePrimaryIdentity
             ? firstCityObject.SourceObjectKey
             : CreateBatchSourceObjectKey(sourceUnitKey, batchIndex);
-        string? sourceUnitKeyValue = sourceUnitKey.SourceUnitKey ?? firstCityObject.SourceUnitKey;
-        string? sourceFileRelativePath = sourceUnitKey.SourceFileRelativePath ?? firstCityObject.SourceFileRelativePath;
+        string? sourceUnitKeyValue = preservePrimaryIdentity
+            ? firstCityObject.SourceUnitKey
+            : GetMergedSourceUnitKey(candidates);
+        string? sourceFileRelativePath = preservePrimaryIdentity
+            ? firstCityObject.SourceFileRelativePath
+            : GetMergedSourceFileRelativePath(candidates);
 
         ResoniteFloat3 bakeOrigin = ComputeBakeOrigin(candidates);
         List<ResoniteMeshVertex> vertices = [];
@@ -693,6 +697,28 @@ internal sealed class Lod2AtlasCityObjectBaker(
             SourceObjectKey: sourceObjectKey,
             SourceUnitKey: sourceUnitKeyValue,
             SourceFileRelativePath: sourceFileRelativePath);
+    }
+
+    private static string? GetMergedSourceUnitKey(IEnumerable<CityObjectBakeCandidate> candidates)
+    {
+        HashSet<string?> sourceUnitKeys = [];
+        foreach (CityObjectBakeCandidate candidate in candidates)
+        {
+            sourceUnitKeys.Add(candidate.CityObject.SourceUnitKey);
+        }
+
+        return sourceUnitKeys.Count == 1 ? sourceUnitKeys.Single() : null;
+    }
+
+    private static string? GetMergedSourceFileRelativePath(IEnumerable<CityObjectBakeCandidate> candidates)
+    {
+        HashSet<string?> sourceFileRelativePaths = [];
+        foreach (CityObjectBakeCandidate candidate in candidates)
+        {
+            sourceFileRelativePaths.Add(candidate.CityObject.SourceFileRelativePath);
+        }
+
+        return sourceFileRelativePaths.Count == 1 ? sourceFileRelativePaths.Single() : null;
     }
 
     private static void AppendPlacementGeometry(
@@ -1152,20 +1178,41 @@ internal sealed class Lod2AtlasCityObjectBaker(
         Lod2AtlasCityObjectBakePolicy policy)
     {
         string context = policy.Name;
-        string sourceUnitKey = cityObject.SourceUnitKey ?? string.Empty;
-        string sourceFileRelativePath = cityObject.SourceFileRelativePath ?? string.Empty;
-        string sourceUnitIdentity = string.Create(
-            CultureInfo.InvariantCulture,
-            $"{cityObject.ActualMeshCode}|{cityObject.PackageName}|{cityObject.LodLevel?.ToString(CultureInfo.InvariantCulture) ?? "none"}|{sourceUnitKey}|{sourceFileRelativePath}");
+        string batchScopeIdentity = CreateBatchScopeIdentity(cityObject, policy);
+        string? sourceUnitKey = policy.EnableGridPassThrough ? null : cityObject.SourceUnitKey;
+        string? sourceFileRelativePath = policy.EnableGridPassThrough ? null : cityObject.SourceFileRelativePath;
 
         return new SourceUnitBatchKey(
             cityObject.ActualMeshCode,
             cityObject.PackageName,
             cityObject.LodLevel,
-            sourceUnitIdentity,
+            batchScopeIdentity,
             context,
-            SourceUnitKey: cityObject.SourceUnitKey,
-            SourceFileRelativePath: cityObject.SourceFileRelativePath);
+            SourceUnitKey: sourceUnitKey,
+            SourceFileRelativePath: sourceFileRelativePath);
+    }
+
+    private static string CreateBatchScopeIdentity(
+        ResoniteConstructionCityObject cityObject,
+        Lod2AtlasCityObjectBakePolicy policy)
+    {
+        if (!policy.EnableGridPassThrough)
+        {
+            string sourceUnitKey = cityObject.SourceUnitKey ?? string.Empty;
+            string sourceFileRelativePath = cityObject.SourceFileRelativePath ?? string.Empty;
+            return string.Create(
+                CultureInfo.InvariantCulture,
+                $"{cityObject.ActualMeshCode}|{cityObject.PackageName}|{cityObject.LodLevel?.ToString(CultureInfo.InvariantCulture) ?? "none"}|{sourceUnitKey}|{sourceFileRelativePath}");
+        }
+
+        int cellX = GetGridCellCoordinate(cityObject.Transform.Position.X, policy.PassThroughGridCellSizeMeters);
+        int cellZ = GetGridCellCoordinate(cityObject.Transform.Position.Z, policy.PassThroughGridCellSizeMeters);
+        return string.Create(CultureInfo.InvariantCulture, $"grid|{cellX}|{cellZ}");
+    }
+
+    private static int GetGridCellCoordinate(double coordinate, int cellSizeMeters)
+    {
+        return (int)Math.Floor(coordinate / cellSizeMeters);
     }
 
     private static string CreateBatchSlotKey(SourceUnitBatchKey sourceUnitKey, int batchIndex)

--- a/tests/PlateauResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -509,6 +509,50 @@ public sealed class Lod2AtlasCityObjectBakerTests
     }
 
     [Fact]
+    public async Task FlushAllAsyncMergesTranSourceUnitsWithinSameGridCell()
+    {
+        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 1);
+
+        await AssertBufferedAsync(baker, CreateLod2Building("tran-a", CreatePayload("textures/tran-a.png", new Rgba32(255, 0, 0, 255), 4, 4), 0, "unit-a") with
+        {
+            PackageName = "tran",
+        });
+        await AssertBufferedAsync(baker, CreateLod2Building("tran-b", CreatePayload("textures/tran-b.png", new Rgba32(0, 255, 0, 255), 4, 4), 8, "unit-b") with
+        {
+            PackageName = "tran",
+        });
+
+        ResoniteConstructionCityObject baked = Assert.Single(await baker.FlushAllAsync());
+
+        Assert.Equal("tran", baked.PackageName);
+        Assert.Null(baked.SourceUnitKey);
+        Assert.Null(baked.SourceFileRelativePath);
+        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(Assert.Single(baked.Materials).TexturePayload);
+        Assert.StartsWith("atlas-batch-", atlasPayload.Identity, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FlushAllAsyncKeepsTranSourceUnitsInSeparateGridCells()
+    {
+        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 1);
+
+        await AssertBufferedAsync(baker, CreateLod2Building("tran-a", CreatePayload("textures/tran-a.png", new Rgba32(255, 0, 0, 255), 4, 4), 0, "unit-a") with
+        {
+            PackageName = "tran",
+        });
+        await AssertBufferedAsync(baker, CreateLod2Building("tran-b", CreatePayload("textures/tran-b.png", new Rgba32(0, 255, 0, 255), 4, 4), 256, "unit-b") with
+        {
+            PackageName = "tran",
+        });
+
+        IReadOnlyList<ResoniteConstructionCityObject> baked = await baker.FlushAllAsync();
+
+        Assert.Equal(2, baked.Count);
+        Assert.Contains(baked, static cityObject => cityObject.SourceUnitKey == "unit-a" && cityObject.SourceFileRelativePath == "unit-a.gml");
+        Assert.Contains(baked, static cityObject => cityObject.SourceUnitKey == "unit-b" && cityObject.SourceFileRelativePath == "unit-b.gml");
+    }
+
+    [Fact]
     public async Task TryBufferAsyncSkipsOtherNonBuildingLod2CityObjects()
     {
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 1);


### PR DESCRIPTION
Implements #121 by grouping frn/tran atlas batches by grid pass-through scope instead of strict source-unit boundaries.

- keep building batching unchanged
- merge tran source units within one grid cell
- preserve separation across grid cells
- add focused atlas bake regression coverage