### PR TITLE
[codex] Strengthen Resonite boundary contracts

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/DatasetInspectionService.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DatasetInspectionService.cs
@@ -377,7 +377,12 @@ internal sealed class DatasetInspectionService(IPlateauDatasetContentSourceFacto
 
     private static void AddPosListGeometry(string coordinateText, GeometryVramAccumulator geometry)
     {
-        PosListGeometry posListGeometry = InspectPosListGeometry(coordinateText);
+        if (!TryReadParserEquivalentLinearRingTokens(coordinateText, out GmlLinearRingTokenSequence? ringTokens))
+        {
+            return;
+        }
+
+        PosListGeometry posListGeometry = InspectLinearRingTokens(ringTokens);
         long positionCount = posListGeometry.PositionCount;
         if (positionCount <= 0)
         {
@@ -397,10 +402,12 @@ internal sealed class DatasetInspectionService(IPlateauDatasetContentSourceFacto
         }
     }
 
-    private static PosListGeometry InspectPosListGeometry(string coordinateText)
+    private static bool TryReadParserEquivalentLinearRingTokens(
+        string coordinateText,
+        [NotNullWhen(true)] out GmlLinearRingTokenSequence? ringTokens)
     {
-        double[] firstPosition = new double[GeometryCoordinateDimension];
-        double[] lastPosition = new double[GeometryCoordinateDimension];
+        List<GmlPositionToken> positions = [];
+        double[] position = new double[GeometryCoordinateDimension];
         int coordinateValueCount = 0;
         int tokenStart = -1;
 
@@ -423,40 +430,54 @@ internal sealed class DatasetInspectionService(IPlateauDatasetContentSourceFacto
             }
 
             ReadOnlySpan<char> token = coordinateText.AsSpan(tokenStart, index - tokenStart);
+            int ordinateIndex = coordinateValueCount % GeometryCoordinateDimension;
             if (double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out double coordinate))
             {
-                int ordinateIndex = coordinateValueCount % GeometryCoordinateDimension;
-                if (coordinateValueCount < GeometryCoordinateDimension)
-                {
-                    firstPosition[ordinateIndex] = coordinate;
-                }
+                position[ordinateIndex] = coordinate;
+            }
 
-                lastPosition[ordinateIndex] = coordinate;
+            if (ordinateIndex == GeometryCoordinateDimension - 1)
+            {
+                positions.Add(new GmlPositionToken(position[0], position[1], position[2]));
+                position = new double[GeometryCoordinateDimension];
             }
 
             coordinateValueCount++;
             tokenStart = -1;
         }
 
-        long positionCount = coordinateValueCount / GeometryCoordinateDimension;
-        bool hasCompletePositions = coordinateValueCount % GeometryCoordinateDimension == 0;
-        bool isClosedRing = hasCompletePositions
-            && positionCount > 1
-            && AreSamePosition(firstPosition, lastPosition);
+        if (coordinateValueCount % GeometryCoordinateDimension != 0)
+        {
+            ringTokens = null;
+            return false;
+        }
+
+        ringTokens = new GmlLinearRingTokenSequence(positions);
+        return true;
+    }
+
+    private static PosListGeometry InspectLinearRingTokens(GmlLinearRingTokenSequence ringTokens)
+    {
+        long positionCount = ringTokens.Positions.Count;
+        bool isClosedRing = positionCount > 1
+            && AreSamePosition(ringTokens.Positions[0], ringTokens.Positions[^1]);
         return new PosListGeometry(positionCount, isClosedRing);
+    }
+
+    internal static bool AreSamePosition(GmlPositionToken left, GmlPositionToken right)
+    {
+        return Math.Abs(left.X - right.X) < 1e-8
+            && Math.Abs(left.Y - right.Y) < 1e-8
+            && Math.Abs(left.Z - right.Z) < 1e-8;
     }
 
     internal static bool AreSamePosition(double[] left, double[] right)
     {
-        for (int index = 0; index < left.Length; index++)
-        {
-            if (Math.Abs(left[index] - right[index]) >= 1e-8)
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return left.Length == GeometryCoordinateDimension
+            && right.Length == GeometryCoordinateDimension
+            && AreSamePosition(
+                new GmlPositionToken(left[0], left[1], left[2]),
+                new GmlPositionToken(right[0], right[1], right[2]));
     }
 
     private static async Task<DatasetTextureVramEstimate> EstimateTextureVramAsync(
@@ -753,6 +774,13 @@ internal sealed record DatasetSourceFileStats(
 internal readonly record struct PosListGeometry(
     long PositionCount,
     bool IsClosedRing);
+
+internal readonly record struct GmlPositionToken(
+    double X,
+    double Y,
+    double Z);
+
+internal sealed record GmlLinearRingTokenSequence(IReadOnlyList<GmlPositionToken> Positions);
 
 internal sealed record DatasetTextureVramEntry(
     string RelativePath,

--- a/src/PlateauResoniteLink/Application/Importing/DatasetInspectionService.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DatasetInspectionService.cs
@@ -446,12 +446,6 @@ internal sealed class DatasetInspectionService(IPlateauDatasetContentSourceFacto
             tokenStart = -1;
         }
 
-        if (coordinateValueCount % GeometryCoordinateDimension != 0)
-        {
-            ringTokens = null;
-            return false;
-        }
-
         ringTokens = new GmlLinearRingTokenSequence(positions);
         return true;
     }

--- a/src/PlateauResoniteLink/Application/Importing/DatasetInspectionService.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DatasetInspectionService.cs
@@ -406,8 +406,12 @@ internal sealed class DatasetInspectionService(IPlateauDatasetContentSourceFacto
         string coordinateText,
         [NotNullWhen(true)] out GmlLinearRingTokenSequence? ringTokens)
     {
-        List<GmlPositionToken> positions = [];
-        double[] position = new double[GeometryCoordinateDimension];
+        GmlPositionToken? firstPosition = null;
+        GmlPositionToken? lastPosition = null;
+        long positionCount = 0;
+        double x = 0.0;
+        double y = 0.0;
+        double z = 0.0;
         int coordinateValueCount = 0;
         int tokenStart = -1;
 
@@ -433,29 +437,46 @@ internal sealed class DatasetInspectionService(IPlateauDatasetContentSourceFacto
             int ordinateIndex = coordinateValueCount % GeometryCoordinateDimension;
             if (double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out double coordinate))
             {
-                position[ordinateIndex] = coordinate;
+                switch (ordinateIndex)
+                {
+                    case 0:
+                        x = coordinate;
+                        break;
+                    case 1:
+                        y = coordinate;
+                        break;
+                    case 2:
+                        z = coordinate;
+                        break;
+                }
             }
 
             if (ordinateIndex == GeometryCoordinateDimension - 1)
             {
-                positions.Add(new GmlPositionToken(position[0], position[1], position[2]));
-                position = new double[GeometryCoordinateDimension];
+                GmlPositionToken position = new(x, y, z);
+                firstPosition ??= position;
+                lastPosition = position;
+                positionCount++;
             }
 
             coordinateValueCount++;
             tokenStart = -1;
         }
 
-        ringTokens = new GmlLinearRingTokenSequence(positions);
+        ringTokens = new GmlLinearRingTokenSequence(
+            positionCount,
+            firstPosition,
+            lastPosition);
         return true;
     }
 
     private static PosListGeometry InspectLinearRingTokens(GmlLinearRingTokenSequence ringTokens)
     {
-        long positionCount = ringTokens.Positions.Count;
-        bool isClosedRing = positionCount > 1
-            && AreSamePosition(ringTokens.Positions[0], ringTokens.Positions[^1]);
-        return new PosListGeometry(positionCount, isClosedRing);
+        bool isClosedRing = ringTokens.PositionCount > 1
+            && ringTokens.FirstPosition is { } firstPosition
+            && ringTokens.LastPosition is { } lastPosition
+            && AreSamePosition(firstPosition, lastPosition);
+        return new PosListGeometry(ringTokens.PositionCount, isClosedRing);
     }
 
     internal static bool AreSamePosition(GmlPositionToken left, GmlPositionToken right)
@@ -774,7 +795,10 @@ internal readonly record struct GmlPositionToken(
     double Y,
     double Z);
 
-internal sealed record GmlLinearRingTokenSequence(IReadOnlyList<GmlPositionToken> Positions);
+internal sealed record GmlLinearRingTokenSequence(
+    long PositionCount,
+    GmlPositionToken? FirstPosition,
+    GmlPositionToken? LastPosition);
 
 internal sealed record DatasetTextureVramEntry(
     string RelativePath,

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
@@ -25,6 +25,7 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
         string? directRasterPath,
         string? singleRelativeRasterPath,
         IPlateauDatasetContentSource? contentSource,
+        string sourceScopePath,
         string outputRoot,
         IReadOnlyList<string> orderedRelativeRasterPaths,
         IReadOnlyDictionary<string, string> relativeRasterPathsByStem)
@@ -35,7 +36,10 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
         this.outputRoot = outputRoot;
         this.orderedRelativeRasterPaths = orderedRelativeRasterPaths;
         this.relativeRasterPathsByStem = relativeRasterPathsByStem;
+        CacheScope = new DemTerrainRasterSourceScope(sourceScopePath);
     }
+
+    public DemTerrainRasterSourceScope CacheScope { get; }
 
     public static async Task<IDemTerrainGeoReferencedRasterCatalog?> CreateAsync(
         DatasetLocation? source,
@@ -57,6 +61,7 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
                 directRasterPath: fullSourcePath,
                 singleRelativeRasterPath: null,
                 contentSource: null,
+                sourceScopePath: fullSourcePath,
                 outputRoot: Path.GetDirectoryName(fullSourcePath) ?? fullSourcePath,
                 orderedRelativeRasterPaths: [],
                 relativeRasterPathsByStem: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
@@ -91,6 +96,7 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
             directRasterPath: null,
             singleRelativeRasterPath: rasterFiles.Length == 1 ? rasterFiles[0] : null,
             contentSource,
+            sourceScopePath: fullSourcePath,
             outputRoot: Path.GetDirectoryName(fullSourcePath) ?? fullSourcePath,
             orderedRelativeRasterPaths: rasterFiles,
             relativeRasterPathsByStem: rasterFilesByStem);

--- a/src/PlateauResoniteLink/Application/Importing/DemTextureSourcePolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTextureSourcePolicy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,18 +22,41 @@ internal interface IDemTextureSourcePolicy
 
 internal sealed record ResolvedDemTextureSources(IReadOnlyList<TerrainTextureOverlay> Overlays);
 
+internal readonly record struct DemTerrainRasterSourceScope
+{
+    public DemTerrainRasterSourceScope(string sourcePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourcePath);
+
+        SourcePath = Path.GetFullPath(sourcePath);
+    }
+
+    public string SourcePath { get; }
+}
+
 internal readonly record struct DemTerrainRasterCacheKey
 {
-    public DemTerrainRasterCacheKey(string meshCode, GeographicRectangle overlayBounds)
+    public DemTerrainRasterCacheKey(
+        string datasetName,
+        DemTerrainRasterSourceScope sourceScope,
+        string meshCode,
+        GeographicRectangle overlayBounds)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(datasetName);
         ArgumentException.ThrowIfNullOrWhiteSpace(meshCode);
 
+        DatasetName = datasetName;
+        SourceScope = sourceScope;
         MeshCode = meshCode;
         MinLatitude = CanonicalizeCoordinate(overlayBounds.MinLatitude);
         MaxLatitude = CanonicalizeCoordinate(overlayBounds.MaxLatitude);
         MinLongitude = CanonicalizeCoordinate(overlayBounds.MinLongitude);
         MaxLongitude = CanonicalizeCoordinate(overlayBounds.MaxLongitude);
     }
