### PR TITLE
feat(target): route LOD1 fallback-roof buildings around fixed-cell bake

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/ImportedCityObject.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ImportedCityObject.cs
@@ -15,7 +15,8 @@ public sealed record ImportedCityObject(
     bool CollisionEnabled = true,
     string? SourceObjectKey = null,
     string? SourceUnitKey = null,
-    string? SourceFileRelativePath = null)
+    string? SourceFileRelativePath = null,
+    bool UsesFallbackRoofStrategy = false)
 {
     public ImportedCityObject(
         string ObjectKey,
@@ -29,7 +30,8 @@ public sealed record ImportedCityObject(
         bool CollisionEnabled = true,
         string? SourceObjectKey = null,
         string? SourceUnitKey = null,
-        string? SourceFileRelativePath = null)
+        string? SourceFileRelativePath = null,
+        bool UsesFallbackRoofStrategy = false)
         : this(
             ObjectKey,
             DisplayName,
@@ -42,7 +44,8 @@ public sealed record ImportedCityObject(
             CollisionEnabled,
             SourceObjectKey,
             SourceUnitKey,
-            SourceFileRelativePath)
+            SourceFileRelativePath,
+            UsesFallbackRoofStrategy)
     {
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/ImportedCityObject.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ImportedCityObject.cs
@@ -3,6 +3,12 @@ using System.Collections.Generic;
 
 namespace PlateauResoniteLink.Application.Importing;
 
+public enum ImportedCityObjectClassification
+{
+    Default = 0,
+    FallbackRoofBuilding = 1,
+}
+
 public sealed record ImportedCityObject(
     string ObjectKey,
     string DisplayName,
@@ -15,7 +21,8 @@ public sealed record ImportedCityObject(
     bool CollisionEnabled = true,
     string? SourceObjectKey = null,
     string? SourceUnitKey = null,
-    string? SourceFileRelativePath = null)
+    string? SourceFileRelativePath = null,
+    ImportedCityObjectClassification Classification = ImportedCityObjectClassification.Default)
 {
     public ImportedCityObject(
         string ObjectKey,
@@ -29,7 +36,8 @@ public sealed record ImportedCityObject(
         bool CollisionEnabled = true,
         string? SourceObjectKey = null,
         string? SourceUnitKey = null,
-        string? SourceFileRelativePath = null)
+        string? SourceFileRelativePath = null,
+        ImportedCityObjectClassification Classification = ImportedCityObjectClassification.Default)
         : this(
             ObjectKey,
             DisplayName,
@@ -42,7 +50,8 @@ public sealed record ImportedCityObject(
             CollisionEnabled,
             SourceObjectKey,
             SourceUnitKey,
-            SourceFileRelativePath)
+            SourceFileRelativePath,
+            Classification)
     {
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/ImportedCityObject.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ImportedCityObject.cs
@@ -15,8 +15,7 @@ public sealed record ImportedCityObject(
     bool CollisionEnabled = true,
     string? SourceObjectKey = null,
     string? SourceUnitKey = null,
-    string? SourceFileRelativePath = null,
-    bool UsesFallbackRoofStrategy = false)
+    string? SourceFileRelativePath = null)
 {
     public ImportedCityObject(
         string ObjectKey,
@@ -30,8 +29,7 @@ public sealed record ImportedCityObject(
         bool CollisionEnabled = true,
         string? SourceObjectKey = null,
         string? SourceUnitKey = null,
-        string? SourceFileRelativePath = null,
-        bool UsesFallbackRoofStrategy = false)
+        string? SourceFileRelativePath = null)
         : this(
             ObjectKey,
             DisplayName,
@@ -44,8 +42,7 @@ public sealed record ImportedCityObject(
             CollisionEnabled,
             SourceObjectKey,
             SourceUnitKey,
-            SourceFileRelativePath,
-            UsesFallbackRoofStrategy)
+            SourceFileRelativePath)
     {
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1280,8 +1280,6 @@ internal static partial class LocalCityGmlObjectProjection
             materials.Add(CreateMaterialBinding(representativeSurface, materialGroup.Key, materialIndex));
         }
 
-        bool usesFallbackRoofStrategy = materialGroups.Any(group => IsFallbackRoofMaterialGroup(group, materialGroups.Length));
-
         return new ImportedCityObject(
             ObjectKey: cityObject.SlotKey,
             DisplayName: cityObject.DisplayName,
@@ -1293,8 +1291,7 @@ internal static partial class LocalCityGmlObjectProjection
             Materials: materials,
             SourceObjectKey: cityObject.SourceIdentity,
             SourceUnitKey: cityObject.SourceUnitIdentity,
-            SourceFileRelativePath: cityObject.SourceFileRelativePath,
-            UsesFallbackRoofStrategy: usesFallbackRoofStrategy);
+            SourceFileRelativePath: cityObject.SourceFileRelativePath);
     }
 
     private static GeodeticPoint GetCityObjectOrigin(ParsedCityObject cityObject)

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1247,6 +1247,13 @@ internal static partial class LocalCityGmlObjectProjection
                 StringComparer.Ordinal)
             .OrderBy(static group => group.Key, StringComparer.Ordinal)
             .ToArray();
+        ImportedCityObjectClassification classification =
+            cityObject.LodLevel == 1
+            && string.Equals(cityObject.PackageName, "bldg", StringComparison.OrdinalIgnoreCase)
+            && materialGroups.Length == 1
+            && IsFallbackRoofMaterialGroup(materialGroups[0], materialGroups.Length)
+                ? ImportedCityObjectClassification.FallbackRoofBuilding
+                : ImportedCityObjectClassification.Default;
 
         for (int materialIndex = 0; materialIndex < materialGroups.Length; materialIndex++)
         {
@@ -1291,7 +1298,8 @@ internal static partial class LocalCityGmlObjectProjection
             Materials: materials,
             SourceObjectKey: cityObject.SourceIdentity,
             SourceUnitKey: cityObject.SourceUnitIdentity,
-            SourceFileRelativePath: cityObject.SourceFileRelativePath);
+            SourceFileRelativePath: cityObject.SourceFileRelativePath,
+            Classification: classification);
     }
 
     private static GeodeticPoint GetCityObjectOrigin(ParsedCityObject cityObject)

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -22,6 +22,7 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal static partial class LocalCityGmlObjectProjection
 {
+    private const string FallbackRoofMaterialKeySuffix = "|fallback-roof";
     public const string DefaultDemTerrainTexturePath = DemTerrainTextureDefaults.PlateauOrthoPath;
     public const string DefaultDemTerrainTextureUrlTemplate = DemTerrainTextureDefaults.PlateauOrthoUrlTemplate;
     public const string DefaultDemTerrainTextureFallbackUrlTemplate = DemTerrainTextureDefaults.GsiFallbackUrlTemplate;
@@ -1276,8 +1277,11 @@ internal static partial class LocalCityGmlObjectProjection
             }
 
             ResolvedSurfaceMaterial representativeSurface = materialGroup.First();
