### PR TITLE
feat: honor appearance sampler semantics

### DIFF
--- a/docs/appearance-policy.ja.md
+++ b/docs/appearance-policy.ja.md
@@ -19,7 +19,11 @@
 
 - #91 が、対応済みの DEM georeferenced-raster 経路を定義しました。
 - #128 は、`diffuseColor`、`ambientIntensity`、`emissiveColor`、`specularColor`、`shininess`、`transparency` などの `X3DMaterial` optical attributes を扱います。
-- #129 は、sampler、wrap、border、transparency behavior に関する残りの appearance semantics を扱います。
+- #129 は、対応する `ParameterizedTexture` sampler semantics を定義します。
+  - repeat 相当の `wrapMode` (`wrap`, `repeat`) は repeated sampling として扱います。
+  - clamp 相当の `wrapMode` (`none`, `clamp`, `border`) は edge-clamped sampling として扱います。
+  - `borderColor` は audit visibility のため parse しますが、Resonite の border-color sampler としては emit しません。border-style sampling は clamp fallback です。
+- texture alpha は dataset / atlas payload 上で保持します。`X3DMaterial` の `transparency` は material base alpha に乗算します。atlas preparation は edge bleed 低減のため transparent RGB channels を埋めることがありますが、alpha は変更しません。
 - #128 と #129 のどちらも、非 DEM `GeoreferencedTexture` projection の対応を意味しません。
 
 ## レビュー基準

--- a/docs/appearance-policy.md
+++ b/docs/appearance-policy.md
@@ -19,7 +19,11 @@ This document defines the current supported scope for CityGML appearance handlin
 
 - #91 established the supported DEM georeferenced-raster path.
 - #128 covers `X3DMaterial` optical attributes such as `diffuseColor`, `ambientIntensity`, `emissiveColor`, `specularColor`, `shininess`, and `transparency`.
-- #129 covers remaining appearance semantics around sampler, wrap, border, and transparency behavior.
+- #129 defines the supported `ParameterizedTexture` sampler semantics:
+  - `wrapMode` values equivalent to repeat (`wrap`, `repeat`) use repeated sampling.
+  - `wrapMode` values equivalent to clamp (`none`, `clamp`, `border`) use edge-clamped sampling.
+  - `borderColor` is parsed for audit visibility but is not emitted as a Resonite border-color sampler; border-style sampling falls back to clamp.
+- Texture alpha is preserved in dataset and atlas payloads. `X3DMaterial` `transparency` multiplies the material base alpha; atlas preparation may fill transparent RGB channels to reduce edge bleed without changing alpha.
 - Neither #128 nor #129 imply support for non-DEM `GeoreferencedTexture` projection.
 
 ## Review Rule

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlBootstrapParsedObjectModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlBootstrapParsedObjectModels.cs
@@ -44,7 +44,8 @@ internal sealed record BootstrapParsedSurface(
     ColorRgba BaseColor,
     TexturePayload? TexturePayload,
     bool UsesGeneratedDemTexture = false,
-    MaterialOpticalProperties? OpticalProperties = null)
+    MaterialOpticalProperties? OpticalProperties = null,
+    TextureWrapMode? TextureWrapMode = null)
 {
     public IEnumerable<GeodeticPoint> Vertices =>
         ExteriorRing.Vertices.Concat(InteriorRings.SelectMany(static ring => ring.Vertices));
@@ -59,7 +60,8 @@ internal sealed record BootstrapParsedSurface(
             BaseColor,
             TexturePayload,
             UsesGeneratedDemTexture,
-            OpticalProperties);
+            OpticalProperties,
+            TextureWrapMode);
     }
 
     internal static BootstrapParsedSurface FromLegacy(LocalCityGmlObjectProjection.ParsedSurface surface)
@@ -72,7 +74,8 @@ internal sealed record BootstrapParsedSurface(
             new ColorRgba(surface.BaseColor.R, surface.BaseColor.G, surface.BaseColor.B, surface.BaseColor.A),
             surface.TexturePayload,
             surface.UsesGeneratedDemTexture,
-            surface.OpticalProperties);
+            surface.OpticalProperties,
+            surface.TextureWrapMode);
     }
 }
 

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1093,7 +1093,8 @@ internal static partial class LocalCityGmlObjectProjection
             InteriorRings: interiorRings,
             BaseColor: ToInternalColor(appearance.BaseColor),
             TexturePayload: appearance.TexturePayload,
