### PR TITLE
docs(materials): define bundled selection strategy

### DIFF
--- a/THIRD_PARTY_LICENSES/ambientCG-CC0-1.0.txt
+++ b/THIRD_PARTY_LICENSES/ambientCG-CC0-1.0.txt
@@ -14,7 +14,7 @@ Ingest procedure:
 - The ingest tool keeps Color, NormalGL, Displacement-as-Height, and Emission maps when present.
 - The ingest tool generates `<asset-id>_2K-JPG_Metallic.png` as a packed material map. Red is upstream metalness when present or neutral 0, green is upstream ambient occlusion or neutral 255, blue preserves upstream roughness or neutral 255 for diagnostics, and alpha is Unity-style smoothness (`255 - roughness`) for linear data sampling.
 
-Runtime material families currently use only a curated subset of these files. Other collected files are bundled for later height-aware or package-aware material selection work.
+Runtime material families currently use only a curated subset of these files. Other collected files are bundled for later height-aware or package-aware material selection work. The selection strategy for those collected candidates is documented in docs/material-selection-strategy.md.
 
 Bundled ambientCG material sources:
 - src/PlateauResoniteLink/Assets/DefaultMaterials/ambientcg/facade/Facade001_2K-JPG_* -> AmbientCG Facade001 -> https://ambientcg.com/view?id=Facade001

--- a/THIRD_PARTY_LICENSES/texturecan-CC0-1.0.txt
+++ b/THIRD_PARTY_LICENSES/texturecan-CC0-1.0.txt
@@ -8,7 +8,9 @@ License information:
 TextureCan's terms also note that if brand names, logos, or copyrighted graphics
 appear in materials, avoiding third-party infringement remains the user's
 responsibility. The bundled assets listed here were selected as generic facade
-materials and are recorded with their source pages for review.
+materials and are recorded with their source pages for review. The selection
+strategy for collected bundled material candidates is documented in
+docs/material-selection-strategy.md.
 
 Bundled directory covered by this notice:
 - src/PlateauResoniteLink/Assets/DefaultMaterials/texturecan/

