### PR TITLE
feat(materials): align facade UV scaling to floor-square units

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -2108,7 +2108,19 @@ internal static partial class LocalCityGmlObjectProjection
             return null;
         }
 
-        return new SurfaceUvProjection(surfaceAxes.AxisU, surfaceAxes.AxisV);
+        return new SurfaceUvProjection(
+            surfaceAxes.AxisU,
+            surfaceAxes.AxisV,
+            ResolveGeneratedSurfaceUvScale(packageName));
+    }
+
+    private static ResoniteFloat2 ResolveGeneratedSurfaceUvScale(string packageName)
+    {
+        return IsBuildingPackage(packageName)
+            ? new ResoniteFloat2(
+                FacadeMaterialUvScaling.ToFloorSquareUnits(1.0),
+                FacadeMaterialUvScaling.ToFloorSquareUnits(1.0))
+            : new ResoniteFloat2(1.0, 1.0);
     }
 
     private static Float2 CreateGeneratedSurfaceUv(

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -2110,14 +2110,7 @@ internal static partial class LocalCityGmlObjectProjection
 
         return new SurfaceUvProjection(
             surfaceAxes.AxisU,
-            surfaceAxes.AxisV,
-            ResolveGeneratedSurfaceUvScale(packageName));
-    }
-
-    private static ResoniteFloat2 ResolveGeneratedSurfaceUvScale(string packageName)
-    {
-        _ = packageName;
-        return new ResoniteFloat2(1.0, 1.0);
+            surfaceAxes.AxisV);
     }
 
     private static Float2 CreateGeneratedSurfaceUv(

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -2116,11 +2116,8 @@ internal static partial class LocalCityGmlObjectProjection
 
     private static ResoniteFloat2 ResolveGeneratedSurfaceUvScale(string packageName)
     {
-        return IsBuildingPackage(packageName)
-            ? new ResoniteFloat2(
-                FacadeMaterialUvScaling.ToFloorSquareUnits(1.0),
-                FacadeMaterialUvScaling.ToFloorSquareUnits(1.0))
-            : new ResoniteFloat2(1.0, 1.0);
+        _ = packageName;
+        return new ResoniteFloat2(1.0, 1.0);
     }
 
     private static Float2 CreateGeneratedSurfaceUv(

--- a/src/PlateauResoniteLink/Domain/Importing/BundledDefaultMaterialProfiles.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/BundledDefaultMaterialProfiles.cs
@@ -2,10 +2,10 @@ namespace PlateauResoniteLink.Domain.Importing;
 
 public static class BundledDefaultMaterialProfiles
 {
-    public static readonly ScalarPair FacadeDefaultTilesPerMeterValue = CreateTilesPerMeterValue(13.0, 13.0);
-    public static readonly ScalarPair Facade018ATilesPerMeterValue = CreateTilesPerMeterValue(13.0, 13.0);
-    public static readonly ScalarPair Facade019ATilesPerMeterValue = CreateTilesPerMeterValue(13.0, 13.0);
-    public static readonly ScalarPair Facade020ATilesPerMeterValue = CreateTilesPerMeterValue(13.0, 13.0);
+    public static readonly ScalarPair FacadeDefaultTilesPerMeterValue = FacadeMaterialUvScaling.CommonMaterialScaleValue;
+    public static readonly ScalarPair Facade018ATilesPerMeterValue = FacadeMaterialUvScaling.CommonMaterialScaleValue;
+    public static readonly ScalarPair Facade019ATilesPerMeterValue = FacadeMaterialUvScaling.CommonMaterialScaleValue;
+    public static readonly ScalarPair Facade020ATilesPerMeterValue = FacadeMaterialUvScaling.CommonMaterialScaleValue;
     public static readonly ScalarPair ConcreteDefaultTilesPerMeterValue = BundledDefaultMaterialTiling.DefaultTilesPerMeterValue;
     public static readonly ScalarPair RoofingTiles012ATilesPerMeterValue = CreateTilesPerMeterValue(2.9, 2.9);
     public static readonly ScalarPair RoofingTiles014BTilesPerMeterValue = CreateTilesPerMeterValue(2.9, 2.9);

--- a/src/PlateauResoniteLink/Domain/Importing/FacadeMaterialUvScaling.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/FacadeMaterialUvScaling.cs
@@ -1,0 +1,19 @@
+namespace PlateauResoniteLink.Domain.Importing;
+
+public static class FacadeMaterialUvScaling
+{
+    public const double FloorSquareMeters = 3.25;
+
+    public static readonly ScalarPair CommonMaterialScaleValue = new(
+        ToFloorSquareUnits(1.0),
+        ToFloorSquareUnits(1.0));
+
+    public static readonly ResoniteFloat2 CommonMaterialScale = new(
+        CommonMaterialScaleValue.X,
+        CommonMaterialScaleValue.Y);
+
+    public static double ToFloorSquareUnits(double meters)
+    {
+        return meters / FloorSquareMeters;
+    }
+}

--- a/src/PlateauResoniteLink/Domain/Importing/FacadeMaterialUvScaling.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/FacadeMaterialUvScaling.cs
@@ -8,10 +8,6 @@ public static class FacadeMaterialUvScaling
         ToFloorSquareUnits(1.0),
         ToFloorSquareUnits(1.0));
 
-    public static readonly ResoniteFloat2 CommonMaterialScale = new(
-        CommonMaterialScaleValue.X,
-        CommonMaterialScaleValue.Y);
-
     public static double ToFloorSquareUnits(double meters)
     {
         return meters / FloorSquareMeters;

--- a/tests/PlateauResoniteLink.Tests/Profiles/CommonMaterialCatalogTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CommonMaterialCatalogTests.cs
@@ -46,13 +46,13 @@ public sealed class CommonMaterialCatalogTests
 
         Assert.Equal(
             new Float2(
-                FacadeMaterialUvScaling.CommonMaterialScale.X,
-                FacadeMaterialUvScaling.CommonMaterialScale.Y),
+                FacadeMaterialUvScaling.CommonMaterialScaleValue.X,
+                FacadeMaterialUvScaling.CommonMaterialScaleValue.Y),
             facadeMaterial.TextureScale);
         Assert.Equal(
             new Float2(
-                BundledDefaultMaterialProfiles.ConcreteDefaultTilesPerMeter.X,
-                BundledDefaultMaterialProfiles.ConcreteDefaultTilesPerMeter.Y),
+                BundledDefaultMaterialProfiles.ConcreteDefaultTilesPerMeterValue.X,
+                BundledDefaultMaterialProfiles.ConcreteDefaultTilesPerMeterValue.Y),
             roofMaterial.TextureScale);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/CommonMaterialCatalogTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CommonMaterialCatalogTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 
 using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Profiles;
@@ -25,6 +26,34 @@ public sealed class CommonMaterialCatalogTests
             material => material.MaterialKey == ResoniteMaterialSharing.CreateCanonicalVertexColorCommonMaterialKey(
                 ResoniteMaterialProjection.Uv,
                 depthOffset: null));
