### PR TITLE
[codex] Add dynamic DEM terrain mesh switching

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
@@ -37,7 +37,7 @@ public static class CliArgumentsParser
                                 Required. Local dataset/archive path or absolute direct .zip/.7z CityGML archive URL.
           --geotiff-source <path-or-url>
                                 Optional. Local GeoTIFF file/archive path or absolute .tif/.tiff/.zip/.7z GeoTIFF URL.
-          --terrain-mesh <static|grid>
+          --terrain-mesh <static|grid|dynamic>
                                 Optional. Terrain mesh style. Default: static.
           --terrain-grid-meters-per-vertex <value>
                                 Optional. Terrain grid sampling spacing in meters. Default: 2.0.
@@ -253,10 +253,14 @@ public static class CliArgumentsParser
                             {
                                 terrainMesh = TerrainMeshMode.Grid;
                             }
+                            else if (string.Equals(terrainMeshValue, "dynamic", StringComparison.OrdinalIgnoreCase))
+                            {
+                                terrainMesh = TerrainMeshMode.Dynamic;
+                            }
                             else
                             {
                                 return CliParseResult.Failure(
-                                    $"Unsupported terrain mesh '{terrainMeshValue}'. Use 'static' or 'grid'.");
+                                    $"Unsupported terrain mesh '{terrainMeshValue}'. Use 'static', 'grid', or 'dynamic'.");
                             }
 
                             break;

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -2976,23 +2976,13 @@ internal static partial class LocalCityGmlObjectProjection
                      demTerrainTextureOverlays,
                      requestedMeshAreas))
         {
-            ImportedCityObject cityObject = request.TerrainMeshMode == TerrainMeshMode.Grid
-                && string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
-                && TryProjectDemTerrainGridCityObject(
-                    splitCityObject.CityObject,
-                    globalOriginPoint,
-                    globalCartesian,
-                    splitCityObject.Overlay,
-                    request,
-                    materialResolver,
-                    out ImportedCityObject? heightMapCityObject)
-                    ? heightMapCityObject!
-                    : ProjectCityObject(
-                        splitCityObject.CityObject,
-                        globalOriginPoint,
-                        globalCartesian,
-                        splitCityObject.Overlay,
-                        materialResolver);
+            ImportedCityObject cityObject = ProjectTerrainMeshModeCityObject(
+                splitCityObject.CityObject,
+                globalOriginPoint,
+                globalCartesian,
+                splitCityObject.Overlay,
+                request,
+                materialResolver);
 
             if (HasRenderableGeometry(cityObject))
             {
@@ -3032,7 +3022,7 @@ internal static partial class LocalCityGmlObjectProjection
         }
 
         ImportedCityObject[] alignedCityObjects =
-            request.TerrainMeshMode == TerrainMeshMode.Grid
+            request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
             && string.Equals(terrainAlignedBootstrapCityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
                 ? AlignAdjacentDemTerrainGridChunkBoundaries(projectedCityObjects)
                 : [.. projectedCityObjects];
@@ -3081,7 +3071,7 @@ internal static partial class LocalCityGmlObjectProjection
                     splitCityObject.CityObject.ReferenceSystem.Geocentric)
                 : null;
 
-            foreach (MaterialBinding material in request.TerrainMeshMode == TerrainMeshMode.Grid
+            foreach (MaterialBinding material in request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
                          && string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
                             ? CreateDemTerrainGridMaterials(
                                 splitCityObject.CityObject,
@@ -3099,6 +3089,73 @@ internal static partial class LocalCityGmlObjectProjection
                 yield return material;
             }
         }
+    }
+
+    private static ImportedCityObject ProjectTerrainMeshModeCityObject(
+        global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject,
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        PlateauImportRequest request,
+        IDefaultMaterialResolver materialResolver)
+    {
+        bool isDem = string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase);
+        if (!isDem || request.TerrainMeshMode == TerrainMeshMode.Static)
+        {
+            return ProjectCityObject(cityObject, globalOriginPoint, globalCartesian, demTerrainTextureOverlay, materialResolver);
+        }
+
+        bool hasGrid = TryProjectDemTerrainGridCityObject(
+            cityObject,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlay,
+            request,
+            materialResolver,
+            out ImportedCityObject? heightMapCityObject);
+        if (!hasGrid)
+        {
+            return request.TerrainMeshMode == TerrainMeshMode.Dynamic
+                ? CreateNonRenderableCityObject(cityObject)
+                : ProjectCityObject(cityObject, globalOriginPoint, globalCartesian, demTerrainTextureOverlay, materialResolver);
+        }
+
+        if (request.TerrainMeshMode == TerrainMeshMode.Grid)
+        {
+            return heightMapCityObject!;
+        }
+
+        ImportedCityObject staticCityObject = ProjectCityObject(
+            cityObject,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlay,
+            materialResolver);
+        TriangleMeshGeometry staticMesh = AssertTriangleMeshGeometry(staticCityObject);
+        TriangleMeshGeometry rebasedStaticMesh = RebaseTriangleMeshToTransform(
+            staticMesh,
+            staticCityObject.Transform,
+            heightMapCityObject!.Transform);
+        return heightMapCityObject with
+        {
+            Geometry = new DynamicTerrainGeometry(rebasedStaticMesh, AssertTerrainGridGeometry(heightMapCityObject)),
+            Materials = staticCityObject.Materials,
+        };
+    }
+
+    private static ImportedCityObject CreateNonRenderableCityObject(
+        global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject)
+    {
+        return new ImportedCityObject(
+            cityObject.SlotKey,
+            cityObject.DisplayName,
+            cityObject.PackageName,
+            cityObject.ActualMeshCode,
+            cityObject.LodLevel,
+            new Transform3D(new Float3(0.0, 0.0, 0.0)),
+            new TriangleMeshGeometry(new ImportedMesh([], [])),
+            [],
+            SourceFileRelativePath: cityObject.SourceFileRelativePath);
     }
 
     private static global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject ConformCityObjectToTerrain(
@@ -3439,7 +3496,13 @@ internal static partial class LocalCityGmlObjectProjection
 
         public static TerrainGridChunkAlignmentState? TryCreate(ImportedCityObject cityObject)
         {
-            return cityObject.Geometry is TerrainGridGeometry geometry
+            TerrainGridGeometry? geometry = cityObject.Geometry switch
+            {
+                TerrainGridGeometry terrainGrid => terrainGrid,
+                DynamicTerrainGeometry dynamicTerrain => dynamicTerrain.GridMesh,
+                _ => null,
+            };
+            return geometry is not null
                 ? new TerrainGridChunkAlignmentState(cityObject, geometry, geometry.HeightSamples.ToArray())
                 : null;
         }
@@ -3448,21 +3511,38 @@ internal static partial class LocalCityGmlObjectProjection
         {
             double minHeight = HeightSamples.Min();
             double maxHeight = HeightSamples.Max();
+            Transform3D alignedTransform = CityObject.Transform with
+            {
+                Position = CityObject.Transform.Position with
+                {
+                    Y = BaseHeight + maxHeight,
+                },
+            };
 
             return CityObject with
             {
-                Transform = CityObject.Transform with
+                Transform = alignedTransform,
+                Geometry = CityObject.Geometry switch
                 {
-                    Position = CityObject.Transform.Position with
+                    DynamicTerrainGeometry dynamicTerrain => dynamicTerrain with
                     {
-                        Y = BaseHeight + maxHeight,
+                        StaticMesh = RebaseTriangleMeshToTransform(
+                            dynamicTerrain.StaticMesh,
+                            CityObject.Transform,
+                            alignedTransform),
+                        GridMesh = dynamicTerrain.GridMesh with
+                        {
+                            MinHeight = minHeight,
+                            MaxHeight = maxHeight,
+                            HeightSamples = HeightSamples,
+                        },
                     },
-                },
-                Geometry = Geometry with
-                {
-                    MinHeight = minHeight,
-                    MaxHeight = maxHeight,
-                    HeightSamples = HeightSamples,
+                    _ => Geometry with
+                    {
+                        MinHeight = minHeight,
+                        MaxHeight = maxHeight,
+                        HeightSamples = HeightSamples,
+                    },
                 },
             };
         }
@@ -3647,6 +3727,11 @@ internal static partial class LocalCityGmlObjectProjection
         out ImportedCityObject? heightMapCityObject)
     {
         heightMapCityObject = null;
+
+        if (cityObject.Surfaces.SelectMany(static surface => surface.Vertices).Take(3).Count() < 3)
+        {
+            return false;
+        }
 
         global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
@@ -4170,6 +4255,48 @@ internal static partial class LocalCityGmlObjectProjection
         return Add(transform.Position, rotated);
     }
 
+    private static TriangleMeshGeometry AssertTriangleMeshGeometry(ImportedCityObject cityObject)
+    {
+        return cityObject.Geometry as TriangleMeshGeometry
+            ?? throw new InvalidOperationException("Dynamic terrain static variant must be projected as a triangle mesh.");
+    }
+
+    private static TerrainGridGeometry AssertTerrainGridGeometry(ImportedCityObject cityObject)
+    {
+        return cityObject.Geometry as TerrainGridGeometry
+            ?? throw new InvalidOperationException("Dynamic terrain grid variant must be projected as a terrain grid.");
+    }
+
+    private static TriangleMeshGeometry RebaseTriangleMeshToTransform(
+        TriangleMeshGeometry source,
+        Transform3D sourceTransform,
+        Transform3D targetTransform)
+    {
+        ImportedMesh mesh = source.Mesh;
+        MeshVertex[] vertices = mesh.Vertices
+            .Select(vertex =>
+            {
+                Float3 worldPosition = TransformPointToWorld(sourceTransform, vertex.Position);
+                Float3 localPosition = TransformVectorFromWorld(targetTransform, Subtract(worldPosition, targetTransform.Position));
+                Float3 worldNormal = sourceTransform.Rotation is null ? vertex.Normal : Rotate(vertex.Normal, sourceTransform.Rotation);
+                Float3 localNormal = TransformVectorFromWorld(targetTransform, worldNormal);
+                return vertex with
+                {
+                    Position = localPosition,
+                    Normal = localNormal,
+                };
+            })
+            .ToArray();
+        return new TriangleMeshGeometry(new ImportedMesh(vertices, mesh.Submeshes));
+    }
+
+    private static Float3 TransformVectorFromWorld(Transform3D transform, Float3 worldVector)
+    {
+        return transform.Rotation is null
+            ? worldVector
+            : Rotate(worldVector, Conjugate(transform.Rotation));
+    }
+
     private static Float3 Rotate(Float3 value, Quaternion rotation)
     {
         Float3 qv = new(rotation.X, rotation.Y, rotation.Z);
@@ -4180,6 +4307,11 @@ internal static partial class LocalCityGmlObjectProjection
             Add(
                 Scale3(uv, 2.0 * rotation.W),
                 Scale3(uuv, 2.0)));
