### PR TITLE
Fix dynamic DEM live-send stalls

### DIFF
--- a/src/PlateauResoniteLink.Cli/Program.cs
+++ b/src/PlateauResoniteLink.Cli/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -11,9 +12,14 @@ public static class Program
     {
         using IHost host = CliHostFactory.Create(args);
         await host.StartAsync();
+        IHostApplicationLifetime lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
         try
         {
-            return await host.Services.GetRequiredService<CliApplication>().RunAsync(args);
+            return await host.Services.GetRequiredService<CliApplication>().RunAsync(args, lifetime.ApplicationStopping);
+        }
+        catch (OperationCanceledException) when (lifetime.ApplicationStopping.IsCancellationRequested)
+        {
+            return 130;
         }
         finally
         {

--- a/src/PlateauResoniteLink/Application/Importing/DemCityObjectAggregation.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemCityObjectAggregation.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class DemCityObjectAggregation
+{
+    public static BootstrapParsedCityObject[] AggregateBySourceFileAndThirdMesh(
+        SourceFileDescriptor sourceFile,
+        IEnumerable<BootstrapParsedCityObject> cityObjects)
+    {
+        ArgumentNullException.ThrowIfNull(sourceFile);
+        ArgumentNullException.ThrowIfNull(cityObjects);
+
+        BootstrapParsedCityObject[] objects = cityObjects.ToArray();
+        if (!string.Equals(sourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
+        {
+            return objects;
+        }
+
+        return objects
+            .GroupBy(cityObject => new DemCityObjectKey(
+                cityObject.SourceFileRelativePath,
+                ResolveThirdMeshCode(cityObject, sourceFile)),
+                DemCityObjectKeyComparer.Instance)
+            .OrderBy(static group => group.Key.SourceFileRelativePath, StringComparer.Ordinal)
+            .ThenBy(static group => group.Key.ThirdMeshCode, StringComparer.Ordinal)
+            .Select(static group => AggregateGroup(group.Key, group))
+            .Where(static cityObject => cityObject.Surfaces.Length > 0)
+            .ToArray();
+    }
+
+    private static BootstrapParsedCityObject AggregateGroup(
+        DemCityObjectKey key,
+        IEnumerable<BootstrapParsedCityObject> cityObjects)
+    {
+        BootstrapParsedCityObject[] orderedCityObjects = cityObjects
+            .OrderBy(static cityObject => cityObject.SlotKey, StringComparer.Ordinal)
+            .ThenBy(static cityObject => cityObject.DisplayName, StringComparer.Ordinal)
+            .ToArray();
+        BootstrapParsedCityObject first = orderedCityObjects[0];
+        BootstrapParsedSurface[] surfaces = orderedCityObjects
+            .SelectMany(static cityObject => cityObject.Surfaces)
+            .OrderBy(static surface => surface.PolygonId, StringComparer.Ordinal)
+            .ThenBy(static surface => surface.ExteriorRing.RingId, StringComparer.Ordinal)
+            .ToArray();
+
+        return first with
+        {
+            SlotKey = CreateSlotKey(first.PackageName, key.SourceFileRelativePath, key.ThirdMeshCode),
+            DisplayName = $"DEM {key.ThirdMeshCode}",
+            ActualMeshCode = key.ThirdMeshCode,
+            LodLevel = orderedCityObjects
+                .Select(static cityObject => cityObject.LodLevel)
+                .Where(static lodLevel => lodLevel.HasValue)
+                .DefaultIfEmpty()
+                .Max(),
+            Surfaces = surfaces,
+            SourceFileRelativePath = key.SourceFileRelativePath,
+            SharedAcrossMeshCodes = orderedCityObjects.Any(static cityObject => cityObject.SharedAcrossMeshCodes),
+            TerrainAligned = orderedCityObjects.Any(static cityObject => cityObject.TerrainAligned),
+            OriginOverride = null,
+            FloorsAboveGround = null,
+            MeasuredHeightMeters = null,
+        };
+    }
+
+    private static string ResolveThirdMeshCode(
+        BootstrapParsedCityObject cityObject,
+        SourceFileDescriptor sourceFile)
+    {
+        if (TryNormalizeThirdMeshCode(cityObject.ActualMeshCode, out string? actualMeshCode))
+        {
+            return actualMeshCode!;
+        }
+
+        if (TryNormalizeThirdMeshCode(sourceFile.MatchedMeshCode, out string? matchedMeshCode))
+        {
+            return matchedMeshCode!;
+        }
+
+        return cityObject.ActualMeshCode;
+    }
+
+    private static bool TryNormalizeThirdMeshCode(string value, out string? meshCode)
+    {
+        meshCode = null;
+        if (value.Length < 8)
+        {
+            return false;
+        }
+
+        string candidate = value[..8];
+        if (!candidate.All(static character => character is >= '0' and <= '9'))
+        {
+            return false;
+        }
+
+        meshCode = candidate;
+        return true;
+    }
+
+    private static string CreateSlotKey(
+        string packageName,
+        string sourceFileRelativePath,
+        string thirdMeshCode)
+    {
+        string fileStem = Path.GetFileNameWithoutExtension(sourceFileRelativePath);
+        return SanitizeIdentifier($"{packageName}_{fileStem}_{thirdMeshCode}");
+    }
+
+    private static string SanitizeIdentifier(string value)
+    {
+        return string.Concat(value.Select(static character => char.IsLetterOrDigit(character) ? character : '_'));
+    }
+
+    private sealed record DemCityObjectKey(
+        string SourceFileRelativePath,
+        string ThirdMeshCode);
+
+    private sealed class DemCityObjectKeyComparer : IEqualityComparer<DemCityObjectKey>
+    {
+        public static readonly DemCityObjectKeyComparer Instance = new();
+
+        public bool Equals(DemCityObjectKey? left, DemCityObjectKey? right)
+        {
+            return left is not null
+                && right is not null
+                && string.Equals(left.SourceFileRelativePath, right.SourceFileRelativePath, StringComparison.Ordinal)
+                && string.Equals(left.ThirdMeshCode, right.ThirdMeshCode, StringComparison.Ordinal);
+        }
+
+        public int GetHashCode(DemCityObjectKey key)
+        {
+            HashCode hash = new();
+            hash.Add(key.SourceFileRelativePath, StringComparer.Ordinal);
+            hash.Add(key.ThirdMeshCode, StringComparer.Ordinal);
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
+using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Application.Importing;
@@ -100,8 +102,11 @@ internal static class DemTerrainOverlayAssignment
     public static IEnumerable<(BootstrapParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> SplitParsedCityObject(
         BootstrapParsedCityObject parsedCityObject,
         IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
-        IReadOnlyList<MeshCodeBounds>? requestedMeshAreas = null)
+        IReadOnlyList<MeshCodeBounds>? requestedMeshAreas = null,
+        Action<string>? progressReporter = null,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (!string.Equals(parsedCityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
         {
             yield return (parsedCityObject, null);
@@ -124,10 +129,17 @@ internal static class DemTerrainOverlayAssignment
             .Where(static surface => surface.UsesGeneratedDemTexture)
             .ToArray();
 
+        progressReporter?.Invoke(
+            PlateauLog.Debug(
+                "import",
+                $"Splitting DEM city object '{parsedCityObject.SlotKey}' "
+                + $"(generated_surfaces={generatedSurfaces.Length}, non_generated_surfaces={parsedCityObject.Surfaces.Length - generatedSurfaces.Length}, "
+                + $"overlays={demTerrainTextureOverlays.Count}, requested_mesh_areas={requestedMeshBounds.Length})."));
+
         BootstrapParsedSurface[] nonGeneratedSurfaces = parsedCityObject.Surfaces
             .Where(static surface => !surface.UsesGeneratedDemTexture)
             .SelectMany(surface => parsedCityObject.SharedAcrossMeshCodes
-                ? ClipSurfaceToRequestedMeshAreas(surface, requestedMeshBounds)
+                ? ClipSurfaceToRequestedMeshAreas(surface, requestedMeshBounds, progressReporter, cancellationToken)
                 : [surface])
             .ToArray();
 
@@ -146,7 +158,7 @@ internal static class DemTerrainOverlayAssignment
         {
             BootstrapParsedSurface[] texturelessGeneratedSurfaces = generatedSurfaces
                 .SelectMany(generatedSurface => parsedCityObject.SharedAcrossMeshCodes
-                    ? ClipGeneratedSurfaceToRequestedMeshAreas(generatedSurface, requestedMeshBounds)
+                    ? ClipGeneratedSurfaceToRequestedMeshAreas(generatedSurface, requestedMeshBounds, progressReporter, cancellationToken)
                     : [generatedSurface])
                 .ToArray();
             BootstrapParsedSurface[] texturelessSurfaces = [.. texturelessGeneratedSurfaces, .. nonGeneratedSurfaces];
@@ -162,9 +174,10 @@ internal static class DemTerrainOverlayAssignment
         List<(BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> splitGeneratedSurfaces = [];
         foreach (BootstrapParsedSurface generatedSurface in generatedSurfaces)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             BootstrapParsedSurface[] requestedMeshClippedSurfaces =
                 parsedCityObject.SharedAcrossMeshCodes
-                    ? ClipGeneratedSurfaceToRequestedMeshAreas(generatedSurface, requestedMeshBounds)
+                    ? ClipGeneratedSurfaceToRequestedMeshAreas(generatedSurface, requestedMeshBounds, progressReporter, cancellationToken)
                     : [generatedSurface];
             if (requestedMeshClippedSurfaces.Length == 0)
             {
@@ -173,6 +186,7 @@ internal static class DemTerrainOverlayAssignment
 
             foreach (BootstrapParsedSurface requestedMeshClippedSurface in requestedMeshClippedSurfaces)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 GeographicRectangle surfaceBounds = GetSurfaceGeographicBounds(requestedMeshClippedSurface);
                 TerrainTextureOverlay? containingOverlay = demTerrainTextureOverlays.FirstOrDefault(overlay =>
                     surfaceBounds.MinLatitude >= overlay.GeographicBounds.MinLatitude
@@ -201,7 +215,9 @@ internal static class DemTerrainOverlayAssignment
                 IReadOnlyList<(BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> clippedSurfaces =
                     DemTerrainOverlaySurfaceClipper.ClipGeneratedSurfaceToOverlays(
                         requestedMeshClippedSurface,
-                        candidateOverlays);
+                        candidateOverlays,
+                        progressReporter,
+                        cancellationToken);
                 if (clippedSurfaces.Count == 0)
                 {
                     throw new InvalidOperationException(
@@ -221,7 +237,14 @@ internal static class DemTerrainOverlayAssignment
             }
         }
 
-        IGrouping<TerrainTextureOverlay, (BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)>[] groups = splitGeneratedSurfaces
+        IReadOnlyList<(BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> groupedGeneratedSurfaces =
+            TryPruneBoundarySliverGroups(
+                splitGeneratedSurfaces,
+                out IReadOnlyList<(BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> prunedGeneratedSurfaces)
+                ? prunedGeneratedSurfaces
+                : splitGeneratedSurfaces;
+
+        IGrouping<TerrainTextureOverlay, (BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)>[] groups = groupedGeneratedSurfaces
             .GroupBy(static surface => surface.Overlay)
             .OrderBy(static group => group.Key.PackageName, StringComparer.Ordinal)
             .ThenBy(static group => group.Key.GeographicBounds.MinLatitude)
@@ -230,7 +253,7 @@ internal static class DemTerrainOverlayAssignment
 
         if (groups.Length == 1
             && nonGeneratedSurfaces.Length == 0
-            && splitGeneratedSurfaces.Count > 0)
+            && groupedGeneratedSurfaces.Count > 0)
         {
             yield return (
                 parsedCityObject with
@@ -247,6 +270,7 @@ internal static class DemTerrainOverlayAssignment
         for (int index = 0; index < groups.Length; index++)
         {
             IGrouping<TerrainTextureOverlay, (BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> group = groups[index];
+            cancellationToken.ThrowIfCancellationRequested();
             yield return (
                 parsedCityObject with
                 {
@@ -271,7 +295,9 @@ internal static class DemTerrainOverlayAssignment
 
     private static BootstrapParsedSurface[] ClipGeneratedSurfaceToRequestedMeshAreas(
         BootstrapParsedSurface generatedSurface,
-        GeographicRectangle[] requestedMeshBounds)
+        GeographicRectangle[] requestedMeshBounds,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
     {
         if (requestedMeshBounds.Length == 0)
         {
@@ -280,12 +306,16 @@ internal static class DemTerrainOverlayAssignment
 
         return DemTerrainOverlaySurfaceClipper.ClipGeneratedSurfaceToBounds(
             generatedSurface,
-            requestedMeshBounds).ToArray();
+            requestedMeshBounds,
+            progressReporter,
+            cancellationToken).ToArray();
     }
 
     private static BootstrapParsedSurface[] ClipSurfaceToRequestedMeshAreas(
         BootstrapParsedSurface surface,
-        GeographicRectangle[] requestedMeshBounds)
+        GeographicRectangle[] requestedMeshBounds,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
     {
         if (requestedMeshBounds.Length == 0)
         {
@@ -294,7 +324,9 @@ internal static class DemTerrainOverlayAssignment
 
         return DemTerrainOverlaySurfaceClipper.ClipSurfaceToBounds(
             surface,
-            requestedMeshBounds).ToArray();
+            requestedMeshBounds,
+            progressReporter,
+            cancellationToken).ToArray();
     }
 
     private static BootstrapParsedSurface[] ClipBootstrapGeneratedSurfaceToRequestedMeshAreas(
@@ -453,6 +485,78 @@ internal static class DemTerrainOverlayAssignment
         return true;
     }
 
+    private static bool TryPruneBoundarySliverGroups(
+        List<(BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> surfaces,
+        out IReadOnlyList<(BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> prunedSurfaces)
+    {
+        prunedSurfaces = [];
+        if (surfaces.Count <= 1)
+        {
+            return false;
+        }
+
+        GroupMetrics[] groups = surfaces
+            .GroupBy(static surface => surface.Overlay)
+            .Select(static group => new GroupMetrics(
+                group.Key,
+                group.ToArray(),
+                group.Sum(static entry => ComputeSurfaceMetrics(entry.Surface).AreaSquareMeters)))
+            .ToArray();
+        if (groups.Length <= 1)
+        {
+            return false;
+        }
+
+        double totalArea = groups.Sum(static group => group.AreaSquareMeters);
+        if (totalArea <= 1e-9)
+        {
+            return false;
+        }
+
+        int dominantIndex = 0;
+        for (int index = 1; index < groups.Length; index++)
+        {
+            if (groups[index].AreaSquareMeters > groups[dominantIndex].AreaSquareMeters)
+            {
+                dominantIndex = index;
+            }
+        }
+
+        List<(BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> keptSurfaces = [];
+        bool prunedBoundarySliver = false;
+        for (int index = 0; index < groups.Length; index++)
+        {
+            GroupMetrics group = groups[index];
+            if (index != dominantIndex)
+            {
+                double areaRatio = group.AreaSquareMeters / totalArea;
+                bool isBoundarySliver =
+                    areaRatio <= BoundarySliverMaxAreaRatio
+                    || group.AreaSquareMeters <= BoundarySliverMaxAreaSquareMeters;
+                if (isBoundarySliver)
+                {
+                    prunedBoundarySliver = true;
+                    continue;
+                }
+            }
+
+            keptSurfaces.AddRange(group.Surfaces);
+        }
+
+        if (!prunedBoundarySliver || keptSurfaces.Count == surfaces.Count || keptSurfaces.Count == 0)
+        {
+            return false;
+        }
+
+        prunedSurfaces = keptSurfaces
+            .OrderBy(static entry => entry.Overlay.PackageName, StringComparer.Ordinal)
+            .ThenBy(static entry => entry.Overlay.GeographicBounds.MinLatitude)
+            .ThenBy(static entry => entry.Overlay.GeographicBounds.MinLongitude)
+            .ThenBy(static entry => entry.Surface.PolygonId, StringComparer.Ordinal)
+            .ToArray();
+        return true;
+    }
+
     private static GeodeticPoint GetCityObjectOrigin(
         BootstrapParsedCityObject cityObject)
     {
@@ -594,4 +698,9 @@ internal static class DemTerrainOverlayAssignment
     private readonly record struct ProjectedPoint(double X, double Y);
 
     private readonly record struct SurfaceMetrics(double AreaSquareMeters, double EstimatedThicknessMeters);
+
+    private readonly record struct GroupMetrics(
+        TerrainTextureOverlay Overlay,
+        IReadOnlyList<(BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> Surfaces,
+        double AreaSquareMeters);
 }

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
@@ -224,16 +224,7 @@ internal static class DemTerrainOverlayAssignment
                         $"Requested-mesh-clipped DEM surface '{requestedMeshClippedSurface.PolygonId}' did not produce any terrain-overlay-clipped geometry.");
                 }
 
-                if (TryPruneBoundarySliverSplit(
-                        clippedSurfaces,
-                        out IReadOnlyList<(BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> prunedSurfaces))
-                {
-                    splitGeneratedSurfaces.AddRange(prunedSurfaces);
-                }
-                else
-                {
-                    splitGeneratedSurfaces.AddRange(clippedSurfaces);
-                }
+                splitGeneratedSurfaces.AddRange(clippedSurfaces);
             }
         }
 
@@ -453,10 +444,7 @@ internal static class DemTerrainOverlayAssignment
             }
 
             double areaRatio = metrics[index].AreaSquareMeters / totalArea;
-            bool isBoundarySliver =
-                areaRatio <= BoundarySliverMaxAreaRatio
-                || metrics[index].AreaSquareMeters <= BoundarySliverMaxAreaSquareMeters
-                || metrics[index].EstimatedThicknessMeters <= BoundarySliverMaxThicknessMeters;
+            bool isBoundarySliver = IsBoundarySliver(metrics[index], areaRatio);
             if (!isBoundarySliver)
             {
                 keptSurfaces.Add(clippedSurfaces[index]);
@@ -497,10 +485,18 @@ internal static class DemTerrainOverlayAssignment
 
         GroupMetrics[] groups = surfaces
             .GroupBy(static surface => surface.Overlay)
-            .Select(static group => new GroupMetrics(
-                group.Key,
-                group.ToArray(),
-                group.Sum(static entry => ComputeSurfaceMetrics(entry.Surface).AreaSquareMeters)))
+            .Select(static group =>
+            {
+                (BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)[] groupSurfaces = group.ToArray();
+                SurfaceMetrics[] metrics = groupSurfaces
+                    .Select(static entry => ComputeSurfaceMetrics(entry.Surface))
+                    .ToArray();
+                return new GroupMetrics(
+                    group.Key,
+                    groupSurfaces,
+                    metrics.Sum(static metric => metric.AreaSquareMeters),
+                    metrics);
+            })
             .ToArray();
         if (groups.Length <= 1)
         {
@@ -530,10 +526,9 @@ internal static class DemTerrainOverlayAssignment
             if (index != dominantIndex)
             {
                 double areaRatio = group.AreaSquareMeters / totalArea;
-                bool isBoundarySliver =
-                    areaRatio <= BoundarySliverMaxAreaRatio
-                    || group.AreaSquareMeters <= BoundarySliverMaxAreaSquareMeters;
-                if (isBoundarySliver)
+                bool isBoundarySliverGroup = group.SurfaceMetrics.Count > 0
+                    && group.SurfaceMetrics.All(metric => IsBoundarySliver(metric, areaRatio));
+                if (isBoundarySliverGroup)
                 {
                     prunedBoundarySliver = true;
                     continue;
@@ -688,6 +683,13 @@ internal static class DemTerrainOverlayAssignment
         return new SurfaceMetrics(areaSquareMeters, estimatedThicknessMeters);
     }
 
+    private static bool IsBoundarySliver(SurfaceMetrics metrics, double areaRatio)
+    {
+        return metrics.EstimatedThicknessMeters <= BoundarySliverMaxThicknessMeters
+            && (areaRatio <= BoundarySliverMaxAreaRatio
+                || metrics.AreaSquareMeters <= BoundarySliverMaxAreaSquareMeters);
+    }
+
     private static double Distance(ProjectedPoint left, ProjectedPoint right)
     {
         double deltaX = right.X - left.X;
@@ -702,5 +704,6 @@ internal static class DemTerrainOverlayAssignment
     private readonly record struct GroupMetrics(
         TerrainTextureOverlay Overlay,
         IReadOnlyList<(BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> Surfaces,
-        double AreaSquareMeters);
+        double AreaSquareMeters,
+        IReadOnlyList<SurfaceMetrics> SurfaceMetrics);
 }

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlaySurfaceClipper.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlaySurfaceClipper.cs
@@ -1,23 +1,37 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
-using NetTopologySuite.Geometries;
-
+using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Application.Importing;
 
 internal static class DemTerrainOverlaySurfaceClipper
 {
-    private static readonly GeometryFactory GeometryFactory = new();
+    private const double ClipEpsilon = 1e-12;
+    private const long ClipProgressReportInterval = 10_000;
+
+    private static long clipProgressCounter;
+
     private readonly record struct ResolvedSurfaceVertex(
         GeodeticPoint Point,
         Float2? UV);
 
+    private enum ClipBoundary
+    {
+        West,
+        East,
+        South,
+        North,
+    }
+
     public static IReadOnlyList<(BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> ClipGeneratedSurfaceToOverlays(
         BootstrapParsedSurface surface,
-        IReadOnlyList<TerrainTextureOverlay> overlays)
+        IReadOnlyList<TerrainTextureOverlay> overlays,
+        Action<string>? progressReporter = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(surface);
         ArgumentNullException.ThrowIfNull(overlays);
@@ -25,10 +39,13 @@ internal static class DemTerrainOverlaySurfaceClipper
         List<(BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> results = [];
         foreach (TerrainTextureOverlay overlay in overlays)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             foreach (BootstrapParsedSurface clippedSurface in ClipSurfaceCore(
                          surface,
                          [overlay.GeographicBounds],
-                         suffixFactory: (_, localPolygonIndex) => $"{CreateOverlayToken(overlay.GeographicBounds)}_{localPolygonIndex:D2}"))
+                         suffixFactory: (_, localPolygonIndex) => $"{CreateOverlayToken(overlay.GeographicBounds)}_{localPolygonIndex:D2}",
+                         progressReporter,
+                         cancellationToken))
             {
                 results.Add((
                     clippedSurface,
@@ -41,14 +58,18 @@ internal static class DemTerrainOverlaySurfaceClipper
 
     public static IReadOnlyList<BootstrapParsedSurface> ClipGeneratedSurfaceToBounds(
         BootstrapParsedSurface surface,
-        IReadOnlyList<GeographicRectangle> bounds)
+        IReadOnlyList<GeographicRectangle> bounds,
+        Action<string>? progressReporter = null,
+        CancellationToken cancellationToken = default)
     {
-        return ClipSurfaceToBounds(surface, bounds);
+        return ClipSurfaceToBounds(surface, bounds, progressReporter, cancellationToken);
     }
 
     public static IReadOnlyList<BootstrapParsedSurface> ClipSurfaceToBounds(
         BootstrapParsedSurface surface,
-        IReadOnlyList<GeographicRectangle> bounds)
+        IReadOnlyList<GeographicRectangle> bounds,
+        Action<string>? progressReporter = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(surface);
         ArgumentNullException.ThrowIfNull(bounds);
@@ -56,26 +77,51 @@ internal static class DemTerrainOverlaySurfaceClipper
         return ClipSurfaceCore(
             surface,
             bounds,
-            suffixFactory: (boundIndex, polygonIndex) => $"{CreateOverlayToken(bounds[boundIndex])}_{boundIndex:D2}_{polygonIndex:D2}");
+            suffixFactory: (boundIndex, polygonIndex) => $"{CreateOverlayToken(bounds[boundIndex])}_{boundIndex:D2}_{polygonIndex:D2}",
+            progressReporter,
+            cancellationToken);
     }
 
     private static List<BootstrapParsedSurface> ClipSurfaceCore(
         BootstrapParsedSurface surface,
         IReadOnlyList<GeographicRectangle> bounds,
-        Func<int, int, string> suffixFactory)
+        Func<int, int, string> suffixFactory,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         List<BootstrapParsedSurface> results = [];
+        if (surface.ExteriorRing.Vertices.Length < 3)
+        {
+            return results;
+        }
+
+        GeographicRectangle surfaceBounds = GetSurfaceBounds(surface);
         for (int boundIndex = 0; boundIndex < bounds.Count; boundIndex++)
         {
-            int polygonIndex = 0;
-            foreach (Polygon polygon in ClipToOverlay(surface, bounds[boundIndex]))
+            cancellationToken.ThrowIfCancellationRequested();
+            GeographicRectangle bound = bounds[boundIndex];
+            if (!Intersects(surfaceBounds, bound))
             {
-                ResolvedSurfaceVertex[] resolvedVertices = polygon.Coordinates
-                    .Take(Math.Max(polygon.Coordinates.Length - 1, 0))
-                    .Select(coordinate => ResolveSurfaceVertex(surface, coordinate))
-                    .ToArray();
+                continue;
+            }
+
+            if (ShouldReportClipProgress(boundIndex, bounds.Count))
+            {
+                progressReporter?.Invoke(
+                    PlateauLog.Debug(
+                        "import",
+                        $"Clipping DEM surface '{surface.PolygonId}' to geographic bound "
+                        + $"{boundIndex + 1}/{bounds.Count} "
+                        + $"(vertices={surface.ExteriorRing.Vertices.Length})."));
+            }
+
+            int polygonIndex = 0;
+            foreach (IReadOnlyList<ResolvedSurfaceVertex> polygon in ClipToOverlay(surface, bound, cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
                 (GeodeticPoint[] vertices, IReadOnlyList<Float2>? uvs) =
-                    NormalizeResolvedVertices(surface, resolvedVertices);
+                    NormalizeResolvedVertices(surface, polygon);
                 if (vertices.Length < 3)
                 {
                     continue;
@@ -98,180 +144,153 @@ internal static class DemTerrainOverlaySurfaceClipper
         return results;
     }
 
-    private static IEnumerable<Polygon> ClipToOverlay(
+    private static GeographicRectangle GetSurfaceBounds(BootstrapParsedSurface surface)
+    {
+        return new GeographicRectangle(
+            MinLatitude: surface.ExteriorRing.Vertices.Min(static point => point.Latitude),
+            MaxLatitude: surface.ExteriorRing.Vertices.Max(static point => point.Latitude),
+            MinLongitude: surface.ExteriorRing.Vertices.Min(static point => point.Longitude),
+            MaxLongitude: surface.ExteriorRing.Vertices.Max(static point => point.Longitude));
+    }
+
+    private static bool Intersects(GeographicRectangle left, GeographicRectangle right)
+    {
+        return left.MaxLatitude >= right.MinLatitude
+            && left.MinLatitude <= right.MaxLatitude
+            && left.MaxLongitude >= right.MinLongitude
+            && left.MinLongitude <= right.MaxLongitude;
+    }
+
+    private static bool ShouldReportClipProgress(int boundIndex, int boundCount)
+    {
+        _ = boundIndex;
+        _ = boundCount;
+        return Interlocked.Increment(ref clipProgressCounter) % ClipProgressReportInterval == 0;
+    }
+
+    private static IEnumerable<IReadOnlyList<ResolvedSurfaceVertex>> ClipToOverlay(
         BootstrapParsedSurface surface,
-        GeographicRectangle rectangle)
+        GeographicRectangle rectangle,
+        CancellationToken cancellationToken)
     {
         if (surface.InteriorRings.Length != 0 || surface.ExteriorRing.Vertices.Length < 3)
         {
             yield break;
         }
 
-        Polygon input = GeometryFactory.CreatePolygon(ToClosedCoordinates(surface.ExteriorRing.Vertices));
-        Polygon clip = GeometryFactory.CreatePolygon(
-        [
-            new Coordinate(rectangle.MinLongitude, rectangle.MinLatitude),
-            new Coordinate(rectangle.MaxLongitude, rectangle.MinLatitude),
-            new Coordinate(rectangle.MaxLongitude, rectangle.MaxLatitude),
-            new Coordinate(rectangle.MinLongitude, rectangle.MaxLatitude),
-            new Coordinate(rectangle.MinLongitude, rectangle.MinLatitude),
-        ]);
+        cancellationToken.ThrowIfCancellationRequested();
+        List<ResolvedSurfaceVertex> vertices = surface.ExteriorRing.Vertices
+            .Select((point, index) => new ResolvedSurfaceVertex(
+                point,
+                surface.ExteriorRing.UVs is not null && index < surface.ExteriorRing.UVs.Count
+                    ? surface.ExteriorRing.UVs[index]
+                    : null))
+            .ToList();
 
-        Geometry intersection = input.Intersection(clip);
-        foreach (Geometry geometry in EnumeratePolygons(intersection))
+        foreach (ClipBoundary boundary in Enum.GetValues<ClipBoundary>())
         {
-            if (geometry is Polygon polygon && !polygon.IsEmpty)
+            cancellationToken.ThrowIfCancellationRequested();
+            vertices = ClipAgainstBoundary(vertices, rectangle, boundary);
+            if (vertices.Count < 3)
             {
-                yield return polygon;
+                yield break;
             }
         }
+
+        yield return vertices;
     }
 
-    private static IEnumerable<Geometry> EnumeratePolygons(Geometry geometry)
+    private static List<ResolvedSurfaceVertex> ClipAgainstBoundary(
+        IReadOnlyList<ResolvedSurfaceVertex> vertices,
+        GeographicRectangle rectangle,
+        ClipBoundary boundary)
     {
-        if (geometry.IsEmpty)
-        {
-            yield break;
-        }
+        List<ResolvedSurfaceVertex> output = [];
+        ResolvedSurfaceVertex previous = vertices[^1];
+        bool previousInside = IsInside(previous, rectangle, boundary);
 
-        if (geometry is Polygon)
+        foreach (ResolvedSurfaceVertex current in vertices)
         {
-            yield return geometry;
-            yield break;
-        }
-
-        if (geometry is MultiPolygon or GeometryCollection)
-        {
-            for (int index = 0; index < geometry.NumGeometries; index++)
+            bool currentInside = IsInside(current, rectangle, boundary);
+            if (currentInside)
             {
-                foreach (Geometry child in EnumeratePolygons(geometry.GetGeometryN(index)))
+                if (!previousInside)
                 {
-                    yield return child;
+                    output.Add(IntersectBoundary(previous, current, rectangle, boundary));
                 }
+
+                output.Add(current);
             }
+            else if (previousInside)
+            {
+                output.Add(IntersectBoundary(previous, current, rectangle, boundary));
+            }
+
+            previous = current;
+            previousInside = currentInside;
         }
+
+        return output;
     }
 
-    private static Coordinate[] ToClosedCoordinates(GeodeticPoint[] vertices)
+    private static bool IsInside(
+        ResolvedSurfaceVertex vertex,
+        GeographicRectangle rectangle,
+        ClipBoundary boundary)
     {
-        Coordinate[] coordinates = new Coordinate[vertices.Length + 1];
-        for (int index = 0; index < vertices.Length; index++)
+        return boundary switch
         {
-            coordinates[index] = new Coordinate(vertices[index].Longitude, vertices[index].Latitude);
-        }
-
-        coordinates[^1] = new Coordinate(vertices[0].Longitude, vertices[0].Latitude);
-        return coordinates;
+            ClipBoundary.West => vertex.Point.Longitude >= rectangle.MinLongitude - ClipEpsilon,
+            ClipBoundary.East => vertex.Point.Longitude <= rectangle.MaxLongitude + ClipEpsilon,
+            ClipBoundary.South => vertex.Point.Latitude >= rectangle.MinLatitude - ClipEpsilon,
+            ClipBoundary.North => vertex.Point.Latitude <= rectangle.MaxLatitude + ClipEpsilon,
+            _ => throw new ArgumentOutOfRangeException(nameof(boundary), boundary, null),
+        };
     }
 
-    private static ResolvedSurfaceVertex ResolveSurfaceVertex(
-        BootstrapParsedSurface surface,
-        Coordinate coordinate)
+    private static ResolvedSurfaceVertex IntersectBoundary(
+        ResolvedSurfaceVertex start,
+        ResolvedSurfaceVertex end,
+        GeographicRectangle rectangle,
+        ClipBoundary boundary)
     {
-        GeodeticPoint[] vertices = surface.ExteriorRing.Vertices;
-        IReadOnlyList<Float2>? uvs = surface.ExteriorRing.UVs;
-        for (int index = 0; index < vertices.Length; index++)
+        double denominator = boundary is ClipBoundary.West or ClipBoundary.East
+            ? end.Point.Longitude - start.Point.Longitude
+            : end.Point.Latitude - start.Point.Latitude;
+        if (Math.Abs(denominator) <= ClipEpsilon)
         {
-            if (Approximately(vertices[index].Longitude, coordinate.X)
-                && Approximately(vertices[index].Latitude, coordinate.Y))
-            {
-                return new ResolvedSurfaceVertex(vertices[index], uvs is not null && index < uvs.Count ? uvs[index] : null);
-            }
+            return start;
         }
 
-        if (TryResolveEdgePoint(vertices, uvs, coordinate, out ResolvedSurfaceVertex edgePoint))
+        double value = boundary switch
         {
-            return edgePoint;
-        }
+            ClipBoundary.West => rectangle.MinLongitude,
+            ClipBoundary.East => rectangle.MaxLongitude,
+            ClipBoundary.South => rectangle.MinLatitude,
+            ClipBoundary.North => rectangle.MaxLatitude,
+            _ => throw new ArgumentOutOfRangeException(nameof(boundary), boundary, null),
+        };
+        double sourceValue = boundary is ClipBoundary.West or ClipBoundary.East
+            ? start.Point.Longitude
+            : start.Point.Latitude;
+        double ratio = Math.Clamp((value - sourceValue) / denominator, 0.0, 1.0);
 
-        return ResolvePlanarPoint(vertices, uvs, coordinate);
-    }
-
-    private static bool TryResolveEdgePoint(
-        GeodeticPoint[] vertices,
-        IReadOnlyList<Float2>? uvs,
-        Coordinate coordinate,
-        out ResolvedSurfaceVertex point)
-    {
-        for (int index = 0; index < vertices.Length; index++)
+        Float2? uv = null;
+        if (start.UV is not null && end.UV is not null)
         {
-            GeodeticPoint start = vertices[index];
-            GeodeticPoint end = vertices[(index + 1) % vertices.Length];
-            double deltaLongitude = end.Longitude - start.Longitude;
-            double deltaLatitude = end.Latitude - start.Latitude;
-            double edgeLengthSquared = (deltaLongitude * deltaLongitude) + (deltaLatitude * deltaLatitude);
-            if (edgeLengthSquared <= 1e-18)
-            {
-                continue;
-            }
-
-            double ratio = ((coordinate.X - start.Longitude) * deltaLongitude + (coordinate.Y - start.Latitude) * deltaLatitude) / edgeLengthSquared;
-            if (ratio < -1e-8 || ratio > 1.0 + 1e-8)
-            {
-                continue;
-            }
-
-            double projectedLongitude = start.Longitude + (deltaLongitude * ratio);
-            double projectedLatitude = start.Latitude + (deltaLatitude * ratio);
-            if (!Approximately(projectedLongitude, coordinate.X) || !Approximately(projectedLatitude, coordinate.Y))
-            {
-                continue;
-            }
-
-            ratio = Math.Clamp(ratio, 0.0, 1.0);
-            Float2? uv = null;
-            if (uvs is not null
-                && index < uvs.Count
-                && ((index + 1) % vertices.Length) < uvs.Count)
-            {
-                Float2 startUv = uvs[index];
-                Float2 endUv = uvs[(index + 1) % vertices.Length];
-                uv = new Float2(
-                    startUv.X + ((endUv.X - startUv.X) * ratio),
-                    startUv.Y + ((endUv.Y - startUv.Y) * ratio));
-            }
-
-            point = new ResolvedSurfaceVertex(
-                new GeodeticPoint(
-                    coordinate.Y,
-                    coordinate.X,
-                    start.Altitude + ((end.Altitude - start.Altitude) * ratio)),
-                uv);
-            return true;
-        }
-
-        point = default;
-        return false;
-    }
-
-    private static ResolvedSurfaceVertex ResolvePlanarPoint(
-        GeodeticPoint[] vertices,
-        IReadOnlyList<Float2>? uvs,
-        Coordinate coordinate)
-    {
-        GeodeticPoint origin = vertices[0];
-        for (int index = 1; index + 1 < vertices.Length; index++)
-        {
-            Float2? originUv = uvs is not null && 0 < uvs.Count ? uvs[0] : null;
-            Float2? vertexUv = uvs is not null && index < uvs.Count ? uvs[index] : null;
-            Float2? nextUv = uvs is not null && index + 1 < uvs.Count ? uvs[index + 1] : null;
-            if (TryResolveTrianglePoint(
-                    origin,
-                    vertices[index],
-                    vertices[index + 1],
-                    originUv,
-                    vertexUv,
-                    nextUv,
-                    coordinate,
-                    out ResolvedSurfaceVertex point))
-            {
-                return point;
-            }
+            Float2 startUv = start.UV;
+            Float2 endUv = end.UV;
+            uv = new Float2(
+                startUv.X + ((endUv.X - startUv.X) * ratio),
+                startUv.Y + ((endUv.Y - startUv.Y) * ratio));
         }
 
         return new ResolvedSurfaceVertex(
-            new GeodeticPoint(coordinate.Y, coordinate.X, origin.Altitude),
-            uvs is not null && uvs.Count > 0 ? uvs[0] : null);
+            new GeodeticPoint(
+                start.Point.Latitude + ((end.Point.Latitude - start.Point.Latitude) * ratio),
+                start.Point.Longitude + ((end.Point.Longitude - start.Point.Longitude) * ratio),
+                start.Point.Altitude + ((end.Point.Altitude - start.Point.Altitude) * ratio)),
+            uv);
     }
 
     private static (
@@ -362,61 +381,6 @@ internal static class DemTerrainOverlaySurfaceClipper
         }
 
         return signedArea * 0.5;
-    }
-
-    private static bool TryResolveTrianglePoint(
-        GeodeticPoint a,
-        GeodeticPoint b,
-        GeodeticPoint c,
-        Float2? uvA,
-        Float2? uvB,
-        Float2? uvC,
-        Coordinate coordinate,
-        out ResolvedSurfaceVertex point)
-    {
-        double denominator =
-            ((b.Latitude - c.Latitude) * (a.Longitude - c.Longitude))
-            + ((c.Longitude - b.Longitude) * (a.Latitude - c.Latitude));
-        if (Math.Abs(denominator) <= 1e-18)
-        {
-            point = default;
-            return false;
-        }
-
-        double weightA =
-            (((b.Latitude - c.Latitude) * (coordinate.X - c.Longitude))
-             + ((c.Longitude - b.Longitude) * (coordinate.Y - c.Latitude)))
-            / denominator;
-        double weightB =
-            (((c.Latitude - a.Latitude) * (coordinate.X - c.Longitude))
-             + ((a.Longitude - c.Longitude) * (coordinate.Y - c.Latitude)))
-            / denominator;
-        double weightC = 1.0 - weightA - weightB;
-
-        if (weightA < -1e-8 || weightB < -1e-8 || weightC < -1e-8)
-        {
-            point = default;
-            return false;
-        }
-
-        double altitude = (a.Altitude * weightA) + (b.Altitude * weightB) + (c.Altitude * weightC);
-        Float2? uv = null;
-        if (uvA is not null && uvB is not null && uvC is not null)
-        {
-            uv = new Float2(
-                (uvA.X * weightA) + (uvB.X * weightB) + (uvC.X * weightC),
-                (uvA.Y * weightA) + (uvB.Y * weightB) + (uvC.Y * weightC));
-        }
-
-        point = new ResolvedSurfaceVertex(
-            new GeodeticPoint(coordinate.Y, coordinate.X, altitude),
-            uv);
-        return true;
-    }
-
-    private static bool Approximately(double left, double right)
-    {
-        return Math.Abs(left - right) <= 1e-9;
     }
 
     private static string CreateOverlayToken(GeographicRectangle rectangle)

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlaySurfaceClipper.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlaySurfaceClipper.cs
@@ -12,6 +12,7 @@ internal static class DemTerrainOverlaySurfaceClipper
 {
     private const double ClipEpsilon = 1e-12;
     private const long ClipProgressReportInterval = 10_000;
+    private const double ClipVertexQuantization = 1_000_000_000.0;
 
     private static long clipProgressCounter;
 
@@ -187,18 +188,433 @@ internal static class DemTerrainOverlaySurfaceClipper
                     : null))
             .ToList();
 
+        if (!IsConcave(vertices))
+        {
+            foreach (IReadOnlyList<ResolvedSurfaceVertex> polygon in ClipPolygonToRectangle(vertices, rectangle, cancellationToken))
+            {
+                yield return polygon;
+            }
+
+            yield break;
+        }
+
+        List<IReadOnlyList<ResolvedSurfaceVertex>> triangleClipped = [];
+        foreach (IReadOnlyList<ResolvedSurfaceVertex> triangle in Triangulate(vertices, cancellationToken))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            foreach (IReadOnlyList<ResolvedSurfaceVertex> polygon in ClipPolygonToRectangle(triangle, rectangle, cancellationToken))
+            {
+                triangleClipped.Add(polygon);
+            }
+        }
+
+        List<List<ResolvedSurfaceVertex>>? mergedPolygons = TryMergeClippedTriangleComponents(
+            triangleClipped,
+            cancellationToken);
+        IEnumerable<IReadOnlyList<ResolvedSurfaceVertex>> clippedPolygons = mergedPolygons is null
+            ? triangleClipped
+            : mergedPolygons;
+        foreach (IReadOnlyList<ResolvedSurfaceVertex> polygon in clippedPolygons)
+        {
+            if (polygon.Count >= 3)
+            {
+                yield return polygon;
+            }
+        }
+    }
+
+    private static IEnumerable<IReadOnlyList<ResolvedSurfaceVertex>> ClipPolygonToRectangle(
+        IReadOnlyList<ResolvedSurfaceVertex> vertices,
+        GeographicRectangle rectangle,
+        CancellationToken cancellationToken)
+    {
+        List<ResolvedSurfaceVertex> clipped = [.. vertices];
         foreach (ClipBoundary boundary in Enum.GetValues<ClipBoundary>())
         {
             cancellationToken.ThrowIfCancellationRequested();
-            vertices = ClipAgainstBoundary(vertices, rectangle, boundary);
-            if (vertices.Count < 3)
+            clipped = ClipAgainstBoundary(clipped, rectangle, boundary);
+            if (clipped.Count < 3)
             {
                 yield break;
             }
         }
 
-        yield return vertices;
+        if (clipped.Count >= 3)
+        {
+            yield return clipped;
+        }
     }
+
+    private static bool IsConcave(List<ResolvedSurfaceVertex> vertices)
+    {
+        if (vertices.Count < 4)
+        {
+            return false;
+        }
+
+        double polygonSignedArea = ComputeSignedArea(vertices.Select(static vertex => vertex.Point).ToArray());
+        if (Math.Abs(polygonSignedArea) <= ClipEpsilon)
+        {
+            return false;
+        }
+
+        double sign = Math.Sign(polygonSignedArea);
+        for (int index = 0; index < vertices.Count; index++)
+        {
+            GeodeticPoint previous = vertices[(index - 1 + vertices.Count) % vertices.Count].Point;
+            GeodeticPoint current = vertices[index].Point;
+            GeodeticPoint next = vertices[(index + 1) % vertices.Count].Point;
+            if (Math.Sign(Cross(previous, current, next) * sign) < 0.0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<IReadOnlyList<ResolvedSurfaceVertex>> Triangulate(
+        List<ResolvedSurfaceVertex> vertices,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        List<ResolvedSurfaceVertex> sanitizedVertices = [];
+        foreach (ResolvedSurfaceVertex vertex in vertices)
+        {
+            if (sanitizedVertices.Count > 0 && sanitizedVertices[^1].Point.Equals(vertex.Point))
+            {
+                continue;
+            }
+
+            sanitizedVertices.Add(vertex);
+        }
+
+        if (sanitizedVertices.Count < 3)
+        {
+            yield break;
+        }
+
+        double sourceSignedArea = ComputeSignedArea(sanitizedVertices.Select(static vertex => vertex.Point).ToArray());
+        if (Math.Abs(sourceSignedArea) <= ClipEpsilon)
+        {
+            yield break;
+        }
+
+        List<int> remaining = Enumerable.Range(0, sanitizedVertices.Count).ToList();
+        double signedAreaSign = Math.Sign(sourceSignedArea);
+        int safety = sanitizedVertices.Count * sanitizedVertices.Count * 4;
+        while (remaining.Count > 2 && safety > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            bool clippedEar = false;
+            for (int earIndex = 0; earIndex < remaining.Count; earIndex++)
+            {
+                int previous = remaining[(earIndex - 1 + remaining.Count) % remaining.Count];
+                int current = remaining[earIndex];
+                int next = remaining[(earIndex + 1) % remaining.Count];
+                GeodeticPoint previousVertex = sanitizedVertices[previous].Point;
+                GeodeticPoint currentVertex = sanitizedVertices[current].Point;
+                GeodeticPoint nextVertex = sanitizedVertices[next].Point;
+
+                if (!IsConvexEar(previousVertex, currentVertex, nextVertex, signedAreaSign))
+                {
+                    continue;
+                }
+
+                bool containsPoint = false;
+                for (int insideIndex = 0; insideIndex < remaining.Count; insideIndex++)
+                {
+                    int candidateIndex = remaining[insideIndex];
+                    if (candidateIndex == previous || candidateIndex == current || candidateIndex == next)
+                    {
+                        continue;
+                    }
+
+                    if (IsPointInTriangle(
+                            sanitizedVertices[candidateIndex].Point,
+                            previousVertex,
+                            currentVertex,
+                            nextVertex,
+                            signedAreaSign))
+                    {
+                        containsPoint = true;
+                        break;
+                    }
+                }
+
+                if (containsPoint)
+                {
+                    continue;
+                }
+
+                yield return new[]
+                {
+                    sanitizedVertices[previous],
+                    sanitizedVertices[current],
+                    sanitizedVertices[next],
+                };
+                remaining.RemoveAt(earIndex);
+                clippedEar = true;
+                break;
+            }
+
+            if (!clippedEar)
+            {
+                yield break;
+            }
+
+            safety--;
+        }
+    }
+
+    private static bool IsConvexEar(
+        GeodeticPoint previous,
+        GeodeticPoint current,
+        GeodeticPoint next,
+        double signedAreaSign)
+    {
+        double cross = Cross(previous, current, next);
+        if (Math.Abs(cross) <= ClipEpsilon)
+        {
+            return false;
+        }
+
+        return Math.Sign(cross) == Math.Sign(signedAreaSign);
+    }
+
+    private static bool IsPointInTriangle(
+        GeodeticPoint point,
+        GeodeticPoint a,
+        GeodeticPoint b,
+        GeodeticPoint c,
+        double signedAreaSign)
+    {
+        double ab = Cross(a, b, point);
+        double bc = Cross(b, c, point);
+        double ca = Cross(c, a, point);
+
+        return signedAreaSign > 0.0
+            ? ab >= -ClipEpsilon && bc >= -ClipEpsilon && ca >= -ClipEpsilon
+            : ab <= ClipEpsilon && bc <= ClipEpsilon && ca <= ClipEpsilon;
+    }
+
+    private static List<List<ResolvedSurfaceVertex>>? TryMergeClippedTriangleComponents(
+        IReadOnlyList<IReadOnlyList<ResolvedSurfaceVertex>> polygons,
+        CancellationToken cancellationToken)
+    {
+        if (polygons.Count == 0)
+        {
+            return [];
+        }
+
+        Dictionary<DirectedEdgeKey, DirectedEdgeValue> edges = [];
+        Dictionary<PointKey, ResolvedSurfaceVertex> points = [];
+
+        foreach (IReadOnlyList<ResolvedSurfaceVertex> polygon in polygons)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (polygon.Count < 3)
+            {
+                continue;
+            }
+
+            for (int index = 0; index < polygon.Count; index++)
+            {
+                ResolvedSurfaceVertex from = polygon[index];
+                ResolvedSurfaceVertex to = polygon[(index + 1) % polygon.Count];
+                if (from.Point.Equals(to.Point))
+                {
+                    continue;
+                }
+
+                PointKey fromKey = CreatePointKey(from.Point);
+                PointKey toKey = CreatePointKey(to.Point);
+                DirectedEdgeKey key = new(fromKey, toKey);
+                DirectedEdgeKey reverseKey = new(toKey, fromKey);
+                if (edges.Remove(reverseKey))
+                {
+                    continue;
+                }
+
+                edges[key] = new DirectedEdgeValue(from, to);
+                points.TryAdd(fromKey, from);
+                points.TryAdd(toKey, to);
+            }
+        }
+
+        if (edges.Count == 0)
+        {
+            return null;
+        }
+
+        Dictionary<PointKey, List<PointKey>> adjacency = [];
+        foreach (DirectedEdgeKey edge in edges.Keys)
+        {
+            if (!adjacency.TryGetValue(edge.From, out List<PointKey>? values))
+            {
+                values = [];
+                adjacency[edge.From] = values;
+            }
+
+            values.Add(edge.To);
+        }
+
+        foreach (List<PointKey> list in adjacency.Values)
+        {
+            list.Sort();
+        }
+
+        HashSet<DirectedEdgeKey> usedEdges = [];
+        List<List<ResolvedSurfaceVertex>> merged = [];
+
+        foreach (DirectedEdgeKey startEdge in edges.Keys.OrderBy(static edge => edge.From).ThenBy(static edge => edge.To))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (usedEdges.Contains(startEdge))
+            {
+                continue;
+            }
+
+            List<ResolvedSurfaceVertex> ring = [];
+            PointKey start = startEdge.From;
+            PointKey current = start;
+            PointKey next = startEdge.To;
+            ring.Add(points[start]);
+            int safety = edges.Count + 2;
+
+            while (safety > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                DirectedEdgeKey edge = new(current, next);
+                if (!edges.TryGetValue(edge, out DirectedEdgeValue edgeValue))
+                {
+                    break;
+                }
+
+                if (!usedEdges.Add(edge))
+                {
+                    break;
+                }
+
+                ring.Add(edgeValue.To);
+                current = next;
+                if (current.Equals(start))
+                {
+                    break;
+                }
+
+                if (!adjacency.TryGetValue(current, out List<PointKey>? nextCandidates)
+                    || nextCandidates.Count == 0)
+                {
+                    break;
+                }
+
+                PointKey? nextCandidate = null;
+                foreach (PointKey candidate in nextCandidates)
+                {
+                    if (!usedEdges.Contains(new(current, candidate)))
+                    {
+                        nextCandidate = candidate;
+                        break;
+                    }
+                }
+
+                if (nextCandidate is null)
+                {
+                    break;
+                }
+
+                next = nextCandidate.Value;
+                safety--;
+            }
+
+            if (current != start || ring.Count < 3)
+            {
+                continue;
+            }
+
+            List<ResolvedSurfaceVertex>? normalized = NormalizeResolvedVerticesFromRing(ring);
+            if (normalized is null || normalized.Count < 3)
+            {
+                continue;
+            }
+
+            double signedArea = ComputeSignedArea(normalized.Select(static vertex => vertex.Point).ToArray());
+            if (Math.Abs(signedArea) <= ClipEpsilon)
+            {
+                continue;
+            }
+
+            merged.Add(normalized);
+        }
+
+        return merged.Count > 0 && usedEdges.Count == edges.Count
+            ? merged
+            : null;
+    }
+
+    private static List<ResolvedSurfaceVertex>? NormalizeResolvedVerticesFromRing(
+        IReadOnlyList<ResolvedSurfaceVertex> ringVertices)
+    {
+        if (ringVertices.Count < 3)
+        {
+            return null;
+        }
+
+        List<ResolvedSurfaceVertex> normalized = [];
+        foreach (ResolvedSurfaceVertex vertex in ringVertices)
+        {
+            if (normalized.Count > 0 && normalized[^1].Point.Equals(vertex.Point))
+            {
+                continue;
+            }
+
+            normalized.Add(vertex);
+        }
+
+        if (normalized.Count == 0)
+        {
+            return null;
+        }
+
+        if (normalized.Count > 1 && normalized[0].Point.Equals(normalized[^1].Point))
+        {
+            normalized.RemoveAt(normalized.Count - 1);
+        }
+
+        if (normalized.Count < 3)
+        {
+            return null;
+        }
+
+        return normalized;
+    }
+
+    private static PointKey CreatePointKey(GeodeticPoint point)
+    {
+        return new(
+            (long)Math.Round(point.Longitude * ClipVertexQuantization),
+            (long)Math.Round(point.Latitude * ClipVertexQuantization));
+    }
+
+    private static double Cross(GeodeticPoint from, GeodeticPoint through, GeodeticPoint to)
+    {
+        return (through.Longitude - from.Longitude) * (to.Latitude - from.Latitude)
+            - (through.Latitude - from.Latitude) * (to.Longitude - from.Longitude);
+    }
+
+    private readonly record struct PointKey(long LongitudeKey, long LatitudeKey) : IComparable<PointKey>
+    {
+        public int CompareTo(PointKey other)
+        {
+            int longitudeComparison = LongitudeKey.CompareTo(other.LongitudeKey);
+            return longitudeComparison != 0 ? longitudeComparison : LatitudeKey.CompareTo(other.LatitudeKey);
+        }
+    }
+
+    private readonly record struct DirectedEdgeKey(PointKey From, PointKey To);
+
+    private readonly record struct DirectedEdgeValue(ResolvedSurfaceVertex From, ResolvedSurfaceVertex To);
 
     private static List<ResolvedSurfaceVertex> ClipAgainstBoundary(
         IReadOnlyList<ResolvedSurfaceVertex> vertices,

--- a/src/PlateauResoniteLink/Application/Importing/ICityGmlGeometryProjector.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ICityGmlGeometryProjector.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 using GeographicLib;
 
@@ -17,5 +18,7 @@ internal interface ICityGmlGeometryProjector
         IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         PlateauImportRequest request,
-        Func<BootstrapParsedCityObject, bool>? predicate = null);
+        Func<BootstrapParsedCityObject, bool>? predicate = null,
+        Action<string>? progressReporter = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlGeometryProjector.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlGeometryProjector.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 using GeographicLib;
 
@@ -20,7 +21,9 @@ internal sealed class LocalCityGmlGeometryProjector(
         IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         PlateauImportRequest request,
-        Func<BootstrapParsedCityObject, bool>? predicate = null)
+        Func<BootstrapParsedCityObject, bool>? predicate = null,
+        Action<string>? progressReporter = null,
+        CancellationToken cancellationToken = default)
     {
         return LocalCityGmlObjectProjection.ProjectCityObjects(
             sourceFile,
@@ -31,6 +34,8 @@ internal sealed class LocalCityGmlGeometryProjector(
             requestedMeshAreas,
             request,
             materialResolver,
-            predicate);
+            predicate,
+            progressReporter,
+            cancellationToken);
     }
 }

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 
@@ -13,6 +14,7 @@ using GeographicLib;
 
 using LibTessDotNet;
 
+using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Domain.Importing;
 
 using Geocentric = GeographicLib.Geocentric;
@@ -2915,7 +2917,9 @@ internal static partial class LocalCityGmlObjectProjection
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         PlateauImportRequest request,
         IDefaultMaterialResolver materialResolver,
-        Func<global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject, bool>? predicate = null)
+        Func<global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject, bool>? predicate = null,
+        Action<string>? progressReporter = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(sourceFile);
         ArgumentNullException.ThrowIfNull(referenceSystem);
@@ -2928,8 +2932,14 @@ internal static partial class LocalCityGmlObjectProjection
             legacyReferenceSystem,
             sourceFile.CityObjects.FirstOrDefault()?.ReferenceSystem.ToLegacy() ?? legacyReferenceSystem);
 
-        foreach (global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject parsedCityObject in sourceFile.CityObjects)
+        global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject[] projectedInputCityObjects =
+            global::PlateauResoniteLink.Application.Importing.DemCityObjectAggregation.AggregateBySourceFileAndThirdMesh(
+                sourceFile.SourceFile,
+                sourceFile.CityObjects);
+
+        foreach (global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject parsedCityObject in projectedInputCityObjects)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (predicate is not null && !predicate(parsedCityObject))
             {
                 continue;
@@ -2943,7 +2953,9 @@ internal static partial class LocalCityGmlObjectProjection
                          requestedMeshAreas,
                          terrainHeightSampler: null,
                          request,
-                         materialResolver))
+                         materialResolver,
+                         progressReporter,
+                         cancellationToken))
             {
                 yield return cityObject;
             }
@@ -2958,7 +2970,9 @@ internal static partial class LocalCityGmlObjectProjection
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         TerrainHeightSampler? terrainHeightSampler,
         PlateauImportRequest request,
-        IDefaultMaterialResolver materialResolver)
+        IDefaultMaterialResolver materialResolver,
+        Action<string>? progressReporter = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(parsedCityObject);
         ArgumentNullException.ThrowIfNull(globalOriginPoint);
@@ -2974,15 +2988,20 @@ internal static partial class LocalCityGmlObjectProjection
                  in DemTerrainOverlayAssignment.SplitParsedCityObject(
                      terrainAlignedBootstrapCityObject,
                      demTerrainTextureOverlays,
-                     requestedMeshAreas))
+                     requestedMeshAreas,
+                     progressReporter,
+                     cancellationToken))
         {
+            cancellationToken.ThrowIfCancellationRequested();
             ImportedCityObject cityObject = ProjectTerrainMeshModeCityObject(
                 splitCityObject.CityObject,
                 globalOriginPoint,
                 globalCartesian,
                 splitCityObject.Overlay,
                 request,
-                materialResolver);
+                materialResolver,
+                progressReporter,
+                cancellationToken);
 
             if (HasRenderableGeometry(cityObject))
             {
@@ -3029,11 +3048,13 @@ internal static partial class LocalCityGmlObjectProjection
 
         foreach (ImportedCityObject cityObject in alignedCityObjects)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             yield return cityObject;
         }
 
         foreach (ImportedCityObject markingObject in generatedRoadMarkings)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             yield return markingObject;
         }
     }
@@ -3097,7 +3118,9 @@ internal static partial class LocalCityGmlObjectProjection
         LocalCartesian? globalCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         PlateauImportRequest request,
-        IDefaultMaterialResolver materialResolver)
+        IDefaultMaterialResolver materialResolver,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
     {
         bool isDem = string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase);
         if (!isDem || request.TerrainMeshMode == TerrainMeshMode.Static)
@@ -3112,6 +3135,8 @@ internal static partial class LocalCityGmlObjectProjection
             demTerrainTextureOverlay,
             request,
             materialResolver,
+            progressReporter,
+            cancellationToken,
             out ImportedCityObject? heightMapCityObject);
         if (!hasGrid)
         {
@@ -3724,8 +3749,11 @@ internal static partial class LocalCityGmlObjectProjection
         TerrainTextureOverlay? demTerrainTextureOverlay,
         PlateauImportRequest request,
         IDefaultMaterialResolver materialResolver,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken,
         out ImportedCityObject? heightMapCityObject)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         heightMapCityObject = null;
 
         if (cityObject.Surfaces.SelectMany(static surface => surface.Vertices).Take(3).Count() < 3)
@@ -3798,11 +3826,17 @@ internal static partial class LocalCityGmlObjectProjection
             (int)Math.Ceiling(extentZ / request.TerrainGridMetersPerVertex) + 1,
             2,
             request.TerrainGridMaxResolution);
+        progressReporter?.Invoke(
+            PlateauLog.Debug(
+                "import",
+                $"Sampling DEM terrain grid '{cityObject.SlotKey}' "
+                + $"(width={width}, height={height}, triangles={triangles.Length})."));
         double[] localHeights = new double[width * height];
         bool[] sampledInsideTriangles = new bool[width * height];
 
         for (int zIndex = 0; zIndex < height; zIndex++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             double v = height == 1 ? 0.0 : (double)zIndex / (height - 1);
             double sampleZ = minZ + (extentZ * v);
             for (int xIndex = 0; xIndex < width; xIndex++)
@@ -3822,6 +3856,7 @@ internal static partial class LocalCityGmlObjectProjection
             }
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         ExtendBoundaryConnectedMissingHeightSamples(localHeights, sampledInsideTriangles, width, height);
         double minHeight = localHeights.Min();
         double maxHeight = localHeights.Max();

--- a/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
@@ -199,6 +199,8 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource
         IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays = await GetDemTerrainTextureOverlaysAsync(
             sourceFile,
             cancellationToken);
+        bool isDemSourceFile = string.Equals(sourceFile.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase);
+        List<BootstrapParsedCityObject> parsedDemCityObjects = [];
 
         await foreach (BootstrapParsedCityObject parsedCityObject in sourceFile.StreamParsedCityObjectsAsync(cancellationToken))
         {
@@ -206,6 +208,11 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource
             parsedCount++;
             resolvedReferenceSystem ??= ResolveReferenceSystem(parsedCityObject.ReferenceSystem);
             globalCartesian ??= CreateGlobalCartesian(resolvedReferenceSystem);
+            if (isDemSourceFile)
+            {
+                parsedDemCityObjects.Add(parsedCityObject);
+                continue;
+            }
 
             foreach (ImportedCityObject cityObject in geometryProjector.ProjectCityObjects(
                          new CachedSourceFileDescriptor(sourceFile.SourceFile, [parsedCityObject]),
@@ -214,7 +221,36 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource
                          globalCartesian,
                          demTerrainTextureOverlays,
                          requestedMeshAreas,
-                         request))
+                         request,
+                         predicate: null,
+                         progressReporter,
+                         cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yieldedCount++;
+                yield return cityObject;
+            }
+        }
+
+        if (isDemSourceFile && parsedDemCityObjects.Count > 0)
+        {
+            BootstrapParsedCityObject[] aggregatedDemCityObjects =
+                DemCityObjectAggregation.AggregateBySourceFileAndThirdMesh(
+                    sourceFile.SourceFile,
+                    parsedDemCityObjects);
+            foreach (ImportedCityObject cityObject in geometryProjector.ProjectCityObjects(
+                         new CachedSourceFileDescriptor(sourceFile.SourceFile, aggregatedDemCityObjects),
+                         resolvedReferenceSystem
+                             ?? throw new PlateauImportValidationException(
+                                 [$"CityGML file '{sourceFile.SourceFile.RelativePath}' does not declare a supported coordinate reference system."]),
+                         globalOriginPoint,
+                         globalCartesian,
+                         demTerrainTextureOverlays,
+                         requestedMeshAreas,
+                         request,
+                         predicate: null,
+                         progressReporter,
+                         cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 yieldedCount++;

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -139,14 +139,6 @@ internal sealed class TerrainTextureAssetGenerator(
                 $"Terrain texture generation failed for sources [{DescribeTerrainTextureSources(terrainTextureOverlay.Sources)}].");
         }
 
-        if (HasTransparentPixels(composedTexture)
-            && usedSources.Any(static source => source is TerrainTextureTileSource))
-        {
-            composedTexture.Dispose();
-            throw new HttpRequestException(
-                $"Terrain texture generation left uncovered tile-backed pixels for sources [{DescribeTerrainTextureSources(terrainTextureOverlay.Sources)}].");
-        }
-
         using (composedTexture)
         {
             TerrainTextureSource terrainTextureSource = usedSource ?? terrainTextureOverlay.PrimarySource;

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
@@ -79,7 +79,9 @@ public sealed class DefaultImportedSceneSourceComposerTests
             IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
             IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
             PlateauImportRequest request,
-            Func<BootstrapParsedCityObject, bool>? predicate = null)
+            Func<BootstrapParsedCityObject, bool>? predicate = null,
+            Action<string>? progressReporter = null,
+            CancellationToken cancellationToken = default)
         {
             _ = sourceFile;
             _ = referenceSystem;
@@ -89,6 +91,8 @@ public sealed class DefaultImportedSceneSourceComposerTests
             _ = requestedMeshAreas;
             _ = request;
             _ = predicate;
+            _ = progressReporter;
+            _ = cancellationToken;
             throw new InvalidOperationException("Compose should not project geometry.");
         }
     }

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemCityObjectAggregationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemCityObjectAggregationTests.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class DemCityObjectAggregationTests
+{
+    [Fact]
+    public void AggregateBySourceFileAndThirdMeshMergesDemObjectsDeterministically()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("EPSG:4326");
+        SourceFileDescriptor sourceFile = new(
+            "udx/dem/503033/plateau_fukuoka_dem_503033.gml",
+            "dem",
+            "503033",
+            RequiresMeshAreaFilter: true);
+        BootstrapParsedCityObject[] cityObjects =
+        [
+            CreateCityObject("dem-b", "polygon-b", "50303312", sourceFile.RelativePath, referenceSystem),
+            CreateCityObject("dem-a", "polygon-a", "50303312", sourceFile.RelativePath, referenceSystem),
+        ];
+
+        BootstrapParsedCityObject result = Assert.Single(
+            DemCityObjectAggregation.AggregateBySourceFileAndThirdMesh(sourceFile, cityObjects));
+
+        Assert.Equal("dem_plateau_fukuoka_dem_503033_50303312", result.SlotKey);
+        Assert.Equal("DEM 50303312", result.DisplayName);
+        Assert.Equal("50303312", result.ActualMeshCode);
+        Assert.Equal(sourceFile.RelativePath, result.SourceFileRelativePath);
+        Assert.Equal(["polygon-a", "polygon-b"], result.Surfaces.Select(static surface => surface.PolygonId).ToArray());
+    }
+
+    [Fact]
+    public void AggregateBySourceFileAndThirdMeshKeepsDifferentThirdMeshCodesSeparate()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("EPSG:4326");
+        SourceFileDescriptor sourceFile = new(
+            "udx/dem/503033/plateau_fukuoka_dem_503033.gml",
+            "dem",
+            "503033",
+            RequiresMeshAreaFilter: true);
+        BootstrapParsedCityObject[] cityObjects =
+        [
+            CreateCityObject("dem-2", "polygon-2", "50303313", sourceFile.RelativePath, referenceSystem),
+            CreateCityObject("dem-1", "polygon-1", "50303312", sourceFile.RelativePath, referenceSystem),
+        ];
+
+        BootstrapParsedCityObject[] results =
+            DemCityObjectAggregation.AggregateBySourceFileAndThirdMesh(sourceFile, cityObjects);
+
+        Assert.Equal(["50303312", "50303313"], results.Select(static result => result.ActualMeshCode).ToArray());
+        Assert.All(results, static result => Assert.Single(result.Surfaces));
+    }
+
+    private static BootstrapParsedCityObject CreateCityObject(
+        string slotKey,
+        string polygonId,
+        string actualMeshCode,
+        string sourceFileRelativePath,
+        CoordinateReferenceSystem referenceSystem)
+    {
+        BootstrapParsedRing exteriorRing = new(
+            $"{polygonId}-ring",
+            [
+                new GeodeticPoint(35.0, 139.0, 0.0),
+                new GeodeticPoint(35.0, 139.001, 0.0),
+                new GeodeticPoint(35.001, 139.001, 1.0),
+            ],
+            UVs: null);
+        BootstrapParsedSurface surface = new(
+            polygonId,
+            BootstrapParsedSurfaceSemantic.Ground,
+            exteriorRing,
+            [],
+            new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null,
+            UsesGeneratedDemTexture: true);
+        return new BootstrapParsedCityObject(
+            slotKey,
+            slotKey,
+            "dem",
+            actualMeshCode,
+            LodLevel: 1,
+            Surfaces: [surface],
+            referenceSystem,
+            sourceFileRelativePath,
+            SharedAcrossMeshCodes: true);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
@@ -65,6 +65,44 @@ public sealed class DemTerrainOverlayAssignmentTests
     }
 
     [Fact]
+    public void SplitParsedCityObjectPrunesBoundarySliverOverlayGroupAcrossSurfaces()
+    {
+        const double boundaryLongitude = 139.0100;
+        BootstrapParsedSurface dominantSurface = CreateGeneratedSurface(
+            "dem-dominant",
+            [
+                new GeodeticPoint(35.0000, 139.0000, 0.0),
+                new GeodeticPoint(35.0100, 139.0000, 1.0),
+                new GeodeticPoint(35.0100, boundaryLongitude, 2.0),
+            ]);
+        BootstrapParsedSurface sliverSurface = CreateGeneratedSurface(
+            "dem-sliver-group",
+            [
+                new GeodeticPoint(35.0000, boundaryLongitude, 0.0),
+                new GeodeticPoint(35.0100, boundaryLongitude, 1.0),
+                new GeodeticPoint(35.0100, boundaryLongitude + 0.0000005, 2.0),
+            ]);
+        BootstrapParsedCityObject cityObject = CreateCityObject(dominantSurface) with
+        {
+            Surfaces = [dominantSurface, sliverSurface],
+        };
+        TerrainTextureOverlay[] overlays =
+        [
+            CreateOverlay(139.0000, boundaryLongitude),
+            CreateOverlay(boundaryLongitude, 139.0200),
+        ];
+
+        (BootstrapParsedCityObject CityObject, TerrainTextureOverlay? Overlay)[] results =
+            DemTerrainOverlayAssignment.SplitParsedCityObject(cityObject, overlays).ToArray();
+
+        (BootstrapParsedCityObject splitCityObject, TerrainTextureOverlay? overlay) = Assert.Single(results);
+        Assert.NotNull(overlay);
+        Assert.Equal(139.0000, overlay.GeographicBounds.MinLongitude, 6);
+        Assert.Equal(boundaryLongitude, overlay.GeographicBounds.MaxLongitude, 6);
+        Assert.Equal("dem-dominant", Assert.Single(splitCityObject.Surfaces).PolygonId);
+    }
+
+    [Fact]
     public void SplitParsedCityObjectRejectsGeneratedSurfaceWhenSurfaceMissesOverlayBounds()
     {
         BootstrapParsedSurface surface = CreateGeneratedSurface(

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
@@ -103,6 +103,89 @@ public sealed class DemTerrainOverlayAssignmentTests
     }
 
     [Fact]
+    public void SplitParsedCityObjectKeepsSmallCompactOverlayGroupAcrossSurfaces()
+    {
+        const double boundaryLongitude = 139.0100;
+        BootstrapParsedSurface dominantSurface = CreateGeneratedSurface(
+            "dem-dominant",
+            [
+                new GeodeticPoint(35.0000, 139.0000, 0.0),
+                new GeodeticPoint(35.0100, 139.0000, 1.0),
+                new GeodeticPoint(35.0100, boundaryLongitude, 2.0),
+            ]);
+        BootstrapParsedSurface compactSurface = CreateGeneratedSurface(
+            "dem-small-compact",
+            [
+                new GeodeticPoint(35.00000, boundaryLongitude + 0.00020, 0.0),
+                new GeodeticPoint(35.00001, boundaryLongitude + 0.00020, 1.0),
+                new GeodeticPoint(35.00001, boundaryLongitude + 0.00021, 2.0),
+            ]);
+        BootstrapParsedCityObject cityObject = CreateCityObject(dominantSurface) with
+        {
+            Surfaces = [dominantSurface, compactSurface],
+        };
+        TerrainTextureOverlay[] overlays =
+        [
+            CreateOverlay(139.0000, boundaryLongitude),
+            CreateOverlay(boundaryLongitude, 139.0200),
+        ];
+
+        (BootstrapParsedCityObject CityObject, TerrainTextureOverlay? Overlay)[] results =
+            DemTerrainOverlayAssignment.SplitParsedCityObject(cityObject, overlays).ToArray();
+
+        Assert.Equal(2, results.Length);
+        Assert.Contains(
+            results,
+            static result => Assert.Single(result.CityObject.Surfaces).PolygonId == "dem-small-compact");
+    }
+
+    [Fact]
+    public void SplitParsedCityObjectKeepsCompactSurfaceWhenMixedWithSliverInSmallOverlayGroup()
+    {
+        const double boundaryLongitude = 139.0100;
+        BootstrapParsedSurface dominantSurface = CreateGeneratedSurface(
+            "dem-dominant",
+            [
+                new GeodeticPoint(35.0000, 139.0000, 0.0),
+                new GeodeticPoint(35.0100, 139.0000, 1.0),
+                new GeodeticPoint(35.0100, boundaryLongitude, 2.0),
+            ]);
+        BootstrapParsedSurface sliverSurface = CreateGeneratedSurface(
+            "dem-mixed-sliver",
+            [
+                new GeodeticPoint(35.00000, boundaryLongitude + 0.0000010, 0.0),
+                new GeodeticPoint(35.01000, boundaryLongitude + 0.0000010, 1.0),
+                new GeodeticPoint(35.01000, boundaryLongitude + 0.0000015, 2.0),
+            ]);
+        BootstrapParsedSurface compactSurface = CreateGeneratedSurface(
+            "dem-mixed-compact",
+            [
+                new GeodeticPoint(35.00000, boundaryLongitude + 0.00020, 0.0),
+                new GeodeticPoint(35.00001, boundaryLongitude + 0.00020, 1.0),
+                new GeodeticPoint(35.00001, boundaryLongitude + 0.00021, 2.0),
+            ]);
+        BootstrapParsedCityObject cityObject = CreateCityObject(dominantSurface) with
+        {
+            Surfaces = [dominantSurface, sliverSurface, compactSurface],
+        };
+        TerrainTextureOverlay[] overlays =
+        [
+            CreateOverlay(139.0000, boundaryLongitude),
+            CreateOverlay(boundaryLongitude, 139.0200),
+        ];
+
+        (BootstrapParsedCityObject CityObject, TerrainTextureOverlay? Overlay)[] results =
+            DemTerrainOverlayAssignment.SplitParsedCityObject(cityObject, overlays).ToArray();
+
+        Assert.Equal(2, results.Length);
+        BootstrapParsedCityObject mixedOverlayObject = Assert.Single(
+            results.Select(static result => result.CityObject),
+            static cityObject => cityObject.Surfaces.Any(static surface => surface.PolygonId == "dem-mixed-compact"));
+        Assert.Contains(mixedOverlayObject.Surfaces, static surface => surface.PolygonId == "dem-mixed-sliver");
+        Assert.Contains(mixedOverlayObject.Surfaces, static surface => surface.PolygonId == "dem-mixed-compact");
+    }
+
+    [Fact]
     public void SplitParsedCityObjectRejectsGeneratedSurfaceWhenSurfaceMissesOverlayBounds()
     {
         BootstrapParsedSurface surface = CreateGeneratedSurface(

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlaySurfaceClipperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlaySurfaceClipperTests.cs
@@ -220,6 +220,56 @@ public sealed class DemTerrainOverlaySurfaceClipperTests
         Assert.Contains(uvs, static uv => Math.Abs(uv.X - 0.6) < 1e-6 && Math.Abs(uv.Y - 0.6) < 1e-6);
     }
 
+    [Fact]
+    public void ClipGeneratedSurfaceToOverlaysPreservesDisconnectedConcaveIntersectionComponents()
+    {
+        BootstrapParsedSurface surface = new(
+            PolygonId: "dem-surface-disconnected-concave",
+            Semantic: BootstrapParsedSurfaceSemantic.Ground,
+            ExteriorRing: new BootstrapParsedRing(
+                "ring-disconnected",
+                [
+                    new GeodeticPoint(35.0000, 139.0000, 10.0),
+                    new GeodeticPoint(35.0000, 139.0100, 10.0),
+                    new GeodeticPoint(35.0001, 139.0100, 10.0),
+                    new GeodeticPoint(35.0001, 139.0020, 10.0),
+                    new GeodeticPoint(35.0009, 139.0020, 10.0),
+                    new GeodeticPoint(35.0009, 139.0100, 10.0),
+                    new GeodeticPoint(35.0010, 139.0100, 10.0),
+                    new GeodeticPoint(35.0010, 139.0000, 10.0),
+                ],
+                UVs: null),
+            InteriorRings: [],
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null,
+            UsesGeneratedDemTexture: true);
+        TerrainTextureOverlay overlay = new(
+            PackageName: "dem",
+            UrlTemplate: "https://tiles.example/{z}/{x}/{y}.png",
+            ZoomLevel: 18,
+            GeographicBounds: new GeographicRectangle(
+                MinLatitude: 35.0000,
+                MaxLatitude: 35.0010,
+                MinLongitude: 139.0020,
+                MaxLongitude: 139.0080),
+            MaxTextureSize: DemTerrainTextureDefaults.MaxTextureSize);
+
+        IReadOnlyList<(BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> clipped = DemTerrainOverlaySurfaceClipper
+            .ClipGeneratedSurfaceToOverlays(surface, [overlay]);
+
+        Assert.Equal(2, clipped.Count);
+
+        GeographicRectangle[] bounds = clipped
+            .Select(static entry => GetSurfaceBounds(entry.Surface))
+            .OrderBy(static bound => bound.MinLatitude)
+            .ToArray();
+        Assert.InRange(bounds[0].MaxLatitude, 35.0000, 35.0001);
+        Assert.InRange(bounds[0].MinLatitude, 35.0000, 35.0001);
+        Assert.InRange(bounds[1].MinLatitude, 35.0009, 35.0010);
+        Assert.InRange(bounds[1].MaxLatitude, 35.0009, 35.0010);
+        Assert.True(bounds[0].MaxLatitude < bounds[1].MinLatitude);
+    }
+
     private static double ComputeSignedArea(GeodeticPoint[] vertices)
     {
         double signedArea = 0.0;

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -850,7 +850,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             sceneBuilder.CityObjects,
             static cityObject => cityObject.PackageName == "dem"
                 && cityObject.Materials.Any(static material => material.TerrainOverlay is not null)
-                && cityObject.DisplayName == "Chunk Relief");
+                && cityObject.DisplayName == "DEM 53394525");
         Assert.Equal("dem", demCityObject.PackageName);
 
         MaterialBinding material = Assert.Single(demCityObject.Materials);
@@ -1125,8 +1125,8 @@ public sealed class LocalCityGmlObjectProjectionTests
         ImportedCityObject demCityObject = Assert.Single(
             sceneBuilder.CityObjects,
             static cityObject => cityObject.PackageName == "dem"
-                && cityObject.DisplayName == "53394525");
-        Assert.Equal("53394525", demCityObject.DisplayName);
+                && cityObject.DisplayName == "DEM 53394525");
+        Assert.Equal("DEM 53394525", demCityObject.DisplayName);
     }
 
     [Fact]
@@ -1951,6 +1951,8 @@ public sealed class LocalCityGmlObjectProjectionTests
                 null,
                 request,
                 new DefaultMaterialResolver(),
+                null,
+                CancellationToken.None,
             ])!;
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
@@ -311,7 +311,9 @@ public sealed class StreamingImportedSceneSourceStreamingTests
             IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
             IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
             PlateauImportRequest request,
-            Func<BootstrapParsedCityObject, bool>? predicate = null)
+            Func<BootstrapParsedCityObject, bool>? predicate = null,
+            Action<string>? progressReporter = null,
+            CancellationToken cancellationToken = default)
         {
             _ = referenceSystem;
             _ = globalOriginPoint;
@@ -319,6 +321,8 @@ public sealed class StreamingImportedSceneSourceStreamingTests
             _ = demTerrainTextureOverlays;
             _ = requestedMeshAreas;
             _ = request;
+            _ = progressReporter;
+            _ = cancellationToken;
             foreach (BootstrapParsedCityObject cityObject in sourceFile.CityObjects)
             {
                 if (predicate is not null && !predicate(cityObject))

--- a/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceTests.cs
@@ -480,7 +480,9 @@ public sealed class StreamingImportedSceneSourceTests
             IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
             IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
             PlateauImportRequest request,
-            Func<BootstrapParsedCityObject, bool>? predicate = null)
+            Func<BootstrapParsedCityObject, bool>? predicate = null,
+            Action<string>? progressReporter = null,
+            CancellationToken cancellationToken = default)
         {
             _ = referenceSystem;
             _ = globalOriginPoint;
@@ -489,6 +491,8 @@ public sealed class StreamingImportedSceneSourceTests
             _ = requestedMeshAreas;
             _ = request;
             _ = predicate;
+            _ = progressReporter;
+            _ = cancellationToken;
             int concurrency = Interlocked.Increment(ref currentConcurrency);
             UpdateMaxConcurrency(concurrency);
 
@@ -544,13 +548,17 @@ public sealed class StreamingImportedSceneSourceTests
             IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
             IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
             PlateauImportRequest request,
-            Func<BootstrapParsedCityObject, bool>? predicate = null)
+            Func<BootstrapParsedCityObject, bool>? predicate = null,
+            Action<string>? progressReporter = null,
+            CancellationToken cancellationToken = default)
         {
             _ = referenceSystem;
             _ = globalOriginPoint;
             _ = globalCartesian;
             _ = requestedMeshAreas;
             _ = request;
+            _ = progressReporter;
+            _ = cancellationToken;
 
             BootstrapParsedCityObject parsedCityObject = Assert.Single(sourceFile.CityObjects);
             if (predicate is not null && !predicate(parsedCityObject))

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -316,18 +316,19 @@ public sealed class TerrainTextureAssetGeneratorTests
     }
 
     [Fact]