+    }
+
+    [Fact]
+    public void CreateForPackages_UsesFacadeFloorSquareScaleForBundledFacadeCommonMaterials()
+    {
+        IReadOnlyList<MaterialBinding> materials = new CommonMaterialCatalog().CreateForPackages(["bldg"]);
+
+        MaterialBinding facadeMaterial = Assert.Single(
+            materials,
+            material => material.Family == BundledDefaultMaterialFamilies.Facade
+                && material.Projection == MaterialProjection.Uv
+                && material.BundledVariantIndex == 0);
+        MaterialBinding roofMaterial = Assert.Single(
+            materials,
+            material => material.Family == BundledDefaultMaterialFamilies.Roof
+                && material.Projection == MaterialProjection.Triplanar
+                && material.BundledVariantIndex == 0);
+
+        Assert.Equal(
+            new Float2(
+                FacadeMaterialUvScaling.CommonMaterialScale.X,
+                FacadeMaterialUvScaling.CommonMaterialScale.Y),
+            facadeMaterial.TextureScale);
+        Assert.Equal(
+            new Float2(
+                BundledDefaultMaterialProfiles.ConcreteDefaultTilesPerMeter.X,
+                BundledDefaultMaterialProfiles.ConcreteDefaultTilesPerMeter.Y),
+            roofMaterial.TextureScale);
     }
 
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
@@ -44,8 +44,8 @@ public sealed class DefaultMaterialResolverTests
         Assert.Equal(BundledDefaultMaterialFamilies.Facade, material.Family);
         Assert.Equal(
             new Float2(
-                FacadeMaterialUvScaling.CommonMaterialScale.X,
-                FacadeMaterialUvScaling.CommonMaterialScale.Y),
+                FacadeMaterialUvScaling.CommonMaterialScaleValue.X,
+                FacadeMaterialUvScaling.CommonMaterialScaleValue.Y),
             material.TextureScale);
         Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
     }

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
@@ -42,7 +42,11 @@ public sealed class DefaultMaterialResolverTests
         Assert.Equal(TextureSourceKind.Bundled, material.TextureSourceKind);
         Assert.Equal(MaterialProjection.Uv, material.Projection);
         Assert.Equal(BundledDefaultMaterialFamilies.Facade, material.Family);