+    }
+
+    private static Quaternion Conjugate(Quaternion value)
+    {
+        return new Quaternion(-value.X, -value.Y, -value.Z, value.W);
     }
 
     private static Float3 Cross3(Float3 left, Float3 right)
@@ -4201,6 +4333,10 @@ internal static partial class LocalCityGmlObjectProjection
         {
             TriangleMeshGeometry triangleMesh => triangleMesh.Mesh.Submeshes.Count > 0,
             TerrainGridGeometry heightMap => heightMap.Width > 1 && heightMap.Height > 1,
+            DynamicTerrainGeometry dynamicTerrain =>
+                dynamicTerrain.StaticMesh.Mesh.Submeshes.Count > 0
+                && dynamicTerrain.GridMesh.Width > 1
+                && dynamicTerrain.GridMesh.Height > 1,
             _ => false,
         };
     }

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -75,6 +75,11 @@ public sealed record TerrainGridGeometry(
     Float2? UvOffset = null)
     : ConstructionGeometry;
 
+public sealed record DynamicTerrainGeometry(
+    TriangleMeshGeometry StaticMesh,
+    TerrainGridGeometry GridMesh)
+    : ConstructionGeometry;
+
 public sealed record ImportedMesh(
     IReadOnlyList<MeshVertex> Vertices,
     IReadOnlyList<MeshSubmesh> Submeshes);

--- a/src/PlateauResoniteLink/Domain/Importing/TerrainMeshMode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/TerrainMeshMode.cs
@@ -4,4 +4,5 @@ public enum TerrainMeshMode
 {
     Static = 0,
     Grid = 1,
+    Dynamic = 2,
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -17,9 +17,16 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 {
     private const float DefaultNormalScale = 1.0f;
     private const float DefaultBundledHeightScale = 0.002f;
-    private const string TerrainGridPointsDynamicVariableName = "PLATEAU.Terrain.Grid.Points";
-    private const string DynamicValueVariableDriverInt2ComponentType =
-        "[FrooxEngine]FrooxEngine.DynamicValueVariableDriver`1[[Elements.Core.int2, Elements.Core]]";
+    private const string TerrainGridDetailDynamicVariableName = "PLATEAU.Terrain.Grid.Detail";
+    private const string TerrainStaticEnabledVariableName = "PLATEAU.Terrain.Static.Enabled";
+    private const string DynamicValueVariableDriverFloatComponentType =
+        "[FrooxEngine]FrooxEngine.DynamicValueVariableDriver<float>";
+    private const string DynamicValueVariableDriverBoolComponentType =
+        "[FrooxEngine]FrooxEngine.DynamicValueVariableDriver<bool>";
+    private const string ValueGradientDriverInt2ComponentType =
+        "[FrooxEngine]FrooxEngine.ValueGradientDriver<int2>";
+    private const string BooleanAssetDriverMeshComponentType =
+        "[FrooxEngine]FrooxEngine.BooleanAssetDriver<[FrooxEngine]FrooxEngine.Mesh>";
 
     public PlannedBatchEmission Create(
         ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots,
@@ -45,13 +52,15 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             null));
         slotResolutionTargets.Add(meshAssetSlotId);
 
-        BatchPlanComponentLocator geometryComponentId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
+        BatchPlanComponentLocator rendererGeometryComponentId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
         Dictionary<string, PlannedMember>? terrainGridMeshMembers = null;
+        PlannedWorldElementReference? dynamicStaticMeshTarget = null;
+        PlannedWorldElementReference? dynamicGridMeshTarget = null;
         switch (emissionPlan.GeometryAsset)
         {
             case PlannedTriangleMeshGeometryAsset triangleMesh:
                 componentEmissions.Add(new PlannedBatchComponentEmission(
-                    geometryComponentId,
+                    rendererGeometryComponentId,
                     PlannedSlotTargetReference.PlannedSlot(meshAssetSlotId),
                     "[FrooxEngine]FrooxEngine.StaticMesh",
                     new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
@@ -63,76 +72,55 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                     }));
                 break;
             case PlannedTerrainGridGeometryAsset heightMap:
-                BatchPlanSlotLocator heightMapAssetSlotId = CreateBatchPlanSlotLocator(ref nextSlotLocator);
-                BatchPlanComponentLocator heightTextureComponentId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
-                slotEmissions.Add(new PlannedBatchSlotEmission(
-                    heightMapAssetSlotId,
-                    PlannedSlotTargetReference.CanonicalSlot(objectSlots.AssetLodSlot.Locator),
+                terrainGridMeshMembers = AddPlannedTerrainGridTextureAndCreateGridMembers(
+                    slotEmissions,
+                    componentEmissions,
+                    slotResolutionTargets,
+                    objectSlots,
                     heightMap.TerrainGridAssetSlotName,
-                    null,
-                    null));
-                slotResolutionTargets.Add(heightMapAssetSlotId);
+                    heightMap.Geometry,
+                    heightMap.HeightTextureUri,
+                    heightMap.UvScale,
+                    heightMap.UvOffset,
+                    ref nextSlotLocator,
+                    ref nextComponentLocator,
+                    ref nextFieldLocator);
+                break;
+            case PlannedDynamicTerrainGeometryAsset dynamicTerrain:
                 componentEmissions.Add(new PlannedBatchComponentEmission(
-                    heightTextureComponentId,
-                    PlannedSlotTargetReference.PlannedSlot(heightMapAssetSlotId),
-                    "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                    ResoniteGeometryAssetAssembler.CreateTerrainGridTextureMembers(heightMap.HeightTextureUri)
-                        .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal)));
-                double displacementMagnitude = Math.Max(heightMap.Geometry.MaxHeight - heightMap.Geometry.MinHeight, 0.0);
-                BatchPlanFieldLocator pointsFieldId = CreateBatchPlanFieldLocator(ref nextFieldLocator);
-                terrainGridMeshMembers = new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
-                {
-                    ["Points"] = PlannedMembers.AddressableField(pointsFieldId, new Field_int2
+                    rendererGeometryComponentId,
+                    PlannedSlotTargetReference.PlannedSlot(meshAssetSlotId),
+                    "[FrooxEngine]FrooxEngine.StaticMesh",
+                    new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
                     {
-                        Value = new int2
+                        ["URL"] = PlannedMembers.Literal(new Field_Uri
                         {
-                            x = heightMap.Geometry.Width,
-                            y = heightMap.Geometry.Height,
-                        },
-                    }),
-                    ["Size"] = PlannedMembers.Literal(new Field_float2
-                    {
-                        Value = new float2
-                        {
-                            x = (float)heightMap.Geometry.Size.X,
-                            y = (float)heightMap.Geometry.Size.Y,
-                        },
-                    }),
-                    ["DisplacementMagnitude"] = PlannedMembers.Literal(new Field_float
-                    {
-                        Value = (float)displacementMagnitude,
-                    }),
-                    ["DisplacementTexture"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(heightTextureComponentId)),
-                };
-                if (heightMap.UvScale is not null)
-                {
-                    terrainGridMeshMembers["UVScale"] = PlannedMembers.Literal(new Field_float2
-                    {
-                        Value = new float2
-                        {
-                            x = (float)heightMap.UvScale.X,
-                            y = (float)heightMap.UvScale.Y,
-                        },
-                    });
-                }
-
-                if (heightMap.UvOffset is not null)
-                {
-                    terrainGridMeshMembers["UVOffset"] = PlannedMembers.Literal(new Field_float2
-                    {
-                        Value = new float2
-                        {
-                            x = (float)heightMap.UvOffset.X,
-                            y = (float)heightMap.UvOffset.Y,
-                        },
-                    });
-                }
+                            Value = dynamicTerrain.StaticMeshUri,
+                        }),
+                    }));
+                dynamicStaticMeshTarget = PlannedWorldElementReference.Planned(rendererGeometryComponentId);
+                BatchPlanComponentLocator gridMeshComponentId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
+                terrainGridMeshMembers = AddPlannedTerrainGridTextureAndCreateGridMembers(
+                    slotEmissions,
+                    componentEmissions,
+                    slotResolutionTargets,
+                    objectSlots,
+                    dynamicTerrain.TerrainGridAssetSlotName,
+                    dynamicTerrain.GridGeometry,
+                    dynamicTerrain.HeightTextureUri,
+                    dynamicTerrain.UvScale,
+                    dynamicTerrain.UvOffset,
+                    ref nextSlotLocator,
+                    ref nextComponentLocator,
+                    ref nextFieldLocator);
+                rendererGeometryComponentId = gridMeshComponentId;
+                dynamicGridMeshTarget = PlannedWorldElementReference.Planned(gridMeshComponentId);
                 break;
             default:
                 throw new InvalidOperationException(
                     $"Unsupported planned geometry asset type '{emissionPlan.GeometryAsset.GetType().Name}'.");
         }
-        componentResolutionTargets.Add(geometryComponentId);
+        componentResolutionTargets.Add(rendererGeometryComponentId);
 
         Dictionary<MaterialIdentity, PlannedWorldElementReference> emittedMaterialTargets = new();
         foreach (PlannedMaterialAsset materialAsset in emissionPlan.MaterialAssets)
@@ -170,24 +158,28 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         if (terrainGridMeshMembers is not null)
         {
             componentEmissions.Add(new PlannedBatchComponentEmission(
-                geometryComponentId,
+                rendererGeometryComponentId,
                 PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
                 "[FrooxEngine]FrooxEngine.GridMesh",
                 terrainGridMeshMembers));
-            componentEmissions.Add(new PlannedBatchComponentEmission(
-                CreateBatchPlanComponentLocator(ref nextComponentLocator),
-                PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
-                DynamicValueVariableDriverInt2ComponentType,
-                CreateTerrainGridPointsDriverMembers(terrainGridMeshMembers)));
+            AddTerrainGridPointsDriverComponents(
+                componentEmissions,
+                presentationSlotId,
+                terrainGridMeshMembers,
+                ref nextComponentLocator,
+                ref nextFieldLocator);
         }
 
+        BatchPlanFieldLocator rendererMeshFieldId = CreateBatchPlanFieldLocator(ref nextFieldLocator);
         componentEmissions.Add(new PlannedBatchComponentEmission(
             CreateBatchPlanComponentLocator(ref nextComponentLocator),
             PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
             "[FrooxEngine]FrooxEngine.MeshRenderer",
             new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
             {
-                ["Mesh"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(geometryComponentId)),
+                ["Mesh"] = PlannedMembers.AddressableReference(
+                    rendererMeshFieldId,
+                    ResolveInitialMeshTarget(dynamicGridMeshTarget, rendererGeometryComponentId)),
                 ["Materials"] = CreateRendererMaterials(emissionPlan.Renderer.MaterialBindings, emittedMaterialTargets),
                 ["MaterialPropertyBlocks"] = CreateRendererMaterialPropertyBlocks(
                     componentEmissions,
@@ -196,6 +188,19 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                     emissionPlan.Renderer.MaterialBindings,
                     ref nextComponentLocator),
             }));