-            OpticalProperties: CreateMaterialOpticalProperties(appearance.MaterialAttributes));
+            OpticalProperties: CreateMaterialOpticalProperties(appearance.MaterialAttributes),
+            TextureWrapMode: CreateTextureWrapMode(appearance.ParameterizedTexture));
     }
 
     private static ParsedRing? ParseRing(
@@ -1252,7 +1253,8 @@ internal static partial class LocalCityGmlObjectProjection
                     resolvedSurface.Material.TextureScale,
                     resolvedSurface.Surface.BaseColor,
                     resolvedSurface.Material.TextureOffset,
-                    resolvedSurface.Surface.OpticalProperties),
+                    resolvedSurface.Surface.OpticalProperties,
+                    resolvedSurface.Material.TextureWrapMode),
                 StringComparer.Ordinal)
             .OrderBy(static group => group.Key, StringComparer.Ordinal)
             .ToArray();
@@ -1431,6 +1433,7 @@ internal static partial class LocalCityGmlObjectProjection
             preferUvProjection && IsBuildingPackage(cityObject.PackageName) ? BundledDefaultMaterialFamilies.Facade : null,
             $"{cityObject.SlotKey}:{(preferUvProjection ? "uv" : "triplanar")}");
         resolvedMaterial = ApplySurfaceOpticalProperties(resolvedMaterial, surface.OpticalProperties);
+        resolvedMaterial = ApplySurfaceSamplerProperties(resolvedMaterial, surface.TextureWrapMode);
         MaterialDepthOffset? depthOffset = cityObject.TerrainAligned
             ? DefaultTerrainAlignedMaterialDepthOffset
             : null;
@@ -1520,6 +1523,7 @@ internal static partial class LocalCityGmlObjectProjection
             preferUvProjection && IsBuildingPackage(cityObject.PackageName) ? BundledDefaultMaterialFamilies.Facade : null,
             $"{cityObject.SlotKey}:{(preferUvProjection ? "uv" : "triplanar")}");
         resolvedMaterial = ApplySurfaceOpticalProperties(resolvedMaterial, legacySurface.OpticalProperties);
+        resolvedMaterial = ApplySurfaceSamplerProperties(resolvedMaterial, legacySurface.TextureWrapMode);
         MaterialDepthOffset? depthOffset = cityObject.TerrainAligned
             ? DefaultTerrainAlignedMaterialDepthOffset
             : null;
@@ -1542,6 +1546,15 @@ internal static partial class LocalCityGmlObjectProjection
                 : material.ReuseScope,
             OpticalProperties = opticalProperties,
         };
+    }
+
+    private static ResolvedMaterial ApplySurfaceSamplerProperties(
+        ResolvedMaterial material,
+        TextureWrapMode? textureWrapMode)
+    {
+        return textureWrapMode is null
+            ? material
+            : material with { TextureWrapMode = textureWrapMode };
     }
 
     private static bool HasRepresentableOpticalProperties(MaterialOpticalProperties opticalProperties)
@@ -2521,14 +2534,15 @@ internal static partial class LocalCityGmlObjectProjection
         string? family,
         ColorRgba color,
         Float2? textureOffset = null,
-        MaterialOpticalProperties? opticalProperties = null)
+        MaterialOpticalProperties? opticalProperties = null,
+        TextureWrapMode? textureWrapMode = null)
     {
         string terrainToken = terrainOverlay is null ? "none" : CreateTerrainOverlayToken(terrainOverlay);
         string textureToken = texturePayload?.Identity ?? "none";
         string familyToken = string.IsNullOrWhiteSpace(family) ? "none" : family.ToLowerInvariant();
         return string.Create(
             CultureInfo.InvariantCulture,
-            $"material-{MaterialTypeToken(materialType)}-{ProjectionToken(projection)}-terrain-{terrainToken}-texture-{textureToken}-source-{textureSourceKind.ToString().ToLowerInvariant()}-family-{familyToken}-depth-{FormatDepth(depthOffset)}-scale-{FormatFloat2(textureScale)}-offset-{FormatFloat2(textureOffset)}-color-{FormatColor(color)}-optical-{FormatOpticalProperties(opticalProperties)}");
+            $"material-{MaterialTypeToken(materialType)}-{ProjectionToken(projection)}-terrain-{terrainToken}-texture-{textureToken}-source-{textureSourceKind.ToString().ToLowerInvariant()}-family-{familyToken}-depth-{FormatDepth(depthOffset)}-scale-{FormatFloat2(textureScale)}-offset-{FormatFloat2(textureOffset)}-color-{FormatColor(color)}-optical-{FormatOpticalProperties(opticalProperties)}-wrap-{FormatTextureWrapMode(textureWrapMode)}");
     }
 
     private static string CreateBindingMaterialKey(
@@ -2537,7 +2551,8 @@ internal static partial class LocalCityGmlObjectProjection
         Float2? textureScale,
         ColorRgba color,
         Float2? textureOffset = null,
-        MaterialOpticalProperties? opticalProperties = null)
+        MaterialOpticalProperties? opticalProperties = null,
+        TextureWrapMode? textureWrapMode = null)
     {
         if (material.ReuseScope == MaterialReuseScope.Shared)
         {
@@ -2560,7 +2575,8 @@ internal static partial class LocalCityGmlObjectProjection
             material.Family,
             color,
             textureOffset,
-            opticalProperties);
+            opticalProperties,
+            textureWrapMode);
     }
 
     private static string CreateTerrainOverlayToken(TerrainTextureOverlay terrainOverlay)
