### PR TITLE
feat(cli): add guided import assistance

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliApplication.cs
+++ b/src/PlateauResoniteLink.Cli/CliApplication.cs
@@ -20,21 +20,27 @@ public sealed class CliApplication
         WriteIndented = true,
     };
 
+    private readonly TextReader standardInput;
     private readonly TextWriter standardError;
     private readonly TextWriter standardOutput;
     private readonly IImportServiceFactory importServiceFactory;
     private readonly DatasetInspectionService datasetInspectionService;
+    private readonly IResoniteLinkTargetDiscovery targetDiscovery;
 
     internal CliApplication(
+        TextReader standardInput,
         TextWriter standardOutput,
         TextWriter standardError,
         IImportServiceFactory importServiceFactory,
-        DatasetInspectionService datasetInspectionService)
+        DatasetInspectionService datasetInspectionService,
+        IResoniteLinkTargetDiscovery targetDiscovery)
     {
+        this.standardInput = standardInput;
         this.standardOutput = standardOutput;
         this.standardError = standardError;
         this.importServiceFactory = importServiceFactory;
         this.datasetInspectionService = datasetInspectionService;
+        this.targetDiscovery = targetDiscovery;
     }
 
     [SuppressMessage(
@@ -65,12 +71,19 @@ public sealed class CliApplication
             {
                 case ImportCommandOptions options:
                     {
-                        Action<string> reporter = CreateReporter(options.VerboseLogging);
-                        PlateauImportService effectiveImportService = importServiceFactory.Create(options, reporter);
+                        GuidedImportOptionsResolver optionsResolver = new(
+                            standardInput,
+                            standardOutput,
+                            standardError,
+                            datasetInspectionService,
+                            targetDiscovery);
+                        ImportCommandOptions effectiveOptions = await optionsResolver.ResolveAsync(options, cancellationToken);
+                        Action<string> reporter = CreateReporter(effectiveOptions.VerboseLogging);
+                        PlateauImportService effectiveImportService = importServiceFactory.Create(effectiveOptions, reporter);
 
                         ImportExecutionResult result = await effectiveImportService.ExecuteAsync(
-                            options.Request,
-                            options.WorkRoot,
+                            effectiveOptions.Request,
+                            effectiveOptions.WorkRoot,
                             cancellationToken);
 
                         await standardOutput.WriteLineAsync("Resonite import completed.");

--- a/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
@@ -17,10 +17,12 @@ public static class CliArgumentsParser
 
         Usage:
           plateau-resonitelink import --dataset <dataset> --mesh-code <mesh-code> [options]
+          plateau-resonitelink import --guided [options]
           plateau-resonitelink search --citygml-source <path> --mesh-code <mesh-code> [options]
           plateau-resonitelink stats --citygml-source <path> [options]
 
         Import options:
+          --guided               Optional. Prompt interactively for missing import values and use local inspection/discovery assistance.
           --dataset <value>      Required. PLATEAU dataset identifier.
           --mesh-code <value>    Required. PLATEAU mesh code or regex to construct in Resonite.
           --packages <csv>       Optional. Comma-separated PLATEAU package names. Default: dem,bldg,brid,frn,tran,rwy,trk,tun,ubld,unf,veg.
@@ -101,8 +103,11 @@ public static class CliArgumentsParser
         bool enableMeshBake = true;
         bool enableSendMetrics = false;
         bool verboseLogging = false;
+        bool guided = false;
         IReadOnlyList<string> packageNames = DefaultPackageNames;
+        bool packageNamesSpecified = false;
         IReadOnlySet<int>? globalExcludeLods = null;
+        bool globalExcludeLodsSpecified = false;
         IReadOnlyDictionary<string, IReadOnlySet<int>>? packageExcludeLods = null;
         bool hasPackageExcludeLodsOption = false;
         bool includeMarkingAlways = true;
@@ -125,12 +130,16 @@ public static class CliArgumentsParser
                     case "--dataset":
                         dataset = ReadValue(args, ref index, token);
                         break;
+                    case "--guided":
+                        guided = true;
+                        break;
                     case "--mesh-code":
                         meshCode = ReadValue(args, ref index, token);
                         break;
                     case "--packages":
                         {
                             string packageValue = ReadValue(args, ref index, token);
+                            packageNamesSpecified = true;
                             packageNames = ParsePackageNames(packageValue, out string? packageError);
                             if (packageError is not null)
                             {
@@ -300,6 +309,7 @@ public static class CliArgumentsParser
                     case "--exclude-lod":
                         {
                             string excludeLodValue = ReadValue(args, ref index, token);
+                            globalExcludeLodsSpecified = true;
                             if (!TryParseLodExclusionRules(excludeLodValue, out globalExcludeLods, out string? lodError))
                             {
                                 return CliParseResult.Failure(lodError!);
@@ -356,12 +366,15 @@ public static class CliArgumentsParser
             };
         }
 
+        DatasetLocation? source = null;
         if (string.IsNullOrWhiteSpace(cityGmlSourceInput))
         {
-            return CliParseResult.Failure("Specify --citygml-source.");
+            if (!guided)
+            {
+                return CliParseResult.Failure("Specify --citygml-source.");
+            }
         }
-
-        if (!TryParseDatasetLocationInput(cityGmlSourceInput, out DatasetLocation? source, out string? sourceError))
+        else if (!TryParseDatasetLocationInput(cityGmlSourceInput, out source, out string? sourceError))
         {
             return CliParseResult.Failure(sourceError!);
         }
@@ -376,7 +389,7 @@ public static class CliArgumentsParser
         PlateauImportRequest request = new(
             Dataset: dataset ?? string.Empty,
             MeshCode: meshCode ?? string.Empty,
-            Source: source!,
+            Source: source ?? DatasetLocation.Local(string.Empty),
             DemTextureSource: demTextureSource,
             PackageNames: packageNames,
             GlobalExcludeLodLevels: globalExcludeLods,
@@ -387,7 +400,7 @@ public static class CliArgumentsParser
             TerrainGridMetersPerVertex: terrainGridMetersPerVertex,
             TerrainGridMaxResolution: terrainGridMaxResolution);
 
-        if (resoniteLinkUri is null)
+        if (resoniteLinkUri is null && !guided)
         {
             return CliParseResult.Failure(
                 "Specify either --resonitelink-port or --resonitelink-url.");
@@ -404,7 +417,10 @@ public static class CliArgumentsParser
                 terrainTileCacheRoot,
                 disableTerrainTileCache,
                 enableSendMetrics,
-                verboseLogging));
+                verboseLogging,
+                guided,
+                packageNamesSpecified,
+                globalExcludeLodsSpecified));
     }
 
     private static CliParseResult ParseSearch(string[] args)
@@ -597,7 +613,7 @@ public static class CliArgumentsParser
             out _);
     }
 
