### PR TITLE
fix(targets): bake uniform dataset textures as vertex colors

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -336,6 +336,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
         Rgba32 detectedBackgroundColor = DetectRepresentativeBackgroundColor(sourceImage);
         using Image<Rgba32> preparedSourceImage = sourceImage.Clone();
         FillTransparentRgb(preparedSourceImage, detectedBackgroundColor);
+        bool isUniformDatasetTexture = TryGetUniformPixelColor(preparedSourceImage, out _);
 
         int maxTileWidth = EffectiveMaxAtlasTextureEdge;
         int maxTileHeight = EffectiveMaxAtlasTextureEdge;
@@ -344,7 +345,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
         using Image<Rgba32> bakedImage = BakeUsedUvRegion(preparedSourceImage, uvBounds, targetWidth, targetHeight);
 
         ApplyBaseColor(bakedImage, material.BaseColor);
-        if (TryGetUniformPixelColor(bakedImage, out Rgba32 uniformColor))
+        if (isUniformDatasetTexture && TryGetUniformPixelColor(bakedImage, out Rgba32 uniformColor))
         {
             return CreateSolidColorTile(uniformColor);
         }

--- a/src/PlateauResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -159,7 +159,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
                 continue;
             }
 
-            if (candidate.AtlasEntries.Count == 0)
+            if (candidate.AtlasEntries.Count == 0 && !RequiresBakeEmission(candidate))
             {
                 passThroughCandidates.Add(candidate);
                 continue;
@@ -277,6 +277,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
 
         List<AtlasBatchEntry> atlasEntries = [];
         List<PreservedSubmeshEntry> preservedEntries = [];
+        bool hadAtlasCandidateMaterial = false;
         foreach (ResoniteMeshSubmesh submesh in normalizedCityObject.Mesh.Submeshes.OrderBy(static candidate => candidate.Index))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -290,9 +291,22 @@ internal sealed class Lod2AtlasCityObjectBaker(
             switch (category)
             {
                 case Lod2AtlasMaterialBakeCategory.AtlasCandidate:
-                    TextureUvRect uvBounds = ComputeUvBounds(normalizedCityObject.Mesh.Vertices, submesh, material);
-                    MaterialAtlasTile tile = await CreateAtlasTileAsync(material, uvBounds, cancellationToken);
-                    atlasEntries.Add(new AtlasBatchEntry(normalizedCityObject, submesh, material, tile, uvBounds));
+                    hadAtlasCandidateMaterial = true;
+                    AtlasOrPreservedEntry bakeEntry = await CreateAtlasOrPreservedEntryAsync(
+                        normalizedCityObject,
+                        submesh,
+                        material,
+                        cancellationToken);
+                    if (bakeEntry.AtlasEntry is not null)
+                    {
+                        atlasEntries.Add(bakeEntry.AtlasEntry);
+                    }
+
+                    if (bakeEntry.PreservedEntry is not null)
+                    {
+                        preservedEntries.Add(bakeEntry.PreservedEntry);
+                    }
+
                     break;
                 case Lod2AtlasMaterialBakeCategory.PreservedCommonMaterial when policy.PreserveCommonMaterials:
                 case Lod2AtlasMaterialBakeCategory.PreservedTextureless when policy.PreserveTexturelessMaterials:
@@ -305,7 +319,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
             }
         }
 
-        if (policy.RequireAtlasCandidateMaterial && atlasEntries.Count == 0)
+        if (policy.RequireAtlasCandidateMaterial && !hadAtlasCandidateMaterial)
         {
             DisposeCandidateImages(new CityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries));
             return null;
@@ -320,23 +334,34 @@ internal sealed class Lod2AtlasCityObjectBaker(
         return new CityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries);
     }
 
