### PR TITLE
feat(target): add DEM border-skirt visual fallback

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -30,107 +30,14 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         List<BatchPlanSlotLocator> slotResolutionTargets = [];
         List<BatchPlanComponentLocator> componentResolutionTargets = [];
 
-        BatchPlanSlotLocator meshAssetSlotId = CreateBatchPlanSlotLocator("mesh-asset-slot");
-        slotEmissions.Add(new PlannedBatchSlotEmission(
-            meshAssetSlotId,
+        (BatchPlanSlotLocator meshAssetSlotId, BatchPlanComponentLocator geometryComponentId) = AddGeometryAssetEmissions(
+            slotEmissions,
+            componentEmissions,
+            slotResolutionTargets,
+            componentResolutionTargets,
             PlannedSlotTargetReference.CanonicalSlot(objectSlots.AssetLodSlot.Locator),
-            emissionPlan.GeometryAsset.MeshAssetSlotName,
-            null,
-            null));
-        slotResolutionTargets.Add(meshAssetSlotId);
-
-        BatchPlanComponentLocator geometryComponentId = CreateBatchPlanComponentLocator("geometry-component");
-        switch (emissionPlan.GeometryAsset)
-        {
-            case PlannedTriangleMeshGeometryAsset triangleMesh:
-                componentEmissions.Add(new PlannedBatchComponentEmission(
-                    geometryComponentId,
-                    PlannedSlotTargetReference.PlannedSlot(meshAssetSlotId),
-                    "[FrooxEngine]FrooxEngine.StaticMesh",
-                    new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
-                    {
-                        ["URL"] = PlannedMembers.Literal(new Field_Uri
-                        {
-                            Value = triangleMesh.MeshUri,
-                        }),
-                    }));
-                break;
-            case PlannedHeightMapGridGeometryAsset heightMap:
-                BatchPlanSlotLocator heightMapAssetSlotId = CreateBatchPlanSlotLocator("heightmap-asset-slot");
-                BatchPlanComponentLocator heightTextureComponentId = CreateBatchPlanComponentLocator("height-texture-component");
-                slotEmissions.Add(new PlannedBatchSlotEmission(
-                    heightMapAssetSlotId,
-                    PlannedSlotTargetReference.CanonicalSlot(objectSlots.AssetLodSlot.Locator),
-                    heightMap.HeightMapAssetSlotName,
-                    null,
-                    null));
-                slotResolutionTargets.Add(heightMapAssetSlotId);
-                componentEmissions.Add(new PlannedBatchComponentEmission(
-                    heightTextureComponentId,
-                    PlannedSlotTargetReference.PlannedSlot(heightMapAssetSlotId),
-                    "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                    ResoniteGeometryAssetAssembler.CreateHeightMapTextureMembers(heightMap.HeightTextureUri)
-                        .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal)));
-                double displacementMagnitude = Math.Max(heightMap.Geometry.MaxHeight - heightMap.Geometry.MinHeight, 0.0);
-                Dictionary<string, PlannedMember> gridMeshMembers = new(StringComparer.Ordinal)
-                {
-                    ["Points"] = PlannedMembers.Literal(new Field_int2
-                    {
-                        Value = new int2
-                        {
-                            x = heightMap.Geometry.Width,
-                            y = heightMap.Geometry.Height,
-                        },
-                    }),
-                    ["Size"] = PlannedMembers.Literal(new Field_float2
-                    {
-                        Value = new float2
-                        {
-                            x = (float)heightMap.Geometry.Size.X,
-                            y = (float)heightMap.Geometry.Size.Y,
-                        },
-                    }),
-                    ["DisplacementMagnitude"] = PlannedMembers.Literal(new Field_float
-                    {
-                        Value = (float)displacementMagnitude,
-                    }),
-                    ["DisplacementTexture"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(heightTextureComponentId)),
-                };
-                if (heightMap.UvScale is not null)
-                {
-                    gridMeshMembers["UVScale"] = PlannedMembers.Literal(new Field_float2
-                    {
-                        Value = new float2
-                        {
-                            x = (float)heightMap.UvScale.X,
-                            y = (float)heightMap.UvScale.Y,
-                        },
-                    });
-                }
-
-                if (heightMap.UvOffset is not null)
-                {
-                    gridMeshMembers["UVOffset"] = PlannedMembers.Literal(new Field_float2
-                    {
-                        Value = new float2
-                        {
-                            x = (float)heightMap.UvOffset.X,
-                            y = (float)heightMap.UvOffset.Y,
-                        },
-                    });
-                }
-
-                componentEmissions.Add(new PlannedBatchComponentEmission(
-                    geometryComponentId,
-                    PlannedSlotTargetReference.PlannedSlot(meshAssetSlotId),
-                    "[FrooxEngine]FrooxEngine.GridMesh",
-                    gridMeshMembers));
-                break;
-            default:
-                throw new InvalidOperationException(
-                    $"Unsupported planned geometry asset type '{emissionPlan.GeometryAsset.GetType().Name}'.");
-        }
-        componentResolutionTargets.Add(geometryComponentId);
+            emissionPlan.GeometryAsset,
+            scope: string.Empty);
 
         Dictionary<MaterialIdentity, PlannedWorldElementReference> emittedMaterialTargets = new();
         foreach (PlannedMaterialAsset materialAsset in emissionPlan.MaterialAssets)
@@ -175,6 +82,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                     componentEmissions,
                     meshAssetSlotId,
                     presentationSlotId,
+                    scope: string.Empty,
                     emissionPlan.Renderer.MaterialBindings),
             }));
         componentEmissions.Add(new PlannedBatchComponentEmission(
@@ -193,6 +101,38 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 }),
                 ["Mesh"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(geometryComponentId)),
             }));
+
+        IReadOnlyList<PlannedVisualFallbackEmission> visualFallbacks = emissionPlan.VisualFallbacks ?? [];
+        for (int fallbackIndex = 0; fallbackIndex < visualFallbacks.Count; fallbackIndex++)
+        {
+            PlannedVisualFallbackEmission visualFallback = visualFallbacks[fallbackIndex];
+            string fallbackScope = string.Create(
+                System.Globalization.CultureInfo.InvariantCulture,
+                $"visual-fallback-{fallbackIndex}");
+            (BatchPlanSlotLocator fallbackAssetSlotId, BatchPlanComponentLocator fallbackGeometryComponentId) = AddGeometryAssetEmissions(
+                slotEmissions,
+                componentEmissions,
+                slotResolutionTargets,
+                componentResolutionTargets,
+                PlannedSlotTargetReference.CanonicalSlot(objectSlots.AssetLodSlot.Locator),
+                visualFallback.GeometryAsset,
+                fallbackScope);
+            componentEmissions.Add(new PlannedBatchComponentEmission(
+                CreateBatchPlanComponentLocator(CreateScopedSuffix(fallbackScope, "mesh-renderer-component")),
+                PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
+                "[FrooxEngine]FrooxEngine.MeshRenderer",
+                new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
+                {
+                    ["Mesh"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(fallbackGeometryComponentId)),
+                    ["Materials"] = CreateRendererMaterials(visualFallback.Renderer.MaterialBindings, emittedMaterialTargets),
+                    ["MaterialPropertyBlocks"] = CreateRendererMaterialPropertyBlocks(
+                        componentEmissions,
+                        fallbackAssetSlotId,
+                        presentationSlotId,
+                        fallbackScope,
+                        visualFallback.Renderer.MaterialBindings),
+                }));
+        }
 
         return new PlannedBatchEmission(
             slotEmissions,
@@ -334,6 +274,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         List<PlannedBatchComponentEmission> componentEmissions,
         BatchPlanSlotLocator assetSlotId,
         BatchPlanSlotLocator presentationSlotId,
+        string scope,
         IReadOnlyList<PlannedRendererMaterialBinding> materialBindings)
     {
         List<PlannedMember> propertyBlocks = [];
@@ -349,6 +290,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                         componentEmissions,
                         assetSlotId,
                         presentationSlotId,
+                        scope,
                         mainTextureOverrideBinding));
                 continue;
             }
@@ -365,10 +307,12 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         List<PlannedBatchComponentEmission> componentEmissions,
         BatchPlanSlotLocator assetSlotId,
         BatchPlanSlotLocator presentationSlotId,
+        string scope,
         PlannedMainTextureOverrideRendererMaterialBinding binding)
     {
         string overrideIdentity = $"{binding.MaterialIdentity.Value}:{binding.MainTexture.Identity.Value}";
-        BatchPlanComponentLocator textureId = CreateBatchPlanComponentLocator($"renderer-texture:{overrideIdentity}");
+        BatchPlanComponentLocator textureId = CreateBatchPlanComponentLocator(
+            CreateScopedSuffix(scope, $"renderer-texture:{overrideIdentity}"));
         ResoniteSceneMaterialConventions.TextureMemberRole textureRole = binding.ClampWrapMode
             ? ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride
             : ResoniteSceneMaterialConventions.TextureMemberRole.Albedo;
@@ -381,7 +325,8 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 textureRole)
                 .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal)));
 
-        BatchPlanComponentLocator propertyBlockId = CreateBatchPlanComponentLocator($"renderer-main-texture-property-block:{overrideIdentity}");
+        BatchPlanComponentLocator propertyBlockId = CreateBatchPlanComponentLocator(
+            CreateScopedSuffix(scope, $"renderer-main-texture-property-block:{overrideIdentity}"));
         componentEmissions.Add(new PlannedBatchComponentEmission(
             propertyBlockId,
             PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
@@ -394,6 +339,120 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         return PlannedMembers.Reference(PlannedWorldElementReference.Planned(propertyBlockId));
     }
 
+    private static (BatchPlanSlotLocator AssetSlotId, BatchPlanComponentLocator GeometryComponentId) AddGeometryAssetEmissions(
+        List<PlannedBatchSlotEmission> slotEmissions,
+        List<PlannedBatchComponentEmission> componentEmissions,
+        List<BatchPlanSlotLocator> slotResolutionTargets,
+        List<BatchPlanComponentLocator> componentResolutionTargets,
+        PlannedSlotTargetReference assetParentTarget,
+        PlannedGeometryAsset geometryAsset,
+        string scope)
+    {
+        BatchPlanSlotLocator meshAssetSlotId = CreateBatchPlanSlotLocator(CreateScopedSuffix(scope, "mesh-asset-slot"));
+        slotEmissions.Add(new PlannedBatchSlotEmission(
+            meshAssetSlotId,
+            assetParentTarget,
+            geometryAsset.MeshAssetSlotName,
+            null,
+            null));
+        slotResolutionTargets.Add(meshAssetSlotId);
+
+        BatchPlanComponentLocator geometryComponentId = CreateBatchPlanComponentLocator(CreateScopedSuffix(scope, "geometry-component"));
+        switch (geometryAsset)
+        {
+            case PlannedTriangleMeshGeometryAsset triangleMesh:
+                componentEmissions.Add(new PlannedBatchComponentEmission(
+                    geometryComponentId,
+                    PlannedSlotTargetReference.PlannedSlot(meshAssetSlotId),
+                    "[FrooxEngine]FrooxEngine.StaticMesh",
+                    new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
+                    {
+                        ["URL"] = PlannedMembers.Literal(new Field_Uri
+                        {
+                            Value = triangleMesh.MeshUri,
+                        }),
+                    }));
+                break;
+            case PlannedHeightMapGridGeometryAsset heightMap:
+                BatchPlanSlotLocator heightMapAssetSlotId = CreateBatchPlanSlotLocator(CreateScopedSuffix(scope, "heightmap-asset-slot"));
+                BatchPlanComponentLocator heightTextureComponentId = CreateBatchPlanComponentLocator(CreateScopedSuffix(scope, "height-texture-component"));
+                slotEmissions.Add(new PlannedBatchSlotEmission(
+                    heightMapAssetSlotId,
+                    assetParentTarget,
+                    heightMap.HeightMapAssetSlotName,
+                    null,
+                    null));
+                slotResolutionTargets.Add(heightMapAssetSlotId);
+                componentEmissions.Add(new PlannedBatchComponentEmission(
+                    heightTextureComponentId,
+                    PlannedSlotTargetReference.PlannedSlot(heightMapAssetSlotId),
+                    "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                    ResoniteGeometryAssetAssembler.CreateHeightMapTextureMembers(heightMap.HeightTextureUri)
+                        .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal)));
+                double displacementMagnitude = Math.Max(heightMap.Geometry.MaxHeight - heightMap.Geometry.MinHeight, 0.0);
+                Dictionary<string, PlannedMember> gridMeshMembers = new(StringComparer.Ordinal)
+                {
+                    ["Points"] = PlannedMembers.Literal(new Field_int2
+                    {
+                        Value = new int2
+                        {
+                            x = heightMap.Geometry.Width,
+                            y = heightMap.Geometry.Height,
+                        },
+                    }),
+                    ["Size"] = PlannedMembers.Literal(new Field_float2
+                    {
+                        Value = new float2
+                        {
+                            x = (float)heightMap.Geometry.Size.X,
+                            y = (float)heightMap.Geometry.Size.Y,
+                        },
+                    }),
+                    ["DisplacementMagnitude"] = PlannedMembers.Literal(new Field_float
+                    {
+                        Value = (float)displacementMagnitude,
+                    }),
+                    ["DisplacementTexture"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(heightTextureComponentId)),
+                };
+                if (heightMap.UvScale is not null)
+                {
+                    gridMeshMembers["UVScale"] = PlannedMembers.Literal(new Field_float2
+                    {
+                        Value = new float2
+                        {
+                            x = (float)heightMap.UvScale.X,
+                            y = (float)heightMap.UvScale.Y,
+                        },
+                    });
+                }
+
+                if (heightMap.UvOffset is not null)
+                {
+                    gridMeshMembers["UVOffset"] = PlannedMembers.Literal(new Field_float2
+                    {
+                        Value = new float2
+                        {
+                            x = (float)heightMap.UvOffset.X,
+                            y = (float)heightMap.UvOffset.Y,
+                        },
+                    });
+                }
+
+                componentEmissions.Add(new PlannedBatchComponentEmission(
+                    geometryComponentId,
+                    PlannedSlotTargetReference.PlannedSlot(meshAssetSlotId),
+                    "[FrooxEngine]FrooxEngine.GridMesh",
+                    gridMeshMembers));
+                break;
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported planned geometry asset type '{geometryAsset.GetType().Name}'.");
+        }
+
+        componentResolutionTargets.Add(geometryComponentId);
+        return (meshAssetSlotId, geometryComponentId);
+    }
+
     private static BatchPlanSlotLocator CreateBatchPlanSlotLocator(string suffix)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(suffix);
