### PR TITLE
feat(materials): warn on X3DMaterial optical attributes

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -70,7 +70,9 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
         ArgumentException.ThrowIfNullOrWhiteSpace(polygonId);
 
         CityGmlMaterialAttributes? materialAttributes = materialAttributesByPolygonId.GetValueOrDefault(polygonId);
-        ColorRgba baseColor = materialAttributes?.DiffuseColor ?? DefaultMaterialColor;
+        ColorRgba baseColor = ApplyTransparency(
+            materialAttributes?.DiffuseColor ?? DefaultMaterialColor,
+            materialAttributes?.Transparency);
 
         CityGmlParameterizedTexture? parameterizedTexture = parameterizedTexturesByPolygonId.GetValueOrDefault(polygonId);
         TexturePayload? texturePayload = null;
@@ -308,6 +310,20 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
             G: values[1],
             B: values[2],
             A: values.Length >= 4 ? values[3] : 1.0);
+    }
+
+    private static ColorRgba ApplyTransparency(ColorRgba color, double? transparency)
+    {
+        if (!transparency.HasValue)
+        {
+            return color;
+        }
+
+        double opacity = 1.0 - Math.Clamp(transparency.Value, 0.0, 1.0);
+        return color with
+        {
+            A = Math.Clamp(color.A * opacity, 0.0, 1.0),
+        };
     }
 
     private static double[]? TryParseDoubles(string value)

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlBootstrapParsedObjectModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlBootstrapParsedObjectModels.cs
@@ -43,7 +43,8 @@ internal sealed record BootstrapParsedSurface(
     BootstrapParsedRing[] InteriorRings,
     ColorRgba BaseColor,
     TexturePayload? TexturePayload,
-    bool UsesGeneratedDemTexture = false)
+    bool UsesGeneratedDemTexture = false,
+    MaterialOpticalProperties? OpticalProperties = null)
 {
     public IEnumerable<GeodeticPoint> Vertices =>
         ExteriorRing.Vertices.Concat(InteriorRings.SelectMany(static ring => ring.Vertices));
@@ -57,7 +58,8 @@ internal sealed record BootstrapParsedSurface(
             InteriorRings.Select(static ring => ring.ToLegacy()).ToArray(),
             BaseColor,
             TexturePayload,
-            UsesGeneratedDemTexture);
+            UsesGeneratedDemTexture,
+            OpticalProperties);
     }
 
     internal static BootstrapParsedSurface FromLegacy(LocalCityGmlObjectProjection.ParsedSurface surface)
@@ -69,7 +71,8 @@ internal sealed record BootstrapParsedSurface(
             surface.InteriorRings.Select(BootstrapParsedRing.FromLegacy).ToArray(),
             new ColorRgba(surface.BaseColor.R, surface.BaseColor.G, surface.BaseColor.B, surface.BaseColor.A),
             surface.TexturePayload,
-            surface.UsesGeneratedDemTexture);
+            surface.UsesGeneratedDemTexture,
+            surface.OpticalProperties);
     }
 }
 

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1093,7 +1093,8 @@ internal static partial class LocalCityGmlObjectProjection
             ExteriorRing: exteriorParsedRing,
             InteriorRings: interiorRings,
             BaseColor: ToInternalColor(appearance.BaseColor),