--- a/docs/material-selection-strategy.ja.md
+++ b/docs/material-selection-strategy.ja.md
@@ -1,0 +1,104 @@
+# Material Selection Strategy
+
+この文書は、拡張済み bundled default material candidate の選択方針を記録します。
+runtime selection に接続する別変更が入るまでは、documentation と test guidance のみです。
+
+## Current Contract
+
+- source の `ParameterizedTexture` やその他の dataset appearance lane は、
+  bundled fallback material より優先する。この方針は、city object に利用可能な
+  source texture がない場合だけに適用する。
+- 既存の deterministic SHA-256 variant selection contract は、同等入力に対して
+  再現可能なままにする。新しい grouping input は selection key を拡張できるが、
+  既存 fallback selection を時刻依存や処理順依存にしてはいけない。
+- 現在の bundled fallback family は `BundledDefaultMaterialFamilies` にある。
+  building の UV fallback は `facade` family、non-UV building fallback は
+  `roof` family、road/path-like package は `road`、vegetation は
+  `vegetation`、city furniture は `city-furniture`、generic fallback は
+  `other` を使う。
+- common material setup は現在、package-scoped family variant を列挙し、
+  UV と triplanar の common material binding を作り、さらに shared generic
+  albedo と vertex-color common material を作る。
+
+## Height Signals
+
+building material grouping は、利用可能な最も信頼できる height signal から導出する。
+優先順位は次の通り。
+
+1. CityGML の明示的な measured height が存在し、正値の場合。
+2. measured height がない場合、地上階 1 階あたり 3.5 m の estimate で換算した
+   CityGML storey count。
+3. metadata がない場合、geometry または bbox height。
+4. 正の height を観測できない場合は `unknown`。
+
+選択された height signal とその source は、strategy boundary の test で観測可能にする。
+selection policy は material texture name や candidate ordering から height を推測しない。
+
+## Candidate Groups
+
+height-aware building fallback は、stable selection の前に candidate を group 化する。
+
+- `unknown`: current-equivalent な保守的 fallback。height 欠落で出力が変わらないよう、
+  既存の facade と roof runtime candidate set を使う。
+- `low`: 10 m 以下の building。小さめの facade pattern と tiled/concrete roof candidate を優先する。
+- `low-mid`: 10 m 超、31 m 以下の building。現在の facade candidate に、少数の neutral な
+  wall/facade alternative を混ぜる。
+- `mid-high`: 31 m 超、60 m 以下の building。大きめの facade surface と控えめな
+  roof/asphalt candidate を優先する。
+- `high`: 60 m 超の building。facade pool は狭く規則的に保つ。将来の package signal が
+  根拠を与えない限り、住宅的すぎる material や小さな tile roof material は避ける。
+
+収集済み candidate inventory には AmbientCG Facade001、Facade005、Facade006、
+Facade018A、Facade019A、Facade020A、asphalt roof variants、roofing tile variants、
+TextureCan Others0021、Others0022、Others0025、Others0026、Others0029 が含まれる。
+provenance は引き続き `THIRD_PARTY_LICENSES/` に置く。
+
+## Fallback Behavior
+
+- dataset texture と vertex-color lane は bundled material selection で置き換えない。
+- height が欠落または不正な場合は `unknown` group を使う。これは current-equivalent な
+  facade または roof fallback pool と一致しなければならない。
+- group candidate が欠落している場合は、その package の current family pool に fallback する。
+- unknown package は、package catalog change が明示的に map しない限り、既存の
+  `other` fallback behavior を維持する。
+- wireframe overlay package は wireframe のままとし、bundled material candidate selection には
+  参加しない。
+
+## Diversity And Pool Cap
+
+candidate group は意図的に小さく保つ。test でより広い pool の必要性を文書化しない限り、
+height group は runtime stable selection に facade candidate を最大 4 個、roof candidate を最大 4 個まで公開する。
+
+selection は dataset、mesh-code、city-object、package、projection、height-group、
+surface-role の粒度で stable にする。収集済み asset が多いという理由だけで、近隣 object が
+不自然にばらついて見えてはいけない。より細かい neighborhood coherence が必要な場合は、
+処理順に頼らず、明示的な neighborhood または tile grouping input を追加する。
+
+## Common Material Warmup
+
+common material warmup は setup contract であり、per-object repair path ではない。
+expanded candidate pool は、全 building dataset に対して収集済み material asset を
+すべて既定で作成することを要求してはいけない。
+
+runtime implementation は、次のいずれかの制約を満たす。
+
+- active な per-package candidate union を cap し、`CommonMaterialCatalog` が setup 中に
+  package-scoped common material set 全体を列挙できるようにする。
+- または、object emission が始まる前に、その run で必要な candidate family と variant だけを
+  列挙する、別の明示的な setup-time discovery result を導入する。
+
+別の design change が bootstrap test と live-send failure behavior を更新しない限り、
+setup planning の代替として lazy runtime common-material creation を追加しない。
+appearance lane は、common-material warmup に引き込まれず、dedicated material flow を
+使えるままにする。
+
+## Test Guidance
+
+implementation test では次を cover する。
+
+- height signal priority と `unknown` fallback。
+- equivalent key に対する stable selection。
+- 各 height group と surface role の pool cap enforcement。
+- bundled fallback に対する source appearance precedence。
+- common material enumeration が意図した active candidate union に収まり、
+  収集済み provenance asset すべてを誤って warmup しないこと。

