### PR TITLE
docs(road): define road-network coexistence policy

### DIFF
--- a/docs/road-network-boundary.ja.md
+++ b/docs/road-network-boundary.ja.md
@@ -1,0 +1,134 @@
+# 道路ネットワーク境界
+
+この文書は、共存挙動を実装する前に road-network support の表現境界を固定する。これは Issue #130 の仕様カットである。Issue #131 は、この出力とより詳細な transport 関連出力の間の重複抑制、優先順位、merge 挙動を担当する。
+
+## 観測された現状
+
+現在の import pipeline は `udx/<package>/...` 配下の CityGML source file を発見し、PLATEAU package name を正規化し、package scope の `ImportedObjectUnit` を target-neutral な construction geometry として stream してから Resonite target layer に渡す。
+
+road 関連 package の扱いは、すでに package based である。
+
+- `tran`、`rwy`、`squr`、`trk` は `RoadPackageNames` である。
+- `wwy` は path-like だが road package ではない。
+- default material selection は road package と path-like package を bundled road material family に割り当てる。
+- CityGML reader は現時点で polygon と triangle surface を投影する。PLATEAU transportation file を既存の topological road graph として扱ってはいない。
+- transportation surface には、Resonite emission 前の target-neutral な terrain alignment 挙動がすでにある。
+
+PLATEAU SDK for Unity は road-network generation を imported road model からの派生処理として説明している。road mesh geometry から road structure、lane、sidewalk、intersection、lane connection を推定し、自動生成される network は推定であると説明している。この repository でもその分離を維持する。source CityGML road geometry は入力証拠であり、それ自体を road-network graph としない。
+
+参考:
+
+- PLATEAU SDK for Unity road-network manual: https://project-plateau.github.io/PLATEAU-SDK-for-Unity/manual/RoadNetwork.html
+- PLATEAU RoadNetwork Generator overview: https://project-plateau.github.io/PLATEAU-RoadNetwork-Generator/index.html
+
+## 決定
+
+road network は derived transport abstraction として表現する。
+
+raw source graph ではない。
+
+- PLATEAU CityGML transportation package content には road surface、marking、より詳細な structure が含まれうるが、現在の importer が信頼して扱えるのは source-file と city-object surface stream である。
+- SDK と揃う挙動は、権威ある road topology の直接再利用ではなく、road model evidence からの生成である。
+
+Resonite-specific target model でもない。
+
+- coexistence decision は ResoniteLink なしで test できるよう、target emission 前に実行できなければならない。
+- geometry、provenance、coverage、generated network semantics は、target adapter が変換するまで target-neutral に保つ。
+
+この abstraction は importing/application 側の boundary に置き、後続 policy に必要な provenance を持つ。
+
+- source package name
+- source file relative path
+- matched mesh code と、利用可能なら resolved actual mesh code
+- source object id または stable object key
+- selected LOD または inferred source-detail level
+- source coordinates または geodetic coordinates の road-space coverage footprint
+- その source evidence が所有する generated road-network elements
+
+## Source Abstraction
+
+source abstraction は概念上 `RoadNetworkSource` である。最初の実装名が別名であってもよいが、これは選択された road-package CityGML evidence に対する read-side contract であり、target output contract ではない。
+
+これは現在の CityGML import と同じ discovery window から作る。
+
+- requested mesh code と requested package だけを見る。
+- normalized road package、つまり `tran`、`rwy`、`squr`、`trk` だけを消費する。
+- 既存の parsed road surface、road marking detection、object id、source file descriptor、LOD selection、CRS conversion を使ってよい。
+- Resonite slot name、material asset identity、target batching state、coexistence decision を source model に持ち込んではならない。
+- generated road-network elements が merge または simplify されても source provenance を保持する。
+
+source abstraction には推定事実を含めてよい。ただし、それは inferred として label する。例として lane count、sidewalk presence、road-axis shape、intersection membership、road-space coverage がある。package name、source file、object id、LOD、CRS、mesh code のような source fact は inferred fact と区別したまま保持する。
+
+## Output Unit
+
+road-network output unit は road-space unit であり、dataset 全体でも individual target slot でもない。
+
+最小の ownership unit は、1つの source road object から派生した generated road-network unit、または mesh-area filtering のために source object が split された場合の stable source-object group である。その unit は次を所有する。
+
+- source provenance
+- road-space coverage footprint
+- road、way、lane、sidewalk、intersection、track などの generated network primitives
+- その generated network unit に付随する generated visual geometry、marking、debug geometry
+
+実装がこれを既存の `ImportedObjectUnit` 経由で投影する場合、descriptor は source-file/package/LOD scope のままとし、各 generated `ImportedCityObject` は stable road-network object key と source provenance を保持しなければならない。将来 dedicated road-network unit type を追加する場合でも、target-specific field なしで target-neutral construction geometry に変換できる必要がある。
+
+後続変更で graph-wide optimization を明示的に導入しない限り、output unit を global road graph にしない。global connectivity は derived view として計算してよいが、ownership と coexistence は road-space unit へ trace できる必要がある。
+
+## Ownership Boundary
+
+road-network generator が所有するもの:
+
+- road-package source evidence から target-neutral road-network unit を導出すること
+- source provenance と inferred-vs-source label を保持すること
+- deterministic object key と deterministic ordering を生成すること
+- coexistence policy に必要な coverage metadata を出力すること
+
+既存の CityGML source discovery と parsing pipeline が所有するもの:
+
+- source file enumeration
+- package normalization
+- mesh-code selection
+- CRS parsing と validation
+- source object parsing
+
+target adapter が所有するもの:
+
+- target-neutral generated geometry から Resonite construction data への変換
+- material と asset emission
+- target-specific slot hierarchy と live-send behavior
+
+Issue #131 が所有するもの:
+
+- detailed transport output が road-network unit を suppress、replace、coexist のどれにするかの決定
+- generated road-network unit と detailed transport-related output の road-space coverage 比較
+- operator から見える precedence behavior の文書化
+
+## #131 の積み上げ方
+
+#131 はこの boundary を消費し、再定義しない。
+
+推奨される build path:
+
+1. road-network unit を code 実装する場合、road-space coverage の executable metadata を追加する。
+2. coexistence は target emission 前、できれば source composition または object-unit optimization path で実行する。
+3. detailed transport-related output と road-network unit は Resonite slot name ではなく coverage と provenance で比較する。
+4. 後続の受け入れ済み design が sub-unit splitting を導入しない限り、policy は road-space unit 全体に適用する。
+5. detailed-output precedence と merge rule は #131 documentation と tests に置き、この #130 boundary document には入れない。
+
+#131 の未決事項:
+
+- どの detailed transport package と object class が road-network unit を suppress するか。
+- detailed output が常に勝つのか、または設定された detail level や coverage threshold に到達した場合だけ勝つのか。
+- road-network unit から生成された marking を network unit と一緒に suppress するか。
+- suppressed-unit count を CLI progress と datasource summary にどう出すか。
+
+## Non-Goals
+
+この文書は次を実装しない。
+
+- road-network generation
+- road-network export
+- coexistence または precedence rule
+- duplicate suppression
+- Resonite-specific slot layout
+- 将来 rename される概念の compatibility alias