-    private async Task<MaterialAtlasTile> CreateAtlasTileAsync(
+    private async Task<AtlasOrPreservedEntry> CreateAtlasOrPreservedEntryAsync(
+        ResoniteConstructionCityObject cityObject,
+        ResoniteMeshSubmesh submesh,
         ResoniteMaterialBinding material,
-        TextureUvRect uvBounds,
         CancellationToken cancellationToken)
     {
         if (material.TexturePayload is null)
         {
-            return CreateSolidColorTile(material.BaseColor);
+            throw new InvalidOperationException("LOD2 atlas bake candidate material must have a texture payload.");
         }
 
+        TextureUvRect uvBounds = ComputeUvBounds(cityObject.Mesh.Vertices, submesh, material);
         using Image<Rgba32> sourceImage = await textureImageLoader.LoadAsync(
             ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
             cancellationToken);
         Rgba32 detectedBackgroundColor = DetectRepresentativeBackgroundColor(sourceImage);
         using Image<Rgba32> preparedSourceImage = sourceImage.Clone();
         FillTransparentRgb(preparedSourceImage, detectedBackgroundColor);
-        bool isUniformDatasetTexture = TryGetUniformPixelColor(preparedSourceImage, out _);
+        if (TryGetUniformPixelColor(preparedSourceImage, out Rgba32 uniformDatasetColor))
+        {
+            return new AtlasOrPreservedEntry(
+                AtlasEntry: null,
+                PreservedEntry: new PreservedSubmeshEntry(
+                    cityObject,
+                    submesh,
+                    CreateVertexColorMaterial(material, submesh.Index),
+                    ToColor(MultiplyPixel(uniformDatasetColor, ToPixel(material.BaseColor)))));
+        }
 
         int maxTileWidth = EffectiveMaxAtlasTextureEdge;
         int maxTileHeight = EffectiveMaxAtlasTextureEdge;
@@ -345,29 +370,17 @@ internal sealed class Lod2AtlasCityObjectBaker(
         using Image<Rgba32> bakedImage = BakeUsedUvRegion(preparedSourceImage, uvBounds, targetWidth, targetHeight);
 
         ApplyBaseColor(bakedImage, material.BaseColor);
-        if (isUniformDatasetTexture && TryGetUniformPixelColor(bakedImage, out Rgba32 uniformColor))
-        {
-            return CreateSolidColorTile(uniformColor);
-        }
-
-        return new MaterialAtlasTile(
-            material.TexturePayload.Identity ?? material.MaterialKey,
-            bakedImage.Clone(),
-            MultiplyPixel(detectedBackgroundColor, ToPixel(material.BaseColor)));
-    }
-
-    private static MaterialAtlasTile CreateSolidColorTile(ResoniteColor color)
-    {
-        return CreateSolidColorTile(ToPixel(color));
-    }
-
-    private static MaterialAtlasTile CreateSolidColorTile(Rgba32 color)
-    {
-        using Image<Rgba32> image = new(1, 1, color);
-        return new MaterialAtlasTile(
-            $"solid:{color.R:0.###},{color.G:0.###},{color.B:0.###},{color.A:0.###}",
-            image.Clone(),
-            color);
+        return new AtlasOrPreservedEntry(
+            AtlasEntry: new AtlasBatchEntry(
+                cityObject,
+                submesh,
+                material,
+                new MaterialAtlasTile(
+                    material.TexturePayload.Identity ?? material.MaterialKey,
+                    bakedImage.Clone(),
+                    MultiplyPixel(detectedBackgroundColor, ToPixel(material.BaseColor))),
+                uvBounds),
+            PreservedEntry: null);
     }
 
     private static bool CanBufferCityObjectMaterials(
@@ -693,6 +706,7 @@ internal sealed class Lod2AtlasCityObjectBaker(
             vertices.Add(sourceVertex with
             {
                 Position = Add(sourceVertex.Position, cityObjectOffset),
+                Color = preservedEntry.VertexColorOverride ?? sourceVertex.Color,
             });
             triangleIndices.Add(vertices.Count - 1);
         }
@@ -1097,6 +1111,33 @@ internal sealed class Lod2AtlasCityObjectBaker(
             (byte)Math.Round(Math.Clamp(color.G, 0.0, 1.0) * 255.0),
             (byte)Math.Round(Math.Clamp(color.B, 0.0, 1.0) * 255.0),
             (byte)Math.Round(Math.Clamp(color.A, 0.0, 1.0) * 255.0));
+    }
+
+    private static ResoniteColor ToColor(Rgba32 color)
+    {
+        return new ResoniteColor(
+            color.R / 255.0,
+            color.G / 255.0,
+            color.B / 255.0,
+            color.A / 255.0);
+    }
+
+    private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)
+    {
+        return material with
+        {
+            MaterialType = ResoniteMaterialType.VertexColor,
+            MaterialKey = $"vertex-color:{material.MaterialKey}",
+            BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            TexturePayload = null,
+            TextureSourceKind = ResoniteTextureSourceKind.Bundled,
+            TextureScale = null,
+            TextureOffset = null,
+            Family = null,
+            TerrainOverlay = null,
+            AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped,
+            SubmeshIndices = [submeshIndex],
+        };
     }
 
     private static SourceUnitBatchKey CreateSourceUnitKey(
@@ -1623,6 +1664,10 @@ internal sealed class Lod2AtlasCityObjectBaker(
 
     private sealed record MaterialAtlasTile(string Identity, Image<Rgba32> Image, Rgba32 BackgroundColor);
 
+    private sealed record AtlasOrPreservedEntry(
+        AtlasBatchEntry? AtlasEntry,
+        PreservedSubmeshEntry? PreservedEntry);
+
     private readonly record struct BufferedCityObject(
         ResoniteConstructionCityObject CityObject,
         Lod2AtlasCityObjectBakePolicy Policy);
@@ -1637,12 +1682,18 @@ internal sealed class Lod2AtlasCityObjectBaker(
     private sealed record PreservedSubmeshEntry(
         ResoniteConstructionCityObject CityObject,
         ResoniteMeshSubmesh Submesh,
-        ResoniteMaterialBinding Material);
+        ResoniteMaterialBinding Material,
+        ResoniteColor? VertexColorOverride = null);
 
     private sealed record CityObjectBakeCandidate(
         ResoniteConstructionCityObject CityObject,
         IReadOnlyList<AtlasBatchEntry> AtlasEntries,
         IReadOnlyList<PreservedSubmeshEntry> PreservedEntries);
+
+    private static bool RequiresBakeEmission(CityObjectBakeCandidate candidate)
+    {
+        return candidate.PreservedEntries.Any(static entry => entry.VertexColorOverride is not null);
+    }
 
     private sealed record AtlasBatchPlan(
         IReadOnlyList<IReadOnlyList<CityObjectBakeCandidate>> Batches,

--- a/src/PlateauResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Lod2AtlasCityObjectBaker.cs
@@ -344,6 +344,11 @@ internal sealed class Lod2AtlasCityObjectBaker(
         using Image<Rgba32> bakedImage = BakeUsedUvRegion(preparedSourceImage, uvBounds, targetWidth, targetHeight);
 
         ApplyBaseColor(bakedImage, material.BaseColor);
+        if (TryGetUniformPixelColor(bakedImage, out Rgba32 uniformColor))
+        {
+            return CreateSolidColorTile(uniformColor);
+        }
+
         return new MaterialAtlasTile(
             material.TexturePayload.Identity ?? material.MaterialKey,
             bakedImage.Clone(),
@@ -352,11 +357,16 @@ internal sealed class Lod2AtlasCityObjectBaker(
 
     private static MaterialAtlasTile CreateSolidColorTile(ResoniteColor color)
     {
-        using Image<Rgba32> image = new(1, 1, ToPixel(color));
+        return CreateSolidColorTile(ToPixel(color));
+    }
+
+    private static MaterialAtlasTile CreateSolidColorTile(Rgba32 color)
+    {
+        using Image<Rgba32> image = new(1, 1, color);
         return new MaterialAtlasTile(
             $"solid:{color.R:0.###},{color.G:0.###},{color.B:0.###},{color.A:0.###}",
             image.Clone(),
-            ToPixel(color));
+            color);
     }
 
     private static bool CanBufferCityObjectMaterials(
@@ -1255,6 +1265,30 @@ internal sealed class Lod2AtlasCityObjectBaker(
                     pixel.A);
             }
         }
+    }
+
+    private static bool TryGetUniformPixelColor(Image<Rgba32> image, out Rgba32 color)
+    {
+        color = default;
+        if (image.Width <= 0 || image.Height <= 0)
+        {
+            return false;
+        }
+
+        Rgba32 firstPixel = image[0, 0];
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                if (!image[x, y].Equals(firstPixel))
+                {
+                    return false;
+                }
+            }
+        }
+
+        color = firstPixel;
+        return true;
     }
 
     private static bool TryAverageBoundaryOpaquePixels(Image<Rgba32> image, out Rgba32 color)

--- a/tests/PlateauResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -82,6 +82,27 @@ public sealed class Lod2AtlasCityObjectBakerTests
     }
 
     [Fact]
+    public async Task FlushAllAsyncKeepsBakedUniformRegionFromNonUniformDatasetTextureAtBakedResolution()
+    {
+        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 0);
+
+        await AssertBufferedAsync(baker, CreateUvScaledLod2Building(
+            "building-nonuniform",
+            CreateStripedPayload("textures/nonuniform-red-region.png", [new Rgba32(255, 0, 0, 255), new Rgba32(255, 0, 0, 255), new Rgba32(0, 255, 0, 255), new Rgba32(0, 0, 255, 255)]),
+            "unit-a",
+            new ResoniteFloat2(0.5, 1.0),
+            new ResoniteFloat2(0.0, 0.0)));
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload);
+
+        Assert.Equal(2, atlasPayload.Width);
+        Assert.Equal(1, atlasPayload.Height);
+        Assert.Equal(new Rgba32(255, 0, 0, 255), ReadPixel(atlasPayload, 0, 0));
+        Assert.Equal(new Rgba32(255, 0, 0, 255), ReadPixel(atlasPayload, 1, 0));
+    }
+
+    [Fact]
     public async Task FlushAllAsyncRepeatsTextureContentWhenUsedUvRangeExceedsUnitSquare()
     {
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 0);

