### PR TITLE
[codex] Narrow shared assets bootstrap reads

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneBootstrapInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneBootstrapInterpreter.cs
@@ -45,13 +45,14 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
 
         string completionMeshCode = ResoniteSourceMeshCodeAnchor.ResolveCompletionMeshCode(setupInfo);
         string datasetRootName = $"PLATEAU {setupInfo.Dataset}";
-        Slot rootSnapshot = await setupClient.GetSlotAsync(new ResoniteTransportSlotLocator(ResoniteSlotLocator.Root.Value), 4, cancellationToken)
+        Slot rootSnapshot = await setupClient.GetSlotAsync(new ResoniteTransportSlotLocator(ResoniteSlotLocator.Root.Value), 1, cancellationToken)
             ?? throw new InvalidOperationException("ResoniteLink did not surface the Root slot during bootstrap.");
         ResoniteSceneSlotSnapshot rootSlotSnapshot = new(rootSnapshot);
         Slot? sharedAssetsSlot = GetReusableChildSlot(rootSlotSnapshot, SharedAssetsRootName, "Root");
-        Slot? sharedCommonMaterialsSlot = sharedAssetsSlot is null
-            ? null
-            : GetReusableChildSlot(new ResoniteSceneSlotSnapshot(sharedAssetsSlot), SharedCommonMaterialsRootName, sharedAssetsSlot.ID!);
+        Slot? sharedCommonMaterialsSlot = await TryGetExistingSharedCommonMaterialsSlotAsync(
+            setupClient,
+            sharedAssetsSlot,
+            cancellationToken);
         CreatedSlot? existingDatasetRoot = await sceneSlotLocator.TryGetDatasetRootAsync(
             setupClient,
             datasetRootName,
@@ -221,6 +222,37 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
         return lookup.State == ResoniteSceneChildLookupState.FoundWithId
             ? lookup.Slot
             : null;
+    }
+
+    private static async Task<Slot?> TryGetExistingSharedCommonMaterialsSlotAsync(
+        IResoniteLinkClient setupClient,
+        Slot? sharedAssetsSlot,
+        CancellationToken cancellationToken)
+    {
+        if (sharedAssetsSlot?.ID is null)
+        {
+            return null;
+        }
+
+        Slot? sharedAssetsSnapshot = await setupClient.GetSlotAsync(
+            new ResoniteTransportSlotLocator(sharedAssetsSlot.ID),
+            1,
+            cancellationToken);
+        Slot? commonMaterialsSlot = sharedAssetsSnapshot is null
+            ? null
+            : GetReusableChildSlot(
+                new ResoniteSceneSlotSnapshot(sharedAssetsSnapshot),
+                SharedCommonMaterialsRootName,
+                sharedAssetsSlot.ID);
+        if (commonMaterialsSlot?.ID is null)
+        {
+            return commonMaterialsSlot;
+        }
+
+        return await setupClient.GetSlotAsync(
+            new ResoniteTransportSlotLocator(commonMaterialsSlot.ID),
+            2,
+            cancellationToken);
     }
 
     private async Task<ResoniteSceneBootstrapState> CreateInitialBootstrapStateAsync(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -341,6 +341,48 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
+    public async Task BuildAsyncReadsExistingSharedMaterialAssetsWithTargetedGetSlotDepth()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ImportedSceneMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        using SceneBuilderRecordingClient client = new();
+
+        string emptyCurrentMaterialSlotId = await SeedEmptyCurrentGenericSharedMaterialSlotAsync(client);
+
+        await ResoniteLiveSceneImportTargetTestSupport.BuildSceneAsync(
+            metadata,
+            [
+                CreatePayloadTriangleCityObject(
+                    "targeted-shared-material-read",
+                    ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(255, 0, 0, "textures/targeted-shared-material-read.png")),
+            ],
+            client,
+            enableMeshBake: false);
+
+        string rendererMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject targeted-shared-material-read");
+        AddComponent materialComponentRequest = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, rendererMaterialId, StringComparison.Ordinal));
+        Assert.Equal(emptyCurrentMaterialSlotId, materialComponentRequest.ContainerSlotId);
+        SlotGetRequest[] rootGetSlotCalls = client.SlotGetRequests
+            .Where(static request => string.Equals(request.SlotPath, "Root", StringComparison.Ordinal))
+            .ToArray();
+        SlotGetRequest[] sharedAssetsGetSlotCalls = client.SlotGetRequests
+            .Where(static request => string.Equals(request.SlotPath, "PLATEAU Shared Assets", StringComparison.Ordinal))
+            .ToArray();
+        SlotGetRequest[] commonMaterialsGetSlotCalls = client.SlotGetRequests
+            .Where(static request => string.Equals(request.SlotPath, "PLATEAU Shared Assets/Common Materials", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.NotEmpty(rootGetSlotCalls);
+        Assert.NotEmpty(sharedAssetsGetSlotCalls);
+        Assert.NotEmpty(commonMaterialsGetSlotCalls);
+        Assert.All(rootGetSlotCalls, request => Assert.Equal(1, request.Depth));
+        Assert.All(sharedAssetsGetSlotCalls, request => Assert.Equal(1, request.Depth));
+        Assert.All(commonMaterialsGetSlotCalls, request => Assert.Equal(2, request.Depth));
+    }
+
+    [Fact]
     public async Task BuildAsyncReusesSharedCommonMaterialAcrossRunsForPayloadAlbedoOverridesWithDifferentUvTransforms()
     {
         using TemporaryDirectory datasetDirectory = new();

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -514,6 +514,8 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
 
 }
 
+internal sealed record SlotGetRequest(string SlotId, string SlotPath, int Depth);
+
 internal sealed class SceneBuilderRecordingClient : IResoniteLinkClient
 {
     private readonly object gate = new();
@@ -539,6 +541,8 @@ internal sealed class SceneBuilderRecordingClient : IResoniteLinkClient
     public Dictionary<string, Slot> SlotsById { get; } = new(StringComparer.Ordinal);
 
     public Dictionary<string, string> SlotPaths { get; } = new(StringComparer.Ordinal);
+
+    public List<SlotGetRequest> SlotGetRequests { get; } = [];
 
     public List<string> OperationNames { get; } = [];
 
@@ -682,6 +686,7 @@ internal sealed class SceneBuilderRecordingClient : IResoniteLinkClient
             string observedSlot = SlotPaths.TryGetValue(slot.Value, out string? path)
                 ? path
                 : slot.Value;
+            SlotGetRequests.Add(new SlotGetRequest(slot.Value, observedSlot, depth));
             OperationNames.Add($"GetSlot:{observedSlot}");
         }
 


### PR DESCRIPTION
## Summary
- avoid reading the full root hierarchy when probing existing `PLATEAU Shared Assets`
- read Shared Assets and Common Materials with targeted depths only when those slots exist
- add a regression test that records `GetSlot` depths for the existing shared material asset path

## Validation
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`

## Live observation
- Yokohama `14100-yokohama-shi` mesh `53391530`, `bldg`, `terrain-mesh static`, `resonitelink-connections 4`
- Existing `PLATEAU Shared Assets/Common Materials` confirmed before send
- Bootstrap completed in `1.41s`; first city object queued after `15.208s`; first sent after `164.769s`
- The live run was stopped after first-send evidence was captured, and the partial Yokohama root was removed while preserving shared assets