### PR TITLE
fix(targets): align LOD1 mesh bake vertex budget with ResoniteLink

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/FixedCellCityObjectMeshBaker.cs
@@ -15,7 +15,7 @@ internal sealed class FixedCellCityObjectMeshBaker : IResoniteBufferedCityObject
 {
     internal const double DefaultCellSizeMeters = 128.0;
     internal const int DefaultMaxCityObjectsPerBatch = 64;
-    internal const int DefaultMaxVerticesPerBatch = 200_000;
+    internal const int DefaultMaxVerticesPerBatch = ResoniteMeshImportFactory.MaxSupportedVertexCount;
     internal const int DefaultMaxBufferedCells = 8;
 
     private readonly double cellSizeMeters;

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
@@ -21,8 +21,7 @@ internal sealed class ResoniteBufferedCityObjectBakerFactory : IResoniteBuffered
 
         int maxVerticesPerBatch = resourceBudget.Name switch
         {
-            ResoniteImportMemoryProfile.Small => 32_768,
-            ResoniteImportMemoryProfile.Large => 65_535,
+            ResoniteImportMemoryProfile.Small or ResoniteImportMemoryProfile.Large => ResoniteMeshImportFactory.MaxSupportedVertexCount,
             _ => throw new ArgumentOutOfRangeException(nameof(resourceBudget), resourceBudget.Name, "Unsupported memory profile."),
         };
         int maxCityObjectsPerBatch = resourceBudget.Name switch

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteMeshImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteMeshImportFactory.cs
@@ -8,6 +8,9 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal static class ResoniteMeshImportFactory
 {
+    // ResoniteLink raw mesh import uses Int32-backed vertex counts and index spans.
+    internal const int MaxSupportedVertexCount = int.MaxValue;
+
     public static ImportMeshRawData Create(ResoniteImportedMesh mesh)
     {
         ArgumentNullException.ThrowIfNull(mesh);

--- a/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/FixedCellCityObjectMeshBakerTests.cs
@@ -336,6 +336,41 @@ public sealed class FixedCellCityObjectMeshBakerTests
     }
 
     [Fact]
+    public void FlushAllKeepsSingleBufferedMeshAboveUInt16VertexRangeWhenBatchLimitAllowsIt()
+    {
+        FixedCellCityObjectMeshBaker baker = new(
+            cellSizeMeters: 64.0,
+            maxCityObjectsPerBatch: 10,
+            maxVerticesPerBatch: ResoniteMeshImportFactory.MaxSupportedVertexCount);
+        Assert.True(baker.TryBuffer(CreateDenseTriangleBuilding("wide", 65_537, 10.0, 12.0, "unit-a", "common.gml"), out _));
+
+        ResoniteConstructionCityObject baked = Assert.Single(baker.FlushAll());
+
+        Assert.Equal(65_537, baked.Mesh.Vertices.Count);
+        Assert.Single(baked.Mesh.Submeshes);
+        Assert.Equal([0, 1, 2], baked.Mesh.Submeshes[0].TriangleVertexIndices);
+    }
+
+    [Fact]
+    public async Task TryBufferAsyncFlushesWhenConfiguredVertexBudgetIsExceeded()
+    {
+        FixedCellCityObjectMeshBaker baker = new(
+            cellSizeMeters: 64.0,
+            maxCityObjectsPerBatch: 10,
+            maxVerticesPerBatch: 6);
+
+        BufferedCityObjectBufferResult first = await baker.TryBufferAsync(CreateDenseTriangleBuilding("first", 4, 10.0, 10.0, "unit-a", null));
+        BufferedCityObjectBufferResult second = await baker.TryBufferAsync(CreateDenseTriangleBuilding("second", 4, 11.0, 10.0, "unit-a", null));
+
+        Assert.True(first.Buffered);
+        Assert.Empty(first.ReadyCityObjects);
+        ResoniteConstructionCityObject flushed = Assert.Single(second.ReadyCityObjects);
+        Assert.Equal(8, flushed.Mesh.Vertices.Count);
+        Assert.Single(flushed.Mesh.Submeshes);
+        Assert.Empty(await baker.FlushAllAsync());
+    }
+
+    [Fact]
     public void FlushAllPreservesConcatenatedVertexAndIndexTopology()
     {
         FixedCellCityObjectMeshBaker baker = new(cellSizeMeters: 64.0, maxCityObjectsPerBatch: 10, maxVerticesPerBatch: 1000);
@@ -445,6 +480,53 @@ public sealed class FixedCellCityObjectMeshBakerTests
                     new ResoniteMeshVertex(new ResoniteFloat3(1.0, 0.0, 0.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(1.0, 0.0)),
                     new ResoniteMeshVertex(new ResoniteFloat3(0.0, 0.0, 1.0), new ResoniteFloat3(0.0, 1.0, 0.0), new ResoniteFloat2(0.0, 1.0)),
                 ],
+                [
+                    new ResoniteMeshSubmesh(0, "shared-material", [0, 1, 2]),
+                ]),
+            Materials:
+            [
+                material,
+            ],
+            SourceObjectKey: $"{sourceUnitKey}:{slotKey}",
+            SourceUnitKey: sourceUnitKey,
+            SourceFileRelativePath: sourceFileRelativePath);
+    }
+
+    private static ResoniteConstructionCityObject CreateDenseTriangleBuilding(
+        string slotKey,
+        int vertexCount,
+        double x,
+        double z,
+        string sourceUnitKey,
+        string? sourceFileRelativePath,
+        ResoniteMaterialBinding? material = null)
+    {
+        material ??= new ResoniteMaterialBinding(
+            MaterialKey: "shared-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0]);
+
+        ResoniteMeshVertex[] vertices = Enumerable.Range(0, vertexCount)
+            .Select(index => new ResoniteMeshVertex(
+                new ResoniteFloat3(index, 0.0, 0.0),
+                new ResoniteFloat3(0.0, 1.0, 0.0),
+                new ResoniteFloat2(0.0, 0.0)))
+            .ToArray();
+
+        return new ResoniteConstructionCityObject(
+            SlotKey: slotKey,
+            DisplayName: slotKey,
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 1,
+            Transform: new ResoniteTransform(new ResoniteFloat3(x, 0.0, z)),
+            Mesh: new ResoniteImportedMesh(
+                vertices,
                 [
                     new ResoniteMeshSubmesh(0, "shared-material", [0, 1, 2]),
                 ]),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -255,37 +255,23 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Theory]
-    [InlineData(ResoniteImportMemoryProfile.Small, 32, 33, 1024)]
-    [InlineData(ResoniteImportMemoryProfile.Large, 63, 64, 1024)]
-    public async Task BufferedCityObjectBakerFactoryAppliesVertexBudgetByMemoryProfile(
-        ResoniteImportMemoryProfile memoryProfile,
-        int noFlushCount,
-        int flushCount,
-        int vertexCount)
+    [InlineData(ResoniteImportMemoryProfile.Small)]
+    [InlineData(ResoniteImportMemoryProfile.Large)]
+    public async Task BufferedCityObjectBakerFactoryKeepsMeshesAboveUInt16VertexRangeBufferedUntilExplicitFlush(
+        ResoniteImportMemoryProfile memoryProfile)
     {
         Assert.Equal(
             0,
             await CountReadyBeforeFlushAsync(
                 memoryProfile,
-                noFlushCount,
+                1,
                 index => CreateDenseTriangleBuilding(
                     $"dense-{index}",
-                    vertexCount,
+                    65_536,
                     x: 10.0 + (index * 0.01),
                     z: 10.0,
                     sourceUnitKey: "shared-unit",
                     sourceFileRelativePath: null)));
-        Assert.True(
-            await CountReadyBeforeFlushAsync(
-                memoryProfile,
-                flushCount,
-                index => CreateDenseTriangleBuilding(
-                    $"dense-{index}",
-                    vertexCount,
-                    x: 10.0 + (index * 0.01),
-                    z: 10.0,
-                    sourceUnitKey: "shared-unit",
-                    sourceFileRelativePath: null)) > 0);
     }
 
     private static ResoniteLiveSceneImportTarget CreateBuilder(bool enableMeshBake = true)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMeshImportFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMeshImportFactoryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 using PlateauResoniteLink.Targets.Resonite;
 
@@ -60,6 +61,42 @@ public sealed class ResoniteMeshImportFactoryTests
         Assert.Equal(1.0f, result.Colors[1].g, 6);
         Assert.Equal(1.0f, result.Colors[1].b, 6);
         Assert.Equal(1.0f, result.Colors[1].a, 6);
+    }
+
+    [Fact]
+    public void CreateAcceptsTriangleIndicesBeyondUInt16Range()
+    {
+        ResoniteMeshVertex[] vertices = Enumerable.Range(0, 65_537)
+            .Select(static index => new ResoniteMeshVertex(
+                new ResoniteFloat3(index, 0.0, 0.0),
+                new ResoniteFloat3(0.0, 1.0, 0.0),
+                new ResoniteFloat2(0.0, 0.0)))
+            .ToArray();
+        vertices[0] = new ResoniteMeshVertex(
+            new ResoniteFloat3(0.0, 0.0, 0.0),
+            new ResoniteFloat3(0.0, 1.0, 0.0),
+            new ResoniteFloat2(0.0, 0.0));
+        vertices[65_535] = new ResoniteMeshVertex(
+            new ResoniteFloat3(1.0, 0.0, 0.0),
+            new ResoniteFloat3(0.0, 1.0, 0.0),
+            new ResoniteFloat2(1.0, 0.0));
+        vertices[65_536] = new ResoniteMeshVertex(
+            new ResoniteFloat3(0.0, 0.0, 1.0),
+            new ResoniteFloat3(0.0, 1.0, 0.0),
+            new ResoniteFloat2(0.0, 1.0));
+
+        ResoniteImportedMesh mesh = new(
+            Vertices: vertices,
+            Submeshes:
+            [
+                new ResoniteMeshSubmesh(0, "wide-index", [0, 65_535, 65_536]),
+            ]);
+
+        ImportMeshRawData result = ResoniteMeshImportFactory.Create(mesh);
+
+        TriangleSubmeshRawData submesh = Assert.IsType<TriangleSubmeshRawData>(Assert.Single(result.Submeshes));
+        Assert.Equal(65_537, result.VertexCount);
+        Assert.Equal([0, 65_535, 65_536], submesh.Indices);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- align LOD1 mesh-bake vertex budgeting with the actual ResoniteLink raw mesh import representation instead of splitting near the uint16 range
- keep meshes above 65,535 vertices buffered when still valid for downstream import
- add regression coverage for wide vertex/index meshes and the updated memory-profile behavior

## Testing
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

## Issues
- Fixes #119