-            submeshes.Add(new MeshSubmesh(materialIndex, materialGroup.Key, indices));
-            materials.Add(CreateMaterialBinding(representativeSurface, materialGroup.Key, materialIndex));
+            string materialKey = MarkFallbackRoofMaterialKey(
+                materialGroup.Key,
+                IsFallbackRoofMaterialGroup(materialGroup, materialGroups.Length));
+            submeshes.Add(new MeshSubmesh(materialIndex, materialKey, indices));
+            materials.Add(CreateMaterialBinding(representativeSurface, materialKey, materialIndex));
         }
 
         return new ImportedCityObject(
@@ -2500,6 +2504,32 @@ internal static partial class LocalCityGmlObjectProjection
             textureOffset);
     }
 
+    private static bool IsFallbackRoofMaterialGroup(
+        IGrouping<string, ResolvedSurfaceMaterial> materialGroup,
+        int totalGroupCount)
+    {
+        if (totalGroupCount != 1)
+        {
+            return false;
+        }
+
+        ResolvedSurfaceMaterial representativeSurface = materialGroup.First();
+        return materialGroup.All(static resolvedSurface => resolvedSurface.Surface.Semantic is ParsedSurfaceSemantic.Roof)
+            && representativeSurface.Material.ReuseScope == MaterialReuseScope.Shared
+            && representativeSurface.Material.TexturePayload is null
+            && representativeSurface.Material.TextureSourceKind == TextureSourceKind.Bundled
+            && representativeSurface.Material.Projection == MaterialProjection.Triplanar
+            && representativeSurface.Material.TerrainOverlay is null
+            && string.Equals(representativeSurface.Material.Family, BundledDefaultMaterialFamilies.Roof, StringComparison.Ordinal);
+    }
+
+    private static string MarkFallbackRoofMaterialKey(string materialKey, bool isFallbackRoof)
+    {
+        return isFallbackRoof
+            ? string.Concat(materialKey, FallbackRoofMaterialKeySuffix)
+            : materialKey;
+    }
+
     private static string CreateTerrainOverlayToken(TerrainTextureOverlay terrainOverlay)
     {
         return string.Create(
@@ -3053,13 +3083,20 @@ internal static partial class LocalCityGmlObjectProjection
             .Select((group, materialIndex) =>
             {
                 ResolvedSurfaceMaterial representativeSurface = group.First();
+                string materialKey = MarkFallbackRoofMaterialKey(
+                    group.Key,
+                    IsFallbackRoofMaterialGroup(group, resolvedSurfaces
+                        .GroupBy(
+                            static resolvedSurface => CreateBindingMaterialKey(
+                                resolvedSurface.Material,
+                                resolvedSurface.DepthOffset,
+                                resolvedSurface.Material.TextureScale,
+                                resolvedSurface.Surface.BaseColor),
+                            StringComparer.Ordinal)
+                        .Count()));
                 return CreateMaterialBinding(
                     representativeSurface,
-                    CreateBindingMaterialKey(
-                        representativeSurface.Material,
-                        representativeSurface.DepthOffset,
-                        representativeSurface.Material.TextureScale,
-                        representativeSurface.Surface.BaseColor),
+                    materialKey,
                     materialIndex);
             })
             .Where(static material => material.ReuseScope == MaterialReuseScope.Shared)

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -22,7 +22,6 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal static partial class LocalCityGmlObjectProjection
 {
-    private const string FallbackRoofMaterialKeySuffix = "|fallback-roof";
     public const string DefaultDemTerrainTexturePath = DemTerrainTextureDefaults.PlateauOrthoPath;
     public const string DefaultDemTerrainTextureUrlTemplate = DemTerrainTextureDefaults.PlateauOrthoUrlTemplate;
     public const string DefaultDemTerrainTextureFallbackUrlTemplate = DemTerrainTextureDefaults.GsiFallbackUrlTemplate;
@@ -1277,12 +1276,11 @@ internal static partial class LocalCityGmlObjectProjection
             }
 
             ResolvedSurfaceMaterial representativeSurface = materialGroup.First();
-            string materialKey = MarkFallbackRoofMaterialKey(
-                materialGroup.Key,
-                IsFallbackRoofMaterialGroup(materialGroup, materialGroups.Length));
-            submeshes.Add(new MeshSubmesh(materialIndex, materialKey, indices));
-            materials.Add(CreateMaterialBinding(representativeSurface, materialKey, materialIndex));
+            submeshes.Add(new MeshSubmesh(materialIndex, materialGroup.Key, indices));
+            materials.Add(CreateMaterialBinding(representativeSurface, materialGroup.Key, materialIndex));
         }
+
+        bool usesFallbackRoofStrategy = materialGroups.Any(group => IsFallbackRoofMaterialGroup(group, materialGroups.Length));
 
         return new ImportedCityObject(
             ObjectKey: cityObject.SlotKey,
@@ -1295,7 +1293,8 @@ internal static partial class LocalCityGmlObjectProjection
             Materials: materials,
             SourceObjectKey: cityObject.SourceIdentity,
             SourceUnitKey: cityObject.SourceUnitIdentity,
-            SourceFileRelativePath: cityObject.SourceFileRelativePath);
+            SourceFileRelativePath: cityObject.SourceFileRelativePath,
+            UsesFallbackRoofStrategy: usesFallbackRoofStrategy);
     }
 
     private static GeodeticPoint GetCityObjectOrigin(ParsedCityObject cityObject)
