### PR TITLE
Rename DEM terrain mesh modes

### DIFF
--- a/.agents/skills/resonite-live-send-debug/references/workflow.ja.md
+++ b/.agents/skills/resonite-live-send-debug/references/workflow.ja.md
@@ -101,7 +101,7 @@ disposable な headless validation では、次の operator sequence を優先�
 2. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot --runtime-root <headless-runtime> --output <repo>/runtime/windows/resonite/root-dumps/baseline.json`
 3. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- remove-slot ws://localhost:19001/ --root-child-name "PLATEAU plateau-20202-matsumoto-shi-2020"`
 4. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/post-removal-pre-send.json`
-5. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-20202-matsumoto-shi-2020 --mesh-code 54372778 --citygml-source <archive> --work-root <repo>/runtime/windows/resonite --dem-terrain-mode heightmap --resonitelink-port 19001 --resonitelink-connections 1`
+5. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-20202-matsumoto-shi-2020 --mesh-code 54372778 --citygml-source <archive> --work-root <repo>/runtime/windows/resonite --terrain-mesh grid --resonitelink-port 19001 --resonitelink-connections 1`
 6. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/after-send.json`
 7. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- stop-headless --runtime-root <headless-runtime> --state-path <headless-runtime>/active-session.json`
 
@@ -112,30 +112,30 @@ Yokohama や Sendai に行く前の default full live verification set として
 ### Matsumoto Mixed-Mode Whole Test
 
 Matsumoto は lightweight な mixed-mode baseline に使います。
-canonical direction は `base=mesh`、`append=heightmap` です。
+canonical direction は `base=static`、`append=grid` です。
 inverse direction も明示的に必要なら有効ですが、default worksheet ではありません。
 
 1. world に `PLATEAU plateau-20202-matsumoto-shi-2020` が既にあり、この run を clean Matsumoto base から始める必要がある場合だけ:
    `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- remove-slot ws://localhost:19001/ --root-child-name "PLATEAU plateau-20202-matsumoto-shi-2020"`
 2. step 1 を実行した場合だけ:
    `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/matsumoto-post-removal-pre-send.json`
-3. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-20202-matsumoto-shi-2020 --mesh-code 54372778 --citygml-source <archive> --work-root <repo>/runtime/windows/resonite --dem-terrain-mode mesh --resonitelink-port 19001 --resonitelink-connections 1`
-4. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-20202-matsumoto-shi-2020 --mesh-code 54372788 --citygml-source <archive> --work-root <repo>/runtime/windows/resonite --dem-terrain-mode heightmap --resonitelink-port 19001 --resonitelink-connections 1`
-5. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/matsumoto-append-heightmap-after-send.json`
+3. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-20202-matsumoto-shi-2020 --mesh-code 54372778 --citygml-source <archive> --work-root <repo>/runtime/windows/resonite --terrain-mesh static --resonitelink-port 19001 --resonitelink-connections 1`
+4. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-20202-matsumoto-shi-2020 --mesh-code 54372788 --citygml-source <archive> --work-root <repo>/runtime/windows/resonite --terrain-mesh grid --resonitelink-port 19001 --resonitelink-connections 1`
+5. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/matsumoto-append-grid-after-send.json`
 
 ### Higashimurayama Mixed-Mode Whole Test
 
 Higashimurayama は standard GeoTIFF-backed mixed-mode whole test に使います。
-canonical direction は `base=heightmap`、`append=mesh` です。
+canonical direction は `base=grid`、`append=static` です。
 inverse direction も明示的に必要なら有効ですが、default worksheet ではありません。
 
 1. world に `PLATEAU plateau-13213-higashimurayama-shi-2020` が既にあり、この run を clean Higashimurayama base から始める必要がある場合だけ:
    `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- remove-slot ws://localhost:19001/ --root-child-name "PLATEAU plateau-13213-higashimurayama-shi-2020"`
 2. step 1 を実行した場合だけ:
    `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/higashimurayama-post-removal-pre-send.json`
-3. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-archive-5039b16c4b1c.zip --geotiff-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-ortho-cc68652cc45c.7z --work-root <repo>/runtime/windows/resonite --dem-terrain-mode heightmap --resonitelink-port 19001 --resonitelink-connections 1`
-4. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395326 --packages dem,bldg --citygml-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-archive-5039b16c4b1c.zip --geotiff-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-ortho-cc68652cc45c.7z --work-root <repo>/runtime/windows/resonite --dem-terrain-mode mesh --resonitelink-port 19001 --resonitelink-connections 1`
-5. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/higashimurayama-append-mesh-after-send.json`
+3. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-archive-5039b16c4b1c.zip --geotiff-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-ortho-cc68652cc45c.7z --work-root <repo>/runtime/windows/resonite --terrain-mesh grid --resonitelink-port 19001 --resonitelink-connections 1`
+4. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395326 --packages dem,bldg --citygml-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-archive-5039b16c4b1c.zip --geotiff-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-ortho-cc68652cc45c.7z --work-root <repo>/runtime/windows/resonite --terrain-mesh static --resonitelink-port 19001 --resonitelink-connections 1`
+5. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/higashimurayama-append-static-after-send.json`
 
 ## Cleanup Escalation
 
@@ -264,7 +264,7 @@ direct `dotnet` 実行では、session tool script や CLI が on demand で reb
   明示した slot を 1 つ remove します。
 - `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- remove-slot ws://localhost:<port>/ --root-child-name "PLATEAU plateau-20202-matsumoto-shi-2020"`
   `Root` 直下の exact direct child を 1 つ解決して remove します。これは operator workflow の convenience であり、semantic cleanup API ではありません。
-- `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset <dataset> --mesh-code <mesh> --citygml-source <archive-or-udx> --work-root <repo>/runtime/windows/resonite --dem-terrain-mode <heightmap|mesh> --resonitelink-port <port> --resonitelink-connections <n>`
+- `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset <dataset> --mesh-code <mesh> --citygml-source <archive-or-udx> --work-root <repo>/runtime/windows/resonite --terrain-mesh <static|grid> --resonitelink-port <port> --resonitelink-connections <n>`
   `runtime/windows/resonite` 配下へ explicit log を出しながら、direct live send を 1 回実行します。
 
 ## Visual Review Procedure

--- a/.agents/skills/resonite-live-send-debug/references/workflow.md
+++ b/.agents/skills/resonite-live-send-debug/references/workflow.md
@@ -100,7 +100,7 @@ For disposable headless validation, prefer this operator sequence:
 2. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot --runtime-root <headless-runtime> --output <repo>/runtime/windows/resonite/root-dumps/baseline.json`
 3. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- remove-slot ws://localhost:19001/ --root-child-name "PLATEAU plateau-20202-matsumoto-shi-2020"`
 4. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/post-removal-pre-send.json`
-5. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-20202-matsumoto-shi-2020 --mesh-code 54372778 --citygml-source <archive> --work-root <repo>/runtime/windows/resonite --dem-terrain-mode heightmap --resonitelink-port 19001 --resonitelink-connections 1`
+5. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-20202-matsumoto-shi-2020 --mesh-code 54372778 --citygml-source <archive> --work-root <repo>/runtime/windows/resonite --terrain-mesh grid --resonitelink-port 19001 --resonitelink-connections 1`
 6. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/after-send.json`
 7. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- stop-headless --runtime-root <headless-runtime> --state-path <headless-runtime>/active-session.json`
 
@@ -111,30 +111,30 @@ Use the next two worksheets as the default full live verification set before rea
 ### Matsumoto Mixed-Mode Whole Test
 
 Use Matsumoto for the lightweight mixed-mode baseline.
-The canonical direction is `base=mesh`, `append=heightmap`.
+The canonical direction is `base=static`, `append=grid`.
 The inverse direction is valid when explicitly needed, but it is not the default worksheet.
 
 1. If and only if the world already contains `PLATEAU plateau-20202-matsumoto-shi-2020` and this run must start from a clean Matsumoto base:
    `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- remove-slot ws://localhost:19001/ --root-child-name "PLATEAU plateau-20202-matsumoto-shi-2020"`
 2. If step 1 ran:
    `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/matsumoto-post-removal-pre-send.json`
-3. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-20202-matsumoto-shi-2020 --mesh-code 54372778 --citygml-source <archive> --work-root <repo>/runtime/windows/resonite --dem-terrain-mode mesh --resonitelink-port 19001 --resonitelink-connections 1`
-4. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-20202-matsumoto-shi-2020 --mesh-code 54372788 --citygml-source <archive> --work-root <repo>/runtime/windows/resonite --dem-terrain-mode heightmap --resonitelink-port 19001 --resonitelink-connections 1`
-5. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/matsumoto-append-heightmap-after-send.json`
+3. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-20202-matsumoto-shi-2020 --mesh-code 54372778 --citygml-source <archive> --work-root <repo>/runtime/windows/resonite --terrain-mesh static --resonitelink-port 19001 --resonitelink-connections 1`
+4. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-20202-matsumoto-shi-2020 --mesh-code 54372788 --citygml-source <archive> --work-root <repo>/runtime/windows/resonite --terrain-mesh grid --resonitelink-port 19001 --resonitelink-connections 1`
+5. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/matsumoto-append-grid-after-send.json`
 
 ### Higashimurayama Mixed-Mode Whole Test
 
 Use Higashimurayama for the standard GeoTIFF-backed mixed-mode whole test.
-The canonical direction is `base=heightmap`, `append=mesh`.
+The canonical direction is `base=grid`, `append=static`.
 The inverse direction is valid when explicitly needed, but it is not the default worksheet.
 
 1. If and only if the world already contains `PLATEAU plateau-13213-higashimurayama-shi-2020` and this run must start from a clean Higashimurayama base:
    `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- remove-slot ws://localhost:19001/ --root-child-name "PLATEAU plateau-13213-higashimurayama-shi-2020"`
 2. If step 1 ran:
    `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/higashimurayama-post-removal-pre-send.json`
-3. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-archive-5039b16c4b1c.zip --geotiff-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-ortho-cc68652cc45c.7z --work-root <repo>/runtime/windows/resonite --dem-terrain-mode heightmap --resonitelink-port 19001 --resonitelink-connections 1`
-4. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395326 --packages dem,bldg --citygml-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-archive-5039b16c4b1c.zip --geotiff-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-ortho-cc68652cc45c.7z --work-root <repo>/runtime/windows/resonite --dem-terrain-mode mesh --resonitelink-port 19001 --resonitelink-connections 1`
-5. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/higashimurayama-append-mesh-after-send.json`
+3. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-archive-5039b16c4b1c.zip --geotiff-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-ortho-cc68652cc45c.7z --work-root <repo>/runtime/windows/resonite --terrain-mesh grid --resonitelink-port 19001 --resonitelink-connections 1`
+4. `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395326 --packages dem,bldg --citygml-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-archive-5039b16c4b1c.zip --geotiff-source <repo>/runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-ortho-cc68652cc45c.7z --work-root <repo>/runtime/windows/resonite --terrain-mesh static --resonitelink-port 19001 --resonitelink-connections 1`
+5. `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- dump-slot ws://localhost:19001/ --slot-id Root --output <repo>/runtime/windows/resonite/root-dumps/higashimurayama-append-static-after-send.json`
 
 ## Cleanup Escalation
 
@@ -263,7 +263,7 @@ Direct `dotnet` execution rebuilds the session tool script or CLI on demand. Fre
   Remove one explicitly addressed slot.
 - `dotnet .agents/skills/resonite-live-send-debug/tools/session-tool.cs -- remove-slot ws://localhost:<port>/ --root-child-name "PLATEAU plateau-20202-matsumoto-shi-2020"`
   Resolve one exact direct child under `Root`, then remove that slot. This is convenience for operator workflow, not a semantic cleanup API.
-- `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset <dataset> --mesh-code <mesh> --citygml-source <archive-or-udx> --work-root <repo>/runtime/windows/resonite --dem-terrain-mode <heightmap|mesh> --resonitelink-port <port> --resonitelink-connections <n>`
+- `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- import --dataset <dataset> --mesh-code <mesh> --citygml-source <archive-or-udx> --work-root <repo>/runtime/windows/resonite --terrain-mesh <static|grid> --resonitelink-port <port> --resonitelink-connections <n>`
   Launch one direct live send with explicit logs under `runtime/windows/resonite`.
 
 ## Visual Review Procedure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
           Highlights before this first tagged release:
           - Added the live CLI pipeline for streaming PLATEAU CityGML datasets into Resonite through ResoniteLink.
           - Hardened direct archive imports with explicit remote archive validation, cache reuse, and pre-validation of import requests.