-    private static string[] ParsePackageNames(
+    internal static string[] ParsePackageNames(
         string csvValue,
         out string? error)
     {
@@ -614,7 +630,7 @@ public static class CliArgumentsParser
         return parsedValues;
     }
 
-    private static bool TryParseLodExclusionRules(
+    internal static bool TryParseLodExclusionRules(
         string? csvValue,
         out IReadOnlySet<int>? lodLevels,
         out string? error)
@@ -730,7 +746,7 @@ public static class CliArgumentsParser
         return true;
     }
 
-    private static bool TryParseDatasetLocationInput(
+    internal static bool TryParseDatasetLocationInput(
         string input,
         out DatasetLocation? source,
         out string? error)
@@ -759,6 +775,37 @@ public static class CliArgumentsParser
         }
 
         source = DatasetLocation.Local(trimmedInput);
+        error = null;
+        return true;
+    }
+
+    internal static bool TryParseResoniteLinkEndpointInput(
+        string input,
+        out Uri? resoniteLinkUri,
+        out string? error)
+    {
+        string trimmedInput = input.Trim();
+        if (int.TryParse(trimmedInput, out int port) && port is >= 1 and <= 65535)
+        {
+            resoniteLinkUri = new Uri($"ws://localhost:{port}/", UriKind.Absolute);
+            error = null;
+            return true;
+        }
+
+        if (!Uri.TryCreate(trimmedInput, UriKind.Absolute, out resoniteLinkUri))
+        {
+            error = $"The value '{input}' is not a valid TCP port or absolute ws/wss URL.";
+            return false;
+        }
+
+        if (!string.Equals(resoniteLinkUri.Scheme, "ws", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(resoniteLinkUri.Scheme, "wss", StringComparison.OrdinalIgnoreCase))
+        {
+            error = "The --resonitelink-url value must use the ws or wss scheme.";
+            resoniteLinkUri = null;
+            return false;
+        }
+
         error = null;
         return true;
     }

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -23,7 +23,7 @@ internal static class CliHostFactory
     {
         HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
         builder.Logging.ClearProviders();
-        builder.Services.AddCliServices(Console.Out, Console.Error);
+        builder.Services.AddCliServices(Console.In, Console.Out, Console.Error);
         return builder.Build();
     }
 }
@@ -32,10 +32,12 @@ internal static class CliServiceCollectionExtensions
 {
     public static IServiceCollection AddCliServices(
         this IServiceCollection services,
+        TextReader standardInput,
         TextWriter standardOutput,
         TextWriter standardError)
     {
         ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(standardInput);
         ArgumentNullException.ThrowIfNull(standardOutput);
         ArgumentNullException.ThrowIfNull(standardError);
 
@@ -46,14 +48,17 @@ internal static class CliServiceCollectionExtensions
         services.AddResoniteLiveSendTargetServices();
 
         services.AddSingleton<DatasetInspectionService>();
+        services.AddSingleton<IResoniteLinkTargetDiscovery, ResoniteLinkTargetDiscovery>();
         services.AddSingleton<IImportServiceFactory, DefaultImportServiceFactory>();
         services.AddSingleton<IPlateauDatasetSourceResolverFactory, DefaultPlateauDatasetSourceResolverFactory>();
         services.AddSingleton<ISceneSinkFactory, DefaultSceneSinkFactory>();
         services.AddSingleton<CliApplication>(_ => new CliApplication(
+            standardInput,
             standardOutput,
             standardError,
             _.GetRequiredService<IImportServiceFactory>(),
-            _.GetRequiredService<DatasetInspectionService>()));
+            _.GetRequiredService<DatasetInspectionService>(),
+            _.GetRequiredService<IResoniteLinkTargetDiscovery>()));
 
         return services;
     }

--- a/src/PlateauResoniteLink.Cli/GuidedImportOptionsResolver.cs
+++ b/src/PlateauResoniteLink.Cli/GuidedImportOptionsResolver.cs
@@ -230,7 +230,8 @@ internal sealed class GuidedImportOptionsResolver(
                 prompt,
                 defaultSelection,
                 value => string.IsNullOrWhiteSpace(value) ? "Specify --mesh-code." : null,
-                cancellationToken);
+                cancellationToken,
+                allowBlank: defaultSelection is not null);
 
             return ResolveSelectionOrValue(selectedInput!, inspection.MeshCodes);
         }