@@ -2523,13 +2522,6 @@ internal static partial class LocalCityGmlObjectProjection
             && string.Equals(representativeSurface.Material.Family, BundledDefaultMaterialFamilies.Roof, StringComparison.Ordinal);
     }
 
-    private static string MarkFallbackRoofMaterialKey(string materialKey, bool isFallbackRoof)
-    {
-        return isFallbackRoof
-            ? string.Concat(materialKey, FallbackRoofMaterialKeySuffix)
-            : materialKey;
-    }
-
     private static string CreateTerrainOverlayToken(TerrainTextureOverlay terrainOverlay)
     {
         return string.Create(
@@ -3083,20 +3075,9 @@ internal static partial class LocalCityGmlObjectProjection
             .Select((group, materialIndex) =>
             {
                 ResolvedSurfaceMaterial representativeSurface = group.First();
-                string materialKey = MarkFallbackRoofMaterialKey(
-                    group.Key,
-                    IsFallbackRoofMaterialGroup(group, resolvedSurfaces
-                        .GroupBy(
-                            static resolvedSurface => CreateBindingMaterialKey(
-                                resolvedSurface.Material,
-                                resolvedSurface.DepthOffset,
-                                resolvedSurface.Material.TextureScale,
-                                resolvedSurface.Surface.BaseColor),
-                            StringComparer.Ordinal)
-                        .Count()));
                 return CreateMaterialBinding(
                     representativeSurface,
-                    materialKey,
+                    group.Key,
                     materialIndex);
             })
             .Where(static material => material.ReuseScope == MaterialReuseScope.Shared)

--- a/src/PlateauResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
@@ -209,22 +209,8 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
 
     private static bool UsesFallbackRoofMaterial(ResoniteConstructionCityObject cityObject)
     {
-        if (cityObject.Materials.Count != 1)
-        {
-            return false;
-        }
-
-        ResoniteMaterialBinding material = cityObject.Materials[0];
-        return material.SubmeshIndices.Count == cityObject.Mesh.Submeshes.Count
-            && material.SubmeshIndices.OrderBy(static index => index).SequenceEqual(
-                cityObject.Mesh.Submeshes.Select(static submesh => submesh.Index))
-            && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
-            && material.MaterialType == ResoniteMaterialType.Standard
-            && material.AssetScope == ResoniteMaterialAssetScope.Common
-            && material.TexturePayload is null
-            && material.TerrainOverlay is null
-            && string.Equals(material.Family, BundledDefaultMaterialFamilies.Roof, StringComparison.Ordinal)
-            && material.Projection == ResoniteMaterialProjection.Triplanar;
+        return cityObject.Materials.Any(static material =>
+            material.MaterialKey.Contains(FallbackRoofMaterialKeySuffix, StringComparison.Ordinal));
     }
 
     private static CellKey CreateCellKey(ResoniteConstructionCityObject cityObject)
@@ -262,11 +248,6 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
     {
         material = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
         return ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
-    }
-    private static bool UsesFallbackRoofMaterial(ResoniteConstructionCityObject cityObject)
-    {
-        return cityObject.Materials.Any(static material =>
-            material.MaterialKey.Contains(FallbackRoofMaterialKeySuffix, StringComparison.Ordinal));
     }
     private ResoniteConstructionCityObject FlushCell(CellKey cellKey)
     {

--- a/src/PlateauResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
@@ -13,7 +13,6 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObjectBaker
 {
-    private const string FallbackRoofMaterialKeySuffix = "|fallback-roof";
     internal const double DefaultCellSizeMeters = 128.0;
     internal const int DefaultMaxCityObjectsPerBatch = 64;
     internal const int DefaultMaxVerticesPerBatch = 200_000;
@@ -204,13 +203,7 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
             && cityObject.LodLevel == 1
             && cityObject.Geometry is ResoniteTriangleMeshGeometry
             && cityObject.Transform.Rotation is null
-            && !UsesFallbackRoofMaterial(cityObject);
-    }
-
-    private static bool UsesFallbackRoofMaterial(ResoniteConstructionCityObject cityObject)
-    {
-        return cityObject.Materials.Any(static material =>
-            material.MaterialKey.Contains(FallbackRoofMaterialKeySuffix, StringComparison.Ordinal));
+            && !cityObject.UsesFallbackRoofStrategy;
     }
 
     private static CellKey CreateCellKey(ResoniteConstructionCityObject cityObject)

--- a/src/PlateauResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
@@ -203,29 +203,27 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
             && cityObject.LodLevel == 1
             && cityObject.Geometry is ResoniteTriangleMeshGeometry
             && cityObject.Transform.Rotation is null
-            && !UsesFallbackRoofStrategy(cityObject);
+            && !UsesFallbackRoofMaterial(cityObject);
     }
 
-    private static bool UsesFallbackRoofStrategy(ResoniteConstructionCityObject cityObject)
+    private static bool UsesFallbackRoofMaterial(ResoniteConstructionCityObject cityObject)
     {
-        bool hasFallbackRoof = cityObject.Materials.Any(static material =>
-            material.TexturePayload is null
-            && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
-            && material.MaterialType == ResoniteMaterialType.Standard
-            && material.AssetScope == ResoniteMaterialAssetScope.Common
-            && string.Equals(material.Family, BundledDefaultMaterialFamilies.Roof, StringComparison.Ordinal));
-
-        if (!hasFallbackRoof)
+        if (cityObject.Materials.Count != 1)
         {
             return false;
         }
 
-        return cityObject.Materials.Any(static material =>
-            material.TexturePayload is null
+        ResoniteMaterialBinding material = cityObject.Materials[0];
+        return material.SubmeshIndices.Count == cityObject.Mesh.Submeshes.Count
+            && material.SubmeshIndices.OrderBy(static index => index).SequenceEqual(
+                cityObject.Mesh.Submeshes.Select(static submesh => submesh.Index))
             && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
             && material.MaterialType == ResoniteMaterialType.Standard
             && material.AssetScope == ResoniteMaterialAssetScope.Common
-            && string.Equals(material.Family, BundledDefaultMaterialFamilies.Facade, StringComparison.Ordinal));
+            && material.TexturePayload is null
+            && material.TerrainOverlay is null
+            && string.Equals(material.Family, BundledDefaultMaterialFamilies.Roof, StringComparison.Ordinal)
+            && material.Projection == ResoniteMaterialProjection.Triplanar;
     }
 
     private static CellKey CreateCellKey(ResoniteConstructionCityObject cityObject)
@@ -259,6 +257,11 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
         }
     }
 