--- a/docs/material-selection-strategy.md
+++ b/docs/material-selection-strategy.md
@@ -1,0 +1,113 @@
+# Material Selection Strategy
+
+This document records the intended selection strategy for expanded bundled
+default material candidates. It is documentation and test guidance only until a
+separate implementation change wires the strategy into runtime selection.
+
+## Current Contract
+
+- Source `ParameterizedTexture` and other dataset appearance lanes win over
+  bundled fallback materials. The strategy here applies only when a city object
+  has no usable source texture.
+- The existing deterministic SHA-256 variant selection contract must remain
+  reproducible for equivalent inputs. New grouping inputs can extend the
+  selection key, but must not make existing fallback selection time-dependent or
+  process-order-dependent.
+- Current bundled fallback families are listed in
+  `BundledDefaultMaterialFamilies`. Building UV fallback uses the `facade`
+  family, non-UV building fallback uses the `roof` family, road/path-like
+  packages use `road`, vegetation uses `vegetation`, city furniture uses
+  `city-furniture`, and generic fallback uses `other`.
+- Common material setup currently enumerates package-scoped family variants and
+  creates both UV and triplanar common material bindings, plus shared generic
+  albedo and vertex-color common materials.
+
+## Height Signals
+
+Building material grouping should derive height from the most reliable
+available signal, in this priority order:
+
+1. CityGML explicit measured height, when present and positive.
+2. CityGML storey count converted with a 3.5 m per above-ground storey estimate,
+   when the measured height is absent.
+3. Geometry or bbox height, when metadata is unavailable.
+4. `unknown`, when no positive height can be observed.
+
+The selected height signal and its source should be observable in tests at the
+strategy boundary. The selection policy must not infer height from material
+texture names or candidate ordering.
+
+## Candidate Groups
+
+Height-aware building fallback should group candidates before stable selection:
+
+- `unknown`: current-equivalent conservative fallback. Use the existing facade
+  and roof runtime candidate sets so missing height does not change output.
+- `low`: buildings up to 10 m. Prefer smaller facade patterns and tiled or
+  concrete roof candidates.
+- `low-mid`: buildings over 10 m and up to 31 m. Mix current facade candidates with a
+  small number of neutral wall/facade alternatives.
+- `mid-high`: buildings over 31 m and up to 60 m. Prefer larger facade surfaces and
+  subdued roof/asphalt candidates.
+- `high`: buildings over 60 m. Keep the facade pool narrow and regular; avoid
+  highly residential or small-tile roof materials unless a future package signal
+  justifies them.
+
+The collected candidate inventory includes AmbientCG Facade001, Facade005,
+Facade006, Facade018A, Facade019A, Facade020A, asphalt roof variants, roofing
+tile variants, and TextureCan Others0021, Others0022, Others0025, Others0026,
+and Others0029. Provenance remains in `THIRD_PARTY_LICENSES/`.
+
+## Fallback Behavior
+
+- Dataset textures and vertex-color lanes are not replaced by bundled material
+  selection.
+- Missing or invalid height uses the `unknown` group, which must match the
+  current-equivalent facade or roof fallback pool.
+- Missing group candidates fall back to the current family pool for the package.
+- Unknown packages keep the existing `other` fallback behavior unless a package
+  catalog change explicitly maps them.
+- Wireframe overlay packages remain wireframe and do not participate in bundled
+  material candidate selection.
+
+## Diversity And Pool Cap
+
+Candidate groups should be intentionally small. A height group should expose no
+more than four facade candidates and four roof candidates to runtime stable
+selection unless a test documents why a wider pool is needed.
+
+Selection should remain stable at dataset, mesh-code, city-object, package,
+projection, height-group, and surface-role granularity. Nearby objects should
+not appear randomly noisy only because many collected assets exist. If finer
+neighborhood coherence is needed, add an explicit neighborhood or tile grouping
+input rather than relying on process order.
+
+## Common Material Warmup
+
+Common material warmup is a setup contract, not a per-object repair path.
+Expanded candidate pools must not require creating every collected material
+asset for every building dataset by default.
+
+Runtime implementation should satisfy one of these constraints:
+
+- Keep the active per-package candidate union capped, so `CommonMaterialCatalog`
+  can enumerate the complete package-scoped common material set during setup.
+- Or introduce a separate, explicit setup-time discovery result that lists only
+  the candidate families and variants required for the run before object
+  emission begins.
+
+Do not add lazy runtime common-material creation as a substitute for setup
+planning unless a separate design change updates bootstrap tests and live-send
+failure behavior. Appearance lanes must remain able to use their dedicated
+material flow without being pulled into common-material warmup.
+
+## Test Guidance
+
+Implementation tests should cover:
+
+- Height signal priority and `unknown` fallback.
+- Stable selection for equivalent keys.
+- Pool cap enforcement for each height group and surface role.
+- Source appearance precedence over bundled fallback.
+- Common material enumeration staying within the intended active candidate
+  union, with no accidental warmup of all collected provenance assets.

