### PR TITLE
Project roof surfaces onto DEM textures

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CommonMaterialCatalog.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CommonMaterialCatalog.cs
@@ -147,7 +147,7 @@ public sealed class CommonMaterialCatalog
             ReuseScope: MaterialReuseScope.Shared);
     }
 
-    private static string CreateCanonicalGenericSharedMaterialKey(
+    internal static string CreateCanonicalGenericSharedMaterialKey(
         MaterialProjection projection,
         Float2? textureScale,
         Float2? textureOffset,

--- a/src/PlateauResoniteLink/Application/Importing/CommonMaterialCatalog.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CommonMaterialCatalog.cs
@@ -147,7 +147,7 @@ public sealed class CommonMaterialCatalog
             ReuseScope: MaterialReuseScope.Shared);
     }
 
-    internal static string CreateCanonicalGenericSharedMaterialKey(
+    private static string CreateCanonicalGenericSharedMaterialKey(
         MaterialProjection projection,
         Float2? textureScale,
         Float2? textureOffset,

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
@@ -45,9 +45,7 @@ internal static class DemTerrainOverlayAssignment
         foreach (BootstrapParsedSurface generatedSurface in generatedSurfaces)
         {
             BootstrapParsedSurface[] requestedMeshClippedSurfaces =
-                parsedCityObject.SharedAcrossMeshCodes
-                    ? ClipBootstrapGeneratedSurfaceToRequestedMeshAreas(generatedSurface, requestedMeshBounds)
-                    : [generatedSurface];
+                ClipBootstrapGeneratedSurfaceToRequestedMeshAreas(generatedSurface, requestedMeshBounds);
             if (requestedMeshClippedSurfaces.Length == 0)
             {
                 continue;
@@ -145,9 +143,7 @@ internal static class DemTerrainOverlayAssignment
         if (demTerrainTextureOverlays.Count == 0)
         {
             BootstrapParsedSurface[] texturelessGeneratedSurfaces = generatedSurfaces
-                .SelectMany(generatedSurface => parsedCityObject.SharedAcrossMeshCodes
-                    ? ClipGeneratedSurfaceToRequestedMeshAreas(generatedSurface, requestedMeshBounds)
-                    : [generatedSurface])
+                .SelectMany(generatedSurface => ClipGeneratedSurfaceToRequestedMeshAreas(generatedSurface, requestedMeshBounds))
                 .ToArray();
             BootstrapParsedSurface[] texturelessSurfaces = [.. texturelessGeneratedSurfaces, .. nonGeneratedSurfaces];
             if (texturelessSurfaces.Length == 0)
@@ -163,9 +159,7 @@ internal static class DemTerrainOverlayAssignment
         foreach (BootstrapParsedSurface generatedSurface in generatedSurfaces)
         {
             BootstrapParsedSurface[] requestedMeshClippedSurfaces =
-                parsedCityObject.SharedAcrossMeshCodes
-                    ? ClipGeneratedSurfaceToRequestedMeshAreas(generatedSurface, requestedMeshBounds)
-                    : [generatedSurface];
+                ClipGeneratedSurfaceToRequestedMeshAreas(generatedSurface, requestedMeshBounds);
             if (requestedMeshClippedSurfaces.Length == 0)
             {
                 continue;

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -2750,7 +2750,7 @@ internal static partial class LocalCityGmlObjectProjection
             }
         }
 
-        return TryResolveThirdMeshCodeFromBounds(terrainOverlay.GeographicBounds);
+        return null;
     }
 
     private static bool BoundsApproximatelyEqual(
@@ -4418,8 +4418,14 @@ internal static partial class LocalCityGmlObjectProjection
             return null;
         }
 
-        TerrainTextureOverlay? matchingOverlay = demTerrainTextureOverlays.FirstOrDefault(overlay =>
-            ResolveTerrainTextureMeshCode(cityObject.ActualMeshCode, overlay) is not null);
+        GeographicRectangle? cityObjectBounds = TryCreateCityObjectGeographicBounds(cityObject);
+        TerrainTextureOverlay? matchingOverlay = demTerrainTextureOverlays
+            .Where(overlay => ResolveTerrainTextureMeshCode(cityObject.ActualMeshCode, overlay) is not null)
+            .Where(overlay => cityObjectBounds is null || BoundsOverlap(cityObjectBounds, overlay.GeographicBounds))
+            .OrderByDescending(overlay => cityObjectBounds is null
+                ? 0.0
+                : CalculateOverlapArea(cityObjectBounds, overlay.GeographicBounds))
+            .FirstOrDefault(overlay => cityObjectBounds is null || CalculateOverlapArea(cityObjectBounds, overlay.GeographicBounds) > 0.0);
         if (matchingOverlay is not null)
         {
             return matchingOverlay;
@@ -4459,6 +4465,45 @@ internal static partial class LocalCityGmlObjectProjection
             && meshBounds.SouthLatitude <= geographicBounds.MaxLatitude
             && meshBounds.EastLongitude >= geographicBounds.MinLongitude
             && meshBounds.WestLongitude <= geographicBounds.MaxLongitude;
+    }
+
+    private static bool BoundsOverlap(GeographicRectangle left, GeographicRectangle right)
+    {
+        return left.MaxLatitude >= right.MinLatitude
+            && left.MinLatitude <= right.MaxLatitude
+            && left.MaxLongitude >= right.MinLongitude
+            && left.MinLongitude <= right.MaxLongitude;
+    }
+
+    private static double CalculateOverlapArea(GeographicRectangle left, GeographicRectangle right)
+    {
+        double latitudeOverlap = Math.Max(
+            0.0,
+            Math.Min(left.MaxLatitude, right.MaxLatitude) - Math.Max(left.MinLatitude, right.MinLatitude));
+        double longitudeOverlap = Math.Max(
+            0.0,
+            Math.Min(left.MaxLongitude, right.MaxLongitude) - Math.Max(left.MinLongitude, right.MinLongitude));
+        return latitudeOverlap * longitudeOverlap;
+    }
+
+    private static GeographicRectangle? TryCreateCityObjectGeographicBounds(
+        global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject)
+    {
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint[] vertices =
+        [
+            .. cityObject.Surfaces
+                .SelectMany(static surface => surface.ExteriorRing.Vertices)
+        ];
+        if (vertices.Length == 0)
+        {
+            return null;
+        }
+
+        return new GeographicRectangle(
+            vertices.Min(static vertex => vertex.Latitude),
+            vertices.Max(static vertex => vertex.Latitude),
+            vertices.Min(static vertex => vertex.Longitude),
+            vertices.Max(static vertex => vertex.Longitude));
     }
 
     private static Float2 ToContractFloat2(Float2 value) => new(value.X, value.Y);

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1579,7 +1579,7 @@ internal static partial class LocalCityGmlObjectProjection
             MaterialProjection.Uv,
             Family: null,
             TextureScale: null,
-            ReuseScope: MaterialReuseScope.Shared,
+            ReuseScope: MaterialReuseScope.PerObject,
             TerrainOverlay: demTerrainTextureOverlay);
     }
 
@@ -2594,24 +2594,30 @@ internal static partial class LocalCityGmlObjectProjection
         ColorRgba color,
         Float2? textureOffset = null)
     {
-        if (material.ReuseScope == MaterialReuseScope.Shared)
+        if (material.TerrainOverlay is not null)
         {
-            if (material.TerrainOverlay is not null)
+            if (ResolveTerrainTextureMeshCode(actualMeshCode, material.TerrainOverlay) is null)
             {
-                if (ResolveTerrainTextureMeshCode(actualMeshCode, material.TerrainOverlay) is not null)
-                {
-                    Float2? normalizedTextureScale = IsIdentityTextureScale(textureScale) ? null : textureScale;
-                    Float2? normalizedTextureOffset = IsZeroTextureOffset(textureOffset) ? null : textureOffset;
-                    return CommonMaterialCatalog.CreateCanonicalGenericSharedMaterialKey(
-                        material.Projection,
-                        normalizedTextureScale,
-                        normalizedTextureOffset,
-                        depthOffset);
-                }
-
                 throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
             }
 
+            Float2? normalizedTextureScale = IsIdentityTextureScale(textureScale) ? null : textureScale;
+            Float2? normalizedTextureOffset = IsZeroTextureOffset(textureOffset) ? null : textureOffset;
+            return CreateMaterialKey(
+                material.MaterialType,
+                terrainOverlay: null,
+                material.TexturePayload,
+                material.TextureSourceKind,
+                material.Projection,
+                depthOffset,
+                normalizedTextureScale,
+                family: null,
+                new ColorRgba(1.0, 1.0, 1.0, 1.0),
+                normalizedTextureOffset);
+        }
+
+        if (material.ReuseScope == MaterialReuseScope.Shared)
+        {
             string family = material.Family ?? throw new InvalidOperationException("Common material must provide a family.");
             int variantIndex = material.BundledVariantIndex ?? 0;
             Float2? effectiveTextureOffset = IsZeroTextureOffset(textureOffset) ? null : textureOffset;
@@ -2641,7 +2647,7 @@ internal static partial class LocalCityGmlObjectProjection
         ColorRgba color,
         Float2? textureOffset = null)
     {
-        if (material.ReuseScope == MaterialReuseScope.Shared && material.TerrainOverlay is not null)
+        if (material.TerrainOverlay is not null)
         {
             if (ResolveTerrainTextureMeshCode(actualMeshCode, material.TerrainOverlay) is null)
             {
@@ -2658,7 +2664,7 @@ internal static partial class LocalCityGmlObjectProjection
                 Family: null,
                 BaseColor: null,
                 IsZeroTextureOffset(textureOffset) ? null : textureOffset,
-                material.ReuseScope,
+                MaterialReuseScope.PerObject,
                 material.BundledVariantIndex,
                 TerrainOverlay: null);
         }
@@ -4291,9 +4297,12 @@ internal static partial class LocalCityGmlObjectProjection
             ? null
             : ResolveTerrainTextureMeshCode(actualMeshCode, representativeSurface.Material.TerrainOverlay)
                 ?? throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+        ColorRgba baseColor = representativeSurface.Material.TerrainOverlay is null
+            ? ToContractColor(representativeSurface.Surface.BaseColor)
+            : new ColorRgba(1.0, 1.0, 1.0, 1.0);
         return new MaterialBinding(
             MaterialKey: materialKey,
-            BaseColor: ToContractColor(representativeSurface.Surface.BaseColor),
+            BaseColor: baseColor,
             MaterialType: representativeSurface.Material.MaterialType,
             TexturePayload: representativeSurface.Material.TexturePayload is null
                 ? null

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -25,6 +25,7 @@ namespace PlateauResoniteLink.Application.Importing;
 internal static partial class LocalCityGmlObjectProjection
 {
     private const double BuildingBottomCullBandMeters = 0.1;
+    private const double UnknownRoofBottomAltitudeToleranceMeters = 0.1;
     public const string DefaultDemTerrainTexturePath = DemTerrainTextureDefaults.PlateauOrthoPath;
     public const string DefaultDemTerrainTextureUrlTemplate = DemTerrainTextureDefaults.PlateauOrthoUrlTemplate;
     public const string DefaultDemTerrainTextureFallbackUrlTemplate = DemTerrainTextureDefaults.GsiFallbackUrlTemplate;
@@ -1231,12 +1232,22 @@ internal static partial class LocalCityGmlObjectProjection
         List<MeshSubmesh> submeshes = [];
         List<MaterialBinding> materials = [];
         DemUvProjection? demUvProjection = TryCreateDemUvProjection(cityObject.ActualMeshCode, demTerrainTextureOverlay);
+        double cityObjectMinAltitude = cityObject.Surfaces
+            .SelectMany(static surface => surface.Vertices)
+            .Min(static vertex => vertex.Altitude);
 
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
             .. cityObject.Surfaces
                 .Where(surface => !culledSurfaceIds.Contains(surface.PolygonId))
-                .Select(surface => ResolveSurfaceMaterial(cityObject, cityObjectOrigin, cityObjectCartesian, surface, demTerrainTextureOverlay, materialResolver)),
+                .Select(surface => ResolveSurfaceMaterial(
+                    cityObject,
+                    cityObjectOrigin,
+                    cityObjectCartesian,
+                    surface,
+                    cityObjectMinAltitude,
+                    demTerrainTextureOverlay,
+                    materialResolver)),
         ];
 
         IGrouping<MaterialGroupingKey, ResolvedSurfaceMaterial>[] materialGroups = resolvedSurfaces
@@ -1355,6 +1366,7 @@ internal static partial class LocalCityGmlObjectProjection
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
         ParsedSurface surface,
+        double cityObjectMinAltitude,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
@@ -1378,6 +1390,7 @@ internal static partial class LocalCityGmlObjectProjection
             cityObject.ActualMeshCode,
             cityObject.PackageName,
             surface,
+            cityObjectMinAltitude,
             demTerrainTextureOverlay,
             cityObjectOrigin,
             cityObjectCartesian);
@@ -1457,6 +1470,7 @@ internal static partial class LocalCityGmlObjectProjection
         global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
         global::PlateauResoniteLink.Application.Importing.BootstrapParsedSurface surface,
+        double cityObjectMinAltitude,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
@@ -1481,6 +1495,7 @@ internal static partial class LocalCityGmlObjectProjection
             cityObject.ActualMeshCode,
             cityObject.PackageName,
             legacySurface,
+            cityObjectMinAltitude,
             demTerrainTextureOverlay,
             cityObjectOrigin.ToLegacy(),
             cityObjectCartesian);
@@ -1559,6 +1574,7 @@ internal static partial class LocalCityGmlObjectProjection
         string actualMeshCode,
         string packageName,
         ParsedSurface surface,
+        double cityObjectMinAltitude,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
@@ -1567,7 +1583,7 @@ internal static partial class LocalCityGmlObjectProjection
             || ResolveTerrainTextureMeshCode(actualMeshCode, demTerrainTextureOverlay) is null
             || surface.TexturePayload is not null
             || !IsBuildingPackage(packageName)
-            || !IsRoofTerrainTextureSurface(surface, cityObjectOrigin, cityObjectCartesian))
+            || !IsRoofTerrainTextureSurface(surface, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian))
         {
             return null;
         }
@@ -1585,6 +1601,7 @@ internal static partial class LocalCityGmlObjectProjection
 
     private static bool IsRoofTerrainTextureSurface(
         ParsedSurface surface,
+        double cityObjectMinAltitude,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
@@ -1599,7 +1616,17 @@ internal static partial class LocalCityGmlObjectProjection
         }
 
         Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
-        return normal is not null && normal.Y >= 0.98;
+        return normal is not null
+            && Math.Abs(normal.Y) >= 0.98
+            && IsAboveCityObjectBottomAltitude(surface, cityObjectMinAltitude);
+    }
+
+    private static bool IsAboveCityObjectBottomAltitude(
+        ParsedSurface surface,
+        double cityObjectMinAltitude)
+    {
+        double surfaceMinAltitude = surface.Vertices.Min(static vertex => vertex.Altitude);
+        return surfaceMinAltitude > cityObjectMinAltitude + UnknownRoofBottomAltitudeToleranceMeters;
     }
 
     private static global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject? CreateGeneratedRoadMarkingCityObject(
@@ -3557,11 +3584,21 @@ internal static partial class LocalCityGmlObjectProjection
             cityObject.Surfaces,
             cityObjectOrigin,
             cityObjectCartesian);
+        double cityObjectMinAltitude = cityObject.Surfaces
+            .SelectMany(static surface => surface.Vertices)
+            .Min(static vertex => vertex.Altitude);
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
             .. cityObject.Surfaces
                 .Where(surface => !culledSurfaceIds.Contains(surface.PolygonId))
-                .Select(surface => ResolveSurfaceMaterial(cityObject, cityObjectOrigin, cityObjectCartesian, surface, demTerrainTextureOverlay, materialResolver)),
+                .Select(surface => ResolveSurfaceMaterial(
+                    cityObject,
+                    cityObjectOrigin,
+                    cityObjectCartesian,
+                    surface,
+                    cityObjectMinAltitude,
+                    demTerrainTextureOverlay,
+                    materialResolver)),
         ];
 
         return resolvedSurfaces
@@ -3600,16 +3637,27 @@ internal static partial class LocalCityGmlObjectProjection
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
+        ParsedSurface[] legacySurfaces = cityObject.Surfaces.Select(static surface => surface.ToLegacy()).ToArray();
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
             cityObject.PackageName,
-            cityObject.Surfaces.Select(static surface => surface.ToLegacy()),
+            legacySurfaces,
             cityObjectOrigin.ToLegacy(),
             cityObjectCartesian);
+        double cityObjectMinAltitude = legacySurfaces
+            .SelectMany(static surface => surface.Vertices)
+            .Min(static vertex => vertex.Altitude);
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
             .. cityObject.Surfaces
                 .Where(surface => !culledSurfaceIds.Contains(surface.PolygonId))
-                .Select(surface => ResolveSurfaceMaterial(cityObject, cityObjectOrigin, cityObjectCartesian, surface, demTerrainTextureOverlay, materialResolver)),
+                .Select(surface => ResolveSurfaceMaterial(
+                    cityObject,
+                    cityObjectOrigin,
+                    cityObjectCartesian,
+                    surface,
+                    cityObjectMinAltitude,
+                    demTerrainTextureOverlay,
+                    materialResolver)),
         ];
 
         return resolvedSurfaces
@@ -4196,11 +4244,21 @@ internal static partial class LocalCityGmlObjectProjection
             cityObject.Surfaces,
             cityObjectOrigin,
             cityObjectCartesian);
+        double cityObjectMinAltitude = cityObject.Surfaces
+            .SelectMany(static surface => surface.Vertices)
+            .Min(static vertex => vertex.Altitude);
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
             .. cityObject.Surfaces
                 .Where(surface => !culledSurfaceIds.Contains(surface.PolygonId))
-                .Select(surface => ResolveSurfaceMaterial(cityObject, cityObjectOrigin, cityObjectCartesian, surface, demTerrainTextureOverlay, materialResolver)),
+                .Select(surface => ResolveSurfaceMaterial(
+                    cityObject,
+                    cityObjectOrigin,
+                    cityObjectCartesian,
+                    surface,
+                    cityObjectMinAltitude,
+                    demTerrainTextureOverlay,
+                    materialResolver)),
         ];
 
         return resolvedSurfaces
@@ -4243,16 +4301,27 @@ internal static partial class LocalCityGmlObjectProjection
         string requestedMeshCode,
         IDefaultMaterialResolver materialResolver)
     {
+        ParsedSurface[] legacySurfaces = cityObject.Surfaces.Select(static surface => surface.ToLegacy()).ToArray();
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
             cityObject.PackageName,
-            cityObject.Surfaces.Select(static surface => surface.ToLegacy()),
+            legacySurfaces,
             cityObjectOrigin.ToLegacy(),
             cityObjectCartesian);
+        double cityObjectMinAltitude = legacySurfaces
+            .SelectMany(static surface => surface.Vertices)
+            .Min(static vertex => vertex.Altitude);
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
             .. cityObject.Surfaces
                 .Where(surface => !culledSurfaceIds.Contains(surface.PolygonId))
-                .Select(surface => ResolveSurfaceMaterial(cityObject, cityObjectOrigin, cityObjectCartesian, surface, demTerrainTextureOverlay, materialResolver)),
+                .Select(surface => ResolveSurfaceMaterial(
+                    cityObject,
+                    cityObjectOrigin,
+                    cityObjectCartesian,
+                    surface,
+                    cityObjectMinAltitude,
+                    demTerrainTextureOverlay,
+                    materialResolver)),
         ];
 
         return resolvedSurfaces
@@ -4419,8 +4488,18 @@ internal static partial class LocalCityGmlObjectProjection
         }
 
         GeographicRectangle? demObjectBounds = TryGetDemObjectGeographicBounds(cityObject, demTerrainTextureOverlay);
+        double cityObjectMinAltitude = cityObject.Surfaces
+            .SelectMany(static surface => surface.Vertices)
+            .Min(static vertex => vertex.Altitude);
         ResolvedSurfaceMaterial? representativeSurface = cityObject.Surfaces
-            .Select(surface => ResolveSurfaceMaterial(cityObject, cityObjectOrigin, cityObjectCartesian, surface, demTerrainTextureOverlay, materialResolver))
+            .Select(surface => ResolveSurfaceMaterial(
+                cityObject,
+                cityObjectOrigin,
+                cityObjectCartesian,
+                surface,
+                cityObjectMinAltitude,
+                demTerrainTextureOverlay,
+                materialResolver))
             .FirstOrDefault(static resolvedSurface => resolvedSurface.Surface.UsesGeneratedDemTexture);
         if (representativeSurface is null)
         {
@@ -4448,8 +4527,18 @@ internal static partial class LocalCityGmlObjectProjection
         }
 
         GeographicRectangle? demObjectBounds = TryGetDemObjectGeographicBounds(cityObject, demTerrainTextureOverlay);
+        double cityObjectMinAltitude = cityObject.Surfaces
+            .SelectMany(static surface => surface.Vertices)
+            .Min(static vertex => vertex.Altitude);
         ResolvedSurfaceMaterial? representativeSurface = cityObject.Surfaces
-            .Select(surface => ResolveSurfaceMaterial(cityObject, cityObjectOrigin, cityObjectCartesian, surface, demTerrainTextureOverlay, materialResolver))
+            .Select(surface => ResolveSurfaceMaterial(
+                cityObject,
+                cityObjectOrigin,
+                cityObjectCartesian,
+                surface,
+                cityObjectMinAltitude,
+                demTerrainTextureOverlay,
+                materialResolver))
             .FirstOrDefault(static resolvedSurface => resolvedSurface.Surface.UsesGeneratedDemTexture);
         if (representativeSurface is null)
         {

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1381,7 +1381,7 @@ internal static partial class LocalCityGmlObjectProjection
                     MaterialProjection.Uv,
                     Family: null,
                     TextureScale: null,
-                    ReuseScope: MaterialReuseScope.PerObject,
+                    ReuseScope: MaterialReuseScope.Shared,
                     TerrainOverlay: demTerrainTextureOverlay),
                 DepthOffset: null);
         }
@@ -1486,7 +1486,7 @@ internal static partial class LocalCityGmlObjectProjection
                     MaterialProjection.Uv,
                     Family: null,
                     TextureScale: null,
-                    ReuseScope: MaterialReuseScope.PerObject,
+                    ReuseScope: MaterialReuseScope.Shared,
                     TerrainOverlay: demTerrainTextureOverlay),
                 DepthOffset: null);
         }
@@ -1595,7 +1595,7 @@ internal static partial class LocalCityGmlObjectProjection
             MaterialProjection.Uv,
             Family: null,
             TextureScale: null,
-            ReuseScope: MaterialReuseScope.PerObject,
+            ReuseScope: MaterialReuseScope.Shared,
             TerrainOverlay: demTerrainTextureOverlay);
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1239,22 +1239,21 @@ internal static partial class LocalCityGmlObjectProjection
                 .Select(surface => ResolveSurfaceMaterial(cityObject, cityObjectOrigin, cityObjectCartesian, surface, demTerrainTextureOverlay, materialResolver)),
         ];
 
-        IGrouping<string, ResolvedSurfaceMaterial>[] materialGroups = resolvedSurfaces
+        IGrouping<MaterialGroupingKey, ResolvedSurfaceMaterial>[] materialGroups = resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateBindingMaterialKey(
+                resolvedSurface => CreateMaterialGroupingKey(
                     cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
                     resolvedSurface.Surface.BaseColor,
-                    resolvedSurface.Material.TextureOffset),
-                StringComparer.Ordinal)
-            .OrderBy(static group => group.Key, StringComparer.Ordinal)
+                    resolvedSurface.Material.TextureOffset))
+            .OrderBy(static group => group.Min(static surface => CreateStableSurfaceSortKey(surface.Surface)), StringComparer.Ordinal)
             .ToArray();
 
         for (int materialIndex = 0; materialIndex < materialGroups.Length; materialIndex++)
         {
-            IGrouping<string, ResolvedSurfaceMaterial> materialGroup = materialGroups[materialIndex];
+            IGrouping<MaterialGroupingKey, ResolvedSurfaceMaterial> materialGroup = materialGroups[materialIndex];
             List<int> indices = [];
             FacadeUvProjectionContext? facadeUvProjectionContext = TryCreateFacadeUvProjectionContext(
                 cityObject.PackageName,
@@ -1286,8 +1285,15 @@ internal static partial class LocalCityGmlObjectProjection
             }
 
             ResolvedSurfaceMaterial representativeSurface = materialGroup.First();
-            submeshes.Add(new MeshSubmesh(materialIndex, materialGroup.Key, indices));
-            materials.Add(CreateMaterialBinding(cityObject.ActualMeshCode, representativeSurface, materialGroup.Key, materialIndex));
+            string materialKey = CreateBindingMaterialKey(
+                cityObject.ActualMeshCode,
+                representativeSurface.Material,
+                representativeSurface.DepthOffset,
+                representativeSurface.Material.TextureScale,
+                representativeSurface.Surface.BaseColor,
+                representativeSurface.Material.TextureOffset);
+            submeshes.Add(new MeshSubmesh(materialIndex, materialKey, indices));
+            materials.Add(CreateMaterialBinding(cityObject.ActualMeshCode, representativeSurface, materialKey, materialIndex));
         }
 
         return new ImportedCityObject(
@@ -2594,9 +2600,13 @@ internal static partial class LocalCityGmlObjectProjection
             {
                 if (ResolveTerrainTextureMeshCode(actualMeshCode, material.TerrainOverlay) is not null)
                 {
-                    return string.Create(
-                        CultureInfo.InvariantCulture,
-                        $"terrain-shared-{ProjectionToken(material.Projection)}-depth-{FormatDepth(depthOffset)}-scale-{FormatFloat2(textureScale)}-offset-{FormatFloat2(textureOffset)}");
+                    Float2? normalizedTextureScale = IsIdentityTextureScale(textureScale) ? null : textureScale;
+                    Float2? normalizedTextureOffset = IsZeroTextureOffset(textureOffset) ? null : textureOffset;
+                    return CommonMaterialCatalog.CreateCanonicalGenericSharedMaterialKey(
+                        material.Projection,
+                        normalizedTextureScale,
+                        normalizedTextureOffset,
+                        depthOffset);
                 }
 
                 throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
@@ -2621,6 +2631,51 @@ internal static partial class LocalCityGmlObjectProjection
             material.Family,
             color,
             textureOffset);
+    }
+
+    private static MaterialGroupingKey CreateMaterialGroupingKey(
+        string actualMeshCode,
+        ResolvedMaterial material,
+        MaterialDepthOffset? depthOffset,
+        Float2? textureScale,
+        ColorRgba color,
+        Float2? textureOffset = null)
+    {
+        if (material.ReuseScope == MaterialReuseScope.Shared && material.TerrainOverlay is not null)
+        {
+            if (ResolveTerrainTextureMeshCode(actualMeshCode, material.TerrainOverlay) is null)
+            {
+                throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+            }
+
+            return new MaterialGroupingKey(
+                material.MaterialType,
+                TexturePayloadIdentity: null,
+                material.TextureSourceKind,
+                material.Projection,
+                depthOffset,
+                IsIdentityTextureScale(textureScale) ? null : textureScale,
+                Family: null,
+                BaseColor: null,
+                IsZeroTextureOffset(textureOffset) ? null : textureOffset,
+                material.ReuseScope,
+                material.BundledVariantIndex,
+                TerrainOverlay: null);
+        }
+
+        return new MaterialGroupingKey(
+            material.MaterialType,
+            material.TexturePayload?.Identity,
+            material.TextureSourceKind,
+            material.Projection,
+            depthOffset,
+            textureScale,
+            material.Family,
+            color,
+            textureOffset,
+            material.ReuseScope,
+            material.BundledVariantIndex,
+            material.TerrainOverlay);
     }
 
     private static string CreateTerrainOverlayToken(TerrainTextureOverlay terrainOverlay)
@@ -2754,6 +2809,13 @@ internal static partial class LocalCityGmlObjectProjection
         return textureOffset is null
             || (Math.Abs(textureOffset.X) < 1e-9
                 && Math.Abs(textureOffset.Y) < 1e-9);
+    }
+
+    private static bool IsIdentityTextureScale(Float2? textureScale)
+    {
+        return textureScale is null
+            || (Math.Abs(textureScale.X - 1.0) < 1e-9
+                && Math.Abs(textureScale.Y - 1.0) < 1e-9);
     }
 
     private static bool ShouldPreferUvProjection(
@@ -3498,15 +3560,14 @@ internal static partial class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateBindingMaterialKey(
+                resolvedSurface => CreateMaterialGroupingKey(
                     cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
                     resolvedSurface.Surface.BaseColor,
-                    resolvedSurface.Material.TextureOffset),
-                StringComparer.Ordinal)
-            .OrderBy(static group => group.Key, StringComparer.Ordinal)
+                    resolvedSurface.Material.TextureOffset))
+            .OrderBy(static group => group.Min(static surface => CreateStableSurfaceSortKey(surface.Surface)), StringComparer.Ordinal)
             .Select((group, materialIndex) =>
             {
                 ResolvedSurfaceMaterial representativeSurface = group.First();
@@ -3547,15 +3608,14 @@ internal static partial class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateBindingMaterialKey(
+                resolvedSurface => CreateMaterialGroupingKey(
                     cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
                     resolvedSurface.Surface.BaseColor,
-                    resolvedSurface.Material.TextureOffset),
-                StringComparer.Ordinal)
-            .OrderBy(static group => group.Key, StringComparer.Ordinal)
+                    resolvedSurface.Material.TextureOffset))
+            .OrderBy(static group => group.Min(static surface => CreateStableSurfaceSortKey(surface.Surface)), StringComparer.Ordinal)
             .Select((group, materialIndex) =>
             {
                 ResolvedSurfaceMaterial representativeSurface = group.First();
@@ -4139,15 +4199,14 @@ internal static partial class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateBindingMaterialKey(
+                resolvedSurface => CreateMaterialGroupingKey(
                     ResolveTerrainTextureMaterialMeshCodeSource(cityObject.ActualMeshCode, requestedMeshCode, resolvedSurface.Material.TerrainOverlay),
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
                     resolvedSurface.Surface.BaseColor,
-                    resolvedSurface.Material.TextureOffset),
-                StringComparer.Ordinal)
-            .OrderBy(static group => group.Key, StringComparer.Ordinal)
+                    resolvedSurface.Material.TextureOffset))
+            .OrderBy(static group => group.Min(static surface => CreateStableSurfaceSortKey(surface.Surface)), StringComparer.Ordinal)
             .Select((group, materialIndex) =>
             {
                 ResolvedSurfaceMaterial representativeSurface = group.First();
@@ -4192,15 +4251,14 @@ internal static partial class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateBindingMaterialKey(
+                resolvedSurface => CreateMaterialGroupingKey(
                     ResolveTerrainTextureMaterialMeshCodeSource(cityObject.ActualMeshCode, requestedMeshCode, resolvedSurface.Material.TerrainOverlay),
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
                     resolvedSurface.Surface.BaseColor,
-                    resolvedSurface.Material.TextureOffset),
-                StringComparer.Ordinal)
-            .OrderBy(static group => group.Key, StringComparer.Ordinal)
+                    resolvedSurface.Material.TextureOffset))
+            .OrderBy(static group => group.Min(static surface => CreateStableSurfaceSortKey(surface.Surface)), StringComparer.Ordinal)
             .Select((group, materialIndex) =>
             {
                 ResolvedSurfaceMaterial representativeSurface = group.First();
@@ -5158,6 +5216,20 @@ internal static partial class LocalCityGmlObjectProjection
         ParsedSurface Surface,
         ResolvedMaterial Material,
         MaterialDepthOffset? DepthOffset);
+
+    private sealed record MaterialGroupingKey(
+        MaterialType MaterialType,
+        string? TexturePayloadIdentity,
+        TextureSourceKind TextureSourceKind,
+        MaterialProjection Projection,
+        MaterialDepthOffset? DepthOffset,
+        Float2? TextureScale,
+        string? Family,
+        ColorRgba? BaseColor,
+        Float2? TextureOffset,
+        MaterialReuseScope ReuseScope,
+        int? BundledVariantIndex,
+        TerrainTextureOverlay? TerrainOverlay);
 
     private sealed record TessellatedVertex(
         Float3 Position,

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1228,11 +1228,7 @@ internal static partial class LocalCityGmlObjectProjection
         List<MeshVertex> vertices = [];
         List<MeshSubmesh> submeshes = [];
         List<MaterialBinding> materials = [];
-        GeographicRectangle? demObjectBounds = TryGetDemObjectGeographicBounds(cityObject, demTerrainTextureOverlay);
-        DemUvProjection? demUvProjection = TryCreateDemUvProjection(
-            demObjectBounds,
-            cityObject.PackageName,
-            demTerrainTextureOverlay);
+        DemUvProjection? demUvProjection = TryCreateDemUvProjection(cityObject.ActualMeshCode, demTerrainTextureOverlay);
 
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
@@ -1244,6 +1240,7 @@ internal static partial class LocalCityGmlObjectProjection
         IGrouping<string, ResolvedSurfaceMaterial>[] materialGroups = resolvedSurfaces
             .GroupBy(
                 resolvedSurface => CreateBindingMaterialKey(
+                    cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
@@ -1288,7 +1285,7 @@ internal static partial class LocalCityGmlObjectProjection
 
             ResolvedSurfaceMaterial representativeSurface = materialGroup.First();
             submeshes.Add(new MeshSubmesh(materialIndex, materialGroup.Key, indices));
-            materials.Add(CreateMaterialBinding(representativeSurface, materialGroup.Key, materialIndex));
+            materials.Add(CreateMaterialBinding(cityObject.ActualMeshCode, representativeSurface, materialGroup.Key, materialIndex));
         }
 
         return new ImportedCityObject(
@@ -1367,6 +1364,17 @@ internal static partial class LocalCityGmlObjectProjection
                     ReuseScope: MaterialReuseScope.PerObject,
                     TerrainOverlay: demTerrainTextureOverlay),
                 DepthOffset: null);
+        }
+
+        ResolvedMaterial? roofTerrainTextureMaterial = TryCreateRoofTerrainTextureMaterial(
+            cityObject.PackageName,
+            surface,
+            demTerrainTextureOverlay,
+            cityObjectOrigin,
+            cityObjectCartesian);
+        if (roofTerrainTextureMaterial is not null)
+        {
+            return new ResolvedSurfaceMaterial(surface, roofTerrainTextureMaterial, DepthOffset: null);
         }
 
         if (string.Equals(cityObject.PackageName, "veg", StringComparison.OrdinalIgnoreCase)
@@ -1457,6 +1465,17 @@ internal static partial class LocalCityGmlObjectProjection
                 DepthOffset: null);
         }
 
