### PR TITLE
[codex] Infer LOD1 roofs for other roof types

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1696,7 +1696,7 @@ internal static partial class LocalCityGmlObjectProjection
         Lod1RoofFootprint footprint)
     {
         CityGmlRoofShape? explicitRoofShape = footprint.Attributes.RoofShape?.Value;
-        if (explicitRoofShape is not null and not CityGmlRoofShape.Unknown)
+        if (explicitRoofShape is not null and not CityGmlRoofShape.Unknown and not CityGmlRoofShape.Other)
         {
             return explicitRoofShape switch
             {

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -416,6 +416,44 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.Contains(projected.Mesh.Vertices, vertex => vertex.UV0.Y is > 0.45 and < 0.55);
     }
 
+    [Fact]
+    public void ProjectCityObjectInfersRoofShapeWhenRoofTypeIsOther()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394525", altitudeMeters: 8.0);
+        ParsedSurface topSurface = CreateParsedSurface(
+            "roof-type-other-lod1-top",
+            ParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        ParsedSurface bottomSurface = CreateParsedSurface(
+            "roof-type-other-lod1-bottom",
+            ParsedSurfaceSemantic.Ground,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 0.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: false),
+            texturePayload: null);
+        ParsedCityObject cityObject = CreateParsedCityObject(
+            "bldg",
+            [bottomSurface, topSurface],
+            referenceSystem,
+            buildingAttributes: CreateBuildingAttributes(
+                CityGmlRoofShape.Other,
+                PlateauBuildingUse.DetachedResidential,
+                PlateauBuildingStructure.Wood));
+
+        ImportedCityObject projected = LocalCityGmlObjectProjection.ProjectCityObject(
+            cityObject,
+            GeodeticPoint.FromProjectionModel(origin),
+            globalCartesian: new GeographicLib.LocalCartesian(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric),
+            demTerrainTextureOverlay: overlay,
+            materialResolver: new DefaultMaterialResolver());
+
+        Assert.Contains(projected.Materials, material => ReferenceEquals(overlay, material.TerrainOverlay));
+        Assert.DoesNotContain(projected.Materials, static material => material.Family == BundledDefaultMaterialFamilies.Roof);
+        Assert.DoesNotContain(projected.Materials, static material => material.Projection == MaterialProjection.Triplanar);
+        Assert.True(projected.Mesh.Vertices.Max(static vertex => vertex.Position.Y) > 8.25);
+    }
+
     [Theory]
     [InlineData((int)PlateauBuildingStructure.NonWood)]
     [InlineData((int)PlateauBuildingStructure.ReinforcedConcrete)]


### PR DESCRIPTION
## Summary
- Treat `CityGmlRoofShape.Other` like an inferred roof input instead of forcing flat generation.
- Add a regression test for `roofType=28` on a low-rise residential LOD1 building.

## Validation
- `dotnet restore`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
