### PR TITLE
[codex] Drive DEM grid points dynamically

### DIFF
--- a/.agents/skills/plateau-dataset-estimate/SKILL.ja.md
+++ b/.agents/skills/plateau-dataset-estimate/SKILL.ja.md
@@ -19,14 +19,19 @@ description: Estimate PLATEAU dataset quality, import cost, rendering risk, text
    - total compressed size、entry count、package ごとの `.gml` count、texture count、compressed/uncompressed bytes を記録します。
    - local file では `7z l`、`tar`、または小さな ZIP central-directory reader を使って構いません。
 
-3. texture VRAM は JPEG bytes だけではなく寸法から推定します。
+3. renderer texture VRAM は JPEG bytes だけではなく寸法から推定します。
    - largest files と evenly distributed files を代表 sample にします。
    - archive が JPEG entry を deflate している場合は、ZIP decompression 後に実 image dimensions を読みます。
-   - sampled `jpeg_bytes_per_pixel` から total texels を推定し、次で計算します。
+   - Archive pixel から effective alpha を確認します。image mode だけでは判断しません。
+     - JPEG は no-alpha として扱います。
+     - PNG など alpha を持ち得る image は alpha channel を検査し、全 pixel が alpha 255 なら no-effective-alpha に分類します。
+     - non-opaque pixel を含む image だけ effective-alpha image として数えます。
+   - sampled `jpeg_bytes_per_pixel` から total texels を推定し、renderer GPU texture estimate として次で計算します。
      - BC1: `texels * 0.5`
-     - BC3/BC7: `texels * 1.0`
-     - RGBA32: `texels * 4.0`
+     - BC3: `texels * 1.0`
      - mip chain: `4/3` を掛ける
+   - 送信後の Resonite renderer GPU estimate では、有効な alpha を持たない PLATEAU imagery は import 後 BC1 と仮定します。Archive pixels に non-opaque alpha がある image だけ BC3 を使います。live engine state で証明されない限り、BC7 を PLATEAU の default estimate にしません。
+   - RGBA32 は sender payload、CPU-side、または upper-bound comparison としてだけ別枠で報告します。compressed runtime format が scope に入っている場合、raw RGBA32 を renderer VRAM の主推定にしません。
    - JPEG compression ratio は content に偏るので、texture estimate は range で出します。
 
 4. DEM surface imagery は DEM terrain geometry と分けて推定します。
@@ -44,19 +49,20 @@ description: Estimate PLATEAU dataset quality, import cost, rendering risk, text
    - renderable coverage が取れる最初の source を使い、mixed fallback coverage は明記します。
    - `TerrainTextureAssetGenerator` の挙動を反映します。tile mosaic を crop し、opaque 化し、必要なら `MaxTextureSize` に resize して、power-of-two canvas に載せます。
 
-5. geometry は別枠で推定します。
+5. renderer geometry は別枠で推定します。
    - 可能なら実 CLI/import metrics または generated mesh stats を優先します。
    - triangle count がない場合、geometry estimate は coarse と明記します。
+   - DEM `--terrain-mesh static` では、source TIN を Unity renderer に mesh buffer として届く通常 triangle mesh data として扱います。uncertainty は高く明記します。source detail は保てますが、bounded Grid より import/rendering が重く振れることがあります。
    - DEM `--terrain-mesh grid` では、bounds と提案する grid settings から Grid Points を推定します。
      - raw columns/rows: `ceil(width_m / meters_per_vertex) + 1`, `ceil(height_m / meters_per_vertex) + 1`
      - clamped columns/rows: 各軸を `--terrain-grid-max-resolution` 以下に制限
      - points: `columns * rows`
      - quads: `(columns - 1) * (rows - 1)`
-     - vertex payload coarse range: `32-64 bytes * points`
-     - indices coarse range: `6 * 4 bytes * quads`
+     - renderer vertex payload coarse range: `32-64 bytes * points`
+     - renderer indices coarse range: `6 * 4 bytes * quads`
+   - DEM Grid では、FrooxEngine が displacement texture を CPU で読み、生成後の GridMesh-style geometry を Unity renderer に送る前提で見積もります。生成された GridMesh geometry を renderer VRAM に計上します。
+   - Grid displacement は通常の renderer texture VRAM として計上しません。live engine state で GPU sampled texture として保持される証拠がない限り、現在の float4 height data では典型的に `16 bytes * points` の CPU/engine-side または payload cost として別枠にします。
    - user が Grid resolution guidance を求めている場合は、default、preview、quality-oriented Grid settings を少なくとも含めます。
-   - engine が GPU texture として保持している証拠がない限り、Grid displacement を通常の BC texture VRAM として計上しません。CPU-side または implementation-dependent として扱います。
-   - DEM `--terrain-mesh static` は uncertainty を高く扱います。source detail は保てますが、bounded Grid より import/rendering が重く振れることがあります。
 
 6. terrain mesh mode と package scope を比較します。
    - full-area DEM では `--terrain-grid-meters-per-vertex` と `--terrain-grid-max-resolution` で上限を切れる `--terrain-mesh grid` が基本的に有利です。
@@ -66,25 +72,25 @@ description: Estimate PLATEAU dataset quality, import cost, rendering risk, text
 
 ## Output Contract
 
-texture、geometry、total を合わせた resource table を必ず含めます。
+renderer GPU memory と CPU/engine-side または sender payload cost を分けた combined resource table を必ず含めます。
 
 ```text
-| Target | Texture VRAM | Geometry VRAM | Total |
-|---|---:|---:|---:|
-| bldg | ... | ... | ... |
-| dem terrain grid | ... | ... | ... |
-| other packages | ... | ... | ... |
-| bldg + dem | ... | ... | ... |
+| Target | Renderer Texture VRAM | Renderer Geometry VRAM | CPU/engine-side extra | Renderer Total |
+|---|---:|---:|---:|---:|
+| bldg | ... | ... | ... | ... |
+| dem terrain grid | ... | ... | ... | ... |
+| other packages | ... | ... | ... | ... |
+| bldg + dem | ... | ... | ... | ... |
 ```
 
 Grid が scope に入る場合は、Grid resolution table も含めます。
 
 ```text
-| Grid setting | Columns x Rows | Grid Points | Geometry VRAM | Use |
-|---|---:|---:|---:|---|
-| default: 2.0 m, max 1024 | ... | ... | ... | baseline |
-| preview | ... | ... | ... | faster import/render |
-| quality | ... | ... | ... | higher DEM detail |
+| Grid setting | Columns x Rows | Grid Points | Renderer Geometry VRAM | Displacement/CPU-side cost | Use |
+|---|---:|---:|---:|---:|---|
+| default: 2.0 m, max 1024 | ... | ... | ... | ... | baseline |
+| preview | ... | ... | ... | ... | faster import/render |
+| quality | ... | ... | ... | ... | higher DEM detail |
 ```
 
 その後に以下を列挙します。
@@ -95,8 +101,9 @@ Grid が scope に入る場合は、Grid resolution table も含めます。
 - observed archive facts
 - package/file-size observations
 - texture format assumptions
-- texture VRAM estimate
-- geometry VRAM estimate
+- renderer texture VRAM estimate
+- renderer geometry VRAM estimate
+- 関連する場合は CPU/engine-side または payload memory estimate
 - 実際に sample した、または仮定した DEM surface source
 - DEM surface imagery cost
 - terrain mesh mode と Grid resolution recommendation
@@ -108,7 +115,9 @@ Grid が scope に入る場合は、Grid resolution table も含めます。
 - hypothesis を conclusion として扱わないでください。
 - 同じ bounded investigation から dataset quality、package/LOD coverage、import cost、rendering risk も見積もれる場合、回答を VRAM だけに狭めないでください。
 - compressed runtime format が論点に入っている場合、raw RGBA だけの計算を主回答にしないでください。
+- live engine-state evidence がない限り、BC7 を PLATEAU renderer texture estimate の default にしないでください。
 - DEM surface imagery を DEM geometry に隠さず、texture cost として別に報告します。
-- Grid を texture-only として扱わないでください。この repo では GridMesh-style geometry と implementation-dependent displacement data になります。
+- Grid を texture-only として扱わないでください。この repo では GridMesh-style geometry と CPU/engine-side displacement data になります。
+- Grid displacement は default では renderer texture VRAM に計上しないでください。user が renderer VRAM を求めている場合、engine が GPU texture として保持していることを live inspection で確認できない限り、displacement は Renderer Total から分けます。
 - DEM surface imagery の `MaxTextureSize` と Grid geometry resolution を混同しないでください。Grid Points は `--terrain-grid-meters-per-vertex` と `--terrain-grid-max-resolution` で決まります。
 - user が実測を求めていない限り、rough estimate のためだけに full live import を実行しないでください。

--- a/.agents/skills/plateau-dataset-estimate/SKILL.ja.md
+++ b/.agents/skills/plateau-dataset-estimate/SKILL.ja.md
@@ -15,11 +15,15 @@ description: Estimate PLATEAU dataset quality, import cost, rendering risk, text
    - 最新 data が求められている場合は、memory ではなく現在の online metadata を確認します。
 
 2. full extraction なしで package weight を調べます。
+   - local dataset directory または archive が存在する場合は、最初に repo の stats command を実行し、local-source inventory の一次情報として扱います。
+     - `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- stats --citygml-source <path> [--packages <csv>] --format json`
+   - package counts、mesh-code counts、LOD coverage、archive-derived VRAM fields は、ad hoc な archive scan に戻る前に `stats` output を使います。
    - remote ZIP は可能なら HTTP `HEAD` と ZIP central-directory range read を使います。
    - total compressed size、entry count、package ごとの `.gml` count、texture count、compressed/uncompressed bytes を記録します。
-   - local file では `7z l`、`tar`、または小さな ZIP central-directory reader を使って構いません。
+   - local file では、`stats` が公開していない事実に限って `7z l`、`tar`、または小さな ZIP central-directory reader を使います。
 
 3. renderer texture VRAM は JPEG bytes だけではなく寸法から推定します。
+   - `stats --format json` に `archiveVramEstimate.rendererTextureVram` がある場合は、archive-referenced textures の source-observed estimate としてその値を使います。
    - largest files と evenly distributed files を代表 sample にします。
    - archive が JPEG entry を deflate している場合は、ZIP decompression 後に実 image dimensions を読みます。
    - Archive pixel から effective alpha を確認します。image mode だけでは判断しません。
@@ -50,8 +54,9 @@ description: Estimate PLATEAU dataset quality, import cost, rendering risk, text
    - `TerrainTextureAssetGenerator` の挙動を反映します。tile mosaic を crop し、opaque 化し、必要なら `MaxTextureSize` に resize して、power-of-two canvas に載せます。
 
 5. renderer geometry は別枠で推定します。
-   - 可能なら実 CLI/import metrics または generated mesh stats を優先します。
+   - 可能なら実 CLI/import metrics、`stats --format json` の `archiveVramEstimate.rendererGeometryVram`、または generated mesh stats を優先します。
    - triangle count がない場合、geometry estimate は coarse と明記します。
+   - `stats` geometry は archive-derived な GML `posList` estimate として扱います。pre-import sizing には有用ですが、post-tessellation/live Renderer measurement ではありません。
    - DEM `--terrain-mesh static` では、source TIN を Unity renderer に mesh buffer として届く通常 triangle mesh data として扱います。uncertainty は高く明記します。source detail は保てますが、bounded Grid より import/rendering が重く振れることがあります。
    - DEM `--terrain-mesh grid` では、bounds と提案する grid settings から Grid Points を推定します。
      - raw columns/rows: `ceil(width_m / meters_per_vertex) + 1`, `ceil(height_m / meters_per_vertex) + 1`