--- a/tests/PlateauResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -59,6 +59,29 @@ public sealed class Lod2AtlasCityObjectBakerTests
     }
 
     [Fact]
+    public async Task FlushAllAsyncCollapsesUniformDatasetTextureToSingleSolidAtlasPixel()
+    {
+        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 0);
+
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-uniform",
+                CreatePayload("textures/uniform-red.png", new Rgba32(255, 0, 0, 255), 8, 8),
+                0,
+                "unit-a"));
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+        ResoniteMaterialBinding material = Assert.Single(cityObject.Materials);
+        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(material.TexturePayload);
+
+        Assert.Equal(ResoniteMaterialType.Standard, material.MaterialType);
+        Assert.Equal(1, atlasPayload.Width);
+        Assert.Equal(1, atlasPayload.Height);
+        Assert.Equal(new Rgba32(255, 0, 0, 255), ReadPixel(atlasPayload, 0, 0));
+    }
+
+    [Fact]
     public async Task FlushAllAsyncRepeatsTextureContentWhenUsedUvRangeExceedsUnitSquare()
     {
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 0);
@@ -346,8 +369,8 @@ public sealed class Lod2AtlasCityObjectBakerTests
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 12, tilePaddingPixels: 1);
         ResoniteConstructionCityObject oversizedCandidate = CreateMultiTextureLod2Building(
             "building-one",
-            CreatePayload("textures/one.png", new Rgba32(255, 0, 0, 255), 12, 12),
-            CreatePayload("textures/two.png", new Rgba32(0, 255, 0, 255), 12, 12),
+            CreateCheckerPayload("textures/one.png", new Rgba32(255, 0, 0, 255), new Rgba32(255, 255, 0, 255), 12, 12),
+            CreateCheckerPayload("textures/two.png", new Rgba32(0, 255, 0, 255), new Rgba32(0, 0, 255, 255), 12, 12),
             "unit-a");
 
         await AssertBufferedAsync(baker, oversizedCandidate);