+        if (dynamicStaticMeshTarget is not null && dynamicGridMeshTarget is not null)
+        {
+            AddDynamicMeshSwitchComponents(
+                componentEmissions,
+                presentationSlotId,
+                rendererMeshFieldId,
+                dynamicGridMeshTarget.Value,
+                dynamicStaticMeshTarget.Value,
+                ref nextComponentLocator,
+                ref nextFieldLocator);
+        }
+
+        BatchPlanFieldLocator colliderMeshFieldId = CreateBatchPlanFieldLocator(ref nextFieldLocator);
         componentEmissions.Add(new PlannedBatchComponentEmission(
             CreateBatchPlanComponentLocator(ref nextComponentLocator),
             PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
@@ -210,8 +215,21 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 {
                     Value = emissionPlan.Collider.CollisionEnabled,
                 }),
-                ["Mesh"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(geometryComponentId)),
+                ["Mesh"] = PlannedMembers.AddressableReference(
+                    colliderMeshFieldId,
+                    ResolveInitialMeshTarget(dynamicGridMeshTarget, rendererGeometryComponentId)),
             }));
+        if (dynamicStaticMeshTarget is not null && dynamicGridMeshTarget is not null)
+        {
+            AddDynamicMeshSwitchComponents(
+                componentEmissions,
+                presentationSlotId,
+                colliderMeshFieldId,
+                dynamicGridMeshTarget.Value,
+                dynamicStaticMeshTarget.Value,
+                ref nextComponentLocator,
+                ref nextFieldLocator);
+        }
 
         return new PlannedBatchEmission(
             slotEmissions,
@@ -220,21 +238,204 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             componentResolutionTargets);
     }
 
-    private static Dictionary<string, PlannedMember> CreateTerrainGridPointsDriverMembers(
-        IReadOnlyDictionary<string, PlannedMember> gridMeshMembers)
+    private static PlannedWorldElementReference ResolveInitialMeshTarget(
+        PlannedWorldElementReference? dynamicGridMeshTarget,
+        BatchPlanComponentLocator defaultGeometryComponentId)
+    {
+        return dynamicGridMeshTarget ?? PlannedWorldElementReference.Planned(defaultGeometryComponentId);
+    }
+
+    private static Dictionary<string, PlannedMember> AddPlannedTerrainGridTextureAndCreateGridMembers(
+        List<PlannedBatchSlotEmission> slotEmissions,
+        List<PlannedBatchComponentEmission> componentEmissions,
+        List<BatchPlanSlotLocator> slotResolutionTargets,
+        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots,
+        string terrainGridAssetSlotName,
+        ResoniteTerrainGridGeometry geometry,
+        Uri heightTextureUri,
+        ResoniteFloat2? uvScale,
+        ResoniteFloat2? uvOffset,
+        ref int nextSlotLocator,
+        ref int nextComponentLocator,
+        ref int nextFieldLocator)
+    {
+        BatchPlanSlotLocator heightMapAssetSlotId = CreateBatchPlanSlotLocator(ref nextSlotLocator);
+        BatchPlanComponentLocator heightTextureComponentId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
+        slotEmissions.Add(new PlannedBatchSlotEmission(
+            heightMapAssetSlotId,
+            PlannedSlotTargetReference.CanonicalSlot(objectSlots.AssetLodSlot.Locator),
+            terrainGridAssetSlotName,
+            null,
+            null));
+        slotResolutionTargets.Add(heightMapAssetSlotId);
+        componentEmissions.Add(new PlannedBatchComponentEmission(
+            heightTextureComponentId,
+            PlannedSlotTargetReference.PlannedSlot(heightMapAssetSlotId),
+            "[FrooxEngine]FrooxEngine.StaticTexture2D",
+            ResoniteGeometryAssetAssembler.CreateTerrainGridTextureMembers(heightTextureUri)
+                .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal)));
+
+        double displacementMagnitude = Math.Max(geometry.MaxHeight - geometry.MinHeight, 0.0);
+        BatchPlanFieldLocator pointsFieldId = CreateBatchPlanFieldLocator(ref nextFieldLocator);
+        Dictionary<string, PlannedMember> terrainGridMeshMembers = new(StringComparer.Ordinal)
+        {
+            ["Points"] = PlannedMembers.AddressableField(pointsFieldId, new Field_int2
+            {
+                Value = new int2
+                {
+                    x = geometry.Width,
+                    y = geometry.Height,
+                },
+            }),
+            ["Size"] = PlannedMembers.Literal(new Field_float2
+            {
+                Value = new float2
+                {
+                    x = (float)geometry.Size.X,
+                    y = (float)geometry.Size.Y,
+                },
+            }),
+            ["DisplacementMagnitude"] = PlannedMembers.Literal(new Field_float
+            {
+                Value = (float)displacementMagnitude,
+            }),
+            ["DisplacementTexture"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(heightTextureComponentId)),
+        };
+        if (uvScale is not null)
+        {
+            terrainGridMeshMembers["UVScale"] = PlannedMembers.Literal(new Field_float2
+            {
+                Value = new float2
+                {
+                    x = (float)uvScale.X,
+                    y = (float)uvScale.Y,
+                },
+            });
+        }
+
+        if (uvOffset is not null)
+        {
+            terrainGridMeshMembers["UVOffset"] = PlannedMembers.Literal(new Field_float2
+            {
+                Value = new float2
+                {
+                    x = (float)uvOffset.X,
+                    y = (float)uvOffset.Y,
+                },
+            });
+        }
+
+        return terrainGridMeshMembers;
+    }
+
+    private static void AddDynamicMeshSwitchComponents(
+        List<PlannedBatchComponentEmission> componentEmissions,
+        BatchPlanSlotLocator presentationSlotId,
+        BatchPlanFieldLocator targetMeshFieldId,
+        PlannedWorldElementReference gridMeshTarget,
+        PlannedWorldElementReference staticMeshTarget,
+        ref int nextComponentLocator,
+        ref int nextFieldLocator)
+    {
+        BatchPlanFieldLocator stateFieldId = CreateBatchPlanFieldLocator(ref nextFieldLocator);
+        Dictionary<string, PlannedMember> switchMembers = new(StringComparer.Ordinal)
+        {
+            ["State"] = PlannedMembers.AddressableField(stateFieldId, new Field_bool
+            {
+                Value = false,
+            }),
+            ["Target"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(targetMeshFieldId)),
+            ["FalseTarget"] = PlannedMembers.Reference(gridMeshTarget),
+            ["TrueTarget"] = PlannedMembers.Reference(staticMeshTarget),
+        };
+        componentEmissions.Add(new PlannedBatchComponentEmission(
+            CreateBatchPlanComponentLocator(ref nextComponentLocator),
+            PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
+            BooleanAssetDriverMeshComponentType,
+            switchMembers));
+        componentEmissions.Add(new PlannedBatchComponentEmission(
+            CreateBatchPlanComponentLocator(ref nextComponentLocator),
+            PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
+            DynamicValueVariableDriverBoolComponentType,
+            new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
+            {
+                ["VariableName"] = PlannedMembers.Literal(new Field_string
+                {
+                    Value = TerrainStaticEnabledVariableName,
+                }),
+                ["Target"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(stateFieldId)),
+                ["DefaultValue"] = PlannedMembers.Literal(new Field_bool
+                {
+                    Value = false,
+                }),
+            }));
+    }
+
+    private static void AddTerrainGridPointsDriverComponents(
+        List<PlannedBatchComponentEmission> componentEmissions,
+        BatchPlanSlotLocator presentationSlotId,
+        IReadOnlyDictionary<string, PlannedMember> gridMeshMembers,
+        ref int nextComponentLocator,
+        ref int nextFieldLocator)
     {
         (BatchPlanFieldLocator gridPointsId, Field_int2 gridPoints) = AssertTerrainGridPointsMember(gridMeshMembers);
-        return new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
+        BatchPlanFieldLocator progressFieldId = CreateBatchPlanFieldLocator(ref nextFieldLocator);
+        componentEmissions.Add(new PlannedBatchComponentEmission(
+            CreateBatchPlanComponentLocator(ref nextComponentLocator),
+            PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
+            ValueGradientDriverInt2ComponentType,
+            new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
+            {
+                ["Progress"] = PlannedMembers.AddressableField(progressFieldId, new Field_float
+                {
+                    Value = 1.0f,
+                }),
+                ["Target"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(gridPointsId)),
+                ["Interpolate"] = PlannedMembers.Literal(new Field_bool
+                {
+                    Value = true,
+                }),
+                ["Points"] = PlannedMembers.List(
+                    PlannedMembers.Literal(CreateTerrainGridPointsGradientPoint(0.0f, new int2
+                    {
+                        x = 2,
+                        y = 2,
+                    })),
+                    PlannedMembers.Literal(CreateTerrainGridPointsGradientPoint(1.0f, gridPoints.Value))),
+            }));
+        componentEmissions.Add(new PlannedBatchComponentEmission(
+            CreateBatchPlanComponentLocator(ref nextComponentLocator),
+            PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
+            DynamicValueVariableDriverFloatComponentType,
+            new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
+            {
+                ["VariableName"] = PlannedMembers.Literal(new Field_string
+                {
+                    Value = TerrainGridDetailDynamicVariableName,
+                }),
+                ["Target"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(progressFieldId)),
+                ["DefaultValue"] = PlannedMembers.Literal(new Field_float
+                {
+                    Value = 1.0f,
+                }),
+            }));
+    }
+
+    private static SyncObject CreateTerrainGridPointsGradientPoint(float position, int2 value)
+    {
+        return new SyncObject
         {
-            ["VariableName"] = PlannedMembers.Literal(new Field_string
+            Members = new Dictionary<string, Member>(StringComparer.Ordinal)
             {
-                Value = TerrainGridPointsDynamicVariableName,
-            }),
-            ["Target"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(gridPointsId)),
-            ["DefaultValue"] = PlannedMembers.Literal(new Field_int2
-            {
-                Value = gridPoints.Value,
-            }),
+                ["Position"] = new Field_float
+                {
+                    Value = position,
+                },
+                ["Value"] = new Field_int2
+                {
+                    Value = value,
+                },
+            },
         };
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -201,6 +201,12 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
                 addressableField,
                 pendingFieldsByPlanId,
                 batchBuilder),