-    public async Task EnsureTextureAsyncRemovesFaultedSharedGenerationAndRetries()
+    public async Task EnsureTextureAsyncCachesPartiallyCoveredTileGeneration()
     {
         using FlakyMapTileHandler handler = new();
         using HttpClient httpClient = new(handler);
         TerrainTextureAssetGenerator generator = new(httpClient, disablePersistentCache: true);
         TerrainTextureOverlay overlay = CreateFullCoverageOverlay("https://tiles.example/{z}/{x}/{y}.png");
 
-        await Assert.ThrowsAsync<HttpRequestException>(() => generator.EnsureTextureAsync(overlay, CancellationToken.None));
+        GeneratedTerrainTexture firstTexture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
+        Assert.Same(firstTexture, texture);
         Assert.Equal(512, texture.TextureImport.Width);
-        Assert.Equal(8, handler.RequestCount);
+        Assert.Equal(4, handler.RequestCount);
     }
 
     [Fact]
@@ -340,7 +341,7 @@ public sealed class TerrainTextureAssetGeneratorTests
         using (HttpClient firstClient = new(firstHandler))
         {
             TerrainTextureAssetGenerator firstGenerator = new(firstClient, cacheRoot.Path);
-            await Assert.ThrowsAsync<HttpRequestException>(() => firstGenerator.EnsureTextureAsync(overlay, CancellationToken.None));
+            _ = await firstGenerator.EnsureTextureAsync(overlay, CancellationToken.None);
         }
 
         using RetryableMapTileHandler secondHandler = new();