@@ -366,7 +389,7 @@ public sealed class Lod2AtlasCityObjectBakerTests
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 10, tilePaddingPixels: 0);
         ResoniteConstructionCityObject oversizedCandidate = CreateUvScaledLod2Building(
             "building-dynamic-fallback",
-            CreatePayload("textures/dynamic-fallback.png", new Rgba32(255, 0, 0, 255), 9, 3),
+            CreateCheckerPayload("textures/dynamic-fallback.png", new Rgba32(255, 0, 0, 255), new Rgba32(0, 255, 0, 255), 9, 3),
             "unit-a",
             new ResoniteFloat2(2.0, 0.5),
             new ResoniteFloat2(0.25, 0.75));
@@ -445,9 +468,9 @@ public sealed class Lod2AtlasCityObjectBakerTests
     {
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 16, tilePaddingPixels: 0);
 
-        await AssertBufferedAsync(baker, CreateLod2Building("building-a", CreatePayload("textures/a.png", new Rgba32(255, 0, 0, 255), 7, 7), 0, "unit-a"));
-        await AssertBufferedAsync(baker, CreateLod2Building("building-b", CreatePayload("textures/b.png", new Rgba32(0, 255, 0, 255), 1, 7), 2, "unit-a"));
-        await AssertBufferedAsync(baker, CreateLod2Building("building-c", CreatePayload("textures/c.png", new Rgba32(0, 0, 255, 255), 3, 3), 4, "unit-a"));
+        await AssertBufferedAsync(baker, CreateLod2Building("building-a", CreateCheckerPayload("textures/a.png", new Rgba32(255, 0, 0, 255), new Rgba32(255, 255, 0, 255), 7, 7), 0, "unit-a"));
+        await AssertBufferedAsync(baker, CreateLod2Building("building-b", CreateCheckerPayload("textures/b.png", new Rgba32(0, 255, 0, 255), new Rgba32(0, 255, 255, 255), 1, 7), 2, "unit-a"));
+        await AssertBufferedAsync(baker, CreateLod2Building("building-c", CreateCheckerPayload("textures/c.png", new Rgba32(0, 0, 255, 255), new Rgba32(255, 0, 255, 255), 3, 3), 4, "unit-a"));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
@@ -510,7 +533,7 @@ public sealed class Lod2AtlasCityObjectBakerTests
             baker,
             CreateLod2Building(
                 "building-large",
-                CreatePayload("textures/large.png", new Rgba32(255, 0, 0, 255), 1024, 1024),
+                CreateVerticalSplitPayload("textures/large.png", new Rgba32(255, 0, 0, 255), new Rgba32(0, 0, 255, 255), 1024, 1024),
                 0,
                 "unit-a"));
 