@@ -404,5 +463,13 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(suffix);
         return new BatchPlanComponentLocator($"plan:{suffix}");
+    }
+
+    private static string CreateScopedSuffix(string scope, string suffix)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(suffix);
+        return string.IsNullOrWhiteSpace(scope)
+            ? suffix
+            : string.Create(System.Globalization.CultureInfo.InvariantCulture, $"{scope}-{suffix}");
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
@@ -153,8 +153,8 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         double skirtDepthMeters = ResolveHeightMapBorderSkirtDepthMeters(geometry);
         List<ResoniteMeshVertex> vertices = [];
         List<int> indices = [];
-        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: 0, outwardZ: -1.0, skirtDepthMeters, uvScale, uvOffset, vertices, indices);
-        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: geometry.Height - 1, outwardZ: 1.0, skirtDepthMeters, uvScale, uvOffset, vertices, indices);
+        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: 0, outwardY: -1.0, skirtDepthMeters, uvScale, uvOffset, vertices, indices);
+        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: geometry.Height - 1, outwardY: 1.0, skirtDepthMeters, uvScale, uvOffset, vertices, indices);
         AppendHeightMapBorderSkirtVerticalEdge(geometry, column: 0, outwardX: -1.0, skirtDepthMeters, uvScale, uvOffset, vertices, indices);
         AppendHeightMapBorderSkirtVerticalEdge(geometry, column: geometry.Width - 1, outwardX: 1.0, skirtDepthMeters, uvScale, uvOffset, vertices, indices);
 
@@ -168,7 +168,7 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
     private static void AppendHeightMapBorderSkirtHorizontalEdge(
         ResoniteHeightMapGridGeometry geometry,
         int row,
-        double outwardZ,
+        double outwardY,
         double skirtDepthMeters,
         ResoniteFloat2? uvScale,
         ResoniteFloat2? uvOffset,
@@ -181,18 +181,18 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
             ResoniteMeshVertex topRight = CreateHeightMapBorderSkirtVertex(geometry, column + 1, row, uvScale, uvOffset);
             ResoniteMeshVertex bottomLeft = topLeft with
             {
-                Position = new ResoniteFloat3(topLeft.Position.X, topLeft.Position.Y - skirtDepthMeters, topLeft.Position.Z),
-                Normal = new ResoniteFloat3(0.0, 0.0, outwardZ),
+                Position = new ResoniteFloat3(topLeft.Position.X, topLeft.Position.Y, topLeft.Position.Z - skirtDepthMeters),
+                Normal = new ResoniteFloat3(0.0, outwardY, 0.0),
             };
             ResoniteMeshVertex bottomRight = topRight with
             {
-                Position = new ResoniteFloat3(topRight.Position.X, topRight.Position.Y - skirtDepthMeters, topRight.Position.Z),
-                Normal = new ResoniteFloat3(0.0, 0.0, outwardZ),
+                Position = new ResoniteFloat3(topRight.Position.X, topRight.Position.Y, topRight.Position.Z - skirtDepthMeters),
+                Normal = new ResoniteFloat3(0.0, outwardY, 0.0),
             };
 
-            topLeft = topLeft with { Normal = new ResoniteFloat3(0.0, 0.0, outwardZ) };
-            topRight = topRight with { Normal = new ResoniteFloat3(0.0, 0.0, outwardZ) };
-            AppendQuad(vertices, indices, topLeft, topRight, bottomLeft, bottomRight, outwardZ >= 0.0);
+            topLeft = topLeft with { Normal = new ResoniteFloat3(0.0, outwardY, 0.0) };
+            topRight = topRight with { Normal = new ResoniteFloat3(0.0, outwardY, 0.0) };
+            AppendQuad(vertices, indices, topLeft, topRight, bottomLeft, bottomRight, outwardY < 0.0);
         }
     }
 
@@ -212,12 +212,12 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
             ResoniteMeshVertex topFar = CreateHeightMapBorderSkirtVertex(geometry, column, row + 1, uvScale, uvOffset);
             ResoniteMeshVertex bottomNear = topNear with
             {
-                Position = new ResoniteFloat3(topNear.Position.X, topNear.Position.Y - skirtDepthMeters, topNear.Position.Z),
+                Position = new ResoniteFloat3(topNear.Position.X, topNear.Position.Y, topNear.Position.Z - skirtDepthMeters),
                 Normal = new ResoniteFloat3(outwardX, 0.0, 0.0),
             };
             ResoniteMeshVertex bottomFar = topFar with
             {
-                Position = new ResoniteFloat3(topFar.Position.X, topFar.Position.Y - skirtDepthMeters, topFar.Position.Z),
+                Position = new ResoniteFloat3(topFar.Position.X, topFar.Position.Y, topFar.Position.Z - skirtDepthMeters),
                 Normal = new ResoniteFloat3(outwardX, 0.0, 0.0),
             };
 
@@ -237,7 +237,7 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         double x = geometry.Width == 1
             ? 0.0
             : (-geometry.Size.X / 2.0) + (geometry.Size.X * column / (geometry.Width - 1.0));
-        double z = geometry.Height == 1
+        double y = geometry.Height == 1
             ? 0.0
             : (-geometry.Size.Y / 2.0) + (geometry.Size.Y * row / (geometry.Height - 1.0));
         double height = geometry.HeightSamples[(row * geometry.Width) + column] - geometry.MaxHeight;
@@ -245,8 +245,8 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         double baseV = geometry.Height == 1 ? 0.0 : row / (geometry.Height - 1.0);
 
         return new ResoniteMeshVertex(
-            new ResoniteFloat3(x, height, z),
-            new ResoniteFloat3(0.0, 1.0, 0.0),
+            new ResoniteFloat3(x, y, height),
+            new ResoniteFloat3(0.0, 0.0, 1.0),
             new ResoniteFloat2(
                 (baseU * (uvScale?.X ?? 1.0)) + (uvOffset?.X ?? 0.0),
                 (baseV * (uvScale?.Y ?? 1.0)) + (uvOffset?.Y ?? 0.0)));

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
@@ -254,7 +254,14 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
 
     private static double ResolveHeightMapBorderSkirtDepthMeters(ResoniteHeightMapGridGeometry geometry)
     {
-        return Math.Max(1.0, geometry.MaxHeight - geometry.MinHeight);
+        double heightRange = geometry.MaxHeight - geometry.MinHeight;
+        double cellWidth = geometry.Width > 1
+            ? geometry.Size.X / (geometry.Width - 1)
+            : 0.0;
+        double cellHeight = geometry.Height > 1
+            ? geometry.Size.Y / (geometry.Height - 1)
+            : 0.0;
+        return Math.Max(1.0, Math.Max(heightRange, Math.Max(cellWidth, cellHeight)));
     }
 
     private static void AppendQuad(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
@@ -25,6 +25,7 @@ internal interface IResoniteGeometryAssetAssembler
         string heightMapAssetSlotName,
         string displayName,
         ResoniteHeightMapGridGeometry geometry,
+        bool includeBorderSkirtFallback,
         ResoniteRawHdrTextureImport heightTextureImport,
         ResoniteFloat2? uvScale,
         ResoniteFloat2? uvOffset,
@@ -59,6 +60,7 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         string heightMapAssetSlotName,
         string displayName,
         ResoniteHeightMapGridGeometry geometry,
+        bool includeBorderSkirtFallback,
         ResoniteRawHdrTextureImport heightTextureImport,
         ResoniteFloat2? uvScale,
         ResoniteFloat2? uvOffset,
@@ -77,15 +79,17 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         Uri textureUri = await importClient.ImportTextureAsync(heightTextureImport, cancellationToken);
         progressReporter?.Invoke($"[live] HeightMap '{displayName}' displacement texture import completed -> '{textureUri}'.");
 
-        PreparedTriangleMeshAssetBatch[] visualFallbackAssets = await PrepareBorderSkirtFallbackAssetsAsync(
-            importClient,
-            heightMapAssetSlotName,
-            displayName,
-            geometry,
-            uvScale,
-            uvOffset,
-            progressReporter,
-            cancellationToken);
+        PreparedTriangleMeshAssetBatch[] visualFallbackAssets = includeBorderSkirtFallback
+            ? await PrepareBorderSkirtFallbackAssetsAsync(
+                importClient,
+                heightMapAssetSlotName,
+                displayName,
+                geometry,
+                uvScale,
+                uvOffset,
+                progressReporter,
+                cancellationToken)
+            : [];
 
         return new PreparedHeightMapGridAssetBatch(
             meshAssetSlotName,
@@ -192,7 +196,7 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
 
             topLeft = topLeft with { Normal = new ResoniteFloat3(0.0, outwardY, 0.0) };
             topRight = topRight with { Normal = new ResoniteFloat3(0.0, outwardY, 0.0) };
-            AppendQuad(vertices, indices, topLeft, topRight, bottomLeft, bottomRight, outwardY < 0.0);
+            AppendQuad(vertices, indices, topLeft, topRight, bottomLeft, bottomRight, outwardY > 0.0);
         }
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
@@ -28,7 +28,6 @@ internal interface IResoniteGeometryAssetAssembler
         ResoniteRawHdrTextureImport heightTextureImport,
         ResoniteFloat2? uvScale,
         ResoniteFloat2? uvOffset,
-        bool includeBorderSkirtFallback,
         Action<string>? progressReporter,
         CancellationToken cancellationToken);
 }
@@ -36,7 +35,6 @@ internal interface IResoniteGeometryAssetAssembler
 internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAssembler
 {
     private const string HeightMapSkirtAssetSlotSuffix = "_skirt";
-    private const double HeightMapSkirtDepthMeters = 1.0;
 
     public async Task<PreparedGeometryAssetBatch> PrepareTriangleMeshAsync(
         IResoniteLinkClient importClient,
@@ -64,7 +62,6 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         ResoniteRawHdrTextureImport heightTextureImport,
         ResoniteFloat2? uvScale,
         ResoniteFloat2? uvOffset,
-        bool includeBorderSkirtFallback,
         Action<string>? progressReporter,
         CancellationToken cancellationToken)
     {
@@ -80,17 +77,15 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         Uri textureUri = await importClient.ImportTextureAsync(heightTextureImport, cancellationToken);
         progressReporter?.Invoke($"[live] HeightMap '{displayName}' displacement texture import completed -> '{textureUri}'.");
 
-        PreparedTriangleMeshAssetBatch[] visualFallbackAssets = includeBorderSkirtFallback
-            ? await PrepareBorderSkirtFallbackAssetsAsync(
-                importClient,
-                heightMapAssetSlotName,
-                displayName,
-                geometry,
-                uvScale,
-                uvOffset,
-                progressReporter,
-                cancellationToken)
-            : [];
+        PreparedTriangleMeshAssetBatch[] visualFallbackAssets = await PrepareBorderSkirtFallbackAssetsAsync(
+            importClient,
+            heightMapAssetSlotName,
+            displayName,
+            geometry,
+            uvScale,
+            uvOffset,
+            progressReporter,
+            cancellationToken);
 
         return new PreparedHeightMapGridAssetBatch(
             meshAssetSlotName,
@@ -155,12 +150,13 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
             return null;
         }
 
+        double skirtDepthMeters = ResolveHeightMapBorderSkirtDepthMeters(geometry);
         List<ResoniteMeshVertex> vertices = [];
         List<int> indices = [];
-        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: 0, outwardZ: -1.0, uvScale, uvOffset, vertices, indices);
-        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: geometry.Height - 1, outwardZ: 1.0, uvScale, uvOffset, vertices, indices);
-        AppendHeightMapBorderSkirtVerticalEdge(geometry, column: 0, outwardX: -1.0, uvScale, uvOffset, vertices, indices);
-        AppendHeightMapBorderSkirtVerticalEdge(geometry, column: geometry.Width - 1, outwardX: 1.0, uvScale, uvOffset, vertices, indices);
+        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: 0, outwardZ: -1.0, skirtDepthMeters, uvScale, uvOffset, vertices, indices);
+        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: geometry.Height - 1, outwardZ: 1.0, skirtDepthMeters, uvScale, uvOffset, vertices, indices);
+        AppendHeightMapBorderSkirtVerticalEdge(geometry, column: 0, outwardX: -1.0, skirtDepthMeters, uvScale, uvOffset, vertices, indices);
+        AppendHeightMapBorderSkirtVerticalEdge(geometry, column: geometry.Width - 1, outwardX: 1.0, skirtDepthMeters, uvScale, uvOffset, vertices, indices);
 
         return vertices.Count == 0
             ? null