-        Assert.NotNull(material.TextureScale);
+        Assert.Equal(
+            new Float2(
+                FacadeMaterialUvScaling.CommonMaterialScale.X,
+                FacadeMaterialUvScaling.CommonMaterialScale.Y),
+            material.TextureScale);
         Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -17,6 +17,7 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Tests.Profiles;
 
+[SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test names describe contract cases.")]
 public sealed class LocalCityGmlObjectProjectionTests
 {
     private static readonly HttpClient SharedDatasetSourceResolverHttpClient = new();
@@ -96,6 +97,45 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.Contains("bldg", source.Metadata.SourceDataset.PackageNames);
         Assert.Contains("53394525", source.Metadata.SourceDataset.SelectedMeshCodes!);
         Assert.NotEmpty(source.Metadata.SourceDataset.SourceFiles);
+    }
+
+    [Fact]
+    public void GeneratedFacadeUvProjection_UsesWorldMeterUnitsForBuildingWalls()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = new(35.0, 139.0, 0.0);
+        GeographicLib.LocalCartesian cartesian = new(
+            origin.Latitude,
+            origin.Longitude,
+            origin.Altitude,
+            referenceSystem.Geocentric);
+        double longitudeDelta = FacadeMaterialUvScaling.FloorSquareMeters
+            / (111320.0 * Math.Cos(origin.Latitude * (Math.PI / 180.0)));
+        LocalCityGmlObjectProjection.GeodeticPoint[] wallVertices =
+        [
+            origin,
+            new(origin.Latitude, origin.Longitude + longitudeDelta, 0.0),
+            new(origin.Latitude, origin.Longitude + longitudeDelta, FacadeMaterialUvScaling.FloorSquareMeters),
+            new(origin.Latitude, origin.Longitude, FacadeMaterialUvScaling.FloorSquareMeters),
+        ];
+        LocalCityGmlObjectProjection.ParsedSurface wallSurface = CreateParsedSurface(
+            "wall",
+            LocalCityGmlObjectProjection.ParsedSurfaceSemantic.Wall,
+            [.. wallVertices, wallVertices[0]]);
+
+        object projection = CreateGeneratedSurfaceUvProjectionForTest(wallSurface, "bldg", origin, cartesian);
+        Float2 uvOrigin = CreateGeneratedSurfaceUvForTest(origin, origin, cartesian, projection);
+        Float2 uvHorizontal = CreateGeneratedSurfaceUvForTest(wallVertices[1], origin, cartesian, projection);
+        Float2 uvVertical = CreateGeneratedSurfaceUvForTest(wallVertices[3], origin, cartesian, projection);
+
+        Assert.InRange(
+            Math.Abs(uvHorizontal.X - uvOrigin.X),
+            FacadeMaterialUvScaling.FloorSquareMeters - 0.05,
+            FacadeMaterialUvScaling.FloorSquareMeters + 0.05);
+        Assert.InRange(
+            Math.Abs(uvVertical.Y - uvOrigin.Y),
+            FacadeMaterialUvScaling.FloorSquareMeters - 0.05,
+            FacadeMaterialUvScaling.FloorSquareMeters + 0.05);
     }
 
     [Fact]
@@ -936,6 +976,46 @@ public sealed class LocalCityGmlObjectProjectionTests
         return (ImportedCityObject[])method.Invoke(null, [cityObjects])!;
     }
 
