### PR TITLE
Preserve DEM roof overlay materials

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1382,7 +1382,7 @@ internal static partial class LocalCityGmlObjectProjection
                     MaterialProjection.Uv,
                     Family: null,
                     TextureScale: null,
-                    ReuseScope: MaterialReuseScope.Shared,
+                    ReuseScope: MaterialReuseScope.PerObject,
                     TerrainOverlay: demTerrainTextureOverlay),
                 DepthOffset: null);
         }
@@ -1487,7 +1487,7 @@ internal static partial class LocalCityGmlObjectProjection
                     MaterialProjection.Uv,
                     Family: null,
                     TextureScale: null,
-                    ReuseScope: MaterialReuseScope.Shared,
+                    ReuseScope: MaterialReuseScope.PerObject,
                     TerrainOverlay: demTerrainTextureOverlay),
                 DepthOffset: null);
         }
@@ -1596,7 +1596,7 @@ internal static partial class LocalCityGmlObjectProjection
             MaterialProjection.Uv,
             Family: null,
             TextureScale: null,
-            ReuseScope: MaterialReuseScope.Shared,
+            ReuseScope: MaterialReuseScope.PerObject,
             TerrainOverlay: demTerrainTextureOverlay);
     }
 
@@ -4550,7 +4550,7 @@ internal static partial class LocalCityGmlObjectProjection
                 yield return (
                     cityObject with
                     {
-                        Surfaces = terrainGroups[0].Select(static entry => entry.Surface).ToArray(),
+                        Surfaces = terrainGroups[0].Select(static entry => MarkUsesGeneratedDemTexture(entry.Surface)).ToArray(),
                         GeodeticOriginOverride = cityObjectOrigin,
                     },
                     terrainGroups[0].Key);
@@ -4578,7 +4578,7 @@ internal static partial class LocalCityGmlObjectProjection
                 {
                     SlotKey = $"{cityObject.SlotKey}_terrain_{terrainMeshCode}",
                     DisplayName = $"{cityObject.DisplayName} ({splitIndex + 1})",
-                    Surfaces = group.Select(static entry => entry.Surface).ToArray(),
+                    Surfaces = group.Select(static entry => MarkUsesGeneratedDemTexture(entry.Surface)).ToArray(),
                     GeodeticOriginOverride = cityObjectOrigin,
                 },
                 group.Key);
@@ -4597,6 +4597,12 @@ internal static partial class LocalCityGmlObjectProjection
                 },
                 null);
         }
+    }
+
+    private static global::PlateauResoniteLink.Application.Importing.ParsedSurface MarkUsesGeneratedDemTexture(
+        global::PlateauResoniteLink.Application.Importing.ParsedSurface surface)
+    {
+        return surface with { UsesGeneratedDemTexture = true };
     }
 
     private static bool IsNonDemTerrainTextureSurface(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -221,7 +221,7 @@ internal static class ResoniteSceneMaterialConventions
             return false;
         }
 
-        if (material.TerrainOverlay is not null && !HasValidTerrainTextureMeshCode(material))
+        if (material.TerrainOverlay is not null)
         {
             return false;
         }
@@ -250,6 +250,15 @@ internal static class ResoniteSceneMaterialConventions
             && (!IsWhiteBaseColor(material.BaseColor)
                 || HasNonDefaultBundledTextureTransform(material)
                 || material.DepthOffset is not null))
+        {
+            return material with
+            {
+                AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped,
+            };
+        }
+
+        if (material.TerrainOverlay is not null
+            && material.AssetScope == ResoniteMaterialAssetScope.Common)
         {
             return material with
             {
@@ -393,8 +402,7 @@ internal static class ResoniteSceneMaterialConventions
             && ResoniteMaterialSharing.IsWhiteBaseColor(material.BaseColor)
             && string.IsNullOrWhiteSpace(material.Family)
             && material.TextureSourceKind == ResoniteTextureSourceKind.Dataset
-            && (material.TerrainOverlay is null || HasValidTerrainTextureMeshCode(material))
-            && (material.TerrainOverlay is null || !HasEffectiveGenericTextureTransform(material));
+            && material.TerrainOverlay is null;
     }
 
     private static string CreateCompactColorSuffix(ResoniteColor color)
@@ -638,22 +646,6 @@ internal static class ResoniteSceneMaterialConventions
             BundledVariantIndex = null,
             TerrainMeshCode = null,
         };