+        ResolvedMaterial? roofTerrainTextureMaterial = TryCreateRoofTerrainTextureMaterial(
+            cityObject.PackageName,
+            legacySurface,
+            demTerrainTextureOverlay,
+            cityObjectOrigin.ToLegacy(),
+            cityObjectCartesian);
+        if (roofTerrainTextureMaterial is not null)
+        {
+            return new ResolvedSurfaceMaterial(legacySurface, roofTerrainTextureMaterial, DepthOffset: null);
+        }
+
         if (string.Equals(cityObject.PackageName, "veg", StringComparison.OrdinalIgnoreCase)
             && legacySurface.TexturePayload is null)
         {
@@ -1518,6 +1537,51 @@ internal static partial class LocalCityGmlObjectProjection
             ? DefaultTerrainAlignedMaterialDepthOffset
             : null;
         return new ResolvedSurfaceMaterial(legacySurface, resolvedMaterial, depthOffset);
+    }
+
+    private static ResolvedMaterial? TryCreateRoofTerrainTextureMaterial(
+        string packageName,
+        ParsedSurface surface,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (demTerrainTextureOverlay is null
+            || surface.TexturePayload is not null
+            || !IsBuildingPackage(packageName)
+            || !IsRoofTerrainTextureSurface(surface, cityObjectOrigin, cityObjectCartesian))
+        {
+            return null;
+        }
+
+        return new ResolvedMaterial(
+            MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind.Dataset,
+            MaterialProjection.Uv,
+            Family: null,
+            TextureScale: null,
+            ReuseScope: MaterialReuseScope.Shared,
+            TerrainOverlay: demTerrainTextureOverlay);
+    }
+
+    private static bool IsRoofTerrainTextureSurface(
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (surface.Semantic == ParsedSurfaceSemantic.Roof)
+        {
+            return true;
+        }
+
+        if (surface.Semantic != ParsedSurfaceSemantic.Unknown)
+        {
+            return false;
+        }
+
+        Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
+        return normal is not null && normal.Y >= 0.98;
     }
 
     private static global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject? CreateGeneratedRoadMarkingCityObject(
@@ -1786,7 +1850,7 @@ internal static partial class LocalCityGmlObjectProjection
     {
         List<(MeshVertex First, MeshVertex Second, MeshVertex Third, string SortKey)> triangles = [];
         bool useVertexColors = material.MaterialType == MaterialType.VertexColor;
-        DemUvProjection? generatedDemUvProjection = surface.UsesGeneratedDemTexture ? demUvProjection : null;
+        DemUvProjection? generatedDemUvProjection = material.TerrainOverlay is not null ? demUvProjection : null;
         bool useGeneratedDemUv = generatedDemUvProjection is not null;
         SurfaceUvProjection? generatedSurfaceUvProjection = !useGeneratedDemUv
             && surface.TexturePayload is null
@@ -2028,13 +2092,13 @@ internal static partial class LocalCityGmlObjectProjection
         TessellatedVertex[] vertices = ring.Vertices
             .Select((point, index) => new TessellatedVertex(
                 CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian),
-                ring.UVs is not null && index < ring.UVs.Count
-                    ? ToInternalFloat2(ring.UVs[index])
-                    : generatedDemUvProjection is not null
-                        ? CreateGeneratedDemUv(point, generatedDemUvProjection.Value)
+                generatedDemUvProjection is not null
+                    ? CreateGeneratedDemUv(point, generatedDemUvProjection.Value)
+                    : ring.UVs is not null && index < ring.UVs.Count
+                        ? ToInternalFloat2(ring.UVs[index])
                         : generatedSurfaceUvProjection is not null
-                            ? CreateGeneratedSurfaceUv(point, cityObjectOrigin, cityObjectCartesian, generatedSurfaceUvProjection)
-                            : new Float2(0.0, 0.0),
+                        ? CreateGeneratedSurfaceUv(point, cityObjectOrigin, cityObjectCartesian, generatedSurfaceUvProjection)
+                        : new Float2(0.0, 0.0),
                 vertexColor))
             .ToArray();
         return new TessellatedRing(ring.RingId, vertices);
@@ -2046,45 +2110,65 @@ internal static partial class LocalCityGmlObjectProjection
     {
         double pointX = WebMercatorTileMath.LongitudeToNormalizedX(point.Longitude);
         double pointY = WebMercatorTileMath.LatitudeToNormalizedY(point.Latitude);
+        double u = (pointX - demUvProjection.West) / demUvProjection.Width;
+        double v = (demUvProjection.South - pointY) / demUvProjection.Height;
 
-        return new Float2(
-            Math.Clamp((pointX - demUvProjection.West) / demUvProjection.Width, 0.0, 1.0),
-            Math.Clamp((demUvProjection.South - pointY) / demUvProjection.Height, 0.0, 1.0));
+        return new Float2(u, v);
     }
 
     private static DemUvProjection? TryCreateDemUvProjection(
-        GeographicRectangle? cityObjectBounds,
+        global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject,
+        TerrainTextureOverlay? demTerrainTextureOverlay)
+    {
+        if (demTerrainTextureOverlay is null
+            || ResolveTerrainTextureMeshCode(cityObject.ActualMeshCode, demTerrainTextureOverlay) is not { } terrainMeshCode
+            || !TryCreateMeshCodeBounds(terrainMeshCode, out MeshCodeBounds? meshCodeBounds))
+        {
+            return null;
+        }
+
+        return CreateDemUvProjection(
+            meshCodeBounds!.WestLongitude,
+            meshCodeBounds.EastLongitude,
+            meshCodeBounds.NorthLatitude,
+            meshCodeBounds.SouthLatitude);
+    }
+
+    private static DemUvProjection? TryCreateDemUvProjection(
         ParsedCityObject cityObject,
         TerrainTextureOverlay? demTerrainTextureOverlay)
     {
-        return TryCreateDemUvProjection(cityObjectBounds, cityObject.PackageName, demTerrainTextureOverlay);
+        return TryCreateDemUvProjection(cityObject.ActualMeshCode, demTerrainTextureOverlay);
     }
 
     private static DemUvProjection? TryCreateDemUvProjection(
-        GeographicRectangle? cityObjectBounds,
-        string packageName,
+        string actualMeshCode,
         TerrainTextureOverlay? demTerrainTextureOverlay)
     {
-        if (cityObjectBounds is null
-            || demTerrainTextureOverlay is null
-            || !string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase))
+        if (demTerrainTextureOverlay is null
+            || ResolveTerrainTextureMeshCode(actualMeshCode, demTerrainTextureOverlay) is not { } terrainMeshCode
+            || !TryCreateMeshCodeBounds(terrainMeshCode, out MeshCodeBounds? meshCodeBounds))
         {
             return null;
         }
 
-        GeographicRectangle objectBounds = IntersectGeographicBounds(
-            cityObjectBounds,
-            demTerrainTextureOverlay.GeographicBounds);
-        if (objectBounds.MinLatitude >= objectBounds.MaxLatitude
-            || objectBounds.MinLongitude >= objectBounds.MaxLongitude)
-        {
-            return null;
-        }
+        return CreateDemUvProjection(
+            meshCodeBounds!.WestLongitude,
+            meshCodeBounds.EastLongitude,
+            meshCodeBounds.NorthLatitude,
+            meshCodeBounds.SouthLatitude);
+    }
 