@@ -554,6 +577,35 @@ public sealed class Lod2AtlasCityObjectBakerTests
         for (int x = 0; x < colors.Count; x++)
         {
             image[x, 0] = colors[x];
+        }
+
+        return ResoniteTextureImportFactory.CreatePayloadFromImage(image, identity: identity);
+    }
+
+    private static ResoniteTexturePayload CreateCheckerPayload(string identity, Rgba32 primary, Rgba32 secondary, int width, int height)
+    {
+        using Image<Rgba32> image = new(width, height);
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                image[x, y] = ((x + y) & 1) == 0 ? primary : secondary;
+            }
+        }
+
+        return ResoniteTextureImportFactory.CreatePayloadFromImage(image, identity: identity);
+    }
+
+    private static ResoniteTexturePayload CreateVerticalSplitPayload(string identity, Rgba32 left, Rgba32 right, int width, int height)
+    {
+        using Image<Rgba32> image = new(width, height);
+        int splitX = width / 2;
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                image[x, y] = x < splitX ? left : right;
+            }
         }
 
         return ResoniteTextureImportFactory.CreatePayloadFromImage(image, identity: identity);

--- a/tests/PlateauResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/Lod2AtlasCityObjectBakerTests.cs
@@ -18,8 +18,8 @@ public sealed class Lod2AtlasCityObjectBakerTests
     {
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 1);
 