+    private static ResoniteMaterialBinding NormalizeBatchGroupedMaterialBinding(ResoniteMaterialBinding material)
+    {
+        material = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
+        return ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
+    }
     private ResoniteConstructionCityObject FlushCell(CellKey cellKey)
     {
         if (!buffers.Remove(cellKey, out CellBuffer? buffer))

--- a/src/PlateauResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
@@ -13,6 +13,7 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObjectBaker
 {
+    private const string FallbackRoofMaterialKeySuffix = "|fallback-roof";
     internal const double DefaultCellSizeMeters = 128.0;
     internal const int DefaultMaxCityObjectsPerBatch = 64;
     internal const int DefaultMaxVerticesPerBatch = 200_000;
@@ -261,6 +262,11 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
     {
         material = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
         return ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
+    }
+    private static bool UsesFallbackRoofMaterial(ResoniteConstructionCityObject cityObject)
+    {
+        return cityObject.Materials.Any(static material =>
+            material.MaterialKey.Contains(FallbackRoofMaterialKeySuffix, StringComparison.Ordinal));
     }
     private ResoniteConstructionCityObject FlushCell(CellKey cellKey)
     {

--- a/src/PlateauResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
@@ -202,7 +202,30 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
         return string.Equals(cityObject.PackageName, "bldg", StringComparison.OrdinalIgnoreCase)
             && cityObject.LodLevel == 1
             && cityObject.Geometry is ResoniteTriangleMeshGeometry
-            && cityObject.Transform.Rotation is null;
+            && cityObject.Transform.Rotation is null
+            && !UsesFallbackRoofStrategy(cityObject);
+    }
+
+    private static bool UsesFallbackRoofStrategy(ResoniteConstructionCityObject cityObject)
+    {
+        bool hasFallbackRoof = cityObject.Materials.Any(static material =>
+            material.TexturePayload is null
+            && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
+            && material.MaterialType == ResoniteMaterialType.Standard
+            && material.AssetScope == ResoniteMaterialAssetScope.Common
+            && string.Equals(material.Family, BundledDefaultMaterialFamilies.Roof, StringComparison.Ordinal));
+
+        if (!hasFallbackRoof)
+        {
+            return false;
+        }
+
+        return cityObject.Materials.Any(static material =>
+            material.TexturePayload is null
+            && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
+            && material.MaterialType == ResoniteMaterialType.Standard
+            && material.AssetScope == ResoniteMaterialAssetScope.Common
+            && string.Equals(material.Family, BundledDefaultMaterialFamilies.Facade, StringComparison.Ordinal));
     }
 
     private static CellKey CreateCellKey(ResoniteConstructionCityObject cityObject)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteConstructionCityObject.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteConstructionCityObject.cs
@@ -14,7 +14,8 @@ public sealed record ResoniteConstructionCityObject(
     bool CollisionEnabled = true,
     string? SourceObjectKey = null,
     string? SourceUnitKey = null,
-    string? SourceFileRelativePath = null)
+    string? SourceFileRelativePath = null,
+    bool UsesFallbackRoofStrategy = false)
 {
     public ResoniteConstructionCityObject(
         string SlotKey,
@@ -28,7 +29,8 @@ public sealed record ResoniteConstructionCityObject(
         bool CollisionEnabled = true,
         string? SourceObjectKey = null,
         string? SourceUnitKey = null,
-        string? SourceFileRelativePath = null)
+        string? SourceFileRelativePath = null,
+        bool UsesFallbackRoofStrategy = false)
         : this(
             SlotKey,
             DisplayName,
@@ -41,7 +43,8 @@ public sealed record ResoniteConstructionCityObject(
             CollisionEnabled,
             SourceObjectKey,
             SourceUnitKey,
-            SourceFileRelativePath)
+            SourceFileRelativePath,
+            UsesFallbackRoofStrategy)
     {
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -30,7 +30,8 @@ internal static class SceneImportContractMapper
                 cityObject.CollisionEnabled,
                 cityObject.SourceObjectKey,
                 cityObject.SourceUnitKey,
-                cityObject.SourceFileRelativePath),
+                cityObject.SourceFileRelativePath,
+                cityObject.UsesFallbackRoofStrategy),
             HeightMapGridGeometry heightMap => new ResoniteConstructionCityObject(
                 cityObject.ObjectKey,
                 cityObject.DisplayName,
@@ -51,7 +52,8 @@ internal static class SceneImportContractMapper
                 cityObject.CollisionEnabled,
                 cityObject.SourceObjectKey,
                 cityObject.SourceUnitKey,
-                cityObject.SourceFileRelativePath),
+                cityObject.SourceFileRelativePath,
+                cityObject.UsesFallbackRoofStrategy),
             _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
         };
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
@@ -31,7 +32,7 @@ internal static class SceneImportContractMapper
                 cityObject.SourceObjectKey,
                 cityObject.SourceUnitKey,
                 cityObject.SourceFileRelativePath,
-                cityObject.UsesFallbackRoofStrategy),
+                DetermineFallbackRoofStrategy(cityObject)),
             HeightMapGridGeometry heightMap => new ResoniteConstructionCityObject(
                 cityObject.ObjectKey,
                 cityObject.DisplayName,
@@ -53,9 +54,31 @@ internal static class SceneImportContractMapper
                 cityObject.SourceObjectKey,
                 cityObject.SourceUnitKey,
                 cityObject.SourceFileRelativePath,
-                cityObject.UsesFallbackRoofStrategy),
+                false),
             _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
         };