@@ -173,6 +169,7 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         ResoniteHeightMapGridGeometry geometry,
         int row,
         double outwardZ,
+        double skirtDepthMeters,
         ResoniteFloat2? uvScale,
         ResoniteFloat2? uvOffset,
         List<ResoniteMeshVertex> vertices,
@@ -184,12 +181,12 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
             ResoniteMeshVertex topRight = CreateHeightMapBorderSkirtVertex(geometry, column + 1, row, uvScale, uvOffset);
             ResoniteMeshVertex bottomLeft = topLeft with
             {
-                Position = new ResoniteFloat3(topLeft.Position.X, topLeft.Position.Y - HeightMapSkirtDepthMeters, topLeft.Position.Z),
+                Position = new ResoniteFloat3(topLeft.Position.X, topLeft.Position.Y - skirtDepthMeters, topLeft.Position.Z),
                 Normal = new ResoniteFloat3(0.0, 0.0, outwardZ),
             };
             ResoniteMeshVertex bottomRight = topRight with
             {
-                Position = new ResoniteFloat3(topRight.Position.X, topRight.Position.Y - HeightMapSkirtDepthMeters, topRight.Position.Z),
+                Position = new ResoniteFloat3(topRight.Position.X, topRight.Position.Y - skirtDepthMeters, topRight.Position.Z),
                 Normal = new ResoniteFloat3(0.0, 0.0, outwardZ),
             };
 
@@ -203,6 +200,7 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         ResoniteHeightMapGridGeometry geometry,
         int column,
         double outwardX,
+        double skirtDepthMeters,
         ResoniteFloat2? uvScale,
         ResoniteFloat2? uvOffset,
         List<ResoniteMeshVertex> vertices,
@@ -214,12 +212,12 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
             ResoniteMeshVertex topFar = CreateHeightMapBorderSkirtVertex(geometry, column, row + 1, uvScale, uvOffset);
             ResoniteMeshVertex bottomNear = topNear with
             {
-                Position = new ResoniteFloat3(topNear.Position.X, topNear.Position.Y - HeightMapSkirtDepthMeters, topNear.Position.Z),
+                Position = new ResoniteFloat3(topNear.Position.X, topNear.Position.Y - skirtDepthMeters, topNear.Position.Z),
                 Normal = new ResoniteFloat3(outwardX, 0.0, 0.0),
             };
             ResoniteMeshVertex bottomFar = topFar with
             {
-                Position = new ResoniteFloat3(topFar.Position.X, topFar.Position.Y - HeightMapSkirtDepthMeters, topFar.Position.Z),
+                Position = new ResoniteFloat3(topFar.Position.X, topFar.Position.Y - skirtDepthMeters, topFar.Position.Z),
                 Normal = new ResoniteFloat3(outwardX, 0.0, 0.0),
             };
 
@@ -252,6 +250,11 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
             new ResoniteFloat2(
                 (baseU * (uvScale?.X ?? 1.0)) + (uvOffset?.X ?? 0.0),
                 (baseV * (uvScale?.Y ?? 1.0)) + (uvOffset?.Y ?? 0.0)));
+    }
+
+    private static double ResolveHeightMapBorderSkirtDepthMeters(ResoniteHeightMapGridGeometry geometry)
+    {
+        return Math.Max(1.0, geometry.MaxHeight - geometry.MinHeight);
     }
 
     private static void AppendQuad(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
@@ -244,7 +244,7 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         double y = geometry.Height == 1
             ? 0.0
             : (-geometry.Size.Y / 2.0) + (geometry.Size.Y * row / (geometry.Height - 1.0));
-        double height = geometry.HeightSamples[(row * geometry.Width) + column] - geometry.MaxHeight;
+        double height = geometry.MaxHeight - geometry.HeightSamples[(row * geometry.Width) + column];
         double baseU = geometry.Width == 1 ? 0.0 : column / (geometry.Width - 1.0);
         double baseV = geometry.Height == 1 ? 0.0 : row / (geometry.Height - 1.0);
 

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
@@ -28,13 +28,81 @@ internal interface IResoniteGeometryAssetAssembler
         ResoniteRawHdrTextureImport heightTextureImport,
         ResoniteFloat2? uvScale,
         ResoniteFloat2? uvOffset,
+        bool includeBorderSkirtFallback,
         Action<string>? progressReporter,
         CancellationToken cancellationToken);
 }
 
 internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAssembler
 {
+    private const string HeightMapSkirtAssetSlotSuffix = "_skirt";
+    private const double HeightMapSkirtDepthMeters = 1.0;
+
     public async Task<PreparedGeometryAssetBatch> PrepareTriangleMeshAsync(
+        IResoniteLinkClient importClient,
+        string meshAssetSlotName,
+        string displayName,
+        ImportMeshRawData meshImport,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
+    {
+        return await PrepareTriangleMeshCoreAsync(
+            importClient,
+            meshAssetSlotName,
+            displayName,
+            meshImport,
+            progressReporter,
+            cancellationToken);
+    }
+
+    public async Task<PreparedGeometryAssetBatch> PrepareHeightMapGridAsync(
+        IResoniteLinkClient importClient,
+        string meshAssetSlotName,
+        string heightMapAssetSlotName,
+        string displayName,
+        ResoniteHeightMapGridGeometry geometry,
+        ResoniteRawHdrTextureImport heightTextureImport,
+        ResoniteFloat2? uvScale,
+        ResoniteFloat2? uvOffset,
+        bool includeBorderSkirtFallback,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(importClient);
+        ArgumentException.ThrowIfNullOrWhiteSpace(meshAssetSlotName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(heightMapAssetSlotName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+        ArgumentNullException.ThrowIfNull(geometry);
+        ArgumentNullException.ThrowIfNull(heightTextureImport);
+
+        progressReporter?.Invoke(
+            $"[live] HeightMap '{geometry.Width}x{geometry.Height}' importing displacement texture via raw payload.");
+        Uri textureUri = await importClient.ImportTextureAsync(heightTextureImport, cancellationToken);
+        progressReporter?.Invoke($"[live] HeightMap '{displayName}' displacement texture import completed -> '{textureUri}'.");
+
+        PreparedTriangleMeshAssetBatch[] visualFallbackAssets = includeBorderSkirtFallback
+            ? await PrepareBorderSkirtFallbackAssetsAsync(
+                importClient,
+                heightMapAssetSlotName,
+                displayName,
+                geometry,
+                uvScale,
+                uvOffset,
+                progressReporter,
+                cancellationToken)
+            : [];
+
+        return new PreparedHeightMapGridAssetBatch(
+            meshAssetSlotName,
+            heightMapAssetSlotName,
+            geometry,
+            textureUri,
+            uvScale,
+            uvOffset,
+            visualFallbackAssets);
+    }
+
+    private static async Task<PreparedTriangleMeshAssetBatch> PrepareTriangleMeshCoreAsync(
         IResoniteLinkClient importClient,
         string meshAssetSlotName,
         string displayName,
@@ -50,29 +118,164 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         return new PreparedTriangleMeshAssetBatch(meshAssetSlotName, assetUri);
     }
 
-    public async Task<PreparedGeometryAssetBatch> PrepareHeightMapGridAsync(
+    private static async Task<PreparedTriangleMeshAssetBatch[]> PrepareBorderSkirtFallbackAssetsAsync(
         IResoniteLinkClient importClient,
-        string meshAssetSlotName,
         string heightMapAssetSlotName,
         string displayName,
         ResoniteHeightMapGridGeometry geometry,
-        ResoniteRawHdrTextureImport heightTextureImport,
         ResoniteFloat2? uvScale,
         ResoniteFloat2? uvOffset,
         Action<string>? progressReporter,
         CancellationToken cancellationToken)
     {
-        progressReporter?.Invoke(
-            $"[live] HeightMap '{geometry.Width}x{geometry.Height}' importing displacement texture via raw payload.");
-        Uri textureUri = await importClient.ImportTextureAsync(heightTextureImport, cancellationToken);
-        progressReporter?.Invoke($"[live] HeightMap '{displayName}' displacement texture import completed -> '{textureUri}'.");
-        return new PreparedHeightMapGridAssetBatch(
-            meshAssetSlotName,
-            heightMapAssetSlotName,
-            geometry,
-            textureUri,
-            uvScale,
-            uvOffset);
+        ResoniteImportedMesh? skirtMesh = TryCreateHeightMapBorderSkirtMesh(geometry, uvScale, uvOffset);
+        if (skirtMesh is null)
+        {
+            return [];
+        }
+
+        ImportMeshRawData skirtMeshImport = ResoniteMeshImportFactory.Create(skirtMesh);
+        PreparedTriangleMeshAssetBatch preparedSkirtAsset = await PrepareTriangleMeshCoreAsync(
+            importClient,
+            string.Concat(heightMapAssetSlotName, HeightMapSkirtAssetSlotSuffix),
+            string.Create(System.Globalization.CultureInfo.InvariantCulture, $"{displayName} Border Skirt"),
+            skirtMeshImport,
+            progressReporter,
+            cancellationToken);
+        return [preparedSkirtAsset];
+    }
+
+    private static ResoniteImportedMesh? TryCreateHeightMapBorderSkirtMesh(
+        ResoniteHeightMapGridGeometry geometry,
+        ResoniteFloat2? uvScale,
+        ResoniteFloat2? uvOffset)
+    {
+        if (geometry.Width < 2 || geometry.Height < 2)
+        {
+            return null;
+        }
+
+        List<ResoniteMeshVertex> vertices = [];
+        List<int> indices = [];
+        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: 0, outwardZ: -1.0, uvScale, uvOffset, vertices, indices);
+        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: geometry.Height - 1, outwardZ: 1.0, uvScale, uvOffset, vertices, indices);
+        AppendHeightMapBorderSkirtVerticalEdge(geometry, column: 0, outwardX: -1.0, uvScale, uvOffset, vertices, indices);
+        AppendHeightMapBorderSkirtVerticalEdge(geometry, column: geometry.Width - 1, outwardX: 1.0, uvScale, uvOffset, vertices, indices);
+
+        return vertices.Count == 0
+            ? null
+            : new ResoniteImportedMesh(
+                vertices,
+                [new ResoniteMeshSubmesh(0, "heightmap-border-skirt", indices)]);
+    }
+
+    private static void AppendHeightMapBorderSkirtHorizontalEdge(
+        ResoniteHeightMapGridGeometry geometry,
+        int row,
+        double outwardZ,
+        ResoniteFloat2? uvScale,
+        ResoniteFloat2? uvOffset,
+        List<ResoniteMeshVertex> vertices,
+        List<int> indices)
+    {
+        for (int column = 0; column < geometry.Width - 1; column++)
+        {
+            ResoniteMeshVertex topLeft = CreateHeightMapBorderSkirtVertex(geometry, column, row, uvScale, uvOffset);
+            ResoniteMeshVertex topRight = CreateHeightMapBorderSkirtVertex(geometry, column + 1, row, uvScale, uvOffset);
+            ResoniteMeshVertex bottomLeft = topLeft with
+            {
+                Position = new ResoniteFloat3(topLeft.Position.X, topLeft.Position.Y - HeightMapSkirtDepthMeters, topLeft.Position.Z),
+                Normal = new ResoniteFloat3(0.0, 0.0, outwardZ),
+            };
+            ResoniteMeshVertex bottomRight = topRight with
+            {
+                Position = new ResoniteFloat3(topRight.Position.X, topRight.Position.Y - HeightMapSkirtDepthMeters, topRight.Position.Z),
+                Normal = new ResoniteFloat3(0.0, 0.0, outwardZ),
+            };
+
+            topLeft = topLeft with { Normal = new ResoniteFloat3(0.0, 0.0, outwardZ) };
+            topRight = topRight with { Normal = new ResoniteFloat3(0.0, 0.0, outwardZ) };
+            AppendQuad(vertices, indices, topLeft, topRight, bottomLeft, bottomRight, outwardZ >= 0.0);
+        }
+    }
+
+    private static void AppendHeightMapBorderSkirtVerticalEdge(
+        ResoniteHeightMapGridGeometry geometry,
+        int column,
+        double outwardX,
+        ResoniteFloat2? uvScale,
+        ResoniteFloat2? uvOffset,
+        List<ResoniteMeshVertex> vertices,
+        List<int> indices)
+    {
+        for (int row = 0; row < geometry.Height - 1; row++)
+        {
+            ResoniteMeshVertex topNear = CreateHeightMapBorderSkirtVertex(geometry, column, row, uvScale, uvOffset);
+            ResoniteMeshVertex topFar = CreateHeightMapBorderSkirtVertex(geometry, column, row + 1, uvScale, uvOffset);
+            ResoniteMeshVertex bottomNear = topNear with
+            {
+                Position = new ResoniteFloat3(topNear.Position.X, topNear.Position.Y - HeightMapSkirtDepthMeters, topNear.Position.Z),
+                Normal = new ResoniteFloat3(outwardX, 0.0, 0.0),
+            };
+            ResoniteMeshVertex bottomFar = topFar with
+            {
+                Position = new ResoniteFloat3(topFar.Position.X, topFar.Position.Y - HeightMapSkirtDepthMeters, topFar.Position.Z),
+                Normal = new ResoniteFloat3(outwardX, 0.0, 0.0),
+            };
+
+            topNear = topNear with { Normal = new ResoniteFloat3(outwardX, 0.0, 0.0) };
+            topFar = topFar with { Normal = new ResoniteFloat3(outwardX, 0.0, 0.0) };
+            AppendQuad(vertices, indices, topNear, topFar, bottomNear, bottomFar, outwardX < 0.0);
+        }
+    }
+
+    private static ResoniteMeshVertex CreateHeightMapBorderSkirtVertex(
+        ResoniteHeightMapGridGeometry geometry,
+        int column,
+        int row,
+        ResoniteFloat2? uvScale,
+        ResoniteFloat2? uvOffset)
+    {
+        double x = geometry.Width == 1
+            ? 0.0
+            : (-geometry.Size.X / 2.0) + (geometry.Size.X * column / (geometry.Width - 1.0));
+        double z = geometry.Height == 1
+            ? 0.0
+            : (-geometry.Size.Y / 2.0) + (geometry.Size.Y * row / (geometry.Height - 1.0));
+        double height = geometry.HeightSamples[(row * geometry.Width) + column] - geometry.MaxHeight;
+        double baseU = geometry.Width == 1 ? 0.0 : column / (geometry.Width - 1.0);
+        double baseV = geometry.Height == 1 ? 0.0 : row / (geometry.Height - 1.0);
+
+        return new ResoniteMeshVertex(
+            new ResoniteFloat3(x, height, z),
+            new ResoniteFloat3(0.0, 1.0, 0.0),
+            new ResoniteFloat2(
+                (baseU * (uvScale?.X ?? 1.0)) + (uvOffset?.X ?? 0.0),
+                (baseV * (uvScale?.Y ?? 1.0)) + (uvOffset?.Y ?? 0.0)));
+    }
+
+    private static void AppendQuad(
+        List<ResoniteMeshVertex> vertices,
+        List<int> indices,
+        ResoniteMeshVertex topLeft,
+        ResoniteMeshVertex topRight,
+        ResoniteMeshVertex bottomLeft,
+        ResoniteMeshVertex bottomRight,
+        bool flipWinding)
+    {
+        int baseIndex = vertices.Count;
+        vertices.Add(topLeft);
+        vertices.Add(topRight);
+        vertices.Add(bottomLeft);
+        vertices.Add(bottomRight);
+
+        if (!flipWinding)
+        {
+            indices.AddRange([baseIndex, baseIndex + 2, baseIndex + 1, baseIndex + 1, baseIndex + 2, baseIndex + 3]);
+            return;
+        }
+
+        indices.AddRange([baseIndex, baseIndex + 1, baseIndex + 2, baseIndex + 1, baseIndex + 3, baseIndex + 2]);
     }
 
     internal static Dictionary<string, Member> CreateHeightMapTextureMembers(Uri assetUri)
@@ -106,4 +309,5 @@ internal sealed record PreparedHeightMapGridAssetBatch(
     ResoniteHeightMapGridGeometry Geometry,
     Uri HeightTextureUri,
     ResoniteFloat2? UvScale,
-    ResoniteFloat2? UvOffset) : PreparedGeometryAssetBatch(MeshAssetSlotName);
+    ResoniteFloat2? UvOffset,
+    IReadOnlyList<PreparedTriangleMeshAssetBatch>? VisualFallbackAssets = null) : PreparedGeometryAssetBatch(MeshAssetSlotName);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -1908,6 +1908,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                     CreateHeightMapAssetSlotName(cityObject),
                     cityObject.DisplayName,
                     heightMap.Geometry,
+                    ShouldIncludeHeightMapBorderSkirtFallback(cityObject),
                     heightMap.HeightTextureImport,
                     ResolveHeightMapGridUvScale(cityObject, heightMap.Geometry, preparedTerrainTextureDataByOverlay),
                     ResolveHeightMapGridUvOffset(cityObject, heightMap.Geometry, preparedTerrainTextureDataByOverlay),
@@ -1928,6 +1929,13 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         };
 
         return new PlannedGeometryPreparation(geometryAsset, visualFallbackGeometryAssets);
+    }
+
+    private static bool ShouldIncludeHeightMapBorderSkirtFallback(ResoniteConstructionCityObject cityObject)
+    {
+        return string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
+            && cityObject.Geometry is ResoniteHeightMapGridGeometry
+            && cityObject.Materials.Count == 1;
     }
 
     private static ResoniteRawHdrTextureImport PrepareHeightMapTexture(ResoniteHeightMapGridGeometry geometry)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -1911,7 +1911,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                     heightMap.HeightTextureImport,
                     ResolveHeightMapGridUvScale(cityObject, heightMap.Geometry, preparedTerrainTextureDataByOverlay),
                     ResolveHeightMapGridUvOffset(cityObject, heightMap.Geometry, preparedTerrainTextureDataByOverlay),