--- a/tests/PlateauResoniteLink.Tests/Docs/MaterialSelectionStrategyDocumentationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Docs/MaterialSelectionStrategyDocumentationTests.cs
@@ -1,0 +1,83 @@
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace PlateauResoniteLink.Tests.Docs;
+
+public sealed partial class MaterialSelectionStrategyDocumentationTests
+{
+    [Fact]
+    public void EnglishAndJapaneseMirrorsKeepMatchingMajorHeadings()
+    {
+        string english = ReadDoc("material-selection-strategy.md");
+        string japanese = ReadDoc("material-selection-strategy.ja.md");
+
+        Assert.Equal(GetHeadings(english), GetHeadings(japanese));
+    }
+
+    [Fact]
+    public void StrategyDocumentsRequiredIssue154Boundaries()
+    {
+        string english = ReadDoc("material-selection-strategy.md");
+
+        Assert.Contains("Source `ParameterizedTexture`", english, System.StringComparison.Ordinal);
+        Assert.Contains("measured height", english, System.StringComparison.Ordinal);
+        Assert.Contains("storey count", english, System.StringComparison.Ordinal);
+        Assert.Contains("3.5 m per above-ground storey", english, System.StringComparison.Ordinal);
+        Assert.Contains("bbox height", english, System.StringComparison.Ordinal);
+        Assert.Contains("`unknown`", english, System.StringComparison.Ordinal);
+        Assert.Contains("up to 10 m", english, System.StringComparison.Ordinal);
+        Assert.Contains("up to 31 m", english, System.StringComparison.Ordinal);
+        Assert.Contains("up to 60 m", english, System.StringComparison.Ordinal);
+        Assert.Contains("over 60 m", english, System.StringComparison.Ordinal);
+        Assert.Contains("four facade candidates", english, System.StringComparison.Ordinal);
+        Assert.Contains("four roof candidates", english, System.StringComparison.Ordinal);
+        Assert.Contains("Common material warmup is a setup contract", english, System.StringComparison.Ordinal);
+        Assert.Contains("Do not add lazy runtime common-material creation", english, System.StringComparison.Ordinal);
+        Assert.Contains("THIRD_PARTY_LICENSES/", english, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StrategyNamesCollectedCandidateInventoryWithoutMakingAllAssetsActive()
+    {
+        string english = ReadDoc("material-selection-strategy.md");
+
+        string[] expectedCandidateNames =
+        [
+            "Facade001",
+            "Facade005",
+            "Facade006",
+            "Facade018A",
+            "Facade019A",
+            "Facade020A",
+            "Others0021",
+            "Others0022",
+            "Others0025",
+            "Others0026",
+            "Others0029",
+        ];
+
+        foreach (string candidateName in expectedCandidateNames)
+        {
+            Assert.Contains(candidateName, english, System.StringComparison.Ordinal);
+        }
+
+        Assert.Contains("must not require creating every collected material", english, System.StringComparison.Ordinal);
+    }
+
+    private static string ReadDoc(string fileName)
+    {
+        return File.ReadAllText(TestData.GetRepositoryPath("docs", fileName));
+    }
+
+    private static string[] GetHeadings(string markdown)
+    {
+        return HeadingRegex()
+            .Matches(markdown)
+            .Select(static match => match.Value)
+            .ToArray();
+    }
+
+    [GeneratedRegex("^## .+$", RegexOptions.Multiline)]
+    private static partial Regex HeadingRegex();
+}


### PR DESCRIPTION
Refs #154

## Summary
- Define bundled material selection strategy and documentation contract tests.
- Keep English/Japanese material strategy docs aligned.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (`528 passed`)