-        await AssertBufferedAsync(baker, CreateLod2Building("building-one", CreatePayload("textures/one.png", new Rgba32(255, 0, 0, 255), 4, 4), 0, "unit-a"));
-        await AssertBufferedAsync(baker, CreateLod2Building("building-two", CreatePayload("textures/two.png", new Rgba32(0, 255, 0, 255), 4, 4), 2, "unit-a"));
+        await AssertBufferedAsync(baker, CreateLod2Building("building-one", CreateCheckerPayload("textures/one.png", new Rgba32(255, 0, 0, 255), new Rgba32(255, 255, 0, 255), 4, 4), 0, "unit-a"));
+        await AssertBufferedAsync(baker, CreateLod2Building("building-two", CreateCheckerPayload("textures/two.png", new Rgba32(0, 255, 0, 255), new Rgba32(0, 255, 255, 255), 4, 4), 2, "unit-a"));
 
         IReadOnlyList<ResoniteConstructionCityObject> baked = await baker.FlushAllAsync();
 
@@ -59,7 +59,7 @@ public sealed class Lod2AtlasCityObjectBakerTests
     }
 
     [Fact]
-    public async Task FlushAllAsyncCollapsesUniformDatasetTextureToSingleSolidAtlasPixel()
+    public async Task FlushAllAsyncConvertsUniformDatasetTextureToSharedVertexColorMaterial()
     {
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 0);
 
@@ -73,12 +73,11 @@ public sealed class Lod2AtlasCityObjectBakerTests
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         ResoniteMaterialBinding material = Assert.Single(cityObject.Materials);
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(material.TexturePayload);
-
-        Assert.Equal(ResoniteMaterialType.Standard, material.MaterialType);
-        Assert.Equal(1, atlasPayload.Width);
-        Assert.Equal(1, atlasPayload.Height);
-        Assert.Equal(new Rgba32(255, 0, 0, 255), ReadPixel(atlasPayload, 0, 0));
+        Assert.Equal(ResoniteMaterialType.VertexColor, material.MaterialType);
+        Assert.Null(material.TexturePayload);
+        Assert.Equal(ResoniteMaterialAssetScope.Common, material.AssetScope);
+        Assert.Equal(new ResoniteColor(1.0, 1.0, 1.0, 1.0), material.BaseColor);
+        Assert.All(cityObject.Mesh.Vertices, static vertex => Assert.Equal(new ResoniteColor(1.0, 0.0, 0.0, 1.0), vertex.Color));
     }
 
     [Fact]
@@ -100,6 +99,34 @@ public sealed class Lod2AtlasCityObjectBakerTests
         Assert.Equal(1, atlasPayload.Height);
         Assert.Equal(new Rgba32(255, 0, 0, 255), ReadPixel(atlasPayload, 0, 0));
         Assert.Equal(new Rgba32(255, 0, 0, 255), ReadPixel(atlasPayload, 1, 0));