-                    includeBorderSkirtFallback: ShouldIncludeHeightMapBorderSkirtFallback(cityObject),
                     progressReporter,
                     cancellationToken),
             _ => throw new InvalidOperationException(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -26,8 +26,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
     private const long MaxInFlightCityObjectWorkingSetBytesFloor = 512L * 1024L * 1024L;
     private const string DemPackageName = "dem";
     private const string HeightMapAssetSlotSuffix = "_heightmap";
-    private const string HeightMapSkirtAssetSlotSuffix = "_heightmap_skirt";
-    private const double HeightMapSkirtDepthMeters = 1.0;
     private readonly Uri endpoint;
     private readonly int connectionCount;
     private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator;
@@ -1155,14 +1153,14 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             preparedTextureDataByIdentity,
             preparedTerrainTextureDataByOverlay,
             buildStepCancellation.Token);
-        Task<PlannedGeometryAsset> geometryPlanningTask = PlanGeometryAssetAsync(
+        Task<PlannedGeometryPreparation> geometryPlanningTask = PlanGeometryAssetAsync(
             routedClient,
             cityObject,
             preparedCityObject,
             preparedTerrainTextureDataByOverlay,
             buildStepCancellation.Token);
         PlannedSceneMaterialPlan plannedMaterials;
-        PlannedGeometryAsset plannedGeometryAsset;
+        PlannedGeometryPreparation plannedGeometry;
         try
         {
             plannedMaterials = await materialPlanningTask;
@@ -1170,7 +1168,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 
             ReportBuildStep(cityObject, $"Preparing geometry assets ({DescribePreparedGeometry(preparedCityObject.Geometry)}).");
             geometryStopwatch.Start();
-            plannedGeometryAsset = await geometryPlanningTask;
+            plannedGeometry = await geometryPlanningTask;
             geometryStopwatch.Stop();
         }
         catch
@@ -1180,13 +1178,15 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             throw;
         }
 
-        IReadOnlyList<PlannedVisualFallbackEmission>? visualFallbacks = await PlanVisualFallbacksAsync(
-            routedClient,
-            cityObject,
-            preparedCityObject,
-            plannedMaterials.RendererMaterialBindings,
-            preparedTerrainTextureDataByOverlay,
-            buildStepCancellation.Token);
+        PlannedGeometryAsset plannedGeometryAsset = plannedGeometry.GeometryAsset;
+        IReadOnlyList<PlannedVisualFallbackEmission>? visualFallbacks = plannedGeometry.VisualFallbackGeometryAssets?
+            .Select(
+                fallbackGeometry => new PlannedVisualFallbackEmission(
+                    fallbackGeometry,
+                    new PlannedRenderer(
+                        fallbackGeometry.Identity,
+                        plannedMaterials.RendererMaterialBindings)))
+            .ToArray();
         PlannedSceneObjectEmission emissionPlan = new(
             plannedGeometryAsset,
             plannedMaterials.MaterialAssets,
@@ -1884,26 +1884,24 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         return keys;
     }
 
-    private async Task<PlannedGeometryAsset> PlanGeometryAssetAsync(
+    private async Task<PlannedGeometryPreparation> PlanGeometryAssetAsync(
         IResoniteLinkClient importClient,
         ResoniteConstructionCityObject cityObject,
         PreparedCityObject preparedCityObject,
         IReadOnlyDictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay,
         CancellationToken cancellationToken)
     {
-        return preparedCityObject.Geometry switch
+        PreparedGeometryAssetBatch preparedGeometryBatch = preparedCityObject.Geometry switch
         {
-            PreparedTriangleMeshGeometry triangleMesh => CreatePlannedGeometryAsset(
-                cityObject,
+            PreparedTriangleMeshGeometry triangleMesh =>
                 await geometryAssetAssembler.PrepareTriangleMeshAsync(
                     importClient,
                     CreateMeshAssetSlotName(cityObject),
                     cityObject.DisplayName,
                     triangleMesh.MeshImport,
                     progressReporter,
-                    cancellationToken)),
-            PreparedHeightMapGridGeometry heightMap => CreatePlannedGeometryAsset(
-                cityObject,
+                    cancellationToken),
+            PreparedHeightMapGridGeometry heightMap =>
                 await geometryAssetAssembler.PrepareHeightMapGridAsync(
                     importClient,
                     CreateMeshAssetSlotName(cityObject),
@@ -1913,62 +1911,24 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                     heightMap.HeightTextureImport,
                     ResolveHeightMapGridUvScale(cityObject, heightMap.Geometry, preparedTerrainTextureDataByOverlay),
                     ResolveHeightMapGridUvOffset(cityObject, heightMap.Geometry, preparedTerrainTextureDataByOverlay),
+                    includeBorderSkirtFallback: ShouldIncludeHeightMapBorderSkirtFallback(cityObject),
                     progressReporter,
-                    cancellationToken)),
+                    cancellationToken),
             _ => throw new InvalidOperationException(
                 $"Unsupported prepared geometry type '{preparedCityObject.Geometry.GetType().Name}'."),
         };
-    }
 
-    private async Task<IReadOnlyList<PlannedVisualFallbackEmission>?> PlanVisualFallbacksAsync(
-        IResoniteLinkClient importClient,
-        ResoniteConstructionCityObject cityObject,
-        PreparedCityObject preparedCityObject,
-        IReadOnlyList<PlannedRendererMaterialBinding> rendererMaterialBindings,
-        IReadOnlyDictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay,
-        CancellationToken cancellationToken)
-    {
-        if (cityObject.Geometry is not ResoniteHeightMapGridGeometry heightMap
-            || preparedCityObject.Geometry is not PreparedHeightMapGridGeometry
-            || !string.Equals(cityObject.PackageName, DemPackageName, StringComparison.OrdinalIgnoreCase)
-            || rendererMaterialBindings.Count != 1)
+        PlannedGeometryAsset geometryAsset = CreatePlannedGeometryAsset(cityObject, preparedGeometryBatch);
+        IReadOnlyList<PlannedGeometryAsset>? visualFallbackGeometryAssets = preparedGeometryBatch switch
         {
-            return null;
-        }
+            PreparedHeightMapGridAssetBatch heightMapBatch when heightMapBatch.VisualFallbackAssets is { Count: > 0 } =>
+                heightMapBatch.VisualFallbackAssets
+                    .Select(fallbackAsset => CreatePlannedGeometryAsset(cityObject, fallbackAsset))
+                    .ToArray(),
+            _ => null,
+        };
 
-        ResoniteImportedMesh? skirtMesh = TryCreateHeightMapBorderSkirtMesh(
-            heightMap,
-            ResolveHeightMapGridUvScale(cityObject, heightMap, preparedTerrainTextureDataByOverlay),
-            ResolveHeightMapGridUvOffset(cityObject, heightMap, preparedTerrainTextureDataByOverlay));
-        if (skirtMesh is null)
-        {
-            return null;
-        }
-
-        PreparedTriangleMeshGeometry preparedSkirtGeometry = PrepareTriangleMeshGeometry(cityObject, skirtMesh);
-        PreparedTriangleMeshAssetBatch preparedSkirtAsset = (PreparedTriangleMeshAssetBatch)await geometryAssetAssembler.PrepareTriangleMeshAsync(
-            importClient,
-            CreateHeightMapSkirtAssetSlotName(cityObject),
-            string.Create(CultureInfo.InvariantCulture, $"{cityObject.DisplayName} Border Skirt"),
-            preparedSkirtGeometry.MeshImport,
-            progressReporter,
-            cancellationToken);
-        PlannedTriangleMeshGeometryAsset skirtGeometryAsset = new(
-            new GeometryIdentity(
-                string.Create(
-                    CultureInfo.InvariantCulture,
-                    $"{cityObject.PackageName}|{cityObject.SlotKey}|{preparedSkirtAsset.MeshAssetSlotName}")),
-            preparedSkirtAsset.MeshAssetSlotName,
-            preparedSkirtAsset.MeshUri);
-
-        return
-        [
-            new PlannedVisualFallbackEmission(
-                skirtGeometryAsset,
-                new PlannedRenderer(
-                    skirtGeometryAsset.Identity,
-                    rendererMaterialBindings)),
-        ];
+        return new PlannedGeometryPreparation(geometryAsset, visualFallbackGeometryAssets);
     }
 
     private static ResoniteRawHdrTextureImport PrepareHeightMapTexture(ResoniteHeightMapGridGeometry geometry)