-    }
-
-    private static bool HasValidTerrainTextureMeshCode(ResoniteMaterialBinding material)
-    {
-        if (material.TerrainMeshCode is not { Length: 8 } meshCode
-            || material.TerrainOverlay is null
-            || !PlateauMeshCode.TryGetBounds(meshCode, out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds))
-        {
-            return false;
-        }
-
-        const double tolerance = 1e-8;
-        return Math.Abs(bounds.SouthLatitude - material.TerrainOverlay.GeographicBounds.MinLatitude) <= tolerance
-            && Math.Abs(bounds.NorthLatitude - material.TerrainOverlay.GeographicBounds.MaxLatitude) <= tolerance
-            && Math.Abs(bounds.WestLongitude - material.TerrainOverlay.GeographicBounds.MinLongitude) <= tolerance
-            && Math.Abs(bounds.EastLongitude - material.TerrainOverlay.GeographicBounds.MaxLongitude) <= tolerance;
     }
 
     private static ResoniteMaterialBinding NormalizeVertexColorSharedMaterialBinding(ResoniteMaterialBinding material)

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -123,9 +123,11 @@ internal static class SceneImportContractMapper
             binding.TextureScale is null ? null : ToInternal(binding.TextureScale),
             binding.Family,
             binding.TextureOffset is null ? null : ToInternal(binding.TextureOffset),
-            binding.ReuseScope == MaterialReuseScope.Shared
-                ? ResoniteMaterialAssetScope.Common
-                : ResoniteMaterialAssetScope.PresentationSlotScoped,
+            binding.TerrainOverlay is not null
+                ? ResoniteMaterialAssetScope.PresentationSlotScoped
+                : binding.ReuseScope == MaterialReuseScope.Shared
+                    ? ResoniteMaterialAssetScope.Common
+                    : ResoniteMaterialAssetScope.PresentationSlotScoped,
             binding.TerrainOverlay,
             binding.BundledVariantIndex,
             binding.TerrainMeshCode);

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -368,7 +368,7 @@ public sealed class LocalCityGmlObjectProjectionTests
         MaterialBinding material = Assert.Single(projected.Materials);
         Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
         Assert.Equal(MaterialProjection.Uv, material.Projection);
-        Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
+        Assert.Equal(MaterialReuseScope.PerObject, material.ReuseScope);
         Assert.Null(material.Family);
         Assert.Null(material.TexturePayload);
         Assert.Same(overlay, material.TerrainOverlay);
@@ -500,7 +500,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public void EnumerateCommonMaterialsForParsedCityObjectSplitsParentMeshBuildingRoofsByThirdMeshOverlay()
+    public void EnumerateCommonMaterialsForParsedCityObjectExcludesTerrainOverlayBuildingRoofs()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
         TerrainTextureOverlay firstOverlay = CreateThirdMeshOverlay("53394525");
@@ -534,20 +534,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             request,
             new DefaultMaterialResolver()).ToArray();
 
-        Assert.Collection(
-            materialBindings.OrderBy(static material => material.TerrainMeshCode, StringComparer.Ordinal),
-            first =>
-            {
-                Assert.Same(firstOverlay, first.TerrainOverlay);
-                Assert.Equal("53394525", first.TerrainMeshCode);
-                Assert.Equal(TextureSourceKind.Dataset, first.TextureSourceKind);
-            },
-            second =>
-            {
-                Assert.Same(secondOverlay, second.TerrainOverlay);
-                Assert.Equal("53394526", second.TerrainMeshCode);
-                Assert.Equal(TextureSourceKind.Dataset, second.TextureSourceKind);
-            });
+        Assert.Empty(materialBindings);
     }
 
     [Fact]