+    private static object CreateGeneratedSurfaceUvProjectionForTest(
+        LocalCityGmlObjectProjection.ParsedSurface surface,
+        string packageName,
+        LocalCityGmlObjectProjection.GeodeticPoint cityObjectOrigin,
+        GeographicLib.LocalCartesian cartesian)
+    {
+        MethodInfo method = typeof(LocalCityGmlObjectProjection).GetMethod(
+                "CreateGeneratedSurfaceUvProjection",
+                BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("Failed to resolve CreateGeneratedSurfaceUvProjection.");
+        return method.Invoke(null, [surface, packageName, cityObjectOrigin, cartesian])!
+            ?? throw new InvalidOperationException("CreateGeneratedSurfaceUvProjection returned null.");
+    }
+
+    private static ResoniteFloat2 CreateGeneratedSurfaceUvForTest(
+        LocalCityGmlObjectProjection.GeodeticPoint point,
+        LocalCityGmlObjectProjection.GeodeticPoint cityObjectOrigin,
+        GeographicLib.LocalCartesian cartesian,
+        object projection)
+    {
+        MethodInfo method = typeof(LocalCityGmlObjectProjection).GetMethod(
+                "CreateGeneratedSurfaceUv",
+                BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("Failed to resolve CreateGeneratedSurfaceUv.");
+        return (Float2)method.Invoke(null, [point, cityObjectOrigin, cartesian, projection])!;
+    }
+
+    private static LocalCityGmlObjectProjection.ParsedSurface CreateParsedSurface(
+        string polygonId,
+        LocalCityGmlObjectProjection.ParsedSurfaceSemantic semantic,
+        IReadOnlyList<LocalCityGmlObjectProjection.GeodeticPoint> vertices)
+    {
+        return new LocalCityGmlObjectProjection.ParsedSurface(
+            polygonId,
+            semantic,
+            new LocalCityGmlObjectProjection.ParsedRing($"{polygonId}-ring", vertices.ToArray(), null),
+            [],
+            new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null);
+    }
     private static ImportedCityObject CreateHeightMapCityObject(
         string slotKey,
         Float3 position,

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -989,7 +989,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             ?? throw new InvalidOperationException("CreateGeneratedSurfaceUvProjection returned null.");
     }
 
-    private static ResoniteFloat2 CreateGeneratedSurfaceUvForTest(
+    private static Float2 CreateGeneratedSurfaceUvForTest(
         LocalCityGmlObjectProjection.GeodeticPoint point,
         LocalCityGmlObjectProjection.GeodeticPoint cityObjectOrigin,
         GeographicLib.LocalCartesian cartesian,

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -98,7 +98,6 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.Contains("53394525", source.Metadata.SourceDataset.SelectedMeshCodes!);
         Assert.NotEmpty(source.Metadata.SourceDataset.SourceFiles);
     }
-
     [Fact]
     public void GeneratedFacadeUvProjection_UsesWorldMeterUnitsForBuildingWalls()
     {

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
@@ -118,8 +118,8 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
         Assert.Null(bundledMaterial.TextureScale);
         Assert.Null(bundledMaterial.TextureOffset);
         Assert.Equal(new ResoniteFloat2(0.0, 0.0), normalized.Mesh.Vertices[3].UV0);
-        Assert.Equal(new ResoniteFloat2(13.0, 0.0), normalized.Mesh.Vertices[4].UV0);
-        Assert.Equal(new ResoniteFloat2(0.0, 13.0), normalized.Mesh.Vertices[5].UV0);
+        Assert.Equal(new ResoniteFloat2(3.25, 0.0), normalized.Mesh.Vertices[4].UV0);
+        Assert.Equal(new ResoniteFloat2(0.0, 3.25), normalized.Mesh.Vertices[5].UV0);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -897,9 +897,9 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.Equal((float)BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.Y, textureScale.Value.y, 6);
         Assert.Equal(0.0f, textureOffset.Value.x, 6);
         Assert.Equal(0.0f, textureOffset.Value.y, 6);
-        float expectedUvScale = (float)(0.5 / BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter.X);
-        float expectedUvOffsetX = (float)(0.125 / BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter.X);
-        float expectedUvOffsetY = (float)(0.25 / BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter.Y);
+        float expectedUvScale = (float)(0.5 / BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.X);
+        float expectedUvOffsetX = (float)(0.125 / BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.X);
+        float expectedUvOffsetY = (float)(0.25 / BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.Y);
         Assert.Equal(expectedUvOffsetX, importedMesh.AccessUV_2D(0)[0].x, 6);
         Assert.Equal(expectedUvOffsetY, importedMesh.AccessUV_2D(0)[0].y, 6);
         Assert.Equal(expectedUvOffsetX + expectedUvScale, importedMesh.AccessUV_2D(0)[1].x, 6);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -819,12 +819,13 @@ public sealed class ResoniteLiveSceneImportTargetTests
             StringComparison.Ordinal);
         Assert.Equal((float)BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.X, textureScale.Value.x, 6);
         Assert.Equal((float)BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.Y, textureScale.Value.y, 6);
+        float expectedUvScale = (float)(0.5 / BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.X);
         Assert.Equal(0.0f, importedMesh.AccessUV_2D(0)[0].x, 6);
         Assert.Equal(0.0f, importedMesh.AccessUV_2D(0)[0].y, 6);
-        Assert.Equal(6.5f, importedMesh.AccessUV_2D(0)[1].x, 6);
+        Assert.Equal(expectedUvScale, importedMesh.AccessUV_2D(0)[1].x, 6);
         Assert.Equal(0.0f, importedMesh.AccessUV_2D(0)[1].y, 6);
         Assert.Equal(0.0f, importedMesh.AccessUV_2D(0)[2].x, 6);
-        Assert.Equal(6.5f, importedMesh.AccessUV_2D(0)[2].y, 6);
+        Assert.Equal(expectedUvScale, importedMesh.AccessUV_2D(0)[2].y, 6);
     }
 
     [Fact]
@@ -896,12 +897,15 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.Equal((float)BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.Y, textureScale.Value.y, 6);
         Assert.Equal(0.0f, textureOffset.Value.x, 6);
         Assert.Equal(0.0f, textureOffset.Value.y, 6);
-        Assert.Equal(1.625f, importedMesh.AccessUV_2D(0)[0].x, 6);
-        Assert.Equal(3.25f, importedMesh.AccessUV_2D(0)[0].y, 6);
-        Assert.Equal(8.125f, importedMesh.AccessUV_2D(0)[1].x, 6);
-        Assert.Equal(3.25f, importedMesh.AccessUV_2D(0)[1].y, 6);
-        Assert.Equal(1.625f, importedMesh.AccessUV_2D(0)[2].x, 6);
-        Assert.Equal(9.75f, importedMesh.AccessUV_2D(0)[2].y, 6);
+        float expectedUvScale = (float)(0.5 / BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter.X);
+        float expectedUvOffsetX = (float)(0.125 / BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter.X);
+        float expectedUvOffsetY = (float)(0.25 / BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter.Y);
+        Assert.Equal(expectedUvOffsetX, importedMesh.AccessUV_2D(0)[0].x, 6);
+        Assert.Equal(expectedUvOffsetY, importedMesh.AccessUV_2D(0)[0].y, 6);
+        Assert.Equal(expectedUvOffsetX + expectedUvScale, importedMesh.AccessUV_2D(0)[1].x, 6);
+        Assert.Equal(expectedUvOffsetY, importedMesh.AccessUV_2D(0)[1].y, 6);
+        Assert.Equal(expectedUvOffsetX, importedMesh.AccessUV_2D(0)[2].x, 6);
+        Assert.Equal(expectedUvOffsetY + expectedUvScale, importedMesh.AccessUV_2D(0)[2].y, 6);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -54,7 +54,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
     public void CreateMaterialSlotName_ForCommonMaterial_UsesStableSharedDiscriminators()
     {
         ResoniteMaterialBinding material = new(
-            MaterialKey: "common|facade|variant:0|Uv|scale:13x13",
+            MaterialKey: "common|facade|variant:0|Uv|scale:0.307692x0.307692",
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
             TexturePayload: null,


### PR DESCRIPTION
Implements #84 under the current boundary split between generated mesh UVs and bundled common facade materials.

- define facade floor-square UV scaling
- apply the shared scale to bundled facade common materials
- scale generated building facade UVs in floor units
- update material and live-target regression coverage