+    }
+
+    [Fact]
+    public async Task FlushAllAsyncKeepsUniformVertexColorAndNonUniformAtlasMaterialsInSameBatch()
+    {
+        Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 0);
+
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-uniform",
+                CreatePayload("textures/uniform-red.png", new Rgba32(255, 0, 0, 255), 8, 8),
+                0,
+                "unit-a"));
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-nonuniform",
+                CreateCheckerPayload("textures/nonuniform.png", new Rgba32(0, 255, 0, 255), new Rgba32(0, 0, 255, 255), 4, 4),
+                2,
+                "unit-a"));
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+        Assert.Equal(2, cityObject.Materials.Count);
+        Assert.Equal(2, cityObject.Mesh.Submeshes.Count);
+        Assert.Contains(cityObject.Materials, static material => material.MaterialType == ResoniteMaterialType.VertexColor && material.TexturePayload is null);
+        Assert.Contains(cityObject.Materials, static material => material.MaterialType == ResoniteMaterialType.Standard && material.TexturePayload is not null);
+        Assert.Contains(cityObject.Mesh.Vertices, static vertex => vertex.Color == new ResoniteColor(1.0, 0.0, 0.0, 1.0));
     }
 
     [Fact]
@@ -159,7 +186,7 @@ public sealed class Lod2AtlasCityObjectBakerTests
     {
         Lod2AtlasCityObjectBaker baker = new(new ResoniteTextureImageLoader(), maxAtlasSize: 32, tilePaddingPixels: 1);
 
-        await AssertBufferedAsync(baker, CreateMixedScopeLod2Building("building-one", CreatePayload("textures/one.png", new Rgba32(255, 0, 0, 255), 4, 4), "unit-a"));
+        await AssertBufferedAsync(baker, CreateMixedScopeLod2Building("building-one", CreateCheckerPayload("textures/one.png", new Rgba32(255, 0, 0, 255), new Rgba32(255, 255, 0, 255), 4, 4), "unit-a"));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         Assert.Equal(2, cityObject.Materials.Count);
@@ -445,28 +472,16 @@ public sealed class Lod2AtlasCityObjectBakerTests
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         Assert.Single(cityObject.Materials);
         Assert.Single(cityObject.Mesh.Submeshes);
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
-        Assert.NotNull(atlasPayload.Width);
-        Assert.NotNull(atlasPayload.Height);
-        Assert.True(atlasPayload.Width > 0);
-        Assert.True(atlasPayload.Height > 0);
+        ResoniteMaterialBinding material = Assert.Single(cityObject.Materials);
+        Assert.Equal(ResoniteMaterialType.VertexColor, material.MaterialType);
+        Assert.Null(material.TexturePayload);
 
-        HashSet<Rgba32> atlasColors = [];
-        int pixelCount = atlasPayload.Width.Value * atlasPayload.Height.Value;
-        ReadOnlySpan<byte> atlasBytes = atlasPayload.BinaryPayload.AsSpan();
-        for (int pixelIndex = 0; pixelIndex < pixelCount; pixelIndex++)
-        {
-            int offset = pixelIndex * 4;
-            atlasColors.Add(new Rgba32(
-                atlasBytes[offset],
-                atlasBytes[offset + 1],
-                atlasBytes[offset + 2],
-                atlasBytes[offset + 3]));
-        }
-
-        Assert.Contains(new Rgba32(255, 0, 0, 255), atlasColors);
-        Assert.Contains(new Rgba32(0, 255, 0, 255), atlasColors);
-        Assert.DoesNotContain(new Rgba32(0, 0, 0, 0), atlasColors);
+        HashSet<ResoniteColor> vertexColors = cityObject.Mesh.Vertices
+            .Select(static vertex => vertex.Color)
+            .OfType<ResoniteColor>()
+            .ToHashSet();
+        Assert.Contains(new ResoniteColor(1.0, 0.0, 0.0, 1.0), vertexColors);
+        Assert.Contains(new ResoniteColor(0.0, 1.0, 0.0, 1.0), vertexColors);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- convert source-uniform dataset textures to `VertexColor` instead of keeping them on the atlas path
- keep non-uniform dataset textures on the existing atlas bake path even if a sampled UV region happens to bake to a uniform color
- add regression coverage for uniform-to-vertex-color conversion and mixed vertex-color plus atlas batches

## Testing
- dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --verbosity minimal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~Lod2AtlasCityObjectBakerTests"
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

## Issues
- Fixes #134