-            TexturePayload: appearance.TexturePayload);
+            TexturePayload: appearance.TexturePayload,
+            OpticalProperties: CreateMaterialOpticalProperties(appearance.MaterialAttributes));
     }
 
     private static ParsedRing? ParseRing(
@@ -4684,6 +4685,22 @@ internal static partial class LocalCityGmlObjectProjection
 
     private static ColorRgba ToInternalColor(ColorRgba value) => new(value.R, value.G, value.B, value.A);
 
+    private static MaterialOpticalProperties? CreateMaterialOpticalProperties(CityGmlMaterialAttributes? attributes)
+    {
+        if (attributes is null)
+        {
+            return null;
+        }
+
+        return new MaterialOpticalProperties(
+            DiffuseColor: ToInternalColor(attributes.DiffuseColor),
+            EmissiveColor: attributes.EmissiveColor is null ? null : ToInternalColor(attributes.EmissiveColor),
+            SpecularColor: attributes.SpecularColor is null ? null : ToInternalColor(attributes.SpecularColor),
+            AmbientIntensity: attributes.AmbientIntensity,
+            Shininess: attributes.Shininess,
+            Transparency: attributes.Transparency);
+    }
+
     private static Float3 ToContractFloat3(Float3 value) => new(value.X, value.Y, value.Z);
 
     private static Quaternion ToContractQuaternion(Quaternion value) => new(value.X, value.Y, value.Z, value.W);
@@ -5519,7 +5536,8 @@ internal static partial class LocalCityGmlObjectProjection
         ParsedRing[] InteriorRings,
         ColorRgba BaseColor,
         TexturePayload? TexturePayload,
-        bool UsesGeneratedDemTexture = false)
+        bool UsesGeneratedDemTexture = false,
+        MaterialOpticalProperties? OpticalProperties = null)
     {
         public IEnumerable<GeodeticPoint> Vertices =>
             ExteriorRing.Vertices.Concat(InteriorRings.SelectMany(static ring => ring.Vertices));

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -156,6 +156,14 @@ public sealed record MaterialDepthOffset(
     double Factor,
     double Units);
 
+public sealed record MaterialOpticalProperties(
+    ColorRgba? DiffuseColor = null,
+    ColorRgba? EmissiveColor = null,
+    ColorRgba? SpecularColor = null,
+    double? AmbientIntensity = null,
+    double? Shininess = null,
+    double? Transparency = null);
+
 public enum MaterialReuseScope
 {
     PerObject = 0,

--- a/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
@@ -28,6 +28,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource
     private readonly object referenceSystemGate = new();
     private readonly object sceneDemTerrainTextureOverlayGate = new();
     private readonly ConcurrentDictionary<string, Task<TerrainTextureOverlay[]>> demTerrainTextureOverlayTasks = new(StringComparer.Ordinal);
+    private readonly X3DMaterialWarningStatistics x3DMaterialWarningStatistics = new();
     private readonly MeshCodeBounds[] requestedMeshAreas;
     private readonly string[] selectedMeshCodes;
     private readonly TerrainTextureOverlay[] bootstrapTerrainTextureOverlays;
@@ -106,6 +107,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource
         }
 
         await completionTask;
+        x3DMaterialWarningStatistics.ReportFinal(ReportProgress);
     }
 
     private LocalCartesian? CreateGlobalCartesian(CoordinateReferenceSystem referenceSystem)
@@ -207,11 +209,14 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource
             cancellationToken);
         bool isDemSourceFile = string.Equals(sourceFile.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase);
         List<BootstrapParsedCityObject> parsedDemCityObjects = [];