+            PlannedAddressableReferenceMember addressableReference => TranslateAddressableReference(
+                addressableReference,
+                pendingSlotsByPlanId,
+                pendingComponentsByPlanId,
+                pendingFieldsByPlanId,
+                batchBuilder),
             PlannedSyncListMember syncList => new SyncList
             {
                 Elements = syncList.Elements
@@ -216,7 +222,27 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         };
     }
 
-    private static Field_int2 TranslateAddressableField(
+    private static Reference TranslateAddressableReference(
+        PlannedAddressableReferenceMember addressableReference,
+        Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId,
+        Dictionary<BatchPlanComponentLocator, ResoniteBatchOperations.PendingBatchComponent> pendingComponentsByPlanId,
+        Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
+        ResoniteBatchOperations.BatchActionBuilder batchBuilder)
+    {
+        string fieldId = ResolveFieldId(addressableReference.Identity, pendingFieldsByPlanId, batchBuilder).Value;
+        return new Reference
+        {
+            ID = fieldId,
+            TargetID = ResolveWorldElementId(
+                addressableReference.Target,
+                pendingSlotsByPlanId,
+                pendingComponentsByPlanId,
+                pendingFieldsByPlanId,
+                batchBuilder),
+        };
+    }
+
+    private static Member TranslateAddressableField(
         PlannedAddressableFieldMember addressableField,
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
@@ -228,6 +254,22 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
             {
                 ID = fieldId,
                 Value = value.Value,
+            },
+            Field_bool value => new Field_bool
+            {
+                ID = fieldId,
+                Value = value.Value,
+            },
+            Field_float value => new Field_float
+            {
+                ID = fieldId,
+                Value = value.Value,
+            },
+            Reference value => new Reference
+            {
+                ID = fieldId,
+                TargetID = value.TargetID,
+                TargetType = value.TargetType,
             },
             _ => throw new InvalidOperationException(
                 $"Unsupported planned addressable field member type '{addressableField.Value.GetType().Name}'."),

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteConstructionGeometry.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteConstructionGeometry.cs
@@ -18,3 +18,8 @@ public sealed record ResoniteTerrainGridGeometry(
     ResoniteFloat2? UvScale = null,
     ResoniteFloat2? UvOffset = null)
     : ResoniteConstructionGeometry;
+
+public sealed record ResoniteDynamicTerrainGeometry(
+    ResoniteTriangleMeshGeometry StaticMesh,
+    ResoniteTerrainGridGeometry GridMesh)
+    : ResoniteConstructionGeometry;

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -787,10 +787,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         {
             ResoniteTriangleMeshGeometry triangleMesh => checked(
                 EstimateTriangleMeshWorkingSetBytes(triangleMesh.Mesh, cityObject.Materials) * triangleMeshExpansionFactor),
-            ResoniteTerrainGridGeometry heightMap => checked(
-                (heightMap.HeightSamples.Count * heightSampleWeightBytes)
-                + ((long)heightMap.Width * heightMap.Height * hdrHeightTextureWeightBytes)
-                * heightMapExpansionFactor),
+            ResoniteTerrainGridGeometry heightMap => EstimateTerrainGridWorkingSetBytes(heightMap),
+            ResoniteDynamicTerrainGeometry dynamicTerrain => checked(
+                (EstimateTriangleMeshWorkingSetBytes(dynamicTerrain.StaticMesh.Mesh, cityObject.Materials) * triangleMeshExpansionFactor)
+                + EstimateTerrainGridWorkingSetBytes(dynamicTerrain.GridMesh)),
             _ => minimumWeightBytes,
         };
 
@@ -809,6 +809,13 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             + (distinctTextureCount * textureReferenceWeightBytes)
             + terrainOverlayWeightBytes);
         return Math.Max(minimumWeightBytes, geometryWeightBytes + materialWeightBytes);
+
+        static long EstimateTerrainGridWorkingSetBytes(ResoniteTerrainGridGeometry heightMap)
+        {
+            return checked(
+                (heightMap.HeightSamples.Count * heightSampleWeightBytes)
+                + (((long)heightMap.Width * heightMap.Height * hdrHeightTextureWeightBytes) * heightMapExpansionFactor));
+        }
 
         static long EstimateTriangleMeshWorkingSetBytes(
             ResoniteImportedMesh mesh,
@@ -960,6 +967,21 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             }
 
         }
+        else if (cityObject.Geometry is ResoniteDynamicTerrainGeometry dynamicTerrain)
+        {
+            try
+            {
+                ValidateTriangleMeshBindings(cityObject, dynamicTerrain.StaticMesh.Mesh);
+            }
+            catch (Exception exception) when (exception is InvalidOperationException && exception is not ResoniteMeshValidationException)
+            {
+                throw new ResoniteMeshValidationException(
+                    $"Triangle mesh '{cityObject.DisplayName}' failed sender-side validation. "
+                    + $"{CreateTriangleMeshDiagnosticSummary(cityObject, dynamicTerrain.StaticMesh.Mesh)} "
+                    + $"Reason: {exception.Message}",
+                    exception);
+            }
+        }
         TerrainTextureOverlay[] distinctTerrainOverlays = cityObject.Materials
             .Where(static material => material.TerrainOverlay is not null)
             .Select(static material => material.TerrainOverlay!)
@@ -981,6 +1003,13 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 cancellationToken),
             ResoniteTerrainGridGeometry heightMap => Task.Run<PreparedConstructionGeometry>(
                 () => new PreparedTerrainGridGeometry(heightMap, PrepareTerrainGridDisplacementTexture(heightMap)),
+                cancellationToken),
+            ResoniteDynamicTerrainGeometry dynamicTerrain => Task.Run<PreparedConstructionGeometry>(
+                () => new PreparedDynamicTerrainGeometry(
+                    PrepareTriangleMeshGeometry(cityObject, dynamicTerrain.StaticMesh.Mesh),
+                    new PreparedTerrainGridGeometry(
+                        dynamicTerrain.GridMesh,
+                        PrepareTerrainGridDisplacementTexture(dynamicTerrain.GridMesh))),
                 cancellationToken),
             _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
         };
@@ -1006,6 +1035,14 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             && preparedGeometry is PreparedTriangleMeshGeometry)
         {
             preparedGeometry = PrepareTriangleMeshGeometry(cityObject, resolvedTriangleMesh.Mesh);
+        }
+        else if (cityObject.Geometry is ResoniteDynamicTerrainGeometry resolvedDynamicTerrain
+            && preparedGeometry is PreparedDynamicTerrainGeometry preparedDynamicTerrain)
+        {
+            preparedGeometry = preparedDynamicTerrain with
+            {
+                StaticMesh = PrepareTriangleMeshGeometry(cityObject, resolvedDynamicTerrain.StaticMesh.Mesh),
+            };
         }
         stopwatch.Stop();
         Diagnostics.RecordPrepare(cityObject.PackageName, stopwatch.Elapsed.TotalSeconds);
@@ -1379,7 +1416,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay)
     {
         _ = preparedTerrainTextureDataByOverlay;
-        return cityObject.Geometry is ResoniteTerrainGridGeometry
+        return (cityObject.Geometry is ResoniteTerrainGridGeometry
+                || cityObject.Geometry is ResoniteDynamicTerrainGeometry)
             && material.TerrainOverlay is not null
             ? material with
             {
@@ -1396,7 +1434,13 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         ArgumentNullException.ThrowIfNull(cityObject);
         ArgumentNullException.ThrowIfNull(preparedTerrainTextureDataByOverlay);
 
-        if (cityObject.Geometry is not ResoniteTriangleMeshGeometry triangleMesh)
+        ResoniteTriangleMeshGeometry? triangleMesh = cityObject.Geometry switch
+        {
+            ResoniteTriangleMeshGeometry value => value,
+            ResoniteDynamicTerrainGeometry value => value.StaticMesh,
+            _ => null,
+        };
+        if (triangleMesh is null)
         {
             return cityObject;
         }
@@ -1449,9 +1493,15 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                     : material)
             .ToArray();
 
+        ResoniteTriangleMeshGeometry adjustedTriangleGeometry = new(
+            new ResoniteImportedMesh(adjustedVertices, adjustedSubmeshes));
+        ResoniteConstructionGeometry adjustedGeometry = cityObject.Geometry is ResoniteDynamicTerrainGeometry dynamicTerrain
+            ? dynamicTerrain with { StaticMesh = adjustedTriangleGeometry }
+            : adjustedTriangleGeometry;
+
         return cityObject with
         {
-            Geometry = new ResoniteTriangleMeshGeometry(new ResoniteImportedMesh(adjustedVertices, adjustedSubmeshes)),
+            Geometry = adjustedGeometry,
             Materials = adjustedMaterials,
         };
     }
@@ -1922,6 +1972,26 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                     ResolveTerrainGridUvOffset(cityObject, heightMap.Geometry, preparedTerrainTextureDataByOverlay),
                     progressReporter,
                     cancellationToken)),
+            PreparedDynamicTerrainGeometry dynamicTerrain => CreatePlannedDynamicTerrainGeometryAsset(
+                cityObject,
+                AssertPreparedTriangleMeshAssetBatch(await geometryAssetAssembler.PrepareTriangleMeshAsync(
+                    importClient,
+                    CreateMeshAssetSlotName(cityObject),
+                    cityObject.DisplayName,
+                    dynamicTerrain.StaticMesh.MeshImport,
+                    progressReporter,
+                    cancellationToken)),
+                AssertPreparedTerrainGridAssetBatch(await geometryAssetAssembler.PrepareTerrainGridAsync(
+                    importClient,
+                    CreateMeshAssetSlotName(cityObject),
+                    CreateTerrainGridAssetSlotName(cityObject),
+                    cityObject.DisplayName,
+                    dynamicTerrain.GridMesh.Geometry,
+                    dynamicTerrain.GridMesh.HeightTextureImport,
+                    ResolveTerrainGridUvScale(cityObject, dynamicTerrain.GridMesh.Geometry, preparedTerrainTextureDataByOverlay),
+                    ResolveTerrainGridUvOffset(cityObject, dynamicTerrain.GridMesh.Geometry, preparedTerrainTextureDataByOverlay),
+                    progressReporter,
+                    cancellationToken))),
             _ => throw new InvalidOperationException(
                 $"Unsupported prepared geometry type '{preparedCityObject.Geometry.GetType().Name}'."),
         };
@@ -1984,6 +2054,43 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         };
     }
 