--- a/docs/road-network-boundary.md
+++ b/docs/road-network-boundary.md
@@ -1,0 +1,134 @@
+# Road Network Boundary
+
+This document fixes the representation boundary for road-network support before coexistence behavior is implemented. It is the specification cut for Issue #130. Issue #131 owns duplicate suppression, precedence, and merge behavior between this output and higher-detail transport-related output.
+
+## Observed Baseline
+
+The current import pipeline discovers CityGML source files under `udx/<package>/...`, normalizes PLATEAU package names, and streams package-scoped `ImportedObjectUnit` values into target-neutral construction geometry before the Resonite target layer emits anything.
+
+Road-related package handling is already package-based:
+
+- `tran`, `rwy`, `squr`, and `trk` are `RoadPackageNames`.
+- `wwy` is path-like, but not a road package.
+- Default material selection maps road and path-like packages to the bundled road material family.
+- The CityGML reader currently projects polygon and triangle surfaces. It does not treat PLATEAU transportation files as an existing topological road graph.
+- Transportation surfaces already have target-neutral terrain alignment behavior before Resonite emission.
+
+The PLATEAU SDK for Unity describes road-network generation as a derived process from imported road models: it estimates road structure, lanes, sidewalks, intersections, and lane connections from road mesh geometry, and warns that automatically generated networks are estimates. This repository should preserve that separation: source CityGML road geometry is input evidence, not itself the road-network graph.
+
+References:
+
+- PLATEAU SDK for Unity road-network manual: https://project-plateau.github.io/PLATEAU-SDK-for-Unity/manual/RoadNetwork.html
+- PLATEAU RoadNetwork Generator overview: https://project-plateau.github.io/PLATEAU-RoadNetwork-Generator/index.html
+
+## Decision
+
+Road network is represented as a derived transport abstraction.
+
+It is not a raw source graph:
+
+- PLATEAU CityGML transportation package content can include road surfaces, markings, and higher-detail structures, but the current importer only has a reliable source-file and city-object surface stream.
+- The SDK-aligned behavior is generation from road model evidence, not direct reuse of an authoritative road topology.
+
+It is not a Resonite-specific target model:
+
+- Coexistence decisions must run before target emission so they can be tested without ResoniteLink.
+- Geometry, provenance, coverage, and generated network semantics must remain target-neutral until the target adapter converts them.
+
+The abstraction must live on the importing/application side of the boundary and carry enough provenance for later policy:
+
+- source package name
+- source file relative path
+- matched mesh code and resolved actual mesh code when available
+- source object id or stable object key
+- selected LOD or inferred source-detail level
+- road-space coverage footprint in source coordinates or geodetic coordinates
+- generated road-network elements owned by that source evidence
+
+## Source Abstraction
+
+The source abstraction is `RoadNetworkSource` in concept, even if the first implementation names it differently. It is a read-side contract over selected road-package CityGML evidence, not a target output contract.
+
+It should be created from the same discovery window as current CityGML import:
+
+- It only sees requested mesh codes and requested packages.
+- It only consumes normalized road packages: `tran`, `rwy`, `squr`, and `trk`.
+- It may use existing parsed road surfaces, road marking detection, object ids, source file descriptors, LOD selection, and CRS conversion.
+- It must not pull Resonite slot names, material asset identities, target batching state, or coexistence decisions into the source model.
+- It must preserve source provenance even when generated road-network elements are merged or simplified.
+
+The source abstraction may contain inferred facts, but they must be labeled as inferred. Examples include lane count, sidewalk presence, road-axis shape, intersection membership, and road-space coverage. Source facts such as package name, source file, object id, LOD, CRS, and mesh code must remain distinguishable from inferred facts.
+
+## Output Unit
+
+The road-network output unit is a road-space unit, not a whole dataset and not an individual target slot.
+
+The minimum unit of ownership is one generated road-network unit derived from one source road object or one stable source-object group when the source object is split for mesh-area filtering. That unit owns:
+
+- its source provenance
+- its road-space coverage footprint
+- its generated network primitives, such as roads, ways, lanes, sidewalks, intersections, or tracks
+- any generated visual geometry, markings, or debug geometry attached to that generated network unit
+
+If the implementation projects this through existing `ImportedObjectUnit`, the descriptor should remain source-file/package/LOD scoped, and each generated `ImportedCityObject` must keep a stable road-network object key and source provenance. If a dedicated road-network unit type is added later, it should still be convertible into target-neutral construction geometry without target-specific fields.
+
+Do not make the output unit a global road graph unless a later change explicitly introduces graph-wide optimization. Global connectivity may be computed as a derived view, but ownership and coexistence must still be traceable to road-space units.
+
+## Ownership Boundary
+
+The road-network generator owns:
+
+- deriving target-neutral road-network units from road-package source evidence
+- preserving source provenance and inferred-vs-source labels
+- producing deterministic object keys and deterministic ordering
+- emitting enough coverage metadata for coexistence policy
+
+The existing CityGML source discovery and parsing pipeline owns:
+
+- source file enumeration
+- package normalization
+- mesh-code selection
+- CRS parsing and validation
+- source object parsing
+
+The target adapters own:
+
+- converting target-neutral generated geometry into Resonite construction data
+- material and asset emission
+- target-specific slot hierarchy and live-send behavior
+
+Issue #131 owns:
+
+- deciding whether detailed transport output suppresses, replaces, or coexists with road-network units
+- comparing road-space coverage between generated road-network units and detailed transport-related output
+- documenting the operator-visible precedence behavior
+
+## #131 Build Path
+
+#131 should consume this boundary instead of redefining it.
+
+The recommended build path is:
+
+1. Add executable metadata for road-space coverage if the road-network unit is implemented in code.
+2. Run coexistence before target emission, preferably in the source composition or object-unit optimization path.
+3. Compare detailed transport-related output and road-network units by coverage and provenance, not by Resonite slot names.
+4. Apply policy to whole road-space units unless a later accepted design introduces sub-unit splitting.
+5. Keep detailed-output precedence and merge rules in #131 documentation and tests, not in this #130 boundary document.
+
+Open questions for #131:
+
+- Which detailed transport packages and object classes suppress road-network units?
+- Whether detailed output should always win, or only when it reaches a configured detail level or coverage threshold.
+- Whether markings generated from the road-network unit are suppressed together with the network unit.
+- How to surface suppressed-unit counts in CLI progress and datasource summaries.
+
+## Non-Goals
+
+This document does not implement:
+
+- road-network generation
+- road-network export
+- coexistence or precedence rules
+- duplicate suppression
+- Resonite-specific slot layout
+- a compatibility alias for future renamed concepts

