### PR TITLE
Fix valid terrain overlay rejection

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliApplication.cs
+++ b/src/PlateauResoniteLink.Cli/CliApplication.cs
@@ -123,9 +123,40 @@ public sealed class CliApplication
         }
         catch (Exception exception)
         {
-            await standardError.WriteLineAsync($"Import failed: {exception.Message}");
+            await WriteImportFailureAsync(exception);
             return 1;
         }
+    }
+
+    private async Task WriteImportFailureAsync(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        if (exception is AggregateException aggregateException)
+        {
+            Exception[] innerExceptions = aggregateException
+                .Flatten()
+                .InnerExceptions
+                .ToArray();
+            if (innerExceptions.Length > 1)
+            {
+                await standardError.WriteLineAsync($"Import failed: {innerExceptions.Length} errors occurred.");
+                for (int index = 0; index < innerExceptions.Length; index++)
+                {
+                    await standardError.WriteLineAsync($"[{index + 1}] {innerExceptions[index].Message}");
+                }
+
+                return;
+            }
+
+            if (innerExceptions.Length == 1)
+            {
+                await standardError.WriteLineAsync($"Import failed: {innerExceptions[0].Message}");
+                return;
+            }
+        }
+
+        await standardError.WriteLineAsync($"Import failed: {exception.Message}");
     }
 
     private async Task WriteSearchResultAsync(

--- a/src/PlateauResoniteLink/Application/Importing/ContinuableImportException.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ContinuableImportException.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Globalization;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+public class ContinuableImportException : Exception
+{
+    public ContinuableImportException(
+        string phase,
+        string packageName,
+        string objectKey,
+        string objectName,
+        string actualMeshCode,
+        string sourceFileRelativePath,
+        string reason,
+        Exception? innerException = null)
+        : base(CreateMessage(phase, packageName, objectKey, objectName, actualMeshCode, sourceFileRelativePath, reason), innerException)
+    {
+        Phase = string.IsNullOrWhiteSpace(phase)
+            ? throw new ArgumentException("Continuable import phase must be provided.", nameof(phase))
+            : phase;
+        PackageName = string.IsNullOrWhiteSpace(packageName)
+            ? throw new ArgumentException("Continuable import package name must be provided.", nameof(packageName))
+            : packageName;
+        ObjectKey = string.IsNullOrWhiteSpace(objectKey)
+            ? throw new ArgumentException("Continuable import object key must be provided.", nameof(objectKey))
+            : objectKey;
+        ObjectName = string.IsNullOrWhiteSpace(objectName)
+            ? throw new ArgumentException("Continuable import object name must be provided.", nameof(objectName))
+            : objectName;
+        ActualMeshCode = string.IsNullOrWhiteSpace(actualMeshCode)
+            ? throw new ArgumentException("Continuable import actual mesh code must be provided.", nameof(actualMeshCode))
+            : actualMeshCode;
+        SourceFileRelativePath = string.IsNullOrWhiteSpace(sourceFileRelativePath)
+            ? throw new ArgumentException("Continuable import source file path must be provided.", nameof(sourceFileRelativePath))
+            : sourceFileRelativePath;
+        Reason = string.IsNullOrWhiteSpace(reason)
+            ? throw new ArgumentException("Continuable import reason must be provided.", nameof(reason))
+            : reason;
+    }
+
+    public string Phase { get; }
+
+    public string PackageName { get; }
+
+    public string ObjectKey { get; }
+
+    public string ObjectName { get; }
+
+    public string ActualMeshCode { get; }
+
+    public string SourceFileRelativePath { get; }
+
+    public string Reason { get; }
+
+    private static string CreateMessage(
+        string phase,
+        string packageName,
+        string objectKey,
+        string objectName,
+        string actualMeshCode,
+        string sourceFileRelativePath,
+        string reason)
+    {
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"Continuable import failure phase='{phase}', package='{packageName}', "
+            + $"object_key='{objectKey}', object_name='{objectName}', "
+            + $"actual_mesh='{actualMeshCode}', source_file='{sourceFileRelativePath}': {reason}");
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/ContinuableImportException.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ContinuableImportException.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 
 namespace PlateauResoniteLink.Application.Importing;
 
-public class ContinuableImportException : Exception
+public sealed class ContinuableImportException : Exception
 {
     public ContinuableImportException(
         string phase,

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -3356,7 +3356,12 @@ internal static partial class LocalCityGmlObjectProjection
         {
             if (ResolveTerrainTextureMeshCode(actualMeshCode, material.TerrainOverlay) is null)
             {
-                throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+                throw CreateTerrainOverlayMeshCodeMismatchException(
+                    "material-grouping",
+                    actualMeshCode,
+                    actualMeshCode,
+                    requestedMeshAreas: null,
+                    material.TerrainOverlay);
             }
 
             return new MaterialGroupingKey(
@@ -3995,9 +4000,18 @@ internal static partial class LocalCityGmlObjectProjection
                      cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!ShouldProjectTerrainOverlaySplit(splitCityObject.CityObject.ActualMeshCode, request.MeshCode, splitCityObject.Overlay))
+            if (!ShouldProjectTerrainOverlaySplit(
+                    splitCityObject.CityObject.ActualMeshCode,
+                    request.MeshCode,
+                    requestedMeshAreas,
+                    splitCityObject.Overlay))
             {
-                throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+                throw CreateTerrainOverlayMeshCodeMismatchException(
+                    "project",
+                    splitCityObject.CityObject.ActualMeshCode,
+                    request.MeshCode,
+                    requestedMeshAreas,
+                    splitCityObject.Overlay);
             }
 
             ImportedCityObject cityObject = ProjectTerrainMeshModeCityObject(
@@ -4094,9 +4108,18 @@ internal static partial class LocalCityGmlObjectProjection
                      demTerrainTextureOverlays,
                      requestedMeshAreas))
         {
-            if (!ShouldProjectTerrainOverlaySplit(splitCityObject.CityObject.ActualMeshCode, request.MeshCode, splitCityObject.Overlay))
+            if (!ShouldProjectTerrainOverlaySplit(
+                    splitCityObject.CityObject.ActualMeshCode,
+                    request.MeshCode,
+                    requestedMeshAreas ?? [],
+                    splitCityObject.Overlay))
             {
-                throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+                throw CreateTerrainOverlayMeshCodeMismatchException(
+                    "common-material-enumeration",
+                    splitCityObject.CityObject.ActualMeshCode,
+                    request.MeshCode,
+                    requestedMeshAreas,
+                    splitCityObject.Overlay);
             }
 
             global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(splitCityObject.CityObject);
@@ -4116,6 +4139,7 @@ internal static partial class LocalCityGmlObjectProjection
                                 cityObjectCartesian,
                                 splitCityObject.Overlay,
                                 request.MeshCode,
+                                requestedMeshAreas,
                                 materialResolver)
                             : CreateCommonMaterialBindings(
                                 splitCityObject.CityObject,
@@ -4720,6 +4744,7 @@ internal static partial class LocalCityGmlObjectProjection
             cityObjectCartesian,
             demTerrainTextureOverlay,
             request.MeshCode,
+            CreateRequestedMeshAreasForRequest(request.MeshCode),
             materialResolver);
         if (materials.Length == 0)
         {
@@ -4896,6 +4921,7 @@ internal static partial class LocalCityGmlObjectProjection
             cityObjectCartesian,
             demTerrainTextureOverlay,
             request.MeshCode,
+            CreateRequestedMeshAreasForRequest(request.MeshCode),
             materialResolver);
         if (materials.Length == 0)
         {
@@ -4951,6 +4977,7 @@ internal static partial class LocalCityGmlObjectProjection
         LocalCartesian? cityObjectCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         string requestedMeshCode,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshAreas,
         IDefaultMaterialResolver materialResolver)
     {
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
@@ -4978,7 +5005,11 @@ internal static partial class LocalCityGmlObjectProjection
         return resolvedSurfaces
             .GroupBy(
                 resolvedSurface => CreateMaterialGroupingKey(
-                    ResolveTerrainTextureMaterialMeshCodeSource(cityObject.ActualMeshCode, requestedMeshCode, resolvedSurface.Material.TerrainOverlay),
+                    ResolveTerrainTextureMaterialMeshCodeSource(
+                        cityObject.ActualMeshCode,
+                        requestedMeshCode,
+                        requestedMeshAreas,
+                        resolvedSurface.Material.TerrainOverlay),
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
@@ -4991,6 +5022,7 @@ internal static partial class LocalCityGmlObjectProjection
                 string terrainMaterialMeshCodeSource = ResolveTerrainTextureMaterialMeshCodeSource(
                     cityObject.ActualMeshCode,
                     requestedMeshCode,
+                    requestedMeshAreas,
                     representativeSurface.Material.TerrainOverlay);
                 return CreateMaterialBinding(
                     terrainMaterialMeshCodeSource,
@@ -5006,6 +5038,7 @@ internal static partial class LocalCityGmlObjectProjection
         LocalCartesian? cityObjectCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         string requestedMeshCode,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshAreas,
         IDefaultMaterialResolver materialResolver)
     {
         ParsedSurface[] projectionSurfaces = cityObject.Surfaces.Select(static surface => surface.ToProjectionModel()).ToArray();
@@ -5034,7 +5067,11 @@ internal static partial class LocalCityGmlObjectProjection
         return resolvedSurfaces
             .GroupBy(
                 resolvedSurface => CreateMaterialGroupingKey(
-                    ResolveTerrainTextureMaterialMeshCodeSource(cityObject.ActualMeshCode, requestedMeshCode, resolvedSurface.Material.TerrainOverlay),
+                    ResolveTerrainTextureMaterialMeshCodeSource(
+                        cityObject.ActualMeshCode,
+                        requestedMeshCode,
+                        requestedMeshAreas,
+                        resolvedSurface.Material.TerrainOverlay),
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
                     resolvedSurface.Material.TextureScale,
@@ -5047,6 +5084,7 @@ internal static partial class LocalCityGmlObjectProjection
                 string terrainMaterialMeshCodeSource = ResolveTerrainTextureMaterialMeshCodeSource(
                     cityObject.ActualMeshCode,
                     requestedMeshCode,
+                    requestedMeshAreas,
                     representativeSurface.Material.TerrainOverlay);
                 return CreateMaterialBinding(
                     terrainMaterialMeshCodeSource,
@@ -5064,7 +5102,12 @@ internal static partial class LocalCityGmlObjectProjection
         string? terrainMeshCode = representativeSurface.Material.TerrainOverlay is null
             ? null
             : ResolveTerrainTextureMeshCode(actualMeshCode, representativeSurface.Material.TerrainOverlay)
-                ?? throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+                ?? throw CreateTerrainOverlayMeshCodeMismatchException(
+                    "material-binding",
+                    actualMeshCode,
+                    actualMeshCode,
+                    requestedMeshAreas: null,
+                    representativeSurface.Material.TerrainOverlay);
         ColorRgba baseColor = representativeSurface.Material.TerrainOverlay is null
             ? ToContractColor(representativeSurface.Surface.BaseColor)
             : new ColorRgba(1.0, 1.0, 1.0, 1.0);
@@ -5108,6 +5151,7 @@ internal static partial class LocalCityGmlObjectProjection
     private static string ResolveTerrainTextureMaterialMeshCodeSource(
         string actualMeshCode,
         string requestedMeshCode,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshAreas,
         TerrainTextureOverlay? terrainOverlay)
     {
         if (terrainOverlay is null
@@ -5116,7 +5160,165 @@ internal static partial class LocalCityGmlObjectProjection
             return actualMeshCode;
         }
 
-        return requestedMeshCode;
+        return ResolveTerrainTextureMeshCode(requestedMeshCode, terrainOverlay)
+            ?? ResolveTerrainTextureMeshCodeFromRequestedAreas(
+                actualMeshCode,
+                requestedMeshCode,
+                requestedMeshAreas,
+                terrainOverlay)
+            ?? requestedMeshCode;
+    }
+
+    private static string? ResolveTerrainTextureMeshCodeForOverlay(
+        string actualMeshCode,
+        string requestedMeshCode,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshAreas,
+        TerrainTextureOverlay terrainOverlay,
+        string phase)
+    {
+        _ = phase;
+        return ResolveTerrainTextureMeshCode(actualMeshCode, terrainOverlay)
+            ?? ResolveTerrainTextureMeshCode(requestedMeshCode, terrainOverlay)
+            ?? ResolveTerrainTextureMeshCodeFromRequestedAreas(
+                actualMeshCode,
+                requestedMeshCode,
+                requestedMeshAreas,
+                terrainOverlay);
+    }
+
+    private static string? ResolveTerrainTextureMeshCodeFromRequestedAreas(
+        string actualMeshCode,
+        string requestedMeshCode,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshAreas,
+        TerrainTextureOverlay terrainOverlay)
+    {
+        if (!IsRequestedTerrainOverlay(terrainOverlay, requestedMeshAreas))
+        {
+            return null;
+        }
+
+        if (ResolveThirdMeshCodeFromOverlayBounds(terrainOverlay) is { } resolvedMeshCode)
+        {
+            return resolvedMeshCode;
+        }
+
+        foreach (string parentMeshCode in EnumerateCandidateParentMeshCodes(actualMeshCode, requestedMeshCode))
+        {
+            for (int latitudeIndex = 0; latitudeIndex < 10; latitudeIndex++)
+            {
+                for (int longitudeIndex = 0; longitudeIndex < 10; longitudeIndex++)
+                {
+                    string thirdMeshCode = string.Create(
+                        CultureInfo.InvariantCulture,
+                        $"{parentMeshCode}{latitudeIndex}{longitudeIndex}");
+                    if (ResolveTerrainTextureMeshCode(thirdMeshCode, terrainOverlay) is { } candidateMeshCode)
+                    {
+                        return candidateMeshCode;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string? ResolveThirdMeshCodeFromOverlayBounds(TerrainTextureOverlay terrainOverlay)
+    {
+        const double firstLatitudeSpan = 40.0 / 60.0;
+        const double firstLongitudeSpan = 1.0;
+        const double tolerance = 1e-8;
+
+        GeographicRectangle bounds = terrainOverlay.GeographicBounds;
+        int firstLatitudeIndex = (int)Math.Floor((bounds.MinLatitude * 1.5) + tolerance);
+        int firstLongitudeIndex = (int)Math.Floor((bounds.MinLongitude - 100.0) + tolerance);
+        if (firstLatitudeIndex < 0 || firstLongitudeIndex < 0)
+        {
+            return null;
+        }
+
+        double firstSouthLatitude = firstLatitudeIndex / 1.5;
+        double firstWestLongitude = 100.0 + firstLongitudeIndex;
+        double secondLatitudeSpan = firstLatitudeSpan / 8.0;
+        double secondLongitudeSpan = firstLongitudeSpan / 8.0;
+        int secondLatitudeIndex = (int)Math.Floor(((bounds.MinLatitude - firstSouthLatitude) / secondLatitudeSpan) + tolerance);
+        int secondLongitudeIndex = (int)Math.Floor(((bounds.MinLongitude - firstWestLongitude) / secondLongitudeSpan) + tolerance);
+        if (secondLatitudeIndex is < 0 or > 7 || secondLongitudeIndex is < 0 or > 7)
+        {
+            return null;
+        }
+
+        double secondSouthLatitude = firstSouthLatitude + (secondLatitudeIndex * secondLatitudeSpan);
+        double secondWestLongitude = firstWestLongitude + (secondLongitudeIndex * secondLongitudeSpan);
+        double thirdLatitudeSpan = secondLatitudeSpan / 10.0;
+        double thirdLongitudeSpan = secondLongitudeSpan / 10.0;
+        int thirdLatitudeIndex = (int)Math.Floor(((bounds.MinLatitude - secondSouthLatitude) / thirdLatitudeSpan) + tolerance);
+        int thirdLongitudeIndex = (int)Math.Floor(((bounds.MinLongitude - secondWestLongitude) / thirdLongitudeSpan) + tolerance);
+        if (thirdLatitudeIndex is < 0 or > 9 || thirdLongitudeIndex is < 0 or > 9)
+        {
+            return null;
+        }
+
+        string meshCode = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{firstLatitudeIndex:00}{firstLongitudeIndex:00}{secondLatitudeIndex}{secondLongitudeIndex}{thirdLatitudeIndex}{thirdLongitudeIndex}");
+        return ResolveTerrainTextureMeshCode(meshCode, terrainOverlay);
+    }
+
+    private static IEnumerable<string> EnumerateCandidateParentMeshCodes(string actualMeshCode, string requestedMeshCode)
+    {
+        return new[] { actualMeshCode, requestedMeshCode }
+            .Where(static meshCode => meshCode.Length >= 6 && meshCode.All(static character => character is >= '0' and <= '9'))
+            .Select(static meshCode => meshCode[..6])
+            .Distinct(StringComparer.Ordinal);
+    }
+
+    private static MeshCodeBounds[] CreateRequestedMeshAreasForRequest(string requestedMeshCode)
+    {
+        return MeshCodeBounds.TryParse(requestedMeshCode) is { } meshArea
+            ? [meshArea]
+            : [];
+    }
+
+    private static bool IsRequestedTerrainOverlay(
+        TerrainTextureOverlay terrainOverlay,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshAreas)
+    {
+        return requestedMeshAreas is { Count: > 0 }
+            && requestedMeshAreas.Any(area => BoundsApproximatelyEqual(area, terrainOverlay.GeographicBounds)
+                || ContainsBounds(area, terrainOverlay.GeographicBounds));
+    }
+
+    private static bool ContainsBounds(MeshCodeBounds outer, GeographicRectangle inner)
+    {
+        return inner.MinLatitude >= outer.SouthLatitude
+            && inner.MaxLatitude <= outer.NorthLatitude
+            && inner.MinLongitude >= outer.WestLongitude
+            && inner.MaxLongitude <= outer.EastLongitude;
+    }
+
+    private static InvalidOperationException CreateTerrainOverlayMeshCodeMismatchException(
+        string phase,
+        string actualMeshCode,
+        string requestedMeshCode,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshAreas,
+        TerrainTextureOverlay? terrainOverlay)
+    {
+        string requestedAreaSummary = requestedMeshAreas is { Count: > 0 }
+            ? string.Join(
+                ",",
+                requestedMeshAreas.Select(static area => string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{FormatRounded(area.SouthLatitude)}-{FormatRounded(area.NorthLatitude)}-{FormatRounded(area.WestLongitude)}-{FormatRounded(area.EastLongitude)}")))
+            : "<none>";
+        string overlaySummary = terrainOverlay is null
+            ? "<null>"
+            : string.Create(
+                CultureInfo.InvariantCulture,
+                $"package='{terrainOverlay.PackageName}', bounds='{FormatBounds(terrainOverlay.GeographicBounds)}', sources='{terrainOverlay.SourceDescriptorKey}'");
+        return new InvalidOperationException(
+            $"Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds. "
+            + $"phase='{phase}', actual_mesh='{actualMeshCode}', requested_mesh='{requestedMeshCode}', "
+            + $"requested_areas='{requestedAreaSummary}', overlay={overlaySummary}.");
     }
 
     private static IEnumerable<(global::PlateauResoniteLink.Application.Importing.ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> SplitParsedCityObjectForTerrainProjection(
@@ -5146,6 +5348,7 @@ internal static partial class LocalCityGmlObjectProjection
                      in SplitNonDemCityObjectByTerrainOverlay(
                          splitCityObject.CityObject,
                          demTerrainTextureOverlays,
+                         requestedMeshAreas,
                          progressReporter,
                          cancellationToken))
             {
@@ -5157,6 +5360,7 @@ internal static partial class LocalCityGmlObjectProjection
     private static IEnumerable<(global::PlateauResoniteLink.Application.Importing.ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> SplitNonDemCityObjectByTerrainOverlay(
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
         IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshAreas,
         Action<string>? progressReporter,
         CancellationToken cancellationToken)
     {
@@ -5202,16 +5406,24 @@ internal static partial class LocalCityGmlObjectProjection
                 NormalizeNonDemTerrainTextureSurface(surface);
 
             TerrainTextureOverlay[] candidateOverlays = demTerrainTextureOverlays
-                .Where(overlay => ResolveTerrainTextureMeshCode(cityObject.ActualMeshCode, overlay) is not null)
+                .Where(overlay => IsRequestedTerrainOverlay(overlay, requestedMeshAreas)
+                    || ResolveTerrainTextureMeshCode(cityObject.ActualMeshCode, overlay) is not null)
                 .Where(overlay => BoundsOverlap(surfaceBounds, overlay.GeographicBounds))
                 .OrderBy(static overlay => overlay.GeographicBounds.MinLatitude)
                 .ThenBy(static overlay => overlay.GeographicBounds.MinLongitude)
                 .ToArray();
             if (candidateOverlays.Length == 0)
             {
-                if (demTerrainTextureOverlays.Any(overlay => BoundsOverlap(surfaceBounds, overlay.GeographicBounds)))
+                TerrainTextureOverlay? overlappingOverlay = demTerrainTextureOverlays
+                    .FirstOrDefault(overlay => BoundsOverlap(surfaceBounds, overlay.GeographicBounds));
+                if (overlappingOverlay is not null)
                 {
-                    throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+                    throw CreateTerrainOverlayMeshCodeMismatchException(
+                        "non-dem-terrain-candidate",
+                        cityObject.ActualMeshCode,
+                        cityObject.ActualMeshCode,
+                        requestedMeshAreas,
+                        overlappingOverlay);
                 }
 
                 untexturedSurfaces.Add(surface);
@@ -5263,9 +5475,22 @@ internal static partial class LocalCityGmlObjectProjection
         {
             if (terrainGroups.Length == 1)
             {
+                string terrainMeshCode = ResolveTerrainTextureMeshCodeForOverlay(
+                        cityObject.ActualMeshCode,
+                        cityObject.ActualMeshCode,
+                        requestedMeshAreas,
+                        terrainGroups[0].Key,
+                        "non-dem-terrain-single-split")
+                    ?? throw CreateTerrainOverlayMeshCodeMismatchException(
+                        "non-dem-terrain-single-split",
+                        cityObject.ActualMeshCode,
+                        cityObject.ActualMeshCode,
+                        requestedMeshAreas,
+                        terrainGroups[0].Key);
                 yield return (
                     cityObject with
                     {
+                        ActualMeshCode = terrainMeshCode,
                         Surfaces = terrainGroups[0].Select(static entry => MarkUsesGeneratedDemTexture(entry.Surface)).ToArray(),
                         GeodeticOriginOverride = cityObjectOrigin,
                     },
@@ -5287,11 +5512,22 @@ internal static partial class LocalCityGmlObjectProjection
         foreach (IGrouping<TerrainTextureOverlay, (global::PlateauResoniteLink.Application.Importing.ParsedSurface Surface, TerrainTextureOverlay Overlay)> group in terrainGroups)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            string terrainMeshCode = ResolveTerrainTextureMeshCode(cityObject.ActualMeshCode, group.Key)
-                ?? splitIndex.ToString("D2", CultureInfo.InvariantCulture);
+            string terrainMeshCode = ResolveTerrainTextureMeshCodeForOverlay(
+                    cityObject.ActualMeshCode,
+                    cityObject.ActualMeshCode,
+                    requestedMeshAreas,
+                    group.Key,
+                    "non-dem-terrain-split")
+                ?? throw CreateTerrainOverlayMeshCodeMismatchException(
+                    "non-dem-terrain-split",
+                    cityObject.ActualMeshCode,
+                    cityObject.ActualMeshCode,
+                    requestedMeshAreas,
+                    group.Key);
             yield return (
                 cityObject with
                 {
+                    ActualMeshCode = terrainMeshCode,
                     SlotKey = $"{cityObject.SlotKey}_terrain_{terrainMeshCode}",
                     DisplayName = $"{cityObject.DisplayName} ({splitIndex + 1})",
                     Surfaces = group.Select(static entry => MarkUsesGeneratedDemTexture(entry.Surface)).ToArray(),
@@ -5348,6 +5584,7 @@ internal static partial class LocalCityGmlObjectProjection
     private static bool ShouldProjectTerrainOverlaySplit(
         string actualMeshCode,
         string requestedMeshCode,
+        IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         TerrainTextureOverlay? terrainOverlay)
     {
         if (terrainOverlay is null)
@@ -5355,13 +5592,18 @@ internal static partial class LocalCityGmlObjectProjection
             return true;
         }
 
-        if (requestedMeshCode.Length == 8
-            && TryCreateMeshCodeBounds(requestedMeshCode, out MeshCodeBounds? requestedMeshBounds))
+        if (requestedMeshAreas.Count > 0)
         {
-            return BoundsApproximatelyEqual(requestedMeshBounds!, terrainOverlay.GeographicBounds);
+            return IsRequestedTerrainOverlay(terrainOverlay, requestedMeshAreas);
         }
 
-        return ResolveTerrainTextureMeshCode(actualMeshCode, terrainOverlay) is not null;
+        return ResolveTerrainTextureMeshCodeForOverlay(
+                actualMeshCode,
+                requestedMeshCode,
+                requestedMeshAreas,
+                terrainOverlay,
+                "project-split-check")
+            is not null;
     }
 
     private static bool BoundsOverlap(MeshCodeBounds meshBounds, GeographicRectangle geographicBounds)

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -5178,10 +5178,8 @@ internal static partial class LocalCityGmlObjectProjection
         string actualMeshCode,
         string requestedMeshCode,
         IReadOnlyList<MeshCodeBounds>? requestedMeshAreas,
-        TerrainTextureOverlay terrainOverlay,
-        string phase)
+        TerrainTextureOverlay terrainOverlay)
     {
-        _ = phase;
         return ResolveTerrainTextureMeshCode(actualMeshCode, terrainOverlay)
             ?? ResolveTerrainTextureMeshCode(requestedMeshCode, terrainOverlay)
             ?? ResolveTerrainTextureMeshCodeFromRequestedAreas(
@@ -5477,8 +5475,7 @@ internal static partial class LocalCityGmlObjectProjection
                         cityObject.ActualMeshCode,
                         cityObject.ActualMeshCode,
                         requestedMeshAreas,
-                        terrainGroups[0].Key,
-                        "non-dem-terrain-single-split")
+                        terrainGroups[0].Key)
                     ?? throw CreateTerrainOverlayMeshCodeMismatchException(
                         "non-dem-terrain-single-split",
                         cityObject.ActualMeshCode,
@@ -5514,8 +5511,7 @@ internal static partial class LocalCityGmlObjectProjection
                     cityObject.ActualMeshCode,
                     cityObject.ActualMeshCode,
                     requestedMeshAreas,
-                    group.Key,
-                    "non-dem-terrain-split")
+                    group.Key)
                 ?? throw CreateTerrainOverlayMeshCodeMismatchException(
                     "non-dem-terrain-split",
                     cityObject.ActualMeshCode,
@@ -5599,8 +5595,7 @@ internal static partial class LocalCityGmlObjectProjection
                 actualMeshCode,
                 requestedMeshCode,
                 requestedMeshAreas,
-                terrainOverlay,
-                "project-split-check")
+                terrainOverlay)
             is not null;
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -4020,6 +4020,7 @@ internal static partial class LocalCityGmlObjectProjection
                 globalCartesian,
                 splitCityObject.Overlay,
                 request,
+                requestedMeshAreas,
                 materialResolver,
                 progressReporter,
                 cancellationToken);
@@ -4159,6 +4160,7 @@ internal static partial class LocalCityGmlObjectProjection
         LocalCartesian? globalCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         PlateauImportRequest request,
+        IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         IDefaultMaterialResolver materialResolver,
         Action<string>? progressReporter,
         CancellationToken cancellationToken)
@@ -4175,6 +4177,7 @@ internal static partial class LocalCityGmlObjectProjection
             globalCartesian,
             demTerrainTextureOverlay,
             request,
+            requestedMeshAreas,
             materialResolver,
             progressReporter,
             cancellationToken,
@@ -4640,6 +4643,7 @@ internal static partial class LocalCityGmlObjectProjection
         LocalCartesian? globalCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         PlateauImportRequest request,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshAreas,
         IDefaultMaterialResolver materialResolver,
         out ImportedCityObject? heightMapCityObject)
     {
@@ -4744,7 +4748,7 @@ internal static partial class LocalCityGmlObjectProjection
             cityObjectCartesian,
             demTerrainTextureOverlay,
             request.MeshCode,
-            CreateRequestedMeshAreasForRequest(request.MeshCode),
+            requestedMeshAreas,
             materialResolver);
         if (materials.Length == 0)
         {
@@ -4802,6 +4806,7 @@ internal static partial class LocalCityGmlObjectProjection
         LocalCartesian? globalCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         PlateauImportRequest request,
+        IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         IDefaultMaterialResolver materialResolver,
         Action<string>? progressReporter,
         CancellationToken cancellationToken,
@@ -4921,7 +4926,7 @@ internal static partial class LocalCityGmlObjectProjection
             cityObjectCartesian,
             demTerrainTextureOverlay,
             request.MeshCode,
-            CreateRequestedMeshAreasForRequest(request.MeshCode),
+            requestedMeshAreas,
             materialResolver);
         if (materials.Length == 0)
         {
@@ -5270,13 +5275,6 @@ internal static partial class LocalCityGmlObjectProjection
             .Where(static meshCode => meshCode.Length >= 6 && meshCode.All(static character => character is >= '0' and <= '9'))
             .Select(static meshCode => meshCode[..6])
             .Distinct(StringComparer.Ordinal);
-    }
-
-    private static MeshCodeBounds[] CreateRequestedMeshAreasForRequest(string requestedMeshCode)
-    {
-        return MeshCodeBounds.TryParse(requestedMeshCode) is { } meshArea
-            ? [meshArea]
-            : [];
     }
 
     private static bool IsRequestedTerrainOverlay(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -683,7 +683,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 
     private static bool IsRecoverableCityObjectSendFailure(Exception exception)
     {
-        return FindResoniteLinkOperationException(exception) is { OperationName: "ImportMesh" or "ImportTexture" or "GetSlot" or "GetComponent" };
+        return exception is ContinuableImportException
+            || FindResoniteLinkOperationException(exception) is { OperationName: "ImportMesh" or "ImportTexture" or "GetSlot" or "GetComponent" };
     }
 
     private static Task<T> AwaitWithSlowCityObjectWarningAsync<T>(
@@ -985,10 +986,16 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             }
         }
         (string TerrainMeshCode, TerrainTextureOverlay TerrainOverlay)[] distinctTerrainOverlays = cityObject.Materials
-            .Where(static material => material.TerrainOverlay is not null && material.TerrainMeshCode is not null)
-            .Select(material => (
-                TerrainMeshCode: ValidateTerrainTextureMeshCode(material.TerrainMeshCode!, material.TerrainOverlay!),
-                TerrainOverlay: material.TerrainOverlay!))
+            .Select((material, materialIndex) => (Material: material, MaterialIndex: materialIndex))
+            .Where(static entry => entry.Material.TerrainOverlay is not null && entry.Material.TerrainMeshCode is not null)
+            .Select(entry => (
+                TerrainMeshCode: ValidateTerrainTextureMeshCode(
+                    cityObject,
+                    entry.MaterialIndex,
+                    entry.Material,
+                    entry.Material.TerrainMeshCode!,
+                    entry.Material.TerrainOverlay!),
+                TerrainOverlay: entry.Material.TerrainOverlay!))
             .Distinct()
             .OrderBy(static entry => entry.TerrainMeshCode, StringComparer.Ordinal)
             .ThenBy(static entry => entry.TerrainOverlay.PackageName, StringComparer.Ordinal)
@@ -1691,13 +1698,18 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             || meshCode.Length != 8
             || !PlateauMeshCode.TryGetBounds(meshCode, out _))
         {
-            throw new InvalidOperationException("Terrain texture overlay preparation requires a valid third-level mesh code.");
+            throw new InvalidOperationException(
+                "Terrain texture overlay preparation requires a valid third-level mesh code. "
+                + $"provided_mesh='{texture.TerrainMeshCode ?? "<null>"}'.");
         }
 
         return meshCode;
     }
 
-    private static ResoniteMaterialBinding ValidateTerrainTextureMaterialContract(ResoniteMaterialBinding material)
+    private static ResoniteMaterialBinding ValidateTerrainTextureMaterialContract(
+        ResoniteConstructionCityObject cityObject,
+        int materialIndex,
+        ResoniteMaterialBinding material)
     {
         if (material.TerrainOverlay is null)
         {
@@ -1706,13 +1718,30 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 
         if (material.TerrainMeshCode is null)
         {
-            throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+            throw CreateTerrainOverlayMaterialContractException(
+                cityObject,
+                materialIndex,
+                material,
+                "missing terrain mesh code");
         }
 
-        return material with { TerrainMeshCode = ValidateTerrainTextureMeshCode(material.TerrainMeshCode, material.TerrainOverlay) };
+        return material with
+        {
+            TerrainMeshCode = ValidateTerrainTextureMeshCode(
+                cityObject,
+                materialIndex,
+                material,
+                material.TerrainMeshCode,
+                material.TerrainOverlay),
+        };
     }
 
-    private static string ValidateTerrainTextureMeshCode(string meshCode, TerrainTextureOverlay terrainOverlay)
+    private static string ValidateTerrainTextureMeshCode(
+        ResoniteConstructionCityObject cityObject,
+        int materialIndex,
+        ResoniteMaterialBinding material,
+        string meshCode,
+        TerrainTextureOverlay terrainOverlay)
     {
         if (meshCode.Length == 8
             && PlateauMeshCode.TryGetBounds(meshCode, out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds)
@@ -1721,7 +1750,42 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             return meshCode;
         }
 
-        throw new InvalidOperationException("Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds.");
+        throw CreateTerrainOverlayMaterialContractException(
+            cityObject,
+            materialIndex,
+            material,
+            "mesh code bounds do not match overlay bounds");
+    }
+
+    private static InvalidOperationException CreateTerrainOverlayMaterialContractException(
+        ResoniteConstructionCityObject cityObject,
+        int materialIndex,
+        ResoniteMaterialBinding material,
+        string reason)
+    {
+        TerrainTextureOverlay? overlay = material.TerrainOverlay;
+        string overlaySummary = overlay is null
+            ? "<null>"
+            : string.Create(
+                CultureInfo.InvariantCulture,
+                $"package='{overlay.PackageName}', bounds='{FormatGeographicBounds(overlay.GeographicBounds)}', sources='{overlay.SourceDescriptorKey}'");
+        return new InvalidOperationException(
+            "Terrain overlay material requires a third-level mesh code that matches the overlay geographic bounds. "
+            + $"reason='{reason}', object_slot='{cityObject.SlotKey}', object_name='{cityObject.DisplayName}', "
+            + $"package='{cityObject.PackageName}', actual_mesh='{cityObject.ActualMeshCode}', source_file='{cityObject.SourceFileRelativePath ?? "<null>"}', "
+            + $"material_index='{materialIndex}', terrain_mesh='{material.TerrainMeshCode ?? "<null>"}', overlay={overlaySummary}.");
+    }
+
+    private static string FormatGeographicBounds(GeographicRectangle bounds)
+    {
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{FormatRounded(bounds.MinLatitude)}-{FormatRounded(bounds.MaxLatitude)}-{FormatRounded(bounds.MinLongitude)}-{FormatRounded(bounds.MaxLongitude)}");
+    }
+
+    private static string FormatRounded(double value)
+    {
+        return value.ToString("G17", CultureInfo.InvariantCulture);
     }
 
     private static bool BoundsApproximatelyEqual(
@@ -2062,7 +2126,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 cityObject,
                 cityObject.Materials[materialIndex],
                 preparedTerrainTextureDataByOverlay);
-            material = ValidateTerrainTextureMaterialContract(material);
+            material = ValidateTerrainTextureMaterialContract(cityObject, materialIndex, material);
             ReportImportStep(
                 cityObject,
                 $"Creating material {materialIndex + 1}/{cityObject.Materials.Count}.");

--- a/tests/PlateauResoniteLink.Tests/Cli/CliApplicationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliApplicationTests.cs
@@ -130,6 +130,33 @@ public sealed class CliApplicationTests
     }
 
     [Fact]
+    public async Task RunAsyncListsAggregateExceptionInnerFailures()
+    {
+        using StringWriter standardOutput = new();
+        using StringWriter standardError = new();
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
+        StubImportServiceFactory importServiceFactory = new(_ => throw new AggregateException(
+            new InvalidOperationException("first terrain overlay failure"),
+            new InvalidOperationException("second terrain overlay failure")));
+
+        CliApplication application = new(
+            standardOutput,
+            standardError,
+            importServiceFactory,
+            CreateDatasetInspectionService());
+
+        int exitCode = await application.RunAsync(
+            CreateImportArgs(fixturePath));
+
+        string error = standardError.ToString();
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Import failed: 2 errors occurred.", error, StringComparison.Ordinal);
+        Assert.Contains("[1] first terrain overlay failure", error, StringComparison.Ordinal);
+        Assert.Contains("[2] second terrain overlay failure", error, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, standardOutput.ToString());
+    }
+
+    [Fact]
     public async Task RunAsyncPassesDocumentedDefaultPackagesWhenPackagesOptionIsOmitted()
     {
         using StringWriter standardOutput = new();

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -1110,6 +1110,46 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
+    public void ProjectParsedCityObjectUsesConcreteRequestedMeshAreasForRegexDemGridOverlay()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay selectedOverlay = CreateThirdMeshOverlay("53394600");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394600", altitudeMeters: 8.0);
+        ParsedSurface demSurface = CreateParsedSurface(
+            "regex-selected-dem",
+            ParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394600", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null) with
+        {
+            UsesGeneratedDemTexture = true,
+        };
+        ParsedCityObject cityObject = CreateParsedCityObject("dem", [demSurface], referenceSystem) with
+        {
+            ActualMeshCode = "533945",
+        };
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394[56]..",
+            Source: DatasetLocation.Local("/tmp/plateau"),
+            PackageNames: ["dem"],
+            TerrainMeshMode: TerrainMeshMode.Grid);
+
+        ImportedCityObject projected = Assert.Single(LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            GeodeticPoint.FromProjectionModel(origin),
+            globalCartesian: null,
+            demTerrainTextureOverlays: [selectedOverlay],
+            requestedMeshAreas: [MeshCodeBounds.TryParse("53394600")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create())));
+
+        MaterialBinding material = Assert.Single(projected.Materials);
+        Assert.Same(selectedOverlay, material.TerrainOverlay);
+        Assert.Equal("53394600", material.TerrainMeshCode);
+    }
+
+    [Fact]
     public void ProjectParsedCityObjectAssignsSelectedAdjacentOverlayToTexturelessBuildingRoof()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
@@ -3626,6 +3666,10 @@ public sealed class LocalCityGmlObjectProjectionTests
                 "ProjectTerrainMeshModeCityObject",
                 BindingFlags.NonPublic | BindingFlags.Static)
             ?? throw new InvalidOperationException("Failed to resolve ProjectTerrainMeshModeCityObject.");
+        IReadOnlyList<MeshCodeBounds> requestedMeshAreas =
+            MeshCodeBounds.TryParse(request.MeshCode) is { } requestedMeshArea
+                ? [requestedMeshArea]
+                : [];
 
         return (ImportedCityObject)method.Invoke(
             null,
@@ -3635,6 +3679,7 @@ public sealed class LocalCityGmlObjectProjectionTests
                 null,
                 null,
                 request,
+                requestedMeshAreas,
                 new DefaultMaterialResolver(CommonMaterialCatalog.Create()),
                 null,
                 CancellationToken.None,

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -1069,6 +1069,123 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
+    public void ProjectParsedCityObjectAllowsSelectedAdjacentDemOverlayWhenRequestMeshIsExact()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay selectedRequestOverlay = CreateThirdMeshOverlay("53394525");
+        TerrainTextureOverlay selectedAdjacentOverlay = CreateThirdMeshOverlay("53394526");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394526", altitudeMeters: 8.0);
+        ParsedSurface demSurface = CreateParsedSurface(
+            "selected-adjacent-dem",
+            ParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394526", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null) with
+        {
+            UsesGeneratedDemTexture = true,
+        };
+        ParsedCityObject cityObject = CreateParsedCityObject("dem", [demSurface], referenceSystem) with
+        {
+            ActualMeshCode = "53394526",
+        };
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            Source: DatasetLocation.Local("/tmp/plateau"),
+            PackageNames: ["dem"],
+            TerrainMeshMode: TerrainMeshMode.Grid);
+
+        ImportedCityObject projected = Assert.Single(LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            GeodeticPoint.FromProjectionModel(origin),
+            globalCartesian: null,
+            demTerrainTextureOverlays: [selectedRequestOverlay, selectedAdjacentOverlay],
+            requestedMeshAreas: [MeshCodeBounds.TryParse("53394525")!, MeshCodeBounds.TryParse("53394526")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create())));
+
+        MaterialBinding material = Assert.Single(projected.Materials);
+        Assert.Same(selectedAdjacentOverlay, material.TerrainOverlay);
+        Assert.Equal("53394526", material.TerrainMeshCode);
+    }
+
+    [Fact]
+    public void ProjectParsedCityObjectAssignsSelectedAdjacentOverlayToTexturelessBuildingRoof()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay selectedRequestOverlay = CreateThirdMeshOverlay("53394525");
+        TerrainTextureOverlay selectedAdjacentOverlay = CreateThirdMeshOverlay("53394526");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394526", altitudeMeters: 8.0);
+        ParsedSurface roofSurface = CreateParsedSurface(
+            "selected-adjacent-textureless-roof",
+            ParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394526", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        ParsedCityObject cityObject = CreateParsedCityObject("bldg", [roofSurface], referenceSystem) with
+        {
+            ActualMeshCode = "53394525",
+        };
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            Source: DatasetLocation.Local("/tmp/plateau"),
+            PackageNames: ["dem", "bldg"]);
+
+        ImportedCityObject projected = Assert.Single(LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            GeodeticPoint.FromProjectionModel(origin),
+            globalCartesian: null,
+            demTerrainTextureOverlays: [selectedRequestOverlay, selectedAdjacentOverlay],
+            requestedMeshAreas: [MeshCodeBounds.TryParse("53394525")!, MeshCodeBounds.TryParse("53394526")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create())));
+
+        MaterialBinding material = Assert.Single(projected.Materials);
+        Assert.Same(selectedAdjacentOverlay, material.TerrainOverlay);
+        Assert.Equal("53394526", material.TerrainMeshCode);
+    }
+
+    [Fact]
+    public void ProjectParsedCityObjectRejectsUnrequestedTerrainOverlayWithTraceableContext()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay unrequestedOverlay = CreateThirdMeshOverlay("53394526");
+        LocalCityGmlObjectProjection.GeodeticPoint origin = CreateMeshCenterPoint("53394526", altitudeMeters: 8.0);
+        ParsedSurface roofSurface = CreateParsedSurface(
+            "unrequested-textureless-roof",
+            ParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394526", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        ParsedCityObject cityObject = CreateParsedCityObject("bldg", [roofSurface], referenceSystem) with
+        {
+            ActualMeshCode = "53394525",
+        };
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            Source: DatasetLocation.Local("/tmp/plateau"),
+            PackageNames: ["dem", "bldg"]);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            LocalCityGmlObjectProjection.ProjectParsedCityObject(
+                cityObject,
+                GeodeticPoint.FromProjectionModel(origin),
+                globalCartesian: null,
+                demTerrainTextureOverlays: [unrequestedOverlay],
+                requestedMeshAreas: [MeshCodeBounds.TryParse("53394525")!],
+                terrainHeightSampler: null,
+                request,
+                new DefaultMaterialResolver(CommonMaterialCatalog.Create())).ToArray());
+
+        Assert.Contains("phase='non-dem-terrain-candidate'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("actual_mesh='53394525'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("requested_mesh='53394525'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("overlay=package='dem'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("sources='tile-z17-https://terrain.example/53394526/{z}/{x}/{y}.png'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void EnumerateCommonMaterialsForParsedCityObjectExcludesTerrainOverlayBuildingRoofs()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -399,6 +399,10 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 client,
                 terrainTextureGenerator));
         Assert.Contains("matches the overlay geographic bounds", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("object_slot='terrain-mismatched-overlay'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains($"actual_mesh='{MeshCode}'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("terrain_mesh='53394525'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("sources='tile-z17-https://tiles.example/{z}/{x}/{y}.png'", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -446,6 +450,9 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 client,
                 terrainTextureGenerator));
         Assert.Contains("matches the overlay geographic bounds", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("object_slot='terrain-missing-mesh-code'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains($"actual_mesh='{MeshCode}'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("terrain_mesh='<null>'", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- accept valid terrain overlays whose bounds are inside selected/requested mesh areas instead of comparing only to the request mesh code
- derive terrain mesh codes from overlay bounds for adjacent/parent mesh splits
- add traceable terrain overlay mismatch diagnostics and numbered CLI aggregate failure output

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false