-        double west = WebMercatorTileMath.LongitudeToNormalizedX(demTerrainTextureOverlay.GeographicBounds.MinLongitude);
-        double east = WebMercatorTileMath.LongitudeToNormalizedX(demTerrainTextureOverlay.GeographicBounds.MaxLongitude);
-        double north = WebMercatorTileMath.LatitudeToNormalizedY(demTerrainTextureOverlay.GeographicBounds.MaxLatitude);
-        double south = WebMercatorTileMath.LatitudeToNormalizedY(demTerrainTextureOverlay.GeographicBounds.MinLatitude);
+    private static DemUvProjection CreateDemUvProjection(
+        double westLongitude,
+        double eastLongitude,
+        double northLatitude,
+        double southLatitude)
+    {
+        double west = WebMercatorTileMath.LongitudeToNormalizedX(westLongitude);
+        double east = WebMercatorTileMath.LongitudeToNormalizedX(eastLongitude);
+        double north = WebMercatorTileMath.LatitudeToNormalizedY(northLatitude);
+        double south = WebMercatorTileMath.LatitudeToNormalizedY(southLatitude);
         double width = Math.Max(east - west, 1e-12);
         double height = Math.Max(south - north, 1e-12);
 
@@ -2485,6 +2569,7 @@ internal static partial class LocalCityGmlObjectProjection
     }
 
     private static string CreateBindingMaterialKey(
+        string actualMeshCode,
         ResolvedMaterial material,
         MaterialDepthOffset? depthOffset,
         Float2? textureScale,
@@ -2493,6 +2578,28 @@ internal static partial class LocalCityGmlObjectProjection
     {
         if (material.ReuseScope == MaterialReuseScope.Shared)
         {
+            if (material.TerrainOverlay is not null)
+            {
+                if (ResolveTerrainTextureMeshCode(actualMeshCode, material.TerrainOverlay) is { } terrainMeshCode)
+                {
+                    return string.Create(
+                        CultureInfo.InvariantCulture,
+                        $"terrain-shared-{terrainMeshCode}-{ProjectionToken(material.Projection)}-depth-{FormatDepth(depthOffset)}-scale-{FormatFloat2(textureScale)}-offset-{FormatFloat2(textureOffset)}");
+                }
+
+                return CreateMaterialKey(
+                    material.MaterialType,
+                    material.TerrainOverlay,
+                    material.TexturePayload,
+                    material.TextureSourceKind,
+                    material.Projection,
+                    depthOffset,
+                    textureScale,
+                    material.Family,
+                    color,
+                    textureOffset);
+            }
+
             string family = material.Family ?? throw new InvalidOperationException("Common material must provide a family.");
             int variantIndex = material.BundledVariantIndex ?? 0;
             Float2? effectiveTextureOffset = IsZeroTextureOffset(textureOffset) ? null : textureOffset;
@@ -2519,6 +2626,51 @@ internal static partial class LocalCityGmlObjectProjection
         return string.Create(
             CultureInfo.InvariantCulture,
             $"terrain-overlay-{terrainOverlay.PackageName.ToLowerInvariant()}-{terrainOverlay.SourceDescriptorKey}-bounds-{FormatBounds(terrainOverlay.GeographicBounds)}");
+    }
+
+    private static string? ResolveTerrainTextureMeshCode(
+        string actualMeshCode,
+        TerrainTextureOverlay terrainOverlay)
+    {
+        if (actualMeshCode.Length == 8
+            && TryCreateMeshCodeBounds(actualMeshCode, out _))
+        {
+            return actualMeshCode;
+        }
+
+        if (actualMeshCode.Length != 6
+            || !TryCreateMeshCodeBounds(actualMeshCode, out _))
+        {
+            return null;
+        }
+
+        for (int latitudeIndex = 0; latitudeIndex < 10; latitudeIndex++)
+        {
+            for (int longitudeIndex = 0; longitudeIndex < 10; longitudeIndex++)
+            {
+                string thirdMeshCode = string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{actualMeshCode}{latitudeIndex}{longitudeIndex}");
+                if (TryCreateMeshCodeBounds(thirdMeshCode, out MeshCodeBounds? thirdMeshBounds)
+                    && BoundsApproximatelyEqual(thirdMeshBounds!, terrainOverlay.GeographicBounds))
+                {
+                    return thirdMeshCode;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static bool BoundsApproximatelyEqual(
+        MeshCodeBounds meshBounds,
+        GeographicRectangle geographicBounds)
+    {
+        const double tolerance = 1e-8;
+        return Math.Abs(meshBounds.SouthLatitude - geographicBounds.MinLatitude) <= tolerance
+            && Math.Abs(meshBounds.NorthLatitude - geographicBounds.MaxLatitude) <= tolerance
+            && Math.Abs(meshBounds.WestLongitude - geographicBounds.MinLongitude) <= tolerance
+            && Math.Abs(meshBounds.EastLongitude - geographicBounds.MaxLongitude) <= tolerance;
     }
 
     private static string MaterialTypeToken(MaterialType materialType) =>
@@ -3279,7 +3431,8 @@ internal static partial class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                static resolvedSurface => CreateBindingMaterialKey(
+                resolvedSurface => CreateBindingMaterialKey(
+                    cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
@@ -3291,8 +3444,10 @@ internal static partial class LocalCityGmlObjectProjection
             {
                 ResolvedSurfaceMaterial representativeSurface = group.First();
                 return CreateMaterialBinding(
+                    cityObject.ActualMeshCode,
                     representativeSurface,
                     CreateBindingMaterialKey(
+                        cityObject.ActualMeshCode,
                         representativeSurface.Material,
                         representativeSurface.DepthOffset,
                         representativeSurface.Material.TextureScale,
@@ -3325,7 +3480,8 @@ internal static partial class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                static resolvedSurface => CreateBindingMaterialKey(
+                resolvedSurface => CreateBindingMaterialKey(
+                    cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
@@ -3337,8 +3493,10 @@ internal static partial class LocalCityGmlObjectProjection
             {
                 ResolvedSurfaceMaterial representativeSurface = group.First();
                 return CreateMaterialBinding(
+                    cityObject.ActualMeshCode,
                     representativeSurface,
                     CreateBindingMaterialKey(
+                        cityObject.ActualMeshCode,
                         representativeSurface.Material,
                         representativeSurface.DepthOffset,
                         representativeSurface.Material.TextureScale,
@@ -3902,6 +4060,7 @@ internal static partial class LocalCityGmlObjectProjection
         return resolvedSurfaces
             .GroupBy(
                 resolvedSurface => CreateBindingMaterialKey(
+                    cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
@@ -3913,8 +4072,10 @@ internal static partial class LocalCityGmlObjectProjection
             {
                 ResolvedSurfaceMaterial representativeSurface = group.First();
                 return CreateMaterialBinding(
+                    cityObject.ActualMeshCode,
                     representativeSurface,
                     CreateBindingMaterialKey(
+                        cityObject.ActualMeshCode,
                         representativeSurface.Material,
                         representativeSurface.DepthOffset,
                         representativeSurface.Material.TextureScale,
@@ -3947,6 +4108,7 @@ internal static partial class LocalCityGmlObjectProjection
         return resolvedSurfaces
             .GroupBy(
                 resolvedSurface => CreateBindingMaterialKey(
+                    cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
@@ -3958,8 +4120,10 @@ internal static partial class LocalCityGmlObjectProjection
             {
                 ResolvedSurfaceMaterial representativeSurface = group.First();
                 return CreateMaterialBinding(
+                    cityObject.ActualMeshCode,
                     representativeSurface,
                     CreateBindingMaterialKey(
+                        cityObject.ActualMeshCode,
                         representativeSurface.Material,
                         representativeSurface.DepthOffset,
                         representativeSurface.Material.TextureScale,
@@ -3971,10 +4135,14 @@ internal static partial class LocalCityGmlObjectProjection
     }
 
     private static MaterialBinding CreateMaterialBinding(
+        string actualMeshCode,
         ResolvedSurfaceMaterial representativeSurface,
         string materialKey,
         int materialIndex)
     {
+        string? terrainMeshCode = representativeSurface.Material.TerrainOverlay is null
+            ? null
+            : ResolveTerrainTextureMeshCode(actualMeshCode, representativeSurface.Material.TerrainOverlay);
         return new MaterialBinding(
             MaterialKey: materialKey,
             BaseColor: ToContractColor(representativeSurface.Surface.BaseColor),
@@ -3997,7 +4165,8 @@ internal static partial class LocalCityGmlObjectProjection
                 : representativeSurface.Material.TextureOffset,
             ReuseScope: representativeSurface.Material.ReuseScope,
             TerrainOverlay: representativeSurface.Material.TerrainOverlay,
-            BundledVariantIndex: representativeSurface.Material.BundledVariantIndex);
+            BundledVariantIndex: representativeSurface.Material.BundledVariantIndex,
+            TerrainMeshCode: terrainMeshCode);
     }
 
     private static Float2 ToContractFloat2(Float2 value) => new(value.X, value.Y);

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1367,6 +1367,7 @@ internal static partial class LocalCityGmlObjectProjection
         }
 
         ResolvedMaterial? roofTerrainTextureMaterial = TryCreateRoofTerrainTextureMaterial(
+            cityObject.ActualMeshCode,
             cityObject.PackageName,
             surface,
             demTerrainTextureOverlay,
@@ -1466,6 +1467,7 @@ internal static partial class LocalCityGmlObjectProjection
         }
 
         ResolvedMaterial? roofTerrainTextureMaterial = TryCreateRoofTerrainTextureMaterial(
+            cityObject.ActualMeshCode,
             cityObject.PackageName,
             legacySurface,
             demTerrainTextureOverlay,
@@ -1540,6 +1542,7 @@ internal static partial class LocalCityGmlObjectProjection
     }
 
     private static ResolvedMaterial? TryCreateRoofTerrainTextureMaterial(
+        string actualMeshCode,
         string packageName,
         ParsedSurface surface,
         TerrainTextureOverlay? demTerrainTextureOverlay,
@@ -1547,6 +1550,7 @@ internal static partial class LocalCityGmlObjectProjection
         LocalCartesian? cityObjectCartesian)
     {
         if (demTerrainTextureOverlay is null
+            || ResolveTerrainTextureMeshCode(actualMeshCode, demTerrainTextureOverlay) is null
             || surface.TexturePayload is not null
             || !IsBuildingPackage(packageName)
             || !IsRoofTerrainTextureSurface(surface, cityObjectOrigin, cityObjectCartesian))
@@ -2587,17 +2591,7 @@ internal static partial class LocalCityGmlObjectProjection
                         $"terrain-shared-{terrainMeshCode}-{ProjectionToken(material.Projection)}-depth-{FormatDepth(depthOffset)}-scale-{FormatFloat2(textureScale)}-offset-{FormatFloat2(textureOffset)}");
                 }
 
-                return CreateMaterialKey(
-                    material.MaterialType,
-                    material.TerrainOverlay,
-                    material.TexturePayload,
-                    material.TextureSourceKind,
-                    material.Projection,
-                    depthOffset,
-                    textureScale,
-                    material.Family,
-                    color,
-                    textureOffset);
+                throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
             }
 
             string family = material.Family ?? throw new InvalidOperationException("Common material must provide a family.");
@@ -2633,13 +2627,14 @@ internal static partial class LocalCityGmlObjectProjection
         TerrainTextureOverlay terrainOverlay)
     {
         if (actualMeshCode.Length == 8
-            && TryCreateMeshCodeBounds(actualMeshCode, out _))
+            && TryCreateMeshCodeBounds(actualMeshCode, out MeshCodeBounds? actualMeshBounds)
+            && BoundsApproximatelyEqual(actualMeshBounds!, terrainOverlay.GeographicBounds))
         {
             return actualMeshCode;
         }
 
         if (actualMeshCode.Length != 6
-            || !TryCreateMeshCodeBounds(actualMeshCode, out _))
+            || !actualMeshCode.All(static character => character is >= '0' and <= '9'))
         {
             return null;
         }
@@ -2659,7 +2654,7 @@ internal static partial class LocalCityGmlObjectProjection
             }
         }
 
-        return null;
+        return TryResolveThirdMeshCodeFromBounds(terrainOverlay.GeographicBounds);
     }
 
     private static bool BoundsApproximatelyEqual(
@@ -2671,6 +2666,32 @@ internal static partial class LocalCityGmlObjectProjection
             && Math.Abs(meshBounds.NorthLatitude - geographicBounds.MaxLatitude) <= tolerance
             && Math.Abs(meshBounds.WestLongitude - geographicBounds.MinLongitude) <= tolerance
             && Math.Abs(meshBounds.EastLongitude - geographicBounds.MaxLongitude) <= tolerance;
+    }
+
+    private static string? TryResolveThirdMeshCodeFromBounds(GeographicRectangle geographicBounds)
+    {
+        int firstLatitudeIndex = (int)Math.Floor(geographicBounds.MinLatitude * 1.5);
+        int firstLongitudeIndex = (int)Math.Floor(geographicBounds.MinLongitude - 100.0);
+        double firstSouthLatitude = firstLatitudeIndex / 1.5;
+        double firstWestLongitude = 100.0 + firstLongitudeIndex;
+        double secondLatitudeSpan = (40.0 / 60.0) / 8.0;
+        double secondLongitudeSpan = 1.0 / 8.0;
+        int secondLatitudeIndex = (int)Math.Floor((geographicBounds.MinLatitude - firstSouthLatitude) / secondLatitudeSpan);
+        int secondLongitudeIndex = (int)Math.Floor((geographicBounds.MinLongitude - firstWestLongitude) / secondLongitudeSpan);
+        double secondSouthLatitude = firstSouthLatitude + (secondLatitudeIndex * secondLatitudeSpan);
+        double secondWestLongitude = firstWestLongitude + (secondLongitudeIndex * secondLongitudeSpan);
+        double thirdLatitudeSpan = secondLatitudeSpan / 10.0;
+        double thirdLongitudeSpan = secondLongitudeSpan / 10.0;
+        int thirdLatitudeIndex = (int)Math.Floor((geographicBounds.MinLatitude - secondSouthLatitude) / thirdLatitudeSpan);
+        int thirdLongitudeIndex = (int)Math.Floor((geographicBounds.MinLongitude - secondWestLongitude) / thirdLongitudeSpan);
+
+        string candidate = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{firstLatitudeIndex:D2}{firstLongitudeIndex:D2}{secondLatitudeIndex}{secondLongitudeIndex}{thirdLatitudeIndex}{thirdLongitudeIndex}");
+        return TryCreateMeshCodeBounds(candidate, out MeshCodeBounds? candidateBounds)
+            && BoundsApproximatelyEqual(candidateBounds!, geographicBounds)
+            ? candidate
+            : null;
     }
 
     private static string MaterialTypeToken(MaterialType materialType) =>
@@ -3128,6 +3149,11 @@ internal static partial class LocalCityGmlObjectProjection
                      demTerrainTextureOverlays,
                      requestedMeshAreas))
         {
+            if (!ShouldProjectTerrainOverlaySplit(splitCityObject.CityObject.ActualMeshCode, request.MeshCode, splitCityObject.Overlay))
+            {
+                continue;
+            }
+
             ImportedCityObject cityObject = ProjectTerrainMeshModeCityObject(
                 splitCityObject.CityObject,
                 globalOriginPoint,
@@ -3214,6 +3240,11 @@ internal static partial class LocalCityGmlObjectProjection
                      demTerrainTextureOverlays,
                      requestedMeshAreas))
         {
+            if (!ShouldProjectTerrainOverlaySplit(splitCityObject.CityObject.ActualMeshCode, request.MeshCode, splitCityObject.Overlay))
+            {
+                continue;
+            }
+
             global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(splitCityObject.CityObject);
             LocalCartesian? cityObjectCartesian = splitCityObject.CityObject.ReferenceSystem.IsGeographic
                 ? new LocalCartesian(
@@ -3230,6 +3261,7 @@ internal static partial class LocalCityGmlObjectProjection
                                 cityObjectOrigin,
                                 cityObjectCartesian,
                                 splitCityObject.Overlay,
+                                request.MeshCode,
                                 materialResolver)
                             : CreateCommonMaterialBindings(
                                 splitCityObject.CityObject,
@@ -3824,6 +3856,7 @@ internal static partial class LocalCityGmlObjectProjection
             cityObjectOrigin,
             cityObjectCartesian,
             demTerrainTextureOverlay,
+            request.MeshCode,
             materialResolver);
         if (materials.Length == 0)
         {
@@ -3989,6 +4022,7 @@ internal static partial class LocalCityGmlObjectProjection
             cityObjectOrigin,
             cityObjectCartesian,
             demTerrainTextureOverlay,
+            request.MeshCode,
             materialResolver);
         if (materials.Length == 0)
         {
@@ -4043,6 +4077,7 @@ internal static partial class LocalCityGmlObjectProjection
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
+        string requestedMeshCode,
         IDefaultMaterialResolver materialResolver)
     {
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
@@ -4060,7 +4095,7 @@ internal static partial class LocalCityGmlObjectProjection
         return resolvedSurfaces
             .GroupBy(
                 resolvedSurface => CreateBindingMaterialKey(
-                    cityObject.ActualMeshCode,
+                    ResolveTerrainTextureMaterialMeshCodeSource(cityObject.ActualMeshCode, requestedMeshCode, resolvedSurface.Material.TerrainOverlay),
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
@@ -4071,11 +4106,15 @@ internal static partial class LocalCityGmlObjectProjection
             .Select((group, materialIndex) =>
             {
                 ResolvedSurfaceMaterial representativeSurface = group.First();
-                return CreateMaterialBinding(
+                string terrainMaterialMeshCodeSource = ResolveTerrainTextureMaterialMeshCodeSource(
                     cityObject.ActualMeshCode,
+                    requestedMeshCode,
+                    representativeSurface.Material.TerrainOverlay);
+                return CreateMaterialBinding(
+                    terrainMaterialMeshCodeSource,
                     representativeSurface,
                     CreateBindingMaterialKey(
-                        cityObject.ActualMeshCode,
+                        terrainMaterialMeshCodeSource,
                         representativeSurface.Material,
                         representativeSurface.DepthOffset,
                         representativeSurface.Material.TextureScale,
@@ -4091,6 +4130,7 @@ internal static partial class LocalCityGmlObjectProjection
         global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
+        string requestedMeshCode,
         IDefaultMaterialResolver materialResolver)
     {
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
@@ -4108,7 +4148,7 @@ internal static partial class LocalCityGmlObjectProjection
         return resolvedSurfaces
             .GroupBy(
                 resolvedSurface => CreateBindingMaterialKey(
-                    cityObject.ActualMeshCode,
+                    ResolveTerrainTextureMaterialMeshCodeSource(cityObject.ActualMeshCode, requestedMeshCode, resolvedSurface.Material.TerrainOverlay),
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
@@ -4119,11 +4159,15 @@ internal static partial class LocalCityGmlObjectProjection
             .Select((group, materialIndex) =>
             {
                 ResolvedSurfaceMaterial representativeSurface = group.First();
-                return CreateMaterialBinding(
+                string terrainMaterialMeshCodeSource = ResolveTerrainTextureMaterialMeshCodeSource(
                     cityObject.ActualMeshCode,
+                    requestedMeshCode,
+                    representativeSurface.Material.TerrainOverlay);
+                return CreateMaterialBinding(
+                    terrainMaterialMeshCodeSource,
                     representativeSurface,
                     CreateBindingMaterialKey(
-                        cityObject.ActualMeshCode,
+                        terrainMaterialMeshCodeSource,
                         representativeSurface.Material,
                         representativeSurface.DepthOffset,
                         representativeSurface.Material.TextureScale,
@@ -4142,7 +4186,8 @@ internal static partial class LocalCityGmlObjectProjection
     {
         string? terrainMeshCode = representativeSurface.Material.TerrainOverlay is null
             ? null
-            : ResolveTerrainTextureMeshCode(actualMeshCode, representativeSurface.Material.TerrainOverlay);
+            : ResolveTerrainTextureMeshCode(actualMeshCode, representativeSurface.Material.TerrainOverlay)
+                ?? throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
         return new MaterialBinding(
             MaterialKey: materialKey,
             BaseColor: ToContractColor(representativeSurface.Surface.BaseColor),
@@ -4167,6 +4212,39 @@ internal static partial class LocalCityGmlObjectProjection
             TerrainOverlay: representativeSurface.Material.TerrainOverlay,
             BundledVariantIndex: representativeSurface.Material.BundledVariantIndex,
             TerrainMeshCode: terrainMeshCode);
+    }
+
+    private static string ResolveTerrainTextureMaterialMeshCodeSource(
+        string actualMeshCode,
+        string requestedMeshCode,
+        TerrainTextureOverlay? terrainOverlay)
+    {
+        if (terrainOverlay is null
+            || ResolveTerrainTextureMeshCode(actualMeshCode, terrainOverlay) is not null)
+        {
+            return actualMeshCode;
+        }
+
+        return requestedMeshCode;
+    }
+
+    private static bool ShouldProjectTerrainOverlaySplit(
+        string actualMeshCode,
+        string requestedMeshCode,
+        TerrainTextureOverlay? terrainOverlay)
+    {
+        if (terrainOverlay is null)
+        {
+            return true;
+        }
+
+        if (requestedMeshCode.Length == 8
+            && TryCreateMeshCodeBounds(requestedMeshCode, out MeshCodeBounds? requestedMeshBounds))
+        {
+            return BoundsApproximatelyEqual(requestedMeshBounds!, terrainOverlay.GeographicBounds);
+        }
+
+        return ResolveTerrainTextureMeshCode(actualMeshCode, terrainOverlay) is not null;
     }
 
     private static Float2 ToContractFloat2(Float2 value) => new(value.X, value.Y);

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -3259,7 +3259,7 @@ internal static partial class LocalCityGmlObjectProjection
         List<ImportedCityObject> generatedRoadMarkings = [];
 
         foreach ((global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
-                 in DemTerrainOverlayAssignment.SplitParsedCityObject(
+                 in SplitParsedCityObjectForTerrainProjection(
                      terrainAlignedBootstrapCityObject,
                      demTerrainTextureOverlays,
                      requestedMeshAreas,
@@ -3267,9 +3267,7 @@ internal static partial class LocalCityGmlObjectProjection
                      cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            TerrainTextureOverlay? projectionOverlay = splitCityObject.Overlay
-                ?? ResolveNonDemTerrainTextureOverlay(splitCityObject.CityObject, demTerrainTextureOverlays);
-            if (!ShouldProjectTerrainOverlaySplit(splitCityObject.CityObject.ActualMeshCode, request.MeshCode, projectionOverlay))
+            if (!ShouldProjectTerrainOverlaySplit(splitCityObject.CityObject.ActualMeshCode, request.MeshCode, splitCityObject.Overlay))
             {
                 throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
             }
@@ -3278,7 +3276,7 @@ internal static partial class LocalCityGmlObjectProjection
                 splitCityObject.CityObject,
                 globalOriginPoint,
                 globalCartesian,
-                projectionOverlay,
+                splitCityObject.Overlay,
                 request,
                 materialResolver,
                 progressReporter,
@@ -3310,7 +3308,7 @@ internal static partial class LocalCityGmlObjectProjection
                 roadMarkingCityObject,
                 globalOriginPoint,
                 globalCartesian,
-                projectionOverlay,
+                splitCityObject.Overlay,
                 materialResolver) with
             {
                 CollisionEnabled = false,
@@ -3359,14 +3357,12 @@ internal static partial class LocalCityGmlObjectProjection
             ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler);
 
         foreach ((global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
-                 in DemTerrainOverlayAssignment.SplitParsedCityObject(
+                 in SplitParsedCityObjectForTerrainProjection(
                      terrainAlignedBootstrapCityObject,
                      demTerrainTextureOverlays,
                      requestedMeshAreas))
         {
-            TerrainTextureOverlay? projectionOverlay = splitCityObject.Overlay
-                ?? ResolveNonDemTerrainTextureOverlay(splitCityObject.CityObject, demTerrainTextureOverlays);
-            if (!ShouldProjectTerrainOverlaySplit(splitCityObject.CityObject.ActualMeshCode, request.MeshCode, projectionOverlay))
+            if (!ShouldProjectTerrainOverlaySplit(splitCityObject.CityObject.ActualMeshCode, request.MeshCode, splitCityObject.Overlay))
             {
                 throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
             }
@@ -3386,14 +3382,14 @@ internal static partial class LocalCityGmlObjectProjection
                                 splitCityObject.CityObject,
                                 cityObjectOrigin,
                                 cityObjectCartesian,
-                                projectionOverlay,
+                                splitCityObject.Overlay,
                                 request.MeshCode,
                                 materialResolver)
                             : CreateCommonMaterialBindings(
                                 splitCityObject.CityObject,
                                 cityObjectOrigin,
                                 cityObjectCartesian,
-                                projectionOverlay,
+                                splitCityObject.Overlay,
                                 materialResolver))
             {
                 yield return material;
@@ -4409,35 +4405,213 @@ internal static partial class LocalCityGmlObjectProjection
         return requestedMeshCode;
     }
 
-    private static TerrainTextureOverlay? ResolveNonDemTerrainTextureOverlay(
+    private static IEnumerable<(global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> SplitParsedCityObjectForTerrainProjection(
         global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject,
-        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays)
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshAreas,
+        Action<string>? progressReporter = null,
+        CancellationToken cancellationToken = default)
     {
-        if (string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
+        foreach ((global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
+                 in DemTerrainOverlayAssignment.SplitParsedCityObject(
+                     cityObject,
+                     demTerrainTextureOverlays,
+                     requestedMeshAreas,
+                     progressReporter,
+                     cancellationToken))
         {
-            return null;
+            cancellationToken.ThrowIfCancellationRequested();
+            if (splitCityObject.Overlay is not null
+                || string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
+            {
+                yield return splitCityObject;
+                continue;
+            }
+
+            foreach ((global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject CityObject, TerrainTextureOverlay? Overlay) nonDemSplit
+                     in SplitNonDemCityObjectByTerrainOverlay(
+                         splitCityObject.CityObject,
+                         demTerrainTextureOverlays,
+                         progressReporter,
+                         cancellationToken))
+            {
+                yield return nonDemSplit;
+            }
+        }
+    }
+
+    private static IEnumerable<(global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> SplitNonDemCityObjectByTerrainOverlay(
+        global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
+    {
+        if (demTerrainTextureOverlays.Count == 0 || !IsBuildingPackage(cityObject.PackageName))
+        {
+            yield return (cityObject, null);
+            yield break;
         }
 
-        GeographicRectangle? cityObjectBounds = TryCreateCityObjectGeographicBounds(cityObject);
-        TerrainTextureOverlay? matchingOverlay = demTerrainTextureOverlays
-            .Where(overlay => ResolveTerrainTextureMeshCode(cityObject.ActualMeshCode, overlay) is not null)
-            .Where(overlay => cityObjectBounds is null || BoundsOverlap(cityObjectBounds, overlay.GeographicBounds))
-            .OrderByDescending(overlay => cityObjectBounds is null
-                ? 0.0
-                : CalculateOverlapArea(cityObjectBounds, overlay.GeographicBounds))
-            .FirstOrDefault(overlay => cityObjectBounds is null || CalculateOverlapArea(cityObjectBounds, overlay.GeographicBounds) > 0.0);
-        if (matchingOverlay is not null)
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
+            ? new LocalCartesian(
+                cityObjectOrigin.Latitude,
+                cityObjectOrigin.Longitude,
+                cityObjectOrigin.Altitude,
+                cityObject.ReferenceSystem.Geocentric)
+            : null;
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint[] cityObjectVertices =
+        [
+            .. cityObject.Surfaces.SelectMany(static surface => surface.Vertices)
+        ];
+        if (cityObjectVertices.Length == 0)
         {
-            return matchingOverlay;
+            yield return (cityObject, null);
+            yield break;
         }
 
-        if (TryCreateMeshCodeBounds(cityObject.ActualMeshCode, out MeshCodeBounds? actualMeshBounds)
-            && demTerrainTextureOverlays.Any(overlay => BoundsOverlap(actualMeshBounds!, overlay.GeographicBounds)))
+        double cityObjectMinAltitude = cityObjectVertices.Min(static vertex => vertex.Altitude);
+
+        List<global::PlateauResoniteLink.Application.Importing.BootstrapParsedSurface> untexturedSurfaces = [];
+        List<(global::PlateauResoniteLink.Application.Importing.BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> terrainOverlaySurfaces = [];
+        foreach (global::PlateauResoniteLink.Application.Importing.BootstrapParsedSurface surface in cityObject.Surfaces)
         {
-            throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!IsNonDemTerrainTextureSurface(cityObject, surface, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian)
+                || !TryCreateSurfaceGeographicBounds(surface, out GeographicRectangle surfaceBounds))
+            {
+                untexturedSurfaces.Add(surface);
+                continue;
+            }
+
+            TerrainTextureOverlay[] candidateOverlays = demTerrainTextureOverlays
+                .Where(overlay => ResolveTerrainTextureMeshCode(cityObject.ActualMeshCode, overlay) is not null)
+                .Where(overlay => BoundsOverlap(surfaceBounds, overlay.GeographicBounds))
+                .OrderBy(static overlay => overlay.GeographicBounds.MinLatitude)
+                .ThenBy(static overlay => overlay.GeographicBounds.MinLongitude)
+                .ToArray();
+            if (candidateOverlays.Length == 0)
+            {
+                if (demTerrainTextureOverlays.Any(overlay => BoundsOverlap(surfaceBounds, overlay.GeographicBounds)))
+                {
+                    throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+                }
+
+                untexturedSurfaces.Add(surface);
+                continue;
+            }
+
+            if (candidateOverlays.Length == 1)
+            {
+                terrainOverlaySurfaces.Add((surface, candidateOverlays[0]));
+                continue;
+            }
+
+            TerrainTextureOverlay? containingOverlay = candidateOverlays.FirstOrDefault(overlay =>
+                ContainsBounds(overlay.GeographicBounds, surfaceBounds));
+            if (containingOverlay is not null)
+            {
+                terrainOverlaySurfaces.Add((surface, containingOverlay));
+                continue;
+            }
+
+            IReadOnlyList<(global::PlateauResoniteLink.Application.Importing.BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> clippedSurfaces =
+                DemTerrainOverlaySurfaceClipper.ClipGeneratedSurfaceToOverlays(
+                    surface,
+                    candidateOverlays,
+                    progressReporter,
+                    cancellationToken);
+            if (clippedSurfaces.Count == 0)
+            {
+                untexturedSurfaces.Add(surface);
+                continue;
+            }
+
+            terrainOverlaySurfaces.AddRange(clippedSurfaces);
         }
 
-        return null;
+        IGrouping<TerrainTextureOverlay, (global::PlateauResoniteLink.Application.Importing.BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)>[] terrainGroups =
+            terrainOverlaySurfaces
+                .GroupBy(static entry => entry.Overlay)
+                .OrderBy(static group => group.Key.GeographicBounds.MinLatitude)
+                .ThenBy(static group => group.Key.GeographicBounds.MinLongitude)
+                .ToArray();
+        int splitCount = terrainGroups.Length + (untexturedSurfaces.Count == 0 ? 0 : 1);
+        if (splitCount == 0)
+        {
+            yield break;
+        }
+
+        if (splitCount == 1)
+        {
+            if (terrainGroups.Length == 1)
+            {
+                yield return (
+                    cityObject with
+                    {
+                        Surfaces = terrainGroups[0].Select(static entry => entry.Surface).ToArray(),
+                        OriginOverride = cityObjectOrigin,
+                    },
+                    terrainGroups[0].Key);
+                yield break;
+            }
+
+            yield return (
+                cityObject with
+                {
+                    Surfaces = untexturedSurfaces.ToArray(),
+                    OriginOverride = cityObjectOrigin,
+                },
+                null);
+            yield break;
+        }
+
+        int splitIndex = 0;
+        foreach (IGrouping<TerrainTextureOverlay, (global::PlateauResoniteLink.Application.Importing.BootstrapParsedSurface Surface, TerrainTextureOverlay Overlay)> group in terrainGroups)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string terrainMeshCode = ResolveTerrainTextureMeshCode(cityObject.ActualMeshCode, group.Key)
+                ?? splitIndex.ToString("D2", CultureInfo.InvariantCulture);
+            yield return (
+                cityObject with
+                {
+                    SlotKey = $"{cityObject.SlotKey}_terrain_{terrainMeshCode}",
+                    DisplayName = $"{cityObject.DisplayName} ({splitIndex + 1})",
+                    Surfaces = group.Select(static entry => entry.Surface).ToArray(),
+                    OriginOverride = cityObjectOrigin,
+                },
+                group.Key);
+            splitIndex++;
+        }
+
+        if (untexturedSurfaces.Count != 0)
+        {
+            yield return (
+                cityObject with
+                {
+                    SlotKey = $"{cityObject.SlotKey}_terrain_none",
+                    DisplayName = $"{cityObject.DisplayName} ({splitIndex + 1})",
+                    Surfaces = untexturedSurfaces.ToArray(),
+                    OriginOverride = cityObjectOrigin,
+                },
+                null);
+        }
+    }
+
+    private static bool IsNonDemTerrainTextureSurface(
+        global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject,
+        global::PlateauResoniteLink.Application.Importing.BootstrapParsedSurface surface,
+        double cityObjectMinAltitude,
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        return surface.TexturePayload is null
+            && !surface.UsesGeneratedDemTexture
+            && IsRoofTerrainTextureSurface(
+                surface.ToLegacy(),
+                cityObjectMinAltitude,
+                cityObjectOrigin.ToLegacy(),
+                cityObjectCartesian);
     }
 
     private static bool ShouldProjectTerrainOverlaySplit(
@@ -4475,35 +4649,31 @@ internal static partial class LocalCityGmlObjectProjection
             && left.MinLongitude <= right.MaxLongitude;
     }
 
-    private static double CalculateOverlapArea(GeographicRectangle left, GeographicRectangle right)
+    private static bool ContainsBounds(GeographicRectangle outer, GeographicRectangle inner)
     {
-        double latitudeOverlap = Math.Max(
-            0.0,
-            Math.Min(left.MaxLatitude, right.MaxLatitude) - Math.Max(left.MinLatitude, right.MinLatitude));
-        double longitudeOverlap = Math.Max(
-            0.0,
-            Math.Min(left.MaxLongitude, right.MaxLongitude) - Math.Max(left.MinLongitude, right.MinLongitude));
-        return latitudeOverlap * longitudeOverlap;
+        return inner.MinLatitude >= outer.MinLatitude
+            && inner.MaxLatitude <= outer.MaxLatitude
+            && inner.MinLongitude >= outer.MinLongitude
+            && inner.MaxLongitude <= outer.MaxLongitude;
     }
 
-    private static GeographicRectangle? TryCreateCityObjectGeographicBounds(
-        global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject)
+    private static bool TryCreateSurfaceGeographicBounds(
+        global::PlateauResoniteLink.Application.Importing.BootstrapParsedSurface surface,
+        out GeographicRectangle bounds)
     {
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint[] vertices =
-        [
-            .. cityObject.Surfaces
-                .SelectMany(static surface => surface.ExteriorRing.Vertices)
-        ];
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint[] vertices = surface.ExteriorRing.Vertices;
         if (vertices.Length == 0)
         {
-            return null;
+            bounds = new GeographicRectangle(0.0, 0.0, 0.0, 0.0);
+            return false;
         }
 
-        return new GeographicRectangle(
+        bounds = new GeographicRectangle(
             vertices.Min(static vertex => vertex.Latitude),
             vertices.Max(static vertex => vertex.Latitude),
             vertices.Min(static vertex => vertex.Longitude),
             vertices.Max(static vertex => vertex.Longitude));
+        return true;
     }
 
     private static Float2 ToContractFloat2(Float2 value) => new(value.X, value.Y);

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1377,7 +1377,10 @@ internal static partial class LocalCityGmlObjectProjection
             cityObjectCartesian);
         if (roofTerrainTextureMaterial is not null)
         {
-            return new ResolvedSurfaceMaterial(surface, roofTerrainTextureMaterial, DepthOffset: null);
+            return new ResolvedSurfaceMaterial(
+                surface with { BaseColor = DefaultMaterialColor },
+                roofTerrainTextureMaterial,
+                DepthOffset: null);
         }
 
         if (string.Equals(cityObject.PackageName, "veg", StringComparison.OrdinalIgnoreCase)
@@ -1477,7 +1480,10 @@ internal static partial class LocalCityGmlObjectProjection
             cityObjectCartesian);
         if (roofTerrainTextureMaterial is not null)
         {
-            return new ResolvedSurfaceMaterial(legacySurface, roofTerrainTextureMaterial, DepthOffset: null);
+            return new ResolvedSurfaceMaterial(
+                legacySurface with { BaseColor = DefaultMaterialColor },
+                roofTerrainTextureMaterial,
+                DepthOffset: null);
         }
 
         if (string.Equals(cityObject.PackageName, "veg", StringComparison.OrdinalIgnoreCase)
@@ -2586,11 +2592,11 @@ internal static partial class LocalCityGmlObjectProjection
         {
             if (material.TerrainOverlay is not null)
             {
-                if (ResolveTerrainTextureMeshCode(actualMeshCode, material.TerrainOverlay) is { } terrainMeshCode)
+                if (ResolveTerrainTextureMeshCode(actualMeshCode, material.TerrainOverlay) is not null)
                 {
                     return string.Create(
                         CultureInfo.InvariantCulture,
-                        $"terrain-shared-{terrainMeshCode}-{ProjectionToken(material.Projection)}-depth-{FormatDepth(depthOffset)}-scale-{FormatFloat2(textureScale)}-offset-{FormatFloat2(textureOffset)}-color-{FormatColor(color)}");
+                        $"terrain-shared-{ProjectionToken(material.Projection)}-depth-{FormatDepth(depthOffset)}-scale-{FormatFloat2(textureScale)}-offset-{FormatFloat2(textureOffset)}");
                 }
 
                 throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
@@ -3166,16 +3172,18 @@ internal static partial class LocalCityGmlObjectProjection
                      cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!ShouldProjectTerrainOverlaySplit(splitCityObject.CityObject.ActualMeshCode, request.MeshCode, splitCityObject.Overlay))
+            TerrainTextureOverlay? projectionOverlay = splitCityObject.Overlay
+                ?? ResolveNonDemTerrainTextureOverlay(splitCityObject.CityObject, demTerrainTextureOverlays);
+            if (!ShouldProjectTerrainOverlaySplit(splitCityObject.CityObject.ActualMeshCode, request.MeshCode, projectionOverlay))
             {
-                continue;
+                throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
             }
 
             ImportedCityObject cityObject = ProjectTerrainMeshModeCityObject(
                 splitCityObject.CityObject,
                 globalOriginPoint,
                 globalCartesian,
-                splitCityObject.Overlay,
+                projectionOverlay,
                 request,
                 materialResolver,
                 progressReporter,
@@ -3207,7 +3215,7 @@ internal static partial class LocalCityGmlObjectProjection
                 roadMarkingCityObject,
                 globalOriginPoint,
                 globalCartesian,
-                splitCityObject.Overlay,
+                projectionOverlay,
                 materialResolver) with
             {
                 CollisionEnabled = false,
@@ -3261,9 +3269,11 @@ internal static partial class LocalCityGmlObjectProjection
                      demTerrainTextureOverlays,
                      requestedMeshAreas))
         {
-            if (!ShouldProjectTerrainOverlaySplit(splitCityObject.CityObject.ActualMeshCode, request.MeshCode, splitCityObject.Overlay))
+            TerrainTextureOverlay? projectionOverlay = splitCityObject.Overlay
+                ?? ResolveNonDemTerrainTextureOverlay(splitCityObject.CityObject, demTerrainTextureOverlays);
+            if (!ShouldProjectTerrainOverlaySplit(splitCityObject.CityObject.ActualMeshCode, request.MeshCode, projectionOverlay))
             {
-                continue;
+                throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
             }
 
             global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(splitCityObject.CityObject);
@@ -3281,14 +3291,14 @@ internal static partial class LocalCityGmlObjectProjection
                                 splitCityObject.CityObject,
                                 cityObjectOrigin,
                                 cityObjectCartesian,
-                                splitCityObject.Overlay,
+                                projectionOverlay,
                                 request.MeshCode,
                                 materialResolver)
                             : CreateCommonMaterialBindings(
                                 splitCityObject.CityObject,
                                 cityObjectOrigin,
                                 cityObjectCartesian,
-                                splitCityObject.Overlay,
+                                projectionOverlay,
                                 materialResolver))
             {
                 yield return material;
@@ -4263,6 +4273,31 @@ internal static partial class LocalCityGmlObjectProjection
         return requestedMeshCode;
     }
 
+    private static TerrainTextureOverlay? ResolveNonDemTerrainTextureOverlay(
+        global::PlateauResoniteLink.Application.Importing.BootstrapParsedCityObject cityObject,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays)
+    {
+        if (string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        TerrainTextureOverlay? matchingOverlay = demTerrainTextureOverlays.FirstOrDefault(overlay =>
+            ResolveTerrainTextureMeshCode(cityObject.ActualMeshCode, overlay) is not null);
+        if (matchingOverlay is not null)
+        {
+            return matchingOverlay;
+        }
+
+        if (TryCreateMeshCodeBounds(cityObject.ActualMeshCode, out MeshCodeBounds? actualMeshBounds)
+            && demTerrainTextureOverlays.Any(overlay => BoundsOverlap(actualMeshBounds!, overlay.GeographicBounds)))
+        {
+            throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+        }
+
+        return null;
+    }
+
     private static bool ShouldProjectTerrainOverlaySplit(
         string actualMeshCode,
         string requestedMeshCode,
@@ -4280,6 +4315,14 @@ internal static partial class LocalCityGmlObjectProjection
         }
 
         return ResolveTerrainTextureMeshCode(actualMeshCode, terrainOverlay) is not null;
+    }
+
+    private static bool BoundsOverlap(MeshCodeBounds meshBounds, GeographicRectangle geographicBounds)
+    {
+        return meshBounds.NorthLatitude >= geographicBounds.MinLatitude
+            && meshBounds.SouthLatitude <= geographicBounds.MaxLatitude
+            && meshBounds.EastLongitude >= geographicBounds.MinLongitude
+            && meshBounds.WestLongitude <= geographicBounds.MaxLongitude;
     }
 
     private static Float2 ToContractFloat2(Float2 value) => new(value.X, value.Y);

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -176,4 +176,5 @@ public sealed record MaterialBinding(
     Float2? TextureOffset = null,
     MaterialReuseScope ReuseScope = MaterialReuseScope.PerObject,
     TerrainTextureOverlay? TerrainOverlay = null,
-    int? BundledVariantIndex = null);
+    int? BundledVariantIndex = null,
+    string? TerrainMeshCode = null);

--- a/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
@@ -26,9 +26,13 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource
     private readonly IImportedObjectUnitOptimizer objectUnitOptimizer;
     private readonly Action<string>? progressReporter;
     private readonly object referenceSystemGate = new();
+    private readonly object sceneDemTerrainTextureOverlayGate = new();
     private readonly ConcurrentDictionary<string, Task<TerrainTextureOverlay[]>> demTerrainTextureOverlayTasks = new(StringComparer.Ordinal);
     private readonly MeshCodeBounds[] requestedMeshAreas;
+    private readonly string[] selectedMeshCodes;
     private readonly TerrainTextureOverlay[] bootstrapTerrainTextureOverlays;
+    private readonly bool hasDemPackage;
+    private Task<TerrainTextureOverlay[]>? sceneDemTerrainTextureOverlayTask;
     private CoordinateReferenceSystem? referenceSystem;
 
     public StreamingImportedSceneSource(
@@ -49,6 +53,8 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource
         this.request = request;
         sourceFiles = bootstrapContext.SourceFilePipelines.ToArray();
         bootstrapTerrainTextureOverlays = documentSet.TerrainTextureOverlays.ToArray();
+        selectedMeshCodes = documentSet.SelectedMeshCodes.ToArray();
+        hasDemPackage = documentSet.PackageNames.Contains("dem", StringComparer.OrdinalIgnoreCase);
         globalOriginPoint = bootstrapContext.GlobalOriginPoint;
         this.geometryProjector = geometryProjector;
         this.demTextureSourcePolicy = demTextureSourcePolicy;
@@ -196,7 +202,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource
         LocalCartesian? globalCartesian = null;
         int parsedCount = 0;
         int yieldedCount = 0;
-        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays = await GetDemTerrainTextureOverlaysAsync(
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays = await GetProjectionDemTerrainTextureOverlaysAsync(
             sourceFile,
             cancellationToken);
         bool isDemSourceFile = string.Equals(sourceFile.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase);
@@ -339,6 +345,72 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource
         }
 
         return bootstrapTerrainTextureOverlays.ToArray();
+    }
+
+    private async Task<TerrainTextureOverlay[]> GetProjectionDemTerrainTextureOverlaysAsync(
+        SourceFilePipeline sourceFile,
+        CancellationToken cancellationToken)
+    {
+        return string.Equals(sourceFile.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
+            ? await GetDemTerrainTextureOverlaysAsync(sourceFile, cancellationToken)
+            : await GetSceneDemTerrainTextureOverlaysAsync(cancellationToken);
+    }
+
+    private async Task<TerrainTextureOverlay[]> GetSceneDemTerrainTextureOverlaysAsync(
+        CancellationToken cancellationToken)
+    {
+        if (!hasDemPackage)
+        {
+            return [];
+        }
+
+        if (bootstrapTerrainTextureOverlays.Length > 0)
+        {
+            return bootstrapTerrainTextureOverlays.ToArray();
+        }
+
+        Task<TerrainTextureOverlay[]> overlayTask;
+        lock (sceneDemTerrainTextureOverlayGate)
+        {
+            overlayTask = sceneDemTerrainTextureOverlayTask ??= CreateSceneDemTerrainTextureOverlaysAsync(cancellationToken);
+        }
+
+        try
+        {
+            return await overlayTask.WaitAsync(cancellationToken);
+        }
+        catch
+        {
+            if (overlayTask.IsCanceled || overlayTask.IsFaulted)
+            {
+                lock (sceneDemTerrainTextureOverlayGate)
+                {
+                    if (ReferenceEquals(sceneDemTerrainTextureOverlayTask, overlayTask))
+                    {
+                        sceneDemTerrainTextureOverlayTask = null;
+                    }
+                }
+            }
+
+            throw;
+        }
+    }
+
+    private async Task<TerrainTextureOverlay[]> CreateSceneDemTerrainTextureOverlaysAsync(
+        CancellationToken cancellationToken)
+    {
+        DemTerrainOverlayRegion[] overlayRegions = DemSourceBootstrapSupport.CreateDemTerrainOverlayRegions(
+            selectedMeshCodes.Length == 0 ? [request.MeshCode] : selectedMeshCodes);
+        if (overlayRegions.Length == 0)
+        {
+            return [];
+        }
+
+        ResolvedDemTextureSources resolvedDemTextureSources = await demTextureSourcePolicy.ResolveAsync(
+            request,
+            overlayRegions,
+            cancellationToken);
+        return resolvedDemTextureSources.Overlays.ToArray();
     }
 
     private bool HasOverlayCoverage(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -645,7 +645,15 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         PlannedMainTextureOverrideRendererMaterialBinding binding,
         ref int nextComponentLocator)
     {
-        BatchPlanComponentLocator textureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
+        PlannedWorldElementReference? sharedTextureTarget = binding is PlannedTerrainMainTextureOverrideRendererMaterialBinding
+        {
+            SharedMainTextureComponent: { } sharedMainTextureComponent,
+        }
+            ? PlannedWorldElementReference.Canonical(sharedMainTextureComponent)
+            : null;
+        BatchPlanComponentLocator? textureId = sharedTextureTarget is null
+            ? CreateBatchPlanComponentLocator(ref nextComponentLocator)
+            : null;
         ResoniteSceneMaterialConventions.TextureMemberRole textureRole = binding switch
         {
             PlannedAlbedoMainTextureOverrideRendererMaterialBinding =>
@@ -655,14 +663,17 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             _ => throw new InvalidOperationException(
                 $"Unsupported planned main texture override binding type '{binding.GetType().Name}'."),
         };
-        componentEmissions.Add(new PlannedBatchComponentEmission(
-            textureId,
-            PlannedSlotTargetReference.PlannedSlot(assetSlotId),
-            "[FrooxEngine]FrooxEngine.StaticTexture2D",
-            ResoniteSceneMaterialConventions.CreateTextureMembers(
-                binding.MainTexture.AssetUri,
-                textureRole)
-                .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal)));
+        if (textureId is { } plannedTextureId)
+        {
+            componentEmissions.Add(new PlannedBatchComponentEmission(
+                plannedTextureId,
+                PlannedSlotTargetReference.PlannedSlot(assetSlotId),
+                "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                ResoniteSceneMaterialConventions.CreateTextureMembers(
+                    binding.MainTexture.AssetUri,
+                    textureRole)
+                    .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal)));
+        }
 
         BatchPlanComponentLocator propertyBlockId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
         componentEmissions.Add(new PlannedBatchComponentEmission(
@@ -671,7 +682,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
             new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
             {
-                ["Texture"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(textureId)),
+                ["Texture"] = PlannedMembers.Reference(sharedTextureTarget ?? PlannedWorldElementReference.Planned(textureId!.Value)),
             }));
 
         return PlannedMembers.Reference(PlannedWorldElementReference.Planned(propertyBlockId));

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
@@ -52,6 +52,15 @@ internal sealed class CommonMaterialAssetCache
     public required IReadOnlySet<string> BootstrapKnownMaterialKeys { get; init; }
 }
 
+internal sealed class TerrainTextureAssetCache
+{
+    public AsyncInFlightResultCache<string, SharedTerrainTextureAsset> AssetsByMeshCode { get; } = new();
+}
+
+internal sealed record SharedTerrainTextureAsset(
+    Uri TextureUri,
+    CreatedComponent TextureComponent);
+
 internal sealed record LiveSendRunPlan(
     ResoniteSceneBootstrapInfo BootstrapInfo,
     string ResolvedWorkRoot,
@@ -79,6 +88,8 @@ internal sealed class LiveSendRunState
     public required LiveSendProgressSink Progress { get; init; }
 
     public required CommonMaterialAssetCache Materials { get; init; }
+
+    public required TerrainTextureAssetCache TerrainTextures { get; init; }
 
     public required ResoniteSharedSlotIndex Placement { get; init; }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
@@ -78,6 +78,7 @@ internal sealed record LiveSendQueuePlan(
 internal sealed record LiveSendRunContext(
     LiveSendRunPlan Plan,
     CreatedSlot DatasetRootSlot,
+    CreatedSlot DatasetAssetsRootSlot,
     CreatedSlot CommonAssetsRootSlot,
     CompositeCityObjectBaker? CityObjectBaker);
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -986,7 +986,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         (string TerrainMeshCode, TerrainTextureOverlay TerrainOverlay)[] distinctTerrainOverlays = cityObject.Materials
             .Where(static material => material.TerrainOverlay is not null && material.TerrainMeshCode is not null)
             .Select(material => (
-                TerrainMeshCode: ValidateTerrainTextureMeshCode(material.TerrainMeshCode!),
+                TerrainMeshCode: ValidateTerrainTextureMeshCode(material.TerrainMeshCode!, material.TerrainOverlay!),
                 TerrainOverlay: material.TerrainOverlay!))
             .Distinct()
             .OrderBy(static entry => entry.TerrainMeshCode, StringComparer.Ordinal)
@@ -1457,15 +1457,13 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             terrainTexturesRoot.Locator,
             meshCode,
             cancellationToken);
-        CreatedComponent? existingComponent = await TryFindSharedTerrainTextureComponentAsync(
+        SharedTerrainTextureAsset? existingTexture = await TryFindSharedTerrainTextureAssetAsync(
             importClient,
             meshSlot,
             cancellationToken);
-        if (existingComponent is { } component)
+        if (existingTexture is not null)
         {
-            return new SharedTerrainTextureAsset(
-                new Uri($"resdb:///terrain-texture/{Uri.EscapeDataString(meshCode)}", UriKind.Absolute),
-                component);
+            return existingTexture;
         }
 
         Uri importedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
@@ -1504,7 +1502,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         return await slotCreator.CreateAsync(client, parentSlot, childSlotName, null, null, cancellationToken);
     }
 
-    private static async Task<CreatedComponent?> TryFindSharedTerrainTextureComponentAsync(
+    private static async Task<SharedTerrainTextureAsset?> TryFindSharedTerrainTextureAssetAsync(
         IResoniteLinkClient importClient,
         CreatedSlot meshSlot,
         CancellationToken cancellationToken)
@@ -1515,9 +1513,17 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             cancellationToken);
         Component? textureComponent = slot?.Components?
             .FirstOrDefault(IsSharedTerrainTextureComponent);
-        return textureComponent?.ID is null
+        if (textureComponent?.ID is null
+            || textureComponent.Members["URL"] is not Field_Uri url)
+        {
+            return null;
+        }
+
+        return url.Value is null
             ? null
-            : new CreatedComponent(new ResoniteComponentLocator(textureComponent.ID), textureComponent.ComponentType);
+            : new SharedTerrainTextureAsset(
+                url.Value,
+                new CreatedComponent(new ResoniteComponentLocator(textureComponent.ID), textureComponent.ComponentType));
     }
 
     private static bool IsSharedTerrainTextureComponent(Component component)
@@ -1553,20 +1559,35 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             return material with { TerrainMeshCode = null };
         }
 
-        return material.TerrainMeshCode is null
-            ? material
-            : material with { TerrainMeshCode = ValidateTerrainTextureMeshCode(material.TerrainMeshCode) };
+        if (material.TerrainMeshCode is null)
+        {
+            throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+        }
+
+        return material with { TerrainMeshCode = ValidateTerrainTextureMeshCode(material.TerrainMeshCode, material.TerrainOverlay) };
     }
 
-    private static string ValidateTerrainTextureMeshCode(string meshCode)
+    private static string ValidateTerrainTextureMeshCode(string meshCode, TerrainTextureOverlay terrainOverlay)
     {
         if (meshCode.Length == 8
-            && PlateauMeshCode.TryGetBounds(meshCode, out _))
+            && PlateauMeshCode.TryGetBounds(meshCode, out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds)
+            && BoundsApproximatelyEqual(bounds, terrainOverlay.GeographicBounds))
         {
             return meshCode;
         }
 
-        throw new InvalidOperationException("Terrain overlay material requires a valid third-level mesh code.");
+        throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+    }
+
+    private static bool BoundsApproximatelyEqual(
+        (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds,
+        GeographicRectangle geographicBounds)
+    {
+        const double tolerance = 1e-8;
+        return Math.Abs(bounds.SouthLatitude - geographicBounds.MinLatitude) <= tolerance
+            && Math.Abs(bounds.NorthLatitude - geographicBounds.MaxLatitude) <= tolerance
+            && Math.Abs(bounds.WestLongitude - geographicBounds.MinLongitude) <= tolerance
+            && Math.Abs(bounds.EastLongitude - geographicBounds.MaxLongitude) <= tolerance;
     }
 
     private static Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> CreatePreparedTerrainTextureDataByOverlay(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -269,6 +269,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             Context = context,
             Progress = progress,
             Materials = materials,
+            TerrainTextures = new TerrainTextureAssetCache(),
             Placement = placement,
             Runtime = runtime,
             GsiFallbackLicenseGate = new SemaphoreSlim(1, 1),
@@ -982,17 +983,24 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                     exception);
             }
         }
-        TerrainTextureOverlay[] distinctTerrainOverlays = cityObject.Materials
-            .Where(static material => material.TerrainOverlay is not null)
-            .Select(static material => material.TerrainOverlay!)
+        (string TerrainMeshCode, TerrainTextureOverlay TerrainOverlay)[] distinctTerrainOverlays = cityObject.Materials
+            .Where(static material => material.TerrainOverlay is not null && material.TerrainMeshCode is not null)
+            .Select(material => (
+                TerrainMeshCode: ValidateTerrainTextureMeshCode(material.TerrainMeshCode!),
+                TerrainOverlay: material.TerrainOverlay!))
             .Distinct()
-            .OrderBy(static overlay => overlay.PackageName, StringComparer.Ordinal)
-            .ThenBy(static overlay => overlay.GeographicBounds.MinLatitude)
-            .ThenBy(static overlay => overlay.GeographicBounds.MinLongitude)
+            .OrderBy(static entry => entry.TerrainMeshCode, StringComparer.Ordinal)
+            .ThenBy(static entry => entry.TerrainOverlay.PackageName, StringComparer.Ordinal)
+            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLatitude)
+            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLongitude)
             .ToArray();
 
         Task<PreparedTextureReference?>[] terrainOverlayTexturePreparationTasks = distinctTerrainOverlays
-            .Select(terrainTextureOverlay => PrepareTerrainOverlayTextureReferenceAsync(state, terrainTextureOverlay, cancellationToken))
+            .Select(entry => PrepareTerrainOverlayTextureReferenceAsync(
+                state,
+                entry.TerrainMeshCode,
+                entry.TerrainOverlay,
+                cancellationToken))
             .ToArray();
         Task<PreparedTextureReference?>[] texturePreparationTasks = [];
 
@@ -1066,6 +1074,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 
     private async Task<PreparedTextureReference?> PrepareTerrainOverlayTextureReferenceAsync(
         LiveSendRunState state,
+        string terrainMeshCode,
         TerrainTextureOverlay terrainTextureOverlay,
         CancellationToken cancellationToken)
     {
@@ -1098,6 +1107,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             TexturePayload: null,
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             TextureImport: terrainTexture.TextureImport,
+            TerrainMeshCode: terrainMeshCode,
             TerrainOverlay: terrainTextureOverlay,
             GeneratedTerrainTexture: terrainTexture);
     }
@@ -1181,6 +1191,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 TexturePayload: material.TexturePayload,
                 TextureSourceKind: material.TextureSourceKind,
                 TextureImport: ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
+                TerrainMeshCode: null,
                 TerrainOverlay: null));
     }
 
@@ -1210,6 +1221,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             preparedTerrainTextureDataByOverlay,
             buildStepCancellation.Token);
         Task<UploadedTextureAssetSet> uploadedTextureAssetsTask = UploadPreparedTexturesAsync(
+            state,
             routedClient,
             preparedCityObject,
             preparedTerrainTextureDataByOverlay,
@@ -1238,6 +1250,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 cityObject,
                 uploadedTextureAssets.TextureUrisByPayload,
                 uploadedTextureAssets.TerrainTextureUrisByOverlay,
+                uploadedTextureAssets.TerrainTextureComponentsByMeshCode,
                 uploadedTextureAssets.GeneratedTerrainTexturesByOverlay,
                 buildStepCancellation.Token);
             plannedMaterials = await materialPlanningTask;
@@ -1346,7 +1359,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         return uploadedTextureAssets;
     }
 
-    private static async Task<UploadedTextureAssetSet> UploadPreparedTexturesAsync(
+    private async Task<UploadedTextureAssetSet> UploadPreparedTexturesAsync(
+        LiveSendRunState state,
         IResoniteLinkClient importClient,
         PreparedCityObject preparedCityObject,
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay,
@@ -1354,9 +1368,10 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
     {
         Dictionary<ResoniteTexturePayload, Uri> textureUrisByPayload = new(TexturePayloadReferenceComparer.Instance);
         Dictionary<TerrainTextureOverlay, Uri> terrainTextureUrisByOverlay = [];
+        Dictionary<string, ResoniteComponentLocator> terrainTextureComponentsByMeshCode = new(StringComparer.Ordinal);
         HashSet<ResoniteTexturePayload> queuedPayloads = new(TexturePayloadReferenceComparer.Instance);
-        HashSet<TerrainTextureOverlay> queuedTerrainOverlays = [];
         List<(PreparedTextureReference Texture, Task<Uri> ImportTask)> textureImportTasks = [];
+        List<(PreparedTextureReference Texture, Task<SharedTerrainTextureAsset> ImportTask)> terrainTextureImportTasks = [];
 
         foreach (PreparedTextureReference texture in preparedCityObject.Textures)
         {
@@ -1365,9 +1380,17 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 continue;
             }
 
-            if (texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null }
-                && !queuedTerrainOverlays.Add(texture.TerrainOverlay))
+            if (texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
             {
+                string meshCode = ResolveTerrainTextureMeshCode(texture);
+                terrainTextureImportTasks.Add((
+                    texture,
+                    EnsureSharedTerrainTextureAssetAsync(
+                        state,
+                        importClient,
+                        meshCode,
+                        texture.TextureImport,
+                        cancellationToken)));
                 continue;
             }
 
@@ -1377,6 +1400,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         }
 
         await Task.WhenAll(textureImportTasks.Select(static textureImport => textureImport.ImportTask));
+        await Task.WhenAll(terrainTextureImportTasks.Select(static textureImport => textureImport.ImportTask));
 
         foreach ((PreparedTextureReference texture, Task<Uri> importTask) in textureImportTasks)
         {
@@ -1386,16 +1410,163 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 textureUrisByPayload.Add(texture.TexturePayload, textureUri);
             }
 
-            if (texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
-            {
-                terrainTextureUrisByOverlay.Add(texture.TerrainOverlay, textureUri);
-            }
+        }
+
+        foreach ((PreparedTextureReference texture, Task<SharedTerrainTextureAsset> importTask) in terrainTextureImportTasks)
+        {
+            SharedTerrainTextureAsset sharedTexture = await importTask;
+            string meshCode = ResolveTerrainTextureMeshCode(texture);
+            terrainTextureUrisByOverlay.Add(texture.TerrainOverlay!, sharedTexture.TextureUri);
+            terrainTextureComponentsByMeshCode.TryAdd(meshCode, sharedTexture.TextureComponent.Locator);
         }
 
         return new UploadedTextureAssetSet(
             textureUrisByPayload,
             terrainTextureUrisByOverlay,
+            terrainTextureComponentsByMeshCode,
             preparedTerrainTextureDataByOverlay);
+    }
+
+    private Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient importClient,
+        string meshCode,
+        ResoniteTextureImport textureImport,
+        CancellationToken cancellationToken)
+    {
+        return state.TerrainTextures.AssetsByMeshCode.GetOrCreateAsync(
+            meshCode,
+            () => EnsureSharedTerrainTextureAssetCoreAsync(importClient, state.Context.DatasetRootSlot, meshCode, textureImport, cancellationToken),
+            cancellationToken);
+    }
+
+    private async Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetCoreAsync(
+        IResoniteLinkClient importClient,
+        CreatedSlot datasetRootSlot,
+        string meshCode,
+        ResoniteTextureImport textureImport,
+        CancellationToken cancellationToken)
+    {
+        CreatedSlot terrainTexturesRoot = await EnsureTerrainTextureChildSlotAsync(
+            importClient,
+            datasetRootSlot.Locator,
+            "Terrain Textures",
+            cancellationToken);
+        CreatedSlot meshSlot = await EnsureTerrainTextureChildSlotAsync(
+            importClient,
+            terrainTexturesRoot.Locator,
+            meshCode,
+            cancellationToken);
+        CreatedComponent? existingComponent = await TryFindSharedTerrainTextureComponentAsync(
+            importClient,
+            meshSlot,
+            cancellationToken);
+        if (existingComponent is { } component)
+        {
+            return new SharedTerrainTextureAsset(
+                new Uri($"resdb:///terrain-texture/{Uri.EscapeDataString(meshCode)}", UriKind.Absolute),
+                component);
+        }
+
+        Uri importedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
+        CreatedComponent textureComponent = await ResoniteMaterialPlanning.CreateComponentAsync(
+            importClient,
+            meshSlot.Locator,
+            "[FrooxEngine]FrooxEngine.StaticTexture2D",
+            ResoniteSceneMaterialConventions.CreateTextureMembers(
+                importedTextureUri,
+                ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride),
+            cancellationToken);
+        return new SharedTerrainTextureAsset(
+            importedTextureUri,
+            textureComponent);
+    }
+
+    private async Task<CreatedSlot> EnsureTerrainTextureChildSlotAsync(
+        IResoniteLinkClient client,
+        ResoniteSlotLocator parentSlot,
+        string childSlotName,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(childSlotName);
+
+        Slot? parentSlotSnapshot = await client.GetSlotAsync(
+            new ResoniteTransportSlotLocator(parentSlot.Value),
+            depth: 1,
+            cancellationToken);
+        ResoniteSceneChildLookupResult childLookup = new ResoniteSceneSlotSnapshot(parentSlotSnapshot)
+            .GetUniqueChildLookupResult(childSlotName, parentSlot.Value);
+        if (childLookup.State == ResoniteSceneChildLookupState.FoundWithId)
+        {
+            return new CreatedSlot(new ResoniteSlotLocator(childLookup.Slot!.ID!), childSlotName);
+        }
+
+        return await slotCreator.CreateAsync(client, parentSlot, childSlotName, null, null, cancellationToken);
+    }
+
+    private static async Task<CreatedComponent?> TryFindSharedTerrainTextureComponentAsync(
+        IResoniteLinkClient importClient,
+        CreatedSlot meshSlot,
+        CancellationToken cancellationToken)
+    {
+        Slot? slot = await importClient.GetSlotAsync(
+            new ResoniteTransportSlotLocator(meshSlot.Locator.Value),
+            depth: 0,
+            cancellationToken);
+        Component? textureComponent = slot?.Components?
+            .FirstOrDefault(IsSharedTerrainTextureComponent);
+        return textureComponent?.ID is null
+            ? null
+            : new CreatedComponent(new ResoniteComponentLocator(textureComponent.ID), textureComponent.ComponentType);
+    }
+
+    private static bool IsSharedTerrainTextureComponent(Component component)
+    {
+        return string.Equals(
+                component.ComponentType,
+                "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                StringComparison.Ordinal)
+            && component.Members.TryGetValue("URL", out Member? urlMember)
+            && urlMember is Field_Uri
+            && component.Members.TryGetValue("WrapModeU", out Member? wrapModeUMember)
+            && wrapModeUMember is Field_Enum { Value: "Clamp" }
+            && component.Members.TryGetValue("WrapModeV", out Member? wrapModeVMember)
+            && wrapModeVMember is Field_Enum { Value: "Clamp" };
+    }
+
+    private static string ResolveTerrainTextureMeshCode(PreparedTextureReference texture)
+    {
+        if (texture.TerrainMeshCode is not { Length: > 0 } meshCode
+            || meshCode.Length != 8
+            || !PlateauMeshCode.TryGetBounds(meshCode, out _))
+        {
+            throw new InvalidOperationException("Terrain texture overlay preparation requires a valid third-level mesh code.");
+        }
+
+        return meshCode;
+    }
+
+    private static ResoniteMaterialBinding ValidateTerrainTextureMaterialContract(ResoniteMaterialBinding material)
+    {
+        if (material.TerrainOverlay is null)
+        {
+            return material with { TerrainMeshCode = null };
+        }
+
+        return material.TerrainMeshCode is null
+            ? material
+            : material with { TerrainMeshCode = ValidateTerrainTextureMeshCode(material.TerrainMeshCode) };
+    }
+
+    private static string ValidateTerrainTextureMeshCode(string meshCode)
+    {
+        if (meshCode.Length == 8
+            && PlateauMeshCode.TryGetBounds(meshCode, out _))
+        {
+            return meshCode;
+        }
+
+        throw new InvalidOperationException("Terrain overlay material requires a valid third-level mesh code.");
     }
 
     private static Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> CreatePreparedTerrainTextureDataByOverlay(
@@ -1553,6 +1724,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             return cityObject;
         }
 
+        bool clampCanvasUv = IsDemPackage(cityObject.PackageName);
         Dictionary<int, GeneratedTerrainTexture> generatedTextureBySubmeshIndex = cityObject.Materials
             .Where(static material => material.TerrainOverlay is not null)
             .SelectMany(material =>
@@ -1576,10 +1748,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             {
                 ResoniteMeshVertex sourceVertex = triangleMesh.Mesh.Vertices[sourceIndex];
                 ResoniteFloat2 adjustedUv = generatedTextureBySubmeshIndex.TryGetValue(submesh.Index, out GeneratedTerrainTexture? generatedTexture)
-                    ? CreateResoniteFloat2(TextureUvRect.RemapValue(
-                        new ScalarPair(sourceVertex.UV0.X, sourceVertex.UV0.Y),
-                        TextureUvRect.Identity,
-                        generatedTexture.OccupiedUvRect))
+                    ? CreateCanvasAdjustedTerrainUv(sourceVertex.UV0, generatedTexture.OccupiedUvRect, clampCanvasUv)
                     : sourceVertex.UV0;
                 adjustedVertices.Add(sourceVertex with { UV0 = adjustedUv });
                 adjustedIndices.Add(adjustedVertices.Count - 1);
@@ -1615,6 +1784,24 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
     }
 
     private static ResoniteFloat2 CreateResoniteFloat2(ScalarPair value) => new(value.X, value.Y);
+
+    private static ResoniteFloat2 CreateCanvasAdjustedTerrainUv(
+        ResoniteFloat2 sourceUv,
+        TextureUvRect occupiedUvRect,
+        bool clampCanvasUv)
+    {
+        if (clampCanvasUv)
+        {
+            return CreateResoniteFloat2(TextureUvRect.RemapValue(
+                new ScalarPair(sourceUv.X, sourceUv.Y),
+                TextureUvRect.Identity,
+                occupiedUvRect));
+        }
+
+        return new ResoniteFloat2(
+            occupiedUvRect.MinU + (sourceUv.X * occupiedUvRect.Width),
+            occupiedUvRect.MinV + (sourceUv.Y * occupiedUvRect.Height));
+    }
 
     private static ResoniteFloat2? ResolveTerrainGridUvScale(
         ResoniteConstructionCityObject cityObject,
@@ -1696,6 +1883,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         ResoniteConstructionCityObject cityObject,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
         IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
+        IReadOnlyDictionary<string, ResoniteComponentLocator> preparedTerrainTextureComponentsByMeshCode,
         IReadOnlyDictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay,
         CancellationToken cancellationToken)
     {
@@ -1707,6 +1895,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 cityObject,
                 cityObject.Materials[materialIndex],
                 preparedTerrainTextureDataByOverlay);
+            material = ValidateTerrainTextureMaterialContract(material);
             ReportBuildStep(
                 cityObject,
                 $"Creating material {materialIndex + 1}/{cityObject.Materials.Count} ({material.MaterialKey}).");
@@ -1764,13 +1953,14 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             sharedPlanTask = PlanSharedCommonRendererMaterialAsync(
                 runState,
                 client,
-                sourceMaterial,
-                normalizedSharedMaterial,
-                familySlotName,
-                materialKey,
-                preparedTextureUrisByPayload,
-                preparedTerrainTextureUrisByOverlay,
-                ct);
+                    sourceMaterial,
+                    normalizedSharedMaterial,
+                    familySlotName,
+                    materialKey,
+                    preparedTextureUrisByPayload,
+                    preparedTerrainTextureUrisByOverlay,
+                    preparedTerrainTextureComponentsByMeshCode,
+                    ct);
             return true;
         }
 
@@ -1783,6 +1973,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             string materialKey,
             IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
             IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
+            IReadOnlyDictionary<string, ResoniteComponentLocator> terrainTextureComponentsByMeshCode,
             CancellationToken ct)
         {
             if (runState.Materials.CommonMaterialFamilyWarmupTasks.TryGetValue(familySlotName, out Task? familyWarmupTask))
@@ -1807,6 +1998,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 : CreateMainTextureOverrideRendererBinding(
                     sharedMaterialAsset.Identity,
                     mainTextureOverride,
+                    terrainTextureComponentsByMeshCode,
                     sourceMaterial);
             return (sharedMaterialAsset, rendererBinding);
         }
@@ -1837,11 +2029,21 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
     private static PlannedMainTextureOverrideRendererMaterialBinding CreateMainTextureOverrideRendererBinding(
         MaterialIdentity materialIdentity,
         PlannedTextureAsset mainTexture,
+        IReadOnlyDictionary<string, ResoniteComponentLocator> terrainTextureComponentsByMeshCode,
         ResoniteMaterialBinding sourceMaterial)
     {
-        return sourceMaterial.TerrainOverlay is null
-            ? new PlannedAlbedoMainTextureOverrideRendererMaterialBinding(materialIdentity, mainTexture)
-            : new PlannedTerrainMainTextureOverrideRendererMaterialBinding(materialIdentity, mainTexture);
+        if (sourceMaterial.TerrainOverlay is null)
+        {
+            return new PlannedAlbedoMainTextureOverrideRendererMaterialBinding(materialIdentity, mainTexture);
+        }
+
+        return new PlannedTerrainMainTextureOverrideRendererMaterialBinding(
+            materialIdentity,
+            mainTexture,
+            sourceMaterial.TerrainMeshCode is not null
+            && terrainTextureComponentsByMeshCode.TryGetValue(sourceMaterial.TerrainMeshCode, out ResoniteComponentLocator textureComponent)
+                ? textureComponent
+                : null);
     }
 
     private async Task EnsureSharedCommonMaterialsPreparedAsync(
@@ -2313,12 +2515,14 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         ResoniteTexturePayload? TexturePayload,
         ResoniteTextureSourceKind TextureSourceKind,
         ResoniteTextureImport TextureImport,
+        string? TerrainMeshCode = null,
         TerrainTextureOverlay? TerrainOverlay = null,
         GeneratedTerrainTexture? GeneratedTerrainTexture = null);
 
     private sealed record UploadedTextureAssetSet(
         Dictionary<ResoniteTexturePayload, Uri> TextureUrisByPayload,
         Dictionary<TerrainTextureOverlay, Uri> TerrainTextureUrisByOverlay,
+        Dictionary<string, ResoniteComponentLocator> TerrainTextureComponentsByMeshCode,
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> GeneratedTerrainTexturesByOverlay);
 
     private sealed class TexturePayloadReferenceComparer : IEqualityComparer<ResoniteTexturePayload>

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -1360,7 +1360,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         return uploadedTextureAssets;
     }
 
-    private async Task<UploadedTextureAssetSet> UploadPreparedTexturesAsync(
+    private static async Task<UploadedTextureAssetSet> UploadPreparedTexturesAsync(
         LiveSendRunState state,
         IResoniteLinkClient importClient,
         PreparedCityObject preparedCityObject,
@@ -1428,7 +1428,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             preparedTerrainTextureDataByOverlay);
     }
 
-    private Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetAsync(
+    private static Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetAsync(
         LiveSendRunState state,
         IResoniteLinkClient importClient,
         string meshCode,
@@ -1437,23 +1437,23 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
     {
         return state.TerrainTextures.AssetsByMeshCode.GetOrCreateAsync(
             meshCode,
-            () => EnsureSharedTerrainTextureAssetCoreAsync(importClient, state.Context.DatasetAssetsRootSlot, meshCode, textureImport, cancellationToken),
+            () => EnsureSharedTerrainTextureAssetCoreAsync(state, importClient, meshCode, textureImport, cancellationToken),
             cancellationToken);
     }
 
-    private async Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetCoreAsync(
+    private static async Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetCoreAsync(
+        LiveSendRunState state,
         IResoniteLinkClient importClient,
-        CreatedSlot datasetAssetsRootSlot,
         string meshCode,
         ResoniteTextureImport textureImport,
         CancellationToken cancellationToken)
     {
-        CreatedSlot terrainTexturesRoot = await EnsureTerrainTextureChildSlotAsync(
+        CreatedSlot terrainTexturesRoot = await state.Placement.GetOrCreateSharedChildSlotAsync(
             importClient,
-            datasetAssetsRootSlot.Locator,
+            state.Context.DatasetAssetsRootSlot.Locator,
             "Terrain Textures",
             cancellationToken);
-        CreatedSlot meshSlot = await EnsureTerrainTextureChildSlotAsync(
+        CreatedSlot meshSlot = await state.Placement.GetOrCreateSharedChildSlotAsync(
             importClient,
             terrainTexturesRoot.Locator,
             meshCode,
@@ -1464,7 +1464,20 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             cancellationToken);
         if (existingTexture is not null)
         {
-            return existingTexture;
+            Uri refreshedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
+            await importClient.UpdateComponentAsync(
+                new ResoniteComponentUpdate
+                {
+                    Component = new ResoniteTransportComponentLocator(existingTexture.TextureComponent.Locator.Value),
+                    Members = ResoniteSceneMaterialConventions.CreateTextureMembers(
+                        refreshedTextureUri,
+                        ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride),
+                },
+                cancellationToken);
+            return existingTexture with
+            {
+                TextureUri = refreshedTextureUri,
+            };
         }
 
         Uri importedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
@@ -1479,28 +1492,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         return new SharedTerrainTextureAsset(
             importedTextureUri,
             textureComponent);
-    }
-
-    private async Task<CreatedSlot> EnsureTerrainTextureChildSlotAsync(
-        IResoniteLinkClient client,
-        ResoniteSlotLocator parentSlot,
-        string childSlotName,
-        CancellationToken cancellationToken)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(childSlotName);
-
-        Slot? parentSlotSnapshot = await client.GetSlotAsync(
-            new ResoniteTransportSlotLocator(parentSlot.Value),
-            depth: 1,
-            cancellationToken);
-        ResoniteSceneChildLookupResult childLookup = new ResoniteSceneSlotSnapshot(parentSlotSnapshot)
-            .GetUniqueChildLookupResult(childSlotName, parentSlot.Value);
-        if (childLookup.State == ResoniteSceneChildLookupState.FoundWithId)
-        {
-            return new CreatedSlot(new ResoniteSlotLocator(childLookup.Slot!.ID!), childSlotName);
-        }
-
-        return await slotCreator.CreateAsync(client, parentSlot, childSlotName, null, null, cancellationToken);
     }
 
     private static async Task<SharedTerrainTextureAsset?> TryFindSharedTerrainTextureAssetAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -262,6 +262,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         LiveSendRunContext context = new(
             runPlan,
             bootstrapState.DatasetRootSlot,
+            bootstrapState.DatasetAssetsRootSlot,
             bootstrapState.CommonAssetsRootSlot,
             cityObjectBaker);
         LiveSendRunState state = new()
@@ -1436,20 +1437,20 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
     {
         return state.TerrainTextures.AssetsByMeshCode.GetOrCreateAsync(
             meshCode,
-            () => EnsureSharedTerrainTextureAssetCoreAsync(importClient, state.Context.DatasetRootSlot, meshCode, textureImport, cancellationToken),
+            () => EnsureSharedTerrainTextureAssetCoreAsync(importClient, state.Context.DatasetAssetsRootSlot, meshCode, textureImport, cancellationToken),
             cancellationToken);
     }
 
     private async Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetCoreAsync(
         IResoniteLinkClient importClient,
-        CreatedSlot datasetRootSlot,
+        CreatedSlot datasetAssetsRootSlot,
         string meshCode,
         ResoniteTextureImport textureImport,
         CancellationToken cancellationToken)
     {
         CreatedSlot terrainTexturesRoot = await EnsureTerrainTextureChildSlotAsync(
             importClient,
-            datasetRootSlot.Locator,
+            datasetAssetsRootSlot.Locator,
             "Terrain Textures",
             cancellationToken);
         CreatedSlot meshSlot = await EnsureTerrainTextureChildSlotAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -2034,15 +2034,42 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             bool preserveDedicatedMaterialSlot,
             CancellationToken ct)
         {
+            ResoniteMaterialBinding materialComponentSource = sourceMaterial.TerrainOverlay is null
+                ? sourceMaterial
+                : sourceMaterial with
+                {
+                    TerrainOverlay = null,
+                    TerrainMeshCode = null,
+                    TextureScale = null,
+                    TextureOffset = null,
+                };
             PlannedDedicatedMaterialAsset plannedMaterial = await materialPlanning.PlanDedicatedMaterialAssetAsync(
                 client,
-                sourceMaterial,
+                materialComponentSource,
                 materialIndex,
                 packageName,
                 preparedTextureUrisByPayload,
                 preparedTerrainTextureUrisByOverlay,
                 preserveDedicatedMaterialSlot,
                 ct);
+            if (sourceMaterial.TerrainOverlay is not null)
+            {
+                PlannedTextureAsset? mainTextureOverride = await ResoniteMaterialPlanning.PlanMainTextureOverrideAsync(
+                    sourceMaterial,
+                    preparedTextureUrisByPayload,
+                    preparedTerrainTextureUrisByOverlay);
+                if (mainTextureOverride is not null)
+                {
+                    return (
+                        plannedMaterial,
+                        CreateMainTextureOverrideRendererBinding(
+                            plannedMaterial.Identity,
+                            mainTextureOverride,
+                            preparedTerrainTextureComponentsByMeshCode,
+                            sourceMaterial));
+                }
+            }
+
             return (plannedMaterial, new PlannedDirectRendererMaterialBinding(plannedMaterial.Identity));
         }
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialBinding.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialBinding.cs
@@ -18,4 +18,5 @@ public sealed record ResoniteMaterialBinding(
     ResoniteFloat2? TextureOffset = null,
     ResoniteMaterialAssetScope AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped,
     TerrainTextureOverlay? TerrainOverlay = null,
-    int? BundledVariantIndex = null);
+    int? BundledVariantIndex = null,
+    string? TerrainMeshCode = null);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -75,7 +75,8 @@ internal sealed record PlannedAlbedoMainTextureOverrideRendererMaterialBinding(
 
 internal sealed record PlannedTerrainMainTextureOverrideRendererMaterialBinding(
     MaterialIdentity MaterialIdentity,
-    PlannedTextureAsset MainTexture)
+    PlannedTextureAsset MainTexture,
+    ResoniteComponentLocator? SharedMainTextureComponent = null)
     : PlannedMainTextureOverrideRendererMaterialBinding(MaterialIdentity, MainTexture);
 
 internal sealed record PlannedRenderer(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -263,6 +263,8 @@ internal static class ResoniteSceneMaterialConventions
             return normalizedSharedMaterial with
             {
                 SubmeshIndices = material.SubmeshIndices,
+                TerrainOverlay = material.TerrainOverlay,
+                TerrainMeshCode = material.TerrainMeshCode,
             };
         }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -216,6 +216,12 @@ internal static class ResoniteSceneMaterialConventions
             return false;
         }
 
+        if (material.TerrainOverlay is not null
+            && !HasValidTerrainTextureMeshCode(material))
+        {
+            return false;
+        }
+
         if (!string.IsNullOrWhiteSpace(material.Family))
         {
             return false;
@@ -631,6 +637,22 @@ internal static class ResoniteSceneMaterialConventions
             AssetScope = ResoniteMaterialAssetScope.Common,
             BundledVariantIndex = null,
         };
+    }
+
+    private static bool HasValidTerrainTextureMeshCode(ResoniteMaterialBinding material)
+    {
+        if (material.TerrainMeshCode is not { Length: 8 } meshCode
+            || material.TerrainOverlay is null
+            || !PlateauMeshCode.TryGetBounds(meshCode, out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds))
+        {
+            return false;
+        }
+
+        const double tolerance = 1e-8;
+        return Math.Abs(bounds.SouthLatitude - material.TerrainOverlay.GeographicBounds.MinLatitude) <= tolerance
+            && Math.Abs(bounds.NorthLatitude - material.TerrainOverlay.GeographicBounds.MaxLatitude) <= tolerance
+            && Math.Abs(bounds.WestLongitude - material.TerrainOverlay.GeographicBounds.MinLongitude) <= tolerance
+            && Math.Abs(bounds.EastLongitude - material.TerrainOverlay.GeographicBounds.MaxLongitude) <= tolerance;
     }
 
     private static ResoniteMaterialBinding NormalizeVertexColorSharedMaterialBinding(ResoniteMaterialBinding material)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -182,7 +182,6 @@ internal static class ResoniteSceneMaterialConventions
         }
 
         if (material.TexturePayload is null
-            && material.TerrainOverlay is null
             && !string.IsNullOrWhiteSpace(material.Family)
             && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
             && material.DepthOffset is null
@@ -194,7 +193,6 @@ internal static class ResoniteSceneMaterialConventions
             {
                 BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                 TexturePayload = null,
-                TerrainOverlay = null,
                 TextureSourceKind = ResoniteTextureSourceKind.Bundled,
                 AssetScope = ResoniteMaterialAssetScope.Common,
             };
@@ -626,7 +624,7 @@ internal static class ResoniteSceneMaterialConventions
                 material.DepthOffset),
             BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             TexturePayload = null,
-            TerrainOverlay = null,
+            TerrainOverlay = material.TerrainOverlay,
             TextureSourceKind = ResoniteTextureSourceKind.Dataset,
             TextureScale = normalizedTextureScale,
             TextureOffset = normalizedTextureOffset,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -216,19 +216,17 @@ internal static class ResoniteSceneMaterialConventions
             return false;
         }
 
-        if (material.TerrainOverlay is not null
-            && !HasValidTerrainTextureMeshCode(material))
-        {
-            return false;
-        }
-
         if (!string.IsNullOrWhiteSpace(material.Family))
         {
             return false;
         }
 
-        if (HasEffectiveGenericTextureTransform(material)
-            && material.TerrainOverlay is null)
+        if (material.TerrainOverlay is not null)
+        {
+            return false;
+        }
+
+        if (HasEffectiveGenericTextureTransform(material))
         {
             return false;
         }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -221,7 +221,7 @@ internal static class ResoniteSceneMaterialConventions
             return false;
         }
 
-        if (material.TerrainOverlay is not null)
+        if (material.TerrainOverlay is not null && !HasValidTerrainTextureMeshCode(material))
         {
             return false;
         }
@@ -258,8 +258,7 @@ internal static class ResoniteSceneMaterialConventions
         }
 
         if (TryNormalizeSharedMaterialBinding(material, out ResoniteMaterialBinding normalizedSharedMaterial, out _)
-            && material.TexturePayload is null
-            && material.TerrainOverlay is null)
+            && material.TexturePayload is null)
         {
             return normalizedSharedMaterial with
             {
@@ -391,8 +390,9 @@ internal static class ResoniteSceneMaterialConventions
             && material.Projection == ResoniteMaterialProjection.Uv
             && ResoniteMaterialSharing.IsWhiteBaseColor(material.BaseColor)
             && string.IsNullOrWhiteSpace(material.Family)
-            && material.TexturePayload is null
-            && material.TerrainOverlay is null;
+            && material.TextureSourceKind == ResoniteTextureSourceKind.Dataset
+            && (material.TerrainOverlay is null || HasValidTerrainTextureMeshCode(material))
+            && (material.TerrainOverlay is null || !HasEffectiveGenericTextureTransform(material));
     }
 
     private static string CreateCompactColorSuffix(ResoniteColor color)
@@ -628,12 +628,13 @@ internal static class ResoniteSceneMaterialConventions
                 material.DepthOffset),
             BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             TexturePayload = null,
-            TerrainOverlay = material.TerrainOverlay,
+            TerrainOverlay = null,
             TextureSourceKind = ResoniteTextureSourceKind.Dataset,
             TextureScale = normalizedTextureScale,
             TextureOffset = normalizedTextureOffset,
             AssetScope = ResoniteMaterialAssetScope.Common,
             BundledVariantIndex = null,
+            TerrainMeshCode = null,
         };
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -123,7 +123,11 @@ internal static class SceneImportContractMapper
             binding.TextureScale is null ? null : ToInternal(binding.TextureScale),
             binding.Family,
             binding.TextureOffset is null ? null : ToInternal(binding.TextureOffset),
-            binding.ReuseScope == MaterialReuseScope.Shared ? ResoniteMaterialAssetScope.Common : ResoniteMaterialAssetScope.PresentationSlotScoped,
+            binding.TerrainOverlay is not null
+                ? ResoniteMaterialAssetScope.PresentationSlotScoped
+                : binding.ReuseScope == MaterialReuseScope.Shared
+                    ? ResoniteMaterialAssetScope.Common
+                    : ResoniteMaterialAssetScope.PresentationSlotScoped,
             binding.TerrainOverlay,
             binding.BundledVariantIndex,
             binding.TerrainMeshCode);

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -123,11 +123,9 @@ internal static class SceneImportContractMapper
             binding.TextureScale is null ? null : ToInternal(binding.TextureScale),
             binding.Family,
             binding.TextureOffset is null ? null : ToInternal(binding.TextureOffset),
-            binding.TerrainOverlay is not null
-                ? ResoniteMaterialAssetScope.PresentationSlotScoped
-                : binding.ReuseScope == MaterialReuseScope.Shared
-                    ? ResoniteMaterialAssetScope.Common
-                    : ResoniteMaterialAssetScope.PresentationSlotScoped,
+            binding.ReuseScope == MaterialReuseScope.Shared
+                ? ResoniteMaterialAssetScope.Common
+                : ResoniteMaterialAssetScope.PresentationSlotScoped,
             binding.TerrainOverlay,
             binding.BundledVariantIndex,
             binding.TerrainMeshCode);

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -125,7 +125,8 @@ internal static class SceneImportContractMapper
             binding.TextureOffset is null ? null : ToInternal(binding.TextureOffset),
             binding.ReuseScope == MaterialReuseScope.Shared ? ResoniteMaterialAssetScope.Common : ResoniteMaterialAssetScope.PresentationSlotScoped,
             binding.TerrainOverlay,
-            binding.BundledVariantIndex);
+            binding.BundledVariantIndex,
+            binding.TerrainMeshCode);
     }
 
     private static ResoniteTexturePayload ToInternal(TexturePayload payload)

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -280,8 +280,8 @@ internal sealed class TerrainTextureAssetGenerator(
         }
 
         using Image<Rgba32> canvasImage = new(canvasWidth, canvasHeight, DefaultDemGroundFillColor);
-        int drawOffsetX = 0;
-        int drawOffsetY = canvasHeight - image.Height;
+        int drawOffsetX = (canvasWidth - image.Width) / 2;
+        int drawOffsetY = (canvasHeight - image.Height) / 2;
         canvasImage.Mutate(context => context.DrawImage(
             image,
             new Point(drawOffsetX, drawOffsetY),

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -81,13 +81,14 @@ internal sealed class TerrainTextureAssetGenerator(
         CancellationToken cancellationToken)
     {
         Image<Rgba32>? composedTexture = null;
+        TextureUvRect? composedOccupiedUvRect = null;
         List<TerrainTextureSource> usedSources = [];
         TerrainTextureSource? usedSource = null;
 
         for (int sourceIndex = 0; sourceIndex < terrainTextureOverlay.Sources.Count; sourceIndex++)
         {
             TerrainTextureSource source = terrainTextureOverlay.Sources[sourceIndex];
-            Image<Rgba32>? image = source switch
+            TerrainTextureSourceImage? sourceImage = source switch
             {
                 TerrainTextureTileSource tileSource => await TryCreateTextureFromTileSourceAsync(
                     terrainTextureOverlay,
@@ -99,13 +100,14 @@ internal sealed class TerrainTextureAssetGenerator(
                     cancellationToken),
                 _ => null,
             };
-            if (image is null)
+            if (sourceImage is null)
             {
                 continue;
             }
 
-            using (image)
+            using (sourceImage)
             {
+                Image<Rgba32> image = sourceImage.Image;
                 if (!HasRenderablePixels(image))
                 {
                     continue;
@@ -114,6 +116,7 @@ internal sealed class TerrainTextureAssetGenerator(
                 if (composedTexture is null)
                 {
                     composedTexture = image.Clone();
+                    composedOccupiedUvRect = sourceImage.OccupiedUvRect;
                     usedSource = source;
                     usedSources.Add(source);
                 }
@@ -146,12 +149,78 @@ internal sealed class TerrainTextureAssetGenerator(
                 composedTexture,
                 terrainTextureOverlay.MaxTextureSize,
                 terrainTextureSource,
-                usedSources);
+                usedSources,
+                composedOccupiedUvRect);
             return new CachedTerrainTexture(generatedTexture, terrainTextureSource);
         }
     }
 
-    private async Task<Image<Rgba32>?> TryCreateTextureFromTileSourceAsync(
+    private static ExpandedTileCrop CreateExpandedTileCrop(
+        TerrainTextureLayoutPlan layoutPlan,
+        int zoomLevel,
+        int maxTextureSize)
+    {
+        int canvasWidth = RoundUpToPowerOfTwo(layoutPlan.CropWidth);
+        int canvasHeight = RoundUpToPowerOfTwo(layoutPlan.CropHeight);
+        if (canvasWidth > maxTextureSize || canvasHeight > maxTextureSize)
+        {
+            return ExpandedTileCrop.FromLayout(layoutPlan);
+        }
+
+        int occupiedLeft = (canvasWidth - layoutPlan.CropWidth) / 2;
+        int occupiedTop = (canvasHeight - layoutPlan.CropHeight) / 2;
+        int layoutGlobalLeft = (layoutPlan.MinTileX * WebMercatorTileMath.TileSizePixels) + layoutPlan.CropLeft;
+        int layoutGlobalTop = (layoutPlan.MinTileY * WebMercatorTileMath.TileSizePixels) + layoutPlan.CropTop;
+        int expandedGlobalLeft = layoutGlobalLeft - occupiedLeft;
+        int expandedGlobalTop = layoutGlobalTop - occupiedTop;
+        int expandedGlobalRight = expandedGlobalLeft + canvasWidth;
+        int expandedGlobalBottom = expandedGlobalTop + canvasHeight;
+        int maxTileIndex = (1 << zoomLevel) - 1;
+        int minTileX = Math.Clamp((int)Math.Floor(expandedGlobalLeft / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
+        int maxTileX = Math.Clamp((int)Math.Floor((expandedGlobalRight - 1) / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
+        int minTileY = Math.Clamp((int)Math.Floor(expandedGlobalTop / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
+        int maxTileY = Math.Clamp((int)Math.Floor((expandedGlobalBottom - 1) / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
+        int stitchedWidth = (maxTileX - minTileX + 1) * WebMercatorTileMath.TileSizePixels;
+        int stitchedHeight = (maxTileY - minTileY + 1) * WebMercatorTileMath.TileSizePixels;
+        int cropLeft = Math.Clamp(expandedGlobalLeft - (minTileX * WebMercatorTileMath.TileSizePixels), 0, Math.Max(0, stitchedWidth - canvasWidth));
+        int cropTop = Math.Clamp(expandedGlobalTop - (minTileY * WebMercatorTileMath.TileSizePixels), 0, Math.Max(0, stitchedHeight - canvasHeight));
+        int actualCropWidth = Math.Min(canvasWidth, stitchedWidth - cropLeft);
+        int actualCropHeight = Math.Min(canvasHeight, stitchedHeight - cropTop);
+        if (actualCropWidth <= 0 || actualCropHeight <= 0)
+        {
+            return ExpandedTileCrop.FromLayout(layoutPlan);
+        }
+
+        int occupiedX = Math.Clamp(
+            layoutGlobalLeft - ((minTileX * WebMercatorTileMath.TileSizePixels) + cropLeft),
+            0,
+            actualCropWidth - 1);
+        int occupiedY = Math.Clamp(
+            layoutGlobalTop - ((minTileY * WebMercatorTileMath.TileSizePixels) + cropTop),
+            0,
+            actualCropHeight - 1);
+        TextureUvRect occupiedUvRect = TextureUvRect.FromTopLeftPixelRect(
+            occupiedX,
+            occupiedY,
+            Math.Min(layoutPlan.CropWidth, actualCropWidth - occupiedX),
+            Math.Min(layoutPlan.CropHeight, actualCropHeight - occupiedY),
+            actualCropWidth,
+            actualCropHeight);
+        return new ExpandedTileCrop(
+            minTileX,
+            maxTileX,
+            minTileY,
+            maxTileY,
+            stitchedWidth,
+            stitchedHeight,
+            cropLeft,
+            cropTop,
+            actualCropWidth,
+            actualCropHeight,
+            occupiedUvRect);
+    }
+
+    private async Task<TerrainTextureSourceImage?> TryCreateTextureFromTileSourceAsync(
         TerrainTextureOverlay terrainTextureOverlay,
         TerrainTextureTileSource tileSource,
         CancellationToken cancellationToken)
@@ -159,11 +228,12 @@ internal sealed class TerrainTextureAssetGenerator(
         TerrainTextureLayoutPlan layoutPlan = TerrainTextureLayoutPlanner.Create(
             terrainTextureOverlay.GeographicBounds,
             tileSource.ZoomLevel);
-        using Image<Rgba32> stitchedImage = new(layoutPlan.StitchedWidth, layoutPlan.StitchedHeight);
+        ExpandedTileCrop tileCrop = CreateExpandedTileCrop(layoutPlan, tileSource.ZoomLevel, terrainTextureOverlay.MaxTextureSize);
+        using Image<Rgba32> stitchedImage = new(tileCrop.StitchedWidth, tileCrop.StitchedHeight);
         bool anyTileRendered = false;
-        for (int tileY = layoutPlan.MinTileY; tileY <= layoutPlan.MaxTileY; tileY++)
+        for (int tileY = tileCrop.MinTileY; tileY <= tileCrop.MaxTileY; tileY++)
         {
-            for (int tileX = layoutPlan.MinTileX; tileX <= layoutPlan.MaxTileX; tileX++)
+            for (int tileX = tileCrop.MinTileX; tileX <= tileCrop.MaxTileX; tileX++)
             {
                 Image<Rgba32>? tileImage = await TryDownloadTileAsync(
                     tileSource,
@@ -181,8 +251,8 @@ internal sealed class TerrainTextureAssetGenerator(
                     stitchedImage.Mutate(context => context.DrawImage(
                         tileImage,
                         new Point(
-                            (tileX - layoutPlan.MinTileX) * WebMercatorTileMath.TileSizePixels,
-                            (tileY - layoutPlan.MinTileY) * WebMercatorTileMath.TileSizePixels),
+                            (tileX - tileCrop.MinTileX) * WebMercatorTileMath.TileSizePixels,
+                            (tileY - tileCrop.MinTileY) * WebMercatorTileMath.TileSizePixels),
                         1.0f));
                 }
             }
@@ -193,14 +263,20 @@ internal sealed class TerrainTextureAssetGenerator(
             return null;
         }
 
-        return stitchedImage.Clone(context => context.Crop(new Rectangle(
-            layoutPlan.CropLeft,
-            layoutPlan.CropTop,
-            layoutPlan.CropWidth,
-            layoutPlan.CropHeight)));
+        return new TerrainTextureSourceImage(
+            stitchedImage.Clone(context => context.Crop(new Rectangle(
+                tileCrop.CropLeft,
+                tileCrop.CropTop,
+                tileCrop.CropWidth,
+                tileCrop.CropHeight))),
+            tileCrop.OccupiedUvRect);
     }
 
-    private static async Task<Image<Rgba32>?> TryCreateTextureFromGeoReferencedRasterSourceAsync(
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "The returned source image owns and disposes the cropped raster image.")]
+    private static async Task<TerrainTextureSourceImage?> TryCreateTextureFromGeoReferencedRasterSourceAsync(
         TerrainTextureOverlay terrainTextureOverlay,
         TerrainTextureGeoReferencedRasterSource rasterSource,
         CancellationToken cancellationToken)
@@ -216,10 +292,13 @@ internal sealed class TerrainTextureAssetGenerator(
         try
         {
             using Image<Rgba32> sourceImage = await Image.LoadAsync<Rgba32>(sourcePath, cancellationToken);
-            return TerrainTextureGeoReferencedRasterCropper.TryCrop(
+            Image<Rgba32>? cropped = TerrainTextureGeoReferencedRasterCropper.TryCrop(
                 sourceImage,
                 metadata,
                 terrainTextureOverlay.GeographicBounds);
+            return cropped is null
+                ? null
+                : new TerrainTextureSourceImage(cropped, null);
         }
         catch (UnknownImageFormatException)
         {
@@ -243,19 +322,20 @@ internal sealed class TerrainTextureAssetGenerator(
         Image<Rgba32> image,
         int maxTextureSize,
         TerrainTextureSource usedSource,
-        List<TerrainTextureSource> usedSources)
+        List<TerrainTextureSource> usedSources,
+        TextureUvRect? sourceOccupiedUvRect)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxTextureSize);
         using Image<Rgba32> opaqueImage = CreateOpaqueGroundImage(image);
 
-        if (TryCreatePowerOfTwoCanvasTexture(opaqueImage, maxTextureSize, usedSource, usedSources, out GeneratedTerrainTexture? generatedTexture))
+        if (TryCreatePowerOfTwoCanvasTexture(opaqueImage, maxTextureSize, usedSource, usedSources, sourceOccupiedUvRect, out GeneratedTerrainTexture? generatedTexture))
         {
             return generatedTexture!;
         }
 
         int fallbackMaxTextureSize = RoundDownToPowerOfTwo(maxTextureSize);
         using Image<Rgba32> resizedImage = ResizeToMaxTextureSize(opaqueImage, fallbackMaxTextureSize);
-        if (TryCreatePowerOfTwoCanvasTexture(resizedImage, fallbackMaxTextureSize, usedSource, usedSources, out generatedTexture))
+        if (TryCreatePowerOfTwoCanvasTexture(resizedImage, fallbackMaxTextureSize, usedSource, usedSources, null, out generatedTexture))
         {
             return generatedTexture!;
         }
@@ -269,6 +349,7 @@ internal sealed class TerrainTextureAssetGenerator(
         int maxTextureSize,
         TerrainTextureSource usedSource,
         IReadOnlyList<TerrainTextureSource> usedSources,
+        TextureUvRect? sourceOccupiedUvRect,
         out GeneratedTerrainTexture? generatedTexture)
     {
         int canvasWidth = RoundUpToPowerOfTwo(image.Width);
@@ -286,19 +367,46 @@ internal sealed class TerrainTextureAssetGenerator(
             image,
             new Point(drawOffsetX, drawOffsetY),
             1.0f));
-        TextureUvRect occupiedUvRect = TextureUvRect.FromTopLeftPixelRect(
-            drawOffsetX,
-            drawOffsetY,
-            image.Width,
-            image.Height,
-            canvasWidth,
-            canvasHeight);
+        TextureUvRect occupiedUvRect = sourceOccupiedUvRect is { } sourceRect
+            ? CreateOccupiedUvRect(
+                (int)Math.Round(drawOffsetX + (sourceRect.MinU * image.Width), MidpointRounding.AwayFromZero),
+                (int)Math.Round(drawOffsetY + ((1.0 - sourceRect.MaxV) * image.Height), MidpointRounding.AwayFromZero),
+                (int)Math.Round(sourceRect.Width * image.Width, MidpointRounding.AwayFromZero),
+                (int)Math.Round(sourceRect.Height * image.Height, MidpointRounding.AwayFromZero),
+                canvasWidth,
+                canvasHeight)
+            : TextureUvRect.FromTopLeftPixelRect(
+                drawOffsetX,
+                drawOffsetY,
+                image.Width,
+                image.Height,
+                canvasWidth,
+                canvasHeight);
         generatedTexture = new GeneratedTerrainTexture(
             CreateRawTextureImport(canvasImage),
             occupiedUvRect,
             usedSource,
             usedSources.Distinct().ToArray());
         return true;
+    }
+
+    private static TextureUvRect CreateOccupiedUvRect(
+        int x,
+        int y,
+        int width,
+        int height,
+        int canvasWidth,
+        int canvasHeight)
+    {
+        int clampedX = Math.Clamp(x, 0, canvasWidth - 1);
+        int clampedY = Math.Clamp(y, 0, canvasHeight - 1);
+        return TextureUvRect.FromTopLeftPixelRect(
+            clampedX,
+            clampedY,
+            Math.Min(width, canvasWidth - clampedX),
+            Math.Min(height, canvasHeight - clampedY),
+            canvasWidth,
+            canvasHeight);
     }
 
     private static Image<Rgba32> CreateOpaqueGroundImage(Image<Rgba32> image)
@@ -568,6 +676,46 @@ internal sealed class TerrainTextureAssetGenerator(
     private sealed record CachedTerrainTexture(
         GeneratedTerrainTexture GeneratedTexture,
         TerrainTextureSource UsedSource);
+
+    private sealed record TerrainTextureSourceImage(
+        Image<Rgba32> Image,
+        TextureUvRect? OccupiedUvRect) : IDisposable
+    {
+        public void Dispose()
+        {
+            Image.Dispose();
+        }
+    }
+
+    private sealed record ExpandedTileCrop(
+        int MinTileX,
+        int MaxTileX,
+        int MinTileY,
+        int MaxTileY,
+        int StitchedWidth,
+        int StitchedHeight,
+        int CropLeft,
+        int CropTop,
+        int CropWidth,
+        int CropHeight,
+        TextureUvRect? OccupiedUvRect)
+    {
+        public static ExpandedTileCrop FromLayout(TerrainTextureLayoutPlan layoutPlan)
+        {
+            return new ExpandedTileCrop(
+                layoutPlan.MinTileX,
+                layoutPlan.MaxTileX,
+                layoutPlan.MinTileY,
+                layoutPlan.MaxTileY,
+                layoutPlan.StitchedWidth,
+                layoutPlan.StitchedHeight,
+                layoutPlan.CropLeft,
+                layoutPlan.CropTop,
+                layoutPlan.CropWidth,
+                layoutPlan.CropHeight,
+                null);
+        }
+    }
 
     private static bool IsTransientStatusCode(int statusCode)
     {

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -366,7 +366,7 @@ public sealed class LocalCityGmlObjectProjectionTests
         MaterialBinding material = Assert.Single(projected.Materials);
         Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
         Assert.Equal(MaterialProjection.Uv, material.Projection);
-        Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
+        Assert.Equal(MaterialReuseScope.PerObject, material.ReuseScope);
         Assert.Null(material.Family);
         Assert.Null(material.TexturePayload);
         Assert.Same(overlay, material.TerrainOverlay);
@@ -502,7 +502,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public void ProjectCityObjectUsesSharedAlbedoOnlyMaterialForTexturelessDemTerrainRoofs()
+    public void ProjectCityObjectUsesDedicatedAlbedoOnlyMaterialForTexturelessDemTerrainRoofs()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
@@ -531,10 +531,10 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         MaterialBinding material = Assert.Single(projected.Materials);
         Assert.Equal(new ColorRgba(1.0, 1.0, 1.0, 1.0), material.BaseColor);
-        Assert.Equal("shared-generic-uv-scale-none-offset-none-depth-none", material.MaterialKey);
+        Assert.Equal("material-standard-uv-terrain-none-texture-none-source-dataset-family-none-depth-none-scale-none-offset-none-color-1-1-1-1", material.MaterialKey);
         Assert.DoesNotContain("terrain-shared", material.MaterialKey, StringComparison.Ordinal);
         Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
-        Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
+        Assert.Equal(MaterialReuseScope.PerObject, material.ReuseScope);
         Assert.Same(overlay, material.TerrainOverlay);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -411,6 +411,44 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
+    public void ProjectParsedCityObjectChoosesOverlappingThirdMeshOverlayForParentMeshBuildingRoof()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay unrelatedFirstOverlay = CreateThirdMeshOverlay("53394525");
+        TerrainTextureOverlay expectedOverlay = CreateThirdMeshOverlay("53394526");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394526", altitudeMeters: 8.0);
+        BootstrapParsedSurface roofSurface = CreateBootstrapParsedSurface(
+            "textureless-parent-roof",
+            BootstrapParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394526", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [roofSurface], referenceSystem) with
+        {
+            ActualMeshCode = "533945",
+        };
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "533945",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "/tmp/plateau",
+            ServerUri: null);
+
+        ImportedCityObject projected = Assert.Single(LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            globalCartesian: null,
+            demTerrainTextureOverlays: [unrelatedFirstOverlay, expectedOverlay],
+            requestedMeshAreas: [MeshCodeBounds.TryParse("533945")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver()));
+
+        MaterialBinding material = Assert.Single(projected.Materials);
+        Assert.Same(expectedOverlay, material.TerrainOverlay);
+        Assert.Equal("53394526", material.TerrainMeshCode);
+    }
+
+    [Fact]
     public void ProjectParsedCityObjectFailsExplicitlyForNonThirdMeshDemOverlay()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -366,7 +366,7 @@ public sealed class LocalCityGmlObjectProjectionTests
         MaterialBinding material = Assert.Single(projected.Materials);
         Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
         Assert.Equal(MaterialProjection.Uv, material.Projection);
-        Assert.Equal(MaterialReuseScope.PerObject, material.ReuseScope);
+        Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
         Assert.Null(material.Family);
         Assert.Null(material.TexturePayload);
         Assert.Same(overlay, material.TerrainOverlay);
@@ -502,7 +502,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public void ProjectCityObjectUsesDedicatedAlbedoOnlyMaterialForTexturelessDemTerrainRoofs()
+    public void ProjectCityObjectUsesSharedAlbedoOnlyMaterialForTexturelessDemTerrainRoofs()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
@@ -534,7 +534,7 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.Equal("material-standard-uv-terrain-none-texture-none-source-dataset-family-none-depth-none-scale-none-offset-none-color-1-1-1-1", material.MaterialKey);
         Assert.DoesNotContain("terrain-shared", material.MaterialKey, StringComparison.Ordinal);
         Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
-        Assert.Equal(MaterialReuseScope.PerObject, material.ReuseScope);
+        Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
         Assert.Same(overlay, material.TerrainOverlay);
     }
 
@@ -730,7 +730,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         MaterialBinding material = Assert.Single(projected.Materials);
         Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
-        Assert.Equal(MaterialReuseScope.PerObject, material.ReuseScope);
+        Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
         Assert.Null(material.Family);
         Assert.Null(material.TexturePayload);
         Assert.Same(overlay, material.TerrainOverlay);

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -376,6 +376,33 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
+    public void ProjectCityObjectDoesNotUseDemTerrainMaterialWhenOverlayBoundsDoNotMatchThirdMesh()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay mismatchedOverlay = CreateThirdMeshOverlay("53394526");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394525", altitudeMeters: 8.0);
+        GeographicLib.LocalCartesian cartesian = new(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric);
+        BootstrapParsedSurface roofSurface = CreateBootstrapParsedSurface(
+            "mismatched-overlay-roof",
+            BootstrapParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [roofSurface], referenceSystem);
+
+        ImportedCityObject projected = LocalCityGmlObjectProjection.ProjectCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            globalCartesian: cartesian,
+            demTerrainTextureOverlay: mismatchedOverlay,
+            materialResolver: new DefaultMaterialResolver());
+
+        MaterialBinding material = Assert.Single(projected.Materials);
+        Assert.Null(material.TerrainOverlay);
+        Assert.Null(material.TerrainMeshCode);
+        Assert.NotEqual(TextureSourceKind.Dataset, material.TextureSourceKind);
+    }
+
+    [Fact]
     public void ProjectCityObjectAssignsDemTerrainMaterialToTexturelessUnknownUpwardHorizontalBuildingSurface()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
@@ -1213,7 +1240,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             static cityObject =>
             {
                 TerrainGridGeometry geometry = Assert.IsType<TerrainGridGeometry>(cityObject.Geometry);
-                Assert.Equal("533945", cityObject.ActualMeshCode);
+                Assert.Equal("53394525", cityObject.ActualMeshCode);
                 Assert.True(geometry.Width > 0);
                 Assert.True(geometry.Height > 0);
             });
@@ -1584,7 +1611,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
     private static void CreateRuntimeParentMeshDemFixture(string datasetRoot, string requestedMeshCode, string adjacentMeshCode)
     {
-        string packageDirectory = Path.Combine(datasetRoot, "udx", "dem", requestedMeshCode[..6]);
+        string packageDirectory = Path.Combine(datasetRoot, "udx", "dem", requestedMeshCode);
         Directory.CreateDirectory(packageDirectory);
 
         (double requestedSouth, double requestedNorth, double requestedWest, double requestedEast) = GetMeshBounds(requestedMeshCode);
@@ -1649,12 +1676,12 @@ public sealed class LocalCityGmlObjectProjectionTests
             </core:CityModel>
             """;
 
-        File.WriteAllText(Path.Combine(packageDirectory, $"plateau_tokyo23ku_dem_{requestedMeshCode[..6]}_parent.gml"), xml);
+        File.WriteAllText(Path.Combine(packageDirectory, $"plateau_tokyo23ku_dem_{requestedMeshCode}_parent.gml"), xml);
     }
 
     private static void CreateRuntimeNamedParentMeshDemFixture(string datasetRoot, string requestedMeshCode, string adjacentMeshCode)
     {
-        string packageDirectory = Path.Combine(datasetRoot, "udx", "dem", requestedMeshCode[..6]);
+        string packageDirectory = Path.Combine(datasetRoot, "udx", "dem", requestedMeshCode);
         Directory.CreateDirectory(packageDirectory);
 
         (double requestedSouth, double requestedNorth, double requestedWest, double requestedEast) = GetMeshBounds(requestedMeshCode);
@@ -1736,7 +1763,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             </core:CityModel>
             """;
 
-        File.WriteAllText(Path.Combine(packageDirectory, $"plateau_tokyo23ku_dem_{requestedMeshCode[..6]}_named-parent.gml"), xml);
+        File.WriteAllText(Path.Combine(packageDirectory, $"plateau_tokyo23ku_dem_{requestedMeshCode}_named-parent.gml"), xml);
     }
 
     private static (double South, double North, double West, double East) GetMeshBounds(string meshCode)

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -449,6 +449,114 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
+    public void ProjectParsedCityObjectSplitsParentMeshBuildingRoofsByThirdMeshOverlay()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay firstOverlay = CreateThirdMeshOverlay("53394525");
+        TerrainTextureOverlay secondOverlay = CreateThirdMeshOverlay("53394526");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394525", altitudeMeters: 8.0);
+        BootstrapParsedSurface firstRoofSurface = CreateBootstrapParsedSurface(
+            "textureless-parent-roof-first",
+            BootstrapParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        BootstrapParsedSurface secondRoofSurface = CreateBootstrapParsedSurface(
+            "textureless-parent-roof-second",
+            BootstrapParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394526", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [firstRoofSurface, secondRoofSurface], referenceSystem) with
+        {
+            ActualMeshCode = "533945",
+        };
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "533945",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "/tmp/plateau",
+            ServerUri: null);
+
+        ImportedCityObject[] projected = LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            globalCartesian: null,
+            demTerrainTextureOverlays: [firstOverlay, secondOverlay],
+            requestedMeshAreas: [MeshCodeBounds.TryParse("533945")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver()).ToArray();
+
+        Assert.Equal(2, projected.Length);
+        Assert.Collection(
+            projected.OrderBy(static cityObject => cityObject.Materials.Single().TerrainMeshCode, StringComparer.Ordinal),
+            first =>
+            {
+                MaterialBinding material = Assert.Single(first.Materials);
+                Assert.Same(firstOverlay, material.TerrainOverlay);
+                Assert.Equal("53394525", material.TerrainMeshCode);
+            },
+            second =>
+            {
+                MaterialBinding material = Assert.Single(second.Materials);
+                Assert.Same(secondOverlay, material.TerrainOverlay);
+                Assert.Equal("53394526", material.TerrainMeshCode);
+            });
+    }
+
+    [Fact]
+    public void EnumerateCommonMaterialsForParsedCityObjectSplitsParentMeshBuildingRoofsByThirdMeshOverlay()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay firstOverlay = CreateThirdMeshOverlay("53394525");
+        TerrainTextureOverlay secondOverlay = CreateThirdMeshOverlay("53394526");
+        BootstrapParsedSurface firstRoofSurface = CreateBootstrapParsedSurface(
+            "textureless-parent-common-roof-first",
+            BootstrapParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        BootstrapParsedSurface secondRoofSurface = CreateBootstrapParsedSurface(
+            "textureless-parent-common-roof-second",
+            BootstrapParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394526", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [firstRoofSurface, secondRoofSurface], referenceSystem) with
+        {
+            ActualMeshCode = "533945",
+        };
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "533945",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "/tmp/plateau",
+            ServerUri: null);
+
+        MaterialBinding[] materialBindings = LocalCityGmlObjectProjection.EnumerateCommonMaterialsForParsedCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(CreateMeshCenterPoint("53394525", altitudeMeters: 8.0)),
+            globalCartesian: null,
+            demTerrainTextureOverlays: [firstOverlay, secondOverlay],
+            requestedMeshAreas: [MeshCodeBounds.TryParse("533945")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver()).ToArray();
+
+        Assert.Collection(
+            materialBindings.OrderBy(static material => material.TerrainMeshCode, StringComparer.Ordinal),
+            first =>
+            {
+                Assert.Same(firstOverlay, first.TerrainOverlay);
+                Assert.Equal("53394525", first.TerrainMeshCode);
+                Assert.Equal(TextureSourceKind.Dataset, first.TextureSourceKind);
+            },
+            second =>
+            {
+                Assert.Same(secondOverlay, second.TerrainOverlay);
+                Assert.Equal("53394526", second.TerrainMeshCode);
+                Assert.Equal(TextureSourceKind.Dataset, second.TextureSourceKind);
+            });
+    }
+
+    [Fact]
     public void ProjectParsedCityObjectFailsExplicitlyForNonThirdMeshDemOverlay()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
@@ -820,6 +928,41 @@ public sealed class LocalCityGmlObjectProjectionTests
             globalCartesian: cartesian,
             demTerrainTextureOverlay: overlay,
             materialResolver: new DefaultMaterialResolver());
+
+        Assert.Contains(projected.Mesh.Vertices, static vertex => vertex.UV0.X < 0.0);
+        Assert.Contains(projected.Mesh.Vertices, static vertex => vertex.UV0.X > 1.0);
+        Assert.Contains(projected.Mesh.Vertices, static vertex => vertex.UV0.Y < 0.0);
+        Assert.Contains(projected.Mesh.Vertices, static vertex => vertex.UV0.Y > 1.0);
+    }
+
+    [Fact]
+    public void ProjectParsedCityObjectKeepsSingleOverlayRoofDemHorizontalUvOutsideThirdMeshUnclamped()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394525", altitudeMeters: 8.0);
+        BootstrapParsedSurface roofSurface = CreateBootstrapParsedSurface(
+            "outside-parsed-roof",
+            BootstrapParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: -0.05, maxRatio: 1.05, reverseWinding: true),
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [roofSurface], referenceSystem);
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "/tmp/plateau",
+            ServerUri: null);
+
+        ImportedCityObject projected = Assert.Single(LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            globalCartesian: null,
+            demTerrainTextureOverlays: [overlay],
+            requestedMeshAreas: [MeshCodeBounds.TryParse("53394525")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver()));
 
         Assert.Contains(projected.Mesh.Vertices, static vertex => vertex.UV0.X < 0.0);
         Assert.Contains(projected.Mesh.Vertices, static vertex => vertex.UV0.X > 1.0);

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -577,7 +577,12 @@ public sealed class LocalCityGmlObjectProjectionTests
             BootstrapParsedSurfaceSemantic.Unknown,
             CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
             texturePayload: null);
-        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [unknownSurface], referenceSystem);
+        BootstrapParsedSurface bottomSurface = CreateBootstrapParsedSurface(
+            "unknown-horizontal-bottom",
+            BootstrapParsedSurfaceSemantic.Unknown,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 0.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: false),
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [bottomSurface, unknownSurface], referenceSystem);
 
         ImportedCityObject projected = LocalCityGmlObjectProjection.ProjectCityObject(
             cityObject,
@@ -591,6 +596,145 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.Null(material.Family);
         Assert.Null(material.TexturePayload);
         Assert.Same(overlay, material.TerrainOverlay);
+    }
+
+    [Fact]
+    public void ProjectCityObjectAssignsDemTerrainMaterialToTexturelessUnknownHorizontalBuildingSurfaceRegardlessOfWinding()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394525", altitudeMeters: 8.0);
+        GeographicLib.LocalCartesian cartesian = new(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric);
+        BootstrapParsedSurface unknownSurface = CreateBootstrapParsedSurface(
+            "unknown-horizontal-roof-source-winding",
+            BootstrapParsedSurfaceSemantic.Unknown,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: false),
+            texturePayload: null);
+        BootstrapParsedSurface bottomSurface = CreateBootstrapParsedSurface(
+            "unknown-horizontal-bottom",
+            BootstrapParsedSurfaceSemantic.Unknown,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 0.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [bottomSurface, unknownSurface], referenceSystem);
+
+        ImportedCityObject projected = LocalCityGmlObjectProjection.ProjectCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            globalCartesian: cartesian,
+            demTerrainTextureOverlay: overlay,
+            materialResolver: new DefaultMaterialResolver());
+
+        MaterialBinding material = Assert.Single(projected.Materials);
+        Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
+        Assert.Null(material.Family);
+        Assert.Null(material.TexturePayload);
+        Assert.Same(overlay, material.TerrainOverlay);
+    }
+
+    [Fact]
+    public void ProjectCityObjectDoesNotAssignDemTerrainMaterialToTexturelessUnknownHorizontalSurfaceAtBuildingBottom()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394525", altitudeMeters: 8.0);
+        GeographicLib.LocalCartesian cartesian = new(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric);
+        BootstrapParsedSurface lowerHorizontalSurface = CreateBootstrapParsedSurface(
+            "unknown-horizontal-lower-surface",
+            BootstrapParsedSurfaceSemantic.Unknown,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: false),
+            texturePayload: null);
+        BootstrapParsedSurface wallSurface = CreateBootstrapParsedSurface(
+            "building-wall-reaching-higher-altitude",
+            BootstrapParsedSurfaceSemantic.Wall,
+            CreateVerticalQuadVertices(origin, widthMeters: 5.0, heightMeters: 2.0),
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [lowerHorizontalSurface, wallSurface], referenceSystem);
+
+        ImportedCityObject projected = LocalCityGmlObjectProjection.ProjectCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            globalCartesian: cartesian,
+            demTerrainTextureOverlay: overlay,
+            materialResolver: new DefaultMaterialResolver());
+
+        Assert.DoesNotContain(projected.Materials, static material => material.TerrainOverlay is not null);
+    }
+
+    [Fact]
+    public void ProjectCityObjectAssignsDemTerrainMaterialToTexturelessUnknownRoofBelowHigherBuildingDetail()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394525", altitudeMeters: 0.0);
+        GeographicLib.LocalCartesian cartesian = new(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric);
+        BootstrapParsedSurface mainRoofSurface = CreateBootstrapParsedSurface(
+            "unknown-horizontal-main-roof",
+            BootstrapParsedSurfaceSemantic.Unknown,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 20.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: false),
+            texturePayload: null);
+        BootstrapParsedSurface higherDetailSurface = CreateBootstrapParsedSurface(
+            "building-detail-reaching-higher-altitude",
+            BootstrapParsedSurfaceSemantic.Wall,
+            CreateVerticalQuadVertices(new(origin.Latitude, origin.Longitude, origin.Altitude), widthMeters: 5.0, heightMeters: 20.2),
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject(
+            "bldg",
+            [mainRoofSurface, higherDetailSurface],
+            referenceSystem);
+
+        ImportedCityObject projected = LocalCityGmlObjectProjection.ProjectCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            globalCartesian: cartesian,
+            demTerrainTextureOverlay: overlay,
+            materialResolver: new DefaultMaterialResolver());
+
+        MaterialBinding roofMaterial = Assert.Single(
+            projected.Materials,
+            static material => material.TerrainOverlay is not null);
+        Assert.Same(overlay, roofMaterial.TerrainOverlay);
+    }
+
+    [Fact]
+    public void ProjectCityObjectAssignsDemTerrainMaterialToMatsumotoLod1SolidTopWinding()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("54372778");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = new(36.23163715441054, 137.97501759714283, 590.343);
+        GeographicLib.LocalCartesian cartesian = new(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric);
+        BootstrapParsedSurface bottomSurface = CreateBootstrapParsedSurface(
+            "matsumoto-lod1-solid-bottom",
+            BootstrapParsedSurfaceSemantic.Unknown,
+            CreateMatsumotoLod1SolidHorizontalRing(altitudeMeters: 590.343),
+            texturePayload: null);
+        BootstrapParsedSurface topSurface = CreateBootstrapParsedSurface(
+            "matsumoto-lod1-solid-top",
+            BootstrapParsedSurfaceSemantic.Unknown,
+            CreateMatsumotoLod1SolidHorizontalRing(altitudeMeters: 595.009),
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject =
+            CreateBootstrapParsedCityObject(
+                "bldg",
+                [bottomSurface, topSurface],
+                referenceSystem) with
+            {
+                ActualMeshCode = "54372778",
+            };
+
+        ImportedCityObject projected = LocalCityGmlObjectProjection.ProjectCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            globalCartesian: cartesian,
+            demTerrainTextureOverlay: overlay,
+            materialResolver: new DefaultMaterialResolver());
+
+        MaterialBinding material = Assert.Single(projected.Materials);
+        Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
+        Assert.Equal(MaterialReuseScope.PerObject, material.ReuseScope);
+        Assert.Null(material.Family);
+        Assert.Null(material.TexturePayload);
+        Assert.Same(overlay, material.TerrainOverlay);
+        Assert.Equal("54372778", material.TerrainMeshCode);
     }
 
     [Fact]
@@ -2208,6 +2352,24 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         vertices.Add(vertices[0]);
         return vertices;
+    }
+
+    private static IReadOnlyList<LocalCityGmlObjectProjection.GeodeticPoint> CreateMatsumotoLod1SolidHorizontalRing(
+        double altitudeMeters)
+    {
+        return
+        [
+            new(36.231592650728494, 137.97499237251273, altitudeMeters),
+            new(36.231590994539204, 137.97504154730566, altitudeMeters),
+            new(36.23162464596417, 137.97504328807037, altitudeMeters),
+            new(36.23162469728465, 137.9750418382012, altitudeMeters),
+            new(36.23168179137365, 137.97505169002244, altitudeMeters),
+            new(36.231683315279405, 137.97498571800617, altitudeMeters),
+            new(36.23165163047712, 137.97498460155376, altitudeMeters),
+            new(36.231620443262884, 137.97498350402472, altitudeMeters),
+            new(36.231620204515266, 137.97499379469681, altitudeMeters),
+            new(36.231592650728494, 137.97499237251273, altitudeMeters),
+        ];
     }
 
     private static LocalCityGmlObjectProjection.GeodeticPoint CreateMeshCenterPoint(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -376,7 +376,133 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public void ProjectCityObjectKeepsDifferentRoofDemBaseColorsInSeparateTerrainMaterials()
+    public void ProjectParsedCityObjectPassesMatchingDemOverlayToTexturelessBuildingRoof()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394525", altitudeMeters: 8.0);
+        BootstrapParsedSurface roofSurface = CreateBootstrapParsedSurface(
+            "textureless-roof",
+            BootstrapParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [roofSurface], referenceSystem);
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "/tmp/plateau",
+            ServerUri: null);
+
+        ImportedCityObject projected = Assert.Single(LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            globalCartesian: null,
+            demTerrainTextureOverlays: [overlay],
+            requestedMeshAreas: [MeshCodeBounds.TryParse("53394525")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver()));
+
+        MaterialBinding material = Assert.Single(projected.Materials);
+        Assert.Same(overlay, material.TerrainOverlay);
+        Assert.Equal("53394525", material.TerrainMeshCode);
+        Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
+    }
+
+    [Fact]
+    public void ProjectParsedCityObjectFailsExplicitlyForNonThirdMeshDemOverlay()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        IReadOnlyList<LocalCityGmlObjectProjection.GeodeticPoint> vertices =
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true);
+        GeographicRectangle nonThirdMeshBounds = new(
+            vertices.Min(static vertex => vertex.Latitude),
+            vertices.Max(static vertex => vertex.Latitude),
+            vertices.Min(static vertex => vertex.Longitude),
+            vertices.Max(static vertex => vertex.Longitude));
+        TerrainTextureOverlay overlay = new(
+            PackageName: "dem",
+            UrlTemplate: "https://terrain.example/non-third/{z}/{x}/{y}.png",
+            ZoomLevel: 17,
+            GeographicBounds: nonThirdMeshBounds,
+            MaxTextureSize: 512);
+        BootstrapParsedSurface demSurface = new(
+            PolygonId: "non-third-dem",
+            Semantic: BootstrapParsedSurfaceSemantic.Ground,
+            ExteriorRing: new BootstrapParsedRing("non-third-dem-ring", vertices.Select(GeodeticPoint.FromLegacy).ToArray(), UVs: null),
+            InteriorRings: [],
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null,
+            UsesGeneratedDemTexture: true);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("dem", [demSurface], referenceSystem);
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "/tmp/plateau",
+            ServerUri: null);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            LocalCityGmlObjectProjection.ProjectParsedCityObject(
+                cityObject,
+                GeodeticPoint.FromLegacy(CreateMeshCenterPoint("53394525", altitudeMeters: 8.0)),
+                globalCartesian: null,
+                demTerrainTextureOverlays: [overlay],
+                requestedMeshAreas: [MeshCodeBounds.TryParse("53394525")!],
+                terrainHeightSampler: null,
+                request,
+                new DefaultMaterialResolver()).ToArray());
+
+        Assert.Contains("third-level mesh code", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProjectParsedCityObjectFailsExplicitlyForNonThirdMeshBuildingOverlay()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        IReadOnlyList<LocalCityGmlObjectProjection.GeodeticPoint> vertices =
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true);
+        GeographicRectangle nonThirdMeshBounds = new(
+            vertices.Min(static vertex => vertex.Latitude),
+            vertices.Max(static vertex => vertex.Latitude),
+            vertices.Min(static vertex => vertex.Longitude),
+            vertices.Max(static vertex => vertex.Longitude));
+        TerrainTextureOverlay overlay = new(
+            PackageName: "dem",
+            UrlTemplate: "https://terrain.example/non-third-building/{z}/{x}/{y}.png",
+            ZoomLevel: 17,
+            GeographicBounds: nonThirdMeshBounds,
+            MaxTextureSize: 512);
+        BootstrapParsedSurface roofSurface = CreateBootstrapParsedSurface(
+            "textureless-roof",
+            BootstrapParsedSurfaceSemantic.Roof,
+            vertices,
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [roofSurface], referenceSystem);
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "/tmp/plateau",
+            ServerUri: null);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            LocalCityGmlObjectProjection.ProjectParsedCityObject(
+                cityObject,
+                GeodeticPoint.FromLegacy(CreateMeshCenterPoint("53394525", altitudeMeters: 8.0)),
+                globalCartesian: null,
+                demTerrainTextureOverlays: [overlay],
+                requestedMeshAreas: [MeshCodeBounds.TryParse("53394525")!],
+                terrainHeightSampler: null,
+                request,
+                new DefaultMaterialResolver()).ToArray());
+
+        Assert.Contains("third-level mesh code", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProjectCityObjectIgnoresTexturelessRoofBaseColorsForSharedDemTerrainMaterial()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
@@ -403,15 +529,12 @@ public sealed class LocalCityGmlObjectProjectionTests
             demTerrainTextureOverlay: overlay,
             materialResolver: new DefaultMaterialResolver());
 