-          - Added DEM heightmap terrain generation, placement fixes, and live asset reuse improvements.
+          - Added DEM terrain grid generation, placement fixes, and live asset reuse improvements.
           - Expanded automated coverage around CLI parsing, import validation, dataset discovery, DEM layout, and live send behavior.
 
           EOF

--- a/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
@@ -37,12 +37,12 @@ public static class CliArgumentsParser
                                 Required. Local dataset/archive path or absolute direct .zip/.7z CityGML archive URL.
           --geotiff-source <path-or-url>
                                 Optional. Local GeoTIFF file/archive path or absolute .tif/.tiff/.zip/.7z GeoTIFF URL.
-          --dem-terrain-mode <mesh|heightmap>
-                                Optional. DEM import mode. Default: mesh.
-          --dem-heightmap-meters-per-vertex <value>
-                                Optional. Heightmap sampling spacing in meters. Default: 2.0.
-          --dem-heightmap-max-resolution <value>
-                                Optional. Maximum heightmap resolution per DEM chunk. Default: 1024.
+          --terrain-mesh <static|grid>
+                                Optional. Terrain mesh style. Default: static.
+          --terrain-grid-meters-per-vertex <value>
+                                Optional. Terrain grid sampling spacing in meters. Default: 2.0.
+          --terrain-grid-max-resolution <value>
+                                Optional. Maximum terrain grid resolution per DEM chunk. Default: 1024.
           --work-root <path>     Optional. Parent directory for dataset-local archive storage and live temporary files. Default: local.
           --terrain-tile-cache-root <path>
                                 Optional. Override the persistent terrain tile cache root.
@@ -107,9 +107,9 @@ public static class CliArgumentsParser
         bool hasPackageExcludeLodsOption = false;
         bool includeMarkingAlways = true;
         Dictionary<string, string>? packagePatterns = null;
-        DemTerrainMode demTerrainMode = DemTerrainMode.Mesh;
-        double demHeightmapMetersPerVertex = 2.0;
-        int demHeightmapMaxResolution = 1024;
+        TerrainMeshMode terrainMesh = TerrainMeshMode.Static;
+        double terrainGridMetersPerVertex = 2.0;
+        int terrainGridMaxResolution = 1024;
 
         try
         {
@@ -242,49 +242,49 @@ public static class CliArgumentsParser
                         return CliParseResult.Failure("The --source option has been replaced. Use --citygml-source.");
                     case "--ortho-source":
                         return CliParseResult.Failure("The --ortho-source option has been replaced. Use --geotiff-source.");
-                    case "--dem-terrain-mode":
+                    case "--terrain-mesh":
                         {
-                            string demTerrainModeValue = ReadValue(args, ref index, token);
-                            if (string.Equals(demTerrainModeValue, nameof(DemTerrainMode.Mesh), StringComparison.OrdinalIgnoreCase))
+                            string terrainMeshValue = ReadValue(args, ref index, token);
+                            if (string.Equals(terrainMeshValue, "static", StringComparison.OrdinalIgnoreCase))
                             {
-                                demTerrainMode = DemTerrainMode.Mesh;
+                                terrainMesh = TerrainMeshMode.Static;
                             }
-                            else if (string.Equals(demTerrainModeValue, "heightmap", StringComparison.OrdinalIgnoreCase))
+                            else if (string.Equals(terrainMeshValue, "grid", StringComparison.OrdinalIgnoreCase))
                             {
-                                demTerrainMode = DemTerrainMode.HeightMap;
+                                terrainMesh = TerrainMeshMode.Grid;
                             }
                             else
                             {
                                 return CliParseResult.Failure(
-                                    $"Unsupported DEM terrain mode '{demTerrainModeValue}'. Use 'mesh' or 'heightmap'.");
+                                    $"Unsupported terrain mesh '{terrainMeshValue}'. Use 'static' or 'grid'.");
                             }
 
                             break;
                         }
-                    case "--dem-heightmap-meters-per-vertex":
+                    case "--terrain-grid-meters-per-vertex":
                         {
                             string metersPerVertexValue = ReadValue(args, ref index, token, IsSignedDecimalValue);
                             if (!double.TryParse(
                                     metersPerVertexValue,
                                     System.Globalization.NumberStyles.Float | System.Globalization.NumberStyles.AllowThousands,
                                     System.Globalization.CultureInfo.InvariantCulture,
-                                    out demHeightmapMetersPerVertex)
-                                || demHeightmapMetersPerVertex <= 0.0)
+                                    out terrainGridMetersPerVertex)
+                                || terrainGridMetersPerVertex <= 0.0)
                             {
                                 return CliParseResult.Failure(
-                                    $"The value '{metersPerVertexValue}' is not a valid positive DEM heightmap meters-per-vertex value.");
+                                    $"The value '{metersPerVertexValue}' is not a valid positive terrain grid meters-per-vertex value.");
                             }
 
                             break;
                         }
-                    case "--dem-heightmap-max-resolution":
+                    case "--terrain-grid-max-resolution":
                         {
                             string maxResolutionValue = ReadValue(args, ref index, token, IsSignedIntegerValue);
-                            if (!int.TryParse(maxResolutionValue, out demHeightmapMaxResolution)
-                                || demHeightmapMaxResolution < 2)
+                            if (!int.TryParse(maxResolutionValue, out terrainGridMaxResolution)
+                                || terrainGridMaxResolution < 2)
                             {
                                 return CliParseResult.Failure(
-                                    $"The value '{maxResolutionValue}' is not a valid DEM heightmap max resolution.");
+                                    $"The value '{maxResolutionValue}' is not a valid terrain grid max resolution.");
                             }
 
                             break;
@@ -379,9 +379,9 @@ public static class CliArgumentsParser
             ExcludeLodLevelsByPackage: packageExcludeLods,
             PackagePatterns: packagePatterns,
             IncludeMarkingAlways: includeMarkingAlways,
-            DemTerrainMode: demTerrainMode,
-            DemHeightmapMetersPerVertex: demHeightmapMetersPerVertex,
-            DemHeightmapMaxResolution: demHeightmapMaxResolution);
+            TerrainMeshMode: terrainMesh,
+            TerrainGridMetersPerVertex: terrainGridMetersPerVertex,
+            TerrainGridMaxResolution: terrainGridMaxResolution);
 
         if (resoniteLinkUri is null)
         {

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
@@ -311,13 +311,13 @@ internal static class DemTerrainOverlayAssignment
             requestedMeshBounds).ToArray();
     }
 
