### PR TITLE
Hotfix dynamic asset preparation memory

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -636,7 +636,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         try
         {
             PreparedCityObject preparedCityObject = await AwaitWithSlowCityObjectWarningAsync(
-                queuedCityObject.PreparationTask,
+                CreatePreparationTask(state, queuedCityObject.CityObject, cancellationToken),
                 cancellationToken);
             await BuildPreparedCityObjectAsync(state, queuedCityObject, preparedCityObject, cancellationToken);
 
@@ -710,7 +710,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         AsyncWeightedGate.Lease cityObjectMemoryLease = await runtime.AcquireCityObjectMemoryAsync(
             estimatedWorksetBytes,
             cancellationToken);
-        Task<PreparedCityObject> preparationTask = CreatePreparationTask(state, cityObject, cancellationToken);
         Task<ResoniteSharedSlotIndex.ObjectSlotHierarchy> objectHierarchyTask = CreateObjectHierarchyTask(state, cityObject, cancellationToken);
         if (Interlocked.CompareExchange(ref state.Progress.FirstQueuedCityObjectLogged, 1, 0) == 0)
         {
@@ -728,7 +727,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         try
         {
             await runtime.WriteAsync(
-                new QueuedCityObject(cityObject, preparationTask, objectHierarchyTask, cityObjectMemoryLease),
+                new QueuedCityObject(cityObject, objectHierarchyTask, cityObjectMemoryLease),
                 enqueueCancellation.Token);
         }
         catch (OperationCanceledException) when (runtime.IsCancellationRequested)
@@ -740,7 +739,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         catch
         {
             await cityObjectMemoryLease.DisposeAsync();
-            _ = ObserveTaskFailureAsync(preparationTask);
             _ = ObserveTaskFailureAsync(objectHierarchyTask);
             throw;
         }
@@ -794,11 +792,12 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             _ => minimumWeightBytes,
         };
 
-        int distinctTextureCount = cityObject.Materials
+        ResoniteTexturePayload[] distinctTexturePayloads = cityObject.Materials
             .Where(static material => material.TexturePayload is not null)
             .Select(static material => material.TexturePayload!)
             .Distinct(TexturePayloadReferenceComparer.Instance)
-            .Count();
+            .ToArray();
+        long directTexturePayloadWeightBytes = distinctTexturePayloads.Sum(static payload => (long)payload.BinaryPayload.Length);
         long terrainOverlayWeightBytes = cityObject.Materials
             .Where(static material => material.TerrainOverlay is not null)
             .Select(static material => material.TerrainOverlay!)
@@ -806,7 +805,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             .Sum(EstimateTerrainOverlayWorkingSetBytes);
         long materialWeightBytes = checked(
             (cityObject.Materials.Count * materialBindingWeightBytes)
-            + (distinctTextureCount * textureReferenceWeightBytes)
+            + (distinctTexturePayloads.Length * textureReferenceWeightBytes)
+            + directTexturePayloadWeightBytes
             + terrainOverlayWeightBytes);
         return Math.Max(minimumWeightBytes, geometryWeightBytes + materialWeightBytes);
 
@@ -2166,7 +2166,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 
     internal sealed record QueuedCityObject(
         ResoniteConstructionCityObject CityObject,
-        Task<PreparedCityObject> PreparationTask,
         Task<ResoniteSharedSlotIndex.ObjectSlotHierarchy> ObjectHierarchyTask,
         AsyncWeightedGate.Lease MemoryLease);
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -351,7 +351,8 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         IResoniteLinkClient routedClient,
         ITerrainTextureAssetGenerator? terrainTextureAssetGenerator = null,
         bool enableMeshBake = true,
-        DelegatingClientSession? session = null)
+        DelegatingClientSession? session = null,
+        Action<string>? progressReporter = null)
     {
         ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
         return new ResoniteLiveSceneImportTarget(
@@ -363,7 +364,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 enableMeshBake,
                 TerrainTileCacheRoot: null,
                 DisableTerrainTileCache: false,
-                ProgressReporter: null),
+                ProgressReporter: progressReporter),
             new ResoniteLiveSceneImportDependencies(
                 session ?? new DelegatingClientSession(routedClient),
                 diagnostics,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -383,7 +383,9 @@ public sealed class ResoniteLiveSceneImportTargetTests
     public async Task BuildAsyncCreatesDynamicTerrainStaticAndGridAssetsWithGridFallback()
     {
         using TemporaryDirectory datasetDirectory = new();
+        using TemporaryDirectory workDirectory = new();
         using SceneBuilderRecordingClient client = new();
+        List<string> progressMessages = [];
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
             MeshCode,
@@ -424,10 +426,24 @@ public sealed class ResoniteLiveSceneImportTargetTests
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
-        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(metadata, [cityObject], client);
+        await using ResoniteLiveSceneImportTarget builder = ResoniteLiveSceneImportTargetTestSupport.CreateBuilder(
+            client,
+            progressReporter: progressMessages.Add);
+        _ = await ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(
+            builder,
+            metadata,
+            workDirectory.Path,
+            [cityObject]);
 
         Assert.Single(client.ImportedMeshes);
         Assert.Single(client.ImportedRawHdrTextures);
+        int queuedMessageIndex = progressMessages.FindIndex(static message => message.Contains("First city object queued", StringComparison.Ordinal));
+        int preparationMessageIndex = progressMessages.FindIndex(static message => message.Contains("City object preparation started", StringComparison.Ordinal));
+        Assert.True(queuedMessageIndex >= 0);
+        Assert.True(preparationMessageIndex >= 0);
+        Assert.True(
+            queuedMessageIndex < preparationMessageIndex,
+            "Dynamic terrain preparation should start only after the city object is queued for a send lane.");
         Component staticMesh = Assert.Single(
             client.ComponentsById.Values,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticMesh", StringComparison.Ordinal));


### PR DESCRIPTION
## Summary
- stop starting city-object preparation at enqueue time so prepared mesh/texture payloads do not sit in the queued item before a send lane consumes it
- keep dynamic terrain asset import immediately after lane-local preparation, preserving URI-based emission once imports complete
- include direct texture payload byte size in the live-send working-set estimate instead of counting only a fixed reference cost

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false