--- a/src/PlateauResoniteLink.Cli/GuidedImportOptionsResolver.cs
+++ b/src/PlateauResoniteLink.Cli/GuidedImportOptionsResolver.cs
@@ -1,0 +1,476 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Cli;
+
+internal sealed class GuidedImportOptionsResolver(
+    TextReader standardInput,
+    TextWriter standardOutput,
+    TextWriter standardError,
+    DatasetInspectionService datasetInspectionService,
+    IResoniteLinkTargetDiscovery targetDiscovery)
+{
+    public async Task<ImportCommandOptions> ResolveAsync(
+        ImportCommandOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (!options.Guided)
+        {
+            return options;
+        }
+
+        DatasetLocation source = await ResolveSourceAsync(options.Request.Source, cancellationToken);
+        GuidedDatasetInspection? inspection = await TryInspectSourceAsync(source, cancellationToken);
+
+        IReadOnlyList<string> packageNames = await ResolvePackageNamesAsync(
+            options.Request.PackageNames ?? CliDefaultOptions.PackageNames,
+            options.PackageNamesSpecified,
+            inspection,
+            cancellationToken);
+
+        IReadOnlySet<int>? globalExcludeLods = await ResolveGlobalExcludeLodsAsync(
+            options.Request.GlobalExcludeLodLevels,
+            options.GlobalExcludeLodLevelsSpecified,
+            inspection,
+            cancellationToken);
+
+        string dataset = await ResolveDatasetAsync(options.Request.Dataset, cancellationToken);
+        string meshCode = await ResolveMeshCodeAsync(options.Request.MeshCode, inspection, cancellationToken);
+        await TryWriteSearchPreviewAsync(source, meshCode, packageNames, cancellationToken);
+
+        Uri resoniteLinkUri = await ResolveResoniteLinkUriAsync(options.ResoniteLinkUri, cancellationToken);
+
+        return options with
+        {
+            Request = options.Request with
+            {
+                Dataset = dataset,
+                MeshCode = meshCode,
+                Source = source,
+                PackageNames = packageNames,
+                GlobalExcludeLodLevels = globalExcludeLods,
+            },
+            ResoniteLinkUri = resoniteLinkUri,
+        };
+    }
+
+    private async Task<DatasetLocation> ResolveSourceAsync(
+        DatasetLocation source,
+        CancellationToken cancellationToken)
+    {
+        if (!IsMissingDatasetLocation(source))
+        {
+            return source;
+        }
+
+        string sourceInput = await PromptRequiredValueAsync(
+            "CityGML source path or URL (--citygml-source)",
+            static value =>
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    return "Specify --citygml-source.";
+                }
+
+                return CliArgumentsParser.TryParseDatasetLocationInput(value, out _, out string? error)
+                    ? null
+                    : error;
+            },
+            cancellationToken);
+        _ = CliArgumentsParser.TryParseDatasetLocationInput(sourceInput, out DatasetLocation? parsedSource, out _);
+        return parsedSource!;
+    }
+
+    private async Task<GuidedDatasetInspection?> TryInspectSourceAsync(
+        DatasetLocation source,
+        CancellationToken cancellationToken)
+    {
+        if (source is not LocalDatasetLocation localSource
+            || string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            DatasetStatsResult stats = await datasetInspectionService.GetStatsAsync(
+                localSource.LocalSourcePath,
+                packageNames: null,
+                cancellationToken);
+
+            string[] packageNames = stats.PackageCounts
+                .OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(static pair => pair.Key)
+                .ToArray();
+            string[] meshCodes = stats.MeshCodeCounts
+                .OrderBy(static pair => pair.Key, StringComparer.Ordinal)
+                .Select(static pair => pair.Key)
+                .ToArray();
+            int[] lodLevels = stats.LodCoverageCounts
+                .OrderBy(static pair => pair.Key)
+                .Select(static pair => pair.Key)
+                .ToArray();
+
+            await standardOutput.WriteLineAsync("Dataset inspection:");
+            await standardOutput.WriteLineAsync($"  Recognized source files: {stats.RecognizedSourceFileCount.ToString(CultureInfo.InvariantCulture)}");
+            await standardOutput.WriteLineAsync($"  Packages: {FormatCounts(stats.PackageCounts)}");
+            await standardOutput.WriteLineAsync($"  Mesh codes: {FormatCounts(stats.MeshCodeCounts)}");
+            await standardOutput.WriteLineAsync($"  LOD coverage: {FormatCounts(stats.LodCoverageCounts)}");
+
+            return new GuidedDatasetInspection(packageNames, meshCodes, lodLevels);
+        }
+        catch (PlateauImportValidationException exception)
+        {
+            await standardError.WriteLineAsync(
+                $"Dataset inspection unavailable: {string.Join(" ", exception.Errors)}");
+            return null;
+        }
+    }
+
+    private async Task<IReadOnlyList<string>> ResolvePackageNamesAsync(
+        IReadOnlyList<string> currentPackageNames,
+        bool packageNamesSpecified,
+        GuidedDatasetInspection? inspection,
+        CancellationToken cancellationToken)
+    {
+        if (packageNamesSpecified || inspection is null || inspection.PackageNames.Count == 0)
+        {
+            return currentPackageNames;
+        }
+
+        await WriteNumberedValuesAsync("Available packages", inspection.PackageNames, cancellationToken);
+        string detectedPackageDefault = string.Join(",", inspection.PackageNames);
+        string? packageInput = await PromptOptionalValueAsync(
+            $"Packages (--packages, blank keeps {detectedPackageDefault})",
+            defaultValue: detectedPackageDefault,
+            value =>
+            {
+                string normalizedValue = ResolveCsvSelectionsOrValue(value, inspection.PackageNames);
+                _ = CliArgumentsParser.ParsePackageNames(normalizedValue, out string? packageError);
+                return packageError;
+            },
+            cancellationToken);
+
+        string normalizedInput = ResolveCsvSelectionsOrValue(packageInput ?? detectedPackageDefault, inspection.PackageNames);
+        return CliArgumentsParser.ParsePackageNames(normalizedInput, out _);
+    }
+
+    private async Task<IReadOnlySet<int>?> ResolveGlobalExcludeLodsAsync(
+        IReadOnlySet<int>? currentGlobalExcludeLods,
+        bool globalExcludeLodsSpecified,
+        GuidedDatasetInspection? inspection,
+        CancellationToken cancellationToken)
+    {
+        if (globalExcludeLodsSpecified || inspection is null || inspection.LodLevels.Count == 0)
+        {
+            return currentGlobalExcludeLods;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await standardOutput.WriteLineAsync(
+            $"Detected LOD levels: {string.Join(", ", inspection.LodLevels.Select(static lod => lod.ToString(CultureInfo.InvariantCulture)))}");
+        string? excludeInput = await PromptOptionalValueAsync(
+            "Exclude global LOD levels (--exclude-lod, blank keeps none)",
+            defaultValue: null,
+            value => CliArgumentsParser.TryParseLodExclusionRules(value, out _, out string? lodError)
+                ? null
+                : lodError,
+            cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(excludeInput))
+        {
+            return currentGlobalExcludeLods;
+        }
+
+        _ = CliArgumentsParser.TryParseLodExclusionRules(excludeInput, out IReadOnlySet<int>? parsedLods, out _);
+        return parsedLods;
+    }
+
+    private async Task<string> ResolveDatasetAsync(string dataset, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(dataset))
+        {
+            return dataset;
+        }
+
+        return await PromptRequiredValueAsync(
+            "PLATEAU dataset (--dataset)",
+            static value => string.IsNullOrWhiteSpace(value) ? "Specify --dataset." : null,
+            cancellationToken);
+    }
+
+    private async Task<string> ResolveMeshCodeAsync(
+        string meshCode,
+        GuidedDatasetInspection? inspection,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(meshCode))
+        {
+            return meshCode;
+        }
+
+        if (inspection is not null && inspection.MeshCodes.Count > 0)
+        {
+            await WriteNumberedValuesAsync("Available mesh codes", inspection.MeshCodes, cancellationToken);
+            string? defaultSelection = inspection.MeshCodes.Count == 1 ? "1" : null;
+            string prompt = defaultSelection is null
+                ? "Mesh code or regex (--mesh-code, number from list accepted)"
+                : $"Mesh code or regex (--mesh-code, blank keeps {inspection.MeshCodes[0]})";
+            string? selectedInput = await PromptOptionalValueAsync(
+                prompt,
+                defaultSelection,
+                value => string.IsNullOrWhiteSpace(value) ? "Specify --mesh-code." : null,
+                cancellationToken);
+
+            return ResolveSelectionOrValue(selectedInput!, inspection.MeshCodes);
+        }
+
+        return await PromptRequiredValueAsync(
+            "Mesh code or regex (--mesh-code)",
+            static value => string.IsNullOrWhiteSpace(value) ? "Specify --mesh-code." : null,
+            cancellationToken);
+    }
+
+    private async Task TryWriteSearchPreviewAsync(
+        DatasetLocation source,
+        string meshCode,
+        IReadOnlyList<string> packageNames,
+        CancellationToken cancellationToken)
+    {
+        if (source is not LocalDatasetLocation localSource
+            || string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
+        {
+            return;
+        }
+
+        DatasetSearchResult result = await datasetInspectionService.SearchAsync(
+            localSource.LocalSourcePath,
+            meshCode,
+            packageNames,
+            cancellationToken);
+
+        await standardOutput.WriteLineAsync("Search preview:");
+        await standardOutput.WriteLineAsync($"  Selected mesh codes: {FormatCsv(result.SelectedMeshCodes)}");
+        await standardOutput.WriteLineAsync($"  Matched source files: {result.SourceFiles.Count.ToString(CultureInfo.InvariantCulture)}");
+    }
+
+    private async Task<Uri> ResolveResoniteLinkUriAsync(
+        Uri? resoniteLinkUri,
+        CancellationToken cancellationToken)
+    {
+        if (resoniteLinkUri is not null)
+        {
+            return resoniteLinkUri;
+        }
+
+        IReadOnlyList<ResoniteLinkTarget> targets = await targetDiscovery.DiscoverAsync(cancellationToken);
+        if (targets.Count > 0)
+        {
+            await WriteDiscoveredTargetsAsync(targets, cancellationToken);
+        }
+
+        string? defaultSelection = targets.Count == 1 ? "1" : null;
+        string prompt = targets.Count > 0
+            ? "ResoniteLink endpoint (--resonitelink-port or --resonitelink-url, number from discovered list accepted)"
+            : "ResoniteLink endpoint (--resonitelink-port or --resonitelink-url)";
+        string endpointInput = await PromptOptionalValueAsync(
+            prompt,
+            defaultSelection,
+            value => ValidateEndpointInput(value, targets),
+            cancellationToken,
+            allowBlank: false) ?? string.Empty;
+
+        string normalizedInput = ResolveTargetSelectionOrValue(endpointInput, targets);
+        _ = CliArgumentsParser.TryParseResoniteLinkEndpointInput(normalizedInput, out Uri? parsedUri, out _);
+        return parsedUri!;
+    }
+
+    private static string? ValidateEndpointInput(string value, IReadOnlyList<ResoniteLinkTarget> targets)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "Specify either --resonitelink-port or --resonitelink-url.";
+        }
+
+        string normalizedInput = ResolveTargetSelectionOrValue(value, targets);
+        return CliArgumentsParser.TryParseResoniteLinkEndpointInput(normalizedInput, out _, out string? error)
+            ? null
+            : error;
+    }
+
+    private async Task<string> PromptRequiredValueAsync(
+        string promptLabel,
+        Func<string, string?> validate,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            string value = await ReadPromptValueAsync(promptLabel, cancellationToken);
+            string? error = validate(value);
+            if (error is null)
+            {
+                return value;
+            }
+
+            await standardError.WriteLineAsync(error);
+        }
+    }
+
+    private async Task<string?> PromptOptionalValueAsync(
+        string promptLabel,
+        string? defaultValue,
+        Func<string, string?> validate,
+        CancellationToken cancellationToken,
+        bool allowBlank = true)
+    {
+        while (true)
+        {
+            string value = await ReadPromptValueAsync(promptLabel, cancellationToken);
+            if (string.IsNullOrWhiteSpace(value) && defaultValue is not null)
+            {
+                value = defaultValue;
+            }
+            else if (string.IsNullOrWhiteSpace(value) && allowBlank)
+            {
+                return null;
+            }
+
+            string? error = validate(value);
+            if (error is null)
+            {
+                return string.IsNullOrWhiteSpace(value) ? null : value;
+            }
+
+            await standardError.WriteLineAsync(error);
+        }
+    }
+
+    private async Task<string> ReadPromptValueAsync(
+        string promptLabel,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await standardOutput.WriteAsync($"{promptLabel}: ");
+        await standardOutput.FlushAsync(cancellationToken);
+
+        string? input = await standardInput.ReadLineAsync(cancellationToken);
+        if (input is null)
+        {
+            throw new PlateauImportValidationException([$"No input received for {promptLabel}."]);
+        }
+
+        return input.Trim();
+    }
+
+    private async Task WriteNumberedValuesAsync(
+        string label,
+        IReadOnlyList<string> values,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await standardOutput.WriteLineAsync($"{label}:");
+        for (int index = 0; index < values.Count; index++)
+        {
+            await standardOutput.WriteLineAsync($"  {index + 1}. {values[index]}");
+        }
+    }
+
+    private async Task WriteDiscoveredTargetsAsync(
+        IReadOnlyList<ResoniteLinkTarget> targets,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await standardOutput.WriteLineAsync("Discovered ResoniteLink targets:");
+        for (int index = 0; index < targets.Count; index++)
+        {
+            ResoniteLinkTarget target = targets[index];
+            string name = string.IsNullOrWhiteSpace(target.SessionName)
+                ? "(unnamed session)"
+                : target.SessionName;
+            await standardOutput.WriteLineAsync($"  {index + 1}. {name} | {target.Endpoint}");
+        }
+    }
+
+    private static string ResolveSelectionOrValue(string input, IReadOnlyList<string> values)
+    {
+        if (int.TryParse(input, out int selection) && selection >= 1 && selection <= values.Count)
+        {
+            return values[selection - 1];
+        }
+
+        return input;
+    }
+
+    private static string ResolveCsvSelectionsOrValue(string input, IReadOnlyList<string> values)
+    {
+        string[] parts = input.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+        {
+            return input;
+        }
+
+        List<string> selectedValues = [];
+        foreach (string part in parts)
+        {
+            if (!int.TryParse(part, out int selection) || selection < 1 || selection > values.Count)
+            {
+                return input;
+            }
+
+            selectedValues.Add(values[selection - 1]);
+        }
+
+        return string.Join(",", selectedValues);
+    }
+
+    private static string ResolveTargetSelectionOrValue(string input, IReadOnlyList<ResoniteLinkTarget> targets)
+    {
+        if (int.TryParse(input, out int selection) && selection >= 1 && selection <= targets.Count)
+        {
+            return targets[selection - 1].Endpoint.AbsoluteUri;
+        }
+
+        return input;
+    }
+
+    private static bool IsMissingDatasetLocation(DatasetLocation source)
+    {
+        return source switch
+        {
+            LocalDatasetLocation localSource => string.IsNullOrWhiteSpace(localSource.LocalSourcePath),
+            RemoteDatasetLocation remoteSource => remoteSource.ServerUri is null,
+            _ => true,
+        };
+    }
+
+    private static string FormatCsv(IReadOnlyList<string> values)
+    {
+        return values.Count == 0 ? "(none)" : string.Join(", ", values);
+    }
+
+    private static string FormatCounts<TKey>(IReadOnlyDictionary<TKey, int> counts)
+        where TKey : notnull
+    {
+        return counts.Count == 0
+            ? "(none)"
+            : string.Join(
+                ", ",
+                counts.Select(
+                    static pair => $"{pair.Key}={pair.Value.ToString(CultureInfo.InvariantCulture)}"));
+    }
+
+    private sealed record GuidedDatasetInspection(
+        IReadOnlyList<string> PackageNames,
+        IReadOnlyList<string> MeshCodes,
+        IReadOnlyList<int> LodLevels);
+}