@@ -99,6 +104,7 @@ Grid が scope に入る場合は、Grid resolution table も含めます。
 - source provenance と metadata freshness
 - official metadata と package/LOD coverage から得られる quality indicators
 - observed archive facts
+- 使用した stats command、version/command line、または使えなかった理由
 - package/file-size observations
 - texture format assumptions
 - renderer texture VRAM estimate
@@ -113,6 +119,7 @@ Grid が scope に入る場合は、Grid resolution table も含めます。
 ## Guardrails
 
 - hypothesis を conclusion として扱わないでください。
+- local source が利用できる場合、package/LOD/VRAM facts のために `stats` を試す前に手動で local archive を再走査しないでください。
 - 同じ bounded investigation から dataset quality、package/LOD coverage、import cost、rendering risk も見積もれる場合、回答を VRAM だけに狭めないでください。
 - compressed runtime format が論点に入っている場合、raw RGBA だけの計算を主回答にしないでください。
 - live engine-state evidence がない限り、BC7 を PLATEAU renderer texture estimate の default にしないでください。

--- a/.agents/skills/plateau-dataset-estimate/SKILL.md
+++ b/.agents/skills/plateau-dataset-estimate/SKILL.md
@@ -15,11 +15,15 @@ Use this skill to produce a bounded dataset-level estimate, not a benchmark resu
    - If latest data is requested, verify current metadata online instead of relying on memory.
 
 2. Inspect package weight without full extraction.
+   - When a local dataset directory or archive exists, run the repo stats command first and treat it as the primary local-source inventory:
+     - `dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj -- stats --citygml-source <path> [--packages <csv>] --format json`
+   - Use `stats` output for package counts, mesh-code counts, LOD coverage, and archive-derived VRAM fields before falling back to ad hoc archive scans.
    - For remote ZIP files, use HTTP `HEAD` and ZIP central-directory range reads when possible.
    - Record total compressed size, entry count, package-level `.gml` counts, texture counts, compressed and uncompressed bytes.
-   - For local files, `7z l`, `tar`, or a small ZIP central-directory reader is acceptable.
+   - For local files, use `7z l`, `tar`, or a small ZIP central-directory reader only for facts that `stats` does not expose.
 
 3. Estimate renderer texture VRAM from dimensions, not JPEG bytes alone.
+   - If `stats --format json` includes `archiveVramEstimate.rendererTextureVram`, use those values for archive-referenced textures and label them as source-observed estimates.
    - Sample representative images: largest files plus evenly distributed files.
    - Read actual image dimensions after ZIP decompression if the archive deflates JPEG entries.
    - Check effective alpha from archive pixels, not only image mode:
@@ -50,8 +54,9 @@ Use this skill to produce a bounded dataset-level estimate, not a benchmark resu
    - Apply `TerrainTextureAssetGenerator` behavior: crop tile mosaic, make opaque, resize to `MaxTextureSize` if needed, then round up to a power-of-two canvas.
 
 5. Estimate renderer geometry separately.
-   - Prefer actual CLI/import metrics or generated mesh stats when available.
+   - Prefer actual CLI/import metrics, `stats --format json` `archiveVramEstimate.rendererGeometryVram`, or generated mesh stats when available.
    - If triangle counts are unavailable, classify the geometry estimate as coarse.
+   - Treat `stats` geometry as an archive-derived GML `posList` estimate. It is useful for pre-import sizing, but it is not a post-tessellation/live Renderer measurement.
    - For DEM `--terrain-mesh static`, treat the source TIN as ordinary triangle mesh data that reaches the Unity renderer as mesh buffers. Flag higher uncertainty: CityGML DEM geometry can preserve more source detail but may import and render heavier than a bounded Grid.
    - For DEM `--terrain-mesh grid`, estimate Grid Points from bounds and the proposed grid settings:
      - raw columns/rows: `ceil(width_m / meters_per_vertex) + 1`, `ceil(height_m / meters_per_vertex) + 1`
@@ -99,6 +104,7 @@ Then list:
 - source provenance and metadata freshness
 - quality indicators from official metadata and package/LOD coverage
 - observed archive facts
+- stats command used, version/command line, or reason it was unavailable
 - package/file-size observations
 - texture format assumptions
 - renderer texture VRAM estimate
@@ -113,6 +119,7 @@ Then list:
 ## Guardrails
 
 - Do not present hypotheses as conclusions.
+- Do not manually rescan a local archive for package/LOD/VRAM facts before trying `stats` when the local source is available.
 - Do not narrow the answer to VRAM when dataset quality, package/LOD coverage, import cost, or rendering risk can also be estimated from the same bounded investigation.
 - Do not use raw RGBA-only accounting as the primary answer when compressed runtime formats are part of the question.
 - Do not use BC7 as the default PLATEAU renderer texture estimate without live engine-state evidence.

--- a/.agents/skills/plateau-dataset-estimate/SKILL.md
+++ b/.agents/skills/plateau-dataset-estimate/SKILL.md
@@ -19,14 +19,19 @@ Use this skill to produce a bounded dataset-level estimate, not a benchmark resu
    - Record total compressed size, entry count, package-level `.gml` counts, texture counts, compressed and uncompressed bytes.
    - For local files, `7z l`, `tar`, or a small ZIP central-directory reader is acceptable.
 
-3. Estimate texture VRAM from dimensions, not JPEG bytes alone.
+3. Estimate renderer texture VRAM from dimensions, not JPEG bytes alone.
    - Sample representative images: largest files plus evenly distributed files.
    - Read actual image dimensions after ZIP decompression if the archive deflates JPEG entries.
-   - Estimate total texels from sampled `jpeg_bytes_per_pixel`, then compute:
+   - Check effective alpha from archive pixels, not only image mode:
+     - Treat JPEG as no-alpha.
+     - For PNG and other alpha-capable images, inspect the alpha channel and classify images whose pixels are all alpha 255 as no-effective-alpha.
+     - Count only images with non-opaque pixels as effective-alpha images.
+   - Estimate total texels from sampled `jpeg_bytes_per_pixel`, then compute renderer GPU texture estimates:
      - BC1: `texels * 0.5`
-     - BC3/BC7: `texels * 1.0`
-     - RGBA32: `texels * 4.0`
+     - BC3: `texels * 1.0`
      - mip chain: multiply by `4/3`
+   - For post-send Resonite renderer GPU estimates, assume PLATEAU imagery without effective alpha is BC1 after import. Use BC3 only for images whose archive pixels contain non-opaque alpha. Do not use BC7 as the default PLATEAU estimate unless live engine state proves it.
+   - Report RGBA32 separately only as sender payload, CPU-side, or upper-bound comparison. Do not use raw RGBA32 as the primary renderer VRAM estimate when compressed runtime formats are in scope.
    - Report texture estimates as a range because sampled JPEG compression ratios are content-biased.
 
 4. Estimate DEM surface imagery separately from DEM terrain geometry.
@@ -44,19 +49,20 @@ Use this skill to produce a bounded dataset-level estimate, not a benchmark resu
    - Use the first source that produces renderable coverage, and note mixed fallback coverage.
    - Apply `TerrainTextureAssetGenerator` behavior: crop tile mosaic, make opaque, resize to `MaxTextureSize` if needed, then round up to a power-of-two canvas.
 
-5. Estimate geometry separately.
+5. Estimate renderer geometry separately.
    - Prefer actual CLI/import metrics or generated mesh stats when available.
    - If triangle counts are unavailable, classify the geometry estimate as coarse.
+   - For DEM `--terrain-mesh static`, treat the source TIN as ordinary triangle mesh data that reaches the Unity renderer as mesh buffers. Flag higher uncertainty: CityGML DEM geometry can preserve more source detail but may import and render heavier than a bounded Grid.
    - For DEM `--terrain-mesh grid`, estimate Grid Points from bounds and the proposed grid settings:
      - raw columns/rows: `ceil(width_m / meters_per_vertex) + 1`, `ceil(height_m / meters_per_vertex) + 1`
      - clamped columns/rows: each axis is capped by `--terrain-grid-max-resolution`
      - points: `columns * rows`
      - quads: `(columns - 1) * (rows - 1)`
-     - vertex payload coarse range: `32-64 bytes * points`
-     - indices coarse range: `6 * 4 bytes * quads`
+     - renderer vertex payload coarse range: `32-64 bytes * points`
+     - renderer indices coarse range: `6 * 4 bytes * quads`
+   - For DEM Grid, assume FrooxEngine reads the displacement texture on CPU and sends the generated GridMesh-style geometry to the Unity renderer. Count the generated GridMesh geometry in renderer VRAM.
+   - Do not count Grid displacement as ordinary renderer texture VRAM. Report it separately as CPU/engine-side or payload cost, typically `16 bytes * points` for the current float4 height data, unless live engine state proves it is retained as a GPU-sampled texture.
    - Include at least default, preview, and quality-oriented Grid settings when the user asks for Grid resolution guidance.
-   - Do not count Grid displacement as ordinary BC texture VRAM unless there is evidence that the engine keeps it as a GPU texture. Treat it as CPU-side or implementation-dependent unless live inspection proves otherwise.
-   - For DEM `--terrain-mesh static`, flag higher uncertainty: CityGML DEM geometry can preserve more source detail but may import and render heavier than a bounded Grid.
 
 6. Compare terrain mesh modes and package scopes.
    - `--terrain-mesh grid` is usually preferable for full-area DEM when bounded by `--terrain-grid-meters-per-vertex` and `--terrain-grid-max-resolution`.
@@ -66,25 +72,25 @@ Use this skill to produce a bounded dataset-level estimate, not a benchmark resu
 
 ## Output Contract
 
-Always include a combined resource table with texture, geometry, and total estimates:
+Always include a combined resource table that labels renderer GPU memory separately from CPU/engine-side or sender payload costs:
 
 ```text
-| Target | Texture VRAM | Geometry VRAM | Total |
-|---|---:|---:|---:|
-| bldg | ... | ... | ... |
-| dem terrain grid | ... | ... | ... |
-| other packages | ... | ... | ... |
-| bldg + dem | ... | ... | ... |
+| Target | Renderer Texture VRAM | Renderer Geometry VRAM | CPU/engine-side extra | Renderer Total |
+|---|---:|---:|---:|---:|
+| bldg | ... | ... | ... | ... |
+| dem terrain grid | ... | ... | ... | ... |
+| other packages | ... | ... | ... | ... |
+| bldg + dem | ... | ... | ... | ... |
 ```
 
 When Grid is in scope, also include a Grid resolution table:
 
 ```text
-| Grid setting | Columns x Rows | Grid Points | Geometry VRAM | Use |
-|---|---:|---:|---:|---|
-| default: 2.0 m, max 1024 | ... | ... | ... | baseline |
-| preview | ... | ... | ... | faster import/render |
-| quality | ... | ... | ... | higher DEM detail |
+| Grid setting | Columns x Rows | Grid Points | Renderer Geometry VRAM | Displacement/CPU-side cost | Use |
+|---|---:|---:|---:|---:|---|
+| default: 2.0 m, max 1024 | ... | ... | ... | ... | baseline |
+| preview | ... | ... | ... | ... | faster import/render |
+| quality | ... | ... | ... | ... | higher DEM detail |
 ```
 
 Then list:
@@ -95,8 +101,9 @@ Then list:
 - observed archive facts
 - package/file-size observations
 - texture format assumptions
-- texture VRAM estimate
-- geometry VRAM estimate
+- renderer texture VRAM estimate
+- renderer geometry VRAM estimate
+- CPU/engine-side or payload memory estimate when relevant
 - DEM surface source actually sampled or assumed
 - DEM surface imagery cost
 - terrain mesh mode and Grid resolution recommendation
@@ -108,7 +115,9 @@ Then list:
 - Do not present hypotheses as conclusions.
 - Do not narrow the answer to VRAM when dataset quality, package/LOD coverage, import cost, or rendering risk can also be estimated from the same bounded investigation.
 - Do not use raw RGBA-only accounting as the primary answer when compressed runtime formats are part of the question.
+- Do not use BC7 as the default PLATEAU renderer texture estimate without live engine-state evidence.
 - Do not hide DEM surface imagery inside DEM geometry; report it as its own texture cost.
-- Do not treat Grid as texture-only. In this repo it becomes GridMesh-style geometry plus implementation-dependent displacement data.
+- Do not treat Grid as texture-only. In this repo it becomes GridMesh-style geometry plus CPU/engine-side displacement data.
+- Do not count Grid displacement as renderer texture VRAM by default. If the user asks for renderer VRAM, keep displacement separate from Renderer Total unless live inspection proves the engine keeps it as a GPU texture.
 - Do not confuse DEM surface imagery `MaxTextureSize` with Grid geometry resolution; Grid Points are controlled by `--terrain-grid-meters-per-vertex` and `--terrain-grid-max-resolution`.
 - Do not run a full live import just for a rough estimate unless the user asks for real measurement.

--- a/.agents/skills/plateau-dataset-estimate/agents/openai.yaml
+++ b/.agents/skills/plateau-dataset-estimate/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "PLATEAU Dataset Estimate"
   short_description: "Estimate PLATEAU dataset quality, import cost, and rendering risk"
-  default_prompt: "Use $plateau-dataset-estimate to estimate PLATEAU dataset quality, import cost, rendering risk, texture VRAM, geometry VRAM, DEM surface imagery, terrain mesh mode tradeoffs, and Grid resolution choices from official metadata and bounded archive sampling."
+  default_prompt: "Use $plateau-dataset-estimate to estimate PLATEAU dataset quality, import cost, rendering risk, texture VRAM, geometry VRAM, DEM surface imagery, terrain mesh mode tradeoffs, and Grid resolution choices from official metadata, stats output, and bounded archive sampling."

--- a/src/PlateauResoniteLink.Cli/CliApplication.cs
+++ b/src/PlateauResoniteLink.Cli/CliApplication.cs
@@ -170,6 +170,19 @@ public sealed class CliApplication
         await standardOutput.WriteLineAsync($"Mesh code counts: {FormatCounts(result.MeshCodeCounts)}");
         await standardOutput.WriteLineAsync($"LOD coverage counts: {FormatCounts(result.LodCoverageCounts)}");
         await standardOutput.WriteLineAsync($"Files without detected LOD: {result.FilesWithoutDetectedLod}");
+        await standardOutput.WriteLineAsync(
+            $"Renderer texture VRAM: {FormatBytes(result.ArchiveVramEstimate.RendererTextureVram.RendererTotalBytes)} "
+            + $"(BC1={FormatBytes(result.ArchiveVramEstimate.RendererTextureVram.Bc1Bytes)}, "
+            + $"BC3={FormatBytes(result.ArchiveVramEstimate.RendererTextureVram.Bc3Bytes)}, "
+            + $"RGBA32 payload upper bound={FormatBytes(result.ArchiveVramEstimate.RendererTextureVram.Rgba32PayloadBytes)})");
+        await standardOutput.WriteLineAsync(
+            $"Renderer geometry VRAM: {FormatBytes(result.ArchiveVramEstimate.RendererGeometryVram.RendererBytesMin)}"
+            + $"..{FormatBytes(result.ArchiveVramEstimate.RendererGeometryVram.RendererBytesMax)} "
+            + $"(positions={result.ArchiveVramEstimate.RendererGeometryVram.PositionCount.ToString(CultureInfo.InvariantCulture)}, "
+            + $"triangles={result.ArchiveVramEstimate.RendererGeometryVram.TriangleCount.ToString(CultureInfo.InvariantCulture)})");
+        await standardOutput.WriteLineAsync(
+            $"Renderer total VRAM: {FormatBytes(result.ArchiveVramEstimate.RendererTotalBytesMin)}"
+            + $"..{FormatBytes(result.ArchiveVramEstimate.RendererTotalBytesMax)}");
     }
 
     private static string FormatCsv(IReadOnlyList<string> values)