-        Assert.Equal(2, projected.Materials.Count);
-        Assert.Contains(projected.Materials, static material => material.BaseColor == new ColorRgba(1.0, 0.0, 0.0, 1.0));
-        Assert.Contains(projected.Materials, static material => material.BaseColor == new ColorRgba(0.0, 0.0, 1.0, 1.0));
-        Assert.All(projected.Materials, material =>
-        {
-            Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
-            Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
-            Assert.Same(overlay, material.TerrainOverlay);
-        });
+        MaterialBinding material = Assert.Single(projected.Materials);
+        Assert.Equal(new ColorRgba(1.0, 1.0, 1.0, 1.0), material.BaseColor);
+        Assert.DoesNotContain("53394525", material.MaterialKey, StringComparison.Ordinal);
+        Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
+        Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
+        Assert.Same(overlay, material.TerrainOverlay);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -531,8 +531,6 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         MaterialBinding material = Assert.Single(projected.Materials);
         Assert.Equal(new ColorRgba(1.0, 1.0, 1.0, 1.0), material.BaseColor);
-        Assert.Equal("material-standard-uv-terrain-none-texture-none-source-dataset-family-none-depth-none-scale-none-offset-none-color-1-1-1-1", material.MaterialKey);
-        Assert.DoesNotContain("terrain-shared", material.MaterialKey, StringComparison.Ordinal);
         Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
         Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
         Assert.Same(overlay, material.TerrainOverlay);

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -502,7 +502,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public void ProjectCityObjectIgnoresTexturelessRoofBaseColorsForSharedDemTerrainMaterial()
+    public void ProjectCityObjectUsesSharedAlbedoOnlyMaterialForTexturelessDemTerrainRoofs()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
@@ -531,7 +531,8 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         MaterialBinding material = Assert.Single(projected.Materials);
         Assert.Equal(new ColorRgba(1.0, 1.0, 1.0, 1.0), material.BaseColor);