+
+    public string DatasetName { get; }
+
+    public DemTerrainRasterSourceScope SourceScope { get; }
 
     public string MeshCode { get; }
 
@@ -53,6 +77,8 @@ internal readonly record struct DemTerrainRasterCacheKey
 
 internal interface IDemTerrainGeoReferencedRasterCatalog
 {
+    DemTerrainRasterSourceScope CacheScope { get; }
+
     Task<TerrainTextureGeoReferencedRasterSource?> TryResolveRasterSourceAsync(
         DemTerrainRasterCacheKey cacheKey,
         string meshCode,
@@ -108,6 +134,7 @@ internal sealed class DefaultDemTextureSourcePolicy(
         {
             overlays[index] = await CreateOverlayAsync(
                 overlayRegions[index],
+                request.Dataset,
                 rasterCatalog,
                 cancellationToken);
         }
@@ -134,6 +161,7 @@ internal sealed class DefaultDemTextureSourcePolicy(
 
     private static async Task<TerrainTextureOverlay> CreateOverlayAsync(
         DemTerrainOverlayRegion region,
+        string datasetName,
         IDemTerrainGeoReferencedRasterCatalog? rasterCatalog,
         CancellationToken cancellationToken)
     {
@@ -163,7 +191,7 @@ internal sealed class DefaultDemTextureSourcePolicy(
         if (rasterCatalog is not null)
         {
             TerrainTextureGeoReferencedRasterSource? rasterSource = await rasterCatalog.TryResolveRasterSourceAsync(
-                new DemTerrainRasterCacheKey(region.Identity, region.GeographicBounds),
+                new DemTerrainRasterCacheKey(datasetName, rasterCatalog.CacheScope, region.Identity, region.GeographicBounds),
                 region.Identity,
                 region.GeographicBounds,
                 cancellationToken);

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -53,9 +53,8 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         slotResolutionTargets.Add(meshAssetSlotId);
 
         BatchPlanComponentLocator rendererGeometryComponentId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
-        Dictionary<string, PlannedMember>? terrainGridMeshMembers = null;
-        PlannedWorldElementReference? dynamicStaticMeshTarget = null;
-        PlannedWorldElementReference? dynamicGridMeshTarget = null;
+        PlannedTerrainGridMeshBundle? terrainGridMesh = null;
+        PlannedDynamicTerrainMeshBundle? dynamicTerrainMesh = null;
         switch (emissionPlan.GeometryAsset)
         {
             case PlannedTriangleMeshGeometryAsset triangleMesh:
@@ -72,7 +71,8 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                     }));
                 break;
             case PlannedTerrainGridGeometryAsset heightMap:
-                terrainGridMeshMembers = AddPlannedTerrainGridTextureAndCreateGridMembers(
+                terrainGridMesh = AddPlannedTerrainGridTextureAndCreateGridBundle(
+                    rendererGeometryComponentId,
                     slotEmissions,
                     componentEmissions,
                     slotResolutionTargets,
@@ -98,9 +98,10 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                             Value = dynamicTerrain.StaticMeshUri,
                         }),
                     }));
-                dynamicStaticMeshTarget = PlannedWorldElementReference.Planned(rendererGeometryComponentId);
+                PlannedWorldElementReference dynamicStaticMeshTarget = PlannedWorldElementReference.Planned(rendererGeometryComponentId);
                 BatchPlanComponentLocator gridMeshComponentId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
-                terrainGridMeshMembers = AddPlannedTerrainGridTextureAndCreateGridMembers(
+                terrainGridMesh = AddPlannedTerrainGridTextureAndCreateGridBundle(
+                    gridMeshComponentId,
                     slotEmissions,
                     componentEmissions,
                     slotResolutionTargets,
@@ -113,8 +114,10 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                     ref nextSlotLocator,
                     ref nextComponentLocator,
                     ref nextFieldLocator);
-                rendererGeometryComponentId = gridMeshComponentId;
-                dynamicGridMeshTarget = PlannedWorldElementReference.Planned(gridMeshComponentId);
+                dynamicTerrainMesh = new PlannedDynamicTerrainMeshBundle(
+                    PlannedWorldElementReference.Planned(gridMeshComponentId),
+                    dynamicStaticMeshTarget);
+                rendererGeometryComponentId = terrainGridMesh.ComponentIdentity;
                 break;
             default:
                 throw new InvalidOperationException(
@@ -155,17 +158,17 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             objectSlots.CityObjectRotation));
         slotResolutionTargets.Add(presentationSlotId);
 
-        if (terrainGridMeshMembers is not null)
+        if (terrainGridMesh is not null)
         {
             componentEmissions.Add(new PlannedBatchComponentEmission(
-                rendererGeometryComponentId,
+                terrainGridMesh.ComponentIdentity,
                 PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
                 "[FrooxEngine]FrooxEngine.GridMesh",
-                terrainGridMeshMembers));
+                CreateTerrainGridMeshMembers(terrainGridMesh)));
             AddTerrainGridPointsDriverComponents(
                 componentEmissions,
                 presentationSlotId,
-                terrainGridMeshMembers,
+                terrainGridMesh,
                 ref nextComponentLocator,
                 ref nextFieldLocator);
         }
@@ -179,7 +182,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             {
                 ["Mesh"] = PlannedMembers.AddressableReference(
                     rendererMeshFieldId,
-                    ResolveInitialMeshTarget(dynamicGridMeshTarget, rendererGeometryComponentId)),
+                    ResolveInitialMeshTarget(dynamicTerrainMesh, rendererGeometryComponentId)),
                 ["Materials"] = CreateRendererMaterials(emissionPlan.Renderer.MaterialBindings, emittedMaterialTargets),
                 ["MaterialPropertyBlocks"] = CreateRendererMaterialPropertyBlocks(
                     componentEmissions,
@@ -188,14 +191,13 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                     emissionPlan.Renderer.MaterialBindings,
                     ref nextComponentLocator),
             }));
-        if (dynamicStaticMeshTarget is not null && dynamicGridMeshTarget is not null)
+        if (dynamicTerrainMesh is not null)
         {
             AddDynamicMeshSwitchComponents(
                 componentEmissions,
                 presentationSlotId,
                 rendererMeshFieldId,
-                dynamicGridMeshTarget.Value,
-                dynamicStaticMeshTarget.Value,
+                dynamicTerrainMesh,
                 ref nextComponentLocator,
                 ref nextFieldLocator);
         }