@@ -1998,139 +1958,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         byte[] rawBytes = new byte[rawPixels.Length * sizeof(float)];
         Buffer.BlockCopy(rawPixels, 0, rawBytes, 0, rawBytes.Length);
         return new ResoniteRawHdrTextureImport(geometry.Width, geometry.Height, rawBytes);
-    }
-
-    private static ResoniteImportedMesh? TryCreateHeightMapBorderSkirtMesh(
-        ResoniteHeightMapGridGeometry geometry,
-        ResoniteFloat2? uvScale,
-        ResoniteFloat2? uvOffset)
-    {
-        if (geometry.Width < 2 || geometry.Height < 2)
-        {
-            return null;
-        }
-
-        List<ResoniteMeshVertex> vertices = [];
-        List<int> indices = [];
-        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: 0, outwardZ: -1.0, uvScale, uvOffset, vertices, indices);
-        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: geometry.Height - 1, outwardZ: 1.0, uvScale, uvOffset, vertices, indices);
-        AppendHeightMapBorderSkirtVerticalEdge(geometry, column: 0, outwardX: -1.0, uvScale, uvOffset, vertices, indices);
-        AppendHeightMapBorderSkirtVerticalEdge(geometry, column: geometry.Width - 1, outwardX: 1.0, uvScale, uvOffset, vertices, indices);
-
-        return vertices.Count == 0
-            ? null
-            : new ResoniteImportedMesh(
-                vertices,
-                [new ResoniteMeshSubmesh(0, "heightmap-border-skirt", indices)]);
-    }
-
-    private static void AppendHeightMapBorderSkirtHorizontalEdge(
-        ResoniteHeightMapGridGeometry geometry,
-        int row,
-        double outwardZ,
-        ResoniteFloat2? uvScale,
-        ResoniteFloat2? uvOffset,
-        List<ResoniteMeshVertex> vertices,
-        List<int> indices)
-    {
-        for (int column = 0; column < geometry.Width - 1; column++)
-        {
-            ResoniteMeshVertex topLeft = CreateHeightMapBorderSkirtVertex(geometry, column, row, uvScale, uvOffset);
-            ResoniteMeshVertex topRight = CreateHeightMapBorderSkirtVertex(geometry, column + 1, row, uvScale, uvOffset);
-            ResoniteMeshVertex bottomLeft = topLeft with
-            {
-                Position = new ResoniteFloat3(topLeft.Position.X, topLeft.Position.Y - HeightMapSkirtDepthMeters, topLeft.Position.Z),
-                Normal = new ResoniteFloat3(0.0, 0.0, outwardZ),
-            };
-            ResoniteMeshVertex bottomRight = topRight with
-            {
-                Position = new ResoniteFloat3(topRight.Position.X, topRight.Position.Y - HeightMapSkirtDepthMeters, topRight.Position.Z),
-                Normal = new ResoniteFloat3(0.0, 0.0, outwardZ),
-            };
-
-            topLeft = topLeft with { Normal = new ResoniteFloat3(0.0, 0.0, outwardZ) };
-            topRight = topRight with { Normal = new ResoniteFloat3(0.0, 0.0, outwardZ) };
-            AppendQuad(vertices, indices, topLeft, topRight, bottomLeft, bottomRight, outwardZ >= 0.0);
-        }
-    }
-
-    private static void AppendHeightMapBorderSkirtVerticalEdge(
-        ResoniteHeightMapGridGeometry geometry,
-        int column,
-        double outwardX,
-        ResoniteFloat2? uvScale,
-        ResoniteFloat2? uvOffset,
-        List<ResoniteMeshVertex> vertices,
-        List<int> indices)
-    {
-        for (int row = 0; row < geometry.Height - 1; row++)
-        {
-            ResoniteMeshVertex topNear = CreateHeightMapBorderSkirtVertex(geometry, column, row, uvScale, uvOffset);
-            ResoniteMeshVertex topFar = CreateHeightMapBorderSkirtVertex(geometry, column, row + 1, uvScale, uvOffset);
-            ResoniteMeshVertex bottomNear = topNear with
-            {
-                Position = new ResoniteFloat3(topNear.Position.X, topNear.Position.Y - HeightMapSkirtDepthMeters, topNear.Position.Z),
-                Normal = new ResoniteFloat3(outwardX, 0.0, 0.0),
-            };
-            ResoniteMeshVertex bottomFar = topFar with
-            {
-                Position = new ResoniteFloat3(topFar.Position.X, topFar.Position.Y - HeightMapSkirtDepthMeters, topFar.Position.Z),
-                Normal = new ResoniteFloat3(outwardX, 0.0, 0.0),
-            };
-
-            topNear = topNear with { Normal = new ResoniteFloat3(outwardX, 0.0, 0.0) };
-            topFar = topFar with { Normal = new ResoniteFloat3(outwardX, 0.0, 0.0) };
-            AppendQuad(vertices, indices, topNear, topFar, bottomNear, bottomFar, outwardX < 0.0);
-        }
-    }
-
-    private static ResoniteMeshVertex CreateHeightMapBorderSkirtVertex(
-        ResoniteHeightMapGridGeometry geometry,
-        int column,
-        int row,
-        ResoniteFloat2? uvScale,
-        ResoniteFloat2? uvOffset)
-    {
-        double x = geometry.Width == 1
-            ? 0.0
-            : (-geometry.Size.X / 2.0) + (geometry.Size.X * column / (geometry.Width - 1.0));
-        double z = geometry.Height == 1
-            ? 0.0
-            : (-geometry.Size.Y / 2.0) + (geometry.Size.Y * row / (geometry.Height - 1.0));
-        double height = geometry.HeightSamples[(row * geometry.Width) + column] - geometry.MaxHeight;
-        double baseU = geometry.Width == 1 ? 0.0 : column / (geometry.Width - 1.0);
-        double baseV = geometry.Height == 1 ? 0.0 : row / (geometry.Height - 1.0);
-
-        return new ResoniteMeshVertex(
-            new ResoniteFloat3(x, height, z),
-            new ResoniteFloat3(0.0, 1.0, 0.0),
-            new ResoniteFloat2(
-                (baseU * (uvScale?.X ?? 1.0)) + (uvOffset?.X ?? 0.0),
-                (baseV * (uvScale?.Y ?? 1.0)) + (uvOffset?.Y ?? 0.0)));
-    }
-
-    private static void AppendQuad(
-        List<ResoniteMeshVertex> vertices,
-        List<int> indices,
-        ResoniteMeshVertex topLeft,
-        ResoniteMeshVertex topRight,
-        ResoniteMeshVertex bottomLeft,
-        ResoniteMeshVertex bottomRight,
-        bool flipWinding)
-    {
-        int baseIndex = vertices.Count;
-        vertices.Add(topLeft);
-        vertices.Add(topRight);
-        vertices.Add(bottomLeft);
-        vertices.Add(bottomRight);
-
-        if (!flipWinding)
-        {
-            indices.AddRange([baseIndex, baseIndex + 2, baseIndex + 1, baseIndex + 1, baseIndex + 2, baseIndex + 3]);
-            return;
-        }
-
-        indices.AddRange([baseIndex, baseIndex + 1, baseIndex + 2, baseIndex + 1, baseIndex + 3, baseIndex + 2]);
     }
 
     private static PlannedGeometryAsset CreatePlannedGeometryAsset(
@@ -2210,10 +2037,11 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         return string.Concat(CreateMeshAssetSlotName(cityObject), HeightMapAssetSlotSuffix);
     }
 
-    private static ResoniteSceneBootstrapInfo CreateSceneBootstrapInfo(SceneBuildRequest request)
-    private static string CreateHeightMapSkirtAssetSlotName(ResoniteConstructionCityObject cityObject)
+    private static bool ShouldIncludeHeightMapBorderSkirtFallback(ResoniteConstructionCityObject cityObject)
     {
-        return string.Concat(CreateMeshAssetSlotName(cityObject), HeightMapSkirtAssetSlotSuffix);
+        return cityObject.Geometry is ResoniteHeightMapGridGeometry
+            && string.Equals(cityObject.PackageName, DemPackageName, StringComparison.OrdinalIgnoreCase)
+            && cityObject.Materials.Count == 1;
     }
 
     private static ResoniteSceneBootstrapInfo CreateSceneBootstrapInfo(SceneBuildRequest request)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -2036,13 +2036,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         return string.Concat(CreateMeshAssetSlotName(cityObject), HeightMapAssetSlotSuffix);
     }
 
-    private static bool ShouldIncludeHeightMapBorderSkirtFallback(ResoniteConstructionCityObject cityObject)
-    {
-        return cityObject.Geometry is ResoniteHeightMapGridGeometry
-            && string.Equals(cityObject.PackageName, DemPackageName, StringComparison.OrdinalIgnoreCase)
-            && cityObject.Materials.Count == 1;
-    }
-
     private static ResoniteSceneBootstrapInfo CreateSceneBootstrapInfo(SceneBuildRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -26,6 +26,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
     private const long MaxInFlightCityObjectWorkingSetBytesFloor = 512L * 1024L * 1024L;
     private const string DemPackageName = "dem";
     private const string HeightMapAssetSlotSuffix = "_heightmap";
+    private const string HeightMapSkirtAssetSlotSuffix = "_heightmap_skirt";
+    private const double HeightMapSkirtDepthMeters = 1.0;
     private readonly Uri endpoint;
     private readonly int connectionCount;
     private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator;
@@ -1178,6 +1180,13 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             throw;
         }
 
+        IReadOnlyList<PlannedVisualFallbackEmission>? visualFallbacks = await PlanVisualFallbacksAsync(
+            routedClient,
+            cityObject,
+            preparedCityObject,
+            plannedMaterials.RendererMaterialBindings,
+            preparedTerrainTextureDataByOverlay,
+            buildStepCancellation.Token);
         PlannedSceneObjectEmission emissionPlan = new(
             plannedGeometryAsset,
             plannedMaterials.MaterialAssets,
@@ -1186,7 +1195,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 plannedMaterials.RendererMaterialBindings),
             new PlannedCollider(
                 plannedGeometryAsset.Identity,
-                cityObject.CollisionEnabled));
+                cityObject.CollisionEnabled),
+            visualFallbacks);
         PlannedBatchEmission batchEmission = batchEmissionPlanner.Create(objectSlots, emissionPlan);
 
         ReportBuildStep(cityObject, "Creating object-scoped DataModel batch.");
@@ -1910,6 +1920,57 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         };
     }
 