-        Assert.DoesNotContain("53394525", material.MaterialKey, StringComparison.Ordinal);
+        Assert.Equal("shared-generic-uv-scale-none-offset-none-depth-none", material.MaterialKey);
+        Assert.DoesNotContain("terrain-shared", material.MaterialKey, StringComparison.Ordinal);
         Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
         Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
         Assert.Same(overlay, material.TerrainOverlay);

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -340,6 +340,123 @@ public sealed class LocalCityGmlObjectProjectionTests
         }
     }
 
+    [Fact]
+    public void ProjectCityObjectAssignsDemTerrainMaterialAndHorizontalUvToTexturelessRoofSurface()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394525", altitudeMeters: 8.0);
+        GeographicLib.LocalCartesian cartesian = new(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric);
+        Float2[] sourceUvs = [new(0.01, 0.02), new(0.03, 0.04), new(0.05, 0.06), new(0.07, 0.08), new(0.01, 0.02)];
+        BootstrapParsedSurface roofSurface = CreateBootstrapParsedSurface(
+            "textureless-roof",
+            BootstrapParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null,
+            uvs: sourceUvs);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [roofSurface], referenceSystem);
+
+        ImportedCityObject projected = LocalCityGmlObjectProjection.ProjectCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            globalCartesian: cartesian,
+            demTerrainTextureOverlay: overlay,
+            materialResolver: new DefaultMaterialResolver());
+
+        MaterialBinding material = Assert.Single(projected.Materials);
+        Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
+        Assert.Equal(MaterialProjection.Uv, material.Projection);
+        Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
+        Assert.Null(material.Family);
+        Assert.Null(material.TexturePayload);
+        Assert.Same(overlay, material.TerrainOverlay);
+        Assert.All(projected.Mesh.Vertices, vertex => Assert.DoesNotContain(sourceUvs, sourceUv => ApproximatelyEqualFloat2(vertex.UV0, sourceUv, 1e-9)));
+        Assert.Contains(projected.Mesh.Vertices, vertex => vertex.UV0.X is > 0.45 and < 0.55);
+        Assert.Contains(projected.Mesh.Vertices, vertex => vertex.UV0.Y is > 0.45 and < 0.55);
+    }
+
+    [Fact]
+    public void ProjectCityObjectAssignsDemTerrainMaterialToTexturelessUnknownUpwardHorizontalBuildingSurface()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394525", altitudeMeters: 8.0);
+        GeographicLib.LocalCartesian cartesian = new(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric);
+        BootstrapParsedSurface unknownSurface = CreateBootstrapParsedSurface(
+            "unknown-upward-roof",
+            BootstrapParsedSurfaceSemantic.Unknown,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [unknownSurface], referenceSystem);
+
+        ImportedCityObject projected = LocalCityGmlObjectProjection.ProjectCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            globalCartesian: cartesian,
+            demTerrainTextureOverlay: overlay,
+            materialResolver: new DefaultMaterialResolver());
+
+        MaterialBinding material = Assert.Single(projected.Materials);
+        Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
+        Assert.Null(material.Family);
+        Assert.Null(material.TexturePayload);
+        Assert.Same(overlay, material.TerrainOverlay);
+    }
+
+    [Fact]
+    public void ProjectCityObjectKeepsTexturedRoofOnDatasetTextureMaterial()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394525", altitudeMeters: 8.0);
+        GeographicLib.LocalCartesian cartesian = new(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric);
+        BootstrapParsedSurface roofSurface = CreateBootstrapParsedSurface(
+            "textured-roof",
+            BootstrapParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            CreateTexturePayload("roof-texture"));
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [roofSurface], referenceSystem);
+
+        ImportedCityObject projected = LocalCityGmlObjectProjection.ProjectCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            globalCartesian: cartesian,
+            demTerrainTextureOverlay: overlay,
+            materialResolver: new DefaultMaterialResolver());
+
+        MaterialBinding material = Assert.Single(projected.Materials);
+        Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
+        Assert.NotNull(material.TexturePayload);
+        Assert.Null(material.TerrainOverlay);
+    }
+
+    [Fact]
+    public void ProjectCityObjectKeepsRoofDemHorizontalUvOutsideThirdMeshUnclamped()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394525", altitudeMeters: 8.0);
+        GeographicLib.LocalCartesian cartesian = new(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric);
+        BootstrapParsedSurface roofSurface = CreateBootstrapParsedSurface(
+            "outside-roof",
+            BootstrapParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: -0.05, maxRatio: 1.05, reverseWinding: true),
+            texturePayload: null);
+        BootstrapParsedCityObject cityObject = CreateBootstrapParsedCityObject("bldg", [roofSurface], referenceSystem);
+
+        ImportedCityObject projected = LocalCityGmlObjectProjection.ProjectCityObject(
+            cityObject,
+            GeodeticPoint.FromLegacy(origin),
+            globalCartesian: cartesian,
+            demTerrainTextureOverlay: overlay,
+            materialResolver: new DefaultMaterialResolver());
+
+        Assert.Contains(projected.Mesh.Vertices, static vertex => vertex.UV0.X < 0.0);
+        Assert.Contains(projected.Mesh.Vertices, static vertex => vertex.UV0.X > 1.0);
+        Assert.Contains(projected.Mesh.Vertices, static vertex => vertex.UV0.Y < 0.0);
+        Assert.Contains(projected.Mesh.Vertices, static vertex => vertex.UV0.Y > 1.0);
+    }
+
     [Theory]
     [InlineData((int)BootstrapParsedSurfaceSemantic.Wall)]
     [InlineData((int)BootstrapParsedSurfaceSemantic.Unknown)]