+        X3DMaterialWarningStatistics fileWarningStatistics = new();
 
         await foreach (BootstrapParsedCityObject parsedCityObject in sourceFile.StreamParsedCityObjectsAsync(cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
             parsedCount++;
+            fileWarningStatistics.Add(parsedCityObject);
+            x3DMaterialWarningStatistics.Add(parsedCityObject);
             resolvedReferenceSystem ??= ResolveReferenceSystem(parsedCityObject.ReferenceSystem);
             globalCartesian ??= CreateGlobalCartesian(resolvedReferenceSystem);
             if (isDemSourceFile)
@@ -265,6 +270,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource
         }
 
         fileStopwatch.Stop();
+        fileWarningStatistics.ReportFile(sourceFile.SourceFile.RelativePath, progressReporter);
         progressReporter?.Invoke(
             PlateauLog.Info(
                 "import",
@@ -568,5 +574,161 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource
 
         throw new PlateauImportValidationException(
             [$"Mixed CityGML coordinate reference systems are not supported. Found '{expectedReferenceSystem.SrsName}' and '{actualReferenceSystem.SrsName}'."]);
+    }
+
+    private sealed class X3DMaterialWarningStatistics
+    {
+        private readonly object gate = new();
+        private int materialSurfaceCount;
+        private int unsupportedMaterialSurfaceCount;
+        private int nonDefaultShininessCount;
+        private int nonDefaultSpecularColorCount;
+        private int specularOnlyCount;
+        private int shininessOnlyCount;
+        private int specularWithShininessCount;
+        private int emissiveColorCount;
+        private int ambientIntensityCount;
+
+        public void Add(BootstrapParsedCityObject cityObject)
+        {
+            ArgumentNullException.ThrowIfNull(cityObject);
+
+            foreach (BootstrapParsedSurface surface in cityObject.Surfaces)
+            {
+                MaterialOpticalProperties? opticalProperties = surface.OpticalProperties;
+                if (opticalProperties is null)
+                {
+                    continue;
+                }
+
+                lock (gate)
+                {
+                    materialSurfaceCount++;
+                    bool hasNonDefaultShininess = HasNonDefaultShininess(opticalProperties.Shininess);
+                    bool hasNonDefaultSpecularColor = HasNonDefaultSpecularColor(opticalProperties.SpecularColor);
+                    bool hasNonDefaultEmissiveColor = HasNonDefaultEmissiveColor(opticalProperties.EmissiveColor);
+                    bool hasNonDefaultAmbientIntensity =
+                        HasNonDefaultAmbientIntensity(opticalProperties.AmbientIntensity);
+                    if (hasNonDefaultShininess)
+                    {
+                        nonDefaultShininessCount++;
+                    }
+
+                    if (hasNonDefaultSpecularColor)
+                    {
+                        nonDefaultSpecularColorCount++;
+                    }
+
+                    if (hasNonDefaultSpecularColor && hasNonDefaultShininess)
+                    {
+                        specularWithShininessCount++;
+                    }
+                    else if (hasNonDefaultSpecularColor)
+                    {
+                        specularOnlyCount++;
+                    }
+                    else if (hasNonDefaultShininess)
+                    {
+                        shininessOnlyCount++;
+                    }
+
+                    if (hasNonDefaultEmissiveColor)
+                    {
+                        emissiveColorCount++;
+                    }
+
+                    if (hasNonDefaultAmbientIntensity)
+                    {
+                        ambientIntensityCount++;
+                    }
+
+                    if (hasNonDefaultShininess
+                        || hasNonDefaultSpecularColor
+                        || hasNonDefaultEmissiveColor
+                        || hasNonDefaultAmbientIntensity)
+                    {
+                        unsupportedMaterialSurfaceCount++;
+                    }
+                }
+            }
+        }
+
+        public void ReportFile(string sourceFileRelativePath, Action<string>? progressReporter)
+        {
+            if (!HasUnsupportedValues)
+            {
+                return;
+            }
+
+            progressReporter?.Invoke(
+                PlateauLog.Warning(
+                    "import",
+                    $"CityGML file '{sourceFileRelativePath}' contains unsupported X3DMaterial optical attributes left unprojected "
+                    + CreateSummarySuffix()));
+        }
+
+        public void ReportFinal(Action<string> progressReporter)
+        {
+            if (!HasUnsupportedValues)
+            {
+                return;
+            }
+
+            progressReporter(
+                PlateauLog.Warning(
+                    "import",
+                    "Unsupported X3DMaterial optical attribute summary: values were parsed for diagnostics but not projected to Resonite materials "
+                    + CreateSummarySuffix()));
+        }
+
+        private bool HasUnsupportedValues =>
+            nonDefaultShininessCount > 0
+            || nonDefaultSpecularColorCount > 0
+            || emissiveColorCount > 0
+            || ambientIntensityCount > 0;
+
+        private string CreateSummarySuffix()
+        {
+            lock (gate)
+            {
+                return string.Create(
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    $"(x3d_material_surfaces={materialSurfaceCount}, unsupported_x3d_material_surfaces={unsupportedMaterialSurfaceCount}, shininess_nonzero={nonDefaultShininessCount}, specular_nondefault={nonDefaultSpecularColorCount}, specular_nondefault_only={specularOnlyCount}, shininess_nonzero_only={shininessOnlyCount}, specular_nondefault_with_shininess={specularWithShininessCount}, emissive_nonzero={emissiveColorCount}, ambient_nonzero={ambientIntensityCount}).");
+            }
+        }
+
+        private static bool HasNonDefaultShininess(double? shininess)
+        {
+            return shininess.HasValue && Math.Abs(Math.Clamp(shininess.Value, 0.0, 1.0)) > 1e-9;
+        }
+
+        private static bool HasNonDefaultAmbientIntensity(double? ambientIntensity)
+        {
+            return ambientIntensity.HasValue && Math.Abs(Math.Clamp(ambientIntensity.Value, 0.0, 1.0)) > 1e-9;
+        }
+
+        private static bool HasNonDefaultEmissiveColor(ColorRgba? emissiveColor)
+        {
+            if (emissiveColor is null)
+            {
+                return false;
+            }
+
+            return Math.Abs(emissiveColor.R) > 1e-6
+                || Math.Abs(emissiveColor.G) > 1e-6
+                || Math.Abs(emissiveColor.B) > 1e-6;
+        }
+
+        private static bool HasNonDefaultSpecularColor(ColorRgba? specularColor)
+        {
+            if (specularColor is null)
+            {
+                return false;
+            }
+
+            return Math.Abs(specularColor.R - 0.4) > 1e-6
+                || Math.Abs(specularColor.G - 0.4) > 1e-6
+                || Math.Abs(specularColor.B - 0.4) > 1e-6;
+        }
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialComponentPolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialComponentPolicy.cs
@@ -269,6 +269,7 @@ internal static class ResoniteMaterialComponentPolicy
     {
         return ResoniteColorSpace.CreateSrgbColorMember(color);
     }
+
 }
 
 internal sealed record BundledDefaultMaterialTextureSet(

--- a/tests/PlateauResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
@@ -69,6 +69,7 @@ public sealed class CityGmlAppearanceStoreTests
         CityGmlResolvedAppearance appearance = store.Resolve("poly-1");
 
         Assert.Equal(0.2, appearance.BaseColor.R, 6);
+        Assert.Equal(0.85, appearance.BaseColor.A, 6);
         Assert.NotNull(appearance.TexturePayload);
         Assert.NotNull(appearance.ParameterizedTexture);
         Assert.Equal("image/png", appearance.ParameterizedTexture!.MimeType);

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -11,7 +11,10 @@ using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
 using PlateauResoniteLink.Tests.Application.Importing;
+
+using ResoniteLink;
 
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -23,7 +26,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 {
     private static readonly HttpClient SharedDatasetSourceResolverHttpClient = new();
 
-    private static PlateauImportService CreateService(ISceneSink sceneBuilder)
+    private static PlateauImportService CreateService(ISceneSink sceneBuilder, Action<string>? progressReporter = null)
     {
         LocalCityGmlDocumentReader documentReader = CreateDocumentReader();
         return new PlateauImportService(
@@ -48,7 +51,8 @@ public sealed class LocalCityGmlObjectProjectionTests
                             new ArchiveFileLayoutPolicy()))),
                 new PassthroughImportedObjectUnitOptimizer()),
             commonMaterialCatalog: new CommonMaterialCatalog(),
-            archiveFileLayoutPolicy: new ArchiveFileLayoutPolicy());
+            archiveFileLayoutPolicy: new ArchiveFileLayoutPolicy(),
+            progressReporter);
     }
 
     private static LocalCityGmlDocumentReader CreateDocumentReader()