--- a/docs/road-network-coexistence.ja.md
+++ b/docs/road-network-coexistence.ja.md
@@ -1,0 +1,95 @@
+# Road Network Coexistence
+
+この文書は、generated road-network output と、より詳細な transport 関連 output の間にある Issue #131 の coexistence と precedence policy を定義する。[road-network-boundary.md](road-network-boundary.md) を前提にし、road-network generation は実装しない。
+
+## Current Execution Surface
+
+現在の import pipeline は、Resonite target emission の前に package scope の `ImportedObjectUnit` を出力する。各 unit は source file、normalized package name、LOD level、利用可能な matched mesh code によって scope される。
+
+現在の object-unit optimization path は target-neutral である。
+
+- `StreamingImportedSceneSource` は projected city object を source file と LOD ごとにまとめる。
+- `IImportedObjectUnitOptimizer` は target sink が受け取る前の stream を変換する。
+- `CompositeImportedObjectUnitOptimizer` は登録された optimizer を順に適用する。
+- 現時点で登録されている optimizer は dynamic material UV metadata を normalize する。road-network coexistence filtering は実行しない。
+
+generated road-network unit が coverage metadata を持った時点では、この optimizer seam が executable coexistence policy を追加する正しい場所である。それまでは、この文書を policy contract とし、runtime suppression がすでに行われるとは示さない。
+
+## Transport Detail Classes
+
+road-network coexistence は、generated road-network unit と detailed transport-related output を road space 上でだけ比較する。
+
+road package は次の通り。
+
+- `tran`
+- `rwy`
+- `squr`
+- `trk`
+
+`wwy` は path-like であり road-family material を共有しうるが、road package ではない。そのため default では generated road-network unit を suppress しない。
+
+detailed transport-related output とは、generated road-network unit と同じ road-space area を同等以上の source-detail level で表す road package 由来の source CityGML geometry である。例として、road surface geometry、road marking、roadside structure、railway または track surface、generated unit の road-space footprint と重なる square/open-space transportation surface がある。
+
+## Precedence Policy
+
+detailed transport-related output は、重なる road-space unit に対して generated road-network output より優先される。
+
+policy は次の通り。
+
+- generated road-network unit と detailed road-package output が同じ road-space unit を cover する場合、detailed output を emit し、generated road-network unit を suppress する。
+- overlap が部分的な場合でも、後続の accepted design が sub-unit splitting を導入しない限り、policy は generated road-network unit 全体に適用する。
+- generated road-network unit と重なる detailed road-package output が無い場合、generated road-network unit を emit する。
+- 重なる output が non-road package output だけの場合、後続の package-specific policy がない限り、両方を保持する。
+- coverage metadata が欠けていて overlap を評価できない場合、generated road-network unit を保持し、silent suppression ではなく metadata 欠落を report する。
+
+suppression は、その unit が所有する generated road-network unit、generated visual geometry、generated marking、generated debug geometry、generated network primitive を取り除く。source CityGML geometry は取り除かない。
+
+## Merge Policy
+
+default の merge behavior は no merge である。
+
+generated road-network unit と detailed transport-related output は、別 unit として coexist するか、generated road-network unit が suppress される。provenance retention を伴う明示的な graph-wide または sub-unit merge design が後続変更で導入されない限り、source CityGML transport geometry と generated road-network primitive を単一 output unit に結合しない。
+
+connectivity view は analysis 用の derived view として作ってよいが、ownership を変えてはならない。suppression と operator reporting は generated road-network unit と、優先された detailed source output へ trace できるままにする。
+
+## Comparison Inputs
+
+coexistence comparison には target-neutral evidence を使う。
+
+- normalized package name
+- source file relative path
+- matched mesh code と、利用可能なら resolved actual mesh code
+- stable source object id または generated road-network object key
+- selected LOD または source-detail level
+- source coordinates または geodetic coordinates の road-space coverage footprint
+- fact が source-observed か inferred か
+
+次で比較してはならない。
+
+- Resonite slot name
+- material asset identity
+- live-send batching state
+- target hierarchy layout
+- generated display name だけ
+
+## Operator-Visible Behavior
+
+operator は selected package と coverage から emitted output を予測できる必要がある。
+
+- road package を選択すると detailed road-package output が生成されうる。
+- 将来 road-network generator を有効化すると、detailed road-package output に cover されていない road-space area に generated road-network unit が生成されうる。
+- 両方の output が同じ road-space unit を claim する場合、detailed road-package output が勝ち、generated unit は suppress される。
+- `wwy` output は path-like だが road package set 外であるため、default では generated road-network unit と coexist できる。
+- runtime suppression を実装したら suppression count を report する。その report は suppressed generated unit、勝った detailed source package、判断に使った source file または object evidence を識別する。
+
+## Non-Goals
+
+この文書は次を定義しない。
+
+- road-network generation algorithm
+- lane、sidewalk、intersection inference
+- Resonite slot layout
+- target material assignment
+- graph-wide optimization
+- sub-unit splitting
+- road-network unit と coverage metadata が存在する前の runtime suppression 実装