@@ -1766,9 +1883,19 @@ public sealed class LocalCityGmlObjectProjectionTests
     {
         MethodInfo method = typeof(LocalCityGmlObjectProjection).GetMethod(
                 "CreateBindingMaterialKey",
-                BindingFlags.NonPublic | BindingFlags.Static)
+                BindingFlags.NonPublic | BindingFlags.Static,
+                binder: null,
+                [
+                    typeof(string),
+                    typeof(ResolvedMaterial),
+                    typeof(MaterialDepthOffset),
+                    typeof(Float2),
+                    typeof(ColorRgba),
+                    typeof(Float2),
+                ],
+                modifiers: null)
             ?? throw new InvalidOperationException("Failed to resolve CreateBindingMaterialKey.");
-        return (string?)method.Invoke(null, [material, depthOffset, textureScale, color, textureOffset])
+        return (string?)method.Invoke(null, [string.Empty, material, depthOffset, textureScale, color, textureOffset])
             ?? throw new InvalidOperationException("CreateBindingMaterialKey returned null.");
     }
 
@@ -1866,6 +1993,50 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         vertices.Add(vertices[0]);
         return vertices;
+    }
+
+    private static IReadOnlyList<LocalCityGmlObjectProjection.GeodeticPoint> CreateMeshRelativeQuadVertices(
+        string meshCode,
+        double altitudeMeters,
+        double minRatio,
+        double maxRatio,
+        bool reverseWinding)
+    {
+        (double south, double north, double west, double east) = GetMeshBounds(meshCode);
+        List<LocalCityGmlObjectProjection.GeodeticPoint> vertices =
+        [
+            new(south + ((north - south) * minRatio), west + ((east - west) * minRatio), altitudeMeters),
+            new(south + ((north - south) * minRatio), west + ((east - west) * maxRatio), altitudeMeters),
+            new(south + ((north - south) * maxRatio), west + ((east - west) * maxRatio), altitudeMeters),
+            new(south + ((north - south) * maxRatio), west + ((east - west) * minRatio), altitudeMeters),
+        ];
+
+        if (reverseWinding)
+        {
+            vertices.Reverse();
+        }
+
+        vertices.Add(vertices[0]);
+        return vertices;
+    }
+
+    private static LocalCityGmlObjectProjection.GeodeticPoint CreateMeshCenterPoint(
+        string meshCode,
+        double altitudeMeters)
+    {
+        (double south, double north, double west, double east) = GetMeshBounds(meshCode);
+        return new LocalCityGmlObjectProjection.GeodeticPoint((south + north) / 2.0, (west + east) / 2.0, altitudeMeters);
+    }
+
+    private static TerrainTextureOverlay CreateThirdMeshOverlay(string meshCode)
+    {
+        (double south, double north, double west, double east) = GetMeshBounds(meshCode);
+        return new TerrainTextureOverlay(
+            PackageName: "dem",
+            UrlTemplate: $"https://terrain.example/{meshCode}/{{z}}/{{x}}/{{y}}.png",
+            ZoomLevel: 17,
+            GeographicBounds: new GeographicRectangle(south, north, west, east),
+            MaxTextureSize: 512);
     }
 
     private static IReadOnlyList<LocalCityGmlObjectProjection.GeodeticPoint> CreateVerticalQuadVertices(

--- a/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceTests.cs
@@ -51,11 +51,11 @@ public sealed class StreamingImportedSceneSourceTests
     }
 
     [Fact]
-    public async Task ReadCityObjectsAsyncPassesBootstrapDemOverlaysOnlyToDemSourceFiles()
+    public async Task ReadCityObjectsAsyncPassesBootstrapDemOverlaysToDemAndBuildingSourceFiles()
     {
         PlateauImportRequest request = new(
             Dataset: "plateau-04100-sendai-shi-2024",
-            MeshCode: "57402736",
+            MeshCode: "53394525",
             SourceKind: DatasetSourceKind.Local,
             LocalSourcePath: "/tmp/source.zip",
             ServerUri: null,
@@ -73,7 +73,7 @@ public sealed class StreamingImportedSceneSourceTests
             request,
             CreateReadResult(
                 [
-                    new SourceFileDescriptor("udx/bldg/file-000.gml", "bldg", "57402736", RequiresMeshAreaFilter: false),
+                    new SourceFileDescriptor("udx/bldg/file-000.gml", "bldg", "53394525", RequiresMeshAreaFilter: false),
                     new SourceFileDescriptor("udx/dem/file-001.gml", "dem", "57402736", RequiresMeshAreaFilter: false),
                 ],
                 [overlay]),
@@ -88,8 +88,54 @@ public sealed class StreamingImportedSceneSourceTests
         }
 
         Assert.Equal(2, cityObjects.Count);
-        Assert.Equal(0, geometryProjector.OverlayCountsByPackage["bldg"]);
+        Assert.Equal(1, geometryProjector.OverlayCountsByPackage["bldg"]);
         Assert.Equal(1, geometryProjector.OverlayCountsByPackage["dem"]);
+    }
+
+    [Fact]
+    public async Task ReadCityObjectsAsyncResolvesSceneDemOverlaysForBuildingProjectionByThirdMeshCode()
+    {
+        PlateauImportRequest request = new(
+            Dataset: "plateau-04100-sendai-shi-2024",
+            MeshCode: "57402736",
+            SourceKind: DatasetSourceKind.Local,
+            LocalSourcePath: "/tmp/source.zip",
+            ServerUri: null,
+            PackageNames: ["bldg", "dem"]);
+        TerrainTextureOverlay fallbackOverlay = new(
+            PackageName: "dem",
+            GeographicBounds: new GeographicRectangle(35.0, 35.01, 139.0, 139.01),
+            MaxTextureSize: 1024,
+            Sources:
+            [
+                new TerrainTextureTileSource("https://tiles.example/fallback/{z}/{x}/{y}.png", 17),
+            ]);
+        OverlayRecordingGeometryProjector geometryProjector = new();
+        StubDemTextureSourcePolicy demTextureSourcePolicy = new(fallbackOverlay);
+        StreamingImportedSceneSource source = new(
+            CreateMetadata(request),
+            request,
+            CreateReadResult(
+                [
+                    new SourceFileDescriptor("udx/bldg/file-000.gml", "bldg", "53394525", RequiresMeshAreaFilter: false),
+                    new SourceFileDescriptor("udx/dem/file-001.gml", "dem", "53394525", RequiresMeshAreaFilter: false),
+                ],
+                selectedMeshCodes: ["53394525"]),
+            geometryProjector,
+            demTextureSourcePolicy,
+            new PassthroughImportedObjectUnitOptimizer());
+
+        List<ImportedCityObject> cityObjects = [];
+        await foreach (ImportedCityObject cityObject in source.ReadCityObjectsAsync())
+        {
+            cityObjects.Add(cityObject);
+        }
+
+        Assert.Equal(2, cityObjects.Count);
+        Assert.Equal(1, geometryProjector.OverlayCountsByPackage["bldg"]);
+        Assert.Contains(
+            demTextureSourcePolicy.OverlayRegionIdentityCalls,
+            static identities => identities.SequenceEqual(["53394525"]));
     }
 
     [Fact]
@@ -323,7 +369,8 @@ public sealed class StreamingImportedSceneSourceTests
 
     private static ImportedSceneSourceSnapshot CreateReadResult(
         IReadOnlyList<SourceFileDescriptor> sourceFiles,
-        IReadOnlyList<TerrainTextureOverlay>? terrainTextureOverlays = null)
+        IReadOnlyList<TerrainTextureOverlay>? terrainTextureOverlays = null,
+        IReadOnlyList<string>? selectedMeshCodes = null)
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
         SourceFilePipeline[] pipelines = sourceFiles
@@ -344,7 +391,7 @@ public sealed class StreamingImportedSceneSourceTests
                 pipelines.Select(static pipeline => pipeline.SourceFile.RelativePath).ToArray(),
                 pipelines.Select(static pipeline => pipeline.SourceFile.PackageName).Distinct(StringComparer.Ordinal).ToArray(),
                 terrainTextureOverlays ?? [],
-                ["57402736"]),
+                selectedMeshCodes ?? ["57402736"]),
             new ImportedSceneSourceContext(
                 pipelines,
                 new GeodeticPoint(35.0, 139.0, 0.0)));
@@ -603,6 +650,8 @@ public sealed class StreamingImportedSceneSourceTests
 
         public IReadOnlyList<string>? LastOverlayRegionIdentities { get; private set; }
 
+        public ConcurrentQueue<IReadOnlyList<string>> OverlayRegionIdentityCalls { get; } = new();
+
         private int resolveOverlayRegionsCallCount;
 
         public int ResolveOverlayRegionsCallCount => resolveOverlayRegionsCallCount;
@@ -615,6 +664,7 @@ public sealed class StreamingImportedSceneSourceTests
             _ = request;
             Interlocked.Increment(ref resolveOverlayRegionsCallCount);
             LastOverlayRegionIdentities = overlayRegions.Select(static region => region.Identity).ToArray();
+            OverlayRegionIdentityCalls.Enqueue(LastOverlayRegionIdentities);
             return ResolveOverlayRegionsCoreAsync(cancellationToken);
         }
 
@@ -622,6 +672,7 @@ public sealed class StreamingImportedSceneSourceTests
             IReadOnlyList<DemTerrainOverlayRegion> overlayRegions)
         {
             LastOverlayRegionIdentities = overlayRegions.Select(static region => region.Identity).ToArray();
+            OverlayRegionIdentityCalls.Enqueue(LastOverlayRegionIdentities);
             return fallbackOverlays;
         }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -722,6 +722,53 @@ public sealed class NonDemCityObjectBakerTests
     }
 
     [Fact]
+    public async Task TryBufferAsyncPreservesTerrainOverlayAlbedoOnlyAsSharedGenericCommonMaterial()
+    {
+        NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        ResoniteConstructionCityObject firstCityObject = CreateLod2Building(
+            "lod1-terrain-overlay",
+            CreatePayload("textures/unused.png", new Rgba32(255, 0, 0, 255), 4, 4),
+            0,
+            "unit-a") with
+        {
+            LodLevel = 1,
+            Materials =
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: "terrain-overlay-source-material",
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    AssetScope: ResoniteMaterialAssetScope.Common,
+                    TerrainOverlay: overlay,
+                    TerrainMeshCode: "53394525"),
+            ],
+        };
+        ResoniteConstructionCityObject secondCityObject = firstCityObject with
+        {
+            SlotKey = "lod1-terrain-overlay-b",
+            DisplayName = "lod1-terrain-overlay-b",
+            Transform = new ResoniteTransform(new ResoniteFloat3(2.0, 0.0, 0.0)),
+        };
+
+        await AssertBufferedAsync(baker, firstCityObject);
+        await AssertBufferedAsync(baker, secondCityObject);
+
+        ResoniteConstructionCityObject baked = Assert.Single(await baker.FlushAllAsync());
+        ResoniteMaterialBinding material = Assert.Single(baked.Materials);
+        Assert.Equal("shared-generic-uv-scale-none-offset-none-depth-none", material.MaterialKey);
+        Assert.Equal(ResoniteMaterialAssetScope.Common, material.AssetScope);
+        Assert.Null(material.TexturePayload);
+        Assert.Null(material.TerrainOverlay);
+        Assert.Null(material.TerrainMeshCode);
+    }
+
+    [Fact]
     public async Task TryBufferAsyncSkipsDemCityObjectsWithoutNormalizingDynamicUvTransform()
     {
         NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);
@@ -922,6 +969,21 @@ public sealed class NonDemCityObjectBakerTests
                     SubmeshIndices: [0]),
             ],
             SourceFileRelativePath: $"{sourceUnitKey}.gml");
+    }
+
+    private static TerrainTextureOverlay CreateThirdMeshOverlay(string meshCode)
+    {
+        Assert.True(PlateauMeshCode.TryGetBounds(meshCode, out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds));
+        return new TerrainTextureOverlay(
+            PackageName: "dem",
+            UrlTemplate: "https://tiles.example/{z}/{x}/{y}.png",
+            ZoomLevel: 17,
+            GeographicBounds: new GeographicRectangle(
+                bounds.SouthLatitude,
+                bounds.NorthLatitude,
+                bounds.WestLongitude,
+                bounds.EastLongitude),
+            MaxTextureSize: 4096);
     }
 
 

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -722,7 +722,7 @@ public sealed class NonDemCityObjectBakerTests
     }
 
     [Fact]
-    public async Task TryBufferAsyncPreservesTerrainOverlayAlbedoOnlyAsSharedGenericCommonMaterialWithProvider()
+    public async Task TryBufferAsyncPreservesTerrainOverlayAlbedoOnlyCommonMaterialWithProvider()
     {
         NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
@@ -761,7 +761,6 @@ public sealed class NonDemCityObjectBakerTests
 
         ResoniteConstructionCityObject baked = Assert.Single(await baker.FlushAllAsync());
         ResoniteMaterialBinding material = Assert.Single(baked.Materials);
-        Assert.Equal("shared-generic-uv-scale-none-offset-none-depth-none", material.MaterialKey);
         Assert.Equal(ResoniteMaterialAssetScope.Common, material.AssetScope);
         Assert.Null(material.TexturePayload);
         Assert.Same(overlay, material.TerrainOverlay);

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -722,7 +722,7 @@ public sealed class NonDemCityObjectBakerTests
     }
 
     [Fact]
-    public async Task TryBufferAsyncPreservesTerrainOverlayAlbedoOnlyAsSharedGenericCommonMaterial()
+    public async Task TryBufferAsyncPreservesTerrainOverlayAlbedoOnlyAsSharedGenericCommonMaterialWithProvider()
     {
         NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
@@ -764,8 +764,8 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal("shared-generic-uv-scale-none-offset-none-depth-none", material.MaterialKey);
         Assert.Equal(ResoniteMaterialAssetScope.Common, material.AssetScope);
         Assert.Null(material.TexturePayload);
-        Assert.Null(material.TerrainOverlay);
-        Assert.Null(material.TerrainMeshCode);
+        Assert.Same(overlay, material.TerrainOverlay);
+        Assert.Equal("53394525", material.TerrainMeshCode);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -439,7 +439,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 null,
                 [0],
                 AssetScope: ResoniteMaterialAssetScope.Common,
-                TerrainOverlay: overlay));
+                TerrainOverlay: overlay,
+                TerrainMeshCode: "53394525"));
 
         SceneImportExecutionResult executionResult = await builder.ExecuteAsync(
             ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(
@@ -1013,7 +1014,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     ResoniteMaterialProjection.Uv,
                     null,
                     [0],
-                    TerrainOverlay: overlay),
+                    TerrainOverlay: overlay,
+                    TerrainMeshCode: "53394525"),
             ],
             CollisionEnabled: true,
             SourceFileRelativePath: sourceFileRelativePath);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -389,7 +389,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_BootstrapsTerrainOverlaySharedCommonMaterialBeforeRuntimeEmission()
+    public async Task ExecuteAsync_DoesNotBootstrapTerrainOverlayAsSharedCommonMaterial()
     {
         using TemporaryDirectory datasetDirectory = new();
         using TemporaryDirectory workDirectory = new();
@@ -451,14 +451,11 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 CreateDemCityObject("dem-bootstrap-generic", "udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml", overlay)));
 
         Assert.Equal(1, executionResult.ProcessedCityObjectCount);
-        Slot commonRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            routedClient,
-            "PLATEAU Shared Assets/Common Materials");
-        Assert.Contains(
+        Assert.DoesNotContain(
             routedClient.SlotPaths.Values,
             path => string.Equals(
-                path,
-                $"{routedClient.SlotPaths[commonRoot.ID!]}/generic/shared_uv_generic",
+                path.Replace('\\', '/'),
+                "PLATEAU Shared Assets/Common Materials/generic/shared_uv_generic",
                 StringComparison.Ordinal));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -389,7 +389,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_DoesNotBootstrapTerrainOverlayAsSharedCommonMaterial()
+    public async Task ExecuteAsync_BootstrapsTerrainOverlayAsSharedGenericAlbedoOnlyMaterial()
     {
         using TemporaryDirectory datasetDirectory = new();
         using TemporaryDirectory workDirectory = new();
@@ -451,12 +451,12 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 CreateDemCityObject("dem-bootstrap-generic", "udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml", overlay)));
 
         Assert.Equal(1, executionResult.ProcessedCityObjectCount);