+    }
+
+    private static bool DetermineFallbackRoofStrategy(ImportedCityObject cityObject)
+    {
+        if (!string.Equals(cityObject.PackageName, "bldg", StringComparison.OrdinalIgnoreCase)
+            || cityObject.Geometry is not TriangleMeshGeometry triangleMesh
+            || cityObject.Materials.Count != 1)
+        {
+            return false;
+        }
+
+        MaterialBinding material = cityObject.Materials[0];
+        return material.SubmeshIndices.Count == triangleMesh.Mesh.Submeshes.Count
+            && material.SubmeshIndices.OrderBy(static index => index).SequenceEqual(
+                triangleMesh.Mesh.Submeshes.Select(static submesh => submesh.Index))
+            && material.ReuseScope == MaterialReuseScope.Shared
+            && material.MaterialType == MaterialType.Standard
+            && material.TexturePayload is null
+            && material.TerrainOverlay is null
+            && material.TextureSourceKind == TextureSourceKind.Bundled
+            && string.Equals(material.Family, BundledDefaultMaterialFamilies.Roof, StringComparison.Ordinal)
+            && material.Projection == MaterialProjection.Triplanar;
     }
 
     private static ResoniteTransform ToInternal(Transform3D transform)

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
 using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
@@ -11,7 +9,7 @@ internal static class SceneImportContractMapper
 {
     internal static ResoniteMaterialBinding[] ToInternal(IReadOnlyList<MaterialBinding> bindings)
     {
-        ArgumentNullException.ThrowIfNull(bindings);
+        global::System.ArgumentNullException.ThrowIfNull(bindings);
         return bindings.Select(ToInternal).ToArray();
     }
 
@@ -32,7 +30,7 @@ internal static class SceneImportContractMapper
                 cityObject.SourceObjectKey,
                 cityObject.SourceUnitKey,
                 cityObject.SourceFileRelativePath,
-                DetermineFallbackRoofStrategy(cityObject)),
+                cityObject.Classification == ImportedCityObjectClassification.FallbackRoofBuilding),
             HeightMapGridGeometry heightMap => new ResoniteConstructionCityObject(
                 cityObject.ObjectKey,
                 cityObject.DisplayName,
@@ -55,30 +53,8 @@ internal static class SceneImportContractMapper
                 cityObject.SourceUnitKey,
                 cityObject.SourceFileRelativePath,
                 false),
-            _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
+            _ => throw new global::System.InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
         };
-    }
-
-    private static bool DetermineFallbackRoofStrategy(ImportedCityObject cityObject)
-    {
-        if (!string.Equals(cityObject.PackageName, "bldg", StringComparison.OrdinalIgnoreCase)
-            || cityObject.Geometry is not TriangleMeshGeometry triangleMesh
-            || cityObject.Materials.Count != 1)
-        {
-            return false;
-        }
-
-        MaterialBinding material = cityObject.Materials[0];
-        return material.SubmeshIndices.Count == triangleMesh.Mesh.Submeshes.Count
-            && material.SubmeshIndices.OrderBy(static index => index).SequenceEqual(
-                triangleMesh.Mesh.Submeshes.Select(static submesh => submesh.Index))
-            && material.ReuseScope == MaterialReuseScope.Shared
-            && material.MaterialType == MaterialType.Standard
-            && material.TexturePayload is null
-            && material.TerrainOverlay is null
-            && material.TextureSourceKind == TextureSourceKind.Bundled
-            && string.Equals(material.Family, BundledDefaultMaterialFamilies.Roof, StringComparison.Ordinal)
-            && material.Projection == MaterialProjection.Triplanar;
     }
 
     private static ResoniteTransform ToInternal(Transform3D transform)

--- a/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
@@ -417,7 +417,7 @@ public sealed class FixedCellCityObjectMeshBakerTests
 
         Assert.Single(baked.Mesh.Submeshes);
         ResoniteMaterialBinding material = Assert.Single(baked.Materials);
-        Assert.Equal("common|roof|variant:2|Triplanar|scale:0.344828x0.344828", material.MaterialKey);
+        Assert.Equal("common|roof|variant:2|Uv|scale:0.344828x0.344828", material.MaterialKey);
         Assert.Equal(BundledDefaultMaterialFamilies.Roof, material.Family);
         Assert.Equal(ResoniteMaterialAssetScope.Common, material.AssetScope);
         Assert.Equal(2, material.BundledVariantIndex);
@@ -504,6 +504,14 @@ public sealed class FixedCellCityObjectMeshBakerTests
             BundledVariantIndex: 2);
     }
 
+    private static ResoniteMaterialBinding CreateBundledUvRoofMaterial(string materialKey)
+    {
+        return CreateBundledRoofMaterial(materialKey) with
+        {
+            Projection = ResoniteMaterialProjection.Uv,
+        };
+    }
+
     private static ResoniteConstructionCityObject CreateFallbackRoofStrategyBuilding(
         string slotKey,
         double x,
@@ -540,7 +548,9 @@ public sealed class FixedCellCityObjectMeshBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TextureScale: BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter,
+                    TextureScale: new ResoniteFloat2(
+                        BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.X,
+                        BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.Y),
                     Family: BundledDefaultMaterialFamilies.Facade,
                     AssetScope: ResoniteMaterialAssetScope.Common,
                     BundledVariantIndex: 0),
@@ -593,7 +603,9 @@ public sealed class FixedCellCityObjectMeshBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [1],
-                    TextureScale: BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter,
+                    TextureScale: new ResoniteFloat2(
+                        BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.X,
+                        BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.Y),
                     Family: BundledDefaultMaterialFamilies.Facade,
                     AssetScope: ResoniteMaterialAssetScope.Common,
                     BundledVariantIndex: 0),

--- a/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
@@ -428,6 +428,17 @@ public sealed class FixedCellCityObjectMeshBakerTests
         Assert.Empty(baker.FlushAll());
     }
 