@@ -638,7 +625,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public void ProjectCityObjectUsesSharedAlbedoOnlyMaterialForTexturelessDemTerrainRoofs()
+    public void ProjectCityObjectUsesPerObjectAlbedoOnlyMaterialForTexturelessDemTerrainRoofs()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
@@ -668,7 +655,7 @@ public sealed class LocalCityGmlObjectProjectionTests
         MaterialBinding material = Assert.Single(projected.Materials);
         Assert.Equal(new ColorRgba(1.0, 1.0, 1.0, 1.0), material.BaseColor);
         Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
-        Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
+        Assert.Equal(MaterialReuseScope.PerObject, material.ReuseScope);
         Assert.Same(overlay, material.TerrainOverlay);
     }
 
@@ -864,7 +851,57 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         MaterialBinding material = Assert.Single(projected.Materials);
         Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
-        Assert.Equal(MaterialReuseScope.Shared, material.ReuseScope);
+        Assert.Equal(MaterialReuseScope.PerObject, material.ReuseScope);
+        Assert.Null(material.Family);
+        Assert.Null(material.TexturePayload);
+        Assert.Same(overlay, material.TerrainOverlay);
+        Assert.Equal("54372778", material.TerrainMeshCode);
+    }
+
+    [Fact]
+    public void ProjectParsedCityObjectAssignsDemTerrainMaterialToMatsumotoLod1SolidTopWinding()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("54372778");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = new(36.23163715441054, 137.97501759714283, 590.343);
+        ParsedSurface bottomSurface = CreateParsedSurface(
+            "matsumoto-parsed-lod1-solid-bottom",
+            ParsedSurfaceSemantic.Unknown,
+            CreateMatsumotoLod1SolidHorizontalRing(altitudeMeters: 590.343),
+            texturePayload: null);
+        ParsedSurface topSurface = CreateParsedSurface(
+            "matsumoto-parsed-lod1-solid-top",
+            ParsedSurfaceSemantic.Unknown,
+            CreateMatsumotoLod1SolidHorizontalRing(altitudeMeters: 595.009),
+            texturePayload: null);
+        ParsedCityObject cityObject =
+            CreateParsedCityObject(
+                "bldg",
+                [bottomSurface, topSurface],
+                referenceSystem) with
+            {
+                ActualMeshCode = "54372778",
+            };
+        PlateauImportRequest request = new(
+            Dataset: "plateau-20202-matsumoto-shi-2020",
+            MeshCode: "54372778",
+            Source: DatasetLocation.Local("/tmp/plateau"));
+
+        ImportedCityObject[] projected = LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            GeodeticPoint.FromProjectionModel(origin),
+            globalCartesian: null,
+            demTerrainTextureOverlays: [overlay],
+            requestedMeshAreas: [MeshCodeBounds.TryParse("54372778")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver()).ToArray();
+
+        MaterialBinding material = Assert.Single(
+            projected.SelectMany(static cityObject => cityObject.Materials),
+            static material => material.TerrainOverlay is not null);
+        Assert.Equal(TextureSourceKind.Dataset, material.TextureSourceKind);
+        Assert.Equal(MaterialReuseScope.PerObject, material.ReuseScope);
         Assert.Null(material.Family);
         Assert.Null(material.TexturePayload);
         Assert.Same(overlay, material.TerrainOverlay);

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -722,7 +722,7 @@ public sealed class NonDemCityObjectBakerTests
     }
 
     [Fact]