@@ -186,6 +199,12 @@ public sealed class CliApplication
                 ", ",
                 counts.Select(
                     static pair => $"{pair.Key}={pair.Value.ToString(CultureInfo.InvariantCulture)}"));
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        const double mib = 1024.0 * 1024.0;
+        return $"{(bytes / mib).ToString("0.##", CultureInfo.InvariantCulture)} MiB";
     }
 
     private async Task WriteDataSourceUsagesAsync(

--- a/src/PlateauResoniteLink/Application/Importing/DatasetInspectionService.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DatasetInspectionService.cs
@@ -8,10 +8,20 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
 namespace PlateauResoniteLink.Application.Importing;
 
 internal sealed class DatasetInspectionService(IPlateauDatasetContentSourceFactory datasetContentSourceFactory)
 {
+    private const int BcBlockPixelSize = 4;
+    private const int Bc1BlockBytes = 8;
+    private const int Bc3BlockBytes = 16;
+    private const int GeometryVertexBytesMin = 32;
+    private const int GeometryVertexBytesMax = 64;
+    private const int GeometryIndexBytes = 4;
+
     [SuppressMessage(
         "Performance",
         "CA1822:Mark members as static",
@@ -86,31 +96,69 @@ internal sealed class DatasetInspectionService(IPlateauDatasetContentSourceFacto
 
             Dictionary<int, int> lodCounts = [];
             int filesWithoutDetectedLod = 0;
+            Dictionary<string, HashSet<string>> textureReferencesByPackage = new(StringComparer.Ordinal);
+            Dictionary<string, GeometryVramAccumulator> geometryByPackage = new(StringComparer.Ordinal);
 
             foreach (LocalCityGmlDatasetSourceFileCandidate candidate in candidates)
             {
                 await using Stream stream = await datasetSource.OpenReadAsync(candidate.RelativePath, cancellationToken);
-                int[] lodLevels = await ReadStructuralLodLevelsAsync(stream, cancellationToken);
+                DatasetSourceFileStats sourceFileStats = await ReadSourceFileStatsAsync(
+                    stream,
+                    candidate.RelativePath,
+                    candidate.PackageName,
+                    datasetSource,
+                    cancellationToken);
 
-                if (lodLevels.Length == 0)
+                if (sourceFileStats.LodLevels.Count == 0)
                 {
                     filesWithoutDetectedLod++;
-                    continue;
                 }
 
-                foreach (int lodLevel in lodLevels)
+                foreach (int lodLevel in sourceFileStats.LodLevels)
                 {
                     lodCounts.TryGetValue(lodLevel, out int currentCount);
                     lodCounts[lodLevel] = currentCount + 1;
                 }
+
+                if (sourceFileStats.ResolvedTexturePaths.Count > 0)
+                {
+                    if (!textureReferencesByPackage.TryGetValue(candidate.PackageName, out HashSet<string>? textureReferences))
+                    {
+                        textureReferences = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        textureReferencesByPackage[candidate.PackageName] = textureReferences;
+                    }
+
+                    foreach (string texturePath in sourceFileStats.ResolvedTexturePaths)
+                    {
+                        textureReferences.Add(texturePath);
+                    }
+                }
+
+                GeometryVramAccumulator geometryAccumulator = GetOrCreateGeometryAccumulator(
+                    geometryByPackage,
+                    candidate.PackageName);
+                geometryAccumulator.PositionCount += sourceFileStats.Geometry.PositionCount;
+                geometryAccumulator.TriangleCount += sourceFileStats.Geometry.TriangleCount;
             }
+
+            DatasetTextureVramEstimate textureVramEstimate = await EstimateTextureVramAsync(
+                datasetSource,
+                textureReferencesByPackage,
+                cancellationToken);
+
+            DatasetGeometryVramEstimate geometryVramEstimate = CreateGeometryVramEstimate(geometryByPackage);
 
             return new DatasetStatsResult(
                 candidates.Length,
                 packageCounts,
                 meshCodeCounts,
                 lodCounts.OrderBy(static pair => pair.Key).ToDictionary(static pair => pair.Key, static pair => pair.Value),
-                filesWithoutDetectedLod);
+                filesWithoutDetectedLod,
+                new DatasetArchiveVramEstimate(
+                    textureVramEstimate,
+                    geometryVramEstimate,
+                    textureVramEstimate.RendererTotalBytes + geometryVramEstimate.RendererBytesMin,
+                    textureVramEstimate.RendererTotalBytes + geometryVramEstimate.RendererBytesMax));
         }
         catch (ArgumentException exception)
         {
@@ -118,8 +166,11 @@ internal sealed class DatasetInspectionService(IPlateauDatasetContentSourceFacto
         }
     }
 
-    private static async Task<int[]> ReadStructuralLodLevelsAsync(
+    private static async Task<DatasetSourceFileStats> ReadSourceFileStatsAsync(
         Stream stream,
+        string relativePath,
+        string packageName,
+        IPlateauDatasetContentSource datasetSource,
         CancellationToken cancellationToken)
     {
         try
@@ -133,25 +184,69 @@ internal sealed class DatasetInspectionService(IPlateauDatasetContentSourceFacto
             };
             using XmlReader reader = XmlReader.Create(stream, settings);
             HashSet<int> lodLevels = [];
+            HashSet<string> resolvedTexturePaths = new(StringComparer.OrdinalIgnoreCase);
+            GeometryVramAccumulator geometry = new();
+            int? parameterizedTextureDepth = null;
 
             while (await reader.ReadAsync())
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                if (reader.NodeType != XmlNodeType.Element
-                    || !IsRecognizedCityGmlNamespace(reader.NamespaceURI)
-                    || !TryParseLodLevel(reader.LocalName, out int lodLevel))
+                if (reader.NodeType == XmlNodeType.EndElement
+                    && parameterizedTextureDepth == reader.Depth
+                    && IsAppearanceElement(reader, "ParameterizedTexture"))
+                {
+                    parameterizedTextureDepth = null;
+                    continue;
+                }
+
+                if (reader.NodeType != XmlNodeType.Element)
                 {
                     continue;
                 }
 
-                lodLevels.Add(lodLevel);
+                if (IsAppearanceElement(reader, "ParameterizedTexture"))
+                {
+                    parameterizedTextureDepth = reader.IsEmptyElement ? null : reader.Depth;
+                    continue;
+                }
+
+                if (IsRecognizedCityGmlNamespace(reader.NamespaceURI)
+                    && TryParseLodLevel(reader.LocalName, out int lodLevel))
+                {
+                    lodLevels.Add(lodLevel);
+                }
+
+                if (IsGmlElement(reader, "posList"))
+                {
+                    int dimension = TryParsePositiveInt(reader.GetAttribute("srsDimension"), out int parsedDimension)
+                        ? parsedDimension
+                        : 3;
+                    string content = await reader.ReadElementContentAsStringAsync();
+                    AddPosListGeometry(content, dimension, geometry);
+                    continue;
+                }
+
+                if (parameterizedTextureDepth is not null
+                    && IsAppearanceElement(reader, "imageURI"))
+                {
+                    string imageUri = (await reader.ReadElementContentAsStringAsync()).Trim();
+                    string? resolvedPath = datasetSource.ResolveRelativePath(relativePath, imageUri);
+                    if (resolvedPath is not null
+                        && IsSupportedRasterImagePath(resolvedPath))
+                    {
+                        resolvedTexturePaths.Add(resolvedPath);
+                    }
+                }
             }
 
-            return lodLevels.OrderBy(static lod => lod).ToArray();
+            return new DatasetSourceFileStats(
+                lodLevels.OrderBy(static lod => lod).ToArray(),
+                resolvedTexturePaths.OrderBy(static path => path, StringComparer.Ordinal).ToArray(),
+                CreatePackageGeometryVramEstimate(packageName, geometry));
         }
         catch (XmlException)
         {
-            return [];
+            return new DatasetSourceFileStats([], [], CreatePackageGeometryVramEstimate(packageName, new GeometryVramAccumulator()));
         }
     }
 
@@ -185,6 +280,281 @@ internal sealed class DatasetInspectionService(IPlateauDatasetContentSourceFacto
                 out lodLevel);
     }
 
+    private static bool IsGmlElement(XmlReader reader, string localName)
+    {
+        return string.Equals(reader.LocalName, localName, StringComparison.Ordinal)
+            && reader.NamespaceURI.Contains("opengis.net/gml", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsAppearanceElement(XmlReader reader, string localName)
+    {
+        return string.Equals(reader.LocalName, localName, StringComparison.Ordinal)
+            && reader.NamespaceURI.Contains("citygml/appearance", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsSupportedRasterImagePath(string path)
+    {
+        string extension = Path.GetExtension(path);
+        return extension.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".png", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryParsePositiveInt(string? value, out int result)
+    {
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result)
+            && result > 0;
+    }
+
+    private static void AddPosListGeometry(string coordinateText, int dimension, GeometryVramAccumulator geometry)
+    {
+        int coordinateValueCount = CountCoordinateValues(coordinateText);
+        long positionCount = coordinateValueCount / dimension;
+        if (positionCount <= 0)
+        {
+            return;
+        }
+
+        long effectiveVertexCount = positionCount > 1 ? positionCount - 1 : positionCount;
+        geometry.PositionCount += effectiveVertexCount;
+        if (effectiveVertexCount >= 3)
+        {
+            geometry.TriangleCount += effectiveVertexCount - 2;
+        }
+    }
+
+    private static int CountCoordinateValues(string coordinateText)
+    {
+        int count = 0;
+        bool inToken = false;
+        foreach (char character in coordinateText)
+        {
+            if (char.IsWhiteSpace(character))
+            {
+                if (inToken)
+                {
+                    count++;
+                    inToken = false;
+                }
+
+                continue;
+            }
+
+            inToken = true;
+        }
+
+        return inToken ? count + 1 : count;
+    }
+
+    private static async Task<DatasetTextureVramEstimate> EstimateTextureVramAsync(
+        IPlateauDatasetContentSource datasetSource,
+        IReadOnlyDictionary<string, HashSet<string>> textureReferencesByPackage,
+        CancellationToken cancellationToken)
+    {
+        Dictionary<string, DatasetTextureVramEntry> textureEntries = new(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, TextureVramAccumulator> packageAccumulators = textureReferencesByPackage.Keys
+            .OrderBy(static packageName => packageName, StringComparer.Ordinal)
+            .ToDictionary(static packageName => packageName, static _ => new TextureVramAccumulator(), StringComparer.Ordinal);
+
+        foreach (string texturePath in textureReferencesByPackage.Values
+            .SelectMany(static paths => paths)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static path => path, StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DatasetTextureVramEntry? entry = await TryReadTextureVramEntryAsync(datasetSource, texturePath, cancellationToken);
+            if (entry is not null)
+            {
+                textureEntries[texturePath] = entry;
+            }
+        }
+
+        foreach ((string packageName, HashSet<string> texturePaths) in textureReferencesByPackage)
+        {
+            TextureVramAccumulator accumulator = packageAccumulators[packageName];
+            foreach (string texturePath in texturePaths)
+            {
+                if (textureEntries.TryGetValue(texturePath, out DatasetTextureVramEntry? entry))
+                {
+                    accumulator.Add(entry);
+                }
+                else
+                {
+                    accumulator.MissingTextureReferenceCount++;
+                }
+            }
+        }
+
+        int referencedTextureCount = textureReferencesByPackage.Values
+            .SelectMany(static paths => paths)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count();
+        TextureVramAccumulator total = new();
+        foreach (DatasetTextureVramEntry entry in textureEntries.Values)
+        {
+            total.Add(entry);
+        }
+
+        total.ReferencedTextureCount = referencedTextureCount;
+        total.MissingTextureReferenceCount = total.ReferencedTextureCount - total.ResolvedTextureFileCount;
+
+        return new DatasetTextureVramEstimate(
+            total.ReferencedTextureCount,
+            total.ResolvedTextureFileCount,
+            total.MissingTextureReferenceCount,
+            total.Bc1TextureCount,
+            total.Bc3TextureCount,
+            total.Bc1Bytes,
+            total.Bc3Bytes,
+            total.RendererTotalBytes,
+            total.Rgba32PayloadBytes,
+            packageAccumulators
+                .OrderBy(static pair => pair.Key, StringComparer.Ordinal)
+                .ToDictionary(
+                    static pair => pair.Key,
+                    static pair => pair.Value.ToEstimate(),
+                    StringComparer.Ordinal));
+    }
+
+    private static async Task<DatasetTextureVramEntry?> TryReadTextureVramEntryAsync(
+        IPlateauDatasetContentSource datasetSource,
+        string texturePath,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!datasetSource.FileExists(texturePath))
+            {
+                return null;
+            }
+
+            await using Stream stream = await datasetSource.OpenReadAsync(texturePath, cancellationToken);
+            using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream, cancellationToken);
+            bool hasEffectiveAlpha = HasNonOpaquePixels(image);
+            long rendererBytes = EstimateBlockCompressedTextureBytes(
+                image.Width,
+                image.Height,
+                hasEffectiveAlpha ? Bc3BlockBytes : Bc1BlockBytes);
+
+            return new DatasetTextureVramEntry(
+                texturePath,
+                image.Width,
+                image.Height,
+                hasEffectiveAlpha,
+                rendererBytes,
+                (long)image.Width * image.Height * 4);
+        }
+        catch (UnknownImageFormatException)
+        {
+            return null;
+        }
+        catch (InvalidImageContentException)
+        {
+            return null;
+        }
+    }
+
+    private static bool HasNonOpaquePixels(Image<Rgba32> image)
+    {
+        bool hasNonOpaquePixels = false;
+        image.ProcessPixelRows(accessor =>
+        {
+            for (int y = 0; y < accessor.Height; y++)
+            {
+                ReadOnlySpan<Rgba32> row = accessor.GetRowSpan(y);
+                foreach (Rgba32 pixel in row)
+                {
+                    if (pixel.A != byte.MaxValue)
+                    {
+                        hasNonOpaquePixels = true;
+                        return;
+                    }
+                }
+            }
+        });
+        return hasNonOpaquePixels;
+    }
+
+    private static long EstimateBlockCompressedTextureBytes(int width, int height, int blockBytes)
+    {
+        long totalBytes = 0;
+        int mipWidth = width;
+        int mipHeight = height;
+        while (true)
+        {
+            long blocksWide = Math.Max(1, (mipWidth + BcBlockPixelSize - 1) / BcBlockPixelSize);
+            long blocksHigh = Math.Max(1, (mipHeight + BcBlockPixelSize - 1) / BcBlockPixelSize);
+            totalBytes += blocksWide * blocksHigh * blockBytes;
+
+            if (mipWidth == 1 && mipHeight == 1)
+            {
+                return totalBytes;
+            }
+
+            mipWidth = Math.Max(1, mipWidth / 2);
+            mipHeight = Math.Max(1, mipHeight / 2);
+        }
+    }
+
+    private static DatasetGeometryVramEstimate CreateGeometryVramEstimate(
+        IReadOnlyDictionary<string, GeometryVramAccumulator> geometryByPackage)
+    {
+        Dictionary<string, DatasetPackageGeometryVramEstimate> packageEstimates = geometryByPackage
+            .OrderBy(static pair => pair.Key, StringComparer.Ordinal)
+            .ToDictionary(
+                static pair => pair.Key,
+                static pair => CreatePackageGeometryVramEstimate(pair.Key, pair.Value),
+                StringComparer.Ordinal);
+
+        long positionCount = packageEstimates.Values.Sum(static estimate => estimate.PositionCount);
+        long triangleCount = packageEstimates.Values.Sum(static estimate => estimate.TriangleCount);
+        long vertexBufferBytesMin = positionCount * GeometryVertexBytesMin;
+        long vertexBufferBytesMax = positionCount * GeometryVertexBytesMax;
+        long indexBufferBytes = triangleCount * 3 * GeometryIndexBytes;
+
+        return new DatasetGeometryVramEstimate(
+            positionCount,
+            triangleCount,
+            vertexBufferBytesMin,
+            vertexBufferBytesMax,
+            indexBufferBytes,
+            vertexBufferBytesMin + indexBufferBytes,
+            vertexBufferBytesMax + indexBufferBytes,
+            packageEstimates);
+    }
+
+    private static DatasetPackageGeometryVramEstimate CreatePackageGeometryVramEstimate(
+        string packageName,
+        GeometryVramAccumulator accumulator)
+    {
+        long vertexBufferBytesMin = accumulator.PositionCount * GeometryVertexBytesMin;
+        long vertexBufferBytesMax = accumulator.PositionCount * GeometryVertexBytesMax;
+        long indexBufferBytes = accumulator.TriangleCount * 3 * GeometryIndexBytes;
+
+        return new DatasetPackageGeometryVramEstimate(
+            packageName,
+            accumulator.PositionCount,
+            accumulator.TriangleCount,
+            vertexBufferBytesMin,
+            vertexBufferBytesMax,
+            indexBufferBytes,
+            vertexBufferBytesMin + indexBufferBytes,
+            vertexBufferBytesMax + indexBufferBytes);
+    }
+
+    private static GeometryVramAccumulator GetOrCreateGeometryAccumulator(
+        Dictionary<string, GeometryVramAccumulator> geometryByPackage,
+        string packageName)
+    {
+        if (!geometryByPackage.TryGetValue(packageName, out GeometryVramAccumulator? accumulator))
+        {
+            accumulator = new GeometryVramAccumulator();
+            geometryByPackage[packageName] = accumulator;
+        }
+
+        return accumulator;
+    }
+
     private static string? ResolveRepresentativeMeshCode(LocalCityGmlDatasetSourceFileCandidate candidate)
     {
         return candidate.FileMeshCodes
@@ -211,4 +581,126 @@ public sealed record DatasetStatsResult(
     IReadOnlyDictionary<string, int> PackageCounts,
     IReadOnlyDictionary<string, int> MeshCodeCounts,
     IReadOnlyDictionary<int, int> LodCoverageCounts,
-    int FilesWithoutDetectedLod);
+    int FilesWithoutDetectedLod,
+    DatasetArchiveVramEstimate ArchiveVramEstimate);
+
+public sealed record DatasetArchiveVramEstimate(
+    DatasetTextureVramEstimate RendererTextureVram,
+    DatasetGeometryVramEstimate RendererGeometryVram,
+    long RendererTotalBytesMin,
+    long RendererTotalBytesMax);
+
+public sealed record DatasetTextureVramEstimate(
+    int ReferencedTextureCount,
+    int ResolvedTextureFileCount,
+    int MissingTextureReferenceCount,
+    long Bc1TextureCount,
+    long Bc3TextureCount,
+    long Bc1Bytes,
+    long Bc3Bytes,
+    long RendererTotalBytes,
+    long Rgba32PayloadBytes,
+    IReadOnlyDictionary<string, DatasetPackageTextureVramEstimate> PackageEstimates);
+
+public sealed record DatasetPackageTextureVramEstimate(
+    int ResolvedTextureFileCount,
+    int MissingTextureReferenceCount,
+    long Bc1TextureCount,
+    long Bc3TextureCount,
+    long Bc1Bytes,
+    long Bc3Bytes,
+    long RendererTotalBytes,
+    long Rgba32PayloadBytes);
+
+public sealed record DatasetGeometryVramEstimate(
+    long PositionCount,
+    long TriangleCount,
+    long VertexBufferBytesMin,
+    long VertexBufferBytesMax,
+    long IndexBufferBytes,
+    long RendererBytesMin,
+    long RendererBytesMax,
+    IReadOnlyDictionary<string, DatasetPackageGeometryVramEstimate> PackageEstimates);
+
+public sealed record DatasetPackageGeometryVramEstimate(
+    string PackageName,
+    long PositionCount,
+    long TriangleCount,
+    long VertexBufferBytesMin,
+    long VertexBufferBytesMax,
+    long IndexBufferBytes,
+    long RendererBytesMin,
+    long RendererBytesMax);
+
+internal sealed record DatasetSourceFileStats(
+    IReadOnlyList<int> LodLevels,
+    IReadOnlyList<string> ResolvedTexturePaths,
+    DatasetPackageGeometryVramEstimate Geometry);
+
+internal sealed record DatasetTextureVramEntry(
+    string RelativePath,
+    int Width,
+    int Height,
+    bool HasEffectiveAlpha,
+    long RendererBytes,
+    long Rgba32PayloadBytes);
+
+internal sealed class TextureVramAccumulator
+{
+    public int ReferencedTextureCount { get; set; }
+
+    public int ResolvedTextureFileCount { get; set; }
+
+    public int MissingTextureReferenceCount { get; set; }
+
+    public long Bc1TextureCount { get; set; }
+
+    public long Bc3TextureCount { get; set; }
+
+    public long Bc1Bytes { get; set; }
+
+    public long Bc3Bytes { get; set; }
+
+    public long RendererTotalBytes { get; set; }
+
+    public long Rgba32PayloadBytes { get; set; }
+
+    public void Add(DatasetTextureVramEntry entry)
+    {
+        ReferencedTextureCount++;
+        ResolvedTextureFileCount++;
+        if (entry.HasEffectiveAlpha)
+        {
+            Bc3TextureCount++;
+            Bc3Bytes += entry.RendererBytes;
+        }
+        else
+        {
+            Bc1TextureCount++;
+            Bc1Bytes += entry.RendererBytes;
+        }
+
+        RendererTotalBytes += entry.RendererBytes;
+        Rgba32PayloadBytes += entry.Rgba32PayloadBytes;
+    }
+
+    public DatasetPackageTextureVramEstimate ToEstimate()
+    {
+        return new DatasetPackageTextureVramEstimate(
+            ResolvedTextureFileCount,
+            MissingTextureReferenceCount,
+            Bc1TextureCount,
+            Bc3TextureCount,
+            Bc1Bytes,
+            Bc3Bytes,
+            RendererTotalBytes,
+            Rgba32PayloadBytes);
+    }
+}
+
+internal sealed class GeometryVramAccumulator
+{
+    public long PositionCount { get; set; }
+
+    public long TriangleCount { get; set; }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -34,6 +34,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         List<BatchPlanComponentLocator> componentResolutionTargets = [];
         int nextSlotLocator = 0;
         int nextComponentLocator = 0;
+        int nextFieldLocator = 0;
 
         BatchPlanSlotLocator meshAssetSlotId = CreateBatchPlanSlotLocator(ref nextSlotLocator);
         slotEmissions.Add(new PlannedBatchSlotEmission(
@@ -78,12 +79,11 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                     ResoniteGeometryAssetAssembler.CreateTerrainGridTextureMembers(heightMap.HeightTextureUri)
                         .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal)));
                 double displacementMagnitude = Math.Max(heightMap.Geometry.MaxHeight - heightMap.Geometry.MinHeight, 0.0);
-                string pointsFieldId = CreatePlannedTerrainGridPointsFieldId(geometryComponentId);
+                BatchPlanFieldLocator pointsFieldId = CreateBatchPlanFieldLocator(ref nextFieldLocator);
                 terrainGridMeshMembers = new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
                 {
-                    ["Points"] = PlannedMembers.Literal(new Field_int2
+                    ["Points"] = PlannedMembers.AddressableField(pointsFieldId, new Field_int2
                     {
-                        ID = pointsFieldId,
                         Value = new int2
                         {
                             x = heightMap.Geometry.Width,
@@ -220,27 +220,17 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             componentResolutionTargets);
     }
 
-    private static string CreatePlannedTerrainGridPointsFieldId(BatchPlanComponentLocator gridMeshComponentId)
-    {
-        return string.Create(
-            System.Globalization.CultureInfo.InvariantCulture,
-            $"local_field_terrain_grid_points_{gridMeshComponentId.Value}");
-    }
-
     private static Dictionary<string, PlannedMember> CreateTerrainGridPointsDriverMembers(
         IReadOnlyDictionary<string, PlannedMember> gridMeshMembers)
     {
-        Field_int2 gridPoints = AssertTerrainGridPointsMember(gridMeshMembers);
+        (BatchPlanFieldLocator gridPointsId, Field_int2 gridPoints) = AssertTerrainGridPointsMember(gridMeshMembers);
         return new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
         {
             ["VariableName"] = PlannedMembers.Literal(new Field_string
             {
                 Value = TerrainGridPointsDynamicVariableName,
             }),
-            ["Target"] = PlannedMembers.Literal(new Reference
-            {
-                TargetID = gridPoints.ID,
-            }),
+            ["Target"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(gridPointsId)),
             ["DefaultValue"] = PlannedMembers.Literal(new Field_int2
             {
                 Value = gridPoints.Value,
@@ -248,14 +238,13 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         };
     }
 
-    private static Field_int2 AssertTerrainGridPointsMember(
+    private static (BatchPlanFieldLocator Identity, Field_int2 Field) AssertTerrainGridPointsMember(
         IReadOnlyDictionary<string, PlannedMember> gridMeshMembers)
     {
         return gridMeshMembers.TryGetValue("Points", out PlannedMember? pointsMember)
-            && pointsMember is PlannedLiteralMember { Value: Field_int2 points }
-            && !string.IsNullOrWhiteSpace(points.ID)
-            ? points
-            : throw new InvalidOperationException("Terrain GridMesh Points member must be planned with a stable field id.");
+            && pointsMember is PlannedAddressableFieldMember { Identity: var identity, Value: Field_int2 points }
+            ? (identity, points)
+            : throw new InvalidOperationException("Terrain GridMesh Points member must be planned as an addressable field.");
     }
 
     private static PlannedWorldElementReference AddPlannedDedicatedMaterialEmissions(
@@ -463,5 +452,10 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
     private static BatchPlanComponentLocator CreateBatchPlanComponentLocator(ref int nextComponentLocator)
     {
         return new BatchPlanComponentLocator(++nextComponentLocator);
+    }
+
+    private static BatchPlanFieldLocator CreateBatchPlanFieldLocator(ref int nextFieldLocator)
+    {
+        return new BatchPlanFieldLocator(++nextFieldLocator);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -17,6 +17,9 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 {
     private const float DefaultNormalScale = 1.0f;
     private const float DefaultBundledHeightScale = 0.002f;
+    private const string TerrainGridPointsDynamicVariableName = "PLATEAU.Terrain.Grid.Points";
+    private const string DynamicValueVariableDriverInt2ComponentType =
+        "[FrooxEngine]FrooxEngine.DynamicValueVariableDriver`1[[Elements.Core.int2, Elements.Core]]";
 
     public PlannedBatchEmission Create(
         ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots,
@@ -42,6 +45,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         slotResolutionTargets.Add(meshAssetSlotId);
 
         BatchPlanComponentLocator geometryComponentId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
+        Dictionary<string, PlannedMember>? terrainGridMeshMembers = null;
         switch (emissionPlan.GeometryAsset)
         {
             case PlannedTriangleMeshGeometryAsset triangleMesh:
@@ -74,10 +78,12 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                     ResoniteGeometryAssetAssembler.CreateTerrainGridTextureMembers(heightMap.HeightTextureUri)
                         .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal)));
                 double displacementMagnitude = Math.Max(heightMap.Geometry.MaxHeight - heightMap.Geometry.MinHeight, 0.0);
-                Dictionary<string, PlannedMember> gridMeshMembers = new(StringComparer.Ordinal)
+                string pointsFieldId = CreatePlannedTerrainGridPointsFieldId(geometryComponentId);
+                terrainGridMeshMembers = new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
                 {
                     ["Points"] = PlannedMembers.Literal(new Field_int2
                     {
+                        ID = pointsFieldId,
                         Value = new int2
                         {
                             x = heightMap.Geometry.Width,
@@ -100,7 +106,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 };
                 if (heightMap.UvScale is not null)
                 {
-                    gridMeshMembers["UVScale"] = PlannedMembers.Literal(new Field_float2
+                    terrainGridMeshMembers["UVScale"] = PlannedMembers.Literal(new Field_float2
                     {
                         Value = new float2
                         {
@@ -112,7 +118,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 
                 if (heightMap.UvOffset is not null)
                 {
-                    gridMeshMembers["UVOffset"] = PlannedMembers.Literal(new Field_float2
+                    terrainGridMeshMembers["UVOffset"] = PlannedMembers.Literal(new Field_float2
                     {
                         Value = new float2
                         {
@@ -121,12 +127,6 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                         },
                     });
                 }
-
-                componentEmissions.Add(new PlannedBatchComponentEmission(
-                    geometryComponentId,
-                    PlannedSlotTargetReference.PlannedSlot(meshAssetSlotId),
-                    "[FrooxEngine]FrooxEngine.GridMesh",
-                    gridMeshMembers));
                 break;
             default:
                 throw new InvalidOperationException(
@@ -167,6 +167,20 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             objectSlots.CityObjectRotation));
         slotResolutionTargets.Add(presentationSlotId);
 
+        if (terrainGridMeshMembers is not null)
+        {
+            componentEmissions.Add(new PlannedBatchComponentEmission(
+                geometryComponentId,
+                PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
+                "[FrooxEngine]FrooxEngine.GridMesh",
+                terrainGridMeshMembers));
+            componentEmissions.Add(new PlannedBatchComponentEmission(
+                CreateBatchPlanComponentLocator(ref nextComponentLocator),
+                PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
+                DynamicValueVariableDriverInt2ComponentType,
+                CreateTerrainGridPointsDriverMembers(terrainGridMeshMembers)));
+        }
+
         componentEmissions.Add(new PlannedBatchComponentEmission(
             CreateBatchPlanComponentLocator(ref nextComponentLocator),
             PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
@@ -204,6 +218,44 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             componentEmissions,
             slotResolutionTargets,
             componentResolutionTargets);
+    }
+
+    private static string CreatePlannedTerrainGridPointsFieldId(BatchPlanComponentLocator gridMeshComponentId)
+    {
+        return string.Create(
+            System.Globalization.CultureInfo.InvariantCulture,
+            $"local_field_terrain_grid_points_{gridMeshComponentId.Value}");
+    }
+
+    private static Dictionary<string, PlannedMember> CreateTerrainGridPointsDriverMembers(
+        IReadOnlyDictionary<string, PlannedMember> gridMeshMembers)
+    {
+        Field_int2 gridPoints = AssertTerrainGridPointsMember(gridMeshMembers);
+        return new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
+        {
+            ["VariableName"] = PlannedMembers.Literal(new Field_string
+            {
+                Value = TerrainGridPointsDynamicVariableName,
+            }),
+            ["Target"] = PlannedMembers.Literal(new Reference
+            {
+                TargetID = gridPoints.ID,
+            }),
+            ["DefaultValue"] = PlannedMembers.Literal(new Field_int2
+            {
+                Value = gridPoints.Value,
+            }),
+        };
+    }
+
+    private static Field_int2 AssertTerrainGridPointsMember(
+        IReadOnlyDictionary<string, PlannedMember> gridMeshMembers)
+    {
+        return gridMeshMembers.TryGetValue("Points", out PlannedMember? pointsMember)
+            && pointsMember is PlannedLiteralMember { Value: Field_int2 points }
+            && !string.IsNullOrWhiteSpace(points.ID)
+            ? points
+            : throw new InvalidOperationException("Terrain GridMesh Points member must be planned with a stable field id.");
     }
 
     private static PlannedWorldElementReference AddPlannedDedicatedMaterialEmissions(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteBatchOperations.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteBatchOperations.cs
@@ -13,6 +13,7 @@ internal static class ResoniteBatchOperations
 {
     internal readonly record struct BatchTemporarySlotId(string Value);
     internal readonly record struct BatchTemporaryComponentId(string Value);
+    internal readonly record struct BatchTemporaryFieldId(string Value);
     internal readonly record struct BatchTemporaryMessageId(string Value);
 
     internal readonly record struct PendingBatchSlot(
@@ -126,6 +127,11 @@ internal static class ResoniteBatchOperations
             return new PendingBatchComponent(localId, messageId, componentType);
         }
 
+        public BatchTemporaryFieldId AllocateFieldId()
+        {
+            return CreateTemporaryFieldId("local_field", batchScopeToken, ++nextEntityId);
+        }
+
         private BatchTemporarySlotId AllocateSlotId(string prefix)
         {
             return CreateTemporarySlotId(prefix, batchScopeToken, ++nextEntityId);
@@ -157,6 +163,15 @@ internal static class ResoniteBatchOperations
         int? sequence = null)
     {
         return new BatchTemporaryComponentId(
+            FormatRequestLocalId(prefix, batchScopeToken, sequence));
+    }
+
+    private static BatchTemporaryFieldId CreateTemporaryFieldId(
+        string prefix,
+        string batchScopeToken,
+        int? sequence = null)
+    {
+        return new BatchTemporaryFieldId(
             FormatRequestLocalId(prefix, batchScopeToken, sequence));
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -44,6 +44,7 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         ResoniteBatchOperations.BatchActionBuilder batchBuilder = new();
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId = new();
         Dictionary<BatchPlanComponentLocator, ResoniteBatchOperations.PendingBatchComponent> pendingComponentsByPlanId = new();
+        Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId = new();
 
         foreach (PlannedBatchSlotEmission slotEmission in batchEmission.SlotEmissions)
         {
@@ -60,7 +61,9 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
             Dictionary<string, Member> translatedMembers = TranslateMembers(
                 componentEmission.Members,
                 pendingSlotsByPlanId,
-                pendingComponentsByPlanId);
+                pendingComponentsByPlanId,
+                pendingFieldsByPlanId,
+                batchBuilder);
             if (string.Equals(componentEmission.ComponentType, "[FrooxEngine]FrooxEngine.GridMesh", StringComparison.Ordinal)
                 && translatedMembers.TryGetValue("Points", out Member? pointsMember)
                 && translatedMembers.TryGetValue("DisplacementMagnitude", out Member? displacementMember)
@@ -128,7 +131,9 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
     private static string ResolveWorldElementId(
         PlannedWorldElementReference target,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId,
-        Dictionary<BatchPlanComponentLocator, ResoniteBatchOperations.PendingBatchComponent> pendingComponentsByPlanId)
+        Dictionary<BatchPlanComponentLocator, ResoniteBatchOperations.PendingBatchComponent> pendingComponentsByPlanId,
+        Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
+        ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
         if (target.CanonicalSlot is ResoniteSlotLocator canonicalSlot)
         {
@@ -152,39 +157,95 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
             return pendingComponent.LocalId.Value;
         }
 
+        if (target.PlannedField is BatchPlanFieldLocator plannedField)
+        {
+            return ResolveFieldId(plannedField, pendingFieldsByPlanId, batchBuilder).Value;
+        }
+
         throw new InvalidOperationException("Batch world element reference did not resolve to a planned or canonical entity.");
     }
 
     private static Dictionary<string, Member> TranslateMembers(
         IReadOnlyDictionary<string, PlannedMember> members,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId,
-        Dictionary<BatchPlanComponentLocator, ResoniteBatchOperations.PendingBatchComponent> pendingComponentsByPlanId)
+        Dictionary<BatchPlanComponentLocator, ResoniteBatchOperations.PendingBatchComponent> pendingComponentsByPlanId,
+        Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
+        ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
         return members.ToDictionary(
             static pair => pair.Key,
-            pair => TranslateMember(pair.Value, pendingSlotsByPlanId, pendingComponentsByPlanId),
+            pair => TranslateMember(pair.Value, pendingSlotsByPlanId, pendingComponentsByPlanId, pendingFieldsByPlanId, batchBuilder),
             StringComparer.Ordinal);
     }
 
     private static Member TranslateMember(
         PlannedMember member,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId,
-        Dictionary<BatchPlanComponentLocator, ResoniteBatchOperations.PendingBatchComponent> pendingComponentsByPlanId)
+        Dictionary<BatchPlanComponentLocator, ResoniteBatchOperations.PendingBatchComponent> pendingComponentsByPlanId,
+        Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
+        ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
         return member switch
         {
             PlannedLiteralMember literal => literal.Value,
             PlannedElementReferenceMember reference => new Reference
             {
-                TargetID = ResolveWorldElementId(reference.Target, pendingSlotsByPlanId, pendingComponentsByPlanId),
+                TargetID = ResolveWorldElementId(
+                    reference.Target,
+                    pendingSlotsByPlanId,
+                    pendingComponentsByPlanId,
+                    pendingFieldsByPlanId,
+                    batchBuilder),
             },
+            PlannedAddressableFieldMember addressableField => TranslateAddressableField(
+                addressableField,
+                pendingFieldsByPlanId,
+                batchBuilder),
             PlannedSyncListMember syncList => new SyncList
             {
                 Elements = syncList.Elements
-                    .Select(element => TranslateMember(element, pendingSlotsByPlanId, pendingComponentsByPlanId))
+                    .Select(element => TranslateMember(
+                        element,
+                        pendingSlotsByPlanId,
+                        pendingComponentsByPlanId,
+                        pendingFieldsByPlanId,
+                        batchBuilder))
                     .ToList(),
             },
             _ => throw new InvalidOperationException($"Unsupported planned member type '{member.GetType().Name}'."),
         };
+    }
+
+    private static Field_int2 TranslateAddressableField(
+        PlannedAddressableFieldMember addressableField,
+        Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
+        ResoniteBatchOperations.BatchActionBuilder batchBuilder)
+    {
+        string fieldId = ResolveFieldId(addressableField.Identity, pendingFieldsByPlanId, batchBuilder).Value;
+        return addressableField.Value switch
+        {
+            Field_int2 value => new Field_int2
+            {
+                ID = fieldId,
+                Value = value.Value,
+            },
+            _ => throw new InvalidOperationException(
+                $"Unsupported planned addressable field member type '{addressableField.Value.GetType().Name}'."),
+        };
+    }
+
+    private static ResoniteBatchOperations.BatchTemporaryFieldId ResolveFieldId(
+        BatchPlanFieldLocator locator,
+        Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
+        ResoniteBatchOperations.BatchActionBuilder batchBuilder)
+    {
+        if (pendingFieldsByPlanId.TryGetValue(locator, out ResoniteBatchOperations.BatchTemporaryFieldId fieldId))
+        {
+            return fieldId;
+        }
+
+        ResoniteBatchOperations.BatchTemporaryFieldId allocatedFieldId = batchBuilder.AllocateFieldId();
+        pendingFieldsByPlanId[locator] = allocatedFieldId;
+        return allocatedFieldId;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -80,6 +80,8 @@ internal readonly record struct BatchPlanSlotLocator(int Value);
 
 internal readonly record struct BatchPlanComponentLocator(int Value);
 
+internal readonly record struct BatchPlanFieldLocator(int Value);
+
 internal readonly record struct PlannedSlotTargetReference
 {
     private PlannedSlotTargetReference(ResoniteSlotLocator? canonical, BatchPlanSlotLocator? planned)
@@ -114,12 +116,14 @@ internal readonly record struct PlannedWorldElementReference
         ResoniteSlotLocator? canonicalSlot,
         ResoniteComponentLocator? canonicalComponent,
         BatchPlanSlotLocator? plannedSlot,
-        BatchPlanComponentLocator? plannedComponent)
+        BatchPlanComponentLocator? plannedComponent,
+        BatchPlanFieldLocator? plannedField)
     {
         CanonicalSlot = canonicalSlot;
         CanonicalComponent = canonicalComponent;
         PlannedSlot = plannedSlot;
         PlannedComponent = plannedComponent;
+        PlannedField = plannedField;
     }
 
     public ResoniteSlotLocator? CanonicalSlot { get; }
@@ -130,26 +134,33 @@ internal readonly record struct PlannedWorldElementReference
 
     public BatchPlanComponentLocator? PlannedComponent { get; }
 
+    public BatchPlanFieldLocator? PlannedField { get; }
+
     public static PlannedWorldElementReference Canonical(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedWorldElementReference(locator, null, null, null);
+        return new PlannedWorldElementReference(locator, null, null, null, null);
     }
 
     public static PlannedWorldElementReference Canonical(ResoniteComponentLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedWorldElementReference(null, locator, null, null);
+        return new PlannedWorldElementReference(null, locator, null, null, null);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanSlotLocator locator)
     {
-        return new PlannedWorldElementReference(null, null, locator, null);
+        return new PlannedWorldElementReference(null, null, locator, null, null);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanComponentLocator locator)
     {
-        return new PlannedWorldElementReference(null, null, null, locator);
+        return new PlannedWorldElementReference(null, null, null, locator, null);
+    }
+
+    public static PlannedWorldElementReference Planned(BatchPlanFieldLocator locator)
+    {
+        return new PlannedWorldElementReference(null, null, null, null, locator);
     }
 }
 
@@ -158,6 +169,8 @@ internal abstract record PlannedMember;
 internal sealed record PlannedLiteralMember(Member Value) : PlannedMember;
 
 internal sealed record PlannedElementReferenceMember(PlannedWorldElementReference Target) : PlannedMember;
+
+internal sealed record PlannedAddressableFieldMember(BatchPlanFieldLocator Identity, Member Value) : PlannedMember;
 
 internal sealed record PlannedSyncListMember(IReadOnlyList<PlannedMember> Elements) : PlannedMember;
 
@@ -172,6 +185,12 @@ internal static class PlannedMembers
     public static PlannedMember Reference(PlannedWorldElementReference target)
     {
         return new PlannedElementReferenceMember(target);
+    }
+
+    public static PlannedMember AddressableField(BatchPlanFieldLocator identity, Member value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return new PlannedAddressableFieldMember(identity, value);
     }
 
     public static PlannedMember List(params PlannedMember[] elements)

--- a/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
 
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
 namespace PlateauResoniteLink.Tests.Application;
 
 public sealed class DatasetInspectionServiceTests
@@ -43,6 +46,133 @@ public sealed class DatasetInspectionServiceTests
         Assert.Equal(2, result.LodCoverageCounts[1]);
         Assert.Equal(1, result.LodCoverageCounts[2]);
         Assert.Equal(1, result.FilesWithoutDetectedLod);
+    }
+
+    [Fact]
+    public async Task GetStatsAsyncEstimatesArchiveDerivedTextureAndGeometryVram()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        WriteDatasetFile(
+            datasetRoot.Path,
+            "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml",
+            """
+            <core:CityModel
+              xmlns:app="http://www.opengis.net/citygml/appearance/2.0"
+              xmlns:bldg="http://www.opengis.net/citygml/building/2.0"
+              xmlns:core="http://www.opengis.net/citygml/2.0"
+              xmlns:gml="http://www.opengis.net/gml">
+              <app:appearanceMember>
+                <app:Appearance>
+                  <app:surfaceDataMember>
+                    <app:ParameterizedTexture>
+                      <app:imageURI>appearance/opaque.png</app:imageURI>
+                    </app:ParameterizedTexture>
+                  </app:surfaceDataMember>
+                  <app:surfaceDataMember>
+                    <app:ParameterizedTexture>
+                      <app:imageURI>appearance/cutout.png</app:imageURI>
+                    </app:ParameterizedTexture>
+                  </app:surfaceDataMember>
+                </app:Appearance>
+              </app:appearanceMember>
+              <core:cityObjectMember>
+                <bldg:Building>
+                  <bldg:lod2MultiSurface>
+                    <gml:MultiSurface>
+                      <gml:surfaceMember>
+                        <gml:Polygon>
+                          <gml:exterior>
+                            <gml:LinearRing>
+                              <gml:posList>0 0 0 1 0 0 1 1 0 0 1 0 0 0 0</gml:posList>
+                            </gml:LinearRing>
+                          </gml:exterior>
+                        </gml:Polygon>
+                      </gml:surfaceMember>
+                    </gml:MultiSurface>
+                  </bldg:lod2MultiSurface>
+                </bldg:Building>
+              </core:cityObjectMember>
+            </core:CityModel>
+            """);
+        await WriteDatasetImageAsync(
+            datasetRoot.Path,
+            "udx/bldg/53394525/appearance/opaque.png",
+            new Rgba32(255, 255, 255, 255));
+        await WriteDatasetImageAsync(
+            datasetRoot.Path,
+            "udx/bldg/53394525/appearance/cutout.png",
+            new Rgba32(255, 255, 255, 128));
+
+        DatasetStatsResult result = await service.GetStatsAsync(datasetRoot.Path, ["bldg"]);
+
+        Assert.Equal(2, result.ArchiveVramEstimate.RendererTextureVram.ResolvedTextureFileCount);
+        Assert.Equal(1, result.ArchiveVramEstimate.RendererTextureVram.Bc1TextureCount);
+        Assert.Equal(1, result.ArchiveVramEstimate.RendererTextureVram.Bc3TextureCount);
+        Assert.Equal(24, result.ArchiveVramEstimate.RendererTextureVram.Bc1Bytes);
+        Assert.Equal(48, result.ArchiveVramEstimate.RendererTextureVram.Bc3Bytes);
+        Assert.Equal(72, result.ArchiveVramEstimate.RendererTextureVram.RendererTotalBytes);
+        Assert.Equal(128, result.ArchiveVramEstimate.RendererTextureVram.Rgba32PayloadBytes);
+        Assert.Equal(4, result.ArchiveVramEstimate.RendererGeometryVram.PositionCount);
+        Assert.Equal(2, result.ArchiveVramEstimate.RendererGeometryVram.TriangleCount);
+        Assert.Equal(152, result.ArchiveVramEstimate.RendererGeometryVram.RendererBytesMin);
+        Assert.Equal(280, result.ArchiveVramEstimate.RendererGeometryVram.RendererBytesMax);
+        Assert.Equal(224, result.ArchiveVramEstimate.RendererTotalBytesMin);
+        Assert.Equal(352, result.ArchiveVramEstimate.RendererTotalBytesMax);
+    }
+
+    [Fact]
+    public async Task GetStatsAsyncEstimatesVramInsideArchiveSource()
+    {
+        byte[] archiveBytes = CreateZipArchive(
+            (
+                "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml",
+                Encoding.UTF8.GetBytes(
+                    """
+                    <core:CityModel
+                      xmlns:app="http://www.opengis.net/citygml/appearance/2.0"
+                      xmlns:bldg="http://www.opengis.net/citygml/building/2.0"
+                      xmlns:core="http://www.opengis.net/citygml/2.0"
+                      xmlns:gml="http://www.opengis.net/gml">
+                      <app:appearanceMember>
+                        <app:Appearance>
+                          <app:surfaceDataMember>
+                            <app:ParameterizedTexture>
+                              <app:imageURI>appearance/opaque.png</app:imageURI>
+                            </app:ParameterizedTexture>
+                          </app:surfaceDataMember>
+                        </app:Appearance>
+                      </app:appearanceMember>
+                      <core:cityObjectMember>
+                        <bldg:Building>
+                          <bldg:lod2MultiSurface>
+                            <gml:MultiSurface>
+                              <gml:surfaceMember>
+                                <gml:Polygon>
+                                  <gml:exterior>
+                                    <gml:LinearRing>
+                                      <gml:posList>0 0 0 1 0 0 1 1 0 0 0 0</gml:posList>
+                                    </gml:LinearRing>
+                                  </gml:exterior>
+                                </gml:Polygon>
+                              </gml:surfaceMember>
+                            </gml:MultiSurface>
+                          </bldg:lod2MultiSurface>
+                        </bldg:Building>
+                      </core:cityObjectMember>
+                    </core:CityModel>
+                    """)),
+            ("udx/bldg/53394525/appearance/opaque.png", await CreatePngBytesAsync(new Rgba32(255, 255, 255, 255))));
+        using TemporaryDirectory workRoot = new();
+        string archivePath = Path.Combine(workRoot.Path, "dataset.zip");
+        await File.WriteAllBytesAsync(archivePath, archiveBytes);
+
+        DatasetStatsResult result = await service.GetStatsAsync(archivePath, ["bldg"]);
+
+        Assert.Equal(1, result.ArchiveVramEstimate.RendererTextureVram.ResolvedTextureFileCount);
+        Assert.Equal(1, result.ArchiveVramEstimate.RendererTextureVram.Bc1TextureCount);
+        Assert.Equal(24, result.ArchiveVramEstimate.RendererTextureVram.RendererTotalBytes);
+        Assert.Equal(3, result.ArchiveVramEstimate.RendererGeometryVram.PositionCount);
+        Assert.Equal(1, result.ArchiveVramEstimate.RendererGeometryVram.TriangleCount);
     }
 
     [Fact]
@@ -149,16 +279,39 @@ public sealed class DatasetInspectionServiceTests
         File.WriteAllText(absolutePath, content);
     }
 
+    private static async Task WriteDatasetImageAsync(string datasetRoot, string relativePath, Rgba32 color)
+    {
+        string absolutePath = Path.Combine(
+            datasetRoot,
+            relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(absolutePath)!);
+        using Image<Rgba32> image = new(4, 4, color);
+        await image.SaveAsPngAsync(absolutePath);
+    }
+
+    private static async Task<byte[]> CreatePngBytesAsync(Rgba32 color)
+    {
+        await using MemoryStream stream = new();
+        using Image<Rgba32> image = new(4, 4, color);
+        await image.SaveAsPngAsync(stream);
+        return stream.ToArray();
+    }
+
     private static byte[] CreateZipArchive(params (string Path, string Content)[] entries)
+    {
+        return CreateZipArchive(entries.Select(static entry => (entry.Path, Encoding.UTF8.GetBytes(entry.Content))).ToArray());
+    }
+
+    private static byte[] CreateZipArchive(params (string Path, byte[] Content)[] entries)
     {
         using MemoryStream stream = new();
         using (ZipArchive archive = new(stream, ZipArchiveMode.Create, leaveOpen: true))
         {
-            foreach ((string path, string content) in entries)
+            foreach ((string path, byte[] content) in entries)
             {
                 ZipArchiveEntry entry = archive.CreateEntry(path);
-                using StreamWriter writer = new(entry.Open(), Encoding.UTF8);
-                writer.Write(content);
+                using Stream entryStream = entry.Open();
+                entryStream.Write(content);
             }
         }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -311,6 +311,54 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
+    public async Task BuildAsyncCreatesDistinctTerrainGridPointsFieldIdsForMultipleDemGrids()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using SceneBuilderRecordingClient client = new();
+        ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            LocalOrigin,
+            packageNames: ["dem"],
+            sourceFiles:
+            [
+                $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml",
+            ]);
+        ResoniteConstructionCityObject first = CreateTerrainGridCityObject("terrain-grid-a", "Terrain Grid A");
+        ResoniteConstructionCityObject second = CreateTerrainGridCityObject("terrain-grid-b", "Terrain Grid B");
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(metadata, [first, second], client);
+
+        List<AddComponent> gridMeshRequests = client.AddedComponents
+            .Where(static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.GridMesh", StringComparison.Ordinal))
+            .ToList();
+        List<AddComponent> pointsDriverRequests = client.AddedComponents
+            .Where(static request => request.Data.ComponentType.Contains("DynamicValueVariableDriver", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.Equal(2, gridMeshRequests.Count);
+        Assert.Equal(2, pointsDriverRequests.Count);
+        Assert.Equal(2, client.ImportedRawHdrTextures.Count);
+
+        string[] pointsIds = gridMeshRequests
+            .Select(static request => Assert.IsType<Field_int2>(request.Data.Members["Points"]).ID)
+            .ToArray();
+        Assert.All(pointsIds, static id => Assert.False(string.IsNullOrWhiteSpace(id)));
+        Assert.Equal(2, pointsIds.Distinct(StringComparer.Ordinal).Count());
+
+        foreach (AddComponent gridMeshRequest in gridMeshRequests)
+        {
+            AddComponent pointsDriverRequest = Assert.Single(
+                pointsDriverRequests,
+                request => string.Equals(request.ContainerSlotId, gridMeshRequest.ContainerSlotId, StringComparison.Ordinal));
+            Field_int2 gridPoints = Assert.IsType<Field_int2>(gridMeshRequest.Data.Members["Points"]);
+            Assert.Equal("PLATEAU.Terrain.Grid.Points", Assert.IsType<Field_string>(pointsDriverRequest.Data.Members["VariableName"]).Value);
+            Assert.Equal(gridPoints.ID, Assert.IsType<Reference>(pointsDriverRequest.Data.Members["Target"]).TargetID);
+        }
+    }
+
+    [Fact]
     public async Task BuildAsyncAppliesTerrainOverlayUvTransformToGridMeshInsteadOfMaterial()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -1219,6 +1267,37 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 new ResoniteMeshSubmesh(0, "first-material", [0, 1, 2]),
                 new ResoniteMeshSubmesh(1, "second-material", [3, 4, 5]),
             ]);
+    }
+
+    private static ResoniteConstructionCityObject CreateTerrainGridCityObject(string slotKey, string displayName)
+    {
+        return new ResoniteConstructionCityObject(
+            SlotKey: slotKey,
+            DisplayName: displayName,
+            PackageName: "dem",
+            ActualMeshCode: MeshCode,
+            LodLevel: 0,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Geometry: new ResoniteTerrainGridGeometry(
+                Width: 2,
+                Height: 2,
+                Size: new ResoniteFloat2(10.0, 10.0),
+                MinHeight: 0.0,
+                MaxHeight: 3.0,
+                HeightSamples: [0.0, 1.0, 2.0, 3.0]),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: string.Concat("wireframe-", slotKey),
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Wireframe,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0]),
+            ],
+            SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
     }
 
     private static void AssertNoPlannedIds(Slot slot)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -277,13 +277,34 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Component gridMesh = Assert.Single(
             client.ComponentsById.Values,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.GridMesh", StringComparison.Ordinal));
+        AddComponent gridMeshRequest = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, gridMesh.ID, StringComparison.Ordinal));
+        Component pointsDriver = Assert.Single(
+            client.ComponentsById.Values,
+            static component => component.ComponentType.Contains("DynamicValueVariableDriver", StringComparison.Ordinal));
+        AddComponent pointsDriverRequest = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, pointsDriver.ID, StringComparison.Ordinal));
         Reference displacementTextureReference = Assert.IsType<Reference>(gridMesh.Members["DisplacementTexture"]);
         Component displacementTexture = client.ComponentsById[displacementTextureReference.TargetID];
+        AddComponent displacementTextureRequest = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, displacementTexture.ID, StringComparison.Ordinal));
         Assert.Equal("[FrooxEngine]FrooxEngine.StaticTexture2D", displacementTexture.ComponentType);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(displacementTexture.Members["WrapModeU"]).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(displacementTexture.Members["WrapModeV"]).Value);
         Assert.Equal("Point", Assert.IsType<Field_Nullable_Enum>(displacementTexture.Members["FilterMode"]).Value);
         Assert.False(Assert.IsType<Field_bool>(displacementTexture.Members["MipMaps"]).Value);
+        Assert.DoesNotContain("/Assets/", client.SlotPaths[gridMeshRequest.ContainerSlotId], StringComparison.Ordinal);
+        Assert.DoesNotContain("/Assets/", client.SlotPaths[pointsDriverRequest.ContainerSlotId], StringComparison.Ordinal);
+        Assert.Contains("/Assets/", client.SlotPaths[displacementTextureRequest.ContainerSlotId], StringComparison.Ordinal);
+        Field_int2 gridPoints = Assert.IsType<Field_int2>(gridMesh.Members["Points"]);
+        Assert.Equal("PLATEAU.Terrain.Grid.Points", Assert.IsType<Field_string>(pointsDriver.Members["VariableName"]).Value);
+        Assert.Equal(gridPoints.ID, Assert.IsType<Reference>(pointsDriver.Members["Target"]).TargetID);
+        Field_int2 defaultPoints = Assert.IsType<Field_int2>(pointsDriver.Members["DefaultValue"]);
+        Assert.Equal(2, defaultPoints.Value.x);
+        Assert.Equal(2, defaultPoints.Value.y);
         Assert.DoesNotContain(
             client.ComponentsById.Values,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -88,13 +88,14 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.False(Assert.IsType<Field_bool>(ToMember(heightTexture.Members["MipMaps"])).Value);
         Reference displacementTexture = Assert.IsType<Reference>(ToMember(gridMesh.Members["DisplacementTexture"]));
         Assert.Equal(ToPlannedTargetId(heightTexture.Identity), displacementTexture.TargetID);
-        Field_int2 gridPoints = Assert.IsType<Field_int2>(ToMember(gridMesh.Members["Points"]));
+        PlannedAddressableFieldMember gridPointsMember = Assert.IsType<PlannedAddressableFieldMember>(gridMesh.Members["Points"]);
+        Field_int2 gridPoints = Assert.IsType<Field_int2>(gridPointsMember.Value);
         Assert.Equal(2, gridPoints.Value.x);
         Assert.Equal(3, gridPoints.Value.y);
-        Assert.False(string.IsNullOrWhiteSpace(gridPoints.ID));
+        Assert.True(string.IsNullOrWhiteSpace(gridPoints.ID));
         Assert.Equal("PLATEAU.Terrain.Grid.Points", Assert.IsType<Field_string>(ToMember(pointsDriver.Members["VariableName"])).Value);
-        Reference pointsTarget = Assert.IsType<Reference>(ToMember(pointsDriver.Members["Target"]));
-        Assert.Equal(gridPoints.ID, pointsTarget.TargetID);
+        PlannedElementReferenceMember pointsTarget = Assert.IsType<PlannedElementReferenceMember>(pointsDriver.Members["Target"]);
+        Assert.Equal(gridPointsMember.Identity, pointsTarget.Target.PlannedField);
         Field_int2 defaultPoints = Assert.IsType<Field_int2>(ToMember(pointsDriver.Members["DefaultValue"]));
         Assert.Equal(2, defaultPoints.Value.x);
         Assert.Equal(3, defaultPoints.Value.y);
@@ -476,6 +477,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             {
                 TargetID = ResolveTargetId(reference.Target),
             },
+            PlannedAddressableFieldMember field => field.Value,
             PlannedSyncListMember syncList => new SyncList
             {
                 Elements = syncList.Elements.Select(ToMember).ToList(),
@@ -509,8 +511,13 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             return ToPlannedTargetId(plannedSlot);
         }
 
-        return target.PlannedComponent is BatchPlanComponentLocator plannedComponent
-            ? ToPlannedTargetId(plannedComponent)
+        if (target.PlannedComponent is BatchPlanComponentLocator plannedComponent)
+        {
+            return ToPlannedTargetId(plannedComponent);
+        }
+
+        return target.PlannedField is BatchPlanFieldLocator plannedField
+            ? ToPlannedTargetId(plannedField)
             : null;
     }
 
@@ -520,6 +527,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     }
 
     private static string ToPlannedTargetId(BatchPlanComponentLocator locator)
+    {
+        return locator.Value.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string ToPlannedTargetId(BatchPlanFieldLocator locator)
     {
         return locator.Value.ToString(CultureInfo.InvariantCulture);
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -51,6 +51,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object", StringComparison.Ordinal)
                 && slot.ParentTarget.Canonical == new ResoniteSlotLocator("asset-lod-slot"));
+        PlannedBatchSlotEmission presentationSlot = Assert.Single(
+            batchPlan.SlotEmissions,
+            static slot => string.Equals(slot.SlotName, "Terrain Grid Object", StringComparison.Ordinal)
+                && slot.ParentTarget.Canonical == new ResoniteSlotLocator("lod-slot"));
         PlannedBatchSlotEmission heightMapSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object_terrain-grid", StringComparison.Ordinal));
@@ -60,11 +64,22 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchComponentEmission gridMesh = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.GridMesh", StringComparison.Ordinal));
+        PlannedBatchComponentEmission pointsDriver = Assert.Single(
+            batchPlan.ComponentEmissions,
+            static component => component.ComponentType.Contains("DynamicValueVariableDriver", StringComparison.Ordinal));
+        PlannedBatchComponentEmission meshRenderer = Assert.Single(
+            batchPlan.ComponentEmissions,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal));
+        PlannedBatchComponentEmission meshCollider = Assert.Single(
+            batchPlan.ComponentEmissions,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshCollider", StringComparison.Ordinal));
 
         Assert.Equal(new ResoniteSlotLocator("asset-lod-slot"), AssertCanonical(meshAssetSlot.ParentTarget));
         Assert.False(meshAssetSlot.ParentTarget.IsPlanned);
         Assert.Equal(new ResoniteSlotLocator("asset-lod-slot"), AssertCanonical(heightMapSlot.ParentTarget));
         Assert.False(heightMapSlot.ParentTarget.IsPlanned);
+        Assert.Equal(presentationSlot.Identity, AssertPlanned(gridMesh.ContainerTarget));
+        Assert.Equal(presentationSlot.Identity, AssertPlanned(pointsDriver.ContainerTarget));
         Assert.Equal(heightMapSlot.Identity, AssertPlanned(heightTexture.ContainerTarget));
         Assert.True(heightTexture.ContainerTarget.IsPlanned);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(heightTexture.Members["WrapModeU"])).Value);
@@ -73,6 +88,18 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.False(Assert.IsType<Field_bool>(ToMember(heightTexture.Members["MipMaps"])).Value);
         Reference displacementTexture = Assert.IsType<Reference>(ToMember(gridMesh.Members["DisplacementTexture"]));
         Assert.Equal(ToPlannedTargetId(heightTexture.Identity), displacementTexture.TargetID);
+        Field_int2 gridPoints = Assert.IsType<Field_int2>(ToMember(gridMesh.Members["Points"]));
+        Assert.Equal(2, gridPoints.Value.x);
+        Assert.Equal(3, gridPoints.Value.y);
+        Assert.False(string.IsNullOrWhiteSpace(gridPoints.ID));
+        Assert.Equal("PLATEAU.Terrain.Grid.Points", Assert.IsType<Field_string>(ToMember(pointsDriver.Members["VariableName"])).Value);
+        Reference pointsTarget = Assert.IsType<Reference>(ToMember(pointsDriver.Members["Target"]));
+        Assert.Equal(gridPoints.ID, pointsTarget.TargetID);
+        Field_int2 defaultPoints = Assert.IsType<Field_int2>(ToMember(pointsDriver.Members["DefaultValue"]));
+        Assert.Equal(2, defaultPoints.Value.x);
+        Assert.Equal(3, defaultPoints.Value.y);
+        Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(meshRenderer.Members["Mesh"])).TargetID);
+        Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(meshCollider.Members["Mesh"])).TargetID);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- move DEM GridMesh components from terrain asset slots onto renderer/object presentation slots
- add same-slot DynamicValueVariableDriver<int2> for GridMesh Points using PLATEAU.Terrain.Grid.Points
- keep displacement StaticTexture2D placement under DatasetRoot/Assets and pin the planner/live-target behavior in tests

## Base
- Stacked on #151 / codex/vram-stats-estimate-skill

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