-    public static (Float2? TextureScale, Float2? TextureOffset) TryCreateHeightMapTextureTransform(
+    public static (Float2? TextureScale, Float2? TextureOffset) TryCreateTerrainGridTextureTransform(
         BootstrapParsedCityObject cityObject,
         LocalCityGmlObjectProjection.ResolvedSurfaceMaterial materializedSurface,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         GeographicRectangle? cityObjectGeographicBounds = null)
     {
-        TextureUvRect? occupiedUvRect = TryCreateHeightMapOccupiedUvRect(
+        TextureUvRect? occupiedUvRect = TryCreateTerrainGridOccupiedUvRect(
             cityObject,
             materializedSurface,
             demTerrainTextureOverlay,
@@ -329,7 +329,7 @@ internal static class DemTerrainOverlayAssignment
                 new Float2(occupiedUvRect.Value.OffsetValue.X, occupiedUvRect.Value.OffsetValue.Y));
     }
 
-    public static TextureUvRect? TryCreateHeightMapOccupiedUvRect(
+    public static TextureUvRect? TryCreateTerrainGridOccupiedUvRect(
         BootstrapParsedCityObject cityObject,
         LocalCityGmlObjectProjection.ResolvedSurfaceMaterial materializedSurface,
         TerrainTextureOverlay? demTerrainTextureOverlay,

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -2979,9 +2979,9 @@ internal static partial class LocalCityGmlObjectProjection
                      demTerrainTextureOverlays,
                      requestedMeshAreas))
         {
-            ImportedCityObject cityObject = request.DemTerrainMode == DemTerrainMode.HeightMap
+            ImportedCityObject cityObject = request.TerrainMeshMode == TerrainMeshMode.Grid
                 && string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
-                && TryProjectDemHeightMapCityObject(
+                && TryProjectDemTerrainGridCityObject(
                     splitCityObject.CityObject,
                     globalOriginPoint,
                     globalCartesian,
@@ -3035,9 +3035,9 @@ internal static partial class LocalCityGmlObjectProjection
         }
 
         ImportedCityObject[] alignedCityObjects =
-            request.DemTerrainMode == DemTerrainMode.HeightMap
+            request.TerrainMeshMode == TerrainMeshMode.Grid
             && string.Equals(terrainAlignedBootstrapCityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
-                ? AlignAdjacentDemHeightMapChunkBoundaries(projectedCityObjects)
+                ? AlignAdjacentDemTerrainGridChunkBoundaries(projectedCityObjects)
                 : [.. projectedCityObjects];
 
         foreach (ImportedCityObject cityObject in alignedCityObjects)
@@ -3084,9 +3084,9 @@ internal static partial class LocalCityGmlObjectProjection
                     splitCityObject.CityObject.ReferenceSystem.Geocentric)
                 : null;
 
-            foreach (MaterialBinding material in request.DemTerrainMode == DemTerrainMode.HeightMap
+            foreach (MaterialBinding material in request.TerrainMeshMode == TerrainMeshMode.Grid
                          && string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
-                            ? CreateDemHeightMapMaterials(
+                            ? CreateDemTerrainGridMaterials(
                                 splitCityObject.CityObject,
                                 cityObjectOrigin,
                                 cityObjectCartesian,
@@ -3296,23 +3296,23 @@ internal static partial class LocalCityGmlObjectProjection
             .ToArray();
     }
 
-    private static ImportedCityObject[] AlignAdjacentDemHeightMapChunkBoundaries(
+    private static ImportedCityObject[] AlignAdjacentDemTerrainGridChunkBoundaries(
         IReadOnlyList<ImportedCityObject> cityObjects)
     {
-        HeightMapChunkAlignmentState?[] states = cityObjects
-            .Select(static cityObject => HeightMapChunkAlignmentState.TryCreate(cityObject))
+        TerrainGridChunkAlignmentState?[] states = cityObjects
+            .Select(static cityObject => TerrainGridChunkAlignmentState.TryCreate(cityObject))
             .ToArray();
         if (states.Any(static state => state is null))
         {
             return cityObjects.ToArray();
         }
 
-        HeightMapChunkAlignmentState[] chunkStates = states
+        TerrainGridChunkAlignmentState[] chunkStates = states
             .Select(static state => state!)
             .ToArray();
         const double seaLevelWorldHeightTolerance = 1e-6;
         Dictionary<DemBoundarySampleKey, List<BoundaryHeightSampleReference>> sampleReferencesByKey = [];
-        foreach (HeightMapChunkAlignmentState state in chunkStates)
+        foreach (TerrainGridChunkAlignmentState state in chunkStates)
         {
             foreach (BoundaryHeightSampleReference sampleReference in EnumerateBoundaryHeightSampleReferences(state))
             {
@@ -3373,7 +3373,7 @@ internal static partial class LocalCityGmlObjectProjection
     }
 
     private static IEnumerable<BoundaryHeightSampleReference> EnumerateBoundaryHeightSampleReferences(
-        HeightMapChunkAlignmentState state)
+        TerrainGridChunkAlignmentState state)
     {
         int width = state.Geometry.Width;
         int height = state.Geometry.Height;
@@ -3396,7 +3396,7 @@ internal static partial class LocalCityGmlObjectProjection
     }
 
     private static BoundaryHeightSampleReference CreateBoundaryHeightSampleReference(
-        HeightMapChunkAlignmentState state,
+        TerrainGridChunkAlignmentState state,
         int row,
         int column)
     {
@@ -3419,11 +3419,11 @@ internal static partial class LocalCityGmlObjectProjection
         return (long)Math.Round(coordinate / boundaryTolerance, MidpointRounding.AwayFromZero);
     }
 
-    private sealed class HeightMapChunkAlignmentState
+    private sealed class TerrainGridChunkAlignmentState
     {
-        public HeightMapChunkAlignmentState(
+        public TerrainGridChunkAlignmentState(
             ImportedCityObject cityObject,
-            HeightMapGridGeometry geometry,
+            TerrainGridGeometry geometry,
             double[] heightSamples)
         {
             CityObject = cityObject;
@@ -3434,16 +3434,16 @@ internal static partial class LocalCityGmlObjectProjection
 
         public ImportedCityObject CityObject { get; }
 
-        public HeightMapGridGeometry Geometry { get; }
+        public TerrainGridGeometry Geometry { get; }
 
         public double[] HeightSamples { get; }
 
         public double BaseHeight { get; }
 
-        public static HeightMapChunkAlignmentState? TryCreate(ImportedCityObject cityObject)
+        public static TerrainGridChunkAlignmentState? TryCreate(ImportedCityObject cityObject)
         {
-            return cityObject.Geometry is HeightMapGridGeometry geometry
-                ? new HeightMapChunkAlignmentState(cityObject, geometry, geometry.HeightSamples.ToArray())
+            return cityObject.Geometry is TerrainGridGeometry geometry
+                ? new TerrainGridChunkAlignmentState(cityObject, geometry, geometry.HeightSamples.ToArray())
                 : null;
         }
 
@@ -3476,11 +3476,11 @@ internal static partial class LocalCityGmlObjectProjection
         long QuantizedZ);
 
     private sealed record BoundaryHeightSampleReference(
-        HeightMapChunkAlignmentState State,
+        TerrainGridChunkAlignmentState State,
         int SampleIndex,
         DemBoundarySampleKey Key);
 
-    private static bool TryProjectDemHeightMapCityObject(
+    private static bool TryProjectDemTerrainGridCityObject(
         ParsedCityObject cityObject,
         GeodeticPoint globalOriginPoint,
         LocalCartesian? globalCartesian,
@@ -3507,10 +3507,10 @@ internal static partial class LocalCityGmlObjectProjection
         Float3 slotPosition = CreateScenePosition(cityObjectOrigin, globalOriginPoint, globalCartesian);
         Float3[] positions = cityObject.Surfaces
             .SelectMany(static surface => surface.Vertices)
-            .Select(point => CreateGlobalHeightMapLocalPosition(point, slotPosition, globalOriginPoint, globalCartesian))
+            .Select(point => CreateGlobalTerrainGridLocalPosition(point, slotPosition, globalOriginPoint, globalCartesian))
             .ToArray();
-        HeightMapTriangle[] triangles = CreateDemHeightMapTriangles(cityObject, slotPosition, globalOriginPoint, globalCartesian);
-        double seaLevelLocalHeight = CreateGlobalHeightMapLocalPosition(
+        TerrainGridTriangle[] triangles = CreateDemTerrainGridTriangles(cityObject, slotPosition, globalOriginPoint, globalCartesian);
+        double seaLevelLocalHeight = CreateGlobalTerrainGridLocalPosition(
             new GeodeticPoint(cityObjectOrigin.Latitude, cityObjectOrigin.Longitude, 0.0),
             slotPosition,
             globalOriginPoint,
@@ -3520,7 +3520,7 @@ internal static partial class LocalCityGmlObjectProjection
             return false;
         }
 
-        DemHeightMapBounds heightMapBounds = CreateDemHeightMapBounds(
+        DemTerrainGridBounds heightMapBounds = CreateDemTerrainGridBounds(
             cityObject,
             cityObjectOrigin,
             slotPosition,
@@ -3541,7 +3541,7 @@ internal static partial class LocalCityGmlObjectProjection
             return false;
         }
 
-        HeightMapSpatialIndex spatialIndex = HeightMapSpatialIndex.Create(
+        TerrainGridSpatialIndex spatialIndex = TerrainGridSpatialIndex.Create(
             triangles,
             minX,
             maxX,
@@ -3549,13 +3549,13 @@ internal static partial class LocalCityGmlObjectProjection
             maxZ);
 
         int width = Math.Clamp(
-            (int)Math.Ceiling(extentX / request.DemHeightmapMetersPerVertex) + 1,
+            (int)Math.Ceiling(extentX / request.TerrainGridMetersPerVertex) + 1,
             2,
-            request.DemHeightmapMaxResolution);
+            request.TerrainGridMaxResolution);
         int height = Math.Clamp(
-            (int)Math.Ceiling(extentZ / request.DemHeightmapMetersPerVertex) + 1,
+            (int)Math.Ceiling(extentZ / request.TerrainGridMetersPerVertex) + 1,
             2,
-            request.DemHeightmapMaxResolution);
+            request.TerrainGridMaxResolution);
         double[] localHeights = new double[width * height];
         bool[] sampledInsideTriangles = new bool[width * height];
 
@@ -3584,7 +3584,7 @@ internal static partial class LocalCityGmlObjectProjection
         double minHeight = localHeights.Min();
         double maxHeight = localHeights.Max();
 
-        MaterialBinding[] materials = CreateDemHeightMapMaterials(
+        MaterialBinding[] materials = CreateDemTerrainGridMaterials(
             cityObject,
             cityObjectOrigin,
             cityObjectCartesian,
@@ -3595,7 +3595,7 @@ internal static partial class LocalCityGmlObjectProjection
             return false;
         }
 
-        TextureUvRect? heightMapOccupiedUvRect = TryCreateDemHeightMapOccupiedUvRect(
+        TextureUvRect? heightMapOccupiedUvRect = TryCreateDemTerrainGridOccupiedUvRect(
             cityObject,
             cityObjectOrigin,
             cityObjectCartesian,
@@ -3612,7 +3612,7 @@ internal static partial class LocalCityGmlObjectProjection
         {
             // Elements.Assets.Grid centers vertices in-plane, so split DEM chunks need their own bbox-center offset here.
             X = slotPosition.X + centerX,
-            // GridMesh displaces the inverted heightmap downward in world Y, so the slot must start at the patch-local maximum height.
+            // GridMesh displaces the inverted terrain grid downward in world Y, so the slot must start at the patch-local maximum height.
             Y = slotPosition.Y + maxHeight,
             Z = slotPosition.Z + centerZ,
         };
@@ -3626,7 +3626,7 @@ internal static partial class LocalCityGmlObjectProjection
             Transform: new Transform3D(
                 ToContractFloat3(adjustedSlotPosition),
                 ToContractQuaternion(GridMeshTerrainRotation)),
-            Geometry: new HeightMapGridGeometry(
+            Geometry: new TerrainGridGeometry(
                 Width: width,
                 Height: height,
                 Size: new Float2(extentX, extentZ),
@@ -3640,7 +3640,7 @@ internal static partial class LocalCityGmlObjectProjection
         return true;
     }
 
-    private static bool TryProjectDemHeightMapCityObject(
+    private static bool TryProjectDemTerrainGridCityObject(
         global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject,
         global::PlateauResoniteLink.Application.Importing.GeodeticPoint globalOriginPoint,
         LocalCartesian? globalCartesian,
@@ -3667,10 +3667,10 @@ internal static partial class LocalCityGmlObjectProjection
         Float3 slotPosition = CreateScenePosition(cityObjectOrigin.ToLegacy(), globalOriginPoint.ToLegacy(), globalCartesian);
         Float3[] positions = cityObject.Surfaces
             .SelectMany(static surface => surface.Vertices)
-            .Select(point => CreateGlobalHeightMapLocalPosition(point.ToLegacy(), slotPosition, globalOriginPoint.ToLegacy(), globalCartesian))
+            .Select(point => CreateGlobalTerrainGridLocalPosition(point.ToLegacy(), slotPosition, globalOriginPoint.ToLegacy(), globalCartesian))
             .ToArray();
-        HeightMapTriangle[] triangles = CreateDemHeightMapTriangles(cityObject, slotPosition, globalOriginPoint, globalCartesian);
-        double seaLevelLocalHeight = CreateGlobalHeightMapLocalPosition(
+        TerrainGridTriangle[] triangles = CreateDemTerrainGridTriangles(cityObject, slotPosition, globalOriginPoint, globalCartesian);
+        double seaLevelLocalHeight = CreateGlobalTerrainGridLocalPosition(
             new GeodeticPoint(cityObjectOrigin.Latitude, cityObjectOrigin.Longitude, 0.0),
             slotPosition,
             globalOriginPoint.ToLegacy(),
@@ -3680,7 +3680,7 @@ internal static partial class LocalCityGmlObjectProjection
             return false;
         }
 
-        DemHeightMapBounds heightMapBounds = CreateDemHeightMapBounds(
+        DemTerrainGridBounds heightMapBounds = CreateDemTerrainGridBounds(
             cityObject,
             cityObjectOrigin,
             slotPosition,
@@ -3701,7 +3701,7 @@ internal static partial class LocalCityGmlObjectProjection
             return false;
         }
 
-        HeightMapSpatialIndex spatialIndex = HeightMapSpatialIndex.Create(
+        TerrainGridSpatialIndex spatialIndex = TerrainGridSpatialIndex.Create(
             triangles,
             minX,
             maxX,
@@ -3709,13 +3709,13 @@ internal static partial class LocalCityGmlObjectProjection
             maxZ);
 
         int width = Math.Clamp(
-            (int)Math.Ceiling(extentX / request.DemHeightmapMetersPerVertex) + 1,
+            (int)Math.Ceiling(extentX / request.TerrainGridMetersPerVertex) + 1,
             2,
-            request.DemHeightmapMaxResolution);
+            request.TerrainGridMaxResolution);
         int height = Math.Clamp(
-            (int)Math.Ceiling(extentZ / request.DemHeightmapMetersPerVertex) + 1,
+            (int)Math.Ceiling(extentZ / request.TerrainGridMetersPerVertex) + 1,
             2,
-            request.DemHeightmapMaxResolution);
+            request.TerrainGridMaxResolution);
         double[] localHeights = new double[width * height];
         bool[] sampledInsideTriangles = new bool[width * height];
 
@@ -3744,7 +3744,7 @@ internal static partial class LocalCityGmlObjectProjection
         double minHeight = localHeights.Min();
         double maxHeight = localHeights.Max();
 
-        MaterialBinding[] materials = CreateDemHeightMapMaterials(
+        MaterialBinding[] materials = CreateDemTerrainGridMaterials(
             cityObject,
             cityObjectOrigin,
             cityObjectCartesian,
@@ -3755,7 +3755,7 @@ internal static partial class LocalCityGmlObjectProjection
             return false;
         }
 
-        TextureUvRect? heightMapOccupiedUvRect = TryCreateDemHeightMapOccupiedUvRect(
+        TextureUvRect? heightMapOccupiedUvRect = TryCreateDemTerrainGridOccupiedUvRect(
             cityObject,
             cityObjectOrigin,
             cityObjectCartesian,
@@ -3784,7 +3784,7 @@ internal static partial class LocalCityGmlObjectProjection
             Transform: new Transform3D(
                 ToContractFloat3(adjustedSlotPosition),
                 ToContractQuaternion(GridMeshTerrainRotation)),
-            Geometry: new HeightMapGridGeometry(
+            Geometry: new TerrainGridGeometry(
                 Width: width,
                 Height: height,
                 Size: new Float2(extentX, extentZ),
@@ -3798,7 +3798,7 @@ internal static partial class LocalCityGmlObjectProjection
         return true;
     }
 
-    private static MaterialBinding[] CreateDemHeightMapMaterials(
+    private static MaterialBinding[] CreateDemTerrainGridMaterials(
         ParsedCityObject cityObject,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
@@ -3843,7 +3843,7 @@ internal static partial class LocalCityGmlObjectProjection
             .ToArray();
     }
 
-    private static MaterialBinding[] CreateDemHeightMapMaterials(
+    private static MaterialBinding[] CreateDemTerrainGridMaterials(
         global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject,
         global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
@@ -3932,7 +3932,7 @@ internal static partial class LocalCityGmlObjectProjection
 
     private static ColorRgba ToContractColor(ColorRgba value) => new(value.R, value.G, value.B, value.A);
 
-    private static TextureUvRect? TryCreateDemHeightMapOccupiedUvRect(
+    private static TextureUvRect? TryCreateDemTerrainGridOccupiedUvRect(
         ParsedCityObject cityObject,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
@@ -3953,7 +3953,7 @@ internal static partial class LocalCityGmlObjectProjection
             return null;
         }
 
-        TextureUvRect? occupiedUvRect = DemTerrainOverlayAssignment.TryCreateHeightMapOccupiedUvRect(
+        TextureUvRect? occupiedUvRect = DemTerrainOverlayAssignment.TryCreateTerrainGridOccupiedUvRect(
             global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject.FromLegacy(cityObject),
             representativeSurface,
             demTerrainTextureOverlay,
@@ -3961,7 +3961,7 @@ internal static partial class LocalCityGmlObjectProjection
         return occupiedUvRect is { IsIdentity: true } ? null : occupiedUvRect;
     }
 
-    private static TextureUvRect? TryCreateDemHeightMapOccupiedUvRect(
+    private static TextureUvRect? TryCreateDemTerrainGridOccupiedUvRect(
         global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject,
         global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
@@ -3982,7 +3982,7 @@ internal static partial class LocalCityGmlObjectProjection
             return null;
         }
 
-        TextureUvRect? occupiedUvRect = DemTerrainOverlayAssignment.TryCreateHeightMapOccupiedUvRect(
+        TextureUvRect? occupiedUvRect = DemTerrainOverlayAssignment.TryCreateTerrainGridOccupiedUvRect(
             cityObject,
             representativeSurface,
             demTerrainTextureOverlay,
@@ -4016,7 +4016,7 @@ internal static partial class LocalCityGmlObjectProjection
         return GetCityObjectGeographicBounds(cityObject);
     }
 
-    private static DemHeightMapBounds CreateDemHeightMapBounds(
+    private static DemTerrainGridBounds CreateDemTerrainGridBounds(
         ParsedCityObject cityObject,
         GeodeticPoint cityObjectOrigin,
         Float3 slotPosition,
@@ -4032,7 +4032,7 @@ internal static partial class LocalCityGmlObjectProjection
 
         if (demTerrainTextureOverlay is null)
         {
-            return new DemHeightMapBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
+            return new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
         }
 
         GeographicRectangle clippedBounds = IntersectGeographicBounds(
@@ -4040,22 +4040,22 @@ internal static partial class LocalCityGmlObjectProjection
             demTerrainTextureOverlay.GeographicBounds);
         double referenceLatitude = cityObjectOrigin.Latitude;
         double referenceLongitude = cityObjectOrigin.Longitude;
-        Float3 westPosition = CreateGlobalHeightMapLocalPosition(
+        Float3 westPosition = CreateGlobalTerrainGridLocalPosition(
             new GeodeticPoint(referenceLatitude, clippedBounds.MinLongitude, cityObjectOrigin.Altitude),
             slotPosition,
             globalOriginPoint,
             globalCartesian);
-        Float3 eastPosition = CreateGlobalHeightMapLocalPosition(
+        Float3 eastPosition = CreateGlobalTerrainGridLocalPosition(
             new GeodeticPoint(referenceLatitude, clippedBounds.MaxLongitude, cityObjectOrigin.Altitude),
             slotPosition,
             globalOriginPoint,
             globalCartesian);
-        Float3 southPosition = CreateGlobalHeightMapLocalPosition(
+        Float3 southPosition = CreateGlobalTerrainGridLocalPosition(
             new GeodeticPoint(clippedBounds.MinLatitude, referenceLongitude, cityObjectOrigin.Altitude),
             slotPosition,
             globalOriginPoint,
             globalCartesian);
-        Float3 northPosition = CreateGlobalHeightMapLocalPosition(
+        Float3 northPosition = CreateGlobalTerrainGridLocalPosition(
             new GeodeticPoint(clippedBounds.MaxLatitude, referenceLongitude, cityObjectOrigin.Altitude),
             slotPosition,
             globalOriginPoint,
@@ -4068,13 +4068,13 @@ internal static partial class LocalCityGmlObjectProjection
 
         if ((clippedMaxX - clippedMinX) <= 1e-6 || (clippedMaxZ - clippedMinZ) <= 1e-6)
         {
-            return new DemHeightMapBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
+            return new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
         }
 
-        return new DemHeightMapBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ);
+        return new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ);
     }
 
-    private static DemHeightMapBounds CreateDemHeightMapBounds(
+    private static DemTerrainGridBounds CreateDemTerrainGridBounds(
         global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject,
         global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
         Float3 slotPosition,
@@ -4090,7 +4090,7 @@ internal static partial class LocalCityGmlObjectProjection
 
         if (demTerrainTextureOverlay is null)
         {
-            return new DemHeightMapBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
+            return new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
         }
 
         GeographicRectangle clippedBounds = IntersectGeographicBounds(
@@ -4098,22 +4098,22 @@ internal static partial class LocalCityGmlObjectProjection
             demTerrainTextureOverlay.GeographicBounds);
         double referenceLatitude = cityObjectOrigin.Latitude;
         double referenceLongitude = cityObjectOrigin.Longitude;
-        Float3 westPosition = CreateGlobalHeightMapLocalPosition(
+        Float3 westPosition = CreateGlobalTerrainGridLocalPosition(
             new GeodeticPoint(referenceLatitude, clippedBounds.MinLongitude, cityObjectOrigin.Altitude),
             slotPosition,
             globalOriginPoint.ToLegacy(),
             globalCartesian);
-        Float3 eastPosition = CreateGlobalHeightMapLocalPosition(
+        Float3 eastPosition = CreateGlobalTerrainGridLocalPosition(
             new GeodeticPoint(referenceLatitude, clippedBounds.MaxLongitude, cityObjectOrigin.Altitude),
             slotPosition,
             globalOriginPoint.ToLegacy(),
             globalCartesian);
-        Float3 southPosition = CreateGlobalHeightMapLocalPosition(
+        Float3 southPosition = CreateGlobalTerrainGridLocalPosition(
             new GeodeticPoint(clippedBounds.MinLatitude, referenceLongitude, cityObjectOrigin.Altitude),
             slotPosition,
             globalOriginPoint.ToLegacy(),
             globalCartesian);
-        Float3 northPosition = CreateGlobalHeightMapLocalPosition(
+        Float3 northPosition = CreateGlobalTerrainGridLocalPosition(
             new GeodeticPoint(clippedBounds.MaxLatitude, referenceLongitude, cityObjectOrigin.Altitude),
             slotPosition,
             globalOriginPoint.ToLegacy(),
@@ -4126,10 +4126,10 @@ internal static partial class LocalCityGmlObjectProjection
 
         if ((clippedMaxX - clippedMinX) <= 1e-6 || (clippedMaxZ - clippedMinZ) <= 1e-6)
         {
-            return new DemHeightMapBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
+            return new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
         }
 
-        return new DemHeightMapBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ);
+        return new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ);
     }
 
     private static GeographicRectangle GetCityObjectGeographicBounds(ParsedCityObject cityObject)
@@ -4203,22 +4203,22 @@ internal static partial class LocalCityGmlObjectProjection
         return cityObject.Geometry switch
         {
             TriangleMeshGeometry triangleMesh => triangleMesh.Mesh.Submeshes.Count > 0,
-            HeightMapGridGeometry heightMap => heightMap.Width > 1 && heightMap.Height > 1,
+            TerrainGridGeometry heightMap => heightMap.Width > 1 && heightMap.Height > 1,
             _ => false,
         };
     }
 
-    private static HeightMapTriangle[] CreateDemHeightMapTriangles(
+    private static TerrainGridTriangle[] CreateDemTerrainGridTriangles(
         ParsedCityObject cityObject,
         Float3 slotPosition,
         GeodeticPoint globalOriginPoint,
         LocalCartesian? globalCartesian)
     {
-        List<HeightMapTriangle> triangles = [];
+        List<TerrainGridTriangle> triangles = [];
         foreach (ParsedSurface surface in cityObject.Surfaces)
         {
             Float3[] positions = surface.ExteriorRing.Vertices
-                .Select(point => CreateGlobalHeightMapLocalPosition(point, slotPosition, globalOriginPoint, globalCartesian))
+                .Select(point => CreateGlobalTerrainGridLocalPosition(point, slotPosition, globalOriginPoint, globalCartesian))
                 .ToArray();
             if (positions.Length < 3)
             {
@@ -4228,24 +4228,24 @@ internal static partial class LocalCityGmlObjectProjection
             Float3 origin = positions[0];
             for (int index = 1; index + 1 < positions.Length; index++)
             {
-                triangles.Add(new HeightMapTriangle(origin, positions[index], positions[index + 1]));
+                triangles.Add(new TerrainGridTriangle(origin, positions[index], positions[index + 1]));
             }
         }
 
         return triangles.ToArray();
     }
 
-    private static HeightMapTriangle[] CreateDemHeightMapTriangles(
+    private static TerrainGridTriangle[] CreateDemTerrainGridTriangles(
         global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject,
         Float3 slotPosition,
         global::PlateauResoniteLink.Application.Importing.GeodeticPoint globalOriginPoint,
         LocalCartesian? globalCartesian)
     {
-        List<HeightMapTriangle> triangles = [];
+        List<TerrainGridTriangle> triangles = [];
         foreach (global::PlateauResoniteLink.Application.Importing.BootstrapParsedSurface surface in cityObject.Surfaces)
         {
             Float3[] positions = surface.ExteriorRing.Vertices
-                .Select(point => CreateGlobalHeightMapLocalPosition(point.ToLegacy(), slotPosition, globalOriginPoint.ToLegacy(), globalCartesian))
+                .Select(point => CreateGlobalTerrainGridLocalPosition(point.ToLegacy(), slotPosition, globalOriginPoint.ToLegacy(), globalCartesian))
                 .ToArray();
             if (positions.Length < 3)
             {
@@ -4255,14 +4255,14 @@ internal static partial class LocalCityGmlObjectProjection
             Float3 origin = positions[0];
             for (int index = 1; index + 1 < positions.Length; index++)
             {
-                triangles.Add(new HeightMapTriangle(origin, positions[index], positions[index + 1]));
+                triangles.Add(new TerrainGridTriangle(origin, positions[index], positions[index + 1]));
             }
         }
 
         return triangles.ToArray();
     }
 
-    private static Float3 CreateGlobalHeightMapLocalPosition(
+    private static Float3 CreateGlobalTerrainGridLocalPosition(
         GeodeticPoint point,
         Float3 slotPosition,
         GeodeticPoint globalOriginPoint,
@@ -4278,13 +4278,13 @@ internal static partial class LocalCityGmlObjectProjection
     private static bool TrySampleLocalDemHeight(
         double x,
         double z,
-        IReadOnlyList<HeightMapTriangle> triangles,
-        HeightMapSpatialIndex spatialIndex,
+        IReadOnlyList<TerrainGridTriangle> triangles,
+        TerrainGridSpatialIndex spatialIndex,
         out double height)
     {
         foreach (int triangleIndex in spatialIndex.GetCandidateTriangleIndices(x, z))
         {
-            HeightMapTriangle triangle = triangles[triangleIndex];
+            TerrainGridTriangle triangle = triangles[triangleIndex];
             if (TryInterpolateLocalTriangleHeight(triangle, x, z, out height))
             {
                 return true;
@@ -4296,7 +4296,7 @@ internal static partial class LocalCityGmlObjectProjection
     }
 
     private static bool TryInterpolateLocalTriangleHeight(
-        HeightMapTriangle triangle,
+        TerrainGridTriangle triangle,
         double x,
         double z,
         out double height)
@@ -4549,18 +4549,18 @@ internal static partial class LocalCityGmlObjectProjection
         GeodeticPoint[] Vertices,
         IReadOnlyList<Float2>? UVs);
 
-    private sealed record HeightMapTriangle(
+    private sealed record TerrainGridTriangle(
         Float3 A,
         Float3 B,
         Float3 C);
 
-    private sealed record DemHeightMapBounds(
+    private sealed record DemTerrainGridBounds(
         double MinX,
         double MaxX,
         double MinZ,
         double MaxZ);
 
-    private sealed class HeightMapSpatialIndex
+    private sealed class TerrainGridSpatialIndex
     {
         private readonly int[] allTriangleIndices;
         private readonly List<int>[] triangleBuckets;
@@ -4571,7 +4571,7 @@ internal static partial class LocalCityGmlObjectProjection
         private readonly int cellsX;
         private readonly int cellsZ;
 
-        private HeightMapSpatialIndex(
+        private TerrainGridSpatialIndex(
             int[] allTriangleIndices,
             List<int>[] triangleBuckets,
             double minX,
@@ -4591,8 +4591,8 @@ internal static partial class LocalCityGmlObjectProjection
             this.cellsZ = cellsZ;
         }
 
-        public static HeightMapSpatialIndex Create(
-            IReadOnlyList<HeightMapTriangle> triangles,
+        public static TerrainGridSpatialIndex Create(
+            IReadOnlyList<TerrainGridTriangle> triangles,
             double minX,
             double maxX,
             double minZ,
@@ -4601,7 +4601,7 @@ internal static partial class LocalCityGmlObjectProjection
             int[] allTriangleIndices = Enumerable.Range(0, triangles.Count).ToArray();
             if (triangles.Count == 0)
             {
-                return new HeightMapSpatialIndex(allTriangleIndices, [], minX, minZ, 1.0, 1.0, 1, 1);
+                return new TerrainGridSpatialIndex(allTriangleIndices, [], minX, minZ, 1.0, 1.0, 1, 1);
             }
 
             double extentX = Math.Max(maxX - minX, 1e-6);
@@ -4616,7 +4616,7 @@ internal static partial class LocalCityGmlObjectProjection
 
             for (int triangleIndex = 0; triangleIndex < triangles.Count; triangleIndex++)
             {
-                HeightMapTriangle triangle = triangles[triangleIndex];
+                TerrainGridTriangle triangle = triangles[triangleIndex];
                 double triangleMinX = Math.Min(triangle.A.X, Math.Min(triangle.B.X, triangle.C.X));
                 double triangleMaxX = Math.Max(triangle.A.X, Math.Max(triangle.B.X, triangle.C.X));
                 double triangleMinZ = Math.Min(triangle.A.Z, Math.Min(triangle.B.Z, triangle.C.Z));
@@ -4636,7 +4636,7 @@ internal static partial class LocalCityGmlObjectProjection
                 }
             }
 
-            return new HeightMapSpatialIndex(
+            return new TerrainGridSpatialIndex(
                 allTriangleIndices,
                 triangleBuckets,
                 minX,

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
@@ -239,14 +239,14 @@ public static class PlateauImportRequestValidator
             }
         }
 
-        if (normalizedRequest.DemHeightmapMetersPerVertex <= 0)
+        if (normalizedRequest.TerrainGridMetersPerVertex <= 0)
         {
-            validationErrors.Add("The DEM heightmap meters-per-vertex value must be greater than zero.");
+            validationErrors.Add("The terrain grid meters-per-vertex value must be greater than zero.");
         }
 
-        if (normalizedRequest.DemHeightmapMaxResolution < 2)
+        if (normalizedRequest.TerrainGridMaxResolution < 2)
         {
-            validationErrors.Add("The DEM heightmap max resolution value must be at least 2.");
+            validationErrors.Add("The terrain grid max resolution value must be at least 2.");
         }
 
         if (validationErrors.Count > 0)
@@ -267,9 +267,9 @@ public static class PlateauImportRequestValidator
             normalizedPackageExclusions,
             normalizedPackagePatterns,
             normalizedRequest.IncludeMarkingAlways,
-            normalizedRequest.DemTerrainMode,
-            normalizedRequest.DemHeightmapMetersPerVertex,
-            normalizedRequest.DemHeightmapMaxResolution);
+            normalizedRequest.TerrainMeshMode,
+            normalizedRequest.TerrainGridMetersPerVertex,
+            normalizedRequest.TerrainGridMaxResolution);
         errors = Array.Empty<string>();
         return true;
     }

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -64,7 +64,7 @@ public sealed record TriangleMeshGeometry(
     ImportedMesh Mesh)
     : ConstructionGeometry;
 
-public sealed record HeightMapGridGeometry(
+public sealed record TerrainGridGeometry(
     int Width,
     int Height,
     Float2 Size,

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionPlan.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionPlan.cs
@@ -85,9 +85,9 @@ public sealed record SceneImportExecutionPlan
             || !SourcesEqual(resolvedRequest.Source, buildRequest.Source)
             || !SourcesEqual(resolvedRequest.DemTextureSource, buildRequest.DemTextureSource)
             || normalizedRequest.IncludeMarkingAlways != buildRequest.IncludeMarkingAlways
-            || normalizedRequest.DemTerrainMode != buildRequest.DemTerrainMode
-            || normalizedRequest.DemHeightmapMetersPerVertex != buildRequest.DemHeightmapMetersPerVertex
-            || normalizedRequest.DemHeightmapMaxResolution != buildRequest.DemHeightmapMaxResolution
+            || normalizedRequest.TerrainMeshMode != buildRequest.TerrainMeshMode
+            || normalizedRequest.TerrainGridMetersPerVertex != buildRequest.TerrainGridMetersPerVertex
+            || normalizedRequest.TerrainGridMaxResolution != buildRequest.TerrainGridMaxResolution
             || !SequenceEqual(normalizedRequest.PackageNames, buildRequest.PackageNames)
             || !SetEqual(normalizedRequest.GlobalExcludeLodLevels, buildRequest.GlobalExcludeLodLevels)
             || !DictionaryOfSetsEqual(normalizedRequest.ExcludeLodLevelsByPackage, buildRequest.ExcludeLodLevelsByPackage)

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedPlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedPlateauImportRequest.cs
@@ -18,9 +18,9 @@ public sealed record ValidatedPlateauImportRequest(
     IReadOnlyDictionary<string, IReadOnlySet<int>>? ExcludeLodLevelsByPackage = null,
     IReadOnlyDictionary<string, string>? PackagePatterns = null,
     bool IncludeMarkingAlways = true,
-    DemTerrainMode DemTerrainMode = DemTerrainMode.Mesh,
-    double DemHeightmapMetersPerVertex = 2.0,
-    int DemHeightmapMaxResolution = 1024)
+    TerrainMeshMode TerrainMeshMode = TerrainMeshMode.Static,
+    double TerrainGridMetersPerVertex = 2.0,
+    int TerrainGridMaxResolution = 1024)
 {
     public DatasetSourceKind SourceKind => Source.SourceKind;
 
@@ -60,8 +60,8 @@ public sealed record ValidatedPlateauImportRequest(
             ExcludeLodLevelsByPackage,
             PackagePatterns,
             IncludeMarkingAlways,
-            DemTerrainMode,
-            DemHeightmapMetersPerVertex,
-            DemHeightmapMaxResolution);
+            TerrainMeshMode,
+            TerrainGridMetersPerVertex,
+            TerrainGridMaxResolution);
     }
 }

--- a/src/PlateauResoniteLink/Domain/Importing/DemTerrainMode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/DemTerrainMode.cs
@@ -1,7 +1,0 @@
-namespace PlateauResoniteLink.Domain.Importing;
-
-public enum DemTerrainMode
-{
-    Mesh = 0,
-    HeightMap = 1,
-}

--- a/src/PlateauResoniteLink/Domain/Importing/PlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/PlateauImportRequest.cs
@@ -13,9 +13,9 @@ public sealed record PlateauImportRequest(
     IReadOnlyDictionary<string, IReadOnlySet<int>>? ExcludeLodLevelsByPackage = null,
     IReadOnlyDictionary<string, string>? PackagePatterns = null,
     bool IncludeMarkingAlways = true,
-    DemTerrainMode DemTerrainMode = DemTerrainMode.Mesh,
-    double DemHeightmapMetersPerVertex = 2.0,
-    int DemHeightmapMaxResolution = 1024)
+    TerrainMeshMode TerrainMeshMode = TerrainMeshMode.Static,
+    double TerrainGridMetersPerVertex = 2.0,
+    int TerrainGridMaxResolution = 1024)
 {
     public PlateauImportRequest(
         string Dataset,
@@ -31,9 +31,9 @@ public sealed record PlateauImportRequest(
         IReadOnlyDictionary<string, IReadOnlySet<int>>? ExcludeLodLevelsByPackage = null,
         IReadOnlyDictionary<string, string>? PackagePatterns = null,
         bool IncludeMarkingAlways = true,
-        DemTerrainMode DemTerrainMode = DemTerrainMode.Mesh,
-        double DemHeightmapMetersPerVertex = 2.0,
-        int DemHeightmapMaxResolution = 1024)
+        TerrainMeshMode TerrainMeshMode = TerrainMeshMode.Static,
+        double TerrainGridMetersPerVertex = 2.0,
+        int TerrainGridMaxResolution = 1024)
         : this(
             Dataset,
             MeshCode,
@@ -46,9 +46,9 @@ public sealed record PlateauImportRequest(
             ExcludeLodLevelsByPackage,
             PackagePatterns,
             IncludeMarkingAlways,
-            DemTerrainMode,
-            DemHeightmapMetersPerVertex,
-            DemHeightmapMaxResolution)
+            TerrainMeshMode,
+            TerrainGridMetersPerVertex,
+            TerrainGridMaxResolution)
     {
     }
 

--- a/src/PlateauResoniteLink/Domain/Importing/TerrainMeshMode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/TerrainMeshMode.cs
@@ -1,0 +1,7 @@
+namespace PlateauResoniteLink.Domain.Importing;
+
+public enum TerrainMeshMode
+{
+    Static = 0,
+    Grid = 1,
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -57,13 +57,13 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                         }),
                     }));
                 break;
-            case PlannedHeightMapGridGeometryAsset heightMap:
+            case PlannedTerrainGridGeometryAsset heightMap:
                 BatchPlanSlotLocator heightMapAssetSlotId = CreateBatchPlanSlotLocator(ref nextSlotLocator);
                 BatchPlanComponentLocator heightTextureComponentId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
                 slotEmissions.Add(new PlannedBatchSlotEmission(
                     heightMapAssetSlotId,
                     PlannedSlotTargetReference.CanonicalSlot(objectSlots.AssetLodSlot.Locator),
-                    heightMap.HeightMapAssetSlotName,
+                    heightMap.TerrainGridAssetSlotName,
                     null,
                     null));
                 slotResolutionTargets.Add(heightMapAssetSlotId);
@@ -71,7 +71,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                     heightTextureComponentId,
                     PlannedSlotTargetReference.PlannedSlot(heightMapAssetSlotId),
                     "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                    ResoniteGeometryAssetAssembler.CreateHeightMapTextureMembers(heightMap.HeightTextureUri)
+                    ResoniteGeometryAssetAssembler.CreateTerrainGridTextureMembers(heightMap.HeightTextureUri)
                         .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal)));
                 double displacementMagnitude = Math.Max(heightMap.Geometry.MaxHeight - heightMap.Geometry.MinHeight, 0.0);
                 Dictionary<string, PlannedMember> gridMeshMembers = new(StringComparer.Ordinal)

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
@@ -19,12 +19,12 @@ internal interface IResoniteGeometryAssetAssembler
         Action<string>? progressReporter,
         CancellationToken cancellationToken);
 
-    Task<PreparedGeometryAssetBatch> PrepareHeightMapGridAsync(
+    Task<PreparedGeometryAssetBatch> PrepareTerrainGridAsync(
         IResoniteLinkClient importClient,
         string meshAssetSlotName,
         string heightMapAssetSlotName,
         string displayName,
-        ResoniteHeightMapGridGeometry geometry,
+        ResoniteTerrainGridGeometry geometry,
         ResoniteRawHdrTextureImport heightTextureImport,
         ResoniteFloat2? uvScale,
         ResoniteFloat2? uvOffset,
@@ -50,12 +50,12 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         return new PreparedTriangleMeshAssetBatch(meshAssetSlotName, assetUri);
     }
 
-    public async Task<PreparedGeometryAssetBatch> PrepareHeightMapGridAsync(
+    public async Task<PreparedGeometryAssetBatch> PrepareTerrainGridAsync(
         IResoniteLinkClient importClient,
         string meshAssetSlotName,
         string heightMapAssetSlotName,
         string displayName,
-        ResoniteHeightMapGridGeometry geometry,
+        ResoniteTerrainGridGeometry geometry,
         ResoniteRawHdrTextureImport heightTextureImport,
         ResoniteFloat2? uvScale,
         ResoniteFloat2? uvOffset,
@@ -63,10 +63,10 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         CancellationToken cancellationToken)
     {
         progressReporter?.Invoke(
-            $"[live] HeightMap '{geometry.Width}x{geometry.Height}' importing displacement texture via raw payload.");
+            $"[live] Terrain grid '{geometry.Width}x{geometry.Height}' importing displacement texture via raw payload.");
         Uri textureUri = await importClient.ImportTextureAsync(heightTextureImport, cancellationToken);
-        progressReporter?.Invoke($"[live] HeightMap '{displayName}' displacement texture import completed -> '{textureUri}'.");
-        return new PreparedHeightMapGridAssetBatch(
+        progressReporter?.Invoke($"[live] Terrain grid '{displayName}' displacement texture import completed -> '{textureUri}'.");
+        return new PreparedTerrainGridAssetBatch(
             meshAssetSlotName,
             heightMapAssetSlotName,
             geometry,
@@ -75,7 +75,7 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
             uvOffset);
     }
 
-    internal static Dictionary<string, Member> CreateHeightMapTextureMembers(Uri assetUri)
+    internal static Dictionary<string, Member> CreateTerrainGridTextureMembers(Uri assetUri)
     {
         return new Dictionary<string, Member>(StringComparer.Ordinal)
         {
@@ -100,10 +100,10 @@ internal sealed record PreparedTriangleMeshAssetBatch(
     string MeshAssetSlotName,
     Uri MeshUri) : PreparedGeometryAssetBatch(MeshAssetSlotName);
 
-internal sealed record PreparedHeightMapGridAssetBatch(
+internal sealed record PreparedTerrainGridAssetBatch(
     string MeshAssetSlotName,
-    string HeightMapAssetSlotName,
-    ResoniteHeightMapGridGeometry Geometry,
+    string TerrainGridAssetSlotName,
+    ResoniteTerrainGridGeometry Geometry,
     Uri HeightTextureUri,
     ResoniteFloat2? UvScale,
     ResoniteFloat2? UvOffset) : PreparedGeometryAssetBatch(MeshAssetSlotName);

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -68,7 +68,7 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
                 && displacementMember is Field_float displacement)
             {
                 reportProgress?.Invoke(
-                    $"[live] HeightMap texture ready. Creating GridMesh "
+                    $"[live] Terrain grid displacement texture ready. Creating GridMesh "
                     + $"({points.Value.x}x{points.Value.y}, displacement={displacement.Value:F3}).");
             }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteConstructionGeometry.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteConstructionGeometry.cs
@@ -8,7 +8,7 @@ public sealed record ResoniteTriangleMeshGeometry(
     ResoniteImportedMesh Mesh)
     : ResoniteConstructionGeometry;
 
-public sealed record ResoniteHeightMapGridGeometry(
+public sealed record ResoniteTerrainGridGeometry(
     int Width,
     int Height,
     ResoniteFloat2 Size,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -26,7 +26,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
     private const long MaxInFlightCityObjectWorkingSetBytesPerLane = 256L * 1024L * 1024L;
     private const long MaxInFlightCityObjectWorkingSetBytesFloor = 512L * 1024L * 1024L;
     private const string DemPackageName = "dem";
-    private const string HeightMapAssetSlotSuffix = "_heightmap";
+    private const string TerrainGridAssetSlotSuffix = "_terrain-grid";
     private readonly Uri endpoint;
     private readonly int connectionCount;
     private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator;
@@ -787,7 +787,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         {
             ResoniteTriangleMeshGeometry triangleMesh => checked(
                 EstimateTriangleMeshWorkingSetBytes(triangleMesh.Mesh, cityObject.Materials) * triangleMeshExpansionFactor),
-            ResoniteHeightMapGridGeometry heightMap => checked(
+            ResoniteTerrainGridGeometry heightMap => checked(
                 (heightMap.HeightSamples.Count * heightSampleWeightBytes)
                 + ((long)heightMap.Width * heightMap.Height * hdrHeightTextureWeightBytes)
                 * heightMapExpansionFactor),
@@ -979,8 +979,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             ResoniteTriangleMeshGeometry triangleMesh => Task.Run<PreparedConstructionGeometry>(
                 () => PrepareTriangleMeshGeometry(cityObject, triangleMesh.Mesh),
                 cancellationToken),
-            ResoniteHeightMapGridGeometry heightMap => Task.Run<PreparedConstructionGeometry>(
-                () => new PreparedHeightMapGridGeometry(heightMap, PrepareHeightMapTexture(heightMap)),
+            ResoniteTerrainGridGeometry heightMap => Task.Run<PreparedConstructionGeometry>(
+                () => new PreparedTerrainGridGeometry(heightMap, PrepareTerrainGridDisplacementTexture(heightMap)),
                 cancellationToken),
             _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
         };
@@ -1379,7 +1379,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay)
     {
         _ = preparedTerrainTextureDataByOverlay;
-        return cityObject.Geometry is ResoniteHeightMapGridGeometry
+        return cityObject.Geometry is ResoniteTerrainGridGeometry
             && material.TerrainOverlay is not null
             ? material with
             {
@@ -1458,12 +1458,12 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 
     private static ResoniteFloat2 CreateResoniteFloat2(ScalarPair value) => new(value.X, value.Y);
 
-    private static ResoniteFloat2? ResolveHeightMapGridUvScale(
+    private static ResoniteFloat2? ResolveTerrainGridUvScale(
         ResoniteConstructionCityObject cityObject,
-        ResoniteHeightMapGridGeometry geometry,
+        ResoniteTerrainGridGeometry geometry,
         IReadOnlyDictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay)
     {
-        TextureUvRect? terrainTextureRect = ResolveHeightMapTerrainTextureRect(
+        TextureUvRect? terrainTextureRect = ResolveTerrainGridTerrainTextureRect(
             cityObject,
             geometry,
             preparedTerrainTextureDataByOverlay);
@@ -1472,12 +1472,12 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             : new ResoniteFloat2(terrainTextureRect.Value.ScaleValue.X, terrainTextureRect.Value.ScaleValue.Y);
     }
 
-    private static ResoniteFloat2? ResolveHeightMapGridUvOffset(
+    private static ResoniteFloat2? ResolveTerrainGridUvOffset(
         ResoniteConstructionCityObject cityObject,
-        ResoniteHeightMapGridGeometry geometry,
+        ResoniteTerrainGridGeometry geometry,
         IReadOnlyDictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay)
     {
-        TextureUvRect? terrainTextureRect = ResolveHeightMapTerrainTextureRect(
+        TextureUvRect? terrainTextureRect = ResolveTerrainGridTerrainTextureRect(
             cityObject,
             geometry,
             preparedTerrainTextureDataByOverlay);
@@ -1486,9 +1486,9 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             : new ResoniteFloat2(terrainTextureRect.Value.OffsetValue.X, terrainTextureRect.Value.OffsetValue.Y);
     }
 
-    private static TextureUvRect? ResolveHeightMapTerrainTextureRect(
+    private static TextureUvRect? ResolveTerrainGridTerrainTextureRect(
         ResoniteConstructionCityObject cityObject,
-        ResoniteHeightMapGridGeometry geometry,
+        ResoniteTerrainGridGeometry geometry,
         IReadOnlyDictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay)
     {
         TextureUvRect objectRect = geometry.UvScale is not null || geometry.UvOffset is not null
@@ -1909,17 +1909,17 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                     triangleMesh.MeshImport,
                     progressReporter,
                     cancellationToken)),
-            PreparedHeightMapGridGeometry heightMap => CreatePlannedGeometryAsset(
+            PreparedTerrainGridGeometry heightMap => CreatePlannedGeometryAsset(
                 cityObject,
-                await geometryAssetAssembler.PrepareHeightMapGridAsync(
+                await geometryAssetAssembler.PrepareTerrainGridAsync(
                     importClient,
                     CreateMeshAssetSlotName(cityObject),
-                    CreateHeightMapAssetSlotName(cityObject),
+                    CreateTerrainGridAssetSlotName(cityObject),
                     cityObject.DisplayName,
                     heightMap.Geometry,
                     heightMap.HeightTextureImport,
-                    ResolveHeightMapGridUvScale(cityObject, heightMap.Geometry, preparedTerrainTextureDataByOverlay),
-                    ResolveHeightMapGridUvOffset(cityObject, heightMap.Geometry, preparedTerrainTextureDataByOverlay),
+                    ResolveTerrainGridUvScale(cityObject, heightMap.Geometry, preparedTerrainTextureDataByOverlay),
+                    ResolveTerrainGridUvOffset(cityObject, heightMap.Geometry, preparedTerrainTextureDataByOverlay),
                     progressReporter,
                     cancellationToken)),
             _ => throw new InvalidOperationException(
@@ -1927,7 +1927,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         };
     }
 
-    private static ResoniteRawHdrTextureImport PrepareHeightMapTexture(ResoniteHeightMapGridGeometry geometry)
+    private static ResoniteRawHdrTextureImport PrepareTerrainGridDisplacementTexture(ResoniteTerrainGridGeometry geometry)
     {
         float[] rawPixels = new float[geometry.Width * geometry.Height * 4];
         double heightRange = Math.Max(geometry.MaxHeight - geometry.MinHeight, 0.0);
@@ -1971,10 +1971,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 identity,
                 triangleMesh.MeshAssetSlotName,
                 triangleMesh.MeshUri),
-            PreparedHeightMapGridAssetBatch heightMap => new PlannedHeightMapGridGeometryAsset(
+            PreparedTerrainGridAssetBatch heightMap => new PlannedTerrainGridGeometryAsset(
                 identity,
                 heightMap.MeshAssetSlotName,
-                heightMap.HeightMapAssetSlotName,
+                heightMap.TerrainGridAssetSlotName,
                 heightMap.Geometry,
                 heightMap.HeightTextureUri,
                 heightMap.UvScale,
@@ -2001,8 +2001,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         {
             PreparedTriangleMeshGeometry triangleMesh =>
                 $"triangle-mesh(vertices={triangleMesh.MeshImport.VertexCount}, submeshes={triangleMesh.MeshImport.Submeshes.Count})",
-            PreparedHeightMapGridGeometry heightMap =>
-                $"heightmap-grid({heightMap.Geometry.Width}x{heightMap.Geometry.Height})",
+            PreparedTerrainGridGeometry heightMap =>
+                $"terrain-grid({heightMap.Geometry.Width}x{heightMap.Geometry.Height})",
             _ => geometry.GetType().Name,
         };
     }
@@ -2028,9 +2028,9 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         return cityObject.DisplayName;
     }
 
-    private static string CreateHeightMapAssetSlotName(ResoniteConstructionCityObject cityObject)
+    private static string CreateTerrainGridAssetSlotName(ResoniteConstructionCityObject cityObject)
     {
-        return string.Concat(CreateMeshAssetSlotName(cityObject), HeightMapAssetSlotSuffix);
+        return string.Concat(CreateMeshAssetSlotName(cityObject), TerrainGridAssetSlotSuffix);
     }
 
     private static ResoniteSceneBootstrapInfo CreateSceneBootstrapInfo(SceneBuildRequest request)
@@ -2067,8 +2067,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         ImportMeshRawData MeshImport)
         : PreparedConstructionGeometry;
 
-    internal sealed record PreparedHeightMapGridGeometry(
-        ResoniteHeightMapGridGeometry Geometry,
+    internal sealed record PreparedTerrainGridGeometry(
+        ResoniteTerrainGridGeometry Geometry,
         ResoniteRawHdrTextureImport HeightTextureImport)
         : PreparedConstructionGeometry;
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -19,11 +19,11 @@ internal sealed record PlannedTriangleMeshGeometryAsset(
     Uri MeshUri)
     : PlannedGeometryAsset(Identity, MeshAssetSlotName);
 
-internal sealed record PlannedHeightMapGridGeometryAsset(
+internal sealed record PlannedTerrainGridGeometryAsset(
     GeometryIdentity Identity,
     string MeshAssetSlotName,
-    string HeightMapAssetSlotName,
-    ResoniteHeightMapGridGeometry Geometry,
+    string TerrainGridAssetSlotName,
+    ResoniteTerrainGridGeometry Geometry,
     Uri HeightTextureUri,
     ResoniteFloat2? UvScale = null,
     ResoniteFloat2? UvOffset = null)

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -29,14 +29,14 @@ internal static class SceneImportContractMapper
                 cityObject.Materials.Select(ToInternal).ToArray(),
                 cityObject.CollisionEnabled,
                 cityObject.SourceFileRelativePath),
-            HeightMapGridGeometry heightMap => new ResoniteConstructionCityObject(
+            TerrainGridGeometry heightMap => new ResoniteConstructionCityObject(
                 cityObject.ObjectKey,
                 cityObject.DisplayName,
                 cityObject.PackageName,
                 cityObject.ActualMeshCode,
                 cityObject.LodLevel,
                 ToInternal(cityObject.Transform),
-                new ResoniteHeightMapGridGeometry(
+                new ResoniteTerrainGridGeometry(
                     heightMap.Width,
                     heightMap.Height,
                     ToInternal(heightMap.Size),

--- a/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -142,33 +142,33 @@ public sealed class PlateauImportRequestValidatorTests
     [Theory]
     [InlineData(0)]
     [InlineData(-0.01)]
-    public void ValidateRejectsNonPositiveDemHeightmapMetersPerVertex(double metersPerVertex)
+    public void ValidateRejectsNonPositiveTerrainGridMetersPerVertex(double metersPerVertex)
     {
         PlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
             Source: DatasetLocation.Local("C:/dataset"),
-            DemHeightmapMetersPerVertex: metersPerVertex);
+            TerrainGridMetersPerVertex: metersPerVertex);
 
         IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
 
-        Assert.Contains("The DEM heightmap meters-per-vertex value must be greater than zero.", errors);
+        Assert.Contains("The terrain grid meters-per-vertex value must be greater than zero.", errors);
     }
 
     [Theory]
     [InlineData(1)]
     [InlineData(0)]
     [InlineData(-4)]
-    public void ValidateRejectsDemHeightmapMaxResolutionBelowTwo(int maxResolution)
+    public void ValidateRejectsTerrainGridMaxResolutionBelowTwo(int maxResolution)
     {
         PlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
             Source: DatasetLocation.Local("C:/dataset"),
-            DemHeightmapMaxResolution: maxResolution);
+            TerrainGridMaxResolution: maxResolution);
 
         IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
 
-        Assert.Contains("The DEM heightmap max resolution value must be at least 2.", errors);
+        Assert.Contains("The terrain grid max resolution value must be at least 2.", errors);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -198,7 +198,7 @@ public sealed class CliArgumentsParserTests
     }
 
     [Fact]
-    public void ParseParsesDemHeightmapOptions()
+    public void ParseParsesTerrainGridOptions()
     {
         CliParseResult result = CliArgumentsParser.Parse(
             [
@@ -207,15 +207,15 @@ public sealed class CliArgumentsParserTests
                 "--mesh-code", "53394525",
                 "--citygml-source", "/data/plateau",
                 "--resonitelink-port", "12345",
-                "--dem-terrain-mode", "heightmap",
-                "--dem-heightmap-meters-per-vertex", "4.5",
-                "--dem-heightmap-max-resolution", "512",
+                "--terrain-mesh", "grid",
+                "--terrain-grid-meters-per-vertex", "4.5",
+                "--terrain-grid-max-resolution", "512",
             ]);
 
         Assert.Null(result.Error);
-        Assert.Equal(DemTerrainMode.HeightMap, result.Options!.Request.DemTerrainMode);
-        Assert.Equal(4.5, result.Options.Request.DemHeightmapMetersPerVertex, 6);
-        Assert.Equal(512, result.Options.Request.DemHeightmapMaxResolution);
+        Assert.Equal(TerrainMeshMode.Grid, result.Options!.Request.TerrainMeshMode);
+        Assert.Equal(4.5, result.Options.Request.TerrainGridMetersPerVertex, 6);
+        Assert.Equal(512, result.Options.Request.TerrainGridMaxResolution);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
@@ -176,7 +176,7 @@ public sealed class DemTerrainOverlayAssignmentTests
     }
 
     [Fact]
-    public void TryCreateHeightMapTextureTransformReturnsOccupiedOverlayUvTransform()
+    public void TryCreateTerrainGridTextureTransformReturnsOccupiedOverlayUvTransform()
     {
         BootstrapParsedSurface surface = CreateGeneratedSurface(
             "dem-transform",
@@ -205,7 +205,7 @@ public sealed class DemTerrainOverlayAssignmentTests
                 TerrainOverlay: overlay),
             DepthOffset: null);
 
-        (Float2? textureScale, Float2? textureOffset) = DemTerrainOverlayAssignment.TryCreateHeightMapTextureTransform(
+        (Float2? textureScale, Float2? textureOffset) = DemTerrainOverlayAssignment.TryCreateTerrainGridTextureTransform(
             cityObject,
             material,
             overlay);

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -743,7 +743,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public async Task DemHeightMapModeExtendsBoundaryConnectedMissingSamplesWithoutSeaLevelDrop()
+    public async Task DemTerrainGridModeExtendsBoundaryConnectedMissingSamplesWithoutSeaLevelDrop()
     {
         using TemporaryDirectory datasetRoot = new();
         CreateRuntimeDemChunkFixture(datasetRoot.Path);
@@ -758,15 +758,15 @@ public sealed class LocalCityGmlObjectProjectionTests
                 SourceKind: DatasetSourceKind.Local,
                 LocalSourcePath: datasetRoot.Path,
                 PackageNames: ["dem"],
-                DemTerrainMode: DemTerrainMode.HeightMap,
+                TerrainMeshMode: TerrainMeshMode.Grid,
                 ServerUri: null),
             workRoot: "runtime/resonite");
 
         ImportedCityObject demCityObject = Assert.Single(
             sceneBuilder.CityObjects,
             static cityObject => cityObject.PackageName == "dem"
-                && cityObject.Geometry is HeightMapGridGeometry);
-        HeightMapGridGeometry geometry = Assert.IsType<HeightMapGridGeometry>(demCityObject.Geometry);
+                && cityObject.Geometry is TerrainGridGeometry);
+        TerrainGridGeometry geometry = Assert.IsType<TerrainGridGeometry>(demCityObject.Geometry);
 
         double[] topEdge = Enumerable.Range(0, geometry.Width)
             .Select(index => geometry.HeightSamples[index])
@@ -788,7 +788,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public async Task DemHeightMapModeCarriesGeneratedTextureUvTransformOnGeometryInsteadOfMaterial()
+    public async Task DemTerrainGridModeCarriesGeneratedTextureUvTransformOnGeometryInsteadOfMaterial()
     {
         using TemporaryDirectory datasetRoot = new();
         CreateRuntimeDemChunkFixture(datasetRoot.Path);
@@ -803,16 +803,16 @@ public sealed class LocalCityGmlObjectProjectionTests
                 SourceKind: DatasetSourceKind.Local,
                 LocalSourcePath: datasetRoot.Path,
                 PackageNames: ["dem"],
-                DemTerrainMode: DemTerrainMode.HeightMap,
+                TerrainMeshMode: TerrainMeshMode.Grid,
                 ServerUri: null),
             workRoot: "runtime/resonite");
 
         ImportedCityObject demCityObject = Assert.Single(
             sceneBuilder.CityObjects,
             static cityObject => cityObject.PackageName == "dem"
-                && cityObject.Geometry is HeightMapGridGeometry
+                && cityObject.Geometry is TerrainGridGeometry
                 && cityObject.Materials.Any(static material => material.TerrainOverlay is not null));
-        HeightMapGridGeometry geometry = Assert.IsType<HeightMapGridGeometry>(demCityObject.Geometry);
+        TerrainGridGeometry geometry = Assert.IsType<TerrainGridGeometry>(demCityObject.Geometry);
         MaterialBinding material = Assert.Single(demCityObject.Materials);
 
         Assert.NotNull(geometry.UvScale);
@@ -841,13 +841,13 @@ public sealed class LocalCityGmlObjectProjectionTests
                 SourceKind: DatasetSourceKind.Local,
                 LocalSourcePath: datasetRoot.Path,
                 PackageNames: ["dem"],
-                DemTerrainMode: DemTerrainMode.HeightMap,
+                TerrainMeshMode: TerrainMeshMode.Grid,
                 ServerUri: null),
             workRoot: "runtime/resonite");
 
         ImportedCityObject[] demCityObjects = sceneBuilder.CityObjects
             .Where(static cityObject => cityObject.PackageName == "dem"
-                && cityObject.Geometry is HeightMapGridGeometry)
+                && cityObject.Geometry is TerrainGridGeometry)
             .ToArray();
 
         Assert.NotEmpty(demCityObjects);
@@ -855,7 +855,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             demCityObjects,
             static cityObject =>
             {
-                HeightMapGridGeometry geometry = Assert.IsType<HeightMapGridGeometry>(cityObject.Geometry);
+                TerrainGridGeometry geometry = Assert.IsType<TerrainGridGeometry>(cityObject.Geometry);
                 Assert.Equal("533945", cityObject.ActualMeshCode);
                 Assert.True(geometry.Width > 0);
                 Assert.True(geometry.Height > 0);
@@ -878,7 +878,7 @@ public sealed class LocalCityGmlObjectProjectionTests
                 SourceKind: DatasetSourceKind.Local,
                 LocalSourcePath: datasetRoot.Path,
                 PackageNames: ["dem"],
-                DemTerrainMode: DemTerrainMode.HeightMap,
+                TerrainMeshMode: TerrainMeshMode.Grid,
                 ServerUri: null),
             workRoot: "runtime/resonite");
 
@@ -890,9 +890,9 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public void AlignAdjacentDemHeightMapChunkBoundariesAveragesSharedSamplesForPartialOverlapWithDifferentResolution()
+    public void AlignAdjacentDemTerrainGridChunkBoundariesAveragesSharedSamplesForPartialOverlapWithDifferentResolution()
     {
-        ImportedCityObject left = CreateHeightMapCityObject(
+        ImportedCityObject left = CreateTerrainGridCityObject(
             "left-dem",
             new Float3(0.0, 14.0, 0.0),
             width: 2,
@@ -906,7 +906,7 @@ public sealed class LocalCityGmlObjectProjectionTests
                 1.0, 13.0,
                 1.0, 14.0,
             ]);
-        ImportedCityObject right = CreateHeightMapCityObject(
+        ImportedCityObject right = CreateTerrainGridCityObject(
             "right-dem",
             new Float3(2.0, 22.0, 0.0),
             width: 2,
@@ -919,10 +919,10 @@ public sealed class LocalCityGmlObjectProjectionTests
                 22.0, 2.0,
             ]);
 
-        ImportedCityObject[] aligned = AlignAdjacentDemHeightMapChunkBoundariesForTest([left, right]);
+        ImportedCityObject[] aligned = AlignAdjacentDemTerrainGridChunkBoundariesForTest([left, right]);
 
-        HeightMapGridGeometry alignedLeft = Assert.IsType<HeightMapGridGeometry>(aligned[0].Geometry);
-        HeightMapGridGeometry alignedRight = Assert.IsType<HeightMapGridGeometry>(aligned[1].Geometry);
+        TerrainGridGeometry alignedLeft = Assert.IsType<TerrainGridGeometry>(aligned[0].Geometry);
+        TerrainGridGeometry alignedRight = Assert.IsType<TerrainGridGeometry>(aligned[1].Geometry);
 
         Assert.Equal(10.0, alignedLeft.HeightSamples[1], 6);
         Assert.Equal(15.5, alignedLeft.HeightSamples[3], 6);
@@ -1474,14 +1474,14 @@ public sealed class LocalCityGmlObjectProjectionTests
         return min + ((max - min) * ratio);
     }
 
-    private static ImportedCityObject[] AlignAdjacentDemHeightMapChunkBoundariesForTest(
+    private static ImportedCityObject[] AlignAdjacentDemTerrainGridChunkBoundariesForTest(
         IReadOnlyList<ImportedCityObject> cityObjects)
     {
         MethodInfo method = typeof(LocalCityGmlObjectProjection)
             .GetMethod(
-                "AlignAdjacentDemHeightMapChunkBoundaries",
+                "AlignAdjacentDemTerrainGridChunkBoundaries",
                 BindingFlags.NonPublic | BindingFlags.Static)
-            ?? throw new InvalidOperationException("Failed to resolve AlignAdjacentDemHeightMapChunkBoundaries.");
+            ?? throw new InvalidOperationException("Failed to resolve AlignAdjacentDemTerrainGridChunkBoundaries.");
 
         return (ImportedCityObject[])method.Invoke(null, [cityObjects])!;
     }
@@ -1682,7 +1682,7 @@ public sealed class LocalCityGmlObjectProjectionTests
                 new DefaultMaterialResolver(),
             ])!;
     }
-    private static ImportedCityObject CreateHeightMapCityObject(
+    private static ImportedCityObject CreateTerrainGridCityObject(
         string slotKey,
         Float3 position,
         int width,
@@ -1707,7 +1707,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             ActualMeshCode: "53394525",
             LodLevel: 1,
             Transform: new Transform3D(position),
-            Geometry: new HeightMapGridGeometry(
+            Geometry: new TerrainGridGeometry(
                 Width: width,
                 Height: height,
                 Size: new Float2(sizeX, sizeZ),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -690,7 +690,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
-    public async Task BuildAsyncAssignsSourceFileRootPositionForHeightMapDemAndPreservesWorldPosition()
+    public async Task BuildAsyncAssignsSourceFileRootPositionForTerrainGridDemAndPreservesWorldPosition()
     {
         using TemporaryDirectory datasetDirectory = new();
         ImportedSceneMetadata metadata = CreateDemMetadata(datasetDirectory.Path, [PrimaryDemSourceFile, SecondaryDemSourceFile]);
@@ -700,8 +700,8 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
         await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
             metadata,
             [
-                CreateHeightMapDemCityObject(
-                    "dem-heightmap-run-one",
+                CreateTerrainGridDemCityObject(
+                    "dem-terrain-grid-run-one",
                     actualMeshCode: SecondaryMeshCode,
                     sourceFileRelativePath: SecondaryDemSourceFile,
                     worldPosition: worldPosition),
@@ -716,7 +716,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
         Assert.Equal(expectedRootOffset.X, GetSlotPosition(sourceFileRoot).X, 3);
         Assert.Equal(expectedRootOffset.Z, GetSlotPosition(sourceFileRoot).Z, 3);
 
-        Slot objectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "DEM HeightMap dem-heightmap-run-one");
+        Slot objectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "DEM Terrain Grid dem-terrain-grid-run-one");
         ResoniteFloat3 accumulatedPosition = GetAccumulatedPosition(client, objectSlot);
         Assert.Equal(worldPosition.X, accumulatedPosition.X, 3);
         Assert.Equal(worldPosition.Y, accumulatedPosition.Y, 3);
@@ -724,7 +724,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
-    public async Task BuildAsyncCreatesIndependentSourceFileRootAcrossRunsForHeightMapDem()
+    public async Task BuildAsyncCreatesIndependentSourceFileRootAcrossRunsForTerrainGridDem()
     {
         using TemporaryDirectory datasetDirectory = new();
         ImportedSceneMetadata metadata = CreateDemMetadata(datasetDirectory.Path, [PrimaryDemSourceFile, SecondaryDemSourceFile]);
@@ -734,15 +734,15 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
         await ResoniteLiveSceneImportTargetTestSupport.BuildSceneTwiceAsync(
             metadata,
             [
-                CreateHeightMapDemCityObject(
-                    "dem-heightmap-run-one",
+                CreateTerrainGridDemCityObject(
+                    "dem-terrain-grid-run-one",
                     actualMeshCode: SecondaryMeshCode,
                     sourceFileRelativePath: SecondaryDemSourceFile,
                     worldPosition: new ResoniteFloat3(123.0, 15.5, 456.0)),
             ],
             [
-                CreateHeightMapDemCityObject(
-                    "dem-heightmap-run-two",
+                CreateTerrainGridDemCityObject(
+                    "dem-terrain-grid-run-two",
                     actualMeshCode: SecondaryMeshCode,
                     sourceFileRelativePath: SecondaryDemSourceFile,
                     worldPosition: secondRunWorldPosition),
@@ -765,7 +765,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                 Assert.Equal(expectedRootOffset.Z, position.Z, 3);
             });
 
-        Slot objectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "DEM HeightMap dem-heightmap-run-two");
+        Slot objectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "DEM Terrain Grid dem-terrain-grid-run-two");
         ResoniteFloat3 accumulatedPosition = GetAccumulatedPosition(client, objectSlot);
         AssertNear(secondRunWorldPosition, accumulatedPosition, 0.2);
     }
@@ -1099,7 +1099,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             SourceFileRelativePath: sourceFileRelativePath);
     }
 
-    private static ResoniteConstructionCityObject CreateHeightMapDemCityObject(
+    private static ResoniteConstructionCityObject CreateTerrainGridDemCityObject(
         string objectIdentity,
         string actualMeshCode = MeshCode,
         string sourceFileRelativePath = PrimaryDemSourceFile,
@@ -1107,12 +1107,12 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     {
         return new ResoniteConstructionCityObject(
             SlotKey: $"slot-{objectIdentity}",
-            DisplayName: $"DEM HeightMap {objectIdentity}",
+            DisplayName: $"DEM Terrain Grid {objectIdentity}",
             PackageName: "dem",
             ActualMeshCode: actualMeshCode,
             LodLevel: 0,
             Transform: new ResoniteTransform(worldPosition ?? new ResoniteFloat3(0.0, 0.0, 0.0)),
-            Geometry: new ResoniteHeightMapGridGeometry(
+            Geometry: new ResoniteTerrainGridGeometry(
                 Width: 2,
                 Height: 2,
                 Size: new ResoniteFloat2(10.0, 10.0),
@@ -1122,7 +1122,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             Materials:
             [
                 new ResoniteMaterialBinding(
-                    MaterialKey: "dem-heightmap-material",
+                    MaterialKey: "dem-terrain-grid-material",
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Wireframe,
                     TexturePayload: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -419,14 +419,14 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 cityObject.Materials.Select(ToContractMaterial).ToArray(),
                 cityObject.CollisionEnabled,
                 cityObject.SourceFileRelativePath),
-            ResoniteHeightMapGridGeometry heightMap => new ImportedCityObject(
+            ResoniteTerrainGridGeometry heightMap => new ImportedCityObject(
                 cityObject.SlotKey,
                 cityObject.DisplayName,
                 cityObject.PackageName,
                 cityObject.ActualMeshCode,
                 cityObject.LodLevel,
                 ToContractTransform(cityObject.Transform),
-                new HeightMapGridGeometry(
+                new TerrainGridGeometry(
                     heightMap.Width,
                     heightMap.Height,
                     ToContractFloat2(heightMap.Size),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -220,7 +220,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
-    public async Task BuildAsyncSendsHeightMapAsHdrRawTextureAndCreatesGridMesh()
+    public async Task BuildAsyncSendsTerrainGridDisplacementAsHdrRawTextureAndCreatesGridMesh()
     {
         using TemporaryDirectory datasetDirectory = new();
         using SceneBuilderRecordingClient client = new();
@@ -235,13 +235,13 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml",
             ]);
         ResoniteConstructionCityObject cityObject = new(
-            SlotKey: "heightmap-terrain",
-            DisplayName: "HeightMap Terrain",
+            SlotKey: "terrain-grid-terrain",
+            DisplayName: "Terrain Grid Terrain",
             PackageName: "dem",
             ActualMeshCode: MeshCode,
             LodLevel: 0,
             Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
-            Geometry: new ResoniteHeightMapGridGeometry(
+            Geometry: new ResoniteTerrainGridGeometry(
                 Width: 2,
                 Height: 2,
                 Size: new ResoniteFloat2(10.0, 10.0),
@@ -251,7 +251,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
             Materials:
             [
                 new ResoniteMaterialBinding(
-                    MaterialKey: "wireframe-heightmap",
+                    MaterialKey: "wireframe-terrain-grid",
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Wireframe,
                     TexturePayload: null,
@@ -320,13 +320,13 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml",
             ]);
         ResoniteConstructionCityObject cityObject = new(
-            SlotKey: "heightmap-overlay-terrain",
-            DisplayName: "HeightMap Overlay Terrain",
+            SlotKey: "terrain-grid-overlay-terrain",
+            DisplayName: "Terrain Grid Overlay Terrain",
             PackageName: "dem",
             ActualMeshCode: MeshCode,
             LodLevel: 0,
             Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
-            Geometry: new ResoniteHeightMapGridGeometry(
+            Geometry: new ResoniteTerrainGridGeometry(
                 Width: 2,
                 Height: 2,
                 Size: new ResoniteFloat2(10.0, 10.0),
@@ -338,7 +338,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
             Materials:
             [
                 new ResoniteMaterialBinding(
-                    MaterialKey: "heightmap-overlay-material",
+                    MaterialKey: "terrain-grid-overlay-material",
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
                     TexturePayload: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
@@ -148,10 +148,10 @@ public sealed class ResoniteMaterialComponentPolicyTests
     public void CreateMembersCreatesUvMaterialWithoutTransformAfterNormalization()
     {
         ResoniteMaterialBinding material = new(
-            MaterialKey: "direct-heightmap-style-material",
+            MaterialKey: "direct-terrain-grid-style-material",
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/direct-heightmap-style.png"),
+            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/direct-terrain-grid-style.png"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
@@ -199,7 +199,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
     public void CreateMembersPreservesUvTransformForSharedTerrainOverlayMaterial()
     {
         ResoniteMaterialBinding material = new(
-            MaterialKey: "shared-heightmap-overlay",
+            MaterialKey: "shared-terrain-grid-overlay",
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
             TexturePayload: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -16,20 +16,20 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     private static readonly IResoniteBatchEmissionPlanner Planner = new ResoniteBatchEmissionPlanner();
 
     [Fact]
-    public void CreatePlannedBatchEmission_CreatesHeightMapGridPlanWithPlannedTextureReference()
+    public void CreatePlannedBatchEmission_CreatesTerrainGridPlanWithPlannedTextureReference()
     {
         ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
             new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
-            "HeightMap Object",
+            "Terrain Grid Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(1.0, 2.0, 3.0),
             null);
         PlannedSceneObjectEmission emissionPlan = new(
-            new PlannedHeightMapGridGeometryAsset(
+            new PlannedTerrainGridGeometryAsset(
                 new GeometryIdentity("geom"),
-                "HeightMap Object",
-                "HeightMap Object_heightmap",
-                new ResoniteHeightMapGridGeometry(
+                "Terrain Grid Object",
+                "Terrain Grid Object_terrain-grid",
+                new ResoniteTerrainGridGeometry(
                     Width: 2,
                     Height: 3,
                     Size: new PlateauResoniteLink.Targets.Resonite.ResoniteFloat2(10.0, 20.0),
@@ -49,11 +49,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
         PlannedBatchSlotEmission meshAssetSlot = Assert.Single(
             batchPlan.SlotEmissions,
-            static slot => string.Equals(slot.SlotName, "HeightMap Object", StringComparison.Ordinal)
+            static slot => string.Equals(slot.SlotName, "Terrain Grid Object", StringComparison.Ordinal)
                 && slot.ParentTarget.Canonical == new ResoniteSlotLocator("asset-lod-slot"));
         PlannedBatchSlotEmission heightMapSlot = Assert.Single(
             batchPlan.SlotEmissions,
-            static slot => string.Equals(slot.SlotName, "HeightMap Object_heightmap", StringComparison.Ordinal));
+            static slot => string.Equals(slot.SlotName, "Terrain Grid Object_terrain-grid", StringComparison.Ordinal));
         PlannedBatchComponentEmission heightTexture = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
@@ -76,20 +76,20 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     }
 
     [Fact]
-    public void CreatePlannedBatchEmission_CarriesHeightMapGridUvMembers()
+    public void CreatePlannedBatchEmission_CarriesTerrainGridUvMembers()
     {
         ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
             new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
-            "HeightMap Object",
+            "Terrain Grid Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(1.0, 2.0, 3.0),
             null);
         PlannedSceneObjectEmission emissionPlan = new(
-            new PlannedHeightMapGridGeometryAsset(
+            new PlannedTerrainGridGeometryAsset(
                 new GeometryIdentity("geom"),
-                "HeightMap Object",
-                "HeightMap Object_heightmap",
-                new ResoniteHeightMapGridGeometry(
+                "Terrain Grid Object",
+                "Terrain Grid Object_terrain-grid",
+                new ResoniteTerrainGridGeometry(
                     Width: 2,
                     Height: 3,
                     Size: new PlateauResoniteLink.Targets.Resonite.ResoniteFloat2(10.0, 20.0),

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
@@ -356,7 +356,7 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             tileOverlay.ZoomLevel);
 
         using TemporaryDirectory workDirectory = new();
-        string rasterPath = Path.Combine(workDirectory.Path, "default-third-mesh-dem.png");
+        string rasterPath = Path.Combine(workDirectory.Path, "default-third-static-dem.png");
         using (Image<Rgba32> rasterImage = new(layout.CropWidth, layout.CropHeight, new Rgba32(12, 34, 56, 255)))
         {
             await rasterImage.SaveAsPngAsync(rasterPath);


### PR DESCRIPTION
## Summary
- Replace the DEM terrain mode CLI with `--terrain-mesh static|grid` and remove the old `--dem-terrain-mode mesh|heightmap` names.
- Rename internal request/options/contracts from DEM heightmap mode to terrain mesh/grid terminology.
- Update Resonite live-send workflow docs, release workflow wording, and tests to use static/grid names.

## Notes
- The remaining `HeightMap` strings are Resonite/FrooxEngine member literals for GridMesh material wiring, so they are intentionally unchanged.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --no-build --verbosity minimal -m:1 --disable-build-servers -p:UseSharedCompilation=false`