-    public async Task TryBufferAsyncPreservesTerrainOverlayAlbedoOnlyCommonMaterialWithProvider()
+    public async Task TryBufferAsyncPreservesTerrainOverlayAlbedoOnlyMaterialAsPresentationScoped()
     {
         NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
@@ -761,7 +761,7 @@ public sealed class NonDemCityObjectBakerTests
 
         ResoniteConstructionCityObject baked = Assert.Single(await baker.FlushAllAsync());
         ResoniteMaterialBinding material = Assert.Single(baked.Materials);
-        Assert.Equal(ResoniteMaterialAssetScope.Common, material.AssetScope);
+        Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, material.AssetScope);
         Assert.Null(material.TexturePayload);
         Assert.Same(overlay, material.TerrainOverlay);
         Assert.Equal("53394525", material.TerrainMeshCode);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -389,7 +389,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_SetsUpTerrainOverlayAsSharedGenericAlbedoOnlyMaterial()
+    public async Task ExecuteAsync_DoesNotSetUpTerrainOverlayAsSharedGenericAlbedoOnlyMaterial()
     {
         using TemporaryDirectory datasetDirectory = new();
         using TemporaryDirectory workDirectory = new();
@@ -451,12 +451,14 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 CreateDemCityObject("dem-setup-generic", "udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml", overlay)));
 
         Assert.Equal(1, executionResult.ProcessedCityObjectCount);
-        AddComponent sharedGenericMaterial = Assert.Single(
+        Assert.DoesNotContain(
             routedClient.AddedComponents,
             request => request.Data.ComponentType == "[FrooxEngine]FrooxEngine.PBS_Metallic"
                 && routedClient.SlotPaths[request.ContainerSlotId].Replace('\\', '/') ==
                     "PLATEAU Shared Assets/Common Materials/generic/shared_uv_generic");
-        Assert.DoesNotContain("AlbedoTexture", sharedGenericMaterial.Data.Members.Keys);
+        Assert.Contains(
+            routedClient.AddedComponents,
+            static request => request.Data.ComponentType == "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock");
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -95,13 +95,12 @@ public sealed class ResoniteLiveSceneImportTargetTests
             client.AddedComponents,
             request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal)).Data;
 