@@ -970,6 +974,93 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.Contains(projected.Mesh.Vertices, static vertex => vertex.UV0.Y > 1.0);
     }
 
+    [Fact]
+    public async Task ParsedX3DMaterialOpticalAttributesReportWarningsWithoutChangingResoniteMaterialMembers()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        CreateX3DMaterialOpticalFixture(datasetRoot.Path);
+
+        await using StubSceneBuilder sceneBuilder = new();
+        List<string> progressMessages = [];
+        PlateauImportService service = CreateService(sceneBuilder, progressMessages.Add);
+
+        await service.ExecuteAsync(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: datasetRoot.Path,
+                PackageNames: ["bldg"],
+                ServerUri: null),
+            workRoot: "runtime/resonite");
+
+        ImportedCityObject cityObject = Assert.Single(sceneBuilder.CityObjects);
+        MaterialBinding material = Assert.Single(cityObject.Materials);
+
+        Assert.Equal(new ColorRgba(0.2, 0.4, 0.6, 0.75), material.BaseColor);
+        Assert.DoesNotContain(
+            cityObject.Materials,
+            static candidate => candidate.MaterialKey.Contains("optical", StringComparison.Ordinal));
+
+        ResoniteMaterialBinding resoniteMaterial = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(
+            SceneImportContractMapper.ToInternal(material));
+        Dictionary<string, Member> members = ResoniteMaterialComponentPolicy.CreateMembers(resoniteMaterial);
+
+        Field_colorX albedo = Assert.IsType<Field_colorX>(members["AlbedoColor"]);
+        Field_float smoothness = Assert.IsType<Field_float>(members["Smoothness"]);
+
+        Assert.Equal(0.2f, albedo.Value.r, 6);
+        Assert.Equal(0.4f, albedo.Value.g, 6);
+        Assert.Equal(0.6f, albedo.Value.b, 6);
+        Assert.Equal(0.75f, albedo.Value.a, 6);
+        Assert.Equal(0.0f, smoothness.Value, 6);
+        Assert.DoesNotContain("EmissiveColor", members.Keys);
+        Assert.DoesNotContain("AmbientIntensity", members.Keys);
+        Assert.DoesNotContain("SpecularColor", members.Keys);
+
+        Assert.Contains(
+            progressMessages,
+            static message => message.Contains("[import][warn]", StringComparison.Ordinal)
+                && message.Contains("Unsupported X3DMaterial optical attribute summary", StringComparison.Ordinal)
+                && message.Contains("unsupported_x3d_material_surfaces=1", StringComparison.Ordinal)
+                && message.Contains("shininess_nonzero=1", StringComparison.Ordinal)
+                && message.Contains("specular_nondefault=1", StringComparison.Ordinal)
+                && message.Contains("specular_nondefault_only=0", StringComparison.Ordinal)
+                && message.Contains("shininess_nonzero_only=0", StringComparison.Ordinal)
+                && message.Contains("specular_nondefault_with_shininess=1", StringComparison.Ordinal)
+                && message.Contains("emissive_nonzero=1", StringComparison.Ordinal)
+                && message.Contains("ambient_nonzero=1", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DefaultEmissiveAndProjectedTransparencyDoNotReportUnsupportedX3DOpticalWarnings()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        CreateProjectedTransparencyOnlyX3DMaterialFixture(datasetRoot.Path);
+
+        await using StubSceneBuilder sceneBuilder = new();
+        List<string> progressMessages = [];
+        PlateauImportService service = CreateService(sceneBuilder, progressMessages.Add);
+
+        await service.ExecuteAsync(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                SourceKind: DatasetSourceKind.Local,
+                LocalSourcePath: datasetRoot.Path,
+                PackageNames: ["bldg"],
+                ServerUri: null),
+            workRoot: "runtime/resonite");
+
+        ImportedCityObject cityObject = Assert.Single(sceneBuilder.CityObjects);
+        MaterialBinding material = Assert.Single(cityObject.Materials);
+
+        Assert.Equal(new ColorRgba(0.2, 0.4, 0.6, 0.75), material.BaseColor);
+        Assert.DoesNotContain(
+            progressMessages,
+            static message => message.Contains("Unsupported X3DMaterial optical attribute summary", StringComparison.Ordinal));
+    }
+
     [Theory]
     [InlineData((int)BootstrapParsedSurfaceSemantic.Wall)]
     [InlineData((int)BootstrapParsedSurfaceSemantic.Unknown)]