--- a/src/PlateauResoniteLink.Cli/GuidedImportOptionsResolver.cs
+++ b/src/PlateauResoniteLink.Cli/GuidedImportOptionsResolver.cs
@@ -135,6 +135,13 @@ internal sealed class GuidedImportOptionsResolver(
                 $"Dataset inspection unavailable: {string.Join(" ", exception.Errors)}");
             return null;
         }
+#pragma warning disable CA1031
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            await standardError.WriteLineAsync($"Dataset inspection unavailable: {exception.Message}");
+            return null;
+        }
+#pragma warning restore CA1031
     }
 
     private async Task<IReadOnlyList<string>> ResolvePackageNamesAsync(

--- a/src/PlateauResoniteLink.Cli/GuidedImportOptionsResolver.cs
+++ b/src/PlateauResoniteLink.Cli/GuidedImportOptionsResolver.cs
@@ -160,12 +160,7 @@ internal sealed class GuidedImportOptionsResolver(
         string? packageInput = await PromptOptionalValueAsync(
             $"Packages (--packages, blank keeps {detectedPackageDefault})",
             defaultValue: detectedPackageDefault,
-            value =>
-            {
-                string normalizedValue = ResolveCsvSelectionsOrValue(value, inspection.PackageNames);
-                _ = CliArgumentsParser.ParsePackageNames(normalizedValue, out string? packageError);
-                return packageError;
-            },
+            value => ValidatePackageInput(value, inspection.PackageNames),
             cancellationToken);
 
         string normalizedInput = ResolveCsvSelectionsOrValue(packageInput ?? detectedPackageDefault, inspection.PackageNames);
@@ -455,6 +450,50 @@ internal sealed class GuidedImportOptionsResolver(
         }
 
         return string.Join(",", selectedValues);
+    }
+
+    private static string? ValidatePackageInput(string value, IReadOnlyList<string> detectedPackageNames)
+    {
+        string[] parts = value.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+        {
+            _ = CliArgumentsParser.ParsePackageNames(value, out string? emptyPackageError);
+            return emptyPackageError;
+        }
+
+        bool allNumericSelections = parts.All(static part => int.TryParse(
+            part,
+            NumberStyles.Integer,
+            CultureInfo.InvariantCulture,
+            out _));
+        if (allNumericSelections
+            && parts.Any(part =>
+                !int.TryParse(part, NumberStyles.Integer, CultureInfo.InvariantCulture, out int selection)
+                || selection < 1
+                || selection > detectedPackageNames.Count))
+        {
+            return "Select package numbers between 1 and "
+                + $"{detectedPackageNames.Count.ToString(CultureInfo.InvariantCulture)}, "
+                + $"or enter supported package names: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.";
+        }
+
+        string normalizedValue = allNumericSelections
+            ? ResolveCsvSelectionsOrValue(value, detectedPackageNames)
+            : value;
+        string[] parsedPackageNames = CliArgumentsParser.ParsePackageNames(normalizedValue, out string? packageError);
+        if (packageError is not null)
+        {
+            return packageError;
+        }
+
+        string[] unsupportedPackageNames = parsedPackageNames
+            .Where(static packageName => !PlateauPackageCatalog.TryNormalizePackageName(packageName, out _))
+            .ToArray();
+        return unsupportedPackageNames.Length == 0
+            ? null
+            : "Unsupported package name(s): "
+                + $"{string.Join(", ", unsupportedPackageNames)}. "
+                + $"Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.";
     }
 
     private static string ResolveTargetSelectionOrValue(string input, IReadOnlyList<ResoniteLinkTarget> targets)

--- a/src/PlateauResoniteLink.Cli/GuidedImportOptionsResolver.cs
+++ b/src/PlateauResoniteLink.Cli/GuidedImportOptionsResolver.cs
@@ -274,7 +274,23 @@ internal sealed class GuidedImportOptionsResolver(
             return resoniteLinkUri;
         }
 
-        IReadOnlyList<ResoniteLinkTarget> targets = await targetDiscovery.DiscoverAsync(cancellationToken);
+        IReadOnlyList<ResoniteLinkTarget> targets;
+        try
+        {
+            targets = await targetDiscovery.DiscoverAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+#pragma warning disable CA1031
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            await standardError.WriteLineAsync($"ResoniteLink discovery unavailable: {exception.Message}");
+            targets = [];
+        }
+#pragma warning restore CA1031
+
         if (targets.Count > 0)
         {
             await WriteDiscoveredTargetsAsync(targets, cancellationToken);

--- a/src/PlateauResoniteLink.Cli/ImportCommandOptions.cs
+++ b/src/PlateauResoniteLink.Cli/ImportCommandOptions.cs
@@ -14,4 +14,7 @@ public sealed record ImportCommandOptions(
     string? TerrainTileCacheRoot,
     bool DisableTerrainTileCache,
     bool EnableSendMetrics,
-    bool VerboseLogging) : CliCommandOptions;
+    bool VerboseLogging,
+    bool Guided = false,
+    bool PackageNamesSpecified = false,
+    bool GlobalExcludeLodLevelsSpecified = false) : CliCommandOptions;

--- a/src/PlateauResoniteLink.Cli/ResoniteLinkTargetDiscovery.cs
+++ b/src/PlateauResoniteLink.Cli/ResoniteLinkTargetDiscovery.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Cli;
+
+internal interface IResoniteLinkTargetDiscovery
+{
+    Task<IReadOnlyList<ResoniteLinkTarget>> DiscoverAsync(CancellationToken cancellationToken = default);
+}
+
+internal sealed record ResoniteLinkTarget(
+    string SessionName,
+    string SessionId,
+    Uri Endpoint,
+    DateTime LastUpdateTimestamp);
+
+internal sealed class ResoniteLinkTargetDiscovery : IResoniteLinkTargetDiscovery
+{
+    private static readonly TimeSpan DiscoveryWindow = TimeSpan.FromMilliseconds(750);
+
+    public async Task<IReadOnlyList<ResoniteLinkTarget>> DiscoverAsync(CancellationToken cancellationToken = default)
+    {
+        using LinkSessionListener listener = new();
+        listener.Start();
+        await Task.Delay(DiscoveryWindow, cancellationToken);
+
+        List<ResoniteLinkSession> sessions = [];
+        listener.GetDiscoveredSessions(sessions);
+
+        return sessions
+            .Where(static session => session.LinkPort is >= 1 and <= 65535)
+            .Select(static session => new ResoniteLinkTarget(
+                session.SessionName ?? string.Empty,
+                session.SessionId ?? string.Empty,
+                new Uri($"ws://localhost:{session.LinkPort}/", UriKind.Absolute),
+                session.LastUpdateTimestamp))
+            .GroupBy(static target => target.Endpoint, UriComparer.Instance)
+            .Select(static group => group
+                .OrderByDescending(static target => target.LastUpdateTimestamp)
+                .First())
+            .OrderBy(static target => target.SessionName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static target => target.Endpoint.AbsoluteUri, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private sealed class UriComparer : IEqualityComparer<Uri>
+    {
+        public static UriComparer Instance { get; } = new();
+
+        public bool Equals(Uri? x, Uri? y)
+        {
+            return string.Equals(x?.AbsoluteUri, y?.AbsoluteUri, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode(Uri obj)
+        {
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.AbsoluteUri);
+        }
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Cli/CliApplicationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliApplicationTests.cs
@@ -304,6 +304,41 @@ public sealed class CliApplicationTests
     }
 
     [Fact]
+    public async Task RunAsyncGuidedImportRepromptsUnsupportedPackageInput()
+    {
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
+        using StringReader standardInput = new(
+            string.Join(
+                Environment.NewLine,
+                fixturePath,
+                "2",
+                "foo",
+                string.Empty,
+                string.Empty,
+                "tokyo23ku",
+                string.Empty,
+                "12345"));
+        using StringWriter standardOutput = new();
+        using StringWriter standardError = new();
+        StubImportServiceFactory importServiceFactory = new(_ => CreateImportService(new StubImportSink()));
+
+        CliApplication application = CreateApplication(
+            standardOutput,
+            standardError,
+            importServiceFactory,
+            standardInput);
+
+        int exitCode = await application.RunAsync(["import", "--guided"]);
+
+        Assert.Equal(0, exitCode);
+        ImportCommandOptions capturedOptions = Assert.Single(importServiceFactory.CapturedOptions);
+        Assert.Equal(["bldg"], capturedOptions.Request.PackageNames);
+        Assert.Contains("Select package numbers between 1 and 1", standardError.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Unsupported package name(s): foo.", standardError.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Available packages:", standardOutput.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task RunAsyncGuidedImportRepromptsInvalidEndpoint()
     {
         string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");

--- a/tests/PlateauResoniteLink.Tests/Cli/CliApplicationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliApplicationTests.cs
@@ -269,6 +269,41 @@ public sealed class CliApplicationTests
     }
 
     [Fact]
+    public async Task RunAsyncGuidedImportRepromptsBlankMeshCodeWhenMultipleDetected()
+    {
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDatasetParentMeshPackages");
+        using StringReader standardInput = new(
+            string.Join(
+                Environment.NewLine,
+                fixturePath,
+                "1",
+                string.Empty,
+                "tokyo23ku",
+                string.Empty,
+                "2",
+                "12345"));
+        using StringWriter standardOutput = new();
+        using StringWriter standardError = new();
+        StubImportServiceFactory importServiceFactory = new(_ => CreateImportService(new StubImportSink()));
+
+        CliApplication application = CreateApplication(
+            standardOutput,
+            standardError,
+            importServiceFactory,
+            standardInput);
+
+        int exitCode = await application.RunAsync(["import", "--guided"]);
+
+        Assert.Equal(0, exitCode);
+        ImportCommandOptions capturedOptions = Assert.Single(importServiceFactory.CapturedOptions);
+        Assert.Equal("tokyo23ku", capturedOptions.Request.Dataset);
+        Assert.Equal("53394525", capturedOptions.Request.MeshCode);
+        Assert.Equal(["bldg"], capturedOptions.Request.PackageNames);
+        Assert.Contains("Specify --mesh-code.", standardError.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Available mesh codes:", standardOutput.ToString());
+    }
+
+    [Fact]
     public async Task RunAsyncGuidedImportRepromptsInvalidEndpoint()
     {
         string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");

--- a/tests/PlateauResoniteLink.Tests/Cli/CliApplicationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliApplicationTests.cs
@@ -399,9 +399,64 @@ public sealed class CliApplicationTests
         Assert.DoesNotContain("ResoniteLink discovery unavailable", standardError.ToString(), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task GuidedImportFallsBackToManualValuesWhenDatasetInspectionFails()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        string lockedFilePath = WriteDatasetFile(
+            datasetRoot.Path,
+            "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml",
+            "<bldg:CityModel xmlns:bldg=\"http://www.opengis.net/citygml/building/2.0\"><bldg:lod1Solid /></bldg:CityModel>");
+        await using FileStream lockedFile = new(
+            lockedFilePath,
+            FileMode.Open,
+            FileAccess.ReadWrite,
+            FileShare.None);
+        CliParseResult parseResult = CliArgumentsParser.Parse(
+            [
+                "import",
+                "--guided",
+                "--citygml-source",
+                datasetRoot.Path,
+            ]);
+        using StringReader standardInput = new(
+            string.Join(
+                Environment.NewLine,
+                "tokyo23ku",
+                "53394525",
+                "12345"));
+        using StringWriter standardOutput = new();
+        using StringWriter standardError = new();
+        GuidedImportOptionsResolver resolver = new(
+            standardInput,
+            standardOutput,
+            standardError,
+            CreateDatasetInspectionService(),
+            new StubResoniteLinkTargetDiscovery([]));
+
+        ImportCommandOptions resolvedOptions = await resolver.ResolveAsync(parseResult.Options!);
+
+        Assert.Equal("tokyo23ku", resolvedOptions.Request.Dataset);
+        Assert.Equal("53394525", resolvedOptions.Request.MeshCode);
+        Assert.Equal(new Uri("ws://localhost:12345/"), resolvedOptions.ResoniteLinkUri);
+        Assert.Contains("Dataset inspection unavailable", standardError.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("Dataset inspection:", standardOutput.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Search preview:", standardOutput.ToString(), StringComparison.Ordinal);
+    }
+
     private static string[] BuildImportArgs(string fixturePath)
     {
         return CliTestData.BuildLocalImportArgs(fixturePath);
+    }
+
+    private static string WriteDatasetFile(string datasetRoot, string relativePath, string content)
+    {
+        string absolutePath = Path.Combine(
+            datasetRoot,
+            relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(absolutePath)!);
+        File.WriteAllText(absolutePath, content);
+        return absolutePath;
     }
 
     private sealed class StubImportSink : ISceneSink

--- a/tests/PlateauResoniteLink.Tests/Cli/CliApplicationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliApplicationTests.cs
@@ -68,6 +68,22 @@ public sealed class CliApplicationTests
                 new ArchiveFileLayoutPolicy()));
     }
 
+    private static CliApplication CreateApplication(
+        StringWriter standardOutput,
+        StringWriter standardError,
+        StubImportServiceFactory importServiceFactory,
+        TextReader? standardInput = null,
+        IResoniteLinkTargetDiscovery? targetDiscovery = null)
+    {
+        return new CliApplication(
+            standardInput ?? new StringReader(string.Empty),
+            standardOutput,
+            standardError,
+            importServiceFactory,
+            CreateDatasetInspectionService(),
+            targetDiscovery ?? new StubResoniteLinkTargetDiscovery([]));
+    }
+
     [Fact]
     public async Task RunAsyncWritesLiveCompletionForValidImportCommand()
     {
@@ -77,11 +93,7 @@ public sealed class CliApplicationTests
         StubImportSink importSink = new();
         StubImportServiceFactory importServiceFactory = new(_ => CreateImportService(importSink));
 
-        CliApplication application = new(
-            standardOutput,
-            standardError,
-            importServiceFactory,
-            CreateDatasetInspectionService());
+        CliApplication application = CreateApplication(standardOutput, standardError, importServiceFactory);
 
         int exitCode = await application.RunAsync(
             [
@@ -115,11 +127,7 @@ public sealed class CliApplicationTests
         string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
         StubImportServiceFactory importServiceFactory = new(_ => throw new InvalidOperationException("Unexpected transport failure."));
 
-        CliApplication application = new(
-            standardOutput,
-            standardError,
-            importServiceFactory,
-            CreateDatasetInspectionService());
+        CliApplication application = CreateApplication(standardOutput, standardError, importServiceFactory);
 
         int exitCode = await application.RunAsync(
             BuildImportArgs(fixturePath));
@@ -137,11 +145,7 @@ public sealed class CliApplicationTests
         string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
         StubImportServiceFactory importServiceFactory = new(_ => CreateImportService(new StubImportSink()));
 
-        CliApplication application = new(
-            standardOutput,
-            standardError,
-            importServiceFactory,
-            CreateDatasetInspectionService());
+        CliApplication application = CreateApplication(standardOutput, standardError, importServiceFactory);
 
         int exitCode = await application.RunAsync(
             BuildImportArgs(fixturePath));
@@ -162,11 +166,7 @@ public sealed class CliApplicationTests
         string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
         StubImportServiceFactory importServiceFactory = new(_ => CreateImportService(new StubImportSink()));
 
-        CliApplication application = new(
-            standardOutput,
-            standardError,
-            importServiceFactory,
-            CreateDatasetInspectionService());
+        CliApplication application = CreateApplication(standardOutput, standardError, importServiceFactory);
 
         int exitCode = await application.RunAsync(
             [
@@ -187,11 +187,7 @@ public sealed class CliApplicationTests
         string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
         StubImportServiceFactory importServiceFactory = new(_ => CreateImportService(new StubImportSink()));
 
-        CliApplication application = new(
-            standardOutput,
-            standardError,
-            importServiceFactory,
-            CreateDatasetInspectionService());
+        CliApplication application = CreateApplication(standardOutput, standardError, importServiceFactory);
 
         int exitCode = await application.RunAsync(
             [
@@ -213,11 +209,7 @@ public sealed class CliApplicationTests
         string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
         StubImportServiceFactory importServiceFactory = new(_ => throw new OperationCanceledException());
 
-        CliApplication application = new(
-            standardOutput,
-            standardError,
-            importServiceFactory,
-            CreateDatasetInspectionService());
+        CliApplication application = CreateApplication(standardOutput, standardError, importServiceFactory);
 
         using CancellationTokenSource cancellationTokenSource = new();
         await cancellationTokenSource.CancelAsync();
@@ -226,6 +218,86 @@ public sealed class CliApplicationTests
             () => application.RunAsync(
                 BuildImportArgs(fixturePath),
                 cancellationTokenSource.Token));
+    }
+
+    [Fact]
+    public async Task RunAsyncGuidedImportUsesLocalInspectionAndDiscoveredTarget()
+    {
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
+        using StringReader standardInput = new(
+            string.Join(
+                Environment.NewLine,
+                fixturePath,
+                string.Empty,
+                string.Empty,
+                "tokyo23ku",
+                string.Empty,
+                "1",
+                string.Empty));
+        using StringWriter standardOutput = new();
+        using StringWriter standardError = new();
+        StubImportServiceFactory importServiceFactory = new(_ => CreateImportService(new StubImportSink()));
+        ResoniteLinkTarget target = new(
+            "Test World",
+            "session-1",
+            new Uri("ws://localhost:54321/"),
+            DateTime.UtcNow);
+
+        CliApplication application = CreateApplication(
+            standardOutput,
+            standardError,
+            importServiceFactory,
+            standardInput,
+            new StubResoniteLinkTargetDiscovery([target]));
+
+        int exitCode = await application.RunAsync(["import", "--guided"]);
+
+        Assert.Equal(0, exitCode);
+        ImportCommandOptions capturedOptions = Assert.Single(importServiceFactory.CapturedOptions);
+        Assert.Equal("tokyo23ku", capturedOptions.Request.Dataset);
+        Assert.Equal("53394525", capturedOptions.Request.MeshCode);
+        Assert.Equal(["bldg"], capturedOptions.Request.PackageNames);
+        Assert.Equal(fixturePath, capturedOptions.Request.LocalSourcePath);
+        Assert.Equal(new Uri("ws://localhost:54321/"), capturedOptions.ResoniteLinkUri);
+        Assert.Contains("Dataset inspection:", standardOutput.ToString());
+        Assert.Contains("Available packages:", standardOutput.ToString());
+        Assert.Contains("blank keeps bldg", standardOutput.ToString());
+        Assert.Contains("Available mesh codes:", standardOutput.ToString());
+        Assert.Contains("Search preview:", standardOutput.ToString());
+        Assert.Contains("Discovered ResoniteLink targets:", standardOutput.ToString());
+        Assert.Equal(string.Empty, standardError.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsyncGuidedImportRepromptsInvalidEndpoint()
+    {
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
+        using StringReader standardInput = new(
+            string.Join(
+                Environment.NewLine,
+                fixturePath,
+                string.Empty,
+                string.Empty,
+                "tokyo23ku",
+                string.Empty,
+                "https://example.invalid",
+                "12345",
+                string.Empty));
+        using StringWriter standardOutput = new();
+        using StringWriter standardError = new();
+        StubImportServiceFactory importServiceFactory = new(_ => CreateImportService(new StubImportSink()));
+
+        CliApplication application = CreateApplication(
+            standardOutput,
+            standardError,
+            importServiceFactory,
+            standardInput);
+
+        int exitCode = await application.RunAsync(["import", "--guided"]);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("The --resonitelink-url value must use the ws or wss scheme.", standardError.ToString());
+        Assert.Equal(new Uri("ws://localhost:12345/"), Assert.Single(importServiceFactory.CapturedOptions).ResoniteLinkUri);
     }
 
     private static string[] BuildImportArgs(string fixturePath)
@@ -275,6 +347,15 @@ public sealed class CliApplicationTests
         {
             CapturedOptions.Add(options);
             return createImportService(options);
+        }
+    }
+
+    private sealed class StubResoniteLinkTargetDiscovery(IReadOnlyList<ResoniteLinkTarget> targets)
+        : IResoniteLinkTargetDiscovery
+    {
+        public Task<IReadOnlyList<ResoniteLinkTarget>> DiscoverAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(targets);
         }
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Cli/CliApplicationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliApplicationTests.cs
@@ -335,6 +335,70 @@ public sealed class CliApplicationTests
         Assert.Equal(new Uri("ws://localhost:12345/"), Assert.Single(importServiceFactory.CapturedOptions).ResoniteLinkUri);
     }
 
+    [Fact]
+    public async Task RunAsyncGuidedImportFallsBackToManualEndpointWhenDiscoveryFails()
+    {
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
+        using StringReader standardInput = new(
+            string.Join(
+                Environment.NewLine,
+                fixturePath,
+                string.Empty,
+                string.Empty,
+                "tokyo23ku",
+                string.Empty,
+                "12345"));
+        using StringWriter standardOutput = new();
+        using StringWriter standardError = new();
+        StubImportServiceFactory importServiceFactory = new(_ => CreateImportService(new StubImportSink()));
+
+        CliApplication application = CreateApplication(
+            standardOutput,
+            standardError,
+            importServiceFactory,
+            standardInput,
+            new StubResoniteLinkTargetDiscovery(
+                _ => Task.FromException<IReadOnlyList<ResoniteLinkTarget>>(
+                    new InvalidOperationException("discovery failed"))));
+
+        int exitCode = await application.RunAsync(["import", "--guided"]);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("ResoniteLink discovery unavailable", standardError.ToString());
+        Assert.DoesNotContain("Discovered ResoniteLink targets:", standardOutput.ToString());
+        Assert.Equal(new Uri("ws://localhost:12345/"), Assert.Single(importServiceFactory.CapturedOptions).ResoniteLinkUri);
+    }
+
+    [Fact]
+    public async Task RunAsyncGuidedImportPropagatesDiscoveryCancellation()
+    {
+        CliParseResult parseResult = CliArgumentsParser.Parse(
+            [
+                "import",
+                "--guided",
+                "--dataset",
+                "tokyo23ku",
+                "--mesh-code",
+                "53394525",
+                "--citygml-source",
+                "https://example.invalid/source.zip",
+            ]);
+        using StringWriter standardOutput = new();
+        using StringWriter standardError = new();
+        GuidedImportOptionsResolver resolver = new(
+            TextReader.Null,
+            standardOutput,
+            standardError,
+            CreateDatasetInspectionService(),
+            new StubResoniteLinkTargetDiscovery(
+                _ => throw new OperationCanceledException()));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => resolver.ResolveAsync(parseResult.Options!));
+
+        Assert.DoesNotContain("ResoniteLink discovery unavailable", standardError.ToString(), StringComparison.Ordinal);
+    }
+
     private static string[] BuildImportArgs(string fixturePath)
     {
         return CliTestData.BuildLocalImportArgs(fixturePath);
@@ -385,12 +449,30 @@ public sealed class CliApplicationTests
         }
     }
 
-    private sealed class StubResoniteLinkTargetDiscovery(IReadOnlyList<ResoniteLinkTarget> targets)
-        : IResoniteLinkTargetDiscovery
+    private sealed class StubResoniteLinkTargetDiscovery : IResoniteLinkTargetDiscovery
     {
+        private readonly Func<CancellationToken, Task<IReadOnlyList<ResoniteLinkTarget>>> discoverAsync;
+
+        public StubResoniteLinkTargetDiscovery(
+            Func<CancellationToken, Task<IReadOnlyList<ResoniteLinkTarget>>> discoverAsync)
+        {
+            this.discoverAsync = discoverAsync;
+        }
+
+        public StubResoniteLinkTargetDiscovery(
+            IReadOnlyList<ResoniteLinkTarget> targets)
+        {
+            discoverAsync = _ => Task.FromResult(targets);
+        }
+
+        public StubResoniteLinkTargetDiscovery()
+            : this((IReadOnlyList<ResoniteLinkTarget>)[])
+        {
+        }
+
         public Task<IReadOnlyList<ResoniteLinkTarget>> DiscoverAsync(CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(targets);
+            return discoverAsync(cancellationToken);
         }
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -83,6 +83,35 @@ public sealed class CliArgumentsParserTests
     }
 
     [Fact]
+    public void ParseGuidedImportAllowsMissingInteractiveValues()
+    {
+        CliParseResult result = CliArgumentsParser.Parse(["import", "--guided"]);
+
+        Assert.Null(result.Error);
+        Assert.NotNull(result.Options);
+        Assert.True(result.Options.Guided);
+        Assert.Equal(string.Empty, result.Options.Request.Dataset);
+        Assert.Equal(string.Empty, result.Options.Request.MeshCode);
+        Assert.Equal(DatasetSourceKind.Local, result.Options.Request.SourceKind);
+        Assert.Equal(string.Empty, result.Options.Request.LocalSourcePath);
+        Assert.Null(result.Options.ResoniteLinkUri);
+    }
+
+    [Fact]
+    public void ParseStrictImportStillRequiresResoniteLinkEndpoint()
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "import",
+                "--dataset", "tokyo23ku",
+                "--mesh-code", "53394525",
+                "--citygml-source", "/data/plateau",
+            ]);
+
+        Assert.Equal("Specify either --resonitelink-port or --resonitelink-url.", result.Error);
+    }
+
+    [Fact]
     public void ParseRejectsDeprecatedSourceFlags()
     {
         CliParseResult result = CliArgumentsParser.Parse(
@@ -243,6 +272,10 @@ public sealed class CliArgumentsParserTests
             CliArgumentsParser.HelpText,
             StringComparison.Ordinal);
         Assert.Contains(
+            "plateau-resonitelink import --guided [options]",
+            CliArgumentsParser.HelpText,
+            StringComparison.Ordinal);
+        Assert.Contains(
             "Import options:",
             CliArgumentsParser.HelpText,
             StringComparison.Ordinal);
@@ -259,6 +292,7 @@ public sealed class CliArgumentsParserTests
         Assert.DoesNotContain("--local-source-path <path>", CliArgumentsParser.HelpText, StringComparison.Ordinal);
         Assert.DoesNotContain("--source <value>", CliArgumentsParser.HelpText, StringComparison.Ordinal);
         Assert.DoesNotContain("--server-url <url>", CliArgumentsParser.HelpText, StringComparison.Ordinal);
+        Assert.Contains("--guided", CliArgumentsParser.HelpText, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds guided import assistance for missing CLI import values.
- Uses local inspection defaults for guided package/mesh selection and ResoniteLink target discovery.
- Confirms stdin-driven UX, including blank package defaulting to detected packages.

Refs #163

## Verification
- stdin guided UX: prompts reached search preview; blank package prompt showed `blank keeps bldg`
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- live base/append real data: Higashimurayama `PLATEAU real-ba-higa-pr175-issue-163-20260429`, mesh `53395325`, append observed `dataset_root_existed=True`, `attempted=2 sent=2 failed=0`, dump `runtime/windows/resonite/root-dumps/real-ba-higa-pr175-issue-163-20260429-after.json`
- live base/append real data: Matsumoto `PLATEAU real-ba-matsu-pr175-issue-163-20260429`, base mesh `54372778`, append mesh `54372788`, append observed `dataset_root_existed=True`, `attempted=4 sent=4 failed=0`, dump `runtime/windows/resonite/root-dumps/real-ba-matsu-pr175-issue-163-20260429-after.json`