-        AddComponent sharedMaterialOperation = Assert.Single(
+        Assert.DoesNotContain(
             client.AddedComponents,
             request => string.Equals(request.Data.ID, materialId, StringComparison.Ordinal)
                 && client.SlotPaths[request.ContainerSlotId].Replace('\\', '/').Contains(
-                    "PLATEAU Shared Assets/Common Materials/generic/shared_uv_generic",
+                    "PLATEAU Shared Assets/Common Materials/",
                     StringComparison.Ordinal));
-        Assert.DoesNotContain("AlbedoTexture", sharedMaterialOperation.Data.Members.Keys);
         Assert.Equal("[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", propertyBlock.ComponentType);
         string propertyBlockReferenceId = Assert.IsType<Reference>(Assert.Single(propertyBlocks.Elements)).TargetID;
         AddComponent plannedPropertyBlock = Assert.Single(
@@ -421,7 +420,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
-    public async Task ExecuteAsyncReusesExistingGenericCommonMaterialForTerrainOverlayAlbedoOnlyMaterial()
+    public async Task ExecuteAsyncDoesNotReuseExistingGenericCommonMaterialForTerrainOverlayMaterial()
     {
         using TemporaryDirectory datasetDirectory = new();
         using SceneSinkRecordingClient client = new();
@@ -487,7 +486,11 @@ public sealed class ResoniteLiveSceneImportTargetTests
             .Data;
         string materialId = Assert.IsType<Reference>(Assert.Single(Assert.IsType<SyncList>(meshRenderer.Members["Materials"]).Elements)).TargetID;
 
-        Assert.Equal(seededCommonMaterial.ComponentId, materialId);
+        Assert.NotEqual(seededCommonMaterial.ComponentId, materialId);
+        Assert.DoesNotContain(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, materialId, StringComparison.Ordinal)
+                && client.SlotPaths[request.ContainerSlotId].Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal));
         AddComponent propertyBlock = Assert.Single(
             client.AddedComponents,
             static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -288,7 +288,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
     }
 
     [Fact]
-    public void TryNormalizeSharedMaterialBinding_AllowsTerrainOverlayAsGenericSharedMaterial()
+    public void TryNormalizeSharedMaterialBinding_RejectsTerrainOverlayAsGenericSharedMaterial()
     {
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
         ResoniteMaterialBinding material = new(
@@ -310,16 +310,13 @@ public sealed class ResoniteSceneMaterialConventionsTests
             out ResoniteMaterialBinding normalizedMaterial,
             out string familySlotName);
 
-        Assert.True(normalized);
-        Assert.False(string.IsNullOrWhiteSpace(familySlotName));
-        Assert.Equal(ResoniteMaterialAssetScope.Common, normalizedMaterial.AssetScope);
-        Assert.Null(normalizedMaterial.TexturePayload);
-        Assert.Null(normalizedMaterial.TerrainOverlay);
-        Assert.Null(normalizedMaterial.TerrainMeshCode);
+        Assert.False(normalized);
+        Assert.Equal(string.Empty, familySlotName);
+        Assert.Same(material, normalizedMaterial);
     }
 
     [Fact]
-    public void TryNormalizeSharedMaterialBinding_UsesSameGenericSharedMaterialForPayloadAndTerrainOverlayAlbedoOnly()
+    public void TryNormalizeSharedMaterialBinding_DoesNotSharePayloadAndTerrainOverlayAlbedoOnlyMaterials()
     {
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
         ResoniteMaterialBinding payloadMaterial = new(
@@ -350,15 +347,16 @@ public sealed class ResoniteSceneMaterialConventionsTests
             out string terrainFamilySlotName);
 
         Assert.True(payloadNormalized);
-        Assert.True(terrainNormalized);
-        Assert.Equal(payloadFamilySlotName, terrainFamilySlotName);
-        Assert.Equal(normalizedPayloadMaterial.MaterialKey, normalizedTerrainMaterial.MaterialKey);
+        Assert.False(terrainNormalized);
+        Assert.Equal("generic", payloadFamilySlotName);
+        Assert.Equal(string.Empty, terrainFamilySlotName);
+        Assert.NotEqual(normalizedPayloadMaterial.MaterialKey, normalizedTerrainMaterial.MaterialKey);
         Assert.Null(normalizedPayloadMaterial.TexturePayload);
-        Assert.Null(normalizedTerrainMaterial.TerrainOverlay);
+        Assert.Same(overlay, normalizedTerrainMaterial.TerrainOverlay);
     }
 
     [Fact]
-    public void NormalizeBatchGroupedMaterialBinding_PreservesTerrainOverlayProviderForGenericSharedMaterial()
+    public void NormalizeBatchGroupedMaterialBinding_KeepsTerrainOverlayProviderPresentationScoped()
     {
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
         ResoniteMaterialBinding material = new(
@@ -377,7 +375,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
 
         ResoniteMaterialBinding normalized = ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
 
-        Assert.Equal(ResoniteMaterialAssetScope.Common, normalized.AssetScope);
+        Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, normalized.AssetScope);
         Assert.Null(normalized.TexturePayload);
         Assert.Same(overlay, normalized.TerrainOverlay);
         Assert.Equal("53394525", normalized.TerrainMeshCode);


### PR DESCRIPTION
## Summary
- Preserve DEM terrain-overlay classification after parsed CityGML surfaces are split into overlay/non-overlay groups.
- Keep terrain-overlay materials presentation-scoped instead of normalizing them into shared Common Materials.
- Add regression coverage for Matsumoto LOD1 solid-top parsed projection and Resonite material binding paths.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/54f5efc0-3f47-4f2e-a507-4a07a3a0eb3c" />


## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- Live retest on Esnya Workspace / ResoniteLink port 19100:
  - Matsumoto base 54372778 static: sent=6 failed=0, DEM texture sources=2
  - Matsumoto append 54372788 grid: sent=5 failed=0, DEM texture sources=2
  - Root dumps confirm AtlasBake bldg LOD1 MainTexturePropertyBlock points to Assets/Terrain Textures/54372778 and 54372788.