--- a/docs/road-network-coexistence.md
+++ b/docs/road-network-coexistence.md
@@ -1,0 +1,95 @@
+# Road Network Coexistence
+
+This document defines the Issue #131 coexistence and precedence policy between generated road-network output and higher-detail transport-related output. It builds on [road-network-boundary.md](road-network-boundary.md) and does not implement road-network generation.
+
+## Current Execution Surface
+
+The current import pipeline emits package-scoped `ImportedObjectUnit` values before any Resonite target emission. Each unit is scoped by source file, normalized package name, LOD level, and matched mesh code when available.
+
+The current object-unit optimization path is target-neutral:
+
+- `StreamingImportedSceneSource` groups projected city objects by source file and LOD.
+- `IImportedObjectUnitOptimizer` transforms that stream before the target sink receives it.
+- `CompositeImportedObjectUnitOptimizer` applies registered optimizers in order.
+- The registered optimizer today normalizes dynamic material UV metadata; it does not perform road-network coexistence filtering.
+
+That optimizer seam is the correct place to add executable coexistence policy once generated road-network units have coverage metadata. Until that exists, this document is the policy contract and must not imply that runtime suppression already happens.
+
+## Transport Detail Classes
+
+Road-network coexistence only compares generated road-network units against detailed transport-related output in road space.
+
+Road packages are:
+
+- `tran`
+- `rwy`
+- `squr`
+- `trk`
+
+`wwy` is path-like and may share road-family materials, but it is not a road package and does not suppress generated road-network units by default.
+
+Detailed transport-related output is source CityGML geometry from road packages that represents the same road-space area at an equal or higher source-detail level than the generated road-network unit. Examples include road surface geometry, road markings, roadside structures, railway or track surfaces, and square/open-space transportation surfaces when they overlap the generated unit's road-space footprint.
+
+## Precedence Policy
+
+Detailed transport-related output has precedence over generated road-network output for the overlapping road-space unit.
+
+The policy is:
+
+- If a generated road-network unit and detailed road-package output cover the same road-space unit, emit the detailed output and suppress the generated road-network unit.
+- If the overlap is partial, apply the policy to the whole generated road-network unit unless a later accepted design introduces sub-unit splitting.
+- If no detailed road-package output overlaps the generated road-network unit, emit the generated road-network unit.
+- If the only overlapping output is non-road package output, keep both outputs unless a later package-specific policy says otherwise.
+- If the overlap cannot be evaluated because coverage metadata is missing, keep the generated road-network unit and report the missing metadata instead of silently suppressing it.
+
+Suppression removes the generated road-network unit and all generated visual geometry, generated markings, generated debug geometry, and generated network primitives owned by that unit. It does not remove source CityGML geometry.
+
+## Merge Policy
+
+The default merge behavior is no merge.
+
+Generated road-network units and detailed transport-related output either coexist as separate units or the generated road-network unit is suppressed. Do not combine source CityGML transport geometry and generated road-network primitives into a single output unit unless a later change introduces an explicit graph-wide or sub-unit merge design with provenance retention.
+
+Connectivity views may be derived for analysis, but they must not change ownership. Suppression and operator reporting remain traceable to the generated road-network unit and to the detailed source output that took precedence.
+
+## Comparison Inputs
+
+Coexistence comparison must use target-neutral evidence:
+
+- normalized package name
+- source file relative path
+- matched mesh code and resolved actual mesh code when available
+- stable source object id or generated road-network object key
+- selected LOD or source-detail level
+- road-space coverage footprint in source or geodetic coordinates
+- whether a fact is source-observed or inferred
+
+It must not compare by:
+
+- Resonite slot names
+- material asset identities
+- live-send batching state
+- target hierarchy layout
+- generated display names alone
+
+## Operator-Visible Behavior
+
+Operators should be able to predict emitted output from the selected packages and coverage:
+
+- Selecting road packages can produce detailed road-package output.
+- Enabling a future road-network generator can produce generated road-network units for road-space areas not covered by detailed road-package output.
+- Where both outputs claim the same road-space unit, detailed road-package output wins and the generated unit is suppressed.
+- `wwy` output can coexist with generated road-network units by default because it is path-like but outside the road package set.
+- Suppression counts should be reported when runtime suppression is implemented. The report should identify the suppressed generated unit, the winning detailed source package, and the source file or object evidence used for the decision.
+
+## Non-Goals
+
+This document does not define:
+
+- road-network generation algorithms
+- lane, sidewalk, or intersection inference
+- Resonite slot layout
+- target material assignment
+- graph-wide optimization
+- sub-unit splitting
+- runtime implementation of suppression before road-network units and coverage metadata exist