@@ -217,16 +219,15 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 }),
                 ["Mesh"] = PlannedMembers.AddressableReference(
                     colliderMeshFieldId,
-                    ResolveInitialMeshTarget(dynamicGridMeshTarget, rendererGeometryComponentId)),
+                    ResolveInitialMeshTarget(dynamicTerrainMesh, rendererGeometryComponentId)),
             }));
-        if (dynamicStaticMeshTarget is not null && dynamicGridMeshTarget is not null)
+        if (dynamicTerrainMesh is not null)
         {
             AddDynamicMeshSwitchComponents(
                 componentEmissions,
                 presentationSlotId,
                 colliderMeshFieldId,
-                dynamicGridMeshTarget.Value,
-                dynamicStaticMeshTarget.Value,
+                dynamicTerrainMesh,
                 ref nextComponentLocator,
                 ref nextFieldLocator);
         }
@@ -239,13 +240,14 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
     }
 
     private static PlannedWorldElementReference ResolveInitialMeshTarget(
-        PlannedWorldElementReference? dynamicGridMeshTarget,
+        PlannedDynamicTerrainMeshBundle? dynamicTerrainMesh,
         BatchPlanComponentLocator defaultGeometryComponentId)
     {
-        return dynamicGridMeshTarget ?? PlannedWorldElementReference.Planned(defaultGeometryComponentId);
+        return dynamicTerrainMesh?.InitialMeshTarget ?? PlannedWorldElementReference.Planned(defaultGeometryComponentId);
     }
 
-    private static Dictionary<string, PlannedMember> AddPlannedTerrainGridTextureAndCreateGridMembers(
+    private static PlannedTerrainGridMeshBundle AddPlannedTerrainGridTextureAndCreateGridBundle(
+        BatchPlanComponentLocator gridMeshComponentId,
         List<PlannedBatchSlotEmission> slotEmissions,
         List<PlannedBatchComponentEmission> componentEmissions,
         List<BatchPlanSlotLocator> slotResolutionTargets,
@@ -277,76 +279,103 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 
         double displacementMagnitude = Math.Max(geometry.MaxHeight - geometry.MinHeight, 0.0);
         BatchPlanFieldLocator pointsFieldId = CreateBatchPlanFieldLocator(ref nextFieldLocator);
-        Dictionary<string, PlannedMember> terrainGridMeshMembers = new(StringComparer.Ordinal)
+        Field_int2 points = new()
         {
-            ["Points"] = PlannedMembers.AddressableField(pointsFieldId, new Field_int2
+            Value = new int2
             {
-                Value = new int2
-                {
-                    x = geometry.Width,
-                    y = geometry.Height,
-                },
-            }),
-            ["Size"] = PlannedMembers.Literal(new Field_float2
-            {
-                Value = new float2
-                {
-                    x = (float)geometry.Size.X,
-                    y = (float)geometry.Size.Y,
-                },
-            }),
-            ["DisplacementMagnitude"] = PlannedMembers.Literal(new Field_float
-            {
-                Value = (float)displacementMagnitude,
-            }),
-            ["DisplacementTexture"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(heightTextureComponentId)),
+                x = geometry.Width,
+                y = geometry.Height,
+            },
         };
-        if (uvScale is not null)
+        Field_float2 size = new()
         {
-            terrainGridMeshMembers["UVScale"] = PlannedMembers.Literal(new Field_float2
+            Value = new float2
+            {
+                x = (float)geometry.Size.X,
+                y = (float)geometry.Size.Y,
+            },
+        };
+        Field_float displacement = new()
+        {
+            Value = (float)displacementMagnitude,
+        };
+        Field_float2? plannedUvScale = uvScale is null
+            ? null
+            : new Field_float2
             {
                 Value = new float2
                 {
                     x = (float)uvScale.X,
                     y = (float)uvScale.Y,
                 },
-            });
-        }
+            };
 
-        if (uvOffset is not null)
-        {
-            terrainGridMeshMembers["UVOffset"] = PlannedMembers.Literal(new Field_float2
+        Field_float2? plannedUvOffset = uvOffset is null
+            ? null
+            : new Field_float2
             {
                 Value = new float2
                 {
                     x = (float)uvOffset.X,
                     y = (float)uvOffset.Y,
                 },
-            });
+            };
+
+        return new PlannedTerrainGridMeshBundle(
+            gridMeshComponentId,
+            pointsFieldId,
+            points,
+            size,
+            displacement,
+            PlannedWorldElementReference.Planned(heightTextureComponentId),
+            plannedUvScale,
+            plannedUvOffset);
+    }
+
+    private static Dictionary<string, PlannedMember> CreateTerrainGridMeshMembers(
+        PlannedTerrainGridMeshBundle terrainGridMesh)
+    {
+        Dictionary<string, PlannedMember> members = new(StringComparer.Ordinal)
+        {
+            ["Points"] = PlannedMembers.AddressableField(terrainGridMesh.PointsIdentity, terrainGridMesh.Points),
+            ["Size"] = PlannedMembers.Literal(terrainGridMesh.Size),
+            ["DisplacementMagnitude"] = PlannedMembers.Literal(terrainGridMesh.DisplacementMagnitude),
+            ["DisplacementTexture"] = PlannedMembers.Reference(terrainGridMesh.DisplacementTexture),
+        };
+        if (terrainGridMesh.UvScale is not null)
+        {
+            members["UVScale"] = PlannedMembers.Literal(terrainGridMesh.UvScale);
         }
 
-        return terrainGridMeshMembers;
+        if (terrainGridMesh.UvOffset is not null)
+        {
+            members["UVOffset"] = PlannedMembers.Literal(terrainGridMesh.UvOffset);
+        }
+
+        return members;
     }
 
     private static void AddDynamicMeshSwitchComponents(
         List<PlannedBatchComponentEmission> componentEmissions,
         BatchPlanSlotLocator presentationSlotId,
         BatchPlanFieldLocator targetMeshFieldId,
-        PlannedWorldElementReference gridMeshTarget,
-        PlannedWorldElementReference staticMeshTarget,
+        PlannedDynamicTerrainMeshBundle dynamicTerrainMesh,
         ref int nextComponentLocator,
         ref int nextFieldLocator)
     {
         BatchPlanFieldLocator stateFieldId = CreateBatchPlanFieldLocator(ref nextFieldLocator);
-        Dictionary<string, PlannedMember> switchMembers = new(StringComparer.Ordinal)
-        {
-            ["State"] = PlannedMembers.AddressableField(stateFieldId, new Field_bool
+        PlannedDriverTargetBundle stateDriverTarget = PlannedDriverTargetBundle.Create(
+            stateFieldId,
+            new Field_bool
             {
                 Value = false,
-            }),
+            });
+        Dictionary<string, PlannedMember> switchMembers = new(StringComparer.Ordinal)
+        {
+            ["State"] = stateDriverTarget.Field,
             ["Target"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(targetMeshFieldId)),
-            ["FalseTarget"] = PlannedMembers.Reference(gridMeshTarget),
-            ["TrueTarget"] = PlannedMembers.Reference(staticMeshTarget),
+            ["FalseTarget"] = PlannedMembers.Reference(dynamicTerrainMesh.GridMeshTarget),
+            ["TrueTarget"] = PlannedMembers.Reference(dynamicTerrainMesh.StaticMeshTarget),
         };
         componentEmissions.Add(new PlannedBatchComponentEmission(
             CreateBatchPlanComponentLocator(ref nextComponentLocator),
@@ -363,34 +392,33 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 {
                     Value = TerrainStaticEnabledVariableName,
                 }),
-                ["Target"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(stateFieldId)),
-                ["DefaultValue"] = PlannedMembers.Literal(new Field_bool
-                {
-                    Value = false,
-                }),
+                ["Target"] = stateDriverTarget.Target,
+                ["DefaultValue"] = stateDriverTarget.DefaultValue,
             }));
     }
 
     private static void AddTerrainGridPointsDriverComponents(
         List<PlannedBatchComponentEmission> componentEmissions,
         BatchPlanSlotLocator presentationSlotId,
-        IReadOnlyDictionary<string, PlannedMember> gridMeshMembers,
+        PlannedTerrainGridMeshBundle terrainGridMesh,
         ref int nextComponentLocator,
         ref int nextFieldLocator)
     {
-        (BatchPlanFieldLocator gridPointsId, Field_int2 gridPoints) = AssertTerrainGridPointsMember(gridMeshMembers);
         BatchPlanFieldLocator progressFieldId = CreateBatchPlanFieldLocator(ref nextFieldLocator);
+        PlannedDriverTargetBundle progressDriverTarget = PlannedDriverTargetBundle.Create(
+            progressFieldId,
+            new Field_float
+            {
+                Value = 1.0f,
+            });
         componentEmissions.Add(new PlannedBatchComponentEmission(
             CreateBatchPlanComponentLocator(ref nextComponentLocator),
             PlannedSlotTargetReference.PlannedSlot(presentationSlotId),
             ValueGradientDriverInt2ComponentType,
             new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
             {
-                ["Progress"] = PlannedMembers.AddressableField(progressFieldId, new Field_float
-                {
-                    Value = 1.0f,
-                }),
-                ["Target"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(gridPointsId)),
+                ["Progress"] = progressDriverTarget.Field,
+                ["Target"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(terrainGridMesh.PointsIdentity)),
                 ["Interpolate"] = PlannedMembers.Literal(new Field_bool
                 {
                     Value = true,
@@ -401,7 +429,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                         x = 2,
                         y = 2,
                     })),
-                    PlannedMembers.Literal(CreateTerrainGridPointsGradientPoint(1.0f, gridPoints.Value))),
+                    PlannedMembers.Literal(CreateTerrainGridPointsGradientPoint(1.0f, terrainGridMesh.Points.Value))),
             }));
         componentEmissions.Add(new PlannedBatchComponentEmission(
             CreateBatchPlanComponentLocator(ref nextComponentLocator),
@@ -413,11 +441,8 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 {
                     Value = TerrainGridDetailDynamicVariableName,
                 }),
-                ["Target"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(progressFieldId)),
-                ["DefaultValue"] = PlannedMembers.Literal(new Field_float
-                {
-                    Value = 1.0f,
-                }),
+                ["Target"] = progressDriverTarget.Target,
+                ["DefaultValue"] = progressDriverTarget.DefaultValue,
             }));
     }
 
