### PR TITLE
fix(import): materialize DEM rasters lazily

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
@@ -154,8 +154,14 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
         GeographicRectangle overlayBounds,
         CancellationToken cancellationToken)
     {
-        foreach (string rasterPath in await ResolveCandidateRasterPathsAsync(meshCode, cancellationToken))
+        foreach (string candidateRasterPath in await ResolveCandidateRasterPathsAsync(meshCode, cancellationToken))
         {
+            string rasterPath = contentSource is null
+                ? candidateRasterPath
+                : await contentSource.EnsureLocalFileAsync(
+                    candidateRasterPath,
+                    outputRoot,
+                    cancellationToken);
             GeoReferencedRasterMetadata? metadata = await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(
                 rasterPath,
                 cancellationToken);
@@ -191,18 +197,20 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
         }
     }
 
-    private async Task<IReadOnlyList<string>> ResolveCandidateRasterPathsAsync(
+    private Task<IReadOnlyList<string>> ResolveCandidateRasterPathsAsync(
         string meshCode,
         CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (directRasterPath is not null)
         {
-            return [directRasterPath];
+            return Task.FromResult<IReadOnlyList<string>>([directRasterPath]);
         }
 
         if (contentSource is null)
         {
-            return [];
+            return Task.FromResult<IReadOnlyList<string>>([]);
         }
 
         List<string> relativePaths = [];
@@ -227,13 +235,7 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
             }
         }
 
-        List<string> localPaths = [];
-        foreach (string relativePath in relativePaths)
-        {
-            localPaths.Add(await contentSource.EnsureLocalFileAsync(relativePath, outputRoot, cancellationToken));
-        }
-
-        return localPaths;
+        return Task.FromResult<IReadOnlyList<string>>(relativePaths);
     }
 
     private static bool IsSupportedArchive(string path)

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
@@ -85,6 +85,25 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
     }
 
     [Fact]
+    public async Task TryResolveRasterSourceAsyncStopsAfterFirstUsableCandidate()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        RecordingDatasetContentSource datasetSource = CreateResolvableDatasetSource(datasetRoot.Path);
+        DemTerrainGeoReferencedRasterCatalog catalog = await CreateCatalogAsync(datasetSource);
+        GeographicRectangle bounds = new(35.0, 35.1, 139.0, 139.1);
+
+        TerrainTextureGeoReferencedRasterSource? result = await catalog.TryResolveRasterSourceAsync(
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "53394525", bounds),
+            "53394525",
+            bounds,
+            CancellationToken.None);
+
+        TerrainTextureGeoReferencedRasterSource resolvedResult = Assert.IsType<TerrainTextureGeoReferencedRasterSource>(result);
+        Assert.EndsWith("53394525.tif", resolvedResult.SourcePath, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, datasetSource.EnsureLocalFileCallCount);
+    }
+
+    [Fact]
     public async Task TryResolveRasterSourceAsyncKeepsSuccessfulCachedTaskAfterCanceledWaiter()
     {
         using TemporaryDirectory datasetRoot = new();
@@ -161,6 +180,26 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         return new RecordingDatasetContentSource(
             datasetRoot,
             [Path.GetFileName(westRasterPath), Path.GetFileName(eastRasterPath)]);
+    }
+
+    private static RecordingDatasetContentSource CreateResolvableDatasetSource(string datasetRoot)
+    {
+        string exactRasterPath = Path.Combine(datasetRoot, "53394525.tif");
+        string fallbackRasterPath = Path.Combine(datasetRoot, "fallback.tif");
+        File.WriteAllBytes(
+            exactRasterPath,
+            CreateClassicLittleEndianGeoTiffBytes(
+                modelTiePoint: [0.0, 0.0, 0.0, 139.0, 35.1, 0.0],
+                pixelScale: [0.01, 0.01, 0.0],
+                geoKeyDirectory:
+                [
+                    1, 1, 0, 1,
+                    2048, 0, 1, 4326,
+                ]));
+        File.WriteAllText(fallbackRasterPath, "dummy");
+        return new RecordingDatasetContentSource(
+            datasetRoot,
+            [Path.GetFileName(exactRasterPath), Path.GetFileName(fallbackRasterPath)]);
     }
 
     private static FaultingGateableDatasetContentSource CreateFaultingGateableDatasetSource(string datasetRoot)


### PR DESCRIPTION
## Summary
- Defer DEM raster materialization until the catalog entry is used.
- Preserve discovery-time metadata without opening raster files early.
- Add regression coverage for lazy DEM raster materialization.

Refs #161

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

Result: passed, 526 tests.