@@ -1832,6 +1923,108 @@ public sealed class LocalCityGmlObjectProjectionTests
             landUse.Transform.Position.Y > 40.0,
             $"Land-use object was incorrectly snapped toward nearby DEM fallback height: y={landUse.Transform.Position.Y:F6}");
     }
+
+    private static void CreateX3DMaterialOpticalFixture(string datasetRoot)
+    {
+        string packageDirectory = Path.Combine(datasetRoot, "udx", "bldg", "53394525");
+        Directory.CreateDirectory(packageDirectory);
+        string xml =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <core:CityModel
+              xmlns:app="http://www.opengis.net/citygml/appearance/2.0"
+              xmlns:bldg="http://www.opengis.net/citygml/building/2.0"
+              xmlns:core="http://www.opengis.net/citygml/2.0"
+              xmlns:gml="http://www.opengis.net/gml">
+              <app:appearanceMember>
+                <app:Appearance>
+                  <app:surfaceDataMember>
+                    <app:X3DMaterial>
+                      <app:ambientIntensity>0.33</app:ambientIntensity>
+                      <app:diffuseColor>0.2 0.4 0.6</app:diffuseColor>
+                      <app:emissiveColor>0.05 0.10 0.15</app:emissiveColor>
+                      <app:specularColor>0.7 0.8 0.9</app:specularColor>
+                      <app:shininess>0.72</app:shininess>
+                      <app:transparency>0.25</app:transparency>
+                      <app:target uri="#poly-x3d-wall" />
+                    </app:X3DMaterial>
+                  </app:surfaceDataMember>
+                </app:Appearance>
+              </app:appearanceMember>
+              <core:cityObjectMember>
+                <bldg:Building gml:id="bldg-x3d">
+                  <gml:name>X3D optical material test</gml:name>
+                  <bldg:lod2MultiSurface>
+                    <gml:MultiSurface>
+                      <gml:surfaceMember>
+                        <gml:Polygon gml:id="poly-x3d-wall">
+                          <gml:exterior>
+                            <gml:LinearRing gml:id="ring-x3d-wall">
+                              <gml:posList>0 0 0 10 0 0 10 0 10 0 0 10 0 0 0</gml:posList>
+                            </gml:LinearRing>
+                          </gml:exterior>
+                        </gml:Polygon>
+                      </gml:surfaceMember>
+                    </gml:MultiSurface>
+                  </bldg:lod2MultiSurface>
+                </bldg:Building>
+              </core:cityObjectMember>
+            </core:CityModel>
+            """;
+
+        File.WriteAllText(Path.Combine(packageDirectory, "plateau_tokyo23ku_bldg_53394525_x3d_material.gml"), xml);
+    }
+
+    private static void CreateProjectedTransparencyOnlyX3DMaterialFixture(string datasetRoot)
+    {
+        string packageDirectory = Path.Combine(datasetRoot, "udx", "bldg", "53394525");
+        Directory.CreateDirectory(packageDirectory);
+        string xml =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <core:CityModel
+              xmlns:app="http://www.opengis.net/citygml/appearance/2.0"
+              xmlns:bldg="http://www.opengis.net/citygml/building/2.0"
+              xmlns:core="http://www.opengis.net/citygml/2.0"
+              xmlns:gml="http://www.opengis.net/gml">
+              <app:appearanceMember>
+                <app:Appearance>
+                  <app:surfaceDataMember>
+                    <app:X3DMaterial>
+                      <app:diffuseColor>0.2 0.4 0.6</app:diffuseColor>
+                      <app:emissiveColor>0 0 0</app:emissiveColor>
+                      <app:transparency>0.25</app:transparency>
+                      <app:target uri="#poly-x3d-wall" />
+                    </app:X3DMaterial>
+                  </app:surfaceDataMember>
+                </app:Appearance>
+              </app:appearanceMember>
+              <core:cityObjectMember>
+                <bldg:Building gml:id="bldg-x3d">
+                  <gml:name>X3D projected transparency material test</gml:name>
+                  <bldg:lod2MultiSurface>
+                    <gml:MultiSurface>
+                      <gml:surfaceMember>
+                        <gml:Polygon gml:id="poly-x3d-wall">
+                          <gml:exterior>
+                            <gml:LinearRing gml:id="ring-x3d-wall">
+                              <gml:posList>0 0 0 10 0 0 10 0 10 0 0 10 0 0 0</gml:posList>
+                            </gml:LinearRing>
+                          </gml:exterior>
+                        </gml:Polygon>
+                      </gml:surfaceMember>
+                    </gml:MultiSurface>
+                  </bldg:lod2MultiSurface>
+                </bldg:Building>
+              </core:cityObjectMember>
+            </core:CityModel>
+            """;
+
+        File.WriteAllText(
+            Path.Combine(packageDirectory, "plateau_tokyo23ku_bldg_53394525_x3d_transparency.gml"),
+            xml);
+    }
+
     private static void CreateRuntimeMixedSurfaceDemFixture(string datasetRoot)
     {
         string packageDirectory = Path.Combine(datasetRoot, "udx", "dem", "53394525");


### PR DESCRIPTION
## Summary
- Keeps existing X3DMaterial `diffuseColor` handling as base color.
- Parses optional X3DMaterial optical fields for diagnostics only; they are not projected into Resonite material members or material identity.
- Emits warning statistics for unsupported non-default optical values, including affected surface count and `specularColor`/`shininess` overlap.
- Treats projected `transparency` as supported alpha handling and ignores default `emissiveColor=0 0 0` in unsupported warning counts.

closes #128

## Real Data Check
- Yokohama 2024: X3DMaterial 1550 elements / 32 files; warning-worthy unsupported values appear on 17 surfaces total.
- Yokohama detail: 15 surfaces have only non-default gray `specularColor` (`0.2 0.2 0.2`) with `shininess=0`; 2 vegetation surfaces have non-default colored `specularColor` together with `shininess=0.1953125`.
- Yokohama other optical properties: `transparency`, `emissiveColor`, and `ambientIntensity` were not present in the inspected X3DMaterial elements.
- Sendai 2024: X3DMaterial 126 elements / 10 files; `shininess` all 0; no `specularColor`.
- Osaka 2024: X3DMaterial 154 elements / 27 files; non-zero `shininess` 1; non-default `specularColor` 0 under 0.4-default policy.
- Matsumoto, Higashimurayama, Sapporo, Kakogawa, Fukuoka 2024, Tokyo23ku archive: no X3DMaterial found in inspected local data.

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- targeted: X3DMaterial parse/warning and Resonite material convention tests

## Live
- No standard live validation is claimed for this revision. Previous ad hoc base/append runs are not used as merge evidence.
