### PR TITLE
docs: define GeoreferencedTexture appearance policy

### DIFF
--- a/docs/appearance-policy.ja.md
+++ b/docs/appearance-policy.ja.md
@@ -1,0 +1,27 @@
+# Appearance Policy
+
+この文書は、PLATEAU-ResoniteLink における CityGML appearance 処理の現在の対応範囲を定義します。
+
+## 対応済みの経路
+
+- `GeoreferencedTexture` は、#91 で既に扱っている DEM 側の georeferenced raster 経路に限って対応します。
+- その経路では、georeferenced raster のメタデータを使って DEM terrain imagery と terrain texture overlay を解決します。
+- ここでの対応は DEM の terrain imagery に関するものであり、一般の surface appearance projection ではありません。
+
+## 明示的な未対応
+
+- 非 DEM、または building-surface の `GeoreferencedTexture` projection は未対応です。
+- 解析した `GeoreferencedTexture` メタデータは、inspection や diagnostics のために保持してよいですが、非 DEM surface の rendering contract にはなりません。
+- 非 DEM surface に対して、`GeoreferencedTexture` から UV projection、wrap mode、border handling、alpha handling、transparency semantics を推測してはいけません。
+- もし dataset が rendered appearance として非 DEM `GeoreferencedTexture` を前提にしているなら、専用の issue で explicit な projection policy と tests を追加するまで out of scope です。
+
+## 関連 Issue との関係
+
+- #91 が、対応済みの DEM georeferenced-raster 経路を定義しました。
+- #128 は、`diffuseColor`、`ambientIntensity`、`emissiveColor`、`specularColor`、`shininess`、`transparency` などの `X3DMaterial` optical attributes を扱います。
+- #129 は、sampler、wrap、border、transparency behavior に関する残りの appearance semantics を扱います。
+- #128 と #129 のどちらも、非 DEM `GeoreferencedTexture` projection の対応を意味しません。
+
+## レビュー基準
+
+- 今後 non-DEM `GeoreferencedTexture` に触れる code change は、parse-only のまま維持するか、同じ変更内で explicit な rendering policy と tests を追加する必要があります。

--- a/docs/appearance-policy.md
+++ b/docs/appearance-policy.md
@@ -1,0 +1,27 @@
+# Appearance Policy
+
+This document defines the current supported scope for CityGML appearance handling in PLATEAU-ResoniteLink.
+
+## Supported Path
+
+- `GeoreferencedTexture` is supported only as part of the DEM-side georeferenced raster path already handled in #91.
+- In that path, georeferenced raster metadata is used to resolve DEM terrain imagery and terrain texture overlays.
+- That support is about DEM terrain imagery, not about general surface appearance projection.
+
+## Explicitly Unsupported
+
+- Non-DEM or building-surface `GeoreferencedTexture` projection is not supported.
+- Parsed `GeoreferencedTexture` metadata may be retained for inspection or diagnostics, but it does not become a rendering contract for non-DEM surfaces.
+- Do not infer UV projection, wrap mode behavior, border handling, alpha handling, or transparency semantics for non-DEM surfaces from `GeoreferencedTexture`.
+- If a dataset relies on non-DEM `GeoreferencedTexture` for rendered appearance, treat that as out of scope unless a dedicated issue adds an explicit projection policy and tests.
+
+## Relationship To Related Issues
+
+- #91 established the supported DEM georeferenced-raster path.
+- #128 covers `X3DMaterial` optical attributes such as `diffuseColor`, `ambientIntensity`, `emissiveColor`, `specularColor`, `shininess`, and `transparency`.
+- #129 covers remaining appearance semantics around sampler, wrap, border, and transparency behavior.
+- Neither #128 nor #129 imply support for non-DEM `GeoreferencedTexture` projection.
+
+## Review Rule
+
+- If future code changes touch non-DEM `GeoreferencedTexture`, they must either keep it parse-only or add an explicit rendering policy and matching tests in the same change.


### PR DESCRIPTION
## Summary
- document the target-neutral GeoreferencedTexture support policy
- mirror the policy in Japanese documentation

Refs #162

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false