### PR TITLE
feat(target): separate placement correction layers

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePlacementCorrection.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePlacementCorrection.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal enum ResoniteCorrectionAxis

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePlacementCorrection.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePlacementCorrection.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal enum ResoniteCorrectionAxis
+{
+    X,
+    Y,
+    Z,
+}
+
+internal enum ResonitePlacementCorrectionReason
+{
+    RequestRelativeMeshCodeOffset,
+    ObservedRootHeight,
+}
+
+internal readonly record struct ResonitePlacementCorrectionTerm(
+    ResoniteCorrectionAxis Axis,
+    double Value,
+    ResonitePlacementCorrectionReason Reason);
+
+internal sealed record ResonitePlacementCorrectionLayers(
+    IReadOnlyList<ResonitePlacementCorrectionTerm> Source,
+    IReadOnlyList<ResonitePlacementCorrectionTerm> Import,
+    IReadOnlyList<ResonitePlacementCorrectionTerm> Placement,
+    IReadOnlyList<ResonitePlacementCorrectionTerm> PostPlacement)
+{
+    public static ResonitePlacementCorrectionLayers Empty { get; } = new([], [], [], []);
+}
+
+internal sealed record ResonitePlacementCorrectionResult(
+    ResoniteFloat3 CorrectedRootPosition,
+    ResonitePlacementCorrectionLayers Layers)
+{
+    public ResoniteFloat3 ResolveCityObjectLocalPosition(ResoniteFloat3 cityObjectPosition)
+    {
+        return ResonitePlacementPolicy.Subtract(cityObjectPosition, CorrectedRootPosition);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePlacementPolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePlacementPolicy.cs
@@ -137,7 +137,9 @@ internal static class ResonitePlacementPolicy
                 cityObjectPosition.Z);
         }
 
-        ResoniteFloat3 rootOffsetFromRequest = ComputeOriginOffset(requestOrigin, rootMeshCenter);
+        ResoniteFloat3 rootOffsetFromRequest = ComputeOriginOffset(
+            new GeodeticCoordinate(requestOrigin.Latitude, requestOrigin.Longitude, requestOrigin.Altitude),
+            rootMeshCenter);
         ResoniteFloat3 rootPosition = new(
             rootOffsetFromRequest.X,
             observedRootPosition?.Y ?? rootOffsetFromRequest.Y,
@@ -180,7 +182,9 @@ internal static class ResonitePlacementPolicy
                     postPlacementTerms));
         }
 