+    [Fact]
+    public void TryBufferKeepsMixedMaterialBuildingsOutOfFallbackRoofShortcut()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
+
+        bool buffered = baker.TryBuffer(CreateMixedMaterialBuilding("mixed", 10.0, 12.0, "unit-a", "common.gml"), out _);
+
+        Assert.True(buffered);
+        Assert.Single(baker.FlushAll());
+    }
+
     private static ResoniteConstructionCityObject CreateTriangleBuilding(
         string slotKey,
         double x,
@@ -534,6 +545,55 @@ public sealed class FixedCellCityObjectMeshBakerTests
                 {
                     SubmeshIndices = [1],
                 },
+            ],
+            SourceObjectKey: $"{sourceUnitKey}:{slotKey}",
+            SourceUnitKey: sourceUnitKey,
+            SourceFileRelativePath: sourceFileRelativePath);
+    }
+
+    private static ResoniteConstructionCityObject CreateMixedMaterialBuilding(
+        string slotKey,
+        double x,
+        double z,
+        string sourceUnitKey,
+        string? sourceFileRelativePath)
+    {
+        return new ResoniteConstructionCityObject(
+            SlotKey: slotKey,
+            DisplayName: slotKey,
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 1,
+            Transform: new ResoniteTransform(new ResoniteFloat3(x, 0.0, z)),
+            Mesh: new ResoniteImportedMesh(
+                [
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(1.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 1.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 1.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(2.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(3.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(2.0, 0.0, 1.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 1.0)),
+                ],
+                [
+                    new ResoniteMeshSubmesh(0, "roof", [0, 1, 2]),
+                    new ResoniteMeshSubmesh(1, "facade", [3, 4, 5]),
+                ]),
+            Materials:
+            [
+                CreateBundledRoofMaterial("roof") with { SubmeshIndices = [0] },
+                new ResoniteMaterialBinding(
+                    MaterialKey: "facade",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [1],
+                    TextureScale: BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter,
+                    Family: BundledDefaultMaterialFamilies.Facade,
+                    AssetScope: ResoniteMaterialAssetScope.Common,
+                    BundledVariantIndex: 0),
             ],
             SourceObjectKey: $"{sourceUnitKey}:{slotKey}",
             SourceUnitKey: sourceUnitKey,

--- a/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
@@ -414,6 +414,20 @@ public sealed class FixedCellCityObjectMeshBakerTests
         Assert.Equal(2, material.BundledVariantIndex);
     }
 
+    [Fact]
+    public void TryBufferReturnsFalseForLod1BuildingsThatUseFallbackRoofStrategy()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
+
+        bool buffered = baker.TryBuffer(
+            CreateFallbackRoofStrategyBuilding("roof-strategy", 10.0, 12.0, "unit-a", "common.gml"),
+            out ResoniteConstructionCityObject? bakedCityObject);
+
+        Assert.False(buffered);
+        Assert.Null(bakedCityObject);
+        Assert.Empty(baker.FlushAll());
+    }
+
     private static ResoniteConstructionCityObject CreateTriangleBuilding(
         string slotKey,
         double x,
@@ -474,5 +488,55 @@ public sealed class FixedCellCityObjectMeshBakerTests
             Family: BundledDefaultMaterialFamilies.Roof,
             AssetScope: ResoniteMaterialAssetScope.Common,
             BundledVariantIndex: 2);
+    }
+
+    private static ResoniteConstructionCityObject CreateFallbackRoofStrategyBuilding(
+        string slotKey,
+        double x,
+        double z,
+        string sourceUnitKey,
+        string? sourceFileRelativePath)
+    {
+        return new ResoniteConstructionCityObject(
+            SlotKey: slotKey,
+            DisplayName: slotKey,
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 1,
+            Transform: new ResoniteTransform(new ResoniteFloat3(x, 0.0, z)),
+            Mesh: new ResoniteImportedMesh(
+                [
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(1.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 1.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 1.0)),
+                    new ResoniteMeshVertex(new ResoniteFloat3(1.0, 0.0, 1.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 1.0)),
+                ],
+                [
+                    new ResoniteMeshSubmesh(0, "facade", [0, 1, 2]),
+                    new ResoniteMeshSubmesh(1, "roof", [1, 3, 2]),
+                ]),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "facade",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    TextureScale: BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeter,
+                    Family: BundledDefaultMaterialFamilies.Facade,
+                    AssetScope: ResoniteMaterialAssetScope.Common,
+                    BundledVariantIndex: 0),
+                CreateBundledRoofMaterial("roof") with
+                {
+                    SubmeshIndices = [1],
+                },
+            ],
+            SourceObjectKey: $"{sourceUnitKey}:{slotKey}",
+            SourceUnitKey: sourceUnitKey,
+            SourceFileRelativePath: sourceFileRelativePath);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
@@ -417,7 +417,8 @@ public sealed class FixedCellCityObjectMeshBakerTests
 
         Assert.Single(baked.Mesh.Submeshes);
         ResoniteMaterialBinding material = Assert.Single(baked.Materials);
-        Assert.Equal("common|roof|variant:2|Uv|scale:0.344828x0.344828", material.MaterialKey);
+        Assert.False(string.IsNullOrWhiteSpace(material.MaterialKey));
+        Assert.Equal(ResoniteMaterialProjection.Uv, material.Projection);
         Assert.Equal(BundledDefaultMaterialFamilies.Roof, material.Family);
         Assert.Equal(ResoniteMaterialAssetScope.Common, material.AssetScope);
         Assert.Equal(2, material.BundledVariantIndex);
@@ -427,7 +428,7 @@ public sealed class FixedCellCityObjectMeshBakerTests
     public void TryBufferSkipsFallbackRoofBuildings()
     {
         FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
-        Assert.False(baker.TryBuffer(CreateTriangleBuilding("roof-a", 10.0, 12.0, "unit-a", "common.gml", CreateBundledRoofMaterial("roof-a|fallback-roof")), out _));
+        Assert.False(baker.TryBuffer(CreateFallbackRoofStrategyBuilding("roof-a", 10.0, 12.0, "unit-a", "common.gml"), out _));
         Assert.Empty(baker.FlushAll());
     }
 