@@ -2619,6 +2635,9 @@ internal static partial class LocalCityGmlObjectProjection
             CultureInfo.InvariantCulture,
             $"emissive-{emissive}-shininess-{shininess}");
     }
+
+    private static string FormatTextureWrapMode(TextureWrapMode? value) =>
+        value is null ? "default" : value.Value.ToString().ToLowerInvariant();
 
     private static string FormatBounds(GeographicRectangle bounds) =>
         string.Create(
@@ -3371,7 +3390,8 @@ internal static partial class LocalCityGmlObjectProjection
                     resolvedSurface.Material.TextureScale,
                     resolvedSurface.Surface.BaseColor,
                     resolvedSurface.Material.TextureOffset,
-                    resolvedSurface.Surface.OpticalProperties),
+                    resolvedSurface.Surface.OpticalProperties,
+                    resolvedSurface.Material.TextureWrapMode),
                 StringComparer.Ordinal)
             .OrderBy(static group => group.Key, StringComparer.Ordinal)
             .Select((group, materialIndex) =>
@@ -3385,7 +3405,8 @@ internal static partial class LocalCityGmlObjectProjection
                         representativeSurface.Material.TextureScale,
                         representativeSurface.Surface.BaseColor,
                         representativeSurface.Material.TextureOffset,
-                        representativeSurface.Surface.OpticalProperties),
+                        representativeSurface.Surface.OpticalProperties,
+                        representativeSurface.Material.TextureWrapMode),
                     materialIndex);
             })
             .Where(static material => material.ReuseScope == MaterialReuseScope.Shared)
@@ -3419,7 +3440,8 @@ internal static partial class LocalCityGmlObjectProjection
                     resolvedSurface.Material.TextureScale,
                     resolvedSurface.Surface.BaseColor,
                     resolvedSurface.Material.TextureOffset,
-                    resolvedSurface.Surface.OpticalProperties),
+                    resolvedSurface.Surface.OpticalProperties,
+                    resolvedSurface.Material.TextureWrapMode),
                 StringComparer.Ordinal)
             .OrderBy(static group => group.Key, StringComparer.Ordinal)
             .Select((group, materialIndex) =>
@@ -3433,7 +3455,8 @@ internal static partial class LocalCityGmlObjectProjection
                         representativeSurface.Material.TextureScale,
                         representativeSurface.Surface.BaseColor,
                         representativeSurface.Material.TextureOffset,
-                        representativeSurface.Surface.OpticalProperties),
+                        representativeSurface.Surface.OpticalProperties,
+                        representativeSurface.Material.TextureWrapMode),
                     materialIndex);
             })
             .Where(static material => material.ReuseScope == MaterialReuseScope.Shared)
@@ -4007,7 +4030,8 @@ internal static partial class LocalCityGmlObjectProjection
                     resolvedSurface.Material.TextureScale,
                     resolvedSurface.Surface.BaseColor,
                     resolvedSurface.Material.TextureOffset,
-                    resolvedSurface.Surface.OpticalProperties),
+                    resolvedSurface.Surface.OpticalProperties,
+                    resolvedSurface.Material.TextureWrapMode),
                 StringComparer.Ordinal)
             .OrderBy(static group => group.Key, StringComparer.Ordinal)
             .Select((group, materialIndex) =>
@@ -4021,7 +4045,8 @@ internal static partial class LocalCityGmlObjectProjection
                         representativeSurface.Material.TextureScale,
                         representativeSurface.Surface.BaseColor,
                         representativeSurface.Material.TextureOffset,
-                        representativeSurface.Surface.OpticalProperties),
+                        representativeSurface.Surface.OpticalProperties,
+                        representativeSurface.Material.TextureWrapMode),
                     materialIndex);
             })
             .ToArray();
@@ -4054,7 +4079,8 @@ internal static partial class LocalCityGmlObjectProjection
                     resolvedSurface.Material.TextureScale,
                     resolvedSurface.Surface.BaseColor,
                     resolvedSurface.Material.TextureOffset,
-                    resolvedSurface.Surface.OpticalProperties),
+                    resolvedSurface.Surface.OpticalProperties,
+                    resolvedSurface.Material.TextureWrapMode),
                 StringComparer.Ordinal)
             .OrderBy(static group => group.Key, StringComparer.Ordinal)
             .Select((group, materialIndex) =>
@@ -4068,7 +4094,8 @@ internal static partial class LocalCityGmlObjectProjection
                         representativeSurface.Material.TextureScale,
                         representativeSurface.Surface.BaseColor,
                         representativeSurface.Material.TextureOffset,
-                        representativeSurface.Surface.OpticalProperties),
+                        representativeSurface.Surface.OpticalProperties,
+                        representativeSurface.Material.TextureWrapMode),
                     materialIndex);
             })
             .ToArray();