+    private static PlannedDynamicTerrainGeometryAsset CreatePlannedDynamicTerrainGeometryAsset(
+        ResoniteConstructionCityObject cityObject,
+        PreparedTriangleMeshAssetBatch staticMeshBatch,
+        PreparedTerrainGridAssetBatch gridMeshBatch)
+    {
+        GeometryIdentity identity = new(
+            string.Create(
+                CultureInfo.InvariantCulture,
+                $"geometry-{cityObject.PackageName}-{cityObject.SlotKey}-{staticMeshBatch.MeshAssetSlotName}"));
+
+        return new PlannedDynamicTerrainGeometryAsset(
+            identity,
+            staticMeshBatch.MeshAssetSlotName,
+            staticMeshBatch.MeshUri,
+            gridMeshBatch.TerrainGridAssetSlotName,
+            gridMeshBatch.Geometry,
+            gridMeshBatch.HeightTextureUri,
+            gridMeshBatch.UvScale,
+            gridMeshBatch.UvOffset);
+    }
+
+    private static PreparedTriangleMeshAssetBatch AssertPreparedTriangleMeshAssetBatch(
+        PreparedGeometryAssetBatch preparedGeometryBatch)
+    {
+        return preparedGeometryBatch as PreparedTriangleMeshAssetBatch
+            ?? throw new InvalidOperationException(
+                $"Unsupported prepared static terrain asset batch type '{preparedGeometryBatch.GetType().Name}'.");
+    }
+
+    private static PreparedTerrainGridAssetBatch AssertPreparedTerrainGridAssetBatch(
+        PreparedGeometryAssetBatch preparedGeometryBatch)
+    {
+        return preparedGeometryBatch as PreparedTerrainGridAssetBatch
+            ?? throw new InvalidOperationException(
+                $"Unsupported prepared terrain grid asset batch type '{preparedGeometryBatch.GetType().Name}'.");
+    }
+
     private static long EstimateBatchPayloadBytes(int operationCount)
     {
         return Math.Max(1L, operationCount) * 1024L;
@@ -2003,6 +2110,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 $"triangle-mesh(vertices={triangleMesh.MeshImport.VertexCount}, submeshes={triangleMesh.MeshImport.Submeshes.Count})",
             PreparedTerrainGridGeometry heightMap =>
                 $"terrain-grid({heightMap.Geometry.Width}x{heightMap.Geometry.Height})",
+            PreparedDynamicTerrainGeometry dynamicTerrain =>
+                $"dynamic-terrain(static={dynamicTerrain.StaticMesh.MeshImport.VertexCount} vertices, grid={dynamicTerrain.GridMesh.Geometry.Width}x{dynamicTerrain.GridMesh.Geometry.Height})",
             _ => geometry.GetType().Name,
         };
     }
@@ -2070,6 +2179,11 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
     internal sealed record PreparedTerrainGridGeometry(
         ResoniteTerrainGridGeometry Geometry,
         ResoniteRawHdrTextureImport HeightTextureImport)
+        : PreparedConstructionGeometry;
+
+    internal sealed record PreparedDynamicTerrainGeometry(
+        PreparedTriangleMeshGeometry StaticMesh,
+        PreparedTerrainGridGeometry GridMesh)
         : PreparedConstructionGeometry;
 
     internal sealed record PreparedCityObject(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -29,6 +29,17 @@ internal sealed record PlannedTerrainGridGeometryAsset(
     ResoniteFloat2? UvOffset = null)
     : PlannedGeometryAsset(Identity, MeshAssetSlotName);
 
+internal sealed record PlannedDynamicTerrainGeometryAsset(
+    GeometryIdentity Identity,
+    string MeshAssetSlotName,
+    Uri StaticMeshUri,
+    string TerrainGridAssetSlotName,
+    ResoniteTerrainGridGeometry GridGeometry,
+    Uri HeightTextureUri,
+    ResoniteFloat2? UvScale = null,
+    ResoniteFloat2? UvOffset = null)
+    : PlannedGeometryAsset(Identity, MeshAssetSlotName);
+
 internal sealed record PlannedTextureAsset(
     TextureIdentity Identity,
     Uri AssetUri);
@@ -172,6 +183,11 @@ internal sealed record PlannedElementReferenceMember(PlannedWorldElementReferenc
 
 internal sealed record PlannedAddressableFieldMember(BatchPlanFieldLocator Identity, Member Value) : PlannedMember;
 
+internal sealed record PlannedAddressableReferenceMember(
+    BatchPlanFieldLocator Identity,
+    PlannedWorldElementReference Target)
+    : PlannedMember;
+
 internal sealed record PlannedSyncListMember(IReadOnlyList<PlannedMember> Elements) : PlannedMember;
 
 internal static class PlannedMembers
@@ -191,6 +207,11 @@ internal static class PlannedMembers
     {
         ArgumentNullException.ThrowIfNull(value);
         return new PlannedAddressableFieldMember(identity, value);
+    }
+
+    public static PlannedMember AddressableReference(BatchPlanFieldLocator identity, PlannedWorldElementReference target)
+    {
+        return new PlannedAddressableReferenceMember(identity, target);
     }
 
     public static PlannedMember List(params PlannedMember[] elements)

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -48,6 +48,27 @@ internal static class SceneImportContractMapper
                 cityObject.Materials.Select(ToInternal).ToArray(),
                 cityObject.CollisionEnabled,
                 cityObject.SourceFileRelativePath),
+            DynamicTerrainGeometry dynamicTerrain => new ResoniteConstructionCityObject(
+                cityObject.ObjectKey,
+                cityObject.DisplayName,
+                cityObject.PackageName,
+                cityObject.ActualMeshCode,
+                cityObject.LodLevel,
+                ToInternal(cityObject.Transform),
+                new ResoniteDynamicTerrainGeometry(
+                    new ResoniteTriangleMeshGeometry(ToInternal(dynamicTerrain.StaticMesh.Mesh)),
+                    new ResoniteTerrainGridGeometry(
+                        dynamicTerrain.GridMesh.Width,
+                        dynamicTerrain.GridMesh.Height,
+                        ToInternal(dynamicTerrain.GridMesh.Size),
+                        dynamicTerrain.GridMesh.MinHeight,
+                        dynamicTerrain.GridMesh.MaxHeight,
+                        dynamicTerrain.GridMesh.HeightSamples,
+                        dynamicTerrain.GridMesh.UvScale is null ? null : ToInternal(dynamicTerrain.GridMesh.UvScale),
+                        dynamicTerrain.GridMesh.UvOffset is null ? null : ToInternal(dynamicTerrain.GridMesh.UvOffset))),
+                cityObject.Materials.Select(ToInternal).ToArray(),
+                cityObject.CollisionEnabled,
+                cityObject.SourceFileRelativePath),
             _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
         };
     }

--- a/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -108,6 +108,27 @@ public sealed class PlateauImportRequestValidatorTests
     }
 
     [Fact]
+    public void TryNormalizeAndValidatePreservesDynamicTerrainMeshMode()
+    {
+        using TemporaryDirectory sourceRoot = new();
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            Source: DatasetLocation.Local(sourceRoot.Path),
+            TerrainMeshMode: TerrainMeshMode.Dynamic);
+
+        bool success = PlateauImportRequestValidator.TryNormalizeAndValidate(
+            request,
+            out ValidatedPlateauImportRequest? validatedRequest,
+            out IReadOnlyList<string> errors);
+
+        Assert.True(success);
+        Assert.Empty(errors);
+        Assert.NotNull(validatedRequest);
+        Assert.Equal(TerrainMeshMode.Dynamic, validatedRequest!.TerrainMeshMode);
+    }
+
+    [Fact]
     public void ValidateRejectsGeoTiffSourceDirectory()
     {
         using TemporaryDirectory sourceRoot = new();

--- a/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -219,6 +219,23 @@ public sealed class CliArgumentsParserTests
     }
 
     [Fact]
+    public void ParseParsesTerrainDynamicMode()
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "import",
+                "--dataset", "tokyo23ku",
+                "--mesh-code", "53394525",
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+                "--terrain-mesh", "dynamic",
+            ]);
+
+        Assert.Null(result.Error);
+        Assert.Equal(TerrainMeshMode.Dynamic, result.Options!.Request.TerrainMeshMode);
+    }
+
+    [Fact]
     public void HelpTextDocumentsUnifiedSourceOptions()
     {
         Assert.Contains(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -955,6 +955,117 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
+    public async Task DemTerrainDynamicModeProjectsStaticAndGridGeometry()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        CreateRuntimeDemChunkFixture(datasetRoot.Path);
+
+        await using StubSceneBuilder sceneBuilder = new();
+        PlateauImportService service = CreateService(sceneBuilder);
+
+        await service.ExecuteAsync(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: datasetRoot.Path,
+                PackageNames: ["dem"],
+                TerrainMeshMode: TerrainMeshMode.Dynamic,
+                ServerUri: null),
+            workRoot: "runtime/resonite");
+
+        ImportedCityObject demCityObject = Assert.Single(
+            sceneBuilder.CityObjects,
+            static cityObject => cityObject.PackageName == "dem"
+                && cityObject.Geometry is DynamicTerrainGeometry
+                && cityObject.Materials.Any(static material => material.TerrainOverlay is not null));
+        DynamicTerrainGeometry geometry = Assert.IsType<DynamicTerrainGeometry>(demCityObject.Geometry);
+        MaterialBinding material = Assert.Single(demCityObject.Materials);
+
+        Assert.NotEmpty(geometry.StaticMesh.Mesh.Vertices);
+        Assert.NotEmpty(geometry.StaticMesh.Mesh.Submeshes);
+        Assert.True(geometry.GridMesh.Width > 1);
+        Assert.True(geometry.GridMesh.Height > 1);
+        Assert.NotNull(geometry.GridMesh.UvScale);
+        Assert.NotNull(geometry.GridMesh.UvOffset);
+        Assert.Null(material.TextureScale);
+        Assert.Null(material.TextureOffset);
+    }
+
+    [Fact]
+    public void DemTerrainDynamicModeKeepsMaterialBindingsCompatibleWithStaticMesh()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = new(35.0, 139.0, 10.0);
+        BootstrapParsedSurface validSurface = CreateBootstrapParsedSurface(
+            "valid-dem",
+            BootstrapParsedSurfaceSemantic.Ground,
+            CreateHorizontalQuadVertices(origin, origin.Altitude, 10.0, reverseWinding: false),
+            texturePayload: null,
+            baseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0));
+        BootstrapParsedSurface degenerateSurface = CreateBootstrapParsedSurface(
+            "degenerate-dem",
+            BootstrapParsedSurfaceSemantic.Ground,
+            [origin, origin, origin, origin],
+            texturePayload: null,
+            baseColor: new ColorRgba(0.5, 0.5, 0.5, 1.0));
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject(
+            "dem",
+            [validSurface, degenerateSurface],
+            referenceSystem);
+
+        ImportedCityObject projected = ProjectTerrainMeshModeCityObjectForTest(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: "dataset",
+                PackageNames: ["dem"],
+                TerrainMeshMode: TerrainMeshMode.Dynamic,
+                ServerUri: null));
+
+        DynamicTerrainGeometry geometry = Assert.IsType<DynamicTerrainGeometry>(projected.Geometry);
+        HashSet<int> staticSubmeshIndices = geometry.StaticMesh.Mesh.Submeshes
+            .Select(static submesh => submesh.Index)
+            .ToHashSet();
+        MaterialBinding material = Assert.Single(projected.Materials);
+
+        Assert.NotEmpty(staticSubmeshIndices);
+        Assert.All(
+            material.SubmeshIndices,
+            submeshIndex => Assert.Contains(submeshIndex, staticSubmeshIndices));
+    }
+
+    [Fact]
+    public void DemTerrainDynamicModeSkipsDemWhenGridCannotBeProjected()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject(
+            "dem",
+            [],
+            referenceSystem);
+
+        ImportedCityObject projected = ProjectTerrainMeshModeCityObjectForTest(
+            cityObject,
+            new GeodeticPoint(35.0, 139.0, 0.0),
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: "dataset",
+                PackageNames: ["dem"],
+                TerrainMeshMode: TerrainMeshMode.Dynamic,
+                ServerUri: null));
+
+        TriangleMeshGeometry geometry = Assert.IsType<TriangleMeshGeometry>(projected.Geometry);
+        Assert.Empty(geometry.Mesh.Vertices);
+        Assert.Empty(geometry.Mesh.Submeshes);
+        Assert.Empty(projected.Materials);
+    }
+
+    [Fact]
     public async Task DemExactMeshRequestFiltersSplitParentMeshPiecesAfterOverlaySplit()
     {
         using TemporaryDirectory datasetRoot = new();
@@ -1820,6 +1931,29 @@ public sealed class LocalCityGmlObjectProjectionTests
                 new DefaultMaterialResolver(),
             ])!;
     }