@@ -484,6 +485,30 @@ public sealed class TerrainTextureAssetGeneratorTests
         using Image<Rgba32> image = LoadImage(texture.TextureImport);
         Assert.True(ContainsColor(image, 255, 0, 0));
         Assert.True(ContainsColor(image, 255, 0, 255));
+    }
+
+    [Fact]
+    public async Task EnsureTextureAsyncFillsRemainingTileGapsWithDefaultGroundColor()
+    {
+        using MissingTileMapTileHandler handler = new((1, 1));
+        using HttpClient httpClient = new(handler);
+        TerrainTextureAssetGenerator generator = new(httpClient, disablePersistentCache: true);
+        TerrainTextureOverlay overlay = new(
+            PackageName: "dem",
+            GeographicBounds: new GeographicRectangle(
+                MinLatitude: WebMercatorTileMath.PixelYToLatitude(2 * WebMercatorTileMath.TileSizePixels, 1),
+                MaxLatitude: WebMercatorTileMath.PixelYToLatitude(0, 1),
+                MinLongitude: WebMercatorTileMath.PixelXToLongitude(0, 1),
+                MaxLongitude: WebMercatorTileMath.PixelXToLongitude(2 * WebMercatorTileMath.TileSizePixels, 1)),
+            MaxTextureSize: 4096,
+            PrimarySource: new TerrainTextureTileSource("https://primary.example/{z}/{x}/{y}.png", 1));
+
+        GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
+
+        using Image<Rgba32> image = LoadImage(texture.TextureImport);
+        Assert.True(ContainsColor(image, 255, 0, 0));
+        Rgba32 fillColor = TerrainTextureAssetGenerator.DefaultDemGroundFillColor;
+        Assert.True(ContainsColor(image, fillColor.R, fillColor.G, fillColor.B));
     }
 
     [Fact]
@@ -733,6 +758,34 @@ public sealed class TerrainTextureAssetGeneratorTests
             }
 
             return FakeMapTileHandler.GetTileColorForTests(tileX, tileY);
+        }
+    }
+
+    private sealed class MissingTileMapTileHandler((int x, int y) missingTile) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string[] segments = request.RequestUri!.AbsolutePath.Trim('/').Split('/');
+            int tileX = int.Parse(segments[^2], CultureInfo.InvariantCulture);
+            int tileY = int.Parse(Path.GetFileNameWithoutExtension(segments[^1]), CultureInfo.InvariantCulture);
+
+            if ((tileX, tileY) == missingTile)
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            using Image<Rgba32> image = new(
+                WebMercatorTileMath.TileSizePixels,
+                WebMercatorTileMath.TileSizePixels,
+                FakeMapTileHandler.GetTileColorForTests(tileX, tileY));
+            MemoryStream stream = new();
+            await image.SaveAsPngAsync(stream, cancellationToken);
+            stream.Position = 0;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(stream),
+            };
         }
     }
 


### PR DESCRIPTION
## Summary
- stabilize dynamic DEM projection and deterministic DEM aggregation
- fill remaining terrain texture tile gaps with default ground color
- return canceled status on Ctrl-C

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false