@@ -437,15 +462,6 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 },
             },
         };
-    }
-
-    private static (BatchPlanFieldLocator Identity, Field_int2 Field) AssertTerrainGridPointsMember(
-        IReadOnlyDictionary<string, PlannedMember> gridMeshMembers)
-    {
-        return gridMeshMembers.TryGetValue("Points", out PlannedMember? pointsMember)
-            && pointsMember is PlannedAddressableFieldMember { Identity: var identity, Value: Field_int2 points }
-            ? (identity, points)
-            : throw new InvalidOperationException("Terrain GridMesh Points member must be planned as an addressable field.");
     }
 
     private static PlannedWorldElementReference AddPlannedDedicatedMaterialEmissions(
@@ -474,7 +490,9 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         Dictionary<string, PlannedMember> materialMembers = ResoniteMaterialComponentPolicy.CreateMembers(material)
             .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal);
 
-        Uri? albedoTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "albedo");
+        Uri? albedoTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Albedo);
         if (albedoTextureUri is not null)
         {
             BatchPlanComponentLocator albedoTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
@@ -489,7 +507,9 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             materialMembers["AlbedoTexture"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(albedoTextureId));
         }
 
-        Uri? normalTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "normal");
+        Uri? normalTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Normal);
         if (normalTextureUri is not null)
         {
             BatchPlanComponentLocator normalTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
@@ -508,7 +528,9 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             });
         }
 
-        Uri? heightTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "height");
+        Uri? heightTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Height);
         if (heightTextureUri is not null)
         {
             BatchPlanComponentLocator heightTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
@@ -527,7 +549,9 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             });
         }
 
-        Uri? metallicTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "metallic");
+        Uri? metallicTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Metallic);
         if (metallicTextureUri is not null)
         {
             BatchPlanComponentLocator metallicTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
@@ -543,7 +567,9 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             materialMembers["OcclusionMap"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(metallicTextureId));
         }
 
-        Uri? emissionTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "emission");
+        Uri? emissionTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Emission);
         if (emissionTextureUri is not null)
         {
             BatchPlanComponentLocator emissionTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
@@ -620,9 +646,15 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         ref int nextComponentLocator)
     {
         BatchPlanComponentLocator textureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
-        ResoniteSceneMaterialConventions.TextureMemberRole textureRole = binding.ClampWrapMode
-            ? ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride
-            : ResoniteSceneMaterialConventions.TextureMemberRole.Albedo;
+        ResoniteSceneMaterialConventions.TextureMemberRole textureRole = binding switch
+        {
+            PlannedAlbedoMainTextureOverrideRendererMaterialBinding =>
+                ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
+            PlannedTerrainMainTextureOverrideRendererMaterialBinding =>
+                ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride,
+            _ => throw new InvalidOperationException(
+                $"Unsupported planned main texture override binding type '{binding.GetType().Name}'."),
+        };
         componentEmissions.Add(new PlannedBatchComponentEmission(
             textureId,
             PlannedSlotTargetReference.PlannedSlot(assetSlotId),

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
@@ -11,7 +11,7 @@ namespace PlateauResoniteLink.Targets.Resonite.Execution;
 
 internal interface IResoniteGeometryAssetAssembler
 {
-    Task<PreparedGeometryAssetBatch> PrepareTriangleMeshAsync(
+    Task<UploadedGeometryAssetBatch> PrepareTriangleMeshAsync(
         IResoniteLinkClient importClient,
         string meshAssetSlotName,
         string displayName,
@@ -19,7 +19,7 @@ internal interface IResoniteGeometryAssetAssembler
         Action<string>? progressReporter,
         CancellationToken cancellationToken);
 
-    Task<PreparedGeometryAssetBatch> PrepareTerrainGridAsync(
+    Task<UploadedGeometryAssetBatch> PrepareTerrainGridAsync(
         IResoniteLinkClient importClient,
         string meshAssetSlotName,
         string heightMapAssetSlotName,
@@ -34,7 +34,7 @@ internal interface IResoniteGeometryAssetAssembler
 
 internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAssembler
 {
-    public async Task<PreparedGeometryAssetBatch> PrepareTriangleMeshAsync(
+    public async Task<UploadedGeometryAssetBatch> PrepareTriangleMeshAsync(
         IResoniteLinkClient importClient,
         string meshAssetSlotName,
         string displayName,
@@ -47,10 +47,10 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
             + $"(vertices={meshImport.VertexCount}, submeshes={meshImport.Submeshes.Count}).");
         Uri assetUri = await importClient.ImportMeshAsync(meshImport, cancellationToken);
         progressReporter?.Invoke($"[live] Mesh '{displayName}' mesh import completed -> '{assetUri}'.");
-        return new PreparedTriangleMeshAssetBatch(meshAssetSlotName, assetUri);
+        return new UploadedTriangleMeshAssetBatch(meshAssetSlotName, assetUri);
     }
 
-    public async Task<PreparedGeometryAssetBatch> PrepareTerrainGridAsync(
+    public async Task<UploadedGeometryAssetBatch> PrepareTerrainGridAsync(
         IResoniteLinkClient importClient,
         string meshAssetSlotName,
         string heightMapAssetSlotName,
@@ -66,7 +66,7 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
             $"[live] Terrain grid '{geometry.Width}x{geometry.Height}' importing displacement texture via raw payload.");
         Uri textureUri = await importClient.ImportTextureAsync(heightTextureImport, cancellationToken);
         progressReporter?.Invoke($"[live] Terrain grid '{displayName}' displacement texture import completed -> '{textureUri}'.");
-        return new PreparedTerrainGridAssetBatch(
+        return new UploadedTerrainGridAssetBatch(
             meshAssetSlotName,
             heightMapAssetSlotName,
             geometry,
@@ -94,16 +94,16 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
     }
 }
 
-internal abstract record PreparedGeometryAssetBatch(string MeshAssetSlotName);
+internal abstract record UploadedGeometryAssetBatch(string MeshAssetSlotName);
 
-internal sealed record PreparedTriangleMeshAssetBatch(
+internal sealed record UploadedTriangleMeshAssetBatch(
     string MeshAssetSlotName,
-    Uri MeshUri) : PreparedGeometryAssetBatch(MeshAssetSlotName);
+    Uri MeshUri) : UploadedGeometryAssetBatch(MeshAssetSlotName);
 
-internal sealed record PreparedTerrainGridAssetBatch(
+internal sealed record UploadedTerrainGridAssetBatch(
     string MeshAssetSlotName,
     string TerrainGridAssetSlotName,
     ResoniteTerrainGridGeometry Geometry,
     Uri HeightTextureUri,
     ResoniteFloat2? UvScale,
-    ResoniteFloat2? UvOffset) : PreparedGeometryAssetBatch(MeshAssetSlotName);
+    ResoniteFloat2? UvOffset) : UploadedGeometryAssetBatch(MeshAssetSlotName);

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -115,12 +115,12 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
 
     public static Uri? TryGetPlannedTextureUri(
         IEnumerable<PlannedTextureAsset> textures,
-        string role)
+        ResoniteSceneMaterialConventions.TextureMemberRole role)
     {
         ArgumentNullException.ThrowIfNull(textures);
-        ArgumentException.ThrowIfNullOrWhiteSpace(role);
 
-        return textures.FirstOrDefault(texture => string.Equals(texture.Identity.Value, role, StringComparison.Ordinal))?.AssetUri;
+        TextureIdentity identity = ResoniteSceneMaterialConventions.CreateTextureIdentity(role);
+        return textures.FirstOrDefault(texture => texture.Identity == identity)?.AssetUri;
     }
 
     public static async Task<PlannedTextureAsset?> PlanMainTextureOverrideAsync(
@@ -174,7 +174,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         ResoniteSlotLocator materialContainerSlot = materialSlot.Locator;
         Dictionary<string, Member> materialMembers = ResoniteMaterialComponentPolicy.CreateMembers(plannedMaterial.Material);
 
-        Uri? albedoTextureUri = TryGetPlannedTextureUri(plannedMaterial.Textures, "albedo");
+        Uri? albedoTextureUri = TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Albedo);
         if (albedoTextureUri is not null)
         {
             CreatedComponent albedoTexture = await createComponentAsync(
@@ -191,7 +193,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             };
         }
 
-        Uri? normalTextureUri = TryGetPlannedTextureUri(plannedMaterial.Textures, "normal");
+        Uri? normalTextureUri = TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Normal);
         if (normalTextureUri is not null)
         {
             CreatedComponent normalTexture = await createComponentAsync(
@@ -212,7 +216,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             };
         }
 
-        Uri? heightTextureUri = TryGetPlannedTextureUri(plannedMaterial.Textures, "height");
+        Uri? heightTextureUri = TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Height);
         if (heightTextureUri is not null)
         {
             CreatedComponent heightTexture = await createComponentAsync(
@@ -233,7 +239,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             };
         }
 
-        Uri? metallicTextureUri = TryGetPlannedTextureUri(plannedMaterial.Textures, "metallic");
+        Uri? metallicTextureUri = TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Metallic);
         if (metallicTextureUri is not null)
         {
             CreatedComponent metallicTexture = await createComponentAsync(
@@ -254,7 +262,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             };
         }
 
-        Uri? emissionTextureUri = TryGetPlannedTextureUri(plannedMaterial.Textures, "emission");
+        Uri? emissionTextureUri = TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Emission);
         if (emissionTextureUri is not null)
         {
             CreatedComponent emissionTexture = await createComponentAsync(
@@ -420,11 +430,26 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             emissionTextureTask);
 
         List<PlannedTextureAsset> textures = [];
-        AddPlannedTextureAsset(textures, "albedo", await albedoTextureTask);
-        AddPlannedTextureAsset(textures, "normal", await normalTextureTask);
-        AddPlannedTextureAsset(textures, "height", await heightTextureTask);
-        AddPlannedTextureAsset(textures, "metallic", await metallicTextureTask);
-        AddPlannedTextureAsset(textures, "emission", await emissionTextureTask);
+        AddPlannedTextureAsset(
+            textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
+            await albedoTextureTask);
+        AddPlannedTextureAsset(
+            textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Normal,
+            await normalTextureTask);
+        AddPlannedTextureAsset(
+            textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Height,
+            await heightTextureTask);
+        AddPlannedTextureAsset(
+            textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Metallic,
+            await metallicTextureTask);
+        AddPlannedTextureAsset(
+            textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Emission,
+            await emissionTextureTask);
         return textures;
     }
 
@@ -470,7 +495,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
 
     private static void AddPlannedTextureAsset(
         List<PlannedTextureAsset> textures,
-        string role,
+        ResoniteSceneMaterialConventions.TextureMemberRole role,
         Uri? assetUri)
     {
         if (assetUri is null)
@@ -478,7 +503,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             return;
         }
 
-        textures.Add(new PlannedTextureAsset(new TextureIdentity(role), assetUri));
+        textures.Add(new PlannedTextureAsset(
+            ResoniteSceneMaterialConventions.CreateTextureIdentity(role),
+            assetUri));
     }
 
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneBootstrapInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneBootstrapInterpreter.cs
@@ -573,7 +573,9 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
         Dictionary<string, Member> materialMembers = ResoniteMaterialComponentPolicy.CreateMembers(material);
         string componentPrefix = $"bootstrap_common_material_component_{materialIndex}";
 
-        Uri? albedoTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "albedo");
+        Uri? albedoTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Albedo);
         if (albedoTextureUri is not null)
         {
             ResoniteBatchOperations.PendingBatchComponent albedoTexture = ResoniteBatchOperations.CreatePendingComponent(
@@ -594,7 +596,9 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             };
         }
 
-        Uri? normalTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "normal");
+        Uri? normalTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Normal);
         if (normalTextureUri is not null)
         {
             ResoniteBatchOperations.PendingBatchComponent normalTexture = ResoniteBatchOperations.CreatePendingComponent(
@@ -619,7 +623,9 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             };
         }
 