+
+    private static ImportedCityObject ProjectTerrainMeshModeCityObjectForTest(
+        BootstrapParsedCityObject cityObject,
+        GeodeticPoint globalOriginPoint,
+        PlateauImportRequest request)
+    {
+        MethodInfo method = typeof(LocalCityGmlObjectProjection).GetMethod(
+                "ProjectTerrainMeshModeCityObject",
+                BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("Failed to resolve ProjectTerrainMeshModeCityObject.");
+
+        return (ImportedCityObject)method.Invoke(
+            null,
+            [
+                cityObject,
+                globalOriginPoint,
+                null,
+                null,
+                request,
+                new DefaultMaterialResolver(),
+            ])!;
+    }
+
     private static ImportedCityObject CreateTerrainGridCityObject(
         string slotKey,
         Float3 position,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -438,6 +438,27 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 cityObject.Materials.Select(ToContractMaterial).ToArray(),
                 cityObject.CollisionEnabled,
                 cityObject.SourceFileRelativePath),
+            ResoniteDynamicTerrainGeometry dynamicTerrain => new ImportedCityObject(
+                cityObject.SlotKey,
+                cityObject.DisplayName,
+                cityObject.PackageName,
+                cityObject.ActualMeshCode,
+                cityObject.LodLevel,
+                ToContractTransform(cityObject.Transform),
+                new DynamicTerrainGeometry(
+                    new TriangleMeshGeometry(ToContractMesh(dynamicTerrain.StaticMesh.Mesh)),
+                    new TerrainGridGeometry(
+                        dynamicTerrain.GridMesh.Width,
+                        dynamicTerrain.GridMesh.Height,
+                        ToContractFloat2(dynamicTerrain.GridMesh.Size),
+                        dynamicTerrain.GridMesh.MinHeight,
+                        dynamicTerrain.GridMesh.MaxHeight,
+                        dynamicTerrain.GridMesh.HeightSamples,
+                        dynamicTerrain.GridMesh.UvScale is null ? null : ToContractFloat2(dynamicTerrain.GridMesh.UvScale),
+                        dynamicTerrain.GridMesh.UvOffset is null ? null : ToContractFloat2(dynamicTerrain.GridMesh.UvOffset))),
+                cityObject.Materials.Select(ToContractMaterial).ToArray(),
+                cityObject.CollisionEnabled,
+                cityObject.SourceFileRelativePath),
             _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
         };
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -280,12 +280,18 @@ public sealed class ResoniteLiveSceneImportTargetTests
         AddComponent gridMeshRequest = Assert.Single(
             client.AddedComponents,
             request => string.Equals(request.Data.ID, gridMesh.ID, StringComparison.Ordinal));
-        Component pointsDriver = Assert.Single(
+        Component pointsGradientDriver = Assert.Single(
+            client.ComponentsById.Values,
+            static component => component.ComponentType.Contains("ValueGradientDriver", StringComparison.Ordinal));
+        AddComponent pointsGradientDriverRequest = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, pointsGradientDriver.ID, StringComparison.Ordinal));
+        Component pointsProgressDriver = Assert.Single(
             client.ComponentsById.Values,
             static component => component.ComponentType.Contains("DynamicValueVariableDriver", StringComparison.Ordinal));
-        AddComponent pointsDriverRequest = Assert.Single(
+        AddComponent pointsProgressDriverRequest = Assert.Single(
             client.AddedComponents,
-            request => string.Equals(request.Data.ID, pointsDriver.ID, StringComparison.Ordinal));
+            request => string.Equals(request.Data.ID, pointsProgressDriver.ID, StringComparison.Ordinal));
         Reference displacementTextureReference = Assert.IsType<Reference>(gridMesh.Members["DisplacementTexture"]);
         Component displacementTexture = client.ComponentsById[displacementTextureReference.TargetID];
         AddComponent displacementTextureRequest = Assert.Single(
@@ -297,14 +303,20 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.Equal("Point", Assert.IsType<Field_Nullable_Enum>(displacementTexture.Members["FilterMode"]).Value);
         Assert.False(Assert.IsType<Field_bool>(displacementTexture.Members["MipMaps"]).Value);
         Assert.DoesNotContain("/Assets/", client.SlotPaths[gridMeshRequest.ContainerSlotId], StringComparison.Ordinal);
-        Assert.DoesNotContain("/Assets/", client.SlotPaths[pointsDriverRequest.ContainerSlotId], StringComparison.Ordinal);
+        Assert.DoesNotContain("/Assets/", client.SlotPaths[pointsGradientDriverRequest.ContainerSlotId], StringComparison.Ordinal);
+        Assert.DoesNotContain("/Assets/", client.SlotPaths[pointsProgressDriverRequest.ContainerSlotId], StringComparison.Ordinal);
         Assert.Contains("/Assets/", client.SlotPaths[displacementTextureRequest.ContainerSlotId], StringComparison.Ordinal);
         Field_int2 gridPoints = Assert.IsType<Field_int2>(gridMesh.Members["Points"]);
-        Assert.Equal("PLATEAU.Terrain.Grid.Points", Assert.IsType<Field_string>(pointsDriver.Members["VariableName"]).Value);
-        Assert.Equal(gridPoints.ID, Assert.IsType<Reference>(pointsDriver.Members["Target"]).TargetID);
-        Field_int2 defaultPoints = Assert.IsType<Field_int2>(pointsDriver.Members["DefaultValue"]);
-        Assert.Equal(2, defaultPoints.Value.x);
-        Assert.Equal(2, defaultPoints.Value.y);
+        Assert.Equal(gridPoints.ID, Assert.IsType<Reference>(pointsGradientDriver.Members["Target"]).TargetID);
+        Field_float progress = Assert.IsType<Field_float>(pointsGradientDriver.Members["Progress"]);
+        Assert.Equal(1.0f, progress.Value);
+        SyncList gradientPoints = Assert.IsType<SyncList>(pointsGradientDriver.Members["Points"]);
+        Assert.Equal(2, gradientPoints.Elements.Count);
+        AssertGradientPoint(gradientPoints.Elements[0], 0.0f, 2, 2);
+        AssertGradientPoint(gradientPoints.Elements[1], 1.0f, 2, 2);
+        Assert.Equal("PLATEAU.Terrain.Grid.Detail", Assert.IsType<Field_string>(pointsProgressDriver.Members["VariableName"]).Value);
+        Assert.Equal(progress.ID, Assert.IsType<Reference>(pointsProgressDriver.Members["Target"]).TargetID);
+        Assert.Equal(1.0f, Assert.IsType<Field_float>(pointsProgressDriver.Members["DefaultValue"]).Value);
         Assert.DoesNotContain(
             client.ComponentsById.Values,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));