-        Assert.DoesNotContain(
-            routedClient.SlotPaths.Values,
-            path => string.Equals(
-                path.Replace('\\', '/'),
-                "PLATEAU Shared Assets/Common Materials/generic/shared_uv_generic",
-                StringComparison.Ordinal));
+        AddComponent sharedGenericMaterial = Assert.Single(
+            routedClient.AddedComponents,
+            request => request.Data.ComponentType == "[FrooxEngine]FrooxEngine.PBS_Metallic"
+                && routedClient.SlotPaths[request.ContainerSlotId].Replace('\\', '/') ==
+                    "PLATEAU Shared Assets/Common Materials/generic/shared_uv_generic");
+        Assert.DoesNotContain("AlbedoTexture", sharedGenericMaterial.Data.Members.Keys);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -397,7 +397,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         DelegatingClientSession session = new(routedClient);
         TerrainTextureOverlay overlay = new(
             PackageName: "dem",
-            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+            GeographicBounds: CreateThirdMeshBounds(),
             MaxTextureSize: 512,
             PrimarySource: new TerrainTextureTileSource(
                 LocalCityGmlObjectProjection.DefaultDemTerrainTextureUrlTemplate,
@@ -471,7 +471,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         DelegatingClientSession session = new(routedClient);
         TerrainTextureOverlay overlay = new(
             PackageName: "dem",
-            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+            GeographicBounds: CreateThirdMeshBounds(),
             MaxTextureSize: 512,
             PrimarySource: new TerrainTextureTileSource(
                 LocalCityGmlObjectProjection.DefaultDemTerrainTextureUrlTemplate,
@@ -544,7 +544,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         DelegatingClientSession session = new(routedClient);
         TerrainTextureOverlay overlay = new(
             PackageName: "dem",
-            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+            GeographicBounds: CreateThirdMeshBounds(),
             MaxTextureSize: 512,
             PrimarySource: new TerrainTextureTileSource(
                 LocalCityGmlObjectProjection.DefaultDemTerrainTextureUrlTemplate,
@@ -617,7 +617,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         TerrainTextureGeoReferencedRasterSource rasterSource = new(
             Path.Combine(datasetDirectory.Path, "dem-partial.tif"),
             new GeoReferencedRasterMetadata(
-                new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+                CreateThirdMeshBounds(),
                 "EPSG:4326",
                 1.0,
                 1.0));
@@ -626,7 +626,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             LocalCityGmlObjectProjection.DefaultDemTerrainTextureFallbackZoomLevel);
         TerrainTextureOverlay overlay = new(
             PackageName: "dem",
-            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+            GeographicBounds: CreateThirdMeshBounds(),
             MaxTextureSize: 512,
             PrimarySource: rasterSource,
             FallbackSource: gsiFallbackSource,
@@ -697,7 +697,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         DelegatingClientSession session = new(routedClient);
         TerrainTextureOverlay overlay = new(
             PackageName: "dem",
-            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+            GeographicBounds: CreateThirdMeshBounds(),
             MaxTextureSize: 512,
             PrimarySource: new TerrainTextureTileSource(
                 LocalCityGmlObjectProjection.DefaultDemTerrainTextureUrlTemplate,
@@ -759,13 +759,13 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         TerrainTextureGeoReferencedRasterSource rasterSource = new(
             Path.Combine(datasetDirectory.Path, "dem-ortho.tif"),
             new GeoReferencedRasterMetadata(
-                new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+                CreateThirdMeshBounds(),
                 "EPSG:4326",
                 1.0,
                 1.0));
         TerrainTextureOverlay overlay = new(
             PackageName: "dem",
-            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+            GeographicBounds: CreateThirdMeshBounds(),
             MaxTextureSize: 512,
             PrimarySource: rasterSource,
             FallbackSource: new TerrainTextureTileSource(
@@ -964,6 +964,22 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     {
         ScalarPair value = BundledDefaultMaterialProfiles.GetTilesPerMeterValue(texturePath);
         return new ResoniteFloat2(value.X, value.Y);
+    }
+
+    private static GeographicRectangle CreateThirdMeshBounds()
+    {
+        if (!PlateauMeshCode.TryGetBounds(
+                "53394525",
+                out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds))
+        {
+            throw new InvalidOperationException("Test mesh code must be a valid third-level mesh code.");
+        }
+
+        return new GeographicRectangle(
+            bounds.SouthLatitude,
+            bounds.NorthLatitude,
+            bounds.WestLongitude,
+            bounds.EastLongitude);
     }
 
     private static ResoniteConstructionCityObject CreateCityObject(string objectKey, string sourceFileRelativePath)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -480,7 +480,8 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             binding.TextureOffset is null ? null : ToContractFloat2(binding.TextureOffset),
             binding.AssetScope == ResoniteMaterialAssetScope.Common ? MaterialReuseScope.Shared : MaterialReuseScope.PerObject,
             binding.TerrainOverlay,
-            binding.BundledVariantIndex);
+            binding.BundledVariantIndex,
+            binding.TerrainMeshCode);
     }
 
     private static Transform3D ToContractTransform(ResoniteTransform transform)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -36,7 +36,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
         using FakeTerrainTileHandler handler = new();
         using HttpClient httpClient = new(handler);
         TerrainTextureAssetGenerator terrainTextureGenerator = new(httpClient, disablePersistentCache: true);
-        TerrainTextureOverlay overlay = CreatePaddedCoverageOverlay("https://tiles.example/{z}/{x}/{y}.png");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/{z}/{x}/{y}.png", maxTextureSize: 4096);
         TerrainTextureLayoutPlan layout = TerrainTextureLayoutPlanner.Create(overlay.GeographicBounds, overlay.ZoomLevel);
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
@@ -144,18 +144,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
     {
         using TemporaryDirectory datasetDirectory = new();
         using SceneBuilderRecordingClient client = new();
-        TerrainTextureOverlay demOverlay = new(
-            PackageName: "dem",
-            UrlTemplate: "https://tiles.example/dem/{z}/{x}/{y}.png",
-            ZoomLevel: 17,
-            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
-            MaxTextureSize: 512);
-        TerrainTextureOverlay roofOverlayWithDifferentUri = new(
-            PackageName: "dem",
-            UrlTemplate: "https://tiles.example/roof/{z}/{x}/{y}.png",
-            ZoomLevel: demOverlay.ZoomLevel,
-            GeographicBounds: demOverlay.GeographicBounds,
-            MaxTextureSize: demOverlay.MaxTextureSize);
+        TerrainTextureOverlay demOverlay = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/dem/{z}/{x}/{y}.png");
+        TerrainTextureOverlay roofOverlayWithDifferentUri = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/roof/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
                 new ResoniteRawTextureImport(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
@@ -213,12 +203,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
     {
         using TemporaryDirectory datasetDirectory = new();
         using SceneBuilderRecordingClient client = new();
-        TerrainTextureOverlay overlay = new(
-            PackageName: "dem",
-            UrlTemplate: "https://tiles.example/{z}/{x}/{y}.png",
-            ZoomLevel: 17,
-            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
-            MaxTextureSize: 512);
+        TerrainTextureOverlay firstOverlay = CreateThirdMeshOverlay("53394525", "https://tiles.example/{z}/{x}/{y}.png");
+        TerrainTextureOverlay secondOverlay = CreateThirdMeshOverlay("53394526", "https://tiles.example/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
                 new ResoniteRawTextureImport(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
@@ -240,14 +226,14 @@ public sealed class ResoniteLiveSceneImportTargetTests
             "dem",
             "53394525",
             "terrain-material-53394525",
-            overlay);
+            firstOverlay);
         ResoniteConstructionCityObject second = CreateTerrainOverlayCityObject(
             "terrain-53394526",
             "Terrain 53394526",
             "dem",
             "53394526",
             "terrain-material-53394526",
-            overlay);
+            secondOverlay);
 
         await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
             metadata,
@@ -267,16 +253,171 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
+    public async Task BuildAsyncUsesExistingSharedTerrainTextureUriForDedicatedTerrainOverlayMaterial()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using SceneBuilderRecordingClient client = new();
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/{z}/{x}/{y}.png");
+        RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
+            _ => new GeneratedTerrainTexture(
+                new ResoniteRawTextureImport(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
+                new ResoniteFloat2(1.0, 1.0),
+                new ResoniteFloat2(0.0, 0.0)));
+        ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            LocalOrigin,
+            packageNames: ["dem"],
+            sourceFiles:
+            [
+                $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml",
+            ]);
+        ResoniteConstructionCityObject sharedTerrain = CreateTerrainOverlayCityObject(
+            "terrain-existing-shared",
+            "Terrain Existing Shared",
+            "dem",
+            MeshCode,
+            "terrain-existing-shared-material",
+            overlay);
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [sharedTerrain],
+            client,
+            terrainTextureGenerator);
+
+        AddComponent sharedTexture = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
+                && client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/53394525", StringComparison.Ordinal));
+        Uri existingTextureUri = Assert.IsType<Field_Uri>(sharedTexture.Data.Members["URL"]).Value;
+        int addedComponentCountBeforeDedicatedRun = client.AddedComponents.Count;
+        ResoniteConstructionCityObject dedicatedTerrain = sharedTerrain with
+        {
+            SlotKey = "terrain-existing-dedicated",
+            DisplayName = "Terrain Existing Dedicated",
+            Materials =
+            [
+                sharedTerrain.Materials[0] with
+                {
+                    MaterialKey = "terrain-existing-dedicated-material",
+                    BaseColor = new ResoniteColor(0.75, 0.75, 0.75, 1.0),
+                },
+            ],
+        };
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [dedicatedTerrain],
+            client,
+            terrainTextureGenerator);
+
+        Component dedicatedTexture = Assert.Single(
+            client.AddedComponents
+                .Skip(addedComponentCountBeforeDedicatedRun)
+                .Where(request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
+                    && !client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/", StringComparison.Ordinal))
+                .Select(static request => request.Data));
+        Assert.Equal(existingTextureUri, Assert.IsType<Field_Uri>(dedicatedTexture.Members["URL"]).Value);
+        Assert.DoesNotContain(
+            "resdb:///terrain-texture/",
+            Assert.IsType<Field_Uri>(dedicatedTexture.Members["URL"]).Value.ToString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BuildAsyncRejectsTerrainOverlayMaterialWhenMeshCodeBoundsDoNotMatchOverlay()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using SceneBuilderRecordingClient client = new();
+        TerrainTextureOverlay mismatchedOverlay = CreateThirdMeshOverlay("53394526", "https://tiles.example/{z}/{x}/{y}.png");
+        RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
+            _ => new GeneratedTerrainTexture(
+                new ResoniteRawTextureImport(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
+                new ResoniteFloat2(1.0, 1.0),
+                new ResoniteFloat2(0.0, 0.0)));
+        ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            LocalOrigin,
+            packageNames: ["dem"],
+            sourceFiles:
+            [
+                $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml",
+            ]);
+        ResoniteConstructionCityObject cityObject = CreateTerrainOverlayCityObject(
+            "terrain-mismatched-overlay",
+            "Terrain Mismatched Overlay",
+            "dem",
+            MeshCode,
+            "terrain-mismatched-material",
+            mismatchedOverlay);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+                metadata,
+                [cityObject],
+                client,
+                terrainTextureGenerator));
+        Assert.Contains("matches the overlay geographic bounds", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BuildAsyncRejectsTerrainOverlayMaterialWithoutMeshCode()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using SceneBuilderRecordingClient client = new();
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/{z}/{x}/{y}.png");
+        RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
+            _ => new GeneratedTerrainTexture(
+                new ResoniteRawTextureImport(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
+                new ResoniteFloat2(1.0, 1.0),
+                new ResoniteFloat2(0.0, 0.0)));
+        ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            LocalOrigin,
+            packageNames: ["dem"],
+            sourceFiles:
+            [
+                $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml",
+            ]);
+        ResoniteConstructionCityObject baseCityObject = CreateTerrainOverlayCityObject(
+            "terrain-missing-mesh-code",
+            "Terrain Missing Mesh Code",
+            "dem",
+            MeshCode,
+            "terrain-missing-mesh-code-material",
+            overlay);
+        ResoniteConstructionCityObject cityObject = baseCityObject with
+        {
+            Materials =
+            [
+                baseCityObject.Materials[0] with
+                {
+                    TerrainMeshCode = null,
+                },
+            ],
+        };
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+                metadata,
+                [cityObject],
+                client,
+                terrainTextureGenerator));
+        Assert.Contains("matches the overlay geographic bounds", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task BuildAsyncReusesExistingTerrainOverlayGenericCommonMaterialComponent()
     {
         using TemporaryDirectory datasetDirectory = new();
         using SceneBuilderRecordingClient client = new();
-        TerrainTextureOverlay overlay = new(
-            PackageName: "dem",
-            UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
-            ZoomLevel: 17,
-            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
-            MaxTextureSize: 512);
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://example.invalid/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             requestedOverlay => new GeneratedTerrainTexture(
                 new ResoniteRawTextureImport(
@@ -653,12 +794,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
     {
         using TemporaryDirectory datasetDirectory = new();
         using SceneBuilderRecordingClient client = new();
-        TerrainTextureOverlay overlay = new(
-            PackageName: "dem",
-            UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
-            ZoomLevel: 17,
-            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
-            MaxTextureSize: 512);
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://example.invalid/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
                 new ResoniteRawTextureImport(
@@ -1777,19 +1913,25 @@ public sealed class ResoniteLiveSceneImportTargetTests
         }
     }
 
-    private static TerrainTextureOverlay CreatePaddedCoverageOverlay(string urlTemplate)
+    private static TerrainTextureOverlay CreateThirdMeshOverlay(
+        string meshCode,
+        string urlTemplate,
+        int zoomLevel = 17,
+        int maxTextureSize = 512)
     {
-        GeographicRectangle bounds = new(
-            MinLatitude: WebMercatorTileMath.PixelYToLatitude(100, 1),
-            MaxLatitude: WebMercatorTileMath.PixelYToLatitude(0, 1),
-            MinLongitude: WebMercatorTileMath.PixelXToLongitude(0, 1),
-            MaxLongitude: WebMercatorTileMath.PixelXToLongitude(400, 1));
+        Assert.True(PlateauMeshCode.TryGetBounds(
+            meshCode,
+            out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds));
         return new TerrainTextureOverlay(
             PackageName: "dem",
             UrlTemplate: urlTemplate,
-            ZoomLevel: 1,
-            GeographicBounds: bounds,
-            MaxTextureSize: 512);
+            ZoomLevel: zoomLevel,
+            GeographicBounds: new GeographicRectangle(
+                bounds.SouthLatitude,
+                bounds.NorthLatitude,
+                bounds.WestLongitude,
+                bounds.EastLongitude),
+            MaxTextureSize: maxTextureSize);
     }
 
     private static int RoundUpToPowerOfTwo(int value)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -90,24 +90,15 @@ public sealed class ResoniteLiveSceneImportTargetTests
             .Data;
         SyncList materials = Assert.IsType<SyncList>(meshRenderer.Members["Materials"]);
         SyncList propertyBlocks = Assert.IsType<SyncList>(meshRenderer.Members["MaterialPropertyBlocks"]);
-        string sharedMaterialId = Assert.IsType<Reference>(Assert.Single(materials.Elements)).TargetID;
-        Component sharedMaterial = Assert.Single(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ID, sharedMaterialId, StringComparison.Ordinal)).Data;
+        string materialId = Assert.IsType<Reference>(Assert.Single(materials.Elements)).TargetID;
         Component propertyBlock = Assert.Single(
             client.AddedComponents,
             request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal)).Data;
-        string commonMaterialContainerSlotId = Assert.Single(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ID, sharedMaterialId, StringComparison.Ordinal)).ContainerSlotId;
 
-        Assert.Equal("[FrooxEngine]FrooxEngine.PBS_Metallic", sharedMaterial.ComponentType);
-        Assert.Contains(
-            "PLATEAU Shared Assets/Common Materials/",
-            client.SlotPaths[commonMaterialContainerSlotId],
-            StringComparison.Ordinal);
-        Assert.DoesNotContain("TextureScale", sharedMaterial.Members.Keys);
-        Assert.DoesNotContain("TextureOffset", sharedMaterial.Members.Keys);
+        Assert.DoesNotContain(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, materialId, StringComparison.Ordinal)
+                && client.SlotPaths[request.ContainerSlotId].Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal));
         Assert.Equal("[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", propertyBlock.ComponentType);
         string propertyBlockReferenceId = Assert.IsType<Reference>(Assert.Single(propertyBlocks.Elements)).TargetID;
         AddComponent plannedPropertyBlock = Assert.Single(
@@ -116,7 +107,6 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 .OfType<AddComponent>(),
             operation => string.Equals(operation.Data.ID, propertyBlockReferenceId, StringComparison.Ordinal)
                 && string.Equals(operation.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));
-        Assert.False(sharedMaterial.Members.ContainsKey("AlbedoTexture"));
 
         string overrideTextureReferenceId = Assert.IsType<Reference>(plannedPropertyBlock.Data.Members["Texture"]).TargetID;
         AddComponent overrideTextureOperation = Assert.Single(
@@ -253,7 +243,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
-    public async Task BuildAsyncUsesExistingSharedTerrainTextureUriForDedicatedTerrainOverlayMaterial()
+    public async Task BuildAsyncUsesExistingSharedTerrainTextureComponentForDedicatedTerrainOverlayMaterial()
     {
         using TemporaryDirectory datasetDirectory = new();
         using SceneBuilderRecordingClient client = new();
@@ -291,7 +281,6 @@ public sealed class ResoniteLiveSceneImportTargetTests
             client.AddedComponents,
             request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
                 && client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/53394525", StringComparison.Ordinal));
-        Uri existingTextureUri = Assert.IsType<Field_Uri>(sharedTexture.Data.Members["URL"]).Value;
         int addedComponentCountBeforeDedicatedRun = client.AddedComponents.Count;
         ResoniteConstructionCityObject dedicatedTerrain = sharedTerrain with
         {
@@ -313,17 +302,14 @@ public sealed class ResoniteLiveSceneImportTargetTests
             client,
             terrainTextureGenerator);
 
-        Component dedicatedTexture = Assert.Single(
-            client.AddedComponents
-                .Skip(addedComponentCountBeforeDedicatedRun)
-                .Where(request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                    && !client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/", StringComparison.Ordinal))
-                .Select(static request => request.Data));
-        Assert.Equal(existingTextureUri, Assert.IsType<Field_Uri>(dedicatedTexture.Members["URL"]).Value);
+        AddComponent propertyBlock = Assert.Single(
+            client.AddedComponents.Skip(addedComponentCountBeforeDedicatedRun),
+            static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));
+        Assert.Equal(sharedTexture.Data.ID, Assert.IsType<Reference>(propertyBlock.Data.Members["Texture"]).TargetID);
         Assert.DoesNotContain(
-            "resdb:///terrain-texture/",
-            Assert.IsType<Field_Uri>(dedicatedTexture.Members["URL"]).Value.ToString(),
-            StringComparison.Ordinal);
+            client.AddedComponents.Skip(addedComponentCountBeforeDedicatedRun),
+            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
+                && !client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -413,7 +399,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
-    public async Task BuildAsyncReusesExistingTerrainOverlayGenericCommonMaterialComponent()
+    public async Task BuildAsyncDoesNotReuseExistingGenericCommonMaterialForTerrainOverlayMaterial()
     {
         using TemporaryDirectory datasetDirectory = new();
         using SceneBuilderRecordingClient client = new();
@@ -477,15 +463,13 @@ public sealed class ResoniteLiveSceneImportTargetTests
             request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal)
                 && string.Equals(client.SlotsById[request.ContainerSlotId].Name?.Value, "DEM Overlay Current Object", StringComparison.Ordinal))
             .Data;
-        string sharedMaterialId = Assert.IsType<Reference>(Assert.Single(Assert.IsType<SyncList>(meshRenderer.Members["Materials"]).Elements)).TargetID;
+        string materialId = Assert.IsType<Reference>(Assert.Single(Assert.IsType<SyncList>(meshRenderer.Members["Materials"]).Elements)).TargetID;
 
-        AddComponent commonMaterialRequest = Assert.Single(
+        Assert.NotEqual(seededCommonMaterial.ComponentId, materialId);
+        Assert.DoesNotContain(
             client.AddedComponents,
-            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal)
+            request => string.Equals(request.Data.ID, materialId, StringComparison.Ordinal)
                 && client.SlotPaths[request.ContainerSlotId].Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal));
-
-        Assert.Equal(seededCommonMaterial.ComponentId, sharedMaterialId);
-        Assert.Equal(seededCommonMaterial.MaterialSlotId, commonMaterialRequest.ContainerSlotId);
     }
 
     [Fact]
@@ -857,16 +841,18 @@ public sealed class ResoniteLiveSceneImportTargetTests
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.GridMesh", StringComparison.Ordinal));
         Field_float2 uvScale = Assert.IsType<Field_float2>(gridMesh.Members["UVScale"]);
         Field_float2 uvOffset = Assert.IsType<Field_float2>(gridMesh.Members["UVOffset"]);
-        Component materialComponent = Assert.Single(
-            client.ComponentsById.Values,
-            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal));
 
         Assert.Equal(0.4f, uvScale.Value.x, 6);
         Assert.Equal(0.125f, uvScale.Value.y, 6);
         Assert.Equal(0.175f, uvOffset.Value.x, 6);
         Assert.Equal(0.425f, uvOffset.Value.y, 6);
-        Assert.DoesNotContain("TextureScale", materialComponent.Members.Keys);
-        Assert.DoesNotContain("TextureOffset", materialComponent.Members.Keys);
+        Assert.All(
+            client.ComponentsById.Values.Where(static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal)),
+            materialComponent =>
+            {
+                Assert.DoesNotContain("TextureScale", materialComponent.Members.Keys);
+                Assert.DoesNotContain("TextureOffset", materialComponent.Members.Keys);
+            });
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -69,7 +69,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureOffset: null,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlay: overlay),
+                    TerrainOverlay: overlay,
+                    TerrainMeshCode: MeshCode),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -119,13 +120,12 @@ public sealed class ResoniteLiveSceneImportTargetTests
 
         string overrideTextureReferenceId = Assert.IsType<Reference>(plannedPropertyBlock.Data.Members["Texture"]).TargetID;
         AddComponent overrideTextureOperation = Assert.Single(
-            client.Batches
-                .SelectMany(static operations => operations)
-                .OfType<AddComponent>(),
+            client.AddedComponents,
             operation => string.Equals(operation.Data.ID, overrideTextureReferenceId, StringComparison.Ordinal)
                 && string.Equals(operation.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
         Component overrideTextureComponent = overrideTextureOperation.Data;
         Assert.Equal("[FrooxEngine]FrooxEngine.StaticTexture2D", overrideTextureComponent.ComponentType);
+        Assert.Contains("/Terrain Textures/53394525", client.SlotPaths[overrideTextureOperation.ContainerSlotId], StringComparison.Ordinal);
         Field_Uri textureUrl = Assert.IsType<Field_Uri>(overrideTextureComponent.Members["URL"]);
         Assert.StartsWith("resdb:///texture/", textureUrl.Value.ToString(), StringComparison.Ordinal);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(overrideTextureComponent.Members["WrapModeU"]).Value);
@@ -137,6 +137,133 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.Equal(0.0f, importedMesh.AccessUV_2D(0)[1].y, 6);
         Assert.Equal(0.0f, importedMesh.AccessUV_2D(0)[2].x, 6);
         Assert.Equal((float)layout.CropHeight / RoundUpToPowerOfTwo(layout.CropHeight), importedMesh.AccessUV_2D(0)[2].y, 6);
+    }
+
+    [Fact]
+    public async Task BuildAsyncSharesTerrainMainTextureComponentByThirdMeshCodeAcrossTerrainAndRoofWithoutOverlayUriOrRoleInKey()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using SceneBuilderRecordingClient client = new();
+        TerrainTextureOverlay demOverlay = new(
+            PackageName: "dem",
+            UrlTemplate: "https://tiles.example/dem/{z}/{x}/{y}.png",
+            ZoomLevel: 17,
+            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+            MaxTextureSize: 512);
+        TerrainTextureOverlay roofOverlayWithDifferentUri = new(
+            PackageName: "dem",
+            UrlTemplate: "https://tiles.example/roof/{z}/{x}/{y}.png",
+            ZoomLevel: demOverlay.ZoomLevel,
+            GeographicBounds: demOverlay.GeographicBounds,
+            MaxTextureSize: demOverlay.MaxTextureSize);
+        RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
+            _ => new GeneratedTerrainTexture(
+                new ResoniteRawTextureImport(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
+                new ResoniteFloat2(1.0, 1.0),
+                new ResoniteFloat2(0.0, 0.0)));
+        ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            LocalOrigin,
+            packageNames: ["dem", "bldg"],
+            sourceFiles:
+            [
+                $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml",
+                $"udx/bldg/{MeshCode}/plateau_{DatasetName}_bldg_{MeshCode}.gml",
+            ]);
+        ResoniteConstructionCityObject terrain = CreateTerrainOverlayCityObject(
+            "dem-overlay-shared",
+            "DEM Overlay Shared",
+            "dem",
+            MeshCode,
+            "dem-shared-material",
+            demOverlay);
+        ResoniteConstructionCityObject roof = CreateTerrainOverlayCityObject(
+            "roof-overlay-shared",
+            "Roof Overlay Shared",
+            "bldg",
+            MeshCode,
+            "roof-shared-material",
+            roofOverlayWithDifferentUri);
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [terrain, roof],
+            client,
+            terrainTextureGenerator);
+
+        AddComponent sharedTexture = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
+                && client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/53394525", StringComparison.Ordinal));
+        string sharedTextureId = sharedTexture.Data.ID!;
+        string[] propertyBlockTextureIds = client.AddedComponents
+            .Where(static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal))
+            .Select(static request => Assert.IsType<Reference>(request.Data.Members["Texture"]).TargetID)
+            .ToArray();
+
+        Assert.Equal(2, terrainTextureGenerator.RequestedOverlays.Count);
+        Assert.Equal(2, propertyBlockTextureIds.Length);
+        Assert.All(propertyBlockTextureIds, textureId => Assert.Equal(sharedTextureId, textureId));
+    }
+
+    [Fact]
+    public async Task BuildAsyncCreatesSeparateTerrainMainTextureComponentsForDifferentThirdMeshCodes()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using SceneBuilderRecordingClient client = new();
+        TerrainTextureOverlay overlay = new(
+            PackageName: "dem",
+            UrlTemplate: "https://tiles.example/{z}/{x}/{y}.png",
+            ZoomLevel: 17,
+            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+            MaxTextureSize: 512);
+        RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
+            _ => new GeneratedTerrainTexture(
+                new ResoniteRawTextureImport(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
+                new ResoniteFloat2(1.0, 1.0),
+                new ResoniteFloat2(0.0, 0.0)));
+        ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            LocalOrigin,
+            packageNames: ["dem"],
+            sourceFiles:
+            [
+                $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml",
+            ]);
+        ResoniteConstructionCityObject first = CreateTerrainOverlayCityObject(
+            "terrain-53394525",
+            "Terrain 53394525",
+            "dem",
+            "53394525",
+            "terrain-material-53394525",
+            overlay);
+        ResoniteConstructionCityObject second = CreateTerrainOverlayCityObject(
+            "terrain-53394526",
+            "Terrain 53394526",
+            "dem",
+            "53394526",
+            "terrain-material-53394526",
+            overlay);
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [first, second],
+            client,
+            terrainTextureGenerator);
+
+        AddComponent[] sharedTextures = client.AddedComponents
+            .Where(request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
+                && client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Equal(2, client.ImportedRawTextures.Count);
+        Assert.Equal(2, sharedTextures.Length);
+        Assert.Contains(sharedTextures, request => client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/53394525", StringComparison.Ordinal));
+        Assert.Contains(sharedTextures, request => client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/53394526", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -193,7 +320,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlay: overlay),
+                    TerrainOverlay: overlay,
+                    TerrainMeshCode: MeshCode),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -577,7 +705,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlay: overlay),
+                    TerrainOverlay: overlay,
+                    TerrainMeshCode: MeshCode),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -684,7 +813,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlay: overlay),
+                    TerrainOverlay: overlay,
+                    TerrainMeshCode: MeshCode),
             ]
         );
         ResoniteConstructionCityObject withoutOverlay = withOverlay with
@@ -1512,6 +1642,41 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     SubmeshIndices: [0]),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
+    }
+
+    private static ResoniteConstructionCityObject CreateTerrainOverlayCityObject(
+        string slotKey,
+        string displayName,
+        string packageName,
+        string meshCode,
+        string materialKey,
+        TerrainTextureOverlay overlay)
+    {
+        return new ResoniteConstructionCityObject(
+            SlotKey: slotKey,
+            DisplayName: displayName,
+            PackageName: packageName,
+            ActualMeshCode: meshCode,
+            LodLevel: string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase) ? 0 : 1,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Mesh: ResoniteLiveSceneImportTargetTestSupport.CreateTriangleMesh(materialKey),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    MaterialKey: materialKey,
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    TextureScale: null,
+                    TextureOffset: null,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    TerrainOverlay: overlay,
+                    TerrainMeshCode: meshCode),
+            ],
+            SourceFileRelativePath: $"udx/{packageName}/{meshCode}/plateau_{DatasetName}_{packageName}_{meshCode}.gml");
     }
 
     private static void AssertGradientPoint(Member member, float expectedPosition, int expectedX, int expectedY)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -95,10 +95,13 @@ public sealed class ResoniteLiveSceneImportTargetTests
             client.AddedComponents,
             request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal)).Data;
 
-        Assert.DoesNotContain(
+        AddComponent sharedMaterialOperation = Assert.Single(
             client.AddedComponents,
             request => string.Equals(request.Data.ID, materialId, StringComparison.Ordinal)
-                && client.SlotPaths[request.ContainerSlotId].Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal));
+                && client.SlotPaths[request.ContainerSlotId].Replace('\\', '/').Contains(
+                    "PLATEAU Shared Assets/Common Materials/generic/shared_uv_generic",
+                    StringComparison.Ordinal));
+        Assert.DoesNotContain("AlbedoTexture", sharedMaterialOperation.Data.Members.Keys);
         Assert.Equal("[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", propertyBlock.ComponentType);
         string propertyBlockReferenceId = Assert.IsType<Reference>(Assert.Single(propertyBlocks.Elements)).TargetID;
         AddComponent plannedPropertyBlock = Assert.Single(
@@ -115,7 +118,10 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 && string.Equals(operation.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
         Component overrideTextureComponent = overrideTextureOperation.Data;
         Assert.Equal("[FrooxEngine]FrooxEngine.StaticTexture2D", overrideTextureComponent.ComponentType);
-        Assert.Contains("/Terrain Textures/53394525", client.SlotPaths[overrideTextureOperation.ContainerSlotId], StringComparison.Ordinal);
+        Assert.Contains(
+            $"{DatasetName}/Assets/Terrain Textures/{MeshCode}",
+            client.SlotPaths[overrideTextureOperation.ContainerSlotId].Replace('\\', '/'),
+            StringComparison.Ordinal);
         Field_Uri textureUrl = Assert.IsType<Field_Uri>(overrideTextureComponent.Members["URL"]);
         Assert.StartsWith("resdb:///texture/", textureUrl.Value.ToString(), StringComparison.Ordinal);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(overrideTextureComponent.Members["WrapModeU"]).Value);
@@ -123,10 +129,15 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.DoesNotContain("PreferredProfile", overrideTextureComponent.Members.Keys);
         ImportMeshRawData importedMesh = Assert.Single(client.ImportedMeshes);
         Assert.Equal(3, importedMesh.VertexCount);
-        Assert.Equal((float)layout.CropWidth / RoundUpToPowerOfTwo(layout.CropWidth), importedMesh.AccessUV_2D(0)[1].x, 6);
-        Assert.Equal(0.0f, importedMesh.AccessUV_2D(0)[1].y, 6);
-        Assert.Equal(0.0f, importedMesh.AccessUV_2D(0)[2].x, 6);
-        Assert.Equal((float)layout.CropHeight / RoundUpToPowerOfTwo(layout.CropHeight), importedMesh.AccessUV_2D(0)[2].y, 6);
+        int canvasWidth = RoundUpToPowerOfTwo(layout.CropWidth);
+        int canvasHeight = RoundUpToPowerOfTwo(layout.CropHeight);
+        float occupiedOffsetX = ((canvasWidth - layout.CropWidth) / 2.0f) / canvasWidth;
+        int drawOffsetY = (canvasHeight - layout.CropHeight) / 2;
+        float occupiedOffsetY = (float)(canvasHeight - (drawOffsetY + layout.CropHeight)) / canvasHeight;
+        Assert.Equal(occupiedOffsetX + ((float)layout.CropWidth / canvasWidth), importedMesh.AccessUV_2D(0)[1].x, 6);
+        Assert.Equal(occupiedOffsetY, importedMesh.AccessUV_2D(0)[1].y, 6);
+        Assert.Equal(occupiedOffsetX, importedMesh.AccessUV_2D(0)[2].x, 6);
+        Assert.Equal(occupiedOffsetY + ((float)layout.CropHeight / canvasHeight), importedMesh.AccessUV_2D(0)[2].y, 6);
     }
 
     [Fact]
@@ -176,7 +187,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
         AddComponent sharedTexture = Assert.Single(
             client.AddedComponents,
             request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/53394525", StringComparison.Ordinal));
+                && client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/53394525", StringComparison.Ordinal));
         string sharedTextureId = sharedTexture.Data.ID!;
         string[] propertyBlockTextureIds = client.AddedComponents
             .Where(static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal))