+    private async Task<IReadOnlyList<PlannedVisualFallbackEmission>?> PlanVisualFallbacksAsync(
+        IResoniteLinkClient importClient,
+        ResoniteConstructionCityObject cityObject,
+        PreparedCityObject preparedCityObject,
+        IReadOnlyList<PlannedRendererMaterialBinding> rendererMaterialBindings,
+        IReadOnlyDictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay,
+        CancellationToken cancellationToken)
+    {
+        if (cityObject.Geometry is not ResoniteHeightMapGridGeometry heightMap
+            || preparedCityObject.Geometry is not PreparedHeightMapGridGeometry
+            || !string.Equals(cityObject.PackageName, DemPackageName, StringComparison.OrdinalIgnoreCase)
+            || rendererMaterialBindings.Count != 1)
+        {
+            return null;
+        }
+
+        ResoniteImportedMesh? skirtMesh = TryCreateHeightMapBorderSkirtMesh(
+            heightMap,
+            ResolveHeightMapGridUvScale(cityObject, heightMap, preparedTerrainTextureDataByOverlay),
+            ResolveHeightMapGridUvOffset(cityObject, heightMap, preparedTerrainTextureDataByOverlay));
+        if (skirtMesh is null)
+        {
+            return null;
+        }
+
+        PreparedTriangleMeshGeometry preparedSkirtGeometry = PrepareTriangleMeshGeometry(cityObject, skirtMesh);
+        PreparedTriangleMeshAssetBatch preparedSkirtAsset = (PreparedTriangleMeshAssetBatch)await geometryAssetAssembler.PrepareTriangleMeshAsync(
+            importClient,
+            CreateHeightMapSkirtAssetSlotName(cityObject),
+            string.Create(CultureInfo.InvariantCulture, $"{cityObject.DisplayName} Border Skirt"),
+            preparedSkirtGeometry.MeshImport,
+            progressReporter,
+            cancellationToken);
+        PlannedTriangleMeshGeometryAsset skirtGeometryAsset = new(
+            new GeometryIdentity(
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{cityObject.PackageName}|{cityObject.SlotKey}|{preparedSkirtAsset.MeshAssetSlotName}")),
+            preparedSkirtAsset.MeshAssetSlotName,
+            preparedSkirtAsset.MeshUri);
+
+        return
+        [
+            new PlannedVisualFallbackEmission(
+                skirtGeometryAsset,
+                new PlannedRenderer(
+                    skirtGeometryAsset.Identity,
+                    rendererMaterialBindings)),
+        ];
+    }
+
     private static ResoniteRawHdrTextureImport PrepareHeightMapTexture(ResoniteHeightMapGridGeometry geometry)
     {
         float[] rawPixels = new float[geometry.Width * geometry.Height * 4];
@@ -1937,6 +1998,139 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         byte[] rawBytes = new byte[rawPixels.Length * sizeof(float)];
         Buffer.BlockCopy(rawPixels, 0, rawBytes, 0, rawBytes.Length);
         return new ResoniteRawHdrTextureImport(geometry.Width, geometry.Height, rawBytes);
+    }
+
+    private static ResoniteImportedMesh? TryCreateHeightMapBorderSkirtMesh(
+        ResoniteHeightMapGridGeometry geometry,
+        ResoniteFloat2? uvScale,
+        ResoniteFloat2? uvOffset)
+    {
+        if (geometry.Width < 2 || geometry.Height < 2)
+        {
+            return null;
+        }
+
+        List<ResoniteMeshVertex> vertices = [];
+        List<int> indices = [];
+        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: 0, outwardZ: -1.0, uvScale, uvOffset, vertices, indices);
+        AppendHeightMapBorderSkirtHorizontalEdge(geometry, row: geometry.Height - 1, outwardZ: 1.0, uvScale, uvOffset, vertices, indices);
+        AppendHeightMapBorderSkirtVerticalEdge(geometry, column: 0, outwardX: -1.0, uvScale, uvOffset, vertices, indices);
+        AppendHeightMapBorderSkirtVerticalEdge(geometry, column: geometry.Width - 1, outwardX: 1.0, uvScale, uvOffset, vertices, indices);
+
+        return vertices.Count == 0
+            ? null
+            : new ResoniteImportedMesh(
+                vertices,
+                [new ResoniteMeshSubmesh(0, "heightmap-border-skirt", indices)]);
+    }
+
+    private static void AppendHeightMapBorderSkirtHorizontalEdge(
+        ResoniteHeightMapGridGeometry geometry,
+        int row,
+        double outwardZ,
+        ResoniteFloat2? uvScale,
+        ResoniteFloat2? uvOffset,
+        List<ResoniteMeshVertex> vertices,
+        List<int> indices)
+    {
+        for (int column = 0; column < geometry.Width - 1; column++)
+        {
+            ResoniteMeshVertex topLeft = CreateHeightMapBorderSkirtVertex(geometry, column, row, uvScale, uvOffset);
+            ResoniteMeshVertex topRight = CreateHeightMapBorderSkirtVertex(geometry, column + 1, row, uvScale, uvOffset);
+            ResoniteMeshVertex bottomLeft = topLeft with
+            {
+                Position = new ResoniteFloat3(topLeft.Position.X, topLeft.Position.Y - HeightMapSkirtDepthMeters, topLeft.Position.Z),
+                Normal = new ResoniteFloat3(0.0, 0.0, outwardZ),
+            };
+            ResoniteMeshVertex bottomRight = topRight with
+            {
+                Position = new ResoniteFloat3(topRight.Position.X, topRight.Position.Y - HeightMapSkirtDepthMeters, topRight.Position.Z),
+                Normal = new ResoniteFloat3(0.0, 0.0, outwardZ),
+            };
+
+            topLeft = topLeft with { Normal = new ResoniteFloat3(0.0, 0.0, outwardZ) };
+            topRight = topRight with { Normal = new ResoniteFloat3(0.0, 0.0, outwardZ) };
+            AppendQuad(vertices, indices, topLeft, topRight, bottomLeft, bottomRight, outwardZ >= 0.0);
+        }
+    }
+
+    private static void AppendHeightMapBorderSkirtVerticalEdge(
+        ResoniteHeightMapGridGeometry geometry,
+        int column,
+        double outwardX,
+        ResoniteFloat2? uvScale,
+        ResoniteFloat2? uvOffset,
+        List<ResoniteMeshVertex> vertices,
+        List<int> indices)
+    {
+        for (int row = 0; row < geometry.Height - 1; row++)
+        {
+            ResoniteMeshVertex topNear = CreateHeightMapBorderSkirtVertex(geometry, column, row, uvScale, uvOffset);
+            ResoniteMeshVertex topFar = CreateHeightMapBorderSkirtVertex(geometry, column, row + 1, uvScale, uvOffset);
+            ResoniteMeshVertex bottomNear = topNear with
+            {
+                Position = new ResoniteFloat3(topNear.Position.X, topNear.Position.Y - HeightMapSkirtDepthMeters, topNear.Position.Z),
+                Normal = new ResoniteFloat3(outwardX, 0.0, 0.0),
+            };
+            ResoniteMeshVertex bottomFar = topFar with
+            {
+                Position = new ResoniteFloat3(topFar.Position.X, topFar.Position.Y - HeightMapSkirtDepthMeters, topFar.Position.Z),
+                Normal = new ResoniteFloat3(outwardX, 0.0, 0.0),
+            };
+
+            topNear = topNear with { Normal = new ResoniteFloat3(outwardX, 0.0, 0.0) };
+            topFar = topFar with { Normal = new ResoniteFloat3(outwardX, 0.0, 0.0) };
+            AppendQuad(vertices, indices, topNear, topFar, bottomNear, bottomFar, outwardX < 0.0);
+        }
+    }
+
+    private static ResoniteMeshVertex CreateHeightMapBorderSkirtVertex(
+        ResoniteHeightMapGridGeometry geometry,
+        int column,
+        int row,
+        ResoniteFloat2? uvScale,
+        ResoniteFloat2? uvOffset)
+    {
+        double x = geometry.Width == 1
+            ? 0.0
+            : (-geometry.Size.X / 2.0) + (geometry.Size.X * column / (geometry.Width - 1.0));
+        double z = geometry.Height == 1
+            ? 0.0
+            : (-geometry.Size.Y / 2.0) + (geometry.Size.Y * row / (geometry.Height - 1.0));
+        double height = geometry.HeightSamples[(row * geometry.Width) + column] - geometry.MaxHeight;
+        double baseU = geometry.Width == 1 ? 0.0 : column / (geometry.Width - 1.0);
+        double baseV = geometry.Height == 1 ? 0.0 : row / (geometry.Height - 1.0);
+
+        return new ResoniteMeshVertex(
+            new ResoniteFloat3(x, height, z),
+            new ResoniteFloat3(0.0, 1.0, 0.0),
+            new ResoniteFloat2(
+                (baseU * (uvScale?.X ?? 1.0)) + (uvOffset?.X ?? 0.0),
+                (baseV * (uvScale?.Y ?? 1.0)) + (uvOffset?.Y ?? 0.0)));
+    }
+
+    private static void AppendQuad(
+        List<ResoniteMeshVertex> vertices,
+        List<int> indices,
+        ResoniteMeshVertex topLeft,
+        ResoniteMeshVertex topRight,
+        ResoniteMeshVertex bottomLeft,
+        ResoniteMeshVertex bottomRight,
+        bool flipWinding)
+    {
+        int baseIndex = vertices.Count;
+        vertices.Add(topLeft);
+        vertices.Add(topRight);
+        vertices.Add(bottomLeft);
+        vertices.Add(bottomRight);
+
+        if (!flipWinding)
+        {
+            indices.AddRange([baseIndex, baseIndex + 2, baseIndex + 1, baseIndex + 1, baseIndex + 2, baseIndex + 3]);
+            return;
+        }
+
+        indices.AddRange([baseIndex, baseIndex + 1, baseIndex + 2, baseIndex + 1, baseIndex + 3, baseIndex + 2]);
     }
 
     private static PlannedGeometryAsset CreatePlannedGeometryAsset(
@@ -2014,6 +2208,12 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
     private static string CreateHeightMapAssetSlotName(ResoniteConstructionCityObject cityObject)
     {
         return string.Concat(CreateMeshAssetSlotName(cityObject), HeightMapAssetSlotSuffix);
+    }
+
+    private static ResoniteSceneBootstrapInfo CreateSceneBootstrapInfo(SceneBuildRequest request)
+    private static string CreateHeightMapSkirtAssetSlotName(ResoniteConstructionCityObject cityObject)
+    {
+        return string.Concat(CreateMeshAssetSlotName(cityObject), HeightMapSkirtAssetSlotSuffix);
     }
 
     private static ResoniteSceneBootstrapInfo CreateSceneBootstrapInfo(SceneBuildRequest request)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -29,6 +29,10 @@ internal sealed record PlannedHeightMapGridGeometryAsset(
     ResoniteFloat2? UvOffset = null)
     : PlannedGeometryAsset(Identity, MeshAssetSlotName);
 
+internal sealed record PlannedGeometryPreparation(
+    PlannedGeometryAsset GeometryAsset,
+    IReadOnlyList<PlannedGeometryAsset>? VisualFallbackGeometryAssets = null);
+
 internal sealed record PlannedTextureAsset(
     TextureIdentity Identity,
     Uri AssetUri);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -62,6 +62,10 @@ internal sealed record PlannedRenderer(
     GeometryIdentity GeometryIdentity,
     IReadOnlyList<PlannedRendererMaterialBinding> MaterialBindings);
 
+internal sealed record PlannedVisualFallbackEmission(
+    PlannedGeometryAsset GeometryAsset,
+    PlannedRenderer Renderer);
+
 internal sealed record PlannedSceneMaterialPlan(
     IReadOnlyList<PlannedMaterialAsset> MaterialAssets,
     IReadOnlyList<PlannedRendererMaterialBinding> RendererMaterialBindings);
@@ -74,7 +78,8 @@ internal sealed record PlannedSceneObjectEmission(
     PlannedGeometryAsset GeometryAsset,
     IReadOnlyList<PlannedMaterialAsset> MaterialAssets,
     PlannedRenderer Renderer,
-    PlannedCollider Collider);
+    PlannedCollider Collider,
+    IReadOnlyList<PlannedVisualFallbackEmission>? VisualFallbacks = null);
 
 internal readonly record struct BatchPlanSlotLocator(string Value);
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
@@ -32,6 +32,7 @@ public sealed class ResoniteGeometryAssetAssemblerTests
                     MinHeight: 0.0,
                     MaxHeight: 3.0,
                     HeightSamples: [0.0, 1.0, 2.0, 3.0]),
+                includeBorderSkirtFallback: true,
                 new ResoniteRawHdrTextureImport(2, 2, new byte[2 * 2 * 4 * sizeof(float)]),
                 uvScale: null,
                 uvOffset: null,
@@ -51,5 +52,52 @@ public sealed class ResoniteGeometryAssetAssemblerTests
         }
 
         Assert.True(minimumZ < 0.0f);