-        Uri? heightTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "height");
+        Uri? heightTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Height);
         if (heightTextureUri is not null)
         {
             ResoniteBatchOperations.PendingBatchComponent heightTexture = ResoniteBatchOperations.CreatePendingComponent(
@@ -644,7 +650,9 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             };
         }
 
-        Uri? metallicTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "metallic");
+        Uri? metallicTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Metallic);
         if (metallicTextureUri is not null)
         {
             ResoniteBatchOperations.PendingBatchComponent metallicTexture = ResoniteBatchOperations.CreatePendingComponent(
@@ -669,7 +677,9 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
             };
         }
 
-        Uri? emissionTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedMaterial.Textures, "emission");
+        Uri? emissionTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
+            plannedMaterial.Textures,
+            ResoniteSceneMaterialConventions.TextureMemberRole.Emission);
         if (emissionTextureUri is not null)
         {
             ResoniteBatchOperations.PendingBatchComponent emissionTexture = ResoniteBatchOperations.CreatePendingComponent(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -1209,7 +1209,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             cityObject,
             preparedTerrainTextureDataByOverlay,
             buildStepCancellation.Token);
-        Task<PreparedTextureUriData> preparedTextureUriTask = ImportPreparedTextureUrisAsync(
+        Task<UploadedTextureAssetSet> uploadedTextureAssetsTask = UploadPreparedTexturesAsync(
             routedClient,
             preparedCityObject,
             preparedTerrainTextureDataByOverlay,
@@ -1227,8 +1227,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         PlannedGeometryAsset plannedGeometryAsset;
         try
         {
-            PreparedTextureUriData preparedTextureUris = await AwaitMaterialPlanningPrerequisitesAsync(
-                preparedTextureUriTask,
+            UploadedTextureAssetSet uploadedTextureAssets = await AwaitMaterialPlanningPrerequisitesAsync(
+                uploadedTextureAssetsTask,
                 sharedCommonMaterialPreparationTask,
                 geometryPlanningTask);
             materialStopwatch.Start();
@@ -1236,9 +1236,9 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 state,
                 routedClient,
                 cityObject,
-                preparedTextureUris.TextureUrisByPayload,
-                preparedTextureUris.TerrainTextureUrisByOverlay,
-                preparedTextureUris.GeneratedTerrainTexturesByOverlay,
+                uploadedTextureAssets.TextureUrisByPayload,
+                uploadedTextureAssets.TerrainTextureUrisByOverlay,
+                uploadedTextureAssets.GeneratedTerrainTexturesByOverlay,
                 buildStepCancellation.Token);
             plannedMaterials = await materialPlanningTask;
             materialStopwatch.Stop();
@@ -1251,8 +1251,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         {
             await buildStepCancellation.CancelAsync();
             IEnumerable<Task> tasksToObserve = materialPlanningTask is null
-                ? [preparedTextureUriTask, sharedCommonMaterialPreparationTask, geometryPlanningTask]
-                : [preparedTextureUriTask, sharedCommonMaterialPreparationTask, materialPlanningTask, geometryPlanningTask];
+                ? [uploadedTextureAssetsTask, sharedCommonMaterialPreparationTask, geometryPlanningTask]
+                : [uploadedTextureAssetsTask, sharedCommonMaterialPreparationTask, materialPlanningTask, geometryPlanningTask];
             await ObserveTaskFailuresAsync(tasksToObserve);
             throw;
         }
@@ -1298,18 +1298,18 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         }
     }
 
-    private static async Task<PreparedTextureUriData> AwaitMaterialPlanningPrerequisitesAsync(
-        Task<PreparedTextureUriData> preparedTextureUriTask,
+    private static async Task<UploadedTextureAssetSet> AwaitMaterialPlanningPrerequisitesAsync(
+        Task<UploadedTextureAssetSet> uploadedTextureAssetsTask,
         Task sharedCommonMaterialPreparationTask,
         Task<PlannedGeometryAsset> geometryPlanningTask)
     {
-        PreparedTextureUriData? preparedTextureUris = null;
+        UploadedTextureAssetSet? uploadedTextureAssets = null;
         bool sharedCommonMaterialPrepared = false;
-        while (preparedTextureUris is null || !sharedCommonMaterialPrepared)
+        while (uploadedTextureAssets is null || !sharedCommonMaterialPrepared)
         {
-            if (preparedTextureUriTask.IsCompleted)
+            if (uploadedTextureAssetsTask.IsCompleted)
             {
-                preparedTextureUris = await preparedTextureUriTask;
+                uploadedTextureAssets = await uploadedTextureAssetsTask;
             }
 
             if (sharedCommonMaterialPreparationTask.IsCompleted)
@@ -1318,15 +1318,15 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 sharedCommonMaterialPrepared = true;
             }
 
-            if (preparedTextureUris is not null && sharedCommonMaterialPrepared)
+            if (uploadedTextureAssets is not null && sharedCommonMaterialPrepared)
             {
                 break;
             }
 
             List<Task> waitTasks = [];
-            if (!preparedTextureUriTask.IsCompleted)
+            if (!uploadedTextureAssetsTask.IsCompleted)
             {
-                waitTasks.Add(preparedTextureUriTask);
+                waitTasks.Add(uploadedTextureAssetsTask);
             }
 
             if (!sharedCommonMaterialPreparationTask.IsCompleted)
@@ -1343,10 +1343,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             await completedTask;
         }
 
-        return preparedTextureUris;
+        return uploadedTextureAssets;
     }
 
-    private static async Task<PreparedTextureUriData> ImportPreparedTextureUrisAsync(
+    private static async Task<UploadedTextureAssetSet> UploadPreparedTexturesAsync(
         IResoniteLinkClient importClient,
         PreparedCityObject preparedCityObject,
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay,
@@ -1392,7 +1392,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             }
         }
 
-        return new PreparedTextureUriData(
+        return new UploadedTextureAssetSet(
             textureUrisByPayload,
             terrainTextureUrisByOverlay,
             preparedTerrainTextureDataByOverlay);
@@ -1804,10 +1804,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 preparedTerrainTextureUrisByOverlay);
             PlannedRendererMaterialBinding rendererBinding = mainTextureOverride is null
                 ? new PlannedDirectRendererMaterialBinding(sharedMaterialAsset.Identity)
-                : new PlannedMainTextureOverrideRendererMaterialBinding(
+                : CreateMainTextureOverrideRendererBinding(
                     sharedMaterialAsset.Identity,
                     mainTextureOverride,
-                    ClampWrapMode: sourceMaterial.TerrainOverlay is not null);
+                    sourceMaterial);
             return (sharedMaterialAsset, rendererBinding);
         }
 
@@ -1832,6 +1832,16 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 ct);
             return (plannedMaterial, new PlannedDirectRendererMaterialBinding(plannedMaterial.Identity));
         }