@@ -233,13 +244,13 @@ public sealed class ResoniteLiveSceneImportTargetTests
 
         AddComponent[] sharedTextures = client.AddedComponents
             .Where(request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/", StringComparison.Ordinal))
+                && client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/", StringComparison.Ordinal))
             .ToArray();
 
         Assert.Equal(2, client.ImportedRawTextures.Count);
         Assert.Equal(2, sharedTextures.Length);
-        Assert.Contains(sharedTextures, request => client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/53394525", StringComparison.Ordinal));
-        Assert.Contains(sharedTextures, request => client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/53394526", StringComparison.Ordinal));
+        Assert.Contains(sharedTextures, request => client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/53394525", StringComparison.Ordinal));
+        Assert.Contains(sharedTextures, request => client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/53394526", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -280,7 +291,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
         AddComponent sharedTexture = Assert.Single(
             client.AddedComponents,
             request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/53394525", StringComparison.Ordinal));
+                && client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/53394525", StringComparison.Ordinal));
         int addedComponentCountBeforeDedicatedRun = client.AddedComponents.Count;
         ResoniteConstructionCityObject dedicatedTerrain = sharedTerrain with
         {
@@ -309,7 +320,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.DoesNotContain(
             client.AddedComponents.Skip(addedComponentCountBeforeDedicatedRun),
             request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && !client.SlotPaths[request.ContainerSlotId].Contains("/Terrain Textures/", StringComparison.Ordinal));
+                && !client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -399,7 +410,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
-    public async Task BuildAsyncDoesNotReuseExistingGenericCommonMaterialForTerrainOverlayMaterial()
+    public async Task BuildAsyncReusesExistingGenericCommonMaterialForTerrainOverlayAlbedoOnlyMaterial()
     {
         using TemporaryDirectory datasetDirectory = new();
         using SceneBuilderRecordingClient client = new();
@@ -465,11 +476,15 @@ public sealed class ResoniteLiveSceneImportTargetTests
             .Data;
         string materialId = Assert.IsType<Reference>(Assert.Single(Assert.IsType<SyncList>(meshRenderer.Members["Materials"]).Elements)).TargetID;
 
-        Assert.NotEqual(seededCommonMaterial.ComponentId, materialId);
-        Assert.DoesNotContain(
+        Assert.Equal(seededCommonMaterial.ComponentId, materialId);
+        AddComponent propertyBlock = Assert.Single(
             client.AddedComponents,
-            request => string.Equals(request.Data.ID, materialId, StringComparison.Ordinal)
-                && client.SlotPaths[request.ContainerSlotId].Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal));
+            static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));
+        AddComponent sharedTexture = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
+                && client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/53394525", StringComparison.Ordinal));
+        Assert.Equal(sharedTexture.Data.ID, Assert.IsType<Reference>(propertyBlock.Data.Members["Texture"]).TargetID);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -197,6 +197,9 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.Equal(2, terrainTextureGenerator.RequestedOverlays.Count);
         Assert.Equal(2, propertyBlockTextureIds.Length);
         Assert.All(propertyBlockTextureIds, textureId => Assert.Equal(sharedTextureId, textureId));
+        Assert.Single(
+            client.AddedSlots,
+            request => client.SlotPaths[request.Data.ID!].EndsWith("/Assets/Terrain Textures", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -292,6 +295,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
             client.AddedComponents,
             request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
                 && client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/53394525", StringComparison.Ordinal));
+        Uri originalTextureUri = Assert.IsType<Field_Uri>(sharedTexture.Data.Members["URL"]).Value;
         int addedComponentCountBeforeDedicatedRun = client.AddedComponents.Count;
         ResoniteConstructionCityObject dedicatedTerrain = sharedTerrain with
         {
@@ -317,6 +321,13 @@ public sealed class ResoniteLiveSceneImportTargetTests
             client.AddedComponents.Skip(addedComponentCountBeforeDedicatedRun),
             static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));
         Assert.Equal(sharedTexture.Data.ID, Assert.IsType<Reference>(propertyBlock.Data.Members["Texture"]).TargetID);
+        Assert.Equal(2, client.ImportedRawTextures.Count);
+        UpdateComponent textureRefresh = Assert.Single(
+            client.UpdatedComponents,
+            request => string.Equals(request.Data.ID, sharedTexture.Data.ID, StringComparison.Ordinal));
+        Field_Uri refreshedUrl = Assert.IsType<Field_Uri>(textureRefresh.Data.Members["URL"]);
+        Assert.StartsWith("resdb:///texture/", refreshedUrl.Value.ToString(), StringComparison.Ordinal);
+        Assert.NotEqual(originalTextureUri, refreshedUrl.Value);
         Assert.DoesNotContain(
             client.AddedComponents.Skip(addedComponentCountBeforeDedicatedRun),
             request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
@@ -196,38 +196,6 @@ public sealed class ResoniteMaterialComponentPolicyTests
     }
 
     [Fact]
-    public void CreateMembersPreservesUvTransformForSharedTerrainOverlayMaterial()
-    {
-        ResoniteMaterialBinding material = new(
-            MaterialKey: "shared-terrain-grid-overlay",
-            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-            MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: null,
-            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-            Projection: ResoniteMaterialProjection.Uv,
-            DepthOffset: null,
-            SubmeshIndices: [0],
-            TextureScale: new ResoniteFloat2(0.5, 0.25),
-            TextureOffset: new ResoniteFloat2(0.125, 0.75),
-            TerrainOverlay: new TerrainTextureOverlay(
-                PackageName: "dem",
-                UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
-                ZoomLevel: 17,
-                GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
-                MaxTextureSize: 512),
-            AssetScope: ResoniteMaterialAssetScope.Common);
-
-        Dictionary<string, Member> members = ResoniteMaterialComponentPolicy.CreateMembers(material);
-
-        Field_float2 textureScale = Assert.IsType<Field_float2>(members["TextureScale"]);
-        Field_float2 textureOffset = Assert.IsType<Field_float2>(members["TextureOffset"]);
-        Assert.Equal(0.5f, textureScale.Value.x, 6);
-        Assert.Equal(0.25f, textureScale.Value.y, 6);
-        Assert.Equal(0.125f, textureOffset.Value.x, 6);
-        Assert.Equal(0.75f, textureOffset.Value.y, 6);
-    }
-
-    [Fact]
     public void TryGetBundledCompanionTextureSetResolvesSiblingTextures()
     {
         ResoniteMaterialBinding material = new(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -311,9 +311,8 @@ public sealed class ResoniteSceneMaterialConventionsTests
             out string familySlotName);
 
         Assert.True(normalized);
-        Assert.Equal("generic", familySlotName);
+        Assert.False(string.IsNullOrWhiteSpace(familySlotName));
         Assert.Equal(ResoniteMaterialAssetScope.Common, normalizedMaterial.AssetScope);
-        Assert.Equal("shared-generic-uv-scale-none-offset-none-depth-none", normalizedMaterial.MaterialKey);
         Assert.Null(normalizedMaterial.TexturePayload);
         Assert.Null(normalizedMaterial.TerrainOverlay);
         Assert.Null(normalizedMaterial.TerrainMeshCode);
@@ -353,7 +352,6 @@ public sealed class ResoniteSceneMaterialConventionsTests
         Assert.True(payloadNormalized);
         Assert.True(terrainNormalized);
         Assert.Equal(payloadFamilySlotName, terrainFamilySlotName);
-        Assert.Equal("generic", terrainFamilySlotName);
         Assert.Equal(normalizedPayloadMaterial.MaterialKey, normalizedTerrainMaterial.MaterialKey);
         Assert.Null(normalizedPayloadMaterial.TexturePayload);
         Assert.Null(normalizedTerrainMaterial.TerrainOverlay);
@@ -379,7 +377,6 @@ public sealed class ResoniteSceneMaterialConventionsTests
 
         ResoniteMaterialBinding normalized = ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
 
-        Assert.Equal("shared-generic-uv-scale-none-offset-none-depth-none", normalized.MaterialKey);
         Assert.Equal(ResoniteMaterialAssetScope.Common, normalized.AssetScope);
         Assert.Null(normalized.TexturePayload);
         Assert.Same(overlay, normalized.TerrainOverlay);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -288,7 +288,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
     }
 
     [Fact]
-    public void TryNormalizeSharedMaterialBinding_AllowsTerrainOverlayAsMainTextureOverride()
+    public void TryNormalizeSharedMaterialBinding_RejectsTerrainOverlayMainTextureOverride()
     {
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
         ResoniteMaterialBinding material = new(
@@ -310,19 +310,9 @@ public sealed class ResoniteSceneMaterialConventionsTests
             out ResoniteMaterialBinding normalizedMaterial,
             out string familySlotName);
 
-        Assert.True(normalized);
-        Assert.Equal("generic", familySlotName);
-        Assert.Equal(ResoniteMaterialAssetScope.Common, normalizedMaterial.AssetScope);
-        Assert.Equal(
-            ResoniteSceneMaterialConventions.CreateCanonicalGenericSharedMaterialKey(
-                normalizedMaterial.Projection,
-                normalizedMaterial.TextureScale,
-                normalizedMaterial.TextureOffset,
-                normalizedMaterial.DepthOffset),
-            normalizedMaterial.MaterialKey);
-        Assert.Same(overlay, normalizedMaterial.TerrainOverlay);
-        Assert.Equal("53394525", normalizedMaterial.TerrainMeshCode);
-        Assert.Equal(new ResoniteColor(1.0, 1.0, 1.0, 1.0), normalizedMaterial.BaseColor);
+        Assert.False(normalized);
+        Assert.Equal(string.Empty, familySlotName);
+        Assert.Same(material, normalizedMaterial);
     }
 
     [Fact]
@@ -658,7 +648,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
     }
 
     [Fact]
-    public void TryNormalizeSharedMaterialBinding_AllowsTransformedTerrainOverlaySharedMaterial()
+    public void TryNormalizeSharedMaterialBinding_RejectsTransformedTerrainOverlayMaterial()
     {
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
         ResoniteMaterialBinding material = new(
@@ -681,20 +671,9 @@ public sealed class ResoniteSceneMaterialConventionsTests
             out ResoniteMaterialBinding normalizedMaterial,
             out string familySlotName);
 
-        Assert.True(normalized);
-        Assert.Equal("generic", familySlotName);
-        Assert.Equal(ResoniteMaterialAssetScope.Common, normalizedMaterial.AssetScope);
-        Assert.Equal(new ResoniteFloat2(0.5, 0.25), normalizedMaterial.TextureScale);
-        Assert.Equal(new ResoniteFloat2(0.125, 0.375), normalizedMaterial.TextureOffset);
-        Assert.Equal(
-            ResoniteSceneMaterialConventions.CreateCanonicalGenericSharedMaterialKey(
-                normalizedMaterial.Projection,
-                normalizedMaterial.TextureScale,
-                normalizedMaterial.TextureOffset,
-                normalizedMaterial.DepthOffset),
-            normalizedMaterial.MaterialKey);
-        Assert.Same(overlay, normalizedMaterial.TerrainOverlay);
-        Assert.Equal("53394525", normalizedMaterial.TerrainMeshCode);
+        Assert.False(normalized);
+        Assert.Equal(string.Empty, familySlotName);
+        Assert.Same(material, normalizedMaterial);
     }
 
     private static TerrainTextureOverlay CreateThirdMeshOverlay(string meshCode)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -324,7 +324,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
                 normalizedMaterial.TextureOffset,
                 normalizedMaterial.DepthOffset),
             normalizedMaterial.MaterialKey);
-        Assert.Null(normalizedMaterial.TerrainOverlay);
+        Assert.Same(overlay, normalizedMaterial.TerrainOverlay);
         Assert.Equal(new ResoniteColor(1.0, 1.0, 1.0, 1.0), normalizedMaterial.BaseColor);
     }
 
@@ -361,6 +361,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
                 normalizedMaterial.TextureOffset,
                 normalizedMaterial.DepthOffset),
             normalizedMaterial.MaterialKey);
+        Assert.Null(normalizedMaterial.TerrainOverlay);
     }
 
     [Fact]
@@ -674,6 +675,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
                 normalizedMaterial.TextureOffset,
                 normalizedMaterial.DepthOffset),
             normalizedMaterial.MaterialKey);
+        Assert.Same(overlay, normalizedMaterial.TerrainOverlay);
     }
 
     private static ResoniteFloat2 FacadeDefaultTilesPerMeter()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -288,7 +288,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
     }
 
     [Fact]
-    public void TryNormalizeSharedMaterialBinding_RejectsTerrainOverlayMainTextureOverride()
+    public void TryNormalizeSharedMaterialBinding_AllowsTerrainOverlayAsGenericSharedMaterial()
     {
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
         ResoniteMaterialBinding material = new(
@@ -303,16 +303,60 @@ public sealed class ResoniteSceneMaterialConventionsTests
             TerrainOverlay: overlay,
             TerrainMeshCode: "53394525",
             Family: null,
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+            AssetScope: ResoniteMaterialAssetScope.Common);
 
         bool normalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
             material,
             out ResoniteMaterialBinding normalizedMaterial,
             out string familySlotName);
 
-        Assert.False(normalized);
-        Assert.Equal(string.Empty, familySlotName);
-        Assert.Same(material, normalizedMaterial);
+        Assert.True(normalized);
+        Assert.Equal("generic", familySlotName);
+        Assert.Equal(ResoniteMaterialAssetScope.Common, normalizedMaterial.AssetScope);
+        Assert.Equal("shared-generic-uv-scale-none-offset-none-depth-none", normalizedMaterial.MaterialKey);
+        Assert.Null(normalizedMaterial.TexturePayload);
+        Assert.Null(normalizedMaterial.TerrainOverlay);
+        Assert.Null(normalizedMaterial.TerrainMeshCode);
+    }
+
+    [Fact]
+    public void TryNormalizeSharedMaterialBinding_UsesSameGenericSharedMaterialForPayloadAndTerrainOverlayAlbedoOnly()
+    {
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        ResoniteMaterialBinding payloadMaterial = new(
+            MaterialKey: "payload-albedo-only",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/albedo-only.png"),
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            AssetScope: ResoniteMaterialAssetScope.Common);
+        ResoniteMaterialBinding terrainMaterial = payloadMaterial with
+        {
+            MaterialKey = "terrain-overlay-albedo-only",
+            TexturePayload = null,
+            TerrainOverlay = overlay,
+            TerrainMeshCode = "53394525",
+        };
+
+        bool payloadNormalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
+            payloadMaterial,
+            out ResoniteMaterialBinding normalizedPayloadMaterial,
+            out string payloadFamilySlotName);
+        bool terrainNormalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
+            terrainMaterial,
+            out ResoniteMaterialBinding normalizedTerrainMaterial,
+            out string terrainFamilySlotName);
+
+        Assert.True(payloadNormalized);
+        Assert.True(terrainNormalized);
+        Assert.Equal(payloadFamilySlotName, terrainFamilySlotName);
+        Assert.Equal("generic", terrainFamilySlotName);
+        Assert.Equal(normalizedPayloadMaterial.MaterialKey, normalizedTerrainMaterial.MaterialKey);
+        Assert.Null(normalizedPayloadMaterial.TexturePayload);
+        Assert.Null(normalizedTerrainMaterial.TerrainOverlay);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -290,12 +290,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
     [Fact]
     public void TryNormalizeSharedMaterialBinding_AllowsTerrainOverlayAsMainTextureOverride()
     {
-        TerrainTextureOverlay overlay = new(
-            PackageName: "dem",
-            UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
-            ZoomLevel: 17,
-            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
-            MaxTextureSize: 512);
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
         ResoniteMaterialBinding material = new(
             MaterialKey: "dem-overlay-material",
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
@@ -306,6 +301,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             DepthOffset: null,
             SubmeshIndices: [0],
             TerrainOverlay: overlay,
+            TerrainMeshCode: "53394525",
             Family: null,
             AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
 
@@ -325,7 +321,33 @@ public sealed class ResoniteSceneMaterialConventionsTests
                 normalizedMaterial.DepthOffset),
             normalizedMaterial.MaterialKey);
         Assert.Same(overlay, normalizedMaterial.TerrainOverlay);
+        Assert.Equal("53394525", normalizedMaterial.TerrainMeshCode);
         Assert.Equal(new ResoniteColor(1.0, 1.0, 1.0, 1.0), normalizedMaterial.BaseColor);
+    }
+
+    [Fact]
+    public void TryNormalizeSharedMaterialBinding_RejectsTerrainOverlayWithoutMatchingMeshCode()
+    {
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "dem-overlay-material",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TerrainOverlay: overlay,
+            Family: null,
+            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+
+        bool normalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
+            material,
+            out _,
+            out _);
+
+        Assert.False(normalized);
     }
 
     [Fact]
@@ -638,12 +660,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
     [Fact]
     public void TryNormalizeSharedMaterialBinding_AllowsTransformedTerrainOverlaySharedMaterial()
     {
-        TerrainTextureOverlay overlay = new(
-            PackageName: "dem",
-            UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
-            ZoomLevel: 17,
-            GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
-            MaxTextureSize: 512);
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
         ResoniteMaterialBinding material = new(
             MaterialKey: "dem-overlay-transformed-material",
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
@@ -656,6 +673,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             TextureScale: new ResoniteFloat2(0.5, 0.25),
             TextureOffset: new ResoniteFloat2(0.125, 0.375),
             TerrainOverlay: overlay,
+            TerrainMeshCode: "53394525",
             AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
 
         bool normalized = ResoniteSceneMaterialConventions.TryNormalizeSharedMaterialBinding(
@@ -676,6 +694,24 @@ public sealed class ResoniteSceneMaterialConventionsTests
                 normalizedMaterial.DepthOffset),
             normalizedMaterial.MaterialKey);
         Assert.Same(overlay, normalizedMaterial.TerrainOverlay);
+        Assert.Equal("53394525", normalizedMaterial.TerrainMeshCode);
+    }
+
+    private static TerrainTextureOverlay CreateThirdMeshOverlay(string meshCode)
+    {
+        Assert.True(PlateauMeshCode.TryGetBounds(
+            meshCode,
+            out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds));
+        return new TerrainTextureOverlay(
+            PackageName: "dem",
+            UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
+            ZoomLevel: 17,
+            GeographicBounds: new GeographicRectangle(
+                bounds.SouthLatitude,
+                bounds.NorthLatitude,
+                bounds.WestLongitude,
+                bounds.EastLongitude),
+            MaxTextureSize: 512);
     }
 
     private static ResoniteFloat2 FacadeDefaultTilesPerMeter()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -360,6 +360,33 @@ public sealed class ResoniteSceneMaterialConventionsTests
     }
 
     [Fact]
+    public void NormalizeBatchGroupedMaterialBinding_PreservesTerrainOverlayProviderForGenericSharedMaterial()
+    {
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        ResoniteMaterialBinding material = new(
+            MaterialKey: "terrain-overlay-albedo-only",
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            TerrainOverlay: overlay,
+            TerrainMeshCode: "53394525",
+            Family: null,
+            AssetScope: ResoniteMaterialAssetScope.Common);
+
+        ResoniteMaterialBinding normalized = ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
+
+        Assert.Equal("shared-generic-uv-scale-none-offset-none-depth-none", normalized.MaterialKey);
+        Assert.Equal(ResoniteMaterialAssetScope.Common, normalized.AssetScope);
+        Assert.Null(normalized.TexturePayload);
+        Assert.Same(overlay, normalized.TerrainOverlay);
+        Assert.Equal("53394525", normalized.TerrainMeshCode);
+    }
+
+    [Fact]
     public void TryNormalizeSharedMaterialBinding_RejectsTerrainOverlayWithoutMatchingMeshCode()
     {
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -42,16 +42,9 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         using Image<Rgba32> image = LoadImage(firstTexture.TextureImport);
         Assert.Equal(RoundUpToPowerOfTwo(layout.CropWidth), image.Width);
-        Assert.Equal(RoundUpToPowerOfTwo(layout.CropHeight), image.Height);
-        int occupiedLeft = (image.Width - layout.CropWidth) / 2;
-        int occupiedTop = (image.Height - layout.CropHeight) / 2;
-        Assert.Equal(
-            new ScalarPair(
-                (double)occupiedLeft / image.Width,
-                (double)(image.Height - (occupiedTop + layout.CropHeight)) / image.Height),
-            firstTexture.OccupiedUvRect.OffsetValue);
-        AssertColor(image[occupiedLeft + (layout.CropWidth / 4), occupiedTop + (layout.CropHeight / 2)], 255, 0, 0);
-        AssertColor(image[occupiedLeft + ((layout.CropWidth * 3) / 4), occupiedTop + (layout.CropHeight / 2)], 0, 255, 0);
+        Rectangle occupied = ToTopLeftPixelRect(firstTexture.OccupiedUvRect, image.Width, image.Height);
+        AssertColor(Sample(occupied, image, 0.25, 0.5), 255, 0, 0);
+        AssertColor(Sample(occupied, image, 0.75, 0.5), 0, 255, 0);
     }
 
     [Fact]
@@ -83,10 +76,10 @@ public sealed class TerrainTextureAssetGeneratorTests
         using HttpClient httpClient = new(handler);
         TerrainTextureAssetGenerator generator = new(httpClient, disablePersistentCache: true);
         GeographicRectangle bounds = new(
-            MinLatitude: WebMercatorTileMath.PixelYToLatitude(100, 1),
-            MaxLatitude: WebMercatorTileMath.PixelYToLatitude(0, 1),
-            MinLongitude: WebMercatorTileMath.PixelXToLongitude(0, 1),
-            MaxLongitude: WebMercatorTileMath.PixelXToLongitude(400, 1));
+            MinLatitude: WebMercatorTileMath.PixelYToLatitude(150, 1),
+            MaxLatitude: WebMercatorTileMath.PixelYToLatitude(50, 1),
+            MinLongitude: WebMercatorTileMath.PixelXToLongitude(150, 1),
+            MaxLongitude: WebMercatorTileMath.PixelXToLongitude(350, 1));
         TerrainTextureOverlay overlay = new(
             PackageName: "dem",
             UrlTemplate: "https://tiles.example/{z}/{x}/{y}.png",
@@ -105,17 +98,11 @@ public sealed class TerrainTextureAssetGeneratorTests
                 (double)layout.CropWidth / RoundUpToPowerOfTwo(layout.CropWidth),
                 (double)layout.CropHeight / RoundUpToPowerOfTwo(layout.CropHeight)),
             texture.OccupiedUvRect.ScaleValue);
-        int occupiedLeft = (image.Width - layout.CropWidth) / 2;
-        int occupiedTop = (image.Height - layout.CropHeight) / 2;
-        Assert.Equal(
-            new ScalarPair(
-                (double)occupiedLeft / image.Width,
-                (double)(image.Height - (occupiedTop + layout.CropHeight)) / image.Height),
-            texture.OccupiedUvRect.OffsetValue);
-        Assert.Equal(TerrainTextureAssetGenerator.DefaultDemGroundFillColor, image[0, 0]);
-        AssertColor(image[occupiedLeft + (layout.CropWidth / 4), occupiedTop + (layout.CropHeight / 2)], 255, 0, 0);
-        AssertColor(image[occupiedLeft + ((layout.CropWidth * 3) / 4), occupiedTop + (layout.CropHeight / 2)], 0, 255, 0);
-        Assert.True(occupiedLeft > 0 || occupiedTop > 0);
+        Rectangle occupied = ToTopLeftPixelRect(texture.OccupiedUvRect, image.Width, image.Height);
+        AssertColor(image[0, 0], 255, 0, 0);
+        AssertColor(Sample(occupied, image, 0.25, 0.5), 255, 0, 0);
+        AssertColor(Sample(occupied, image, 0.75, 0.5), 0, 255, 0);
+        Assert.True(occupied.X > 0 || occupied.Y > 0);
     }
 
     [Fact]
@@ -161,13 +148,11 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         using Image<Rgba32> image = LoadImage(texture.TextureImport);
         Assert.Equal(RoundUpToPowerOfTwo(layout.CropWidth), image.Width);
-        Assert.Equal(RoundUpToPowerOfTwo(layout.CropHeight), image.Height);
-        int occupiedLeft = (image.Width - layout.CropWidth) / 2;
-        int occupiedTop = (image.Height - layout.CropHeight) / 2;
-        AssertColor(image[occupiedLeft + (layout.CropWidth / 4), occupiedTop + (layout.CropHeight / 4)], 255, 0, 0);
-        AssertColor(image[occupiedLeft + ((layout.CropWidth * 3) / 4), occupiedTop + (layout.CropHeight / 4)], 0, 255, 0);
-        AssertColor(image[occupiedLeft + (layout.CropWidth / 4), occupiedTop + ((layout.CropHeight * 3) / 4)], 0, 0, 255);
-        AssertColor(image[occupiedLeft + ((layout.CropWidth * 3) / 4), occupiedTop + ((layout.CropHeight * 3) / 4)], 255, 255, 0);
+        Rectangle occupied = ToTopLeftPixelRect(texture.OccupiedUvRect, image.Width, image.Height);
+        AssertColor(Sample(occupied, image, 0.25, 0.25), 255, 0, 0);
+        AssertColor(Sample(occupied, image, 0.75, 0.25), 0, 255, 0);
+        AssertColor(Sample(occupied, image, 0.25, 0.75), 0, 0, 255);
+        AssertColor(Sample(occupied, image, 0.75, 0.75), 255, 255, 0);
     }
 
     [Fact]
@@ -395,14 +380,12 @@ public sealed class TerrainTextureAssetGeneratorTests
         TerrainTextureOverlay overlay = CreateFullCoverageOverlay(
             "https://primary.example/{z}/{x}/{y}.png",
             "https://fallback.example/{z}/{x}/{y}.png");
-        TerrainTextureLayoutPlan layout = TerrainTextureLayoutPlanner.Create(overlay.GeographicBounds, overlay.ZoomLevel);
-
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
         using Image<Rgba32> image = LoadImage(texture.TextureImport);
-        int occupiedTop = image.Height - layout.CropHeight;
-        AssertColor(image[layout.CropWidth / 4, occupiedTop + (layout.CropHeight / 2)], 255, 0, 0);
-        AssertColor(image[(layout.CropWidth * 3) / 4, occupiedTop + (layout.CropHeight / 2)], 0, 255, 0);
+        Rectangle occupied = ToTopLeftPixelRect(texture.OccupiedUvRect, image.Width, image.Height);
+        AssertColor(Sample(occupied, image, 0.25, 0.5), 255, 0, 0);
+        AssertColor(Sample(occupied, image, 0.75, 0.5), 0, 255, 0);
     }
 
     [Fact]
@@ -612,6 +595,29 @@ public sealed class TerrainTextureAssetGeneratorTests
         });
 
         return found;
+    }
+
+    private static Rectangle ToTopLeftPixelRect(TextureUvRect uvRect, int imageWidth, int imageHeight)
+    {
+        int x = (int)Math.Round(uvRect.MinU * imageWidth, MidpointRounding.AwayFromZero);
+        int y = (int)Math.Round((1.0 - uvRect.MaxV) * imageHeight, MidpointRounding.AwayFromZero);
+        int width = (int)Math.Round(uvRect.Width * imageWidth, MidpointRounding.AwayFromZero);
+        int height = (int)Math.Round(uvRect.Height * imageHeight, MidpointRounding.AwayFromZero);
+        int clampedX = Math.Clamp(x, 0, imageWidth - 1);
+        int clampedY = Math.Clamp(y, 0, imageHeight - 1);
+
+        return new Rectangle(
+            clampedX,
+            clampedY,
+            Math.Clamp(width, 1, imageWidth - clampedX),
+            Math.Clamp(height, 1, imageHeight - clampedY));
+    }
+
+    private static Rgba32 Sample(Rectangle rect, Image<Rgba32> image, double xFraction, double yFractionFromTop)
+    {
+        int x = rect.X + Math.Clamp((int)Math.Floor(rect.Width * xFraction), 0, rect.Width - 1);
+        int y = rect.Y + Math.Clamp((int)Math.Floor(rect.Height * yFractionFromTop), 0, rect.Height - 1);
+        return image[x, y];
     }
 
     private static void AssertColor(Rgba32 color, byte expectedR, byte expectedG, byte expectedB)

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -43,9 +43,15 @@ public sealed class TerrainTextureAssetGeneratorTests
         using Image<Rgba32> image = LoadImage(firstTexture.TextureImport);
         Assert.Equal(RoundUpToPowerOfTwo(layout.CropWidth), image.Width);
         Assert.Equal(RoundUpToPowerOfTwo(layout.CropHeight), image.Height);
-        int occupiedTop = image.Height - layout.CropHeight;
-        AssertColor(image[layout.CropWidth / 4, occupiedTop + (layout.CropHeight / 2)], 255, 0, 0);
-        AssertColor(image[(layout.CropWidth * 3) / 4, occupiedTop + (layout.CropHeight / 2)], 0, 255, 0);
+        int occupiedLeft = (image.Width - layout.CropWidth) / 2;
+        int occupiedTop = (image.Height - layout.CropHeight) / 2;
+        Assert.Equal(
+            new ScalarPair(
+                (double)occupiedLeft / image.Width,
+                (double)(image.Height - (occupiedTop + layout.CropHeight)) / image.Height),
+            firstTexture.OccupiedUvRect.OffsetValue);
+        AssertColor(image[occupiedLeft + (layout.CropWidth / 4), occupiedTop + (layout.CropHeight / 2)], 255, 0, 0);
+        AssertColor(image[occupiedLeft + ((layout.CropWidth * 3) / 4), occupiedTop + (layout.CropHeight / 2)], 0, 255, 0);
     }
 
     [Fact]
@@ -99,16 +105,17 @@ public sealed class TerrainTextureAssetGeneratorTests
                 (double)layout.CropWidth / RoundUpToPowerOfTwo(layout.CropWidth),
                 (double)layout.CropHeight / RoundUpToPowerOfTwo(layout.CropHeight)),
             texture.OccupiedUvRect.ScaleValue);
+        int occupiedLeft = (image.Width - layout.CropWidth) / 2;
+        int occupiedTop = (image.Height - layout.CropHeight) / 2;
         Assert.Equal(
             new ScalarPair(
-                0.0,
-                0.0),
+                (double)occupiedLeft / image.Width,
+                (double)(image.Height - (occupiedTop + layout.CropHeight)) / image.Height),
             texture.OccupiedUvRect.OffsetValue);
-        int occupiedTop = image.Height - layout.CropHeight;
         Assert.Equal(TerrainTextureAssetGenerator.DefaultDemGroundFillColor, image[0, 0]);
-        AssertColor(image[layout.CropWidth / 4, occupiedTop + (layout.CropHeight / 2)], 255, 0, 0);
-        AssertColor(image[(layout.CropWidth * 3) / 4, occupiedTop + (layout.CropHeight / 2)], 0, 255, 0);
-        Assert.True(occupiedTop > 0);
+        AssertColor(image[occupiedLeft + (layout.CropWidth / 4), occupiedTop + (layout.CropHeight / 2)], 255, 0, 0);
+        AssertColor(image[occupiedLeft + ((layout.CropWidth * 3) / 4), occupiedTop + (layout.CropHeight / 2)], 0, 255, 0);
+        Assert.True(occupiedLeft > 0 || occupiedTop > 0);
     }
 
     [Fact]
@@ -155,11 +162,12 @@ public sealed class TerrainTextureAssetGeneratorTests
         using Image<Rgba32> image = LoadImage(texture.TextureImport);
         Assert.Equal(RoundUpToPowerOfTwo(layout.CropWidth), image.Width);
         Assert.Equal(RoundUpToPowerOfTwo(layout.CropHeight), image.Height);
-        int occupiedTop = image.Height - layout.CropHeight;
-        AssertColor(image[layout.CropWidth / 4, occupiedTop + (layout.CropHeight / 4)], 255, 0, 0);
-        AssertColor(image[(layout.CropWidth * 3) / 4, occupiedTop + (layout.CropHeight / 4)], 0, 255, 0);
-        AssertColor(image[layout.CropWidth / 4, occupiedTop + ((layout.CropHeight * 3) / 4)], 0, 0, 255);
-        AssertColor(image[(layout.CropWidth * 3) / 4, occupiedTop + ((layout.CropHeight * 3) / 4)], 255, 255, 0);
+        int occupiedLeft = (image.Width - layout.CropWidth) / 2;
+        int occupiedTop = (image.Height - layout.CropHeight) / 2;
+        AssertColor(image[occupiedLeft + (layout.CropWidth / 4), occupiedTop + (layout.CropHeight / 4)], 255, 0, 0);
+        AssertColor(image[occupiedLeft + ((layout.CropWidth * 3) / 4), occupiedTop + (layout.CropHeight / 4)], 0, 255, 0);
+        AssertColor(image[occupiedLeft + (layout.CropWidth / 4), occupiedTop + ((layout.CropHeight * 3) / 4)], 0, 0, 255);
+        AssertColor(image[occupiedLeft + ((layout.CropWidth * 3) / 4), occupiedTop + ((layout.CropHeight * 3) / 4)], 255, 255, 0);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
@@ -390,9 +390,10 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             texture.TextureImport.RawRgba32Bytes,
             texture.TextureImport.Width,
             texture.TextureImport.Height);
-        int occupiedTop = outputImage.Height - layout.CropHeight;
+        int occupiedLeft = (outputImage.Width - layout.CropWidth) / 2;
+        int occupiedTop = (outputImage.Height - layout.CropHeight) / 2;
         Assert.Equal(TerrainTextureAssetGenerator.DefaultDemGroundFillColor, outputImage[0, 0]);
-        Assert.Equal(new Rgba32(12, 34, 56, 255), outputImage[0, occupiedTop]);
+        Assert.Equal(new Rgba32(12, 34, 56, 255), outputImage[occupiedLeft, occupiedTop]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- project textureless roof surfaces onto DEM terrain textures with WebMercator horizontal UVs
- add mesh-code keyed shared terrain texture assets under DatasetRoot
- let terrain and roof renderer overrides share the same StaticTexture2D component per third-level mesh code

## Tests
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

## Review
- fresh context review: no blocking regression, design debt, or test validity findings