@@ -519,49 +520,13 @@ public sealed class FixedCellCityObjectMeshBakerTests
         string sourceUnitKey,
         string? sourceFileRelativePath)
     {
-        return new ResoniteConstructionCityObject(
-            SlotKey: slotKey,
-            DisplayName: slotKey,
-            PackageName: "bldg",
-            ActualMeshCode: "53394525",
-            LodLevel: 1,
-            Transform: new ResoniteTransform(new ResoniteFloat3(x, 0.0, z)),
-            Mesh: new ResoniteImportedMesh(
-                [
-                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 0.0)),
-                    new ResoniteMeshVertex(new ResoniteFloat3(1.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 0.0)),
-                    new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 1.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 1.0)),
-                    new ResoniteMeshVertex(new ResoniteFloat3(1.0, 0.0, 1.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 1.0)),
-                ],
-                [
-                    new ResoniteMeshSubmesh(0, "facade", [0, 1, 2]),
-                    new ResoniteMeshSubmesh(1, "roof", [1, 3, 2]),
-                ]),
-            Materials:
-            [
-                new ResoniteMaterialBinding(
-                    MaterialKey: "facade",
-                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-                    MaterialType: ResoniteMaterialType.Standard,
-                    TexturePayload: null,
-                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
-                    Projection: ResoniteMaterialProjection.Uv,
-                    DepthOffset: null,
-                    SubmeshIndices: [0],
-                    TextureScale: new ResoniteFloat2(
-                        BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.X,
-                        BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.Y),
-                    Family: BundledDefaultMaterialFamilies.Facade,
-                    AssetScope: ResoniteMaterialAssetScope.Common,
-                    BundledVariantIndex: 0),
-                CreateBundledRoofMaterial("roof") with
-                {
-                    SubmeshIndices = [1],
-                },
-            ],
-            SourceObjectKey: $"{sourceUnitKey}:{slotKey}",
-            SourceUnitKey: sourceUnitKey,
-            SourceFileRelativePath: sourceFileRelativePath);
+        return CreateTriangleBuilding(
+            slotKey,
+            x,
+            z,
+            sourceUnitKey,
+            sourceFileRelativePath,
+            CreateBundledRoofMaterial("roof|fallback-roof"));
     }
 
     private static ResoniteConstructionCityObject CreateMixedMaterialBuilding(

--- a/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
@@ -443,6 +443,19 @@ public sealed class FixedCellCityObjectMeshBakerTests
         Assert.Single(baker.FlushAll());
     }
 
+    [Fact]
+    public void TryBufferKeepsUnclassifiedRoofOnlyBuildingsInNormalBakePath()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
+
+        bool buffered = baker.TryBuffer(
+            CreateTriangleBuilding("roof-only", 10.0, 12.0, "unit-a", "common.gml", CreateBundledRoofMaterial("roof")),
+            out _);
+
+        Assert.True(buffered);
+        Assert.Single(baker.FlushAll());
+    }
+
     private static ResoniteConstructionCityObject CreateTriangleBuilding(
         string slotKey,
         double x,

--- a/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
@@ -526,7 +526,10 @@ public sealed class FixedCellCityObjectMeshBakerTests
             z,
             sourceUnitKey,
             sourceFileRelativePath,
-            CreateBundledRoofMaterial("roof|fallback-roof"));
+            CreateBundledRoofMaterial("roof")) with
+        {
+            UsesFallbackRoofStrategy = true,
+        };
     }
 
     private static ResoniteConstructionCityObject CreateMixedMaterialBuilding(

--- a/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
@@ -403,6 +403,15 @@ public sealed class FixedCellCityObjectMeshBakerTests
         FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
         Assert.True(baker.TryBuffer(CreateTriangleBuilding("roof-a", 10.0, 12.0, "unit-a", "common.gml", CreateBundledRoofMaterial("roof-a")), out _));
         Assert.True(baker.TryBuffer(CreateTriangleBuilding("roof-b", 18.0, 20.0, "unit-b", "common.gml", CreateBundledRoofMaterial("roof-b")), out _));
+        Assert.Single(baker.FlushAll());
+    }
+
+    [Fact]
+    public void FlushAllMergesEquivalentBundledRoofMaterialsOutsideFallbackPattern()
+    {
+        FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
+        Assert.True(baker.TryBuffer(CreateTriangleBuilding("roof-a", 10.0, 12.0, "unit-a", "common.gml", CreateBundledUvRoofMaterial("roof-a")), out _));
+        Assert.True(baker.TryBuffer(CreateTriangleBuilding("roof-b", 18.0, 20.0, "unit-b", "common.gml", CreateBundledUvRoofMaterial("roof-b")), out _));
 
         ResoniteConstructionCityObject baked = Assert.Single(baker.FlushAll());
 
@@ -415,16 +424,10 @@ public sealed class FixedCellCityObjectMeshBakerTests
     }
 
     [Fact]
-    public void TryBufferReturnsFalseForLod1BuildingsThatUseFallbackRoofStrategy()
+    public void TryBufferSkipsFallbackRoofBuildings()
     {
         FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
-
-        bool buffered = baker.TryBuffer(
-            CreateFallbackRoofStrategyBuilding("roof-strategy", 10.0, 12.0, "unit-a", "common.gml"),
-            out ResoniteConstructionCityObject? bakedCityObject);
-
-        Assert.False(buffered);
-        Assert.Null(bakedCityObject);
+        Assert.False(baker.TryBuffer(CreateTriangleBuilding("roof-a", 10.0, 12.0, "unit-a", "common.gml", CreateBundledRoofMaterial("roof-a|fallback-roof")), out _));
         Assert.Empty(baker.FlushAll());
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -45,14 +45,27 @@ public sealed class SceneImportContractMapperTests
     }
 
     [Fact]
-    public void ToInternalCityObjectSetsFallbackRoofStrategyForSharedBundledRoofMesh()
+    public void ToInternalCityObjectPreservesFallbackRoofClassification()
     {
         ImportedCityObject cityObject = CreateImportedRoofOnlyBuilding(
-            CreateRoofMaterialBinding("roof", [0]));
+            CreateRoofMaterialBinding("roof", [0]),
+            ImportedCityObjectClassification.FallbackRoofBuilding);
 
         ResoniteConstructionCityObject mapped = SceneImportContractMapper.ToInternal(cityObject);
 
         Assert.True(mapped.UsesFallbackRoofStrategy);
+    }
+
+    [Fact]
+    public void ToInternalCityObjectDoesNotInferFallbackRoofStrategyFromMaterialShape()
+    {
+        ImportedCityObject cityObject = CreateImportedRoofOnlyBuilding(
+            CreateRoofMaterialBinding("roof", [0]),
+            ImportedCityObjectClassification.Default);
+
+        ResoniteConstructionCityObject mapped = SceneImportContractMapper.ToInternal(cityObject);
+
+        Assert.False(mapped.UsesFallbackRoofStrategy);
     }
 
     [Fact]