+    }
+
+    private static PlannedMainTextureOverrideRendererMaterialBinding CreateMainTextureOverrideRendererBinding(
+        MaterialIdentity materialIdentity,
+        PlannedTextureAsset mainTexture,
+        ResoniteMaterialBinding sourceMaterial)
+    {
+        return sourceMaterial.TerrainOverlay is null
+            ? new PlannedAlbedoMainTextureOverrideRendererMaterialBinding(materialIdentity, mainTexture)
+            : new PlannedTerrainMainTextureOverrideRendererMaterialBinding(materialIdentity, mainTexture);
     }
 
     private async Task EnsureSharedCommonMaterialsPreparedAsync(
@@ -2083,14 +2093,14 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                     cancellationToken)),
             PreparedDynamicTerrainGeometry dynamicTerrain => CreatePlannedDynamicTerrainGeometryAsset(
                 cityObject,
-                AssertPreparedTriangleMeshAssetBatch(await geometryAssetAssembler.PrepareTriangleMeshAsync(
+                AssertUploadedTriangleMeshAssetBatch(await geometryAssetAssembler.PrepareTriangleMeshAsync(
                     importClient,
                     CreateMeshAssetSlotName(cityObject),
                     cityObject.DisplayName,
                     dynamicTerrain.StaticMesh.MeshImport,
                     progressReporter,
                     cancellationToken)),
-                AssertPreparedTerrainGridAssetBatch(await geometryAssetAssembler.PrepareTerrainGridAsync(
+                AssertUploadedTerrainGridAssetBatch(await geometryAssetAssembler.PrepareTerrainGridAsync(
                     importClient,
                     CreateMeshAssetSlotName(cityObject),
                     CreateTerrainGridAssetSlotName(cityObject),
@@ -2137,20 +2147,20 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 
     private static PlannedGeometryAsset CreatePlannedGeometryAsset(
         ResoniteConstructionCityObject cityObject,
-        PreparedGeometryAssetBatch preparedGeometryBatch)
+        UploadedGeometryAssetBatch uploadedGeometryBatch)
     {
         GeometryIdentity identity = new(
             string.Create(
                 CultureInfo.InvariantCulture,
-                $"geometry-{cityObject.PackageName}-{cityObject.SlotKey}-{preparedGeometryBatch.MeshAssetSlotName}"));
+                $"geometry-{cityObject.PackageName}-{cityObject.SlotKey}-{uploadedGeometryBatch.MeshAssetSlotName}"));
 
-        return preparedGeometryBatch switch
+        return uploadedGeometryBatch switch
         {
-            PreparedTriangleMeshAssetBatch triangleMesh => new PlannedTriangleMeshGeometryAsset(
+            UploadedTriangleMeshAssetBatch triangleMesh => new PlannedTriangleMeshGeometryAsset(
                 identity,
                 triangleMesh.MeshAssetSlotName,
                 triangleMesh.MeshUri),
-            PreparedTerrainGridAssetBatch heightMap => new PlannedTerrainGridGeometryAsset(
+            UploadedTerrainGridAssetBatch heightMap => new PlannedTerrainGridGeometryAsset(
                 identity,
                 heightMap.MeshAssetSlotName,
                 heightMap.TerrainGridAssetSlotName,
@@ -2159,14 +2169,14 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 heightMap.UvScale,
                 heightMap.UvOffset),
             _ => throw new InvalidOperationException(
-                $"Unsupported prepared geometry asset batch type '{preparedGeometryBatch.GetType().Name}'."),
+                $"Unsupported uploaded geometry asset batch type '{uploadedGeometryBatch.GetType().Name}'."),
         };
     }
 
     private static PlannedDynamicTerrainGeometryAsset CreatePlannedDynamicTerrainGeometryAsset(
         ResoniteConstructionCityObject cityObject,
-        PreparedTriangleMeshAssetBatch staticMeshBatch,
-        PreparedTerrainGridAssetBatch gridMeshBatch)
+        UploadedTriangleMeshAssetBatch staticMeshBatch,
+        UploadedTerrainGridAssetBatch gridMeshBatch)
     {
         GeometryIdentity identity = new(
             string.Create(
@@ -2184,20 +2194,20 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             gridMeshBatch.UvOffset);
     }
 
-    private static PreparedTriangleMeshAssetBatch AssertPreparedTriangleMeshAssetBatch(
-        PreparedGeometryAssetBatch preparedGeometryBatch)
+    private static UploadedTriangleMeshAssetBatch AssertUploadedTriangleMeshAssetBatch(
+        UploadedGeometryAssetBatch uploadedGeometryBatch)
     {
-        return preparedGeometryBatch as PreparedTriangleMeshAssetBatch
+        return uploadedGeometryBatch as UploadedTriangleMeshAssetBatch
             ?? throw new InvalidOperationException(
-                $"Unsupported prepared static terrain asset batch type '{preparedGeometryBatch.GetType().Name}'.");
+                $"Unsupported uploaded static terrain asset batch type '{uploadedGeometryBatch.GetType().Name}'.");
     }
 
-    private static PreparedTerrainGridAssetBatch AssertPreparedTerrainGridAssetBatch(
-        PreparedGeometryAssetBatch preparedGeometryBatch)
+    private static UploadedTerrainGridAssetBatch AssertUploadedTerrainGridAssetBatch(
+        UploadedGeometryAssetBatch uploadedGeometryBatch)
     {
-        return preparedGeometryBatch as PreparedTerrainGridAssetBatch
+        return uploadedGeometryBatch as UploadedTerrainGridAssetBatch
             ?? throw new InvalidOperationException(
-                $"Unsupported prepared terrain grid asset batch type '{preparedGeometryBatch.GetType().Name}'.");
+                $"Unsupported uploaded terrain grid asset batch type '{uploadedGeometryBatch.GetType().Name}'.");
     }
 
     private static long EstimateBatchPayloadBytes(int operationCount)
@@ -2306,7 +2316,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         TerrainTextureOverlay? TerrainOverlay = null,
         GeneratedTerrainTexture? GeneratedTerrainTexture = null);
 
-    private sealed record PreparedTextureUriData(
+    private sealed record UploadedTextureAssetSet(
         Dictionary<ResoniteTexturePayload, Uri> TextureUrisByPayload,
         Dictionary<TerrainTextureOverlay, Uri> TerrainTextureUrisByOverlay,
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> GeneratedTerrainTexturesByOverlay);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -63,11 +63,20 @@ internal abstract record PlannedRendererMaterialBinding(MaterialIdentity Materia
 internal sealed record PlannedDirectRendererMaterialBinding(MaterialIdentity MaterialIdentity)
     : PlannedRendererMaterialBinding(MaterialIdentity);
 
-internal sealed record PlannedMainTextureOverrideRendererMaterialBinding(
+internal abstract record PlannedMainTextureOverrideRendererMaterialBinding(
     MaterialIdentity MaterialIdentity,
-    PlannedTextureAsset MainTexture,
-    bool ClampWrapMode = false)
+    PlannedTextureAsset MainTexture)
     : PlannedRendererMaterialBinding(MaterialIdentity);
+
+internal sealed record PlannedAlbedoMainTextureOverrideRendererMaterialBinding(
+    MaterialIdentity MaterialIdentity,
+    PlannedTextureAsset MainTexture)
+    : PlannedMainTextureOverrideRendererMaterialBinding(MaterialIdentity, MainTexture);
+
+internal sealed record PlannedTerrainMainTextureOverrideRendererMaterialBinding(
+    MaterialIdentity MaterialIdentity,
+    PlannedTextureAsset MainTexture)
+    : PlannedMainTextureOverrideRendererMaterialBinding(MaterialIdentity, MainTexture);
 
 internal sealed record PlannedRenderer(
     GeometryIdentity GeometryIdentity,
@@ -92,6 +101,23 @@ internal readonly record struct BatchPlanSlotLocator(int Value);
 internal readonly record struct BatchPlanComponentLocator(int Value);
 
 internal readonly record struct BatchPlanFieldLocator(int Value);
+
+internal sealed record PlannedTerrainGridMeshBundle(
+    BatchPlanComponentLocator ComponentIdentity,
+    BatchPlanFieldLocator PointsIdentity,
+    Field_int2 Points,
+    Field_float2 Size,
+    Field_float DisplacementMagnitude,
+    PlannedWorldElementReference DisplacementTexture,
+    Field_float2? UvScale,
+    Field_float2? UvOffset);
+
+internal sealed record PlannedDynamicTerrainMeshBundle(
+    PlannedWorldElementReference GridMeshTarget,
+    PlannedWorldElementReference StaticMeshTarget)
+{
+    public PlannedWorldElementReference InitialMeshTarget => GridMeshTarget;
+}
 
 internal readonly record struct PlannedSlotTargetReference
 {
@@ -189,6 +215,38 @@ internal sealed record PlannedAddressableReferenceMember(
     : PlannedMember;
 
 internal sealed record PlannedSyncListMember(IReadOnlyList<PlannedMember> Elements) : PlannedMember;
+
+internal sealed record PlannedDriverTargetBundle(
+    PlannedAddressableFieldMember Field,
+    PlannedElementReferenceMember Target,
+    PlannedLiteralMember DefaultValue)
+{
+    public static PlannedDriverTargetBundle Create(BatchPlanFieldLocator fieldIdentity, Member defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(defaultValue);
+        return new PlannedDriverTargetBundle(
+            new PlannedAddressableFieldMember(fieldIdentity, defaultValue),
+            new PlannedElementReferenceMember(PlannedWorldElementReference.Planned(fieldIdentity)),
+            new PlannedLiteralMember(CloneDriverDefaultValue(defaultValue)));
+    }
+
+    private static Member CloneDriverDefaultValue(Member value)
+    {
+        return value switch
+        {
+            Field_bool field => new Field_bool
+            {
+                Value = field.Value,
+            },
+            Field_float field => new Field_float
+            {
+                Value = field.Value,
+            },
+            _ => throw new InvalidOperationException(
+                $"Unsupported planned driver default value type '{value.GetType().Name}'."),
+        };
+    }
+}
 
 internal static class PlannedMembers
 {

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -26,6 +26,10 @@ internal static class ResoniteSceneMaterialConventions
         TerrainMainTextureOverride,
     }
 
+    internal readonly record struct TextureSamplingPolicy(
+        string? PreferredProfile,
+        string? WrapMode);
+
     public static string CreateMaterialSlotName(ResoniteMaterialBinding material, bool useCommonMaterialAssets)
     {
         ArgumentNullException.ThrowIfNull(material);
@@ -308,9 +312,43 @@ internal static class ResoniteSceneMaterialConventions
         return ResoniteMaterialSharing.CreateCanonicalVertexColorCommonMaterialKey(projection, depthOffset);
     }
 
+    public static TextureIdentity CreateTextureIdentity(TextureMemberRole role)
+    {
+        return new TextureIdentity(role switch
+        {
+            TextureMemberRole.Albedo => "albedo",
+            TextureMemberRole.Normal => "normal",
+            TextureMemberRole.Height => "height",
+            TextureMemberRole.Metallic => "metallic",
+            TextureMemberRole.Emission => "emission",
+            _ => throw new InvalidOperationException($"Texture role '{role}' does not have a planned texture identity."),
+        });
+    }
+
+    public static TextureSamplingPolicy GetTextureSamplingPolicy(TextureMemberRole role)
+    {
+        return role switch
+        {
+            TextureMemberRole.Normal
+                or TextureMemberRole.Height
+                or TextureMemberRole.Metallic => new TextureSamplingPolicy(
+                    ResoniteTextureColorProfiles.Linear,
+                    WrapMode: null),
+            TextureMemberRole.TerrainMainTextureOverride => new TextureSamplingPolicy(
+                PreferredProfile: null,
+                WrapMode: "Clamp"),
+            TextureMemberRole.Albedo
+                or TextureMemberRole.Emission => new TextureSamplingPolicy(
+                    PreferredProfile: null,
+                    WrapMode: null),
+            _ => throw new InvalidOperationException($"Unsupported texture member role '{role}'."),
+        };
+    }
+
     public static Dictionary<string, Member> CreateTextureMembers(Uri assetUri, TextureMemberRole role)
     {
         ArgumentNullException.ThrowIfNull(assetUri);
+        TextureSamplingPolicy samplingPolicy = GetTextureSamplingPolicy(role);
 
         Dictionary<string, Member> members = new(StringComparer.Ordinal)
         {
@@ -320,22 +358,15 @@ internal static class ResoniteSceneMaterialConventions
             },
         };
 
-        switch (role)
+        if (samplingPolicy.PreferredProfile is not null)
         {
-            case TextureMemberRole.Normal:
-            case TextureMemberRole.Height:
-            case TextureMemberRole.Metallic:
-                members["PreferredProfile"] = CreateNullableEnumMember(ResoniteTextureColorProfiles.Linear);
-                break;
-            case TextureMemberRole.TerrainMainTextureOverride:
-                members["WrapModeU"] = CreateEnumMember("Clamp");
-                members["WrapModeV"] = CreateEnumMember("Clamp");
-                break;
-            case TextureMemberRole.Albedo:
-            case TextureMemberRole.Emission:
-                break;
-            default:
-                throw new InvalidOperationException($"Unsupported texture member role '{role}'.");
+            members["PreferredProfile"] = CreateNullableEnumMember(samplingPolicy.PreferredProfile);
+        }
+
+        if (samplingPolicy.WrapMode is not null)
+        {
+            members["WrapModeU"] = CreateEnumMember(samplingPolicy.WrapMode);
+            members["WrapModeV"] = CreateEnumMember(samplingPolicy.WrapMode);
         }
 
         return members;

--- a/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
@@ -214,6 +214,44 @@ public sealed class DatasetInspectionServiceTests
     }
 
     [Fact]
+    public async Task GetStatsAsyncIgnoresTrailingPosListRemainderLikeImporterParser()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        WriteDatasetFile(
+            datasetRoot.Path,
+            "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml",
+            """
+            <core:CityModel
+              xmlns:bldg="http://www.opengis.net/citygml/building/2.0"
+              xmlns:core="http://www.opengis.net/citygml/2.0"
+              xmlns:gml="http://www.opengis.net/gml">
+              <core:cityObjectMember>
+                <bldg:Building>
+                  <bldg:lod2MultiSurface>
+                    <gml:MultiSurface>
+                      <gml:surfaceMember>
+                        <gml:Polygon>
+                          <gml:exterior>
+                            <gml:LinearRing>
+                              <gml:posList>0 0 0 1 0 0 0 1 0 42</gml:posList>
+                            </gml:LinearRing>
+                          </gml:exterior>
+                        </gml:Polygon>
+                      </gml:surfaceMember>
+                    </gml:MultiSurface>
+                  </bldg:lod2MultiSurface>
+                </bldg:Building>
+              </core:cityObjectMember>
+            </core:CityModel>
+            """);
+
+        DatasetStatsResult result = await service.GetStatsAsync(datasetRoot.Path, ["bldg"]);
+
+        Assert.Equal(3, result.ArchiveVramEstimate.RendererGeometryVram.PositionCount);
+        Assert.Equal(1, result.ArchiveVramEstimate.RendererGeometryVram.TriangleCount);
+    }
+
+    [Fact]
     public async Task GetStatsAsyncEstimatesGeometryVramFromGmlPosFallback()
     {
         using TemporaryDirectory datasetRoot = new();

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultDemTextureSourcePolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultDemTextureSourcePolicyTests.cs
@@ -161,6 +161,8 @@ public sealed class DefaultDemTextureSourcePolicyTests
         IReadOnlyDictionary<string, TerrainTextureGeoReferencedRasterSource?> rasterSourcesByMeshCode)
         : IDemTerrainGeoReferencedRasterCatalog
     {
+        public DemTerrainRasterSourceScope CacheScope { get; } = new("C:\\ortho");
+
         public Task<TerrainTextureGeoReferencedRasterSource?> TryResolveRasterSourceAsync(
             DemTerrainRasterCacheKey cacheKey,
             string meshCode,

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
@@ -14,6 +14,31 @@ namespace PlateauResoniteLink.Tests.Profiles;
 public sealed class DemTerrainGeoReferencedRasterCatalogTests
 {
     [Fact]
+    public void DemTerrainRasterCacheKeySeparatesSourceScopeFromMeshAndBounds()
+    {
+        GeographicRectangle bounds = new(35.0, 35.1, 139.0, 139.1);
+
+        DemTerrainRasterCacheKey firstKey = new(
+            "tokyo-a",
+            new DemTerrainRasterSourceScope("C:\\ortho-a"),
+            "dem-fallback",
+            bounds);
+        DemTerrainRasterCacheKey secondKey = new(
+            "tokyo-a",
+            new DemTerrainRasterSourceScope("C:\\ortho-b"),
+            "dem-fallback",
+            bounds);
+        DemTerrainRasterCacheKey thirdKey = new(
+            "tokyo-b",
+            new DemTerrainRasterSourceScope("C:\\ortho-a"),
+            "dem-fallback",
+            bounds);
+
+        Assert.NotEqual(firstKey, secondKey);
+        Assert.NotEqual(firstKey, thirdKey);
+    }
+
+    [Fact]
     public async Task TryResolveRasterSourceAsyncDoesNotReuseFallbackMaterializationAcrossDistinctBoundsKeys()
     {
         using TemporaryDirectory datasetRoot = new();
@@ -23,12 +48,12 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         GeographicRectangle secondBounds = new(35.1, 35.2, 139.1, 139.2);
 
         _ = await catalog.TryResolveRasterSourceAsync(
-            new DemTerrainRasterCacheKey("dem-fallback", firstBounds),
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", firstBounds),
             "dem-fallback",
             firstBounds,
             CancellationToken.None);
         _ = await catalog.TryResolveRasterSourceAsync(
-            new DemTerrainRasterCacheKey("dem-fallback", secondBounds),
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", secondBounds),
             "dem-fallback",
             secondBounds,
             CancellationToken.None);
@@ -46,12 +71,12 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         GeographicRectangle secondBounds = new(35.0000001, 35.1000001, 139.0000001, 139.1000001);
 
         _ = await catalog.TryResolveRasterSourceAsync(
-            new DemTerrainRasterCacheKey("dem-fallback", firstBounds),
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", firstBounds),
             "dem-fallback",
             firstBounds,
             CancellationToken.None);
         _ = await catalog.TryResolveRasterSourceAsync(
-            new DemTerrainRasterCacheKey("dem-fallback", secondBounds),
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", secondBounds),
             "dem-fallback",
             secondBounds,
             CancellationToken.None);
@@ -69,13 +94,13 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         using CancellationTokenSource firstCallerCancellation = new();
 
         Task<TerrainTextureGeoReferencedRasterSource?> firstCall = catalog.TryResolveRasterSourceAsync(
-            new DemTerrainRasterCacheKey("dem-fallback", bounds),
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", bounds),
             "dem-fallback",
             bounds,
             firstCallerCancellation.Token);
         await datasetSource.EnsureLocalFileStarted.Task.WaitAsync(CancellationToken.None);
         Task<TerrainTextureGeoReferencedRasterSource?> secondCall = catalog.TryResolveRasterSourceAsync(
-            new DemTerrainRasterCacheKey("dem-fallback", bounds),
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", bounds),
             "dem-fallback",
             bounds,
             CancellationToken.None);
@@ -89,7 +114,7 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         Assert.Equal("EPSG:4326", resolvedSecondResult.Metadata?.CoordinateSystemIdentifier);
 
         TerrainTextureGeoReferencedRasterSource? thirdResult = await catalog.TryResolveRasterSourceAsync(
-            new DemTerrainRasterCacheKey("dem-fallback", bounds),
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", bounds),
             "dem-fallback",
             bounds,
             CancellationToken.None);
@@ -107,7 +132,7 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         using CancellationTokenSource firstCallerCancellation = new();
 
         Task<TerrainTextureGeoReferencedRasterSource?> firstCall = catalog.TryResolveRasterSourceAsync(
-            new DemTerrainRasterCacheKey("dem-fallback", bounds),
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", bounds),
             "dem-fallback",
             bounds,
             firstCallerCancellation.Token);
@@ -120,7 +145,7 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         await Task.Delay(10);
 
         await Assert.ThrowsAnyAsync<IOException>(async () => await catalog.TryResolveRasterSourceAsync(
-            new DemTerrainRasterCacheKey("dem-fallback", bounds),
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", bounds),
             "dem-fallback",
             bounds,
             CancellationToken.None));

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -16,6 +16,25 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     private static readonly IResoniteBatchEmissionPlanner Planner = new ResoniteBatchEmissionPlanner();
 
     [Fact]
+    public void PlannedDriverTargetBundle_CreatePairsFieldTargetAndDefaultValue()
+    {
+        BatchPlanFieldLocator fieldIdentity = new(42);
+
+        PlannedDriverTargetBundle bundle = PlannedDriverTargetBundle.Create(
+            fieldIdentity,
+            new Field_bool
+            {
+                Value = false,
+            });
+
+        Assert.Equal(fieldIdentity, bundle.Field.Identity);
+        Assert.Equal(fieldIdentity, bundle.Target.Target.PlannedField);
+        Assert.False(Assert.IsType<Field_bool>(bundle.Field.Value).Value);
+        Assert.False(Assert.IsType<Field_bool>(bundle.DefaultValue.Value).Value);
+        Assert.NotSame(bundle.Field.Value, bundle.DefaultValue.Value);
+    }
+
+    [Fact]
     public void CreatePlannedBatchEmission_CreatesTerrainGridPlanWithPlannedTextureReference()
     {
         ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
@@ -419,7 +438,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             new PlannedRenderer(
                 new GeometryIdentity("geom"),
                 [
-                    new PlannedMainTextureOverrideRendererMaterialBinding(
+                    new PlannedAlbedoMainTextureOverrideRendererMaterialBinding(
                         reusableMaterial.Identity,
                         new PlannedTextureAsset(new TextureIdentity("override"), new Uri("resdb:///texture/override"))),
                 ]),
@@ -476,10 +495,9 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             new PlannedRenderer(
                 new GeometryIdentity("geom"),
                 [
-                    new PlannedMainTextureOverrideRendererMaterialBinding(
+                    new PlannedTerrainMainTextureOverrideRendererMaterialBinding(
                         reusableMaterial.Identity,
-                        new PlannedTextureAsset(new TextureIdentity("override"), new Uri("resdb:///texture/override")),
-                        ClampWrapMode: true),
+                        new PlannedTextureAsset(new TextureIdentity("override"), new Uri("resdb:///texture/override"))),
                 ]),
             new PlannedCollider(
                 new GeometryIdentity("geom"),
@@ -516,10 +534,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             new PlannedRenderer(
                 new GeometryIdentity("geom"),
                 [
-                    new PlannedMainTextureOverrideRendererMaterialBinding(
+                    new PlannedAlbedoMainTextureOverrideRendererMaterialBinding(
                         reusableMaterial.Identity,
                         new PlannedTextureAsset(new TextureIdentity("override-a"), new Uri("resdb:///texture/override-a"))),
-                    new PlannedMainTextureOverrideRendererMaterialBinding(
+                    new PlannedAlbedoMainTextureOverrideRendererMaterialBinding(
                         reusableMaterial.Identity,
                         new PlannedTextureAsset(new TextureIdentity("override-b"), new Uri("resdb:///texture/override-b"))),
                 ]),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -51,6 +51,31 @@ public sealed class ResoniteSceneMaterialConventionsTests
     }
 
     [Fact]
+    public void CreateTextureIdentity_ForMaterialTextureRoles_UsesStableTokens()
+    {
+        Assert.Equal(
+            new TextureIdentity("albedo"),
+            ResoniteSceneMaterialConventions.CreateTextureIdentity(
+                ResoniteSceneMaterialConventions.TextureMemberRole.Albedo));
+        Assert.Equal(
+            new TextureIdentity("normal"),
+            ResoniteSceneMaterialConventions.CreateTextureIdentity(
+                ResoniteSceneMaterialConventions.TextureMemberRole.Normal));
+        Assert.Equal(
+            new TextureIdentity("height"),
+            ResoniteSceneMaterialConventions.CreateTextureIdentity(
+                ResoniteSceneMaterialConventions.TextureMemberRole.Height));
+        Assert.Equal(
+            new TextureIdentity("metallic"),
+            ResoniteSceneMaterialConventions.CreateTextureIdentity(
+                ResoniteSceneMaterialConventions.TextureMemberRole.Metallic));
+        Assert.Equal(
+            new TextureIdentity("emission"),
+            ResoniteSceneMaterialConventions.CreateTextureIdentity(
+                ResoniteSceneMaterialConventions.TextureMemberRole.Emission));
+    }
+
+    [Fact]
     public void CreateMaterialSlotName_ForCommonMaterial_UsesStableSharedDiscriminators()
     {
         ResoniteMaterialBinding material = new(


### PR DESCRIPTION
## Summary
- closes the remaining #155 boundary-contract gaps before pending feature work
- splits main texture override policy into typed albedo and terrain override bindings
- moves terrain GridMesh member bags to the emission edge behind a typed grid plan
- removes raw string texture-role lookup from material planning/bootstrap paths

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