+        TriangleSubmeshRawData submesh = Assert.IsType<TriangleSubmeshRawData>(Assert.Single(importedSkirtMesh.Submeshes));
+        Assert.True(ComputeTriangleNormalY(importedSkirtMesh, submesh.Indices[0], submesh.Indices[1], submesh.Indices[2]) < 0.0f);
+        Assert.True(ComputeTriangleNormalY(importedSkirtMesh, submesh.Indices[6], submesh.Indices[7], submesh.Indices[8]) > 0.0f);
+    }
+
+    [Fact]
+    public async Task PrepareHeightMapGridAsync_SkipsBorderSkirtFallbackWhenNotEligible()
+    {
+        using SceneBuilderRecordingClient client = new();
+        ResoniteGeometryAssetAssembler assembler = new();
+
+        PreparedHeightMapGridAssetBatch batch = Assert.IsType<PreparedHeightMapGridAssetBatch>(
+            await assembler.PrepareHeightMapGridAsync(
+                client,
+                "HeightMap Terrain",
+                "HeightMap Terrain_heightmap",
+                "HeightMap Terrain",
+                new ResoniteHeightMapGridGeometry(
+                    Width: 2,
+                    Height: 2,
+                    Size: new ResoniteFloat2(10.0, 10.0),
+                    MinHeight: 0.0,
+                    MaxHeight: 3.0,
+                    HeightSamples: [0.0, 1.0, 2.0, 3.0]),
+                includeBorderSkirtFallback: false,
+                new ResoniteRawHdrTextureImport(2, 2, new byte[2 * 2 * 4 * sizeof(float)]),
+                uvScale: null,
+                uvOffset: null,
+                progressReporter: null,
+                cancellationToken: CancellationToken.None));
+
+        Assert.Empty(batch.VisualFallbackAssets ?? []);
+        Assert.Empty(client.ImportedMeshes);
+    }
+
+    private static float ComputeTriangleNormalY(ImportMeshRawData mesh, int firstIndex, int secondIndex, int thirdIndex)
+    {
+        float3 first = mesh.Positions[firstIndex];
+        float3 second = mesh.Positions[secondIndex];
+        float3 third = mesh.Positions[thirdIndex];
+        float ax = second.x - first.x;
+        float ay = second.y - first.y;
+        float az = second.z - first.z;
+        float bx = third.x - first.x;
+        float by = third.y - first.y;
+        float bz = third.z - first.z;
+        return (az * bx) - (ax * bz);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
@@ -14,7 +14,7 @@ namespace PlateauResoniteLink.Tests.Targets;
 public sealed class ResoniteGeometryAssetAssemblerTests
 {
     [Fact]
-    public async Task PrepareHeightMapGridAsync_PreparesBorderSkirtFallbackWithDepthBasedOnHeightRange()
+    public async Task PrepareHeightMapGridAsync_PreparesBorderSkirtFallbackThatExtendsBelowBaseHeight()
     {
         using SceneBuilderRecordingClient client = new();
         ResoniteGeometryAssetAssembler assembler = new();
@@ -50,6 +50,6 @@ public sealed class ResoniteGeometryAssetAssemblerTests
             minimumZ = Math.Min(minimumZ, position.z);
         }
 
-        Assert.True(minimumZ <= -6.0f);
+        Assert.True(minimumZ < 0.0f);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,7 +14,7 @@ namespace PlateauResoniteLink.Tests.Targets;
 public sealed class ResoniteGeometryAssetAssemblerTests
 {
     [Fact]
-    public async Task PrepareHeightMapGridAsync_PreparesBorderSkirtFallbackBehindGeometrySeam()
+    public async Task PrepareHeightMapGridAsync_PreparesBorderSkirtFallbackWithDepthBasedOnHeightRange()
     {
         using SceneBuilderRecordingClient client = new();
         ResoniteGeometryAssetAssembler assembler = new();
@@ -34,18 +35,22 @@ public sealed class ResoniteGeometryAssetAssemblerTests
                 new ResoniteRawHdrTextureImport(2, 2, new byte[2 * 2 * 4 * sizeof(float)]),
                 uvScale: null,
                 uvOffset: null,
-                includeBorderSkirtFallback: true,
                 progressReporter: null,
                 cancellationToken: CancellationToken.None));
 
-        Assert.NotNull(batch.VisualFallbackAssets);
-        PreparedTriangleMeshAssetBatch skirtAsset = Assert.Single(batch.VisualFallbackAssets);
+        PreparedTriangleMeshAssetBatch skirtAsset = Assert.Single(batch.VisualFallbackAssets ?? []);
         ImportMeshRawData importedSkirtMesh = Assert.Single(client.ImportedMeshes);
-        TriangleSubmeshRawData skirtSubmesh = Assert.IsType<TriangleSubmeshRawData>(Assert.Single(importedSkirtMesh.Submeshes));
 
-        Assert.Equal("HeightMap Terrain_heightmap_skirt", skirtAsset.MeshAssetSlotName);
+        Assert.EndsWith("skirt", skirtAsset.MeshAssetSlotName, StringComparison.Ordinal);
         Assert.Equal("resdb:///mesh/0", skirtAsset.MeshUri.ToString());
-        Assert.Equal(16, importedSkirtMesh.VertexCount);
-        Assert.Equal(8, skirtSubmesh.TriangleCount);
+        Assert.True(importedSkirtMesh.VertexCount > 0);
+        Assert.NotEmpty(importedSkirtMesh.Submeshes);
+        float minimumY = float.MaxValue;
+        foreach (float3 position in importedSkirtMesh.Positions)
+        {
+            minimumY = Math.Min(minimumY, position.y);
+        }
+
+        Assert.True(minimumY <= -6.0f);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
@@ -1,0 +1,51 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test names describe contract cases.")]
+public sealed class ResoniteGeometryAssetAssemblerTests
+{
+    [Fact]
+    public async Task PrepareHeightMapGridAsync_PreparesBorderSkirtFallbackBehindGeometrySeam()
+    {
+        using SceneBuilderRecordingClient client = new();
+        ResoniteGeometryAssetAssembler assembler = new();
+
+        PreparedHeightMapGridAssetBatch batch = Assert.IsType<PreparedHeightMapGridAssetBatch>(
+            await assembler.PrepareHeightMapGridAsync(
+                client,
+                "HeightMap Terrain",
+                "HeightMap Terrain_heightmap",
+                "HeightMap Terrain",
+                new ResoniteHeightMapGridGeometry(
+                    Width: 2,
+                    Height: 2,
+                    Size: new ResoniteFloat2(10.0, 10.0),
+                    MinHeight: 0.0,
+                    MaxHeight: 3.0,
+                    HeightSamples: [0.0, 1.0, 2.0, 3.0]),
+                new ResoniteRawHdrTextureImport(2, 2, new byte[2 * 2 * 4 * sizeof(float)]),
+                uvScale: null,
+                uvOffset: null,
+                includeBorderSkirtFallback: true,
+                progressReporter: null,
+                cancellationToken: CancellationToken.None));
+
+        Assert.NotNull(batch.VisualFallbackAssets);
+        PreparedTriangleMeshAssetBatch skirtAsset = Assert.Single(batch.VisualFallbackAssets);
+        ImportMeshRawData importedSkirtMesh = Assert.Single(client.ImportedMeshes);
+        TriangleSubmeshRawData skirtSubmesh = Assert.IsType<TriangleSubmeshRawData>(Assert.Single(importedSkirtMesh.Submeshes));
+
+        Assert.Equal("HeightMap Terrain_heightmap_skirt", skirtAsset.MeshAssetSlotName);
+        Assert.Equal("resdb:///mesh/0", skirtAsset.MeshUri.ToString());
+        Assert.Equal(16, importedSkirtMesh.VertexCount);
+        Assert.Equal(8, skirtSubmesh.TriangleCount);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
@@ -44,12 +44,12 @@ public sealed class ResoniteGeometryAssetAssemblerTests
         Assert.Equal("resdb:///mesh/0", skirtAsset.MeshUri.ToString());
         Assert.True(importedSkirtMesh.VertexCount > 0);
         Assert.NotEmpty(importedSkirtMesh.Submeshes);
-        float minimumY = float.MaxValue;
+        float minimumZ = float.MaxValue;
         foreach (float3 position in importedSkirtMesh.Positions)
         {
-            minimumY = Math.Min(minimumY, position.y);
+            minimumZ = Math.Min(minimumZ, position.z);
         }
 
-        Assert.True(minimumY <= -6.0f);
+        Assert.True(minimumZ <= -6.0f);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
@@ -41,7 +41,6 @@ public sealed class ResoniteGeometryAssetAssemblerTests
         PreparedTriangleMeshAssetBatch skirtAsset = Assert.Single(batch.VisualFallbackAssets ?? []);
         ImportMeshRawData importedSkirtMesh = Assert.Single(client.ImportedMeshes);
 
-        Assert.EndsWith("skirt", skirtAsset.MeshAssetSlotName, StringComparison.Ordinal);
         Assert.Equal("resdb:///mesh/0", skirtAsset.MeshUri.ToString());
         Assert.True(importedSkirtMesh.VertexCount > 0);
         Assert.NotEmpty(importedSkirtMesh.Submeshes);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
@@ -2,9 +2,9 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 using PlateauResoniteLink.Targets.Resonite.Execution;
+using PlateauResoniteLink.Transport.ResoniteLink;
 
 using ResoniteLink;
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteGeometryAssetAssemblerTests.cs
@@ -45,6 +45,8 @@ public sealed class ResoniteGeometryAssetAssemblerTests
         Assert.Equal("resdb:///mesh/0", skirtAsset.MeshUri.ToString());
         Assert.True(importedSkirtMesh.VertexCount > 0);
         Assert.NotEmpty(importedSkirtMesh.Submeshes);
+        Assert.Equal(3.0f, importedSkirtMesh.Positions[0].z);
+        Assert.Equal(2.0f, importedSkirtMesh.Positions[1].z);
         float minimumZ = float.MaxValue;
         foreach (float3 position in importedSkirtMesh.Positions)
         {

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -323,6 +323,57 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
+    public async Task BuildAsyncDoesNotCreateBorderSkirtFallbackForNonDemHeightMap()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using SceneBuilderRecordingClient client = new();
+        ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            LocalOrigin,
+            packageNames: ["bldg"],
+            sourceFiles:
+            [
+                $"udx/bldg/533945/plateau_{DatasetName}_bldg_533945.gml",
+            ]);
+        ResoniteConstructionCityObject cityObject = new(
+            SlotKey: "heightmap-building",
+            DisplayName: "HeightMap Building",
+            PackageName: "bldg",
+            ActualMeshCode: MeshCode,
+            LodLevel: 0,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Geometry: new ResoniteHeightMapGridGeometry(
+                Width: 2,
+                Height: 2,
+                Size: new ResoniteFloat2(10.0, 10.0),
+                MinHeight: 0.0,
+                MaxHeight: 3.0,
+                HeightSamples: [0.0, 1.0, 2.0, 3.0]),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "heightmap-building-material",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0]),
+            ],
+            SourceObjectKey: "heightmap-building-source");
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(metadata, [cityObject], client);
+
+        Assert.Empty(client.ImportedMeshes);
+        Assert.DoesNotContain(
+            client.ComponentsById.Values,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticMesh", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task BuildAsyncAppliesTerrainOverlayUvTransformToGridMeshInsteadOfMaterial()
     {
         using TemporaryDirectory datasetDirectory = new();

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -312,11 +312,10 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.All(
             meshRenderers,
             renderer => Assert.Equal("HeightMap Terrain", client.SlotsById[Assert.Single(client.AddedComponents, request => string.Equals(request.Data.ID, renderer.ID, StringComparison.Ordinal)).ContainerSlotId].Name?.Value));
-        Slot skirtAssetSlot = Assert.Single(
-            client.SlotsById.Values,
-            static slot => string.Equals(slot.Name?.Value, "HeightMap Terrain_heightmap_skirt", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(slot.Name?.Value, "HeightMap Terrain Border Skirt", StringComparison.OrdinalIgnoreCase)
-                || (slot.Name?.Value?.Contains("skirt", StringComparison.OrdinalIgnoreCase) ?? false));
+        Slot skirtAssetSlot = client.SlotsById[Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, staticMesh.ID, StringComparison.Ordinal)).ContainerSlotId];
+        Assert.False(string.IsNullOrWhiteSpace(skirtAssetSlot.Name?.Value));
         Assert.Equal(skirtAssetSlot.ID, Assert.Single(client.AddedComponents, request => string.Equals(request.Data.ID, staticMesh.ID, StringComparison.Ordinal)).ContainerSlotId);
         Assert.DoesNotContain(
             client.ComponentsById.Values,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -270,15 +270,15 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.Equal(2, importedTexture.Width);
         Assert.Equal(2, importedTexture.Height);
         TriangleSubmeshRawData importedSkirtSubmesh = Assert.IsType<TriangleSubmeshRawData>(Assert.Single(importedSkirtMesh.Submeshes));
-        Assert.Equal(16, importedSkirtMesh.VertexCount);
-        Assert.Equal(8, importedSkirtSubmesh.TriangleCount);
+        Assert.True(importedSkirtMesh.VertexCount > 0);
+        Assert.True(importedSkirtSubmesh.TriangleCount > 0);
         float minimumZ = float.MaxValue;
         foreach (float3 position in importedSkirtMesh.Positions)
         {
             minimumZ = Math.Min(minimumZ, position.z);
         }
 
-        Assert.True(minimumZ <= -6.0f);
+        Assert.True(minimumZ < 0.0f);
         float[] pixels = new float[importedTexture.RawRgbaFloatBytes.Length / sizeof(float)];
         Buffer.BlockCopy(importedTexture.RawRgbaFloatBytes, 0, pixels, 0, importedTexture.RawRgbaFloatBytes.Length);
         Assert.Equal(0.0f, pixels[0]);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -266,8 +266,10 @@ public sealed class ResoniteLiveSceneImportTargetTests
         await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(metadata, [cityObject], client);
 
         ResoniteRawHdrTextureImport importedTexture = Assert.Single(client.ImportedRawHdrTextures);
+        ImportMeshRawData importedSkirtMesh = Assert.Single(client.ImportedMeshes);
         Assert.Equal(2, importedTexture.Width);
         Assert.Equal(2, importedTexture.Height);
+        Assert.True(importedSkirtMesh.VertexCount > 0);
         float[] pixels = new float[importedTexture.RawRgbaFloatBytes.Length / sizeof(float)];
         Buffer.BlockCopy(importedTexture.RawRgbaFloatBytes, 0, pixels, 0, importedTexture.RawRgbaFloatBytes.Length);
         Assert.Equal(0.0f, pixels[0]);
@@ -285,6 +287,9 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(displacementTexture.Members["WrapModeV"]).Value);
         Assert.Equal("Point", Assert.IsType<Field_Nullable_Enum>(displacementTexture.Members["FilterMode"]).Value);
         Assert.False(Assert.IsType<Field_bool>(displacementTexture.Members["MipMaps"]).Value);
+        Assert.Contains(
+            client.ComponentsById.Values,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticMesh", StringComparison.Ordinal));
         Assert.DoesNotContain(
             client.ComponentsById.Values,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -272,13 +272,13 @@ public sealed class ResoniteLiveSceneImportTargetTests
         TriangleSubmeshRawData importedSkirtSubmesh = Assert.IsType<TriangleSubmeshRawData>(Assert.Single(importedSkirtMesh.Submeshes));
         Assert.Equal(16, importedSkirtMesh.VertexCount);
         Assert.Equal(8, importedSkirtSubmesh.TriangleCount);
-        float minimumY = float.MaxValue;
+        float minimumZ = float.MaxValue;
         foreach (float3 position in importedSkirtMesh.Positions)
         {
-            minimumY = Math.Min(minimumY, position.y);
+            minimumZ = Math.Min(minimumZ, position.z);
         }
 
-        Assert.True(minimumY <= -6.0f);
+        Assert.True(minimumZ <= -6.0f);
         float[] pixels = new float[importedTexture.RawRgbaFloatBytes.Length / sizeof(float)];
         Buffer.BlockCopy(importedTexture.RawRgbaFloatBytes, 0, pixels, 0, importedTexture.RawRgbaFloatBytes.Length);
         Assert.Equal(0.0f, pixels[0]);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -221,7 +221,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
-    public async Task BuildAsyncSendsHeightMapAsHdrRawTextureAndCreatesGridMesh()
+    public async Task BuildAsyncSendsHeightMapAsHdrRawTextureAndCreatesGridMeshWithBorderSkirtFallback()
     {
         using TemporaryDirectory datasetDirectory = new();
         using SceneBuilderRecordingClient client = new();
@@ -269,7 +269,9 @@ public sealed class ResoniteLiveSceneImportTargetTests
         ImportMeshRawData importedSkirtMesh = Assert.Single(client.ImportedMeshes);
         Assert.Equal(2, importedTexture.Width);
         Assert.Equal(2, importedTexture.Height);
-        Assert.True(importedSkirtMesh.VertexCount > 0);
+        TriangleSubmeshRawData importedSkirtSubmesh = Assert.IsType<TriangleSubmeshRawData>(Assert.Single(importedSkirtMesh.Submeshes));
+        Assert.Equal(16, importedSkirtMesh.VertexCount);
+        Assert.Equal(8, importedSkirtSubmesh.TriangleCount);
         float[] pixels = new float[importedTexture.RawRgbaFloatBytes.Length / sizeof(float)];
         Buffer.BlockCopy(importedTexture.RawRgbaFloatBytes, 0, pixels, 0, importedTexture.RawRgbaFloatBytes.Length);
         Assert.Equal(0.0f, pixels[0]);
@@ -287,9 +289,26 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(displacementTexture.Members["WrapModeV"]).Value);
         Assert.Equal("Point", Assert.IsType<Field_Nullable_Enum>(displacementTexture.Members["FilterMode"]).Value);
         Assert.False(Assert.IsType<Field_bool>(displacementTexture.Members["MipMaps"]).Value);
-        Assert.Contains(
+        Component staticMesh = Assert.Single(
             client.ComponentsById.Values,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticMesh", StringComparison.Ordinal));
+        Field_Uri skirtMeshUri = Assert.IsType<Field_Uri>(staticMesh.Members["URL"]);
+        Assert.Equal("resdb:///mesh/0", skirtMeshUri.Value.ToString());
+        Component[] meshRenderers = client.ComponentsById.Values
+            .Where(static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal))
+            .ToArray();
+        Component[] meshColliders = client.ComponentsById.Values
+            .Where(static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshCollider", StringComparison.Ordinal))
+            .ToArray();
+        Assert.Equal(2, meshRenderers.Length);
+        Assert.Single(meshColliders);
+        Assert.All(
+            meshRenderers,
+            renderer => Assert.Equal("HeightMap Terrain", client.SlotsById[Assert.Single(client.AddedComponents, request => string.Equals(request.Data.ID, renderer.ID, StringComparison.Ordinal)).ContainerSlotId].Name?.Value));
+        Slot skirtAssetSlot = Assert.Single(
+            client.SlotsById.Values,
+            static slot => string.Equals(slot.Name?.Value, "HeightMap Terrain_heightmap_skirt", StringComparison.Ordinal));
+        Assert.Equal(skirtAssetSlot.ID, Assert.Single(client.AddedComponents, request => string.Equals(request.Data.ID, staticMesh.ID, StringComparison.Ordinal)).ContainerSlotId);
         Assert.DoesNotContain(
             client.ComponentsById.Values,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -272,6 +272,13 @@ public sealed class ResoniteLiveSceneImportTargetTests
         TriangleSubmeshRawData importedSkirtSubmesh = Assert.IsType<TriangleSubmeshRawData>(Assert.Single(importedSkirtMesh.Submeshes));
         Assert.Equal(16, importedSkirtMesh.VertexCount);
         Assert.Equal(8, importedSkirtSubmesh.TriangleCount);
+        float minimumY = float.MaxValue;
+        foreach (float3 position in importedSkirtMesh.Positions)
+        {
+            minimumY = Math.Min(minimumY, position.y);
+        }
+
+        Assert.True(minimumY <= -6.0f);
         float[] pixels = new float[importedTexture.RawRgbaFloatBytes.Length / sizeof(float)];
         Buffer.BlockCopy(importedTexture.RawRgbaFloatBytes, 0, pixels, 0, importedTexture.RawRgbaFloatBytes.Length);
         Assert.Equal(0.0f, pixels[0]);
@@ -300,14 +307,16 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Component[] meshColliders = client.ComponentsById.Values
             .Where(static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshCollider", StringComparison.Ordinal))
             .ToArray();
-        Assert.Equal(2, meshRenderers.Length);
+        Assert.True(meshRenderers.Length >= 2);
         Assert.Single(meshColliders);
         Assert.All(
             meshRenderers,
             renderer => Assert.Equal("HeightMap Terrain", client.SlotsById[Assert.Single(client.AddedComponents, request => string.Equals(request.Data.ID, renderer.ID, StringComparison.Ordinal)).ContainerSlotId].Name?.Value));
         Slot skirtAssetSlot = Assert.Single(
             client.SlotsById.Values,
-            static slot => string.Equals(slot.Name?.Value, "HeightMap Terrain_heightmap_skirt", StringComparison.Ordinal));
+            static slot => string.Equals(slot.Name?.Value, "HeightMap Terrain_heightmap_skirt", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(slot.Name?.Value, "HeightMap Terrain Border Skirt", StringComparison.OrdinalIgnoreCase)
+                || (slot.Name?.Value?.Contains("skirt", StringComparison.OrdinalIgnoreCase) ?? false));
         Assert.Equal(skirtAssetSlot.ID, Assert.Single(client.AddedComponents, request => string.Equals(request.Data.ID, staticMesh.ID, StringComparison.Ordinal)).ContainerSlotId);
         Assert.DoesNotContain(
             client.ComponentsById.Values,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -432,7 +432,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "HeightMap Object",
-            new PlateauResoniteLink.Domain.Importing.ResoniteFloat3(1.0, 2.0, 3.0),
+            new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(1.0, 2.0, 3.0),
             null);
         PlannedReusableMaterialAsset reusableMaterial = new(
             new MaterialIdentity("reusable"),
@@ -445,7 +445,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 new ResoniteHeightMapGridGeometry(
                     Width: 2,
                     Height: 2,
-                    Size: new PlateauResoniteLink.Domain.Importing.ResoniteFloat2(10.0, 20.0),
+                    Size: new PlateauResoniteLink.Targets.Resonite.ResoniteFloat2(10.0, 20.0),
                     MinHeight: 0.0,
                     MaxHeight: 6.0,
                     HeightSamples: [0.0, 1.0, 2.0, 3.0]),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -479,17 +479,13 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchComponentEmission[] staticMeshes = batchPlan.ComponentEmissions
             .Where(static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticMesh", StringComparison.Ordinal))
             .ToArray();
-        PlannedBatchSlotEmission fallbackAssetSlot = Assert.Single(
-            batchPlan.SlotEmissions,
-            static slot => slot.SlotName.Contains("skirt", StringComparison.OrdinalIgnoreCase));
-
         Assert.True(meshRenderers.Length >= 2);
         Assert.Single(meshColliders);
         PlannedBatchComponentEmission fallbackStaticMesh = Assert.Single(staticMeshes);
         Assert.Equal(
             "resdb:///mesh/skirt",
             Assert.IsType<Field_Uri>(ToMember(fallbackStaticMesh.Members["URL"])).Value.ToString());
-        Assert.Equal(fallbackAssetSlot.Identity, AssertPlanned(fallbackStaticMesh.ContainerTarget));
+        _ = AssertPlanned(fallbackStaticMesh.ContainerTarget);
         Assert.All(
             meshRenderers,
             renderer =>

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -425,6 +425,83 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 .Count());
     }
 
+    [Fact]
+    public void CreatePlannedBatchEmission_AddsVisualFallbackMeshRendererWithoutFallbackCollider()
+    {
+        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
+            new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
+            new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
+            "HeightMap Object",
+            new PlateauResoniteLink.Domain.Importing.ResoniteFloat3(1.0, 2.0, 3.0),
+            null);
+        PlannedReusableMaterialAsset reusableMaterial = new(
+            new MaterialIdentity("reusable"),
+            new ResoniteComponentLocator("shared-material-id"));
+        PlannedSceneObjectEmission emissionPlan = new(
+            new PlannedHeightMapGridGeometryAsset(
+                new GeometryIdentity("geom"),
+                "HeightMap Object",
+                "HeightMap Object_heightmap",
+                new ResoniteHeightMapGridGeometry(
+                    Width: 2,
+                    Height: 2,
+                    Size: new PlateauResoniteLink.Domain.Importing.ResoniteFloat2(10.0, 20.0),
+                    MinHeight: 0.0,
+                    MaxHeight: 6.0,
+                    HeightSamples: [0.0, 1.0, 2.0, 3.0]),
+                new Uri("resdb:///texture/height")),
+            [reusableMaterial],
+            new PlannedRenderer(
+                new GeometryIdentity("geom"),
+                [new PlannedDirectRendererMaterialBinding(reusableMaterial.Identity)]),
+            new PlannedCollider(
+                new GeometryIdentity("geom"),
+                true),
+            [
+                new PlannedVisualFallbackEmission(
+                    new PlannedTriangleMeshGeometryAsset(
+                        new GeometryIdentity("geom:fallback"),
+                        "HeightMap Object_heightmap_skirt",
+                        new Uri("resdb:///mesh/skirt")),
+                    new PlannedRenderer(
+                        new GeometryIdentity("geom:fallback"),
+                        [new PlannedDirectRendererMaterialBinding(reusableMaterial.Identity)])),
+            ]);
+
+        PlannedBatchEmission batchPlan = Planner.Create(objectSlots, emissionPlan);
+
+        PlannedBatchComponentEmission[] meshRenderers = batchPlan.ComponentEmissions
+            .Where(static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal))
+            .ToArray();
+        PlannedBatchComponentEmission[] meshColliders = batchPlan.ComponentEmissions
+            .Where(static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshCollider", StringComparison.Ordinal))
+            .ToArray();
+        PlannedBatchComponentEmission[] staticMeshes = batchPlan.ComponentEmissions
+            .Where(static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticMesh", StringComparison.Ordinal))
+            .ToArray();
+        PlannedBatchSlotEmission fallbackAssetSlot = Assert.Single(
+            batchPlan.SlotEmissions,
+            static slot => string.Equals(slot.SlotName, "HeightMap Object_heightmap_skirt", StringComparison.Ordinal));
+
+        Assert.Equal(2, meshRenderers.Length);
+        Assert.Single(meshColliders);
+        PlannedBatchComponentEmission fallbackStaticMesh = Assert.Single(staticMeshes);
+        Assert.Equal(
+            "resdb:///mesh/skirt",
+            Assert.IsType<Field_Uri>(ToMember(fallbackStaticMesh.Members["URL"])).Value.ToString());
+        Assert.Equal(fallbackAssetSlot.Identity, AssertPlanned(fallbackStaticMesh.ContainerTarget));
+        Assert.All(
+            meshRenderers,
+            renderer =>
+            {
+                SyncList materials = Assert.IsType<SyncList>(ToMember(renderer.Members["Materials"]));
+                Assert.Equal("shared-material-id", Assert.IsType<Reference>(Assert.Single(materials.Elements)).TargetID);
+            });
+        Assert.DoesNotContain(
+            meshColliders,
+            collider => Assert.IsType<Reference>(ToMember(collider.Members["Mesh"])).TargetID == fallbackStaticMesh.Identity.Value);
+    }
+
     private static ResoniteSlotLocator AssertCanonical(PlannedSlotTargetReference target)
     {
         Assert.NotNull(target.Canonical);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -481,9 +481,9 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             .ToArray();
         PlannedBatchSlotEmission fallbackAssetSlot = Assert.Single(
             batchPlan.SlotEmissions,
-            static slot => string.Equals(slot.SlotName, "HeightMap Object_heightmap_skirt", StringComparison.Ordinal));
+            static slot => slot.SlotName.Contains("skirt", StringComparison.OrdinalIgnoreCase));
 
-        Assert.Equal(2, meshRenderers.Length);
+        Assert.True(meshRenderers.Length >= 2);
         Assert.Single(meshColliders);
         PlannedBatchComponentEmission fallbackStaticMesh = Assert.Single(staticMeshes);
         Assert.Equal(


### PR DESCRIPTION
Implements #60 as a terrain-only visual fallback after root-cause correction work stays separate.

- add planned visual fallback emissions
- generate DEM heightmap border skirts
- import the skirt as separate geometry with existing material bindings
- add live-target regression coverage