@@ -4102,7 +4129,8 @@ internal static partial class LocalCityGmlObjectProjection
             ReuseScope: representativeSurface.Material.ReuseScope,
             TerrainOverlay: representativeSurface.Material.TerrainOverlay,
             BundledVariantIndex: representativeSurface.Material.BundledVariantIndex,
-            OpticalProperties: representativeSurface.Material.OpticalProperties);
+            OpticalProperties: representativeSurface.Material.OpticalProperties,
+            TextureWrapMode: representativeSurface.Material.TextureWrapMode);
     }
 
     private static Float2 ToContractFloat2(Float2 value) => new(value.X, value.Y);
@@ -4127,6 +4155,21 @@ internal static partial class LocalCityGmlObjectProjection
             SpecularColor: attributes.SpecularColor is null ? null : ToInternalColor(attributes.SpecularColor),
             Shininess: attributes.Shininess,
             Transparency: attributes.Transparency);
+    }
+
+    private static TextureWrapMode? CreateTextureWrapMode(CityGmlParameterizedTexture? texture)
+    {
+        if (string.IsNullOrWhiteSpace(texture?.WrapMode))
+        {
+            return null;
+        }
+
+        return texture.WrapMode.Trim().ToLowerInvariant() switch
+        {
+            "wrap" or "repeat" => TextureWrapMode.Repeat,
+            "none" or "clamp" or "border" => TextureWrapMode.Clamp,
+            _ => null,
+        };
     }
 
     private static Float3 ToContractFloat3(Float3 value) => new(value.X, value.Y, value.Z);
@@ -4945,7 +4988,8 @@ internal static partial class LocalCityGmlObjectProjection
         ColorRgba BaseColor,
         TexturePayload? TexturePayload,
         bool UsesGeneratedDemTexture = false,
-        MaterialOpticalProperties? OpticalProperties = null)
+        MaterialOpticalProperties? OpticalProperties = null,
+        TextureWrapMode? TextureWrapMode = null)
     {
         public IEnumerable<GeodeticPoint> Vertices =>
             ExteriorRing.Vertices.Concat(InteriorRings.SelectMany(static ring => ring.Vertices));

--- a/src/PlateauResoniteLink/Application/Importing/ResolvedMaterial.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ResolvedMaterial.cs
@@ -13,4 +13,5 @@ internal sealed record ResolvedMaterial(
     TerrainTextureOverlay? TerrainOverlay = null,
     int? BundledVariantIndex = null,
     Float2? TextureOffset = null,
-    MaterialOpticalProperties? OpticalProperties = null);
+    MaterialOpticalProperties? OpticalProperties = null,
+    TextureWrapMode? TextureWrapMode = null);

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -139,6 +139,12 @@ public enum TextureSourceKind
     Bundled = 1,
 }
 