@@ -333,12 +345,16 @@ public sealed class ResoniteLiveSceneImportTargetTests
         List<AddComponent> gridMeshRequests = client.AddedComponents
             .Where(static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.GridMesh", StringComparison.Ordinal))
             .ToList();
-        List<AddComponent> pointsDriverRequests = client.AddedComponents
+        List<AddComponent> pointsGradientDriverRequests = client.AddedComponents
+            .Where(static request => request.Data.ComponentType.Contains("ValueGradientDriver", StringComparison.Ordinal))
+            .ToList();
+        List<AddComponent> pointsProgressDriverRequests = client.AddedComponents
             .Where(static request => request.Data.ComponentType.Contains("DynamicValueVariableDriver", StringComparison.Ordinal))
             .ToList();
 
         Assert.Equal(2, gridMeshRequests.Count);
-        Assert.Equal(2, pointsDriverRequests.Count);
+        Assert.Equal(2, pointsGradientDriverRequests.Count);
+        Assert.Equal(2, pointsProgressDriverRequests.Count);
         Assert.Equal(2, client.ImportedRawHdrTextures.Count);
 
         string[] pointsIds = gridMeshRequests
@@ -349,12 +365,142 @@ public sealed class ResoniteLiveSceneImportTargetTests
 
         foreach (AddComponent gridMeshRequest in gridMeshRequests)
         {
-            AddComponent pointsDriverRequest = Assert.Single(
-                pointsDriverRequests,
+            AddComponent pointsGradientDriverRequest = Assert.Single(
+                pointsGradientDriverRequests,
+                request => string.Equals(request.ContainerSlotId, gridMeshRequest.ContainerSlotId, StringComparison.Ordinal));
+            AddComponent pointsProgressDriverRequest = Assert.Single(
+                pointsProgressDriverRequests,
                 request => string.Equals(request.ContainerSlotId, gridMeshRequest.ContainerSlotId, StringComparison.Ordinal));
             Field_int2 gridPoints = Assert.IsType<Field_int2>(gridMeshRequest.Data.Members["Points"]);
-            Assert.Equal("PLATEAU.Terrain.Grid.Points", Assert.IsType<Field_string>(pointsDriverRequest.Data.Members["VariableName"]).Value);
-            Assert.Equal(gridPoints.ID, Assert.IsType<Reference>(pointsDriverRequest.Data.Members["Target"]).TargetID);
+            Field_float progress = Assert.IsType<Field_float>(pointsGradientDriverRequest.Data.Members["Progress"]);
+            Assert.Equal(gridPoints.ID, Assert.IsType<Reference>(pointsGradientDriverRequest.Data.Members["Target"]).TargetID);
+            Assert.Equal("PLATEAU.Terrain.Grid.Detail", Assert.IsType<Field_string>(pointsProgressDriverRequest.Data.Members["VariableName"]).Value);
+            Assert.Equal(progress.ID, Assert.IsType<Reference>(pointsProgressDriverRequest.Data.Members["Target"]).TargetID);
+        }
+    }
+
+    [Fact]
+    public async Task BuildAsyncCreatesDynamicTerrainStaticAndGridAssetsWithGridFallback()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using SceneBuilderRecordingClient client = new();
+        ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            LocalOrigin,
+            packageNames: ["dem"],
+            sourceFiles:
+            [
+                $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml",
+            ]);
+        ResoniteConstructionCityObject cityObject = new(
+            SlotKey: "dynamic-terrain",
+            DisplayName: "Dynamic Terrain",
+            PackageName: "dem",
+            ActualMeshCode: MeshCode,
+            LodLevel: 0,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Geometry: new ResoniteDynamicTerrainGeometry(
+                new ResoniteTriangleMeshGeometry(ResoniteLiveSceneImportTargetTestSupport.CreateTriangleMesh("dynamic-terrain-material")),
+                new ResoniteTerrainGridGeometry(
+                    Width: 2,
+                    Height: 2,
+                    Size: new ResoniteFloat2(10.0, 10.0),
+                    MinHeight: 0.0,
+                    MaxHeight: 3.0,
+                    HeightSamples: [0.0, 1.0, 2.0, 3.0])),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "dynamic-terrain-material",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Wireframe,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0]),
+            ],
+            SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(metadata, [cityObject], client);
+
+        Assert.Single(client.ImportedMeshes);
+        Assert.Single(client.ImportedRawHdrTextures);
+        Component staticMesh = Assert.Single(
+            client.ComponentsById.Values,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticMesh", StringComparison.Ordinal));
+        Component gridMesh = Assert.Single(
+            client.ComponentsById.Values,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.GridMesh", StringComparison.Ordinal));
+        Component meshRenderer = Assert.Single(
+            client.ComponentsById.Values,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal));
+        Component meshCollider = Assert.Single(
+            client.ComponentsById.Values,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshCollider", StringComparison.Ordinal));
+        AddComponent meshRendererRequest = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, meshRenderer.ID, StringComparison.Ordinal));
+        AddComponent meshColliderRequest = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, meshCollider.ID, StringComparison.Ordinal));
+        Component displacementTexture = client.ComponentsById[Assert.IsType<Reference>(gridMesh.Members["DisplacementTexture"]).TargetID];
+        Component[] meshSwitches = client.ComponentsById.Values
+            .Where(static component => component.ComponentType.Contains("BooleanAssetDriver", StringComparison.Ordinal))
+            .ToArray();
+        Component[] boolDrivers = client.ComponentsById.Values
+            .Where(static component => component.ComponentType.Contains("DynamicValueVariableDriver", StringComparison.Ordinal)
+                && component.ComponentType.Contains("bool", StringComparison.Ordinal))
+            .ToArray();
+        AddComponent[] meshSwitchRequests = meshSwitches
+            .Select(meshSwitch => Assert.Single(
+                client.AddedComponents,
+                request => string.Equals(request.Data.ID, meshSwitch.ID, StringComparison.Ordinal)))
+            .ToArray();
+        AddComponent[] boolDriverRequests = boolDrivers
+            .Select(boolDriver => Assert.Single(
+                client.AddedComponents,
+                request => string.Equals(request.Data.ID, boolDriver.ID, StringComparison.Ordinal)))
+            .ToArray();
+        AddComponent gridMeshRequest = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, gridMesh.ID, StringComparison.Ordinal));
+        AddComponent displacementTextureRequest = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, displacementTexture.ID, StringComparison.Ordinal));
+
+        Assert.Equal(2, meshSwitches.Length);
+        Assert.Equal(2, boolDrivers.Length);
+        Assert.DoesNotContain("/Assets/", client.SlotPaths[gridMeshRequest.ContainerSlotId], StringComparison.Ordinal);
+        Assert.Contains("/Assets/", client.SlotPaths[displacementTextureRequest.ContainerSlotId], StringComparison.Ordinal);
+        Reference rendererMesh = Assert.IsType<Reference>(meshRendererRequest.Data.Members["Mesh"]);
+        Reference colliderMesh = Assert.IsType<Reference>(meshColliderRequest.Data.Members["Mesh"]);
+        Assert.Equal(gridMesh.ID, rendererMesh.TargetID);
+        Assert.Equal(gridMesh.ID, colliderMesh.TargetID);
+        foreach (Component meshSwitch in meshSwitches)
+        {
+            AddComponent meshSwitchRequest = Assert.Single(
+                meshSwitchRequests,
+                request => string.Equals(request.Data.ID, meshSwitch.ID, StringComparison.Ordinal));
+            Field_bool state = Assert.IsType<Field_bool>(meshSwitchRequest.Data.Members["State"]);
+            Assert.False(state.Value);
+            string targetFieldId = Assert.IsType<Reference>(meshSwitchRequest.Data.Members["Target"]).TargetID;
+            Assert.StartsWith("local_field_", targetFieldId, StringComparison.Ordinal);
+            Assert.Equal(gridMesh.ID, Assert.IsType<Reference>(meshSwitch.Members["FalseTarget"]).TargetID);
+            Assert.Equal(staticMesh.ID, Assert.IsType<Reference>(meshSwitch.Members["TrueTarget"]).TargetID);
+        }
+
+        foreach (Component boolDriver in boolDrivers)
+        {
+            AddComponent boolDriverRequest = Assert.Single(
+                boolDriverRequests,
+                request => string.Equals(request.Data.ID, boolDriver.ID, StringComparison.Ordinal));
+            string targetFieldId = Assert.IsType<Reference>(boolDriverRequest.Data.Members["Target"]).TargetID;
+            Assert.StartsWith("local_field_", targetFieldId, StringComparison.Ordinal);
+            Assert.Equal("PLATEAU.Terrain.Static.Enabled", Assert.IsType<Field_string>(boolDriver.Members["VariableName"]).Value);
+            Assert.False(Assert.IsType<Field_bool>(boolDriverRequest.Data.Members["DefaultValue"]).Value);
         }
     }
 
@@ -1039,6 +1185,58 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
+    public async Task BuildAsyncFailsFastOnDynamicTerrainOutOfRangeMaterialSubmeshAssignment()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using SceneBuilderRecordingClient client = new();
+        ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            LocalOrigin,
+            packageNames: ["dem"],
+            sourceFiles:
+            [
+                $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml",
+            ]);
+        ResoniteConstructionCityObject cityObject = new(
+            SlotKey: "invalid-dynamic-terrain-submesh-range",
+            DisplayName: "Invalid Dynamic Terrain Submesh Range",
+            PackageName: "dem",
+            ActualMeshCode: MeshCode,
+            LodLevel: 0,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Geometry: new ResoniteDynamicTerrainGeometry(
+                new ResoniteTriangleMeshGeometry(ResoniteLiveSceneImportTargetTestSupport.CreateTriangleMesh("only-submesh")),
+                new ResoniteTerrainGridGeometry(
+                    Width: 2,
+                    Height: 2,
+                    Size: new ResoniteFloat2(10.0, 10.0),
+                    MinHeight: 0.0,
+                    MaxHeight: 3.0,
+                    HeightSamples: [0.0, 1.0, 2.0, 3.0])),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "only-submesh",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [1]),
+            ],
+            SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
+
+        ResoniteMeshValidationException exception = await Assert.ThrowsAsync<ResoniteMeshValidationException>(
+            () => ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(metadata, [cityObject], client, enableMeshBake: false));
+
+        Assert.Contains("targeted missing submesh index 1", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("material_bindings=[only-submesh[1]]", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task BuildAsyncFailsFastOnDuplicateMaterialSubmeshAssignment()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -1298,6 +1496,15 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     SubmeshIndices: [0]),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
+    }
+
+    private static void AssertGradientPoint(Member member, float expectedPosition, int expectedX, int expectedY)
+    {
+        SyncObject point = Assert.IsType<SyncObject>(member);
+        Assert.Equal(expectedPosition, Assert.IsType<Field_float>(point.Members["Position"]).Value);
+        Field_int2 value = Assert.IsType<Field_int2>(point.Members["Value"]);
+        Assert.Equal(expectedX, value.Value.x);
+        Assert.Equal(expectedY, value.Value.y);
     }
 
     private static void AssertNoPlannedIds(Slot slot)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -64,7 +64,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchComponentEmission gridMesh = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.GridMesh", StringComparison.Ordinal));
-        PlannedBatchComponentEmission pointsDriver = Assert.Single(
+        PlannedBatchComponentEmission pointsGradientDriver = Assert.Single(
+            batchPlan.ComponentEmissions,
+            static component => component.ComponentType.Contains("ValueGradientDriver", StringComparison.Ordinal));
+        PlannedBatchComponentEmission pointsProgressDriver = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => component.ComponentType.Contains("DynamicValueVariableDriver", StringComparison.Ordinal));
         PlannedBatchComponentEmission meshRenderer = Assert.Single(
@@ -79,7 +82,8 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.Equal(new ResoniteSlotLocator("asset-lod-slot"), AssertCanonical(heightMapSlot.ParentTarget));
         Assert.False(heightMapSlot.ParentTarget.IsPlanned);
         Assert.Equal(presentationSlot.Identity, AssertPlanned(gridMesh.ContainerTarget));
-        Assert.Equal(presentationSlot.Identity, AssertPlanned(pointsDriver.ContainerTarget));
+        Assert.Equal(presentationSlot.Identity, AssertPlanned(pointsGradientDriver.ContainerTarget));
+        Assert.Equal(presentationSlot.Identity, AssertPlanned(pointsProgressDriver.ContainerTarget));
         Assert.Equal(heightMapSlot.Identity, AssertPlanned(heightTexture.ContainerTarget));
         Assert.True(heightTexture.ContainerTarget.IsPlanned);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(heightTexture.Members["WrapModeU"])).Value);
@@ -93,14 +97,104 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.Equal(2, gridPoints.Value.x);
         Assert.Equal(3, gridPoints.Value.y);
         Assert.True(string.IsNullOrWhiteSpace(gridPoints.ID));
-        Assert.Equal("PLATEAU.Terrain.Grid.Points", Assert.IsType<Field_string>(ToMember(pointsDriver.Members["VariableName"])).Value);
-        PlannedElementReferenceMember pointsTarget = Assert.IsType<PlannedElementReferenceMember>(pointsDriver.Members["Target"]);
+        PlannedAddressableFieldMember progress = Assert.IsType<PlannedAddressableFieldMember>(pointsGradientDriver.Members["Progress"]);
+        Assert.Equal(1.0f, Assert.IsType<Field_float>(progress.Value).Value);
+        PlannedElementReferenceMember pointsTarget = Assert.IsType<PlannedElementReferenceMember>(pointsGradientDriver.Members["Target"]);
         Assert.Equal(gridPointsMember.Identity, pointsTarget.Target.PlannedField);