-        ResoniteFloat3 rootOffsetFromRequest = ComputeOriginOffset(requestOrigin, rootMeshCenter);
+        ResoniteFloat3 rootOffsetFromRequest = ComputeOriginOffset(
+            new GeodeticCoordinate(requestOrigin.Latitude, requestOrigin.Longitude, requestOrigin.Altitude),
+            rootMeshCenter);
         placementTerms.Add(new ResonitePlacementCorrectionTerm(
             ResoniteCorrectionAxis.X,
             rootOffsetFromRequest.X,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePlacementPolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePlacementPolicy.cs
@@ -131,12 +131,13 @@ internal static class ResonitePlacementPolicy
     {
         if (!PlateauMeshCode.TryGetGeodeticCenter(rootMeshCode, out GeodeticCoordinate rootMeshCenter))
         {
-            return cityObjectPosition;
+            return new ResoniteFloat3(
+                cityObjectPosition.X,
+                cityObjectPosition.Y - (observedRootPosition?.Y ?? 0.0),
+                cityObjectPosition.Z);
         }
 
-        ResoniteFloat3 rootOffsetFromRequest = ComputeOriginOffset(
-            new GeodeticCoordinate(requestOrigin.Latitude, requestOrigin.Longitude, requestOrigin.Altitude),
-            rootMeshCenter);
+        ResoniteFloat3 rootOffsetFromRequest = ComputeOriginOffset(requestOrigin, rootMeshCenter);
         ResoniteFloat3 rootPosition = new(
             rootOffsetFromRequest.X,
             observedRootPosition?.Y ?? rootOffsetFromRequest.Y,
@@ -149,18 +150,64 @@ internal static class ResonitePlacementPolicy
         string rootMeshCode,
         double? observedRootHeight = null)
     {
+        return EvaluateRootPlacementCorrection(requestOrigin, rootMeshCode, observedRootHeight).CorrectedRootPosition;
+    }
+
+    public static ResonitePlacementCorrectionResult EvaluateRootPlacementCorrection(
+        ResoniteLocalOrigin requestOrigin,
+        string rootMeshCode,
+        double? observedRootHeight = null)
+    {
+        List<ResonitePlacementCorrectionTerm> placementTerms = [];
+        List<ResonitePlacementCorrectionTerm> postPlacementTerms = [];
+
         if (!PlateauMeshCode.TryGetGeodeticCenter(rootMeshCode, out GeodeticCoordinate rootMeshCenter))
         {
-            return new ResoniteFloat3(0.0, observedRootHeight ?? 0.0, 0.0);
+            if (observedRootHeight.HasValue)
+            {
+                postPlacementTerms.Add(new ResonitePlacementCorrectionTerm(
+                    ResoniteCorrectionAxis.Y,
+                    observedRootHeight.Value,
+                    ResonitePlacementCorrectionReason.ObservedRootHeight));
+            }
+
+            return new ResonitePlacementCorrectionResult(
+                new ResoniteFloat3(0.0, observedRootHeight ?? 0.0, 0.0),
+                new ResonitePlacementCorrectionLayers(
+                    [],
+                    [],
+                    placementTerms,
+                    postPlacementTerms));
         }
 
-        ResoniteFloat3 rootOffsetFromRequest = ComputeOriginOffset(
-            new GeodeticCoordinate(requestOrigin.Latitude, requestOrigin.Longitude, requestOrigin.Altitude),
-            rootMeshCenter);
-        return new ResoniteFloat3(
+        ResoniteFloat3 rootOffsetFromRequest = ComputeOriginOffset(requestOrigin, rootMeshCenter);
+        placementTerms.Add(new ResonitePlacementCorrectionTerm(
+            ResoniteCorrectionAxis.X,
+            rootOffsetFromRequest.X,
+            ResonitePlacementCorrectionReason.RequestRelativeMeshCodeOffset));
+        placementTerms.Add(new ResonitePlacementCorrectionTerm(
+            ResoniteCorrectionAxis.Z,
+            rootOffsetFromRequest.Z,
+            ResonitePlacementCorrectionReason.RequestRelativeMeshCodeOffset));
+
+        if (observedRootHeight.HasValue)
+        {
+            postPlacementTerms.Add(new ResonitePlacementCorrectionTerm(
+                ResoniteCorrectionAxis.Y,
+                observedRootHeight.Value,
+                ResonitePlacementCorrectionReason.ObservedRootHeight));
+        }
+
+        return new ResonitePlacementCorrectionResult(
+            new ResoniteFloat3(
             rootOffsetFromRequest.X,
             observedRootHeight ?? rootOffsetFromRequest.Y,
-            rootOffsetFromRequest.Z);
+            rootOffsetFromRequest.Z),
+            new ResonitePlacementCorrectionLayers(
+                [],
+                [],
+                placementTerms,
+                postPlacementTerms));
     }
 
     public static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePlacementPolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePlacementPolicy.cs
@@ -152,7 +152,18 @@ internal static class ResonitePlacementPolicy
         string rootMeshCode,
         double? observedRootHeight = null)
     {
-        return EvaluateRootPlacementCorrection(requestOrigin, rootMeshCode, observedRootHeight).CorrectedRootPosition;
+        if (!PlateauMeshCode.TryGetGeodeticCenter(rootMeshCode, out GeodeticCoordinate rootMeshCenter))
+        {
+            return new ResoniteFloat3(0.0, observedRootHeight ?? 0.0, 0.0);
+        }
+
+        ResoniteFloat3 rootOffsetFromRequest = ComputeOriginOffset(
+            new GeodeticCoordinate(requestOrigin.Latitude, requestOrigin.Longitude, requestOrigin.Altitude),
+            rootMeshCenter);
+        return new ResoniteFloat3(
+            rootOffsetFromRequest.X,
+            observedRootHeight ?? rootOffsetFromRequest.Y,
+            rootOffsetFromRequest.Z);
     }
 
     public static ResonitePlacementCorrectionResult EvaluateRootPlacementCorrection(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResonitePlacementPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResonitePlacementPolicyTests.cs
@@ -43,6 +43,55 @@ public sealed class ResonitePlacementPolicyTests
     }
 
     [Fact]
+    public void EvaluateRootPlacementCorrection_SplitsPlacementAndPostPlacementLayers()
+    {
+        PlateauResoniteLink.Domain.Importing.ResoniteLocalOrigin requestOrigin = RequireMeshCodeCenter("53394535");
+        PlateauResoniteLink.Domain.Importing.ResoniteLocalOrigin rootOrigin = RequireMeshCodeCenter("53394525");
+
+        PlateauResoniteLink.Targets.Resonite.ResonitePlacementCorrectionResult correction =
+            PlateauResoniteLink.Targets.Resonite.ResonitePlacementPolicy.EvaluateRootPlacementCorrection(
+                requestOrigin,
+                "53394525",
+                observedRootHeight: 5.0);
+        PlateauResoniteLink.Domain.Importing.ResoniteFloat3 expectedOffset =
+            PlateauResoniteLink.Targets.Resonite.ResonitePlacementPolicy.ComputeOriginOffset(requestOrigin, rootOrigin);
+
+        Assert.Empty(correction.Layers.Source);
+        Assert.Empty(correction.Layers.Import);
+        Assert.Collection(
+            correction.Layers.Placement,
+            term =>
+            {
+                Assert.Equal(PlateauResoniteLink.Targets.Resonite.ResoniteCorrectionAxis.X, term.Axis);
+                Assert.Equal(expectedOffset.X, term.Value, 6);
+                Assert.Equal(
+                    PlateauResoniteLink.Targets.Resonite.ResonitePlacementCorrectionReason.RequestRelativeMeshCodeOffset,
+                    term.Reason);
+            },
+            term =>
+            {
+                Assert.Equal(PlateauResoniteLink.Targets.Resonite.ResoniteCorrectionAxis.Z, term.Axis);
+                Assert.Equal(expectedOffset.Z, term.Value, 6);
+                Assert.Equal(
+                    PlateauResoniteLink.Targets.Resonite.ResonitePlacementCorrectionReason.RequestRelativeMeshCodeOffset,
+                    term.Reason);
+            });
+        Assert.Collection(
+            correction.Layers.PostPlacement,
+            term =>
+            {
+                Assert.Equal(PlateauResoniteLink.Targets.Resonite.ResoniteCorrectionAxis.Y, term.Axis);
+                Assert.Equal(5.0, term.Value, 6);
+                Assert.Equal(
+                    PlateauResoniteLink.Targets.Resonite.ResonitePlacementCorrectionReason.ObservedRootHeight,
+                    term.Reason);
+            });
+        Assert.Equal(expectedOffset.X, correction.CorrectedRootPosition.X, 6);
+        Assert.Equal(5.0, correction.CorrectedRootPosition.Y, 6);
+        Assert.Equal(expectedOffset.Z, correction.CorrectedRootPosition.Z, 6);
+    }
+
+    [Fact]
     public void ResolveMeshRootPosition_UsesRequestRelativeHorizontalOffsetAndObservedVerticalOffset()
     {
         PlateauResoniteLink.Targets.Resonite.ResoniteLocalOrigin requestOrigin = RequireMeshCodeCenter("53394535");

--- a/tests/PlateauResoniteLink.Tests/Targets/ResonitePlacementPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResonitePlacementPolicyTests.cs
@@ -45,15 +45,15 @@ public sealed class ResonitePlacementPolicyTests
     [Fact]
     public void EvaluateRootPlacementCorrection_SplitsPlacementAndPostPlacementLayers()
     {
-        PlateauResoniteLink.Domain.Importing.ResoniteLocalOrigin requestOrigin = RequireMeshCodeCenter("53394535");
-        PlateauResoniteLink.Domain.Importing.ResoniteLocalOrigin rootOrigin = RequireMeshCodeCenter("53394525");
+        PlateauResoniteLink.Targets.Resonite.ResoniteLocalOrigin requestOrigin = RequireMeshCodeCenter("53394535");
+        PlateauResoniteLink.Targets.Resonite.ResoniteLocalOrigin rootOrigin = RequireMeshCodeCenter("53394525");
 
         PlateauResoniteLink.Targets.Resonite.ResonitePlacementCorrectionResult correction =
             PlateauResoniteLink.Targets.Resonite.ResonitePlacementPolicy.EvaluateRootPlacementCorrection(
                 requestOrigin,
                 "53394525",
                 observedRootHeight: 5.0);
-        PlateauResoniteLink.Domain.Importing.ResoniteFloat3 expectedOffset =
+        PlateauResoniteLink.Targets.Resonite.ResoniteFloat3 expectedOffset =
             PlateauResoniteLink.Targets.Resonite.ResonitePlacementPolicy.ComputeOriginOffset(requestOrigin, rootOrigin);
 
         Assert.Empty(correction.Layers.Source);


### PR DESCRIPTION
Implements #59 groundwork by separating root placement correction results into explicit correction layers.

- add correction result/value types
- split placement and post-placement terms
- route existing root resolution through the layered result
- add regression coverage for correction layering