+public enum TextureWrapMode
+{
+    Repeat = 0,
+    Clamp = 1,
+}
+
 public enum MaterialType
 {
     Standard = 0,
@@ -185,4 +191,5 @@ public sealed record MaterialBinding(
     MaterialReuseScope ReuseScope = MaterialReuseScope.PerObject,
     TerrainTextureOverlay? TerrainOverlay = null,
     int? BundledVariantIndex = null,
-    MaterialOpticalProperties? OpticalProperties = null);
+    MaterialOpticalProperties? OpticalProperties = null,
+    TextureWrapMode? TextureWrapMode = null);

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -502,7 +502,8 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
                 ResoniteSceneMaterialConventions.CreateTextureMembers(
                     albedoTextureUri,
-                    ResoniteSceneMaterialConventions.TextureMemberRole.Albedo)
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
+                    material.TextureWrapMode)
                     .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal)));
             materialMembers["AlbedoTexture"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(albedoTextureId));
         }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -185,7 +185,8 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
                 ResoniteSceneMaterialConventions.CreateTextureMembers(
                     albedoTextureUri,
-                    ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
+                    plannedMaterial.Material.TextureWrapMode),
                 cancellationToken);
             materialMembers["AlbedoTexture"] = new Reference
             {

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneBootstrapInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneBootstrapInterpreter.cs
@@ -589,7 +589,8 @@ internal sealed class ResoniteSceneBootstrapInterpreter : IResoniteSceneBootstra
                 StaticTextureComponentType,
                 ResoniteSceneMaterialConventions.CreateTextureMembers(
                     albedoTextureUri,
-                    ResoniteSceneMaterialConventions.TextureMemberRole.Albedo));
+                    ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
+                    plannedMaterial.Material.TextureWrapMode));
             materialMembers["AlbedoTexture"] = new Reference
             {
                 TargetID = albedoTexture.LocalId.Value,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -367,7 +367,12 @@ internal sealed class NonDemCityObjectBaker(
         int maxTileHeight = EffectiveMaxAtlasTextureEdge;
         int targetWidth = Math.Max(1, Math.Min(maxTileWidth, (int)Math.Ceiling(sourceImage.Width * uvBounds.Width)));
         int targetHeight = Math.Max(1, Math.Min(maxTileHeight, (int)Math.Ceiling(sourceImage.Height * uvBounds.Height)));
-        using Image<Rgba32> bakedImage = BakeUsedUvRegion(preparedSourceImage, uvBounds, targetWidth, targetHeight);
+        using Image<Rgba32> bakedImage = BakeUsedUvRegion(
+            preparedSourceImage,
+            uvBounds,
+            targetWidth,
+            targetHeight,
+            material.TextureWrapMode ?? ResoniteTextureWrapMode.Repeat);
 
         ApplyBaseColor(bakedImage, material.BaseColor);
         return new AtlasOrPreservedEntry(
@@ -1232,7 +1237,8 @@ internal sealed class NonDemCityObjectBaker(
         Image<Rgba32> sourceImage,
         TextureUvRect uvBounds,
         int targetWidth,
-        int targetHeight)
+        int targetHeight,
+        ResoniteTextureWrapMode textureWrapMode)
     {
         Image<Rgba32> bakedImage = new(targetWidth, targetHeight);
         for (int y = 0; y < targetHeight; y++)
@@ -1242,7 +1248,7 @@ internal sealed class NonDemCityObjectBaker(
             {
                 double normalizedU = (x + 0.5) / targetWidth;
                 ScalarPair sourceUv = uvBounds.DenormalizeValue(normalizedU, normalizedV);
-                bakedImage[x, y] = SampleWrappedPixelBilinear(sourceImage, sourceUv.X, sourceUv.Y);
+                bakedImage[x, y] = SamplePixelBilinear(sourceImage, sourceUv.X, sourceUv.Y, textureWrapMode);
             }
         }
 
@@ -1465,12 +1471,16 @@ internal sealed class NonDemCityObjectBaker(
         atlasCoverage[(y * atlasWidth) + x] = true;
     }
 
-    private static Rgba32 SampleWrappedPixelBilinear(Image<Rgba32> sourceImage, double u, double v)
+    private static Rgba32 SamplePixelBilinear(
+        Image<Rgba32> sourceImage,
+        double u,
+        double v,
+        ResoniteTextureWrapMode textureWrapMode)
     {
-        double wrappedU = WrapUvCoordinate(u);
-        double wrappedV = WrapUvCoordinate(v);
-        double sourceX = (wrappedU * sourceImage.Width) - 0.5;
-        double sourceY = ((1.0 - wrappedV) * sourceImage.Height) - 0.5;
+        double sampledU = SampleUvCoordinate(u, textureWrapMode);
+        double sampledV = SampleUvCoordinate(v, textureWrapMode);
+        double sourceX = (sampledU * sourceImage.Width) - 0.5;
+        double sourceY = ((1.0 - sampledV) * sourceImage.Height) - 0.5;
         int x0 = (int)Math.Floor(sourceX);
         int y0 = (int)Math.Floor(sourceY);
         int x1 = x0 + 1;
@@ -1478,11 +1488,29 @@ internal sealed class NonDemCityObjectBaker(
         double tx = sourceX - x0;
         double ty = sourceY - y0;
 
-        Rgba32 topLeft = sourceImage[WrapPixelCoordinate(x0, sourceImage.Width), WrapPixelCoordinate(y0, sourceImage.Height)];
-        Rgba32 topRight = sourceImage[WrapPixelCoordinate(x1, sourceImage.Width), WrapPixelCoordinate(y0, sourceImage.Height)];
-        Rgba32 bottomLeft = sourceImage[WrapPixelCoordinate(x0, sourceImage.Width), WrapPixelCoordinate(y1, sourceImage.Height)];
-        Rgba32 bottomRight = sourceImage[WrapPixelCoordinate(x1, sourceImage.Width), WrapPixelCoordinate(y1, sourceImage.Height)];
+        Rgba32 topLeft = sourceImage[
+            SamplePixelCoordinate(x0, sourceImage.Width, textureWrapMode),
+            SamplePixelCoordinate(y0, sourceImage.Height, textureWrapMode)];
+        Rgba32 topRight = sourceImage[
+            SamplePixelCoordinate(x1, sourceImage.Width, textureWrapMode),
+            SamplePixelCoordinate(y0, sourceImage.Height, textureWrapMode)];
+        Rgba32 bottomLeft = sourceImage[
+            SamplePixelCoordinate(x0, sourceImage.Width, textureWrapMode),
+            SamplePixelCoordinate(y1, sourceImage.Height, textureWrapMode)];
+        Rgba32 bottomRight = sourceImage[
+            SamplePixelCoordinate(x1, sourceImage.Width, textureWrapMode),
+            SamplePixelCoordinate(y1, sourceImage.Height, textureWrapMode)];
         return LerpPixels(topLeft, topRight, bottomLeft, bottomRight, tx, ty);
+    }
+
+    private static double SampleUvCoordinate(double value, ResoniteTextureWrapMode textureWrapMode)
+    {
+        return textureWrapMode switch
+        {
+            ResoniteTextureWrapMode.Repeat => WrapUvCoordinate(value),
+            ResoniteTextureWrapMode.Clamp => Math.Clamp(value, 0.0, 1.0),
+            _ => throw new InvalidOperationException($"Unsupported texture wrap mode '{textureWrapMode}'."),
+        };
     }
 
     private static double WrapUvCoordinate(double value)
@@ -1495,6 +1523,16 @@ internal sealed class NonDemCityObjectBaker(
     {
         int wrapped = value % length;
         return wrapped < 0 ? wrapped + length : wrapped;
+    }
+
+    private static int SamplePixelCoordinate(int value, int length, ResoniteTextureWrapMode textureWrapMode)
+    {
+        return textureWrapMode switch
+        {
+            ResoniteTextureWrapMode.Repeat => WrapPixelCoordinate(value, length),
+            ResoniteTextureWrapMode.Clamp => Math.Clamp(value, 0, length - 1),
+            _ => throw new InvalidOperationException($"Unsupported texture wrap mode '{textureWrapMode}'."),
+        };
     }
 
     private static Rgba32 LerpPixels(
@@ -1541,7 +1579,8 @@ internal sealed class NonDemCityObjectBaker(
             normalizedMaterial.TextureScale,
             normalizedMaterial.TextureOffset,
             normalizedMaterial.AssetScope,
-            normalizedMaterial.OpticalProperties);
+            normalizedMaterial.OpticalProperties,
+            normalizedMaterial.TextureWrapMode);
     }
 
     private static ResoniteMaterialBinding NormalizePreservedMaterial(ResoniteMaterialBinding material)
@@ -1713,7 +1752,8 @@ internal sealed class NonDemCityObjectBaker(
         ResoniteFloat2? TextureScale,
         ResoniteFloat2? TextureOffset,
         ResoniteMaterialAssetScope AssetScope,
-        ResoniteMaterialOpticalProperties? OpticalProperties);
+        ResoniteMaterialOpticalProperties? OpticalProperties,
+        ResoniteTextureWrapMode? TextureWrapMode);
 
     private sealed class SourceFileBatchKeyComparer : IComparer<SourceFileBatchKey>
     {
@@ -1772,7 +1812,8 @@ internal sealed class NonDemCityObjectBaker(
                 && EqualityComparer<ResoniteFloat2?>.Default.Equals(x.TextureScale, y.TextureScale)
                 && EqualityComparer<ResoniteFloat2?>.Default.Equals(x.TextureOffset, y.TextureOffset)
                 && x.AssetScope == y.AssetScope
-                && EqualityComparer<ResoniteMaterialOpticalProperties?>.Default.Equals(x.OpticalProperties, y.OpticalProperties);
+                && EqualityComparer<ResoniteMaterialOpticalProperties?>.Default.Equals(x.OpticalProperties, y.OpticalProperties)
+                && x.TextureWrapMode == y.TextureWrapMode;
         }
 
         public int GetHashCode(PreservedMaterialGroupingKey obj)
@@ -1793,6 +1834,7 @@ internal sealed class NonDemCityObjectBaker(
             hash.Add(obj.TextureOffset);
             hash.Add(obj.AssetScope);
             hash.Add(obj.OpticalProperties);
+            hash.Add(obj.TextureWrapMode);
             return hash.ToHashCode();
         }
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialBinding.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialBinding.cs
@@ -19,7 +19,14 @@ public sealed record ResoniteMaterialBinding(
     ResoniteMaterialAssetScope AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped,
     TerrainTextureOverlay? TerrainOverlay = null,
     int? BundledVariantIndex = null,
-    ResoniteMaterialOpticalProperties? OpticalProperties = null);
+    ResoniteMaterialOpticalProperties? OpticalProperties = null,
+    ResoniteTextureWrapMode? TextureWrapMode = null);
+
+public enum ResoniteTextureWrapMode
+{
+    Repeat = 0,
+    Clamp = 1,
+}
 
 public sealed record ResoniteMaterialOpticalProperties(
     ResoniteColor? DiffuseColor = null,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -73,6 +73,7 @@ internal static class ResoniteSceneMaterialConventions
             : normalizedMaterial.Family!;
         string colorName = CreateCompactColorSuffix(normalizedMaterial.BaseColor);
         string opticalName = CreateOpticalSuffix(normalizedMaterial.OpticalProperties);
+        string wrapName = CreateWrapSuffix(normalizedMaterial.TextureWrapMode);
         string depthName = normalizedMaterial.DepthOffset is not null
             ? string.Create(
                 CultureInfo.InvariantCulture,
@@ -81,7 +82,7 @@ internal static class ResoniteSceneMaterialConventions
 
         return string.Create(
             CultureInfo.InvariantCulture,
-            $"{componentKind}_{projectionName}_{sourceName}_{familyName}_{depthName}_{colorName}_{opticalName}");
+            $"{componentKind}_{projectionName}_{sourceName}_{familyName}_{depthName}_{colorName}_{opticalName}_{wrapName}");
     }
 
     public static IReadOnlyList<string> CreateCommonMaterialSlotLookupNames(ResoniteMaterialBinding material)
@@ -349,10 +350,14 @@ internal static class ResoniteSceneMaterialConventions
         };
     }
 
-    public static Dictionary<string, Member> CreateTextureMembers(Uri assetUri, TextureMemberRole role)
+    public static Dictionary<string, Member> CreateTextureMembers(
+        Uri assetUri,
+        TextureMemberRole role,
+        ResoniteTextureWrapMode? textureWrapMode = null)
     {
         ArgumentNullException.ThrowIfNull(assetUri);
         TextureSamplingPolicy samplingPolicy = GetTextureSamplingPolicy(role);
+        string? wrapMode = textureWrapMode is null ? samplingPolicy.WrapMode : ToResoniteWrapMode(textureWrapMode.Value);
 
         Dictionary<string, Member> members = new(StringComparer.Ordinal)
         {
@@ -367,10 +372,10 @@ internal static class ResoniteSceneMaterialConventions
             members["PreferredProfile"] = CreateNullableEnumMember(samplingPolicy.PreferredProfile);
         }
 
-        if (samplingPolicy.WrapMode is not null)
+        if (wrapMode is not null)
         {
-            members["WrapModeU"] = CreateEnumMember(samplingPolicy.WrapMode);
-            members["WrapModeV"] = CreateEnumMember(samplingPolicy.WrapMode);
+            members["WrapModeU"] = CreateEnumMember(wrapMode);
+            members["WrapModeV"] = CreateEnumMember(wrapMode);
         }
 
         return members;
@@ -421,6 +426,17 @@ internal static class ResoniteSceneMaterialConventions
             : FormatRounded(opticalProperties.Shininess.Value);
         return string.Create(CultureInfo.InvariantCulture, $"optical-e-{emissive}-s-{shininess}");
     }
+
+    private static string CreateWrapSuffix(ResoniteTextureWrapMode? textureWrapMode) =>
+        textureWrapMode is null ? "wrap-default" : $"wrap-{textureWrapMode.Value.ToString().ToLowerInvariant()}";
+
+    private static string ToResoniteWrapMode(ResoniteTextureWrapMode textureWrapMode) =>
+        textureWrapMode switch
+        {
+            ResoniteTextureWrapMode.Repeat => "Repeat",
+            ResoniteTextureWrapMode.Clamp => "Clamp",
+            _ => throw new InvalidOperationException($"Unsupported texture wrap mode '{textureWrapMode}'."),
+        };
 
     private static string CreateCommonMaterialSlotName(ResoniteMaterialBinding material)
     {

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -126,7 +126,8 @@ internal static class SceneImportContractMapper
             binding.ReuseScope == MaterialReuseScope.Shared ? ResoniteMaterialAssetScope.Common : ResoniteMaterialAssetScope.PresentationSlotScoped,
             binding.TerrainOverlay,
             binding.BundledVariantIndex,
-            binding.OpticalProperties is null ? null : ToInternal(binding.OpticalProperties));
+            binding.OpticalProperties is null ? null : ToInternal(binding.OpticalProperties),
+            binding.TextureWrapMode is null ? null : (ResoniteTextureWrapMode)binding.TextureWrapMode.Value);
     }
 
     private static ResoniteMaterialOpticalProperties ToInternal(MaterialOpticalProperties properties)