-        Field_int2 defaultPoints = Assert.IsType<Field_int2>(ToMember(pointsDriver.Members["DefaultValue"]));
-        Assert.Equal(2, defaultPoints.Value.x);
-        Assert.Equal(3, defaultPoints.Value.y);
+        SyncList gradientPoints = Assert.IsType<SyncList>(ToMember(pointsGradientDriver.Members["Points"]));
+        Assert.Equal(2, gradientPoints.Elements.Count);
+        AssertGradientPoint(gradientPoints.Elements[0], 0.0f, 2, 2);
+        AssertGradientPoint(gradientPoints.Elements[1], 1.0f, 2, 3);
+        Assert.Equal("PLATEAU.Terrain.Grid.Detail", Assert.IsType<Field_string>(ToMember(pointsProgressDriver.Members["VariableName"])).Value);
+        PlannedElementReferenceMember progressTarget = Assert.IsType<PlannedElementReferenceMember>(pointsProgressDriver.Members["Target"]);
+        Assert.Equal(progress.Identity, progressTarget.Target.PlannedField);
+        Assert.Equal(1.0f, Assert.IsType<Field_float>(ToMember(pointsProgressDriver.Members["DefaultValue"])).Value);
         Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(meshRenderer.Members["Mesh"])).TargetID);
         Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(meshCollider.Members["Mesh"])).TargetID);
+    }
+
+    [Fact]
+    public void CreatePlannedBatchEmission_CreatesDynamicTerrainPlanWithGridAsFalseFallback()
+    {
+        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
+            new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
+            new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
+            "Dynamic Terrain Object",
+            new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(1.0, 2.0, 3.0),
+            null);
+        PlannedSceneObjectEmission emissionPlan = new(
+            new PlannedDynamicTerrainGeometryAsset(
+                new GeometryIdentity("geom"),
+                "Dynamic Terrain Object",
+                new Uri("resdb:///mesh/static"),
+                "Dynamic Terrain Object_terrain-grid",
+                new ResoniteTerrainGridGeometry(
+                    Width: 4,
+                    Height: 5,
+                    Size: new PlateauResoniteLink.Targets.Resonite.ResoniteFloat2(40.0, 50.0),
+                    MinHeight: 1.0,
+                    MaxHeight: 11.0,
+                    HeightSamples: Enumerable.Range(0, 20).Select(static value => (double)value).ToArray()),
+                new Uri("resdb:///texture/height")),
+            [],
+            new PlannedRenderer(
+                new GeometryIdentity("geom"),
+                []),
+            new PlannedCollider(
+                new GeometryIdentity("geom"),
+                true));
+
+        PlannedBatchEmission batchPlan = Planner.Create(objectSlots, emissionPlan);
+
+        PlannedBatchComponentEmission staticMesh = Assert.Single(
+            batchPlan.ComponentEmissions,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticMesh", StringComparison.Ordinal));
+        PlannedBatchComponentEmission gridMesh = Assert.Single(
+            batchPlan.ComponentEmissions,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.GridMesh", StringComparison.Ordinal));
+        PlannedBatchComponentEmission meshRenderer = Assert.Single(
+            batchPlan.ComponentEmissions,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal));
+        PlannedBatchComponentEmission meshCollider = Assert.Single(
+            batchPlan.ComponentEmissions,
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshCollider", StringComparison.Ordinal));
+        PlannedBatchComponentEmission[] meshSwitches = batchPlan.ComponentEmissions
+            .Where(static component => component.ComponentType.Contains("BooleanAssetDriver", StringComparison.Ordinal))
+            .ToArray();
+        PlannedBatchComponentEmission[] boolDrivers = batchPlan.ComponentEmissions
+            .Where(static component => component.ComponentType.Contains("DynamicValueVariableDriver", StringComparison.Ordinal)
+                && component.ComponentType.Contains("bool", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Equal(2, meshSwitches.Length);
+        Assert.Equal(2, boolDrivers.Length);
+        PlannedAddressableReferenceMember rendererMesh = Assert.IsType<PlannedAddressableReferenceMember>(meshRenderer.Members["Mesh"]);
+        PlannedAddressableReferenceMember colliderMesh = Assert.IsType<PlannedAddressableReferenceMember>(meshCollider.Members["Mesh"]);
+        Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(rendererMesh)).TargetID);
+        Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(colliderMesh)).TargetID);
+        foreach (PlannedBatchComponentEmission meshSwitch in meshSwitches)
+        {
+            PlannedAddressableFieldMember state = Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]);
+            PlannedElementReferenceMember target = Assert.IsType<PlannedElementReferenceMember>(meshSwitch.Members["Target"]);
+            Assert.True(
+                target.Target.PlannedField is BatchPlanFieldLocator plannedTarget
+                && new[] { rendererMesh.Identity, colliderMesh.Identity }.Contains(plannedTarget));
+            Assert.False(Assert.IsType<Field_bool>(state.Value).Value);
+            Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(meshSwitch.Members["FalseTarget"])).TargetID);
+            Assert.Equal(ToPlannedTargetId(staticMesh.Identity), Assert.IsType<Reference>(ToMember(meshSwitch.Members["TrueTarget"])).TargetID);
+        }
+
+        foreach (PlannedBatchComponentEmission boolDriver in boolDrivers)
+        {
+            PlannedElementReferenceMember target = Assert.IsType<PlannedElementReferenceMember>(boolDriver.Members["Target"]);
+            Assert.True(
+                target.Target.PlannedField is BatchPlanFieldLocator plannedStateTarget
+                && meshSwitches
+                    .Select(meshSwitch => Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]).Identity)
+                    .Contains(plannedStateTarget));
+            Assert.Equal("PLATEAU.Terrain.Static.Enabled", Assert.IsType<Field_string>(ToMember(boolDriver.Members["VariableName"])).Value);
+            Assert.False(Assert.IsType<Field_bool>(ToMember(boolDriver.Members["DefaultValue"])).Value);
+        }
     }
 
     [Fact]
@@ -468,6 +562,15 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         return target.Planned.Value;
     }
 
+    private static void AssertGradientPoint(Member member, float expectedPosition, int expectedX, int expectedY)
+    {
+        SyncObject point = Assert.IsType<SyncObject>(member);
+        Assert.Equal(expectedPosition, Assert.IsType<Field_float>(point.Members["Position"]).Value);
+        Field_int2 value = Assert.IsType<Field_int2>(point.Members["Value"]);
+        Assert.Equal(expectedX, value.Value.x);
+        Assert.Equal(expectedY, value.Value.y);
+    }
+
     private static Member ToMember(PlannedMember member)
     {
         return member switch
@@ -478,6 +581,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 TargetID = ResolveTargetId(reference.Target),
             },
             PlannedAddressableFieldMember field => field.Value,
+            PlannedAddressableReferenceMember reference => new Reference
+            {
+                ID = ToPlannedTargetId(reference.Identity),
+                TargetID = ResolveTargetId(reference.Target),
+            },
             PlannedSyncListMember syncList => new SyncList
             {
                 Elements = syncList.Elements.Select(ToMember).ToList(),

--- a/tests/PlateauResoniteLink.Tests/UseCases/SceneImportExecutionPlanTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/SceneImportExecutionPlanTests.cs
@@ -78,6 +78,27 @@ public sealed class SceneImportExecutionPlanTests
     }
 
     [Fact]
+    public void Constructor_RejectsDifferentTerrainMeshMode()
+    {
+        PlateauImportRequest normalizedRequest = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            Source: DatasetLocation.Local("raw-source"),
+            TerrainMeshMode: TerrainMeshMode.Static,
+            PackageNames: ["bldg"]);
+        PlateauImportRequest mismatchedRequest = normalizedRequest with
+        {
+            TerrainMeshMode = TerrainMeshMode.Dynamic,
+        };
+
+        Assert.Throws<ArgumentException>(
+            () => new SceneImportExecutionPlan(
+                normalizedRequest,
+                mismatchedRequest,
+                new SceneBuildRequest(CreateMetadata(mismatchedRequest), "resolved-source", "work", [])));
+    }
+
+    [Fact]
     public void Constructor_AllowsResolvedLocalDemTextureSourceForRemoteInput()
     {
         string workRoot = "work";


### PR DESCRIPTION
## Summary
- Adds `--terrain-mesh dynamic` for DEM terrain so each DEM sends both StaticMesh and GridMesh.
- Keeps GridMesh selected by default/fail-safe: `BooleanAssetDriver<Mesh>` uses `FalseTarget=GridMesh`, `TrueTarget=StaticMesh`, and `PLATEAU.Terrain.Static.Enabled` defaults to `false`.
- Replaces direct int2 points DV with a non-uniform-safe control: `ValueGradientDriver<int2>` drives `GridMesh.Points`, while `DynamicValueVariableDriver<float>` drives its `Progress` via `PLATEAU.Terrain.Grid.Points.Progress`.
- Keeps GridMesh and drivers on the renderer/object slot, static mesh and displacement texture under Assets, and preserves Grid mode fallback behavior.

## Resonite reflection / live evidence
- Confirmed through ResoniteLink reflection on `ws://localhost:19100/`:
  - `[FrooxEngine]FrooxEngine.DynamicValueVariableDriver<>`: `VariableName`, `Target`, `DefaultValue`
  - `[FrooxEngine]FrooxEngine.ValueGradientDriver<>`: `Progress`, `Target`, `Interpolate`, `Points`
  - `[FrooxEngine]FrooxEngine.ValueGradientDriver<>+Point`: `Position`, `Value`
  - `[FrooxEngine]FrooxEngine.BooleanAssetDriver<>`: `State`, `Target`, `FalseTarget`, `TrueTarget`
- Live sent Yokohama 2024 normal archive DEM dynamic:
  - dataset `14100_yokohama-shi_city_2024`, mesh `53391530`, package `dem`
  - prepared `dynamic-terrain(static=200388 vertices, grid=569x464)`
  - DataModel batch completed, `Sent city object 1`, `sent=1 failed=0`

## Points uniformity note
- Yokohama `533915` archive inspection showed DEM GridMesh Points are not generally uniform across the dataset area.
- The new float progress DV preserves each mesh's own max points at progress `1.0`, while allowing a shared quality knob down to `2x2` at progress `0.0`.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`

## Review gate
- Latest explorer review for the ValueGradientDriver-based points control: no findings.
- A separate generic-type warning was rejected based on ResoniteLink reflection and successful live DataModel batch execution, which are the relevant integration boundaries for this repository.