### PR TITLE
docs(terminology): freeze current terminology map

### DIFF
--- a/docs/terminology.ja.md
+++ b/docs/terminology.ja.md
@@ -1,0 +1,46 @@
+# 用語
+
+この文書は current main に対するリネームマップです。Issue #165 以降の用語移行では、この英語版を正とします。
+
+## ルール
+
+- dataset、package、mesh-code、tile、adapter の概念名は PLATEAU SDK for Unity の用語に寄せます。
+- 概念名を変えるときは、directory、file name、namespace、CLI help、docs、tests、resources を同じ変更単位でそろえます。
+- repository 内部概念の rename では互換 alias を追加しません。古い名前は、外部入力、serialized data、履歴文書の境界にだけ残します。
+- adapter 境界より上では target-neutral な名前を使います。Resonite 固有語は Resonite target、transport、live-send adapter 配下に閉じます。
+
+## Canonical Map
+
+| 現在または曖昧な用語 | canonical term | 対象 | migration rule |
+| --- | --- | --- | --- |
+| 日本標準地域メッシュを指す `tile` | `mesh-code` | CLI、docs、source discovery、dataset selection | user-facing text と internal identifier を rename します。`--tile` は migration cut で alias を消すまで deprecated external CLI alias としてだけ残します。 |
+| PLATEAU mesh-code area を指す `mesh` | `mesh-code` または `mesh-code bounds` | discovery、filtering、source grouping | geography に `mesh` を使いません。`mesh` は renderable geometry payload のみに予約します。 |
+| 単独の `source` | `CityGML source`、`GeoTIFF source`、`terrain texture source`、`dataset source` | CLI、import requests、source adapters | 型名や境界名で明示できていない限り、source kind を修飾します。 |
+| 地理座標を指す `origin` | `geo origin` または `geodetic origin` | projection、local-coordinate conversion | `local origin` は projection 後の target/local scene anchor だけに使います。 |
+| object/source ownership を指す `origin` | `source unit` または `source file` | parsed objects、bake scope、provenance | logical ownership は `source unit`、物理 CityGML file identity は `source file` とします。 |
+| import preparation を指す `build` | `prepare`、`plan`、`bake`、`emit` | import pipeline、target execution | phase-specific verb を選びます。generic lifecycle phase として `build` を使いません。 |
+| long-lived import state を指す `bootstrap` | `discovery`、`parsed`、`prepared`、`plan` | setup/discovery、result models | `bootstrap` は pre-streaming setup が固定 scene/session context を作る場合だけに残します。 |
+| runtime policy を指す `profile` | `policy`、`preset`、`material profile` | import options、material defaults、budget settings | `profile` は named reusable material/budget preset のみに使い、任意の policy object には使いません。 |
+| `package` | `PLATEAU package` または `package name` | `bldg`、`tran`、`dem` などの UDX package concepts | `package` は PLATEAU/UDX package name に使います。import code では file archive や dependency package に流用しません。 |
+| `adapter` | `source adapter`、`target adapter`、`transport adapter` | boundary implementations | boundary の側を修飾します。 |
+
+## Grandfathered Surfaces
+
+次の名前は、専用 migration で取り除くまで残せます。
+
+- 古い flag から canonical flag へ誘導するためだけにある deprecated CLI alias と error message。
+- 過去の issue、PR、changelog、release note。
+- third-party name、upstream schema name、package ID、外部定義の file path。
+- ResoniteLink、CityGML、GeoTIFF、その他 external format が要求する serialized name または wire name。
+
+## #165 の Cut Boundary
+
+Issue #165 は repository-owned names だけを移行します。明示的な CLI alias removal を除き、external schema name、third-party asset path、user data format は変更しません。
+
+最初の migration cut では次を行います。
+
+- mesh-code concept に対する `tile` の deprecated internal use を取り除く。
+- CityGML、GeoTIFF、terrain texture、dataset の境界をまたぐ曖昧な `source` identifier を分ける。
+- generic な `origin` identifier を `geo origin`、`geodetic origin`、`local origin`、`source unit`、`source file` のいずれかへ置き換える。
+- generic な `build` と misplaced `bootstrap` concept を phase-specific name に置き換える。
+- 各 rename 後の directory ownership と namespace を一致させる。

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -1,0 +1,46 @@
+# Terminology
+
+This document is the current-main rename map for repository concepts. It is the source of truth for issue #165 and later terminology migrations.
+
+## Rules
+
+- Prefer PLATEAU SDK for Unity terminology when naming dataset, package, mesh-code, tile, and adapter concepts.
+- Rename a concept in one cut across directories, filenames, namespaces, CLI help, docs, tests, and resources.
+- Do not add compatibility aliases for renamed internal concepts. Keep old names only at explicit external input, serialized data, or historical documentation boundaries.
+- Use target-neutral names above adapter edges. Resonite-specific terms belong under Resonite target, transport, or live-send adapters.
+
+## Canonical Map
+
+| Current or ambiguous term | Canonical term | Applies to | Migration rule |
+| --- | --- | --- | --- |
+| `tile` when it means a Japanese standard mesh code | `mesh-code` | CLI, docs, source discovery, dataset selection | Rename user-facing text and internal identifiers. Keep `--tile` only as a deprecated external CLI alias until the migration cut removes aliases. |
+| `mesh` when it means PLATEAU mesh-code area | `mesh-code` or `mesh-code bounds` | discovery, filtering, source grouping | Do not use `mesh` for geography. Reserve `mesh` for renderable geometry payloads. |
+| `source` by itself | `CityGML source`, `GeoTIFF source`, `terrain texture source`, or `dataset source` | CLI, import requests, source adapters | Qualify the source kind unless the local type already names the boundary. |
+| `origin` for geographic coordinates | `geo origin` or `geodetic origin` | projection and local-coordinate conversion | Use `local origin` only for the target/local scene anchor after projection. |
+| `origin` for object/source ownership | `source unit` or `source file` | parsed objects, bake scope, provenance | Use `source unit` for logical ownership and `source file` for physical CityGML file identity. |
+| `build` for import preparation | `prepare`, `plan`, `bake`, or `emit` | import pipeline and target execution | Pick the phase-specific verb. Do not use `build` as a generic lifecycle phase. |
+| `bootstrap` for long-lived import state | `discovery`, `parsed`, `prepared`, or `plan` | setup/discovery and result models | Keep `bootstrap` only for pre-streaming setup that creates fixed scene/session context. |
+| `profile` for runtime policy | `policy`, `preset`, or `material profile` | import options, material defaults, budget settings | Use `profile` only for named reusable material/budget presets, not for arbitrary policy objects. |
+| `package` | `PLATEAU package` or `package name` | `bldg`, `tran`, `dem`, and other UDX package concepts | Keep `package` for PLATEAU/UDX package names. Do not reuse it for file archives or dependency packages in import code. |
+| `adapter` | `source adapter`, `target adapter`, or `transport adapter` | boundary implementations | Qualify the side of the boundary. |
+
+## Grandfathered Surfaces
+
+These names may remain until a dedicated migration removes them:
+
+- Deprecated CLI aliases and error messages that exist only to guide users from old flags to canonical flags.
+- Historical issue, PR, changelog, and release-note text.
+- Third-party names, upstream schema names, package IDs, and file paths whose spelling is externally defined.
+- Serialized or wire names required by ResoniteLink, CityGML, GeoTIFF, or other external formats.
+
+## Cut Boundary for #165
+
+Issue #165 should migrate repository-owned names only. It must not change external schema names, third-party asset paths, or user data formats unless the change is an explicit CLI alias removal.
+
+The first migration cut should:
+
+- remove deprecated internal uses of `tile` for mesh-code concepts;
+- split ambiguous `source` identifiers where the code crosses CityGML, GeoTIFF, terrain texture, or dataset boundaries;
+- replace generic `origin` identifiers with `geo origin`, `geodetic origin`, `local origin`, `source unit`, or `source file`;
+- rename generic `build` and misplaced `bootstrap` concepts to phase-specific names;
+- keep namespaces aligned with the final directory ownership after each rename.


### PR DESCRIPTION
## Summary
- Freezes the current terminology map for Lane A.
- Documents the accepted terminology surface before the migration branch.

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

Refs #164