--- a/tests/PlateauResoniteLink.Tests/Docs/LiveSendDocumentationContractTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Docs/LiveSendDocumentationContractTests.cs
@@ -3,6 +3,8 @@ using System.Linq;
 
 using System.Text.RegularExpressions;
 
+using PlateauResoniteLink.Domain.Importing;
+
 namespace PlateauResoniteLink.Tests.Docs;
 
 public sealed partial class LiveSendDocumentationContractTests
@@ -17,6 +19,43 @@ public sealed partial class LiveSendDocumentationContractTests
 
         Assert.Equal(GetHeadings(skill), GetHeadings(skillJa));
         Assert.Equal(GetHeadings(workflow), GetHeadings(workflowJa));
+    }
+
+    [Fact]
+    public void RoadNetworkCoexistenceMirrorsKeepMatchingMajorHeadings()
+    {
+        string coexistence = File.ReadAllText(TestData.GetRepositoryPath("docs", "road-network-coexistence.md"));
+        string coexistenceJa = File.ReadAllText(TestData.GetRepositoryPath("docs", "road-network-coexistence.ja.md"));
+
+        Assert.Equal(GetHeadings(coexistence), GetHeadings(coexistenceJa));
+    }
+
+    [Fact]
+    public void RoadNetworkCoexistenceDocumentsCurrentRoadPackageBoundary()
+    {
+        string coexistence = File.ReadAllText(TestData.GetRepositoryPath("docs", "road-network-coexistence.md"));
+
+        foreach (string packageName in PlateauPackageCatalog.RoadPackageNames)
+        {
+            Assert.Contains($"`{packageName}`", coexistence);
+        }
+
+        Assert.Contains("`wwy` is path-like", coexistence);
+        Assert.Contains("not a road package", coexistence);
+        Assert.Contains("does not suppress generated road-network units by default", coexistence);
+    }
+
+    [Fact]
+    public void RoadNetworkCoexistenceDocumentsTargetNeutralOptimizerSeam()
+    {
+        string coexistence = File.ReadAllText(TestData.GetRepositoryPath("docs", "road-network-coexistence.md"));
+
+        Assert.Contains("IImportedObjectUnitOptimizer", coexistence);
+        Assert.Contains("CompositeImportedObjectUnitOptimizer", coexistence);
+        Assert.Contains("It must not compare by:", coexistence);
+        Assert.Contains("Resonite slot names", coexistence);
+        Assert.Contains("live-send batching state", coexistence);
+        Assert.Contains("does not perform road-network coexistence filtering", coexistence);
     }
 
     private static string[] GetHeadings(string markdown)


### PR DESCRIPTION
Refs #131

## Summary
- Define road-network coexistence policy for PLATEAU road packages and existing Resonite scene content.
- Add English/Japanese documentation plus a documentation contract test.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (`528 passed`)

## Notes
- #130 remains separately suspended on DEM observation.