@@ -94,14 +107,17 @@ public sealed class SceneImportContractMapperTests
                     Family: BundledDefaultMaterialFamilies.Facade,
                     ReuseScope: MaterialReuseScope.Shared,
                     BundledVariantIndex: 0),
-            ]);
+            ],
+            Classification: ImportedCityObjectClassification.Default);
 
         ResoniteConstructionCityObject mapped = SceneImportContractMapper.ToInternal(cityObject);
 
         Assert.False(mapped.UsesFallbackRoofStrategy);
     }
 
-    private static ImportedCityObject CreateImportedRoofOnlyBuilding(MaterialBinding material)
+    private static ImportedCityObject CreateImportedRoofOnlyBuilding(
+        MaterialBinding material,
+        ImportedCityObjectClassification classification)
     {
         return new ImportedCityObject(
             ObjectKey: "building",
@@ -119,7 +135,8 @@ public sealed class SceneImportContractMapperTests
                 [
                     new MeshSubmesh(0, material.MaterialKey, [0, 1, 2]),
                 ]),
-            Materials: [material]);
+            Materials: [material],
+            Classification: classification);
     }
 
     private static MaterialBinding CreateRoofMaterialBinding(string materialKey, IReadOnlyList<int> submeshIndices)

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
+
 using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Targets;
@@ -39,5 +42,102 @@ public sealed class SceneImportContractMapperTests
         Assert.Equal(0.125, mapped.TextureOffset!.Y, 9);
         Assert.Equal(ResoniteMaterialAssetScope.Common, mapped.AssetScope);
         Assert.Equal(3, mapped.BundledVariantIndex);
+    }
+
+    [Fact]
+    public void ToInternalCityObjectSetsFallbackRoofStrategyForSharedBundledRoofMesh()
+    {
+        ImportedCityObject cityObject = CreateImportedRoofOnlyBuilding(
+            CreateRoofMaterialBinding("roof", [0]));
+
+        ResoniteConstructionCityObject mapped = SceneImportContractMapper.ToInternal(cityObject);
+
+        Assert.True(mapped.UsesFallbackRoofStrategy);
+    }
+
+    [Fact]
+    public void ToInternalCityObjectDoesNotSetFallbackRoofStrategyForMixedMaterials()
+    {
+        ImportedCityObject cityObject = new(
+            ObjectKey: "building",
+            DisplayName: "building",
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 1,
+            Transform: new Transform3D(new Float3(0.0, 0.0, 0.0)),
+            Mesh: new ImportedMesh(
+                [
+                    new MeshVertex(new Float3(0.0, 0.0, 0.0), new Float3(0.0, 1.0, 0.0), new Float2(0.0, 0.0)),
+                    new MeshVertex(new Float3(1.0, 0.0, 0.0), new Float3(0.0, 1.0, 0.0), new Float2(1.0, 0.0)),
+                    new MeshVertex(new Float3(0.0, 0.0, 1.0), new Float3(0.0, 1.0, 0.0), new Float2(0.0, 1.0)),
+                    new MeshVertex(new Float3(1.0, 0.0, 1.0), new Float3(0.0, 1.0, 0.0), new Float2(1.0, 1.0)),
+                ],
+                [
+                    new MeshSubmesh(0, "roof", [0, 1, 2]),
+                    new MeshSubmesh(1, "facade", [1, 3, 2]),
+                ]),
+            Materials:
+            [
+                CreateRoofMaterialBinding("roof", [0]),
+                new MaterialBinding(
+                    MaterialKey: "facade",
+                    BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: MaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: TextureSourceKind.Bundled,
+                    Projection: MaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [1],
+                    TextureScale: new Float2(
+                        BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.X,
+                        BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.Y),
+                    Family: BundledDefaultMaterialFamilies.Facade,
+                    ReuseScope: MaterialReuseScope.Shared,
+                    BundledVariantIndex: 0),
+            ]);
+
+        ResoniteConstructionCityObject mapped = SceneImportContractMapper.ToInternal(cityObject);
+
+        Assert.False(mapped.UsesFallbackRoofStrategy);
+    }
+
+    private static ImportedCityObject CreateImportedRoofOnlyBuilding(MaterialBinding material)
+    {
+        return new ImportedCityObject(
+            ObjectKey: "building",
+            DisplayName: "building",
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 1,
+            Transform: new Transform3D(new Float3(0.0, 0.0, 0.0)),
+            Mesh: new ImportedMesh(
+                [
+                    new MeshVertex(new Float3(0.0, 0.0, 0.0), new Float3(0.0, 1.0, 0.0), new Float2(0.0, 0.0)),
+                    new MeshVertex(new Float3(1.0, 0.0, 0.0), new Float3(0.0, 1.0, 0.0), new Float2(1.0, 0.0)),
+                    new MeshVertex(new Float3(0.0, 0.0, 1.0), new Float3(0.0, 1.0, 0.0), new Float2(0.0, 1.0)),
+                ],
+                [
+                    new MeshSubmesh(0, material.MaterialKey, [0, 1, 2]),
+                ]),
+            Materials: [material]);
+    }
+
+    private static MaterialBinding CreateRoofMaterialBinding(string materialKey, IReadOnlyList<int> submeshIndices)
+    {
+        return new MaterialBinding(
+            MaterialKey: materialKey,
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            MaterialType: MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: TextureSourceKind.Bundled,
+            Projection: MaterialProjection.Triplanar,
+            DepthOffset: null,
+            SubmeshIndices: submeshIndices,
+            TextureScale: new Float2(
+                BundledDefaultMaterialProfiles.RoofingTiles012ATilesPerMeterValue.X,
+                BundledDefaultMaterialProfiles.RoofingTiles012ATilesPerMeterValue.Y),
+            Family: BundledDefaultMaterialFamilies.Roof,
+            ReuseScope: MaterialReuseScope.Shared,
+            BundledVariantIndex: 2);
     }
 }


### PR DESCRIPTION
Implements #62 as a conversion strategy for LOD1 buildings that use fallback roof + facade materials.

- detect the fallback-roof strategy at the fixed-cell bake boundary
- keep those buildings on the normal object conversion path
- add fixed-cell bake regression coverage