--- a/tests/PlateauResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
@@ -42,6 +42,8 @@ public sealed class CityGmlAppearanceStoreTests
                     <app:ParameterizedTexture>
                       <app:imageURI>appearance/roof.png</app:imageURI>
                       <app:mimeType>image/png</app:mimeType>
+                      <app:wrapMode>none</app:wrapMode>
+                      <app:borderColor>0.1 0.2 0.3 1.0</app:borderColor>
                       <app:target uri="#poly-1">
                         <app:TexCoordList>
                           <app:textureCoordinates ring="#ring-1">0 0 1 0 1 1 0 1</app:textureCoordinates>
@@ -73,6 +75,8 @@ public sealed class CityGmlAppearanceStoreTests
         Assert.NotNull(appearance.TexturePayload);
         Assert.NotNull(appearance.ParameterizedTexture);
         Assert.Equal("image/png", appearance.ParameterizedTexture!.MimeType);
+        Assert.Equal("none", appearance.ParameterizedTexture.WrapMode);
+        Assert.Equal(new ColorRgba(0.1, 0.2, 0.3, 1.0), appearance.ParameterizedTexture.BorderColor);
         Assert.NotNull(appearance.MaterialAttributes);
         Assert.Equal(0.25, appearance.MaterialAttributes!.AmbientIntensity!.Value, 6);
         Assert.Equal(0.5, appearance.MaterialAttributes.Shininess!.Value, 6);

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -1875,7 +1875,7 @@ public sealed class LocalCityGmlObjectProjectionTests
                 "CreateBindingMaterialKey",
                 BindingFlags.NonPublic | BindingFlags.Static)
             ?? throw new InvalidOperationException("Failed to resolve CreateBindingMaterialKey.");
-        return (string?)method.Invoke(null, [material, depthOffset, textureScale, color, textureOffset, opticalProperties])
+        return (string?)method.Invoke(null, [material, depthOffset, textureScale, color, textureOffset, opticalProperties, null])
             ?? throw new InvalidOperationException("CreateBindingMaterialKey returned null.");
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -165,6 +165,30 @@ public sealed class NonDemCityObjectBakerTests
     }
 
     [Fact]
+    public async Task FlushAllAsyncClampsTextureContentWhenWrapModeRequestsClamp()
+    {
+        NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 0);
+
+        await AssertBufferedAsync(baker, CreateUvScaledLod2Building(
+            "building-clamp",
+            CreateStripedPayload("textures/clamp.png", [new Rgba32(255, 0, 0, 255), new Rgba32(0, 255, 0, 255)]),
+            "unit-a",
+            new ResoniteFloat2(2.0, 1.0),
+            null,
+            ResoniteTextureWrapMode.Clamp));
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+
+        Assert.Equal(4, atlasPayload.Width);
+        Assert.Equal(1, atlasPayload.Height);
+        Assert.Equal(new Rgba32(255, 0, 0, 255), ReadPixel(atlasPayload, 0, 0));
+        Assert.Equal(new Rgba32(0, 255, 0, 255), ReadPixel(atlasPayload, 1, 0));
+        Assert.Equal(new Rgba32(0, 255, 0, 255), ReadPixel(atlasPayload, 2, 0));
+        Assert.Equal(new Rgba32(0, 255, 0, 255), ReadPixel(atlasPayload, 3, 0));
+    }
+
+    [Fact]
     public async Task FlushAllAsyncNormalizesRepeatedSourceUvIntoAtlasSpace()
     {
         NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 0);
@@ -1030,7 +1054,8 @@ public sealed class NonDemCityObjectBakerTests
         ResoniteTexturePayload payload,
         string sourceUnitKey,
         ResoniteFloat2 textureScale,
-        ResoniteFloat2? textureOffset)
+        ResoniteFloat2? textureOffset,
+        ResoniteTextureWrapMode? textureWrapMode = null)
     {
         return CreateLod2Building(slotKey, payload, 0.0, sourceUnitKey) with
         {
@@ -1046,7 +1071,8 @@ public sealed class NonDemCityObjectBakerTests
                     DepthOffset: null,
                     SubmeshIndices: [0],
                     TextureScale: textureScale,
-                    TextureOffset: textureOffset),
+                    TextureOffset: textureOffset,
+                    TextureWrapMode: textureWrapMode),
             ],
         };
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -27,6 +27,18 @@ public sealed class ResoniteSceneMaterialConventionsTests
     }
 
     [Fact]
+    public void CreateTextureMembers_ForAlbedoWithClampWrap_EmitsTextureWrapModes()
+    {
+        Dictionary<string, Member> members = ResoniteSceneMaterialConventions.CreateTextureMembers(
+            new Uri("resdb:///texture/albedo"),
+            ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
+            ResoniteTextureWrapMode.Clamp);
+
+        Assert.Equal("Clamp", Assert.IsType<Field_Enum>(members["WrapModeU"]).Value);
+        Assert.Equal("Clamp", Assert.IsType<Field_Enum>(members["WrapModeV"]).Value);
+    }
+
+    [Fact]
     public void CreateTextureMembers_ForMetallic_PrefersLinearProfileWithoutExplicitWrap()
     {
         Dictionary<string, Member> members = ResoniteSceneMaterialConventions.CreateTextureMembers(


### PR DESCRIPTION
## Summary
- carry appearance sampler repeat and wrap semantics through material projection
- apply sampler semantics during non-DEM material baking and Resonite material planning
- document and test the appearance sampler behavior

Refs #129

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false