### PR TITLE
Fix deterministic append placement from observed source roots

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,6 +26,7 @@ internal sealed class ResoniteSharedSlotIndex(
     private readonly ConcurrentDictionary<string, byte> createdSlotIds = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<SharedSlotIndexKey, CreatedSlot> sharedSlotIndex = new();
     private readonly ConcurrentDictionary<string, Slot> observedSlotSnapshotsById = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, ResoniteFloat3> terrainResidualByRootMeshCode = new(StringComparer.Ordinal);
     public SceneAnchor? SceneAnchor { get; private set; } = initialSceneAnchor;
 
     public void IndexSetupHierarchy(ResoniteSceneSetupState setupState)
@@ -53,24 +55,6 @@ internal sealed class ResoniteSharedSlotIndex(
             cityObject,
             processingCancellationToken,
             cancellationToken);
-    }
-
-    public ResoniteFloat3 ResolveMeshCodeRootPosition(string meshCode)
-    {
-        SceneAnchor? anchor = SceneAnchor;
-        if (anchor is null)
-        {
-            return new ResoniteFloat3(0.0, 0.0, 0.0);
-        }
-
-        if (string.Equals(anchor.Value.MeshCode, meshCode, StringComparison.Ordinal))
-        {
-            return anchor.Value.Position;
-        }
-
-        return ResonitePlacementPolicy.Add(
-            anchor.Value.Position,
-            ResonitePlacementPolicy.ComputeMeshCodeOffset(anchor.Value.MeshCode, meshCode));
     }
 
     public Task<CreatedSlot> GetOrCreateSharedChildSlotAsync(
@@ -102,11 +86,11 @@ internal sealed class ResoniteSharedSlotIndex(
         string sourceFileRelativePath = ResonitePlacementPolicy.ResolveSourceFileRelativePath(cityObject);
         string sourceFileSlotName = ResonitePlacementPolicy.ResolveSourceFileSlotName(cityObject, sourceFileRelativePath, sourceFileSlotNamesByRelativePath);
         string rootMeshCode = ResonitePlacementPolicy.ResolveRequiredSourceFileRootMeshCode(sourceFileSlotName, cityObject.ActualMeshCode);
+        SourceRootPlacement sourceRootPlacement = ResolveSourceRootPlacement(sourceFileSlotName, rootMeshCode, cityObject);
         CanonicalParentScope parentScope = await canonicalParentScopeCache.GetOrCreateAsync(
             new CanonicalParentSourceFile(sourceFileRelativePath, rootMeshCode, cityObject.LodLevel),
-            ct => CreateCanonicalParentScopeAsync(client, sourceFileSlotName, rootMeshCode, cityObject.LodLevel, ct),
+            ct => CreateCanonicalParentScopeAsync(client, sourceFileSlotName, rootMeshCode, cityObject.LodLevel, sourceRootPlacement.RootPosition, ct),
             cancellationToken);
-        ResoniteFloat3 plannedRootPosition = ResolvePlannedRootPosition(rootMeshCode);
         return new ObjectSlotHierarchy(
             parentScope.AssetLodSlot,
             parentScope.LodSlot,
@@ -114,7 +98,7 @@ internal sealed class ResoniteSharedSlotIndex(
             ResonitePlacementPolicy.ResolveCityObjectLocalPosition(
                 requestLocalOrigin,
                 rootMeshCode,
-                TryGetObservedSlotPosition(parentScope.SourceFileSlot.Locator),
+                sourceRootPlacement.LocalPositionReferenceRoot,
                 cityObject.Transform.Position),
             cityObject.Transform.Rotation);
     }
@@ -124,10 +108,10 @@ internal sealed class ResoniteSharedSlotIndex(
         string sourceFileSlotName,
         string rootMeshCode,
         int? lodLevel,
+        ResoniteFloat3 rootPosition,
         CancellationToken cancellationToken)
     {
         string lodSlotName = ResonitePlacementPolicy.FormatLodSlotName(lodLevel);
-        ResoniteFloat3 rootPosition = ResolvePlannedRootPosition(rootMeshCode);
         CreatedSlot sourceFileSlot = await GetOrCreateRunScopedSourceFileRootAsync(
             client,
             datasetRootSlot.Locator,
@@ -271,53 +255,239 @@ internal sealed class ResoniteSharedSlotIndex(
         return createdSlot;
     }
 
-    private ResoniteFloat3? TryGetObservedSlotPosition(ResoniteSlotLocator slot)
+    private SourceRootPlacement ResolveSourceRootPlacement(
+        string sourceFileSlotName,
+        string rootMeshCode,
+        ResoniteConstructionCityObject cityObject)
     {
-        if (!observedSlotSnapshotsById.TryGetValue(slot.Value, out Slot? observedSlot)
-            || observedSlot.Position is not Field_float3 position)
+        ResoniteFloat3 baseRootPosition = TryResolveObservedSourceRootPosition(sourceFileSlotName, rootMeshCode)
+            ?? ResonitePlacementPolicy.ResolveMeshRootPosition(requestLocalOrigin, rootMeshCode);
+        ResoniteFloat3 terrainResidual = ResolveTerrainResidual(rootMeshCode, cityObject);
+        ResoniteFloat3 rootPosition = IsTerrainGridDem(cityObject)
+            ? baseRootPosition
+            : ResonitePlacementPolicy.Add(baseRootPosition, terrainResidual);
+
+        return new SourceRootPlacement(rootPosition, baseRootPosition);
+    }
+
+    private ResoniteFloat3? TryResolveObservedSourceRootPosition(
+        string sourceFileSlotName,
+        string rootMeshCode)
+    {
+        Slot[] directSourceRoots = EnumerateObservedDatasetSourceRoots().ToArray();
+        Slot[] exactSourceRoots = directSourceRoots
+            .Where(slot => string.Equals(slot.Name?.Value, sourceFileSlotName, StringComparison.Ordinal))
+            .ToArray();
+        if (exactSourceRoots.Length > 1)
         {
+            throw new InvalidOperationException(
+                $"Dataset root contains multiple observed source roots named '{sourceFileSlotName}'. Append placement is ambiguous.");
+        }
+
+        if (exactSourceRoots.Length == 1)
+        {
+            return GetSlotPositionOrDefault(exactSourceRoots[0]);
+        }
+
+        (Slot Slot, string MeshCode)[] ancestorCandidates = directSourceRoots
+            .Select(static slot => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name?.Value ?? string.Empty, out string meshCode)
+                ? (Slot: slot, MeshCode: meshCode)
+                : default)
+            .Where(candidate => candidate.Slot is not null
+                && rootMeshCode.StartsWith(candidate.MeshCode, StringComparison.Ordinal))
+            .OrderByDescending(static candidate => candidate.MeshCode.Length)
+            .ToArray();
+        if (ancestorCandidates.Length == 0)
+        {
+            (Slot Slot, string MeshCode)[] observedMeshCodeRoots = directSourceRoots
+                .Select(static slot => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name?.Value ?? string.Empty, out string meshCode)
+                    ? (Slot: slot, MeshCode: meshCode)
+                    : default)
+                .Where(static candidate => candidate.Slot is not null)
+                .ToArray();
+            if (observedMeshCodeRoots.Length == 1)
+            {
+                return ResonitePlacementPolicy.Add(
+                    GetSlotPositionOrDefault(observedMeshCodeRoots[0].Slot),
+                    ResonitePlacementPolicy.ComputeMeshCodeOffset(observedMeshCodeRoots[0].MeshCode, rootMeshCode));
+            }
+
             return null;
         }
 
-        return new ResoniteFloat3(position.Value.x, position.Value.y, position.Value.z);
-    }
-
-    private ResoniteFloat3 ResolvePlannedRootPosition(string rootMeshCode)
-    {
-        SceneAnchor? anchor = SceneAnchor;
-        if (anchor is null)
+        int bestLength = ancestorCandidates[0].MeshCode.Length;
+        (Slot Slot, string MeshCode)[] bestCandidates = ancestorCandidates
+            .Where(candidate => candidate.MeshCode.Length == bestLength)
+            .ToArray();
+        if (bestCandidates.Length > 1)
         {
-            return ResonitePlacementPolicy.ResolveMeshRootPosition(requestLocalOrigin, rootMeshCode);
+            throw new InvalidOperationException(
+                $"Dataset root contains multiple observed source roots for meshcode '{bestCandidates[0].MeshCode}'. Append placement is ambiguous.");
         }
 
-        if (TryResolveReferenceSourceFileRootPosition(anchor.Value, rootMeshCode, out ResoniteFloat3 referenceRootPosition))
-        {
-            return referenceRootPosition;
-        }
-
-        return ResolveMeshCodeRootPosition(rootMeshCode);
+        return ResonitePlacementPolicy.Add(
+            GetSlotPositionOrDefault(bestCandidates[0].Slot),
+            ResonitePlacementPolicy.ComputeMeshCodeOffset(bestCandidates[0].MeshCode, rootMeshCode));
     }
 
-    private bool TryResolveReferenceSourceFileRootPosition(
-        SceneAnchor anchor,
+    private ResoniteFloat3 ResolveTerrainResidual(
         string rootMeshCode,
-        out ResoniteFloat3 position)
+        ResoniteConstructionCityObject cityObject)
     {
-        position = new ResoniteFloat3(0.0, 0.0, 0.0);
-        if (anchor.ReferenceSourceFileRoot is not ResoniteSlotLocator referenceSourceFileRoot
-            || !observedSlotSnapshotsById.TryGetValue(referenceSourceFileRoot.Value, out Slot? referenceSlot)
-            || !ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(referenceSlot.Name?.Value ?? string.Empty, out string referenceMeshCode))
+        if (IsTerrainGridDem(cityObject))
+        {
+            ResoniteFloat3 terrainResidual = TryResolveObservedTerrainWorldPosition(rootMeshCode, cityObject.Transform.Position, out ResoniteFloat3 observedTerrainPosition)
+                ? CreateVerticalResidual(ResonitePlacementPolicy.Subtract(observedTerrainPosition, cityObject.Transform.Position))
+                : new ResoniteFloat3(0.0, 0.0, 0.0);
+            terrainResidualByRootMeshCode[rootMeshCode] = terrainResidual;
+            return terrainResidual;
+        }
+
+        if (terrainResidualByRootMeshCode.TryGetValue(rootMeshCode, out ResoniteFloat3? cachedResidual))
+        {
+            return cachedResidual;
+        }
+
+        ResoniteFloat3 inferredResidual = TryResolveObservedTerrainWorldPosition(rootMeshCode, cityObject.Transform.Position, out ResoniteFloat3 observedTerrain)
+            ? CreateVerticalResidual(ResonitePlacementPolicy.Subtract(observedTerrain, cityObject.Transform.Position))
+            : new ResoniteFloat3(0.0, 0.0, 0.0);
+        terrainResidualByRootMeshCode.TryAdd(rootMeshCode, inferredResidual);
+        return inferredResidual;
+    }
+
+    private static ResoniteFloat3 CreateVerticalResidual(ResoniteFloat3 residual)
+    {
+        return new ResoniteFloat3(0.0, residual.Y, 0.0);
+    }
+
+    private bool TryResolveObservedTerrainWorldPosition(
+        string rootMeshCode,
+        ResoniteFloat3 cityObjectPosition,
+        out ResoniteFloat3 worldPosition)
+    {
+        const double maxDistanceSquared = 300.0 * 300.0;
+        worldPosition = new ResoniteFloat3(0.0, 0.0, 0.0);
+        string parentMeshCode = rootMeshCode.Length >= 6 ? rootMeshCode[..6] : rootMeshCode;
+        (Slot Slot, ResoniteFloat3 WorldPosition, double DistanceSquared)[] candidates = observedSlotSnapshotsById.Values
+            .Where(static slot => !string.IsNullOrWhiteSpace(slot.ID))
+            .Where(slot => !createdSlotIds.ContainsKey(slot.ID!))
+            .Where(HasGridMeshComponent)
+            .Where(slot => !IsDescendantOf(slot.ID!, datasetAssetsRootSlot.Locator.Value))
+            .Where(slot => TryGetDatasetSourceRoot(slot, out Slot? sourceRoot)
+                && IsDemSourceRootForMeshCode(sourceRoot, parentMeshCode))
+            .Select(slot =>
+            {
+                ResoniteFloat3 candidateWorldPosition = GetAccumulatedPosition(slot);
+                return (Slot: slot, WorldPosition: candidateWorldPosition, DistanceSquared: ComputeHorizontalDistanceSquared(candidateWorldPosition, cityObjectPosition));
+            })
+            .Where(static candidate => candidate.DistanceSquared <= maxDistanceSquared)
+            .OrderBy(static candidate => candidate.DistanceSquared)
+            .ThenBy(static candidate => candidate.Slot.ID ?? string.Empty, StringComparer.Ordinal)
+            .ToArray();
+        if (candidates.Length == 0)
         {
             return false;
         }
 
-        ResoniteFloat3 referencePosition = GetSlotPositionOrDefault(referenceSlot);
-        position = string.Equals(referenceMeshCode, rootMeshCode, StringComparison.Ordinal)
-            ? referencePosition
-            : ResonitePlacementPolicy.Add(
-                referencePosition,
-                ResonitePlacementPolicy.ComputeMeshCodeOffset(referenceMeshCode, rootMeshCode));
+        if (candidates.Length > 1 && Math.Abs(candidates[0].DistanceSquared - candidates[1].DistanceSquared) < 0.000001)
+        {
+            throw new InvalidOperationException(
+                $"Dataset root contains multiple observed terrain grid slots for meshcode '{rootMeshCode}'. Append placement is ambiguous.");
+        }
+
+        worldPosition = candidates[0].WorldPosition;
         return true;
+    }
+
+    private IEnumerable<Slot> EnumerateObservedDatasetSourceRoots()
+    {
+        return observedSlotSnapshotsById.Values
+            .Where(slot => string.Equals(slot.Parent?.TargetID, datasetRootSlot.Locator.Value, StringComparison.Ordinal))
+            .Where(slot => string.IsNullOrWhiteSpace(slot.ID) || !createdSlotIds.ContainsKey(slot.ID!))
+            .Where(static slot => !string.Equals(slot.Name?.Value, "Assets", StringComparison.Ordinal));
+    }
+
+    private static bool IsTerrainGridDem(ResoniteConstructionCityObject cityObject)
+    {
+        return string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
+            && cityObject.Geometry is ResoniteTerrainGridGeometry;
+    }
+
+    private static bool HasGridMeshComponent(Slot slot)
+    {
+        return slot.Components?.Any(static component =>
+            string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.GridMesh", StringComparison.Ordinal)) == true;
+    }
+
+    private bool TryGetDatasetSourceRoot(Slot slot, out Slot sourceRoot)
+    {
+        sourceRoot = slot;
+        Slot current = slot;
+        while (current.Parent is not null
+               && !string.IsNullOrWhiteSpace(current.Parent.TargetID)
+               && observedSlotSnapshotsById.TryGetValue(current.Parent.TargetID, out Slot? parent))
+        {
+            if (string.Equals(parent.ID, datasetRootSlot.Locator.Value, StringComparison.Ordinal))
+            {
+                sourceRoot = current;
+                return true;
+            }
+
+            current = parent;
+        }
+
+        return false;
+    }
+
+    private static bool IsDemSourceRootForMeshCode(Slot sourceRoot, string parentMeshCode)
+    {
+        string sourceRootName = sourceRoot.Name?.Value ?? string.Empty;
+        return sourceRootName.Contains("dem", StringComparison.OrdinalIgnoreCase)
+            && ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(sourceRootName, out string sourceRootMeshCode)
+            && parentMeshCode.StartsWith(sourceRootMeshCode, StringComparison.Ordinal);
+    }
+
+    private bool IsDescendantOf(string slotId, string ancestorSlotId)
+    {
+        string? currentSlotId = slotId;
+        while (!string.IsNullOrWhiteSpace(currentSlotId)
+               && observedSlotSnapshotsById.TryGetValue(currentSlotId, out Slot? slot)
+               && slot.Parent is not null)
+        {
+            if (string.Equals(slot.Parent.TargetID, ancestorSlotId, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            currentSlotId = slot.Parent.TargetID;
+        }
+
+        return false;
+    }
+
+    private ResoniteFloat3 GetAccumulatedPosition(Slot slot)
+    {
+        ResoniteFloat3 accumulated = new(0.0, 0.0, 0.0);
+        Slot? current = slot;
+        while (current is not null)
+        {
+            accumulated = ResonitePlacementPolicy.Add(accumulated, GetSlotPositionOrDefault(current));
+            if (current.Parent is null
+                || string.IsNullOrWhiteSpace(current.Parent.TargetID)
+                || !observedSlotSnapshotsById.TryGetValue(current.Parent.TargetID, out current))
+            {
+                break;
+            }
+        }
+
+        return accumulated;
+    }
+
+    private static double ComputeHorizontalDistanceSquared(ResoniteFloat3 left, ResoniteFloat3 right)
+    {
+        double x = left.X - right.X;
+        double z = left.Z - right.Z;
+        return (x * x) + (z * z);
     }
 
     private static Field_float3 CreateFloat3(ResoniteFloat3 value)
@@ -355,6 +525,10 @@ internal sealed class ResoniteSharedSlotIndex(
         CreatedSlot AssetSourceFileSlot,
         CreatedSlot LodSlot,
         CreatedSlot AssetLodSlot);
+
+    private readonly record struct SourceRootPlacement(
+        ResoniteFloat3 RootPosition,
+        ResoniteFloat3 LocalPositionReferenceRoot);
 
     private readonly record struct CanonicalParentSourceFile(
         string SourceFileRelativePath,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -29,10 +29,12 @@ internal sealed class ResoniteSharedSlotIndex(
     private readonly ConcurrentDictionary<string, byte> createdSlotIds = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<SharedSlotIndexKey, CreatedSlot> sharedSlotIndex = new();
     private readonly ConcurrentDictionary<string, Slot> observedSlotSnapshotsById = new(StringComparer.Ordinal);
+    private Slot[]? observedDatasetSourceRoots;
     public SceneAnchor? SceneAnchor { get; private set; } = initialSceneAnchor;
 
     public void IndexSetupHierarchy(ResoniteSceneSetupState setupState)
     {
+        observedDatasetSourceRoots = null;
         if (setupState.DatasetRootSnapshot is not null)
         {
             observedSlotSnapshotsById.Clear();
@@ -283,7 +285,7 @@ internal sealed class ResoniteSharedSlotIndex(
         string sourceFileSlotName,
         string rootMeshCode)
     {
-        Slot[] directSourceRoots = EnumerateObservedDatasetSourceRoots().ToArray();
+        Slot[] directSourceRoots = GetObservedDatasetSourceRoots();
         ObservedSourceRootPlacement[] exactSourceRoots = directSourceRoots
             .Where(slot => string.Equals(slot.Name?.Value, sourceFileSlotName, StringComparison.Ordinal))
             .Select(slot => new ObservedSourceRootPlacement(
@@ -353,6 +355,10 @@ internal sealed class ResoniteSharedSlotIndex(
             .Where(static slot => !string.Equals(slot.Name?.Value, "Assets", StringComparison.Ordinal));
     }
 
+    private Slot[] GetObservedDatasetSourceRoots()
+    {
+        return observedDatasetSourceRoots ??= EnumerateObservedDatasetSourceRoots().ToArray();
+    }
 
     private static ObservedSourceRootPlacement SelectDeterministicObservedPlacement(
         IReadOnlyCollection<ObservedSourceRootPlacement> candidates,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -26,7 +26,6 @@ internal sealed class ResoniteSharedSlotIndex(
     private readonly ConcurrentDictionary<string, byte> createdSlotIds = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<SharedSlotIndexKey, CreatedSlot> sharedSlotIndex = new();
     private readonly ConcurrentDictionary<string, Slot> observedSlotSnapshotsById = new(StringComparer.Ordinal);
-    private readonly ConcurrentDictionary<string, ResoniteFloat3> terrainResidualByRootMeshCode = new(StringComparer.Ordinal);
     public SceneAnchor? SceneAnchor { get; private set; } = initialSceneAnchor;
 
     public void IndexSetupHierarchy(ResoniteSceneSetupState setupState)
@@ -260,99 +259,93 @@ internal sealed class ResoniteSharedSlotIndex(
         string rootMeshCode,
         ResoniteConstructionCityObject cityObject)
     {
-        ResoniteFloat3 baseRootPosition = TryResolveObservedSourceRootPosition(sourceFileSlotName, rootMeshCode)
+        ObservedSourceRootPlacement? observedRootPlacement = TryResolveObservedSourceRootPosition(sourceFileSlotName, rootMeshCode);
+        ResoniteFloat3 baseRootPosition = observedRootPlacement?.Position
             ?? ResonitePlacementPolicy.ResolveMeshRootPosition(requestLocalOrigin, rootMeshCode);
         ResoniteFloat3 terrainResidual = ResolveTerrainResidual(rootMeshCode, cityObject);
-        ResoniteFloat3 rootPosition = IsTerrainGridDem(cityObject)
+        ResoniteFloat3 rootPosition = IsTerrainDem(cityObject) || observedRootPlacement?.IsExact == true
             ? baseRootPosition
             : ResonitePlacementPolicy.Add(baseRootPosition, terrainResidual);
 
         return new SourceRootPlacement(rootPosition, baseRootPosition);
     }
 
-    private ResoniteFloat3? TryResolveObservedSourceRootPosition(
+    private ObservedSourceRootPlacement? TryResolveObservedSourceRootPosition(
         string sourceFileSlotName,
         string rootMeshCode)
     {
         Slot[] directSourceRoots = EnumerateObservedDatasetSourceRoots().ToArray();
-        Slot[] exactSourceRoots = directSourceRoots
+        ObservedSourceRootPlacement[] exactSourceRoots = directSourceRoots
             .Where(slot => string.Equals(slot.Name?.Value, sourceFileSlotName, StringComparison.Ordinal))
+            .Select(slot => new ObservedSourceRootPlacement(
+                GetSlotPositionOrDefault(slot),
+                IsExact: true,
+                ReferenceMeshCode: rootMeshCode,
+                SlotId: slot.ID ?? string.Empty))
             .ToArray();
-        if (exactSourceRoots.Length > 1)
+        if (exactSourceRoots.Length > 0)
         {
-            throw new InvalidOperationException(
-                $"Dataset root contains multiple observed source roots named '{sourceFileSlotName}'. Append placement is ambiguous.");
+            return SelectDeterministicObservedPlacement(
+                exactSourceRoots,
+                $"Dataset root contains multiple observed source roots named '{sourceFileSlotName}' with different placements. Append placement is ambiguous.");
         }
 
-        if (exactSourceRoots.Length == 1)
-        {
-            return GetSlotPositionOrDefault(exactSourceRoots[0]);
-        }
-
-        (Slot Slot, string MeshCode)[] ancestorCandidates = directSourceRoots
+        ObservedSourceRootPlacement[] ancestorCandidates = directSourceRoots
             .Select(static slot => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name?.Value ?? string.Empty, out string meshCode)
                 ? (Slot: slot, MeshCode: meshCode)
                 : default)
             .Where(candidate => candidate.Slot is not null
                 && rootMeshCode.StartsWith(candidate.MeshCode, StringComparison.Ordinal))
-            .OrderByDescending(static candidate => candidate.MeshCode.Length)
+            .Select(candidate => new ObservedSourceRootPlacement(
+                ResonitePlacementPolicy.Add(
+                    GetSlotPositionOrDefault(candidate.Slot),
+                    ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
+                IsExact: false,
+                ReferenceMeshCode: candidate.MeshCode,
+                SlotId: candidate.Slot.ID ?? string.Empty))
+            .OrderByDescending(static candidate => candidate.ReferenceMeshCode.Length)
             .ToArray();
         if (ancestorCandidates.Length == 0)
         {
-            (Slot Slot, string MeshCode)[] observedMeshCodeRoots = directSourceRoots
+            ObservedSourceRootPlacement[] observedMeshCodeRoots = directSourceRoots
                 .Select(static slot => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name?.Value ?? string.Empty, out string meshCode)
                     ? (Slot: slot, MeshCode: meshCode)
                     : default)
                 .Where(static candidate => candidate.Slot is not null)
+                .Select(candidate => new ObservedSourceRootPlacement(
+                    ResonitePlacementPolicy.Add(
+                        GetSlotPositionOrDefault(candidate.Slot),
+                        ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
+                    IsExact: false,
+                    ReferenceMeshCode: candidate.MeshCode,
+                    SlotId: candidate.Slot.ID ?? string.Empty))
+                .OrderBy(candidate => ComputeHorizontalDistanceSquared(
+                    ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.ReferenceMeshCode, rootMeshCode),
+                    new ResoniteFloat3(0.0, 0.0, 0.0)))
+                .ThenBy(static candidate => candidate.ReferenceMeshCode, StringComparer.Ordinal)
+                .ThenBy(static candidate => candidate.SlotId, StringComparer.Ordinal)
                 .ToArray();
-            if (observedMeshCodeRoots.Length == 1)
-            {
-                return ResonitePlacementPolicy.Add(
-                    GetSlotPositionOrDefault(observedMeshCodeRoots[0].Slot),
-                    ResonitePlacementPolicy.ComputeMeshCodeOffset(observedMeshCodeRoots[0].MeshCode, rootMeshCode));
-            }
-
-            return null;
+            return observedMeshCodeRoots.Length == 0
+                ? null
+                : observedMeshCodeRoots[0];
         }
 
-        int bestLength = ancestorCandidates[0].MeshCode.Length;
-        (Slot Slot, string MeshCode)[] bestCandidates = ancestorCandidates
-            .Where(candidate => candidate.MeshCode.Length == bestLength)
+        int bestLength = ancestorCandidates[0].ReferenceMeshCode.Length;
+        ObservedSourceRootPlacement[] bestCandidates = ancestorCandidates
+            .Where(candidate => candidate.ReferenceMeshCode.Length == bestLength)
             .ToArray();
-        if (bestCandidates.Length > 1)
-        {
-            throw new InvalidOperationException(
-                $"Dataset root contains multiple observed source roots for meshcode '{bestCandidates[0].MeshCode}'. Append placement is ambiguous.");
-        }
-
-        return ResonitePlacementPolicy.Add(
-            GetSlotPositionOrDefault(bestCandidates[0].Slot),
-            ResonitePlacementPolicy.ComputeMeshCodeOffset(bestCandidates[0].MeshCode, rootMeshCode));
+        return SelectDeterministicObservedPlacement(
+            bestCandidates,
+            $"Dataset root contains multiple observed source roots for meshcode '{bestCandidates[0].ReferenceMeshCode}' with different placements. Append placement is ambiguous.");
     }
 
     private ResoniteFloat3 ResolveTerrainResidual(
         string rootMeshCode,
         ResoniteConstructionCityObject cityObject)
     {
-        if (IsTerrainGridDem(cityObject))
-        {
-            ResoniteFloat3 terrainResidual = TryResolveObservedTerrainWorldPosition(rootMeshCode, cityObject.Transform.Position, out ResoniteFloat3 observedTerrainPosition)
-                ? CreateVerticalResidual(ResonitePlacementPolicy.Subtract(observedTerrainPosition, cityObject.Transform.Position))
-                : new ResoniteFloat3(0.0, 0.0, 0.0);
-            terrainResidualByRootMeshCode[rootMeshCode] = terrainResidual;
-            return terrainResidual;
-        }
-
-        if (terrainResidualByRootMeshCode.TryGetValue(rootMeshCode, out ResoniteFloat3? cachedResidual))
-        {
-            return cachedResidual;
-        }
-
-        ResoniteFloat3 inferredResidual = TryResolveObservedTerrainWorldPosition(rootMeshCode, cityObject.Transform.Position, out ResoniteFloat3 observedTerrain)
+        return TryResolveObservedTerrainLocalPosition(rootMeshCode, cityObject.Transform.Position, out ResoniteFloat3 observedTerrain)
             ? CreateVerticalResidual(ResonitePlacementPolicy.Subtract(observedTerrain, cityObject.Transform.Position))
             : new ResoniteFloat3(0.0, 0.0, 0.0);
-        terrainResidualByRootMeshCode.TryAdd(rootMeshCode, inferredResidual);
-        return inferredResidual;
     }
 
     private static ResoniteFloat3 CreateVerticalResidual(ResoniteFloat3 residual)
@@ -360,25 +353,24 @@ internal sealed class ResoniteSharedSlotIndex(
         return new ResoniteFloat3(0.0, residual.Y, 0.0);
     }
 
-    private bool TryResolveObservedTerrainWorldPosition(
+    private bool TryResolveObservedTerrainLocalPosition(
         string rootMeshCode,
         ResoniteFloat3 cityObjectPosition,
-        out ResoniteFloat3 worldPosition)
+        out ResoniteFloat3 localPosition)
     {
         const double maxDistanceSquared = 300.0 * 300.0;
-        worldPosition = new ResoniteFloat3(0.0, 0.0, 0.0);
-        string parentMeshCode = rootMeshCode.Length >= 6 ? rootMeshCode[..6] : rootMeshCode;
-        (Slot Slot, ResoniteFloat3 WorldPosition, double DistanceSquared)[] candidates = observedSlotSnapshotsById.Values
+        localPosition = new ResoniteFloat3(0.0, 0.0, 0.0);
+        (Slot Slot, ResoniteFloat3 LocalPosition, double DistanceSquared)[] candidates = observedSlotSnapshotsById.Values
             .Where(static slot => !string.IsNullOrWhiteSpace(slot.ID))
             .Where(slot => !createdSlotIds.ContainsKey(slot.ID!))
             .Where(HasGridMeshComponent)
             .Where(slot => !IsDescendantOf(slot.ID!, datasetAssetsRootSlot.Locator.Value))
             .Where(slot => TryGetDatasetSourceRoot(slot, out Slot? sourceRoot)
-                && IsDemSourceRootForMeshCode(sourceRoot, parentMeshCode))
+                && IsDemSourceRootForMeshCode(sourceRoot, rootMeshCode))
             .Select(slot =>
             {
-                ResoniteFloat3 candidateWorldPosition = GetAccumulatedPosition(slot);
-                return (Slot: slot, WorldPosition: candidateWorldPosition, DistanceSquared: ComputeHorizontalDistanceSquared(candidateWorldPosition, cityObjectPosition));
+                ResoniteFloat3 candidateLocalPosition = GetAccumulatedPositionRelativeToDatasetRoot(slot);
+                return (Slot: slot, LocalPosition: candidateLocalPosition, DistanceSquared: ComputeHorizontalDistanceSquared(candidateLocalPosition, cityObjectPosition));
             })
             .Where(static candidate => candidate.DistanceSquared <= maxDistanceSquared)
             .OrderBy(static candidate => candidate.DistanceSquared)
@@ -389,13 +381,15 @@ internal sealed class ResoniteSharedSlotIndex(
             return false;
         }
 
-        if (candidates.Length > 1 && Math.Abs(candidates[0].DistanceSquared - candidates[1].DistanceSquared) < 0.000001)
+        if (candidates.Length > 1
+            && Math.Abs(candidates[0].DistanceSquared - candidates[1].DistanceSquared) < 0.000001
+            && !AreEquivalentPositions(candidates[0].LocalPosition, candidates[1].LocalPosition))
         {
             throw new InvalidOperationException(
                 $"Dataset root contains multiple observed terrain grid slots for meshcode '{rootMeshCode}'. Append placement is ambiguous.");
         }
 
-        worldPosition = candidates[0].WorldPosition;
+        localPosition = candidates[0].LocalPosition;
         return true;
     }
 
@@ -407,10 +401,10 @@ internal sealed class ResoniteSharedSlotIndex(
             .Where(static slot => !string.Equals(slot.Name?.Value, "Assets", StringComparison.Ordinal));
     }
 
-    private static bool IsTerrainGridDem(ResoniteConstructionCityObject cityObject)
+    private static bool IsTerrainDem(ResoniteConstructionCityObject cityObject)
     {
         return string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
-            && cityObject.Geometry is ResoniteTerrainGridGeometry;
+            && cityObject.Geometry is ResoniteTerrainGridGeometry or ResoniteDynamicTerrainGeometry;
     }
 
     private static bool HasGridMeshComponent(Slot slot)
@@ -439,12 +433,12 @@ internal sealed class ResoniteSharedSlotIndex(
         return false;
     }
 
-    private static bool IsDemSourceRootForMeshCode(Slot sourceRoot, string parentMeshCode)
+    private static bool IsDemSourceRootForMeshCode(Slot sourceRoot, string requestedMeshCode)
     {
         string sourceRootName = sourceRoot.Name?.Value ?? string.Empty;
         return sourceRootName.Contains("dem", StringComparison.OrdinalIgnoreCase)
             && ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(sourceRootName, out string sourceRootMeshCode)
-            && parentMeshCode.StartsWith(sourceRootMeshCode, StringComparison.Ordinal);
+            && requestedMeshCode.StartsWith(sourceRootMeshCode, StringComparison.Ordinal);
     }
 
     private bool IsDescendantOf(string slotId, string ancestorSlotId)
@@ -481,6 +475,49 @@ internal sealed class ResoniteSharedSlotIndex(
         }
 
         return accumulated;
+    }
+
+    private ResoniteFloat3 GetAccumulatedPositionRelativeToDatasetRoot(Slot slot)
+    {
+        ResoniteFloat3 accumulated = new(0.0, 0.0, 0.0);
+        Slot? current = slot;
+        while (current is not null
+               && !string.Equals(current.ID, datasetRootSlot.Locator.Value, StringComparison.Ordinal))
+        {
+            accumulated = ResonitePlacementPolicy.Add(accumulated, GetSlotPositionOrDefault(current));
+            if (current.Parent is null
+                || string.IsNullOrWhiteSpace(current.Parent.TargetID)
+                || !observedSlotSnapshotsById.TryGetValue(current.Parent.TargetID, out current))
+            {
+                break;
+            }
+        }
+
+        return accumulated;
+    }
+
+    private static ObservedSourceRootPlacement SelectDeterministicObservedPlacement(
+        IReadOnlyCollection<ObservedSourceRootPlacement> candidates,
+        string ambiguousMessage)
+    {
+        ObservedSourceRootPlacement selected = candidates
+            .OrderBy(static candidate => candidate.ReferenceMeshCode, StringComparer.Ordinal)
+            .ThenBy(static candidate => candidate.SlotId, StringComparer.Ordinal)
+            .First();
+        if (candidates.Any(candidate => !AreEquivalentPositions(candidate.Position, selected.Position)))
+        {
+            throw new InvalidOperationException(ambiguousMessage);
+        }
+
+        return selected;
+    }
+
+    private static bool AreEquivalentPositions(ResoniteFloat3 left, ResoniteFloat3 right)
+    {
+        const double tolerance = 0.001;
+        return Math.Abs(left.X - right.X) <= tolerance
+            && Math.Abs(left.Y - right.Y) <= tolerance
+            && Math.Abs(left.Z - right.Z) <= tolerance;
     }
 
     private static double ComputeHorizontalDistanceSquared(ResoniteFloat3 left, ResoniteFloat3 right)
@@ -529,6 +566,12 @@ internal sealed class ResoniteSharedSlotIndex(
     private readonly record struct SourceRootPlacement(
         ResoniteFloat3 RootPosition,
         ResoniteFloat3 LocalPositionReferenceRoot);
+
+    private readonly record struct ObservedSourceRootPlacement(
+        ResoniteFloat3 Position,
+        bool IsExact,
+        string ReferenceMeshCode,
+        string SlotId);
 
     private readonly record struct CanonicalParentSourceFile(
         string SourceFileRelativePath,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -20,6 +20,9 @@ internal sealed class ResoniteSharedSlotIndex(
     SceneAnchor? initialSceneAnchor,
     Func<IResoniteLinkClient, ResoniteSlotLocator, string, ResoniteFloat3?, ResoniteFloatQ?, CancellationToken, Task<CreatedSlot>> createSlotAsync)
 {
+    private const double StrictPlacementEquivalenceTolerance = 0.001;
+    private const double SiblingProjectionDriftTolerance = 0.25;
+
     private readonly AsyncCompletedResultCache<SharedSlotIndexKey, CreatedSlot> sharedSlotCache = new();
     private readonly AsyncCompletedResultCache<SharedSlotIndexKey, CreatedSlot> runScopedSourceFileRootCache = new();
     private readonly AsyncCompletedResultCache<CanonicalParentSourceFile, CanonicalParentScope> canonicalParentScopeCache = new();
@@ -85,7 +88,7 @@ internal sealed class ResoniteSharedSlotIndex(
         string sourceFileRelativePath = ResonitePlacementPolicy.ResolveSourceFileRelativePath(cityObject);
         string sourceFileSlotName = ResonitePlacementPolicy.ResolveSourceFileSlotName(cityObject, sourceFileRelativePath, sourceFileSlotNamesByRelativePath);
         string rootMeshCode = ResonitePlacementPolicy.ResolveRequiredSourceFileRootMeshCode(sourceFileSlotName, cityObject.ActualMeshCode);
-        SourceRootPlacement sourceRootPlacement = ResolveSourceRootPlacement(sourceFileSlotName, rootMeshCode, cityObject);
+        SourceRootPlacement sourceRootPlacement = ResolveSourceRootPlacement(sourceFileSlotName, rootMeshCode);
         CanonicalParentScope parentScope = await canonicalParentScopeCache.GetOrCreateAsync(
             new CanonicalParentSourceFile(sourceFileRelativePath, rootMeshCode, cityObject.LodLevel),
             ct => CreateCanonicalParentScopeAsync(client, sourceFileSlotName, rootMeshCode, cityObject.LodLevel, sourceRootPlacement.RootPosition, ct),
@@ -256,18 +259,13 @@ internal sealed class ResoniteSharedSlotIndex(
 
     private SourceRootPlacement ResolveSourceRootPlacement(
         string sourceFileSlotName,
-        string rootMeshCode,
-        ResoniteConstructionCityObject cityObject)
+        string rootMeshCode)
     {
         ObservedSourceRootPlacement? observedRootPlacement = TryResolveObservedSourceRootPosition(sourceFileSlotName, rootMeshCode);
-        ResoniteFloat3 baseRootPosition = observedRootPlacement?.Position
+        ResoniteFloat3 rootPosition = observedRootPlacement?.Position
             ?? ResonitePlacementPolicy.ResolveMeshRootPosition(requestLocalOrigin, rootMeshCode);
-        ResoniteFloat3 terrainResidual = ResolveTerrainResidual(rootMeshCode, cityObject);
-        ResoniteFloat3 rootPosition = IsTerrainDem(cityObject) || observedRootPlacement?.IsExact == true
-            ? baseRootPosition
-            : ResonitePlacementPolicy.Add(baseRootPosition, terrainResidual);
 
-        return new SourceRootPlacement(rootPosition, baseRootPosition);
+        return new SourceRootPlacement(rootPosition, rootPosition);
     }
 
     private ObservedSourceRootPlacement? TryResolveObservedSourceRootPosition(
@@ -279,7 +277,6 @@ internal sealed class ResoniteSharedSlotIndex(
             .Where(slot => string.Equals(slot.Name?.Value, sourceFileSlotName, StringComparison.Ordinal))
             .Select(slot => new ObservedSourceRootPlacement(
                 GetSlotPositionOrDefault(slot),
-                IsExact: true,
                 ReferenceMeshCode: rootMeshCode,
                 SlotId: slot.ID ?? string.Empty))
             .ToArray();
@@ -287,7 +284,8 @@ internal sealed class ResoniteSharedSlotIndex(
         {
             return SelectDeterministicObservedPlacement(
                 exactSourceRoots,
-                $"Dataset root contains multiple observed source roots named '{sourceFileSlotName}' with different placements. Append placement is ambiguous.");
+                $"Dataset root contains multiple observed source roots named '{sourceFileSlotName}' with different placements. Append placement is ambiguous.",
+                StrictPlacementEquivalenceTolerance);
         }
 
         ObservedSourceRootPlacement[] ancestorCandidates = directSourceRoots
@@ -300,7 +298,6 @@ internal sealed class ResoniteSharedSlotIndex(
                 ResonitePlacementPolicy.Add(
                     GetSlotPositionOrDefault(candidate.Slot),
                     ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
-                IsExact: false,
                 ReferenceMeshCode: candidate.MeshCode,
                 SlotId: candidate.Slot.ID ?? string.Empty))
             .OrderByDescending(static candidate => candidate.ReferenceMeshCode.Length)
@@ -316,18 +313,15 @@ internal sealed class ResoniteSharedSlotIndex(
                     ResonitePlacementPolicy.Add(
                         GetSlotPositionOrDefault(candidate.Slot),
                         ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
-                    IsExact: false,
                     ReferenceMeshCode: candidate.MeshCode,
                     SlotId: candidate.Slot.ID ?? string.Empty))
-                .OrderBy(candidate => ComputeHorizontalDistanceSquared(
-                    ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.ReferenceMeshCode, rootMeshCode),
-                    new ResoniteFloat3(0.0, 0.0, 0.0)))
-                .ThenBy(static candidate => candidate.ReferenceMeshCode, StringComparer.Ordinal)
-                .ThenBy(static candidate => candidate.SlotId, StringComparer.Ordinal)
                 .ToArray();
             return observedMeshCodeRoots.Length == 0
                 ? null
-                : observedMeshCodeRoots[0];
+                : SelectDeterministicObservedPlacement(
+                    observedMeshCodeRoots,
+                    $"Dataset root contains multiple observed source roots that resolve different placements for meshcode '{rootMeshCode}'. Append placement is ambiguous.",
+                    SiblingProjectionDriftTolerance);
         }
 
         int bestLength = ancestorCandidates[0].ReferenceMeshCode.Length;
@@ -336,61 +330,8 @@ internal sealed class ResoniteSharedSlotIndex(
             .ToArray();
         return SelectDeterministicObservedPlacement(
             bestCandidates,
-            $"Dataset root contains multiple observed source roots for meshcode '{bestCandidates[0].ReferenceMeshCode}' with different placements. Append placement is ambiguous.");
-    }
-
-    private ResoniteFloat3 ResolveTerrainResidual(
-        string rootMeshCode,
-        ResoniteConstructionCityObject cityObject)
-    {
-        return TryResolveObservedTerrainLocalPosition(rootMeshCode, cityObject.Transform.Position, out ResoniteFloat3 observedTerrain)
-            ? CreateVerticalResidual(ResonitePlacementPolicy.Subtract(observedTerrain, cityObject.Transform.Position))
-            : new ResoniteFloat3(0.0, 0.0, 0.0);
-    }
-
-    private static ResoniteFloat3 CreateVerticalResidual(ResoniteFloat3 residual)
-    {
-        return new ResoniteFloat3(0.0, residual.Y, 0.0);
-    }
-
-    private bool TryResolveObservedTerrainLocalPosition(
-        string rootMeshCode,
-        ResoniteFloat3 cityObjectPosition,
-        out ResoniteFloat3 localPosition)
-    {
-        const double maxDistanceSquared = 300.0 * 300.0;
-        localPosition = new ResoniteFloat3(0.0, 0.0, 0.0);
-        (Slot Slot, ResoniteFloat3 LocalPosition, double DistanceSquared)[] candidates = observedSlotSnapshotsById.Values
-            .Where(static slot => !string.IsNullOrWhiteSpace(slot.ID))
-            .Where(slot => !createdSlotIds.ContainsKey(slot.ID!))
-            .Where(HasGridMeshComponent)
-            .Where(slot => !IsDescendantOf(slot.ID!, datasetAssetsRootSlot.Locator.Value))
-            .Where(slot => TryGetDatasetSourceRoot(slot, out Slot? sourceRoot)
-                && IsDemSourceRootForMeshCode(sourceRoot, rootMeshCode))
-            .Select(slot =>
-            {
-                ResoniteFloat3 candidateLocalPosition = GetAccumulatedPositionRelativeToDatasetRoot(slot);
-                return (Slot: slot, LocalPosition: candidateLocalPosition, DistanceSquared: ComputeHorizontalDistanceSquared(candidateLocalPosition, cityObjectPosition));
-            })
-            .Where(static candidate => candidate.DistanceSquared <= maxDistanceSquared)
-            .OrderBy(static candidate => candidate.DistanceSquared)
-            .ThenBy(static candidate => candidate.Slot.ID ?? string.Empty, StringComparer.Ordinal)
-            .ToArray();
-        if (candidates.Length == 0)
-        {
-            return false;
-        }
-
-        if (candidates.Length > 1
-            && Math.Abs(candidates[0].DistanceSquared - candidates[1].DistanceSquared) < 0.000001
-            && !AreEquivalentPositions(candidates[0].LocalPosition, candidates[1].LocalPosition))
-        {
-            throw new InvalidOperationException(
-                $"Dataset root contains multiple observed terrain grid slots for meshcode '{rootMeshCode}'. Append placement is ambiguous.");
-        }
-
-        localPosition = candidates[0].LocalPosition;
-        return true;
+            $"Dataset root contains multiple observed source roots for meshcode '{bestCandidates[0].ReferenceMeshCode}' with different placements. Append placement is ambiguous.",
+            StrictPlacementEquivalenceTolerance);
     }
 
     private IEnumerable<Slot> EnumerateObservedDatasetSourceRoots()
@@ -401,110 +342,17 @@ internal sealed class ResoniteSharedSlotIndex(
             .Where(static slot => !string.Equals(slot.Name?.Value, "Assets", StringComparison.Ordinal));
     }
 
-    private static bool IsTerrainDem(ResoniteConstructionCityObject cityObject)
-    {
-        return string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
-            && cityObject.Geometry is ResoniteTerrainGridGeometry or ResoniteDynamicTerrainGeometry;
-    }
-
-    private static bool HasGridMeshComponent(Slot slot)
-    {
-        return slot.Components?.Any(static component =>
-            string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.GridMesh", StringComparison.Ordinal)) == true;
-    }
-
-    private bool TryGetDatasetSourceRoot(Slot slot, out Slot sourceRoot)
-    {
-        sourceRoot = slot;
-        Slot current = slot;
-        while (current.Parent is not null
-               && !string.IsNullOrWhiteSpace(current.Parent.TargetID)
-               && observedSlotSnapshotsById.TryGetValue(current.Parent.TargetID, out Slot? parent))
-        {
-            if (string.Equals(parent.ID, datasetRootSlot.Locator.Value, StringComparison.Ordinal))
-            {
-                sourceRoot = current;
-                return true;
-            }
-
-            current = parent;
-        }
-
-        return false;
-    }
-
-    private static bool IsDemSourceRootForMeshCode(Slot sourceRoot, string requestedMeshCode)
-    {
-        string sourceRootName = sourceRoot.Name?.Value ?? string.Empty;
-        return sourceRootName.Contains("dem", StringComparison.OrdinalIgnoreCase)
-            && ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(sourceRootName, out string sourceRootMeshCode)
-            && requestedMeshCode.StartsWith(sourceRootMeshCode, StringComparison.Ordinal);
-    }
-
-    private bool IsDescendantOf(string slotId, string ancestorSlotId)
-    {
-        string? currentSlotId = slotId;
-        while (!string.IsNullOrWhiteSpace(currentSlotId)
-               && observedSlotSnapshotsById.TryGetValue(currentSlotId, out Slot? slot)
-               && slot.Parent is not null)
-        {
-            if (string.Equals(slot.Parent.TargetID, ancestorSlotId, StringComparison.Ordinal))
-            {
-                return true;
-            }
-
-            currentSlotId = slot.Parent.TargetID;
-        }
-
-        return false;
-    }
-
-    private ResoniteFloat3 GetAccumulatedPosition(Slot slot)
-    {
-        ResoniteFloat3 accumulated = new(0.0, 0.0, 0.0);
-        Slot? current = slot;
-        while (current is not null)
-        {
-            accumulated = ResonitePlacementPolicy.Add(accumulated, GetSlotPositionOrDefault(current));
-            if (current.Parent is null
-                || string.IsNullOrWhiteSpace(current.Parent.TargetID)
-                || !observedSlotSnapshotsById.TryGetValue(current.Parent.TargetID, out current))
-            {
-                break;
-            }
-        }
-
-        return accumulated;
-    }
-
-    private ResoniteFloat3 GetAccumulatedPositionRelativeToDatasetRoot(Slot slot)
-    {
-        ResoniteFloat3 accumulated = new(0.0, 0.0, 0.0);
-        Slot? current = slot;
-        while (current is not null
-               && !string.Equals(current.ID, datasetRootSlot.Locator.Value, StringComparison.Ordinal))
-        {
-            accumulated = ResonitePlacementPolicy.Add(accumulated, GetSlotPositionOrDefault(current));
-            if (current.Parent is null
-                || string.IsNullOrWhiteSpace(current.Parent.TargetID)
-                || !observedSlotSnapshotsById.TryGetValue(current.Parent.TargetID, out current))
-            {
-                break;
-            }
-        }
-
-        return accumulated;
-    }
 
     private static ObservedSourceRootPlacement SelectDeterministicObservedPlacement(
         IReadOnlyCollection<ObservedSourceRootPlacement> candidates,
-        string ambiguousMessage)
+        string ambiguousMessage,
+        double tolerance)
     {
         ObservedSourceRootPlacement selected = candidates
             .OrderBy(static candidate => candidate.ReferenceMeshCode, StringComparer.Ordinal)
             .ThenBy(static candidate => candidate.SlotId, StringComparer.Ordinal)
             .First();
-        if (candidates.Any(candidate => !AreEquivalentPositions(candidate.Position, selected.Position)))
+        if (candidates.Any(candidate => !AreEquivalentPositions(candidate.Position, selected.Position, tolerance)))
         {
             throw new InvalidOperationException(ambiguousMessage);
         }
@@ -512,19 +360,11 @@ internal sealed class ResoniteSharedSlotIndex(
         return selected;
     }
 
-    private static bool AreEquivalentPositions(ResoniteFloat3 left, ResoniteFloat3 right)
+    private static bool AreEquivalentPositions(ResoniteFloat3 left, ResoniteFloat3 right, double tolerance)
     {
-        const double tolerance = 0.001;
         return Math.Abs(left.X - right.X) <= tolerance
             && Math.Abs(left.Y - right.Y) <= tolerance
             && Math.Abs(left.Z - right.Z) <= tolerance;
-    }
-
-    private static double ComputeHorizontalDistanceSquared(ResoniteFloat3 left, ResoniteFloat3 right)
-    {
-        double x = left.X - right.X;
-        double z = left.Z - right.Z;
-        return (x * x) + (z * z);
     }
 
     private static Field_float3 CreateFloat3(ResoniteFloat3 value)
@@ -569,7 +409,6 @@ internal sealed class ResoniteSharedSlotIndex(
 
     private readonly record struct ObservedSourceRootPlacement(
         ResoniteFloat3 Position,
-        bool IsExact,
         string ReferenceMeshCode,
         string SlotId);
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -263,9 +263,20 @@ internal sealed class ResoniteSharedSlotIndex(
     {
         ObservedSourceRootPlacement? observedRootPlacement = TryResolveObservedSourceRootPosition(sourceFileSlotName, rootMeshCode);
         ResoniteFloat3 rootPosition = observedRootPlacement?.Position
+            ?? ResolveDatasetRootAnchoredSourceRootPosition(rootMeshCode)
             ?? ResonitePlacementPolicy.ResolveMeshRootPosition(requestLocalOrigin, rootMeshCode);
 
         return new SourceRootPlacement(rootPosition, rootPosition);
+    }
+
+    private ResoniteFloat3? ResolveDatasetRootAnchoredSourceRootPosition(string rootMeshCode)
+    {
+        if (SceneAnchor is not { ReferenceSourceFileRoot: null } anchor)
+        {
+            return null;
+        }
+
+        return ResonitePlacementPolicy.ComputeMeshCodeOffset(anchor.MeshCode, rootMeshCode);
     }
 
     private ObservedSourceRootPlacement? TryResolveObservedSourceRootPosition(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -27,6 +27,8 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     private const string SecondarySourceFile = $"udx/bldg/{SecondaryMeshCode}/plateau_{DatasetName}_bldg_{SecondaryMeshCode}.gml";
     private const string PrimaryDemSourceFile = $"udx/dem/{MeshCode}/plateau_{DatasetName}_dem_{MeshCode}.gml";
     private const string SecondaryDemSourceFile = $"udx/dem/{SecondaryMeshCode}/plateau_{DatasetName}_dem_{SecondaryMeshCode}.gml";
+    private const string ParentMeshCode = "533945";
+    private const string ParentDemSourceFile = $"udx/dem/{ParentMeshCode}/plateau_{DatasetName}_dem_{ParentMeshCode}.gml";
     private static readonly ResoniteLocalOrigin LocalOrigin = new(35.6875, 139.69375, 0.0);
 
     [Fact]
@@ -881,6 +883,87 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
+    public async Task ExecuteAsyncAppendPlacesBldgFromExistingParentDemSourceRootAndTerrainResidual()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ImportedSceneMetadata firstRunMetadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            ParentMeshCode,
+            datasetDirectory.Path,
+            RequireMeshCodeCenter(ParentMeshCode),
+            packageNames: ["dem"],
+            sourceFiles: [ParentDemSourceFile]);
+        ImportedSceneMetadata secondRunMetadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            RequireMeshCodeCenter(MeshCode),
+            packageNames: ["dem", "bldg"],
+            sourceFiles: [ParentDemSourceFile, PrimarySourceFile]);
+        using SceneSinkRecordingClient client = new();
+        using TemporaryDirectory firstWorkDirectory = new();
+        using TemporaryDirectory secondWorkDirectory = new();
+        ResoniteFloat3 firstRunDemWorldPosition = new(250.0, 4.0, 400.0);
+        ResoniteFloat3 secondRunDemWorldPosition = new(230.0, 9.0, 390.0);
+        ResoniteFloat3 sourceRootCorrection = new(16.5, 0.0, -47.25);
+
+        await using (ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(client))
+        {
+            _ = await ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(
+                importTarget,
+                firstRunMetadata,
+                firstWorkDirectory.Path,
+                [
+                    CreateTerrainGridDemCityObject(
+                        "parent-existing",
+                        actualMeshCode: MeshCode,
+                        sourceFileRelativePath: ParentDemSourceFile,
+                        worldPosition: firstRunDemWorldPosition),
+                ]);
+        }
+
+        Slot existingDemSourceRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(ParentDemSourceFile)}");
+        ResoniteFloat3 existingDemRootPosition = Add(GetSlotPosition(existingDemSourceRoot), sourceRootCorrection);
+        existingDemSourceRoot.Position = CreateFloat3(existingDemRootPosition);
+
+        await using (ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(client))
+        {
+            _ = await ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(
+                importTarget,
+                secondRunMetadata,
+                secondWorkDirectory.Path,
+                [
+                    CreateTerrainGridDemCityObject(
+                        "parent-appended",
+                        actualMeshCode: MeshCode,
+                        sourceFileRelativePath: ParentDemSourceFile,
+                        worldPosition: secondRunDemWorldPosition),
+                    CreateBundledTriangleCityObject(
+                        "bldg-appended",
+                        actualMeshCode: MeshCode,
+                        sourceFileRelativePath: PrimarySourceFile,
+                        worldPosition: secondRunDemWorldPosition),
+                ]);
+        }
+
+        Slot appendedDemSourceRoot = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(ParentDemSourceFile)}")
+            .Single(slot => !string.Equals(slot.ID, existingDemSourceRoot.ID, StringComparison.Ordinal));
+        Slot bldgSourceRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
+        ResoniteFloat3 parentToChildOffset = ComputeMeshCodeOffset(ParentMeshCode, MeshCode);
+        ResoniteFloat3 terrainResidual = new(0.0, firstRunDemWorldPosition.Y - secondRunDemWorldPosition.Y, 0.0);
+        ResoniteFloat3 expectedBldgRootPosition = Add(Add(existingDemRootPosition, parentToChildOffset), terrainResidual);
+
+        AssertNear(existingDemRootPosition, GetSlotPosition(appendedDemSourceRoot), 0.2);
+        AssertNear(expectedBldgRootPosition, GetSlotPosition(bldgSourceRoot), 0.2);
+    }
+
+    [Fact]
     public async Task CompleteAsyncReturnsLocationAnchoredToResolvedSourceFileRoot()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -1353,6 +1436,19 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
         return slot.Position is Field_float3 position
             ? new ResoniteFloat3(position.Value.x, position.Value.y, position.Value.z)
             : new ResoniteFloat3(0.0, 0.0, 0.0);
+    }
+
+    private static Field_float3 CreateFloat3(ResoniteFloat3 value)
+    {
+        return new Field_float3
+        {
+            Value = new float3
+            {
+                x = (float)value.X,
+                y = (float)value.Y,
+                z = (float)value.Z,
+            },
+        };
     }
 
     private static ResoniteFloat3 GetAccumulatedPosition(SceneSinkRecordingClient client, Slot slot)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -957,11 +957,19 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
         Slot bldgSourceRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
             client,
             $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
+        Slot bldgObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject bldg-appended");
         ResoniteFloat3 parentToChildOffset = ComputeMeshCodeOffset(ParentMeshCode, MeshCode);
         ResoniteFloat3 expectedBldgRootPosition = Add(existingDemRootPosition, parentToChildOffset);
+        ResoniteFloat3 expectedBldgLocalPosition = ResonitePlacementPolicy.ResolveCityObjectLocalPosition(
+            RequireMeshCodeCenter(MeshCode),
+            MeshCode,
+            expectedBldgRootPosition,
+            secondRunDemWorldPosition);
 
         AssertNear(existingDemRootPosition, GetSlotPosition(appendedDemSourceRoot), 0.2);
         AssertNear(expectedBldgRootPosition, GetSlotPosition(bldgSourceRoot), 0.2);
+        AssertNear(expectedBldgLocalPosition, GetSlotPosition(bldgObjectSlot), 0.2);
+        AssertNear(Add(expectedBldgRootPosition, expectedBldgLocalPosition), GetAccumulatedPosition(client, bldgObjectSlot), 0.2);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -1203,18 +1203,24 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
-    public async Task ExecuteAsyncAppendsIntoAssetsOnlyDatasetRootAndAnchorsFirstActualSourceFileRootAtDatasetRoot()
+    public async Task ExecuteAsyncAppendsIntoAssetsOnlyDatasetRootUsingDatasetRootLocalAnchor()
     {
         using TemporaryDirectory datasetDirectory = new();
         ImportedSceneMetadata metadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile, SecondarySourceFile]);
         using SceneSinkRecordingClient client = new();
         using TemporaryDirectory firstWorkDirectory = new();
         using TemporaryDirectory secondWorkDirectory = new();
+        ResoniteFloat3 datasetRootPosition = new(25.0, 6.0, -14.0);
+        ResoniteFloat3 primaryObjectPosition = new(4.0, 1.0, 8.0);
+        ResoniteFloat3 secondaryObjectPosition = new(10.0, 2.0, 20.0);
 
         await using (ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(client))
         {
             _ = await ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(importTarget, metadata, firstWorkDirectory.Path, []);
         }
+
+        Slot datasetRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(client, $"PLATEAU {DatasetName}");
+        datasetRoot.Position = CreateFloat3(datasetRootPosition);
 
         await using (ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(client))
         {
@@ -1224,27 +1230,38 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                 secondWorkDirectory.Path,
                 [
                     CreateBundledTriangleCityObject(
-                        "assets-only-append",
+                        "assets-only-primary",
+                        actualMeshCode: MeshCode,
+                        sourceFileRelativePath: PrimarySourceFile,
+                        worldPosition: primaryObjectPosition),
+                    CreateBundledTriangleCityObject(
+                        "assets-only-secondary",
                         actualMeshCode: SecondaryMeshCode,
                         sourceFileRelativePath: SecondarySourceFile,
-                        worldPosition: new ResoniteFloat3(10.0, 0.0, 20.0)),
+                        worldPosition: secondaryObjectPosition),
                 ]);
+            Slot primarySourceFileRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+                client,
+                $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
             Slot sourceFileRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
                 client,
                 $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(SecondarySourceFile)}");
             ResoniteFloat3 expectedRootOffset = ComputeMeshCodeOffset(MeshCode, SecondaryMeshCode);
-            Slot objectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject assets-only-append");
+            Slot primaryObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject assets-only-primary");
+            Slot secondaryObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject assets-only-secondary");
 
+            AssertNear(new ResoniteFloat3(0.0, 0.0, 0.0), GetSlotPosition(primarySourceFileRoot), 0.001);
             Assert.Equal(expectedRootOffset.X, GetSlotPosition(sourceFileRoot).X, 3);
             Assert.Equal(expectedRootOffset.Z, GetSlotPosition(sourceFileRoot).Z, 3);
-            AssertNear(new ResoniteFloat3(10.0, 0.0, 20.0), GetAccumulatedPosition(client, objectSlot), 0.2);
+            AssertNear(Add(datasetRootPosition, primaryObjectPosition), GetAccumulatedPosition(client, primaryObjectSlot), 0.2);
+            AssertNear(Add(datasetRootPosition, secondaryObjectPosition), GetAccumulatedPosition(client, secondaryObjectSlot), 0.2);
             string destination = Assert.Single(executionResult.Destinations);
             Assert.StartsWith("ws://localhost:12345/#", destination, StringComparison.Ordinal);
             string destinationAnchorId = GetDestinationAnchorId(destination);
             Assert.True(client.SlotsById.ContainsKey(destinationAnchorId));
             Assert.True(
-                string.Equals(destinationAnchorId, sourceFileRoot.ID, StringComparison.Ordinal)
-                || ResoniteLiveSceneImportTargetTestSupport.IsDescendantOf(client, sourceFileRoot.ID, destinationAnchorId));
+                string.Equals(destinationAnchorId, primarySourceFileRoot.ID, StringComparison.Ordinal)
+                || ResoniteLiveSceneImportTargetTestSupport.IsDescendantOf(client, primarySourceFileRoot.ID, destinationAnchorId));
         }
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -27,6 +27,9 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     private const string SecondarySourceFile = $"udx/bldg/{SecondaryMeshCode}/plateau_{DatasetName}_bldg_{SecondaryMeshCode}.gml";
     private const string PrimaryDemSourceFile = $"udx/dem/{MeshCode}/plateau_{DatasetName}_dem_{MeshCode}.gml";
     private const string SecondaryDemSourceFile = $"udx/dem/{SecondaryMeshCode}/plateau_{DatasetName}_dem_{SecondaryMeshCode}.gml";
+    private const string AlternateSourceFile = $"udx/bldg/{MeshCode}/plateau_{DatasetName}_bldg_{MeshCode}_alternate.gml";
+    private const string ThirdMeshCode = "53394527";
+    private const string ThirdSourceFile = $"udx/bldg/{ThirdMeshCode}/plateau_{DatasetName}_bldg_{ThirdMeshCode}.gml";
     private const string ParentMeshCode = "533945";
     private const string ParentDemSourceFile = $"udx/dem/{ParentMeshCode}/plateau_{DatasetName}_dem_{ParentMeshCode}.gml";
     private static readonly ResoniteLocalOrigin LocalOrigin = new(35.6875, 139.69375, 0.0);
@@ -964,6 +967,313 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
+    public async Task ExecuteAsyncRepeatedBldgAppendDoesNotReapplyTerrainResidualToExactRoot()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ImportedSceneMetadata demMetadata = CreateDemMetadata(datasetDirectory.Path, [PrimaryDemSourceFile]);
+        ImportedSceneMetadata bldgMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile]);
+        using SceneSinkRecordingClient client = new();
+        using TemporaryDirectory firstWorkDirectory = new();
+        using TemporaryDirectory secondWorkDirectory = new();
+        using TemporaryDirectory thirdWorkDirectory = new();
+        ResoniteFloat3 observedDemWorldPosition = new(100.0, 4.0, 100.0);
+        ResoniteFloat3 bldgWorldPosition = new(100.0, 9.0, 100.0);
+
+        await ExecuteImportAsync(
+            client,
+            demMetadata,
+            firstWorkDirectory.Path,
+            [CreateTerrainGridDemCityObject("exact-residual-dem", worldPosition: observedDemWorldPosition)]);
+        await ExecuteImportAsync(
+            client,
+            bldgMetadata,
+            secondWorkDirectory.Path,
+            [CreateBundledTriangleCityObject("exact-residual-bldg-one", worldPosition: bldgWorldPosition)]);
+
+        Slot firstBldgRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
+
+        await ExecuteImportAsync(
+            client,
+            bldgMetadata,
+            thirdWorkDirectory.Path,
+            [CreateBundledTriangleCityObject("exact-residual-bldg-two", worldPosition: bldgWorldPosition)]);
+
+        Slot secondBldgRoot = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}")
+            .Single(slot => !string.Equals(slot.ID, firstBldgRoot.ID, StringComparison.Ordinal));
+
+        AssertNear(GetSlotPosition(firstBldgRoot), GetSlotPosition(secondBldgRoot), 0.2);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncThirdAppendToleratesDuplicateExactSourceRootsWithSamePlacement()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ImportedSceneMetadata metadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile]);
+        using SceneSinkRecordingClient client = new();
+        using TemporaryDirectory firstWorkDirectory = new();
+        using TemporaryDirectory secondWorkDirectory = new();
+        using TemporaryDirectory thirdWorkDirectory = new();
+        ResoniteFloat3 worldPosition = new(10.0, 3.0, 20.0);
+
+        await ExecuteImportAsync(
+            client,
+            metadata,
+            firstWorkDirectory.Path,
+            [CreateBundledTriangleCityObject("duplicate-exact-one", worldPosition: worldPosition)]);
+        await ExecuteImportAsync(
+            client,
+            metadata,
+            secondWorkDirectory.Path,
+            [CreateBundledTriangleCityObject("duplicate-exact-two", worldPosition: worldPosition)]);
+        await ExecuteImportAsync(
+            client,
+            metadata,
+            thirdWorkDirectory.Path,
+            [CreateBundledTriangleCityObject("duplicate-exact-three", worldPosition: worldPosition)]);
+
+        Slot[] sourceRoots = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
+
+        Assert.Equal(3, sourceRoots.Length);
+        Assert.All(sourceRoots, sourceRoot => AssertNear(GetSlotPosition(sourceRoots[0]), GetSlotPosition(sourceRoot), 0.2));
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncAppendToleratesDuplicateParentAncestorRootsWithSamePlacement()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ImportedSceneMetadata demMetadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            ParentMeshCode,
+            datasetDirectory.Path,
+            RequireMeshCodeCenter(ParentMeshCode),
+            packageNames: ["dem"],
+            sourceFiles: [ParentDemSourceFile]);
+        ImportedSceneMetadata bldgMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile]);
+        using SceneSinkRecordingClient client = new();
+        using TemporaryDirectory firstWorkDirectory = new();
+        using TemporaryDirectory secondWorkDirectory = new();
+        using TemporaryDirectory thirdWorkDirectory = new();
+        ResoniteFloat3 parentPosition = new(20.0, 8.0, 30.0);
+
+        await ExecuteImportAsync(
+            client,
+            demMetadata,
+            firstWorkDirectory.Path,
+            [CreateTerrainGridDemCityObject("duplicate-parent-one", actualMeshCode: MeshCode, sourceFileRelativePath: ParentDemSourceFile, worldPosition: parentPosition)]);
+        Slot firstParentRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(ParentDemSourceFile)}");
+        await ExecuteImportAsync(
+            client,
+            demMetadata,
+            secondWorkDirectory.Path,
+            [CreateTerrainGridDemCityObject("duplicate-parent-two", actualMeshCode: MeshCode, sourceFileRelativePath: ParentDemSourceFile, worldPosition: parentPosition)]);
+        Slot secondParentRoot = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(ParentDemSourceFile)}")
+            .Single(slot => !string.Equals(slot.ID, firstParentRoot.ID, StringComparison.Ordinal));
+        secondParentRoot.Position = CreateFloat3(GetSlotPosition(firstParentRoot));
+
+        await ExecuteImportAsync(
+            client,
+            bldgMetadata,
+            thirdWorkDirectory.Path,
+            [CreateBundledTriangleCityObject("duplicate-parent-bldg", worldPosition: new ResoniteFloat3(20.0, 8.0, 30.0))]);
+
+        Slot bldgRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
+        ResoniteFloat3 expectedPosition = Add(GetSlotPosition(firstParentRoot), ComputeMeshCodeOffset(ParentMeshCode, MeshCode));
+        AssertNear(expectedPosition, GetSlotPosition(bldgRoot), 0.2);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncUsesExactEightDigitDemRootForTerrainResidual()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ImportedSceneMetadata demMetadata = CreateDemMetadata(datasetDirectory.Path, [PrimaryDemSourceFile]);
+        ImportedSceneMetadata bldgMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile]);
+        using SceneSinkRecordingClient client = new();
+        using TemporaryDirectory firstWorkDirectory = new();
+        using TemporaryDirectory secondWorkDirectory = new();
+        ResoniteFloat3 demWorldPosition = new(50.0, 4.0, 50.0);
+        ResoniteFloat3 bldgWorldPosition = new(50.0, 9.0, 50.0);
+
+        await ExecuteImportAsync(
+            client,
+            demMetadata,
+            firstWorkDirectory.Path,
+            [CreateTerrainGridDemCityObject("exact-eight-dem", worldPosition: demWorldPosition)]);
+        await ExecuteImportAsync(
+            client,
+            bldgMetadata,
+            secondWorkDirectory.Path,
+            [CreateBundledTriangleCityObject("exact-eight-bldg", worldPosition: bldgWorldPosition)]);
+
+        Slot demRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimaryDemSourceFile)}");
+        Slot bldgRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
+
+        AssertNear(new ResoniteFloat3(GetSlotPosition(demRoot).X, demWorldPosition.Y - bldgWorldPosition.Y, GetSlotPosition(demRoot).Z), GetSlotPosition(bldgRoot), 0.2);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncDoesNotShareTerrainResidualAcrossPositionsForSameRootMeshCode()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ImportedSceneMetadata demMetadata = CreateDemMetadata(datasetDirectory.Path, [PrimaryDemSourceFile]);
+        ImportedSceneMetadata bldgMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile, AlternateSourceFile]);
+        using SceneSinkRecordingClient client = new();
+        using TemporaryDirectory firstWorkDirectory = new();
+        using TemporaryDirectory secondWorkDirectory = new();
+        ResoniteFloat3 firstDemPosition = new(40.0, 4.0, 40.0);
+        ResoniteFloat3 secondDemPosition = new(240.0, 18.0, 240.0);
+        ResoniteFloat3 firstBldgPosition = new(40.0, 9.0, 40.0);
+        ResoniteFloat3 secondBldgPosition = new(240.0, 7.0, 240.0);
+
+        await ExecuteImportAsync(
+            client,
+            demMetadata,
+            firstWorkDirectory.Path,
+            [
+                CreateTerrainGridDemCityObject("residual-cache-dem-one", worldPosition: firstDemPosition),
+                CreateTerrainGridDemCityObject("residual-cache-dem-two", worldPosition: secondDemPosition),
+            ]);
+        await ExecuteImportAsync(
+            client,
+            bldgMetadata,
+            secondWorkDirectory.Path,
+            [
+                CreateBundledTriangleCityObject("residual-cache-bldg-one", sourceFileRelativePath: PrimarySourceFile, worldPosition: firstBldgPosition),
+                CreateBundledTriangleCityObject("residual-cache-bldg-two", sourceFileRelativePath: AlternateSourceFile, worldPosition: secondBldgPosition),
+            ]);
+
+        Slot primaryRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
+        Slot alternateRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(AlternateSourceFile)}");
+
+        Assert.Equal(firstDemPosition.Y - firstBldgPosition.Y, GetSlotPosition(primaryRoot).Y, 1);
+        Assert.Equal(secondDemPosition.Y - secondBldgPosition.Y, GetSlotPosition(alternateRoot).Y, 1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncTreatsDynamicDemAsTerrainDemForAppendPlacement()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ImportedSceneMetadata metadata = CreateDemMetadata(datasetDirectory.Path, [PrimaryDemSourceFile]);
+        using SceneSinkRecordingClient client = new();
+        using TemporaryDirectory firstWorkDirectory = new();
+        using TemporaryDirectory secondWorkDirectory = new();
+
+        await ExecuteImportAsync(
+            client,
+            metadata,
+            firstWorkDirectory.Path,
+            [CreateTerrainGridDemCityObject("dynamic-dem-existing", worldPosition: new ResoniteFloat3(20.0, 4.0, 20.0))]);
+        Slot firstDemRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimaryDemSourceFile)}");
+        firstDemRoot.Position = CreateFloat3(new ResoniteFloat3(GetSlotPosition(firstDemRoot).X, 12.0, GetSlotPosition(firstDemRoot).Z));
+
+        await ExecuteImportAsync(
+            client,
+            metadata,
+            secondWorkDirectory.Path,
+            [CreateDynamicTerrainDemCityObject("dynamic-dem-append", worldPosition: new ResoniteFloat3(20.0, 20.0, 20.0))]);
+
+        Slot secondDemRoot = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimaryDemSourceFile)}")
+            .Single(slot => !string.Equals(slot.ID, firstDemRoot.ID, StringComparison.Ordinal));
+        AssertNear(GetSlotPosition(firstDemRoot), GetSlotPosition(secondDemRoot), 0.2);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncTerrainResidualIgnoresDatasetRootTranslation()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ImportedSceneMetadata demMetadata = CreateDemMetadata(datasetDirectory.Path, [PrimaryDemSourceFile]);
+        ImportedSceneMetadata bldgMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile]);
+        using SceneSinkRecordingClient client = new();
+        using TemporaryDirectory firstWorkDirectory = new();
+        using TemporaryDirectory secondWorkDirectory = new();
+        ResoniteFloat3 demWorldPosition = new(60.0, 4.0, 60.0);
+        ResoniteFloat3 bldgWorldPosition = new(60.0, 9.0, 60.0);
+
+        await ExecuteImportAsync(
+            client,
+            demMetadata,
+            firstWorkDirectory.Path,
+            [CreateTerrainGridDemCityObject("dataset-root-offset-dem", worldPosition: demWorldPosition)]);
+        Slot datasetRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(client, $"PLATEAU {DatasetName}");
+        datasetRoot.Position = CreateFloat3(new ResoniteFloat3(0.0, 100.0, 0.0));
+
+        await ExecuteImportAsync(
+            client,
+            bldgMetadata,
+            secondWorkDirectory.Path,
+            [CreateBundledTriangleCityObject("dataset-root-offset-bldg", worldPosition: bldgWorldPosition)]);
+
+        Slot bldgRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
+        Assert.Equal(demWorldPosition.Y - bldgWorldPosition.Y, GetSlotPosition(bldgRoot).Y, 1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncSiblingAppendUsesObservedRootWhenNoAncestorExists()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ImportedSceneMetadata firstRunMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile, SecondarySourceFile]);
+        ImportedSceneMetadata secondRunMetadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            ThirdMeshCode,
+            datasetDirectory.Path,
+            RequireMeshCodeCenter(ThirdMeshCode),
+            packageNames: ["bldg"],
+            sourceFiles: [ThirdSourceFile]);
+        using SceneSinkRecordingClient client = new();
+        using TemporaryDirectory firstWorkDirectory = new();
+        using TemporaryDirectory secondWorkDirectory = new();
+
+        await ExecuteImportAsync(
+            client,
+            firstRunMetadata,
+            firstWorkDirectory.Path,
+            [
+                CreateBundledTriangleCityObject("sibling-base-primary", actualMeshCode: MeshCode, sourceFileRelativePath: PrimarySourceFile),
+                CreateBundledTriangleCityObject("sibling-base-secondary", actualMeshCode: SecondaryMeshCode, sourceFileRelativePath: SecondarySourceFile),
+            ]);
+        await ExecuteImportAsync(
+            client,
+            secondRunMetadata,
+            secondWorkDirectory.Path,
+            [CreateBundledTriangleCityObject("sibling-append-third", actualMeshCode: ThirdMeshCode, sourceFileRelativePath: ThirdSourceFile)]);
+
+        Slot secondaryRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(SecondarySourceFile)}");
+        Slot thirdRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(ThirdSourceFile)}");
+        ResoniteFloat3 expectedPosition = Add(GetSlotPosition(secondaryRoot), ComputeMeshCodeOffset(SecondaryMeshCode, ThirdMeshCode));
+
+        AssertNear(expectedPosition, GetSlotPosition(thirdRoot), 0.2);
+    }
+
+    [Fact]
     public async Task CompleteAsyncReturnsLocationAnchoredToResolvedSourceFileRoot()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -1179,6 +1489,20 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             sourceFiles: sourceFiles ?? [PrimaryDemSourceFile]);
     }
 
+    private static async Task ExecuteImportAsync(
+        SceneSinkRecordingClient client,
+        ImportedSceneMetadata metadata,
+        string workDirectory,
+        IReadOnlyList<ResoniteConstructionCityObject> cityObjects)
+    {
+        await using ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(client);
+        _ = await ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(
+            importTarget,
+            metadata,
+            workDirectory,
+            cityObjects);
+    }
+
     private static ResoniteConstructionCityObject CreateBundledTriangleCityObject(
         string objectIdentity,
         ResoniteFloat2? textureScale = null,
@@ -1329,6 +1653,27 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     SubmeshIndices: [0]),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
+    }
+
+    private static ResoniteConstructionCityObject CreateDynamicTerrainDemCityObject(
+        string objectIdentity,
+        string actualMeshCode = MeshCode,
+        string sourceFileRelativePath = PrimaryDemSourceFile,
+        ResoniteFloat3? worldPosition = null)
+    {
+        return CreateTerrainGridDemCityObject(objectIdentity, actualMeshCode, sourceFileRelativePath, worldPosition) with
+        {
+            DisplayName = $"DEM Dynamic Terrain {objectIdentity}",
+            Geometry = new ResoniteDynamicTerrainGeometry(
+                new ResoniteTriangleMeshGeometry(ResoniteLiveSceneImportTargetTestSupport.CreateTriangleMesh()),
+                new ResoniteTerrainGridGeometry(
+                    Width: 2,
+                    Height: 2,
+                    Size: new ResoniteFloat2(10.0, 10.0),
+                    MinHeight: 0.0,
+                    MaxHeight: 3.0,
+                    HeightSamples: [0.0, 1.0, 2.0, 3.0])),
+        };
     }
 
     private static ResoniteConstructionCityObject CreateVertexColorTriangleCityObject(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -27,7 +27,6 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     private const string SecondarySourceFile = $"udx/bldg/{SecondaryMeshCode}/plateau_{DatasetName}_bldg_{SecondaryMeshCode}.gml";
     private const string PrimaryDemSourceFile = $"udx/dem/{MeshCode}/plateau_{DatasetName}_dem_{MeshCode}.gml";
     private const string SecondaryDemSourceFile = $"udx/dem/{SecondaryMeshCode}/plateau_{DatasetName}_dem_{SecondaryMeshCode}.gml";
-    private const string AlternateSourceFile = $"udx/bldg/{MeshCode}/plateau_{DatasetName}_bldg_{MeshCode}_alternate.gml";
     private const string ThirdMeshCode = "53394527";
     private const string ThirdSourceFile = $"udx/bldg/{ThirdMeshCode}/plateau_{DatasetName}_bldg_{ThirdMeshCode}.gml";
     private const string ParentMeshCode = "533945";
@@ -886,7 +885,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
-    public async Task ExecuteAsyncAppendPlacesBldgFromExistingParentDemSourceRootAndTerrainResidual()
+    public async Task ExecuteAsyncAppendPlacesBldgFromExistingParentSourceRoot()
     {
         using TemporaryDirectory datasetDirectory = new();
         ImportedSceneMetadata firstRunMetadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
@@ -959,53 +958,46 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             client,
             $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
         ResoniteFloat3 parentToChildOffset = ComputeMeshCodeOffset(ParentMeshCode, MeshCode);
-        ResoniteFloat3 terrainResidual = new(0.0, firstRunDemWorldPosition.Y - secondRunDemWorldPosition.Y, 0.0);
-        ResoniteFloat3 expectedBldgRootPosition = Add(Add(existingDemRootPosition, parentToChildOffset), terrainResidual);
+        ResoniteFloat3 expectedBldgRootPosition = Add(existingDemRootPosition, parentToChildOffset);
 
         AssertNear(existingDemRootPosition, GetSlotPosition(appendedDemSourceRoot), 0.2);
         AssertNear(expectedBldgRootPosition, GetSlotPosition(bldgSourceRoot), 0.2);
     }
 
     [Fact]
-    public async Task ExecuteAsyncRepeatedBldgAppendDoesNotReapplyTerrainResidualToExactRoot()
+    public async Task ExecuteAsyncRepeatedBldgAppendUsesExactObservedRootPosition()
     {
         using TemporaryDirectory datasetDirectory = new();
-        ImportedSceneMetadata demMetadata = CreateDemMetadata(datasetDirectory.Path, [PrimaryDemSourceFile]);
         ImportedSceneMetadata bldgMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile]);
         using SceneSinkRecordingClient client = new();
         using TemporaryDirectory firstWorkDirectory = new();
         using TemporaryDirectory secondWorkDirectory = new();
-        using TemporaryDirectory thirdWorkDirectory = new();
-        ResoniteFloat3 observedDemWorldPosition = new(100.0, 4.0, 100.0);
         ResoniteFloat3 bldgWorldPosition = new(100.0, 9.0, 100.0);
 
         await ExecuteImportAsync(
             client,
-            demMetadata,
-            firstWorkDirectory.Path,
-            [CreateTerrainGridDemCityObject("exact-residual-dem", worldPosition: observedDemWorldPosition)]);
-        await ExecuteImportAsync(
-            client,
             bldgMetadata,
-            secondWorkDirectory.Path,
-            [CreateBundledTriangleCityObject("exact-residual-bldg-one", worldPosition: bldgWorldPosition)]);
+            firstWorkDirectory.Path,
+            [CreateBundledTriangleCityObject("exact-root-bldg-one", worldPosition: bldgWorldPosition)]);
 
         Slot firstBldgRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
             client,
             $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
+        ResoniteFloat3 correctedRootPosition = new(14.0, 6.0, -9.0);
+        firstBldgRoot.Position = CreateFloat3(correctedRootPosition);
 
         await ExecuteImportAsync(
             client,
             bldgMetadata,
-            thirdWorkDirectory.Path,
-            [CreateBundledTriangleCityObject("exact-residual-bldg-two", worldPosition: bldgWorldPosition)]);
+            secondWorkDirectory.Path,
+            [CreateBundledTriangleCityObject("exact-root-bldg-two", worldPosition: bldgWorldPosition)]);
 
         Slot secondBldgRoot = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
             client,
             $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}")
             .Single(slot => !string.Equals(slot.ID, firstBldgRoot.ID, StringComparison.Ordinal));
 
-        AssertNear(GetSlotPosition(firstBldgRoot), GetSlotPosition(secondBldgRoot), 0.2);
+        AssertNear(correctedRootPosition, GetSlotPosition(secondBldgRoot), 0.2);
     }
 
     [Fact]
@@ -1094,145 +1086,6 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
-    public async Task ExecuteAsyncUsesExactEightDigitDemRootForTerrainResidual()
-    {
-        using TemporaryDirectory datasetDirectory = new();
-        ImportedSceneMetadata demMetadata = CreateDemMetadata(datasetDirectory.Path, [PrimaryDemSourceFile]);
-        ImportedSceneMetadata bldgMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile]);
-        using SceneSinkRecordingClient client = new();
-        using TemporaryDirectory firstWorkDirectory = new();
-        using TemporaryDirectory secondWorkDirectory = new();
-        ResoniteFloat3 demWorldPosition = new(50.0, 4.0, 50.0);
-        ResoniteFloat3 bldgWorldPosition = new(50.0, 9.0, 50.0);
-
-        await ExecuteImportAsync(
-            client,
-            demMetadata,
-            firstWorkDirectory.Path,
-            [CreateTerrainGridDemCityObject("exact-eight-dem", worldPosition: demWorldPosition)]);
-        await ExecuteImportAsync(
-            client,
-            bldgMetadata,
-            secondWorkDirectory.Path,
-            [CreateBundledTriangleCityObject("exact-eight-bldg", worldPosition: bldgWorldPosition)]);
-
-        Slot demRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimaryDemSourceFile)}");
-        Slot bldgRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
-
-        AssertNear(new ResoniteFloat3(GetSlotPosition(demRoot).X, demWorldPosition.Y - bldgWorldPosition.Y, GetSlotPosition(demRoot).Z), GetSlotPosition(bldgRoot), 0.2);
-    }
-
-    [Fact]
-    public async Task ExecuteAsyncDoesNotShareTerrainResidualAcrossPositionsForSameRootMeshCode()
-    {
-        using TemporaryDirectory datasetDirectory = new();
-        ImportedSceneMetadata demMetadata = CreateDemMetadata(datasetDirectory.Path, [PrimaryDemSourceFile]);
-        ImportedSceneMetadata bldgMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile, AlternateSourceFile]);
-        using SceneSinkRecordingClient client = new();
-        using TemporaryDirectory firstWorkDirectory = new();
-        using TemporaryDirectory secondWorkDirectory = new();
-        ResoniteFloat3 firstDemPosition = new(40.0, 4.0, 40.0);
-        ResoniteFloat3 secondDemPosition = new(240.0, 18.0, 240.0);
-        ResoniteFloat3 firstBldgPosition = new(40.0, 9.0, 40.0);
-        ResoniteFloat3 secondBldgPosition = new(240.0, 7.0, 240.0);
-
-        await ExecuteImportAsync(
-            client,
-            demMetadata,
-            firstWorkDirectory.Path,
-            [
-                CreateTerrainGridDemCityObject("residual-cache-dem-one", worldPosition: firstDemPosition),
-                CreateTerrainGridDemCityObject("residual-cache-dem-two", worldPosition: secondDemPosition),
-            ]);
-        await ExecuteImportAsync(
-            client,
-            bldgMetadata,
-            secondWorkDirectory.Path,
-            [
-                CreateBundledTriangleCityObject("residual-cache-bldg-one", sourceFileRelativePath: PrimarySourceFile, worldPosition: firstBldgPosition),
-                CreateBundledTriangleCityObject("residual-cache-bldg-two", sourceFileRelativePath: AlternateSourceFile, worldPosition: secondBldgPosition),
-            ]);
-
-        Slot primaryRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
-        Slot alternateRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(AlternateSourceFile)}");
-
-        Assert.Equal(firstDemPosition.Y - firstBldgPosition.Y, GetSlotPosition(primaryRoot).Y, 1);
-        Assert.Equal(secondDemPosition.Y - secondBldgPosition.Y, GetSlotPosition(alternateRoot).Y, 1);
-    }
-
-    [Fact]
-    public async Task ExecuteAsyncTreatsDynamicDemAsTerrainDemForAppendPlacement()
-    {
-        using TemporaryDirectory datasetDirectory = new();
-        ImportedSceneMetadata metadata = CreateDemMetadata(datasetDirectory.Path, [PrimaryDemSourceFile]);
-        using SceneSinkRecordingClient client = new();
-        using TemporaryDirectory firstWorkDirectory = new();
-        using TemporaryDirectory secondWorkDirectory = new();
-
-        await ExecuteImportAsync(
-            client,
-            metadata,
-            firstWorkDirectory.Path,
-            [CreateTerrainGridDemCityObject("dynamic-dem-existing", worldPosition: new ResoniteFloat3(20.0, 4.0, 20.0))]);
-        Slot firstDemRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimaryDemSourceFile)}");
-        firstDemRoot.Position = CreateFloat3(new ResoniteFloat3(GetSlotPosition(firstDemRoot).X, 12.0, GetSlotPosition(firstDemRoot).Z));
-
-        await ExecuteImportAsync(
-            client,
-            metadata,
-            secondWorkDirectory.Path,
-            [CreateDynamicTerrainDemCityObject("dynamic-dem-append", worldPosition: new ResoniteFloat3(20.0, 20.0, 20.0))]);
-
-        Slot secondDemRoot = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimaryDemSourceFile)}")
-            .Single(slot => !string.Equals(slot.ID, firstDemRoot.ID, StringComparison.Ordinal));
-        AssertNear(GetSlotPosition(firstDemRoot), GetSlotPosition(secondDemRoot), 0.2);
-    }
-
-    [Fact]
-    public async Task ExecuteAsyncTerrainResidualIgnoresDatasetRootTranslation()
-    {
-        using TemporaryDirectory datasetDirectory = new();
-        ImportedSceneMetadata demMetadata = CreateDemMetadata(datasetDirectory.Path, [PrimaryDemSourceFile]);
-        ImportedSceneMetadata bldgMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile]);
-        using SceneSinkRecordingClient client = new();
-        using TemporaryDirectory firstWorkDirectory = new();
-        using TemporaryDirectory secondWorkDirectory = new();
-        ResoniteFloat3 demWorldPosition = new(60.0, 4.0, 60.0);
-        ResoniteFloat3 bldgWorldPosition = new(60.0, 9.0, 60.0);
-
-        await ExecuteImportAsync(
-            client,
-            demMetadata,
-            firstWorkDirectory.Path,
-            [CreateTerrainGridDemCityObject("dataset-root-offset-dem", worldPosition: demWorldPosition)]);
-        Slot datasetRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(client, $"PLATEAU {DatasetName}");
-        datasetRoot.Position = CreateFloat3(new ResoniteFloat3(0.0, 100.0, 0.0));
-
-        await ExecuteImportAsync(
-            client,
-            bldgMetadata,
-            secondWorkDirectory.Path,
-            [CreateBundledTriangleCityObject("dataset-root-offset-bldg", worldPosition: bldgWorldPosition)]);
-
-        Slot bldgRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
-        Assert.Equal(demWorldPosition.Y - bldgWorldPosition.Y, GetSlotPosition(bldgRoot).Y, 1);
-    }
-
-    [Fact]
     public async Task ExecuteAsyncSiblingAppendUsesObservedRootWhenNoAncestorExists()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -1262,15 +1115,58 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             secondWorkDirectory.Path,
             [CreateBundledTriangleCityObject("sibling-append-third", actualMeshCode: ThirdMeshCode, sourceFileRelativePath: ThirdSourceFile)]);
 
+        Slot primaryRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
         Slot secondaryRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
             client,
             $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(SecondarySourceFile)}");
         Slot thirdRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
             client,
             $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(ThirdSourceFile)}");
-        ResoniteFloat3 expectedPosition = Add(GetSlotPosition(secondaryRoot), ComputeMeshCodeOffset(SecondaryMeshCode, ThirdMeshCode));
+        ResoniteFloat3 expectedFromPrimary = Add(GetSlotPosition(primaryRoot), ComputeMeshCodeOffset(MeshCode, ThirdMeshCode));
+        ResoniteFloat3 expectedFromSecondary = Add(GetSlotPosition(secondaryRoot), ComputeMeshCodeOffset(SecondaryMeshCode, ThirdMeshCode));
 
-        AssertNear(expectedPosition, GetSlotPosition(thirdRoot), 0.2);
+        AssertNear(expectedFromPrimary, expectedFromSecondary, 0.25);
+        AssertNear(expectedFromPrimary, GetSlotPosition(thirdRoot), 0.2);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncSiblingAppendRejectsObservedRootsWithDifferentCoordinateFrames()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ImportedSceneMetadata firstRunMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile, SecondarySourceFile]);
+        ImportedSceneMetadata secondRunMetadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            ThirdMeshCode,
+            datasetDirectory.Path,
+            RequireMeshCodeCenter(ThirdMeshCode),
+            packageNames: ["bldg"],
+            sourceFiles: [ThirdSourceFile]);
+        using SceneSinkRecordingClient client = new();
+        using TemporaryDirectory firstWorkDirectory = new();
+        using TemporaryDirectory secondWorkDirectory = new();
+
+        await ExecuteImportAsync(
+            client,
+            firstRunMetadata,
+            firstWorkDirectory.Path,
+            [
+                CreateBundledTriangleCityObject("sibling-ambiguous-primary", actualMeshCode: MeshCode, sourceFileRelativePath: PrimarySourceFile),
+                CreateBundledTriangleCityObject("sibling-ambiguous-secondary", actualMeshCode: SecondaryMeshCode, sourceFileRelativePath: SecondarySourceFile),
+            ]);
+        Slot secondaryRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(SecondarySourceFile)}");
+        ResoniteFloat3 shiftedSecondaryRoot = Add(GetSlotPosition(secondaryRoot), new ResoniteFloat3(1.0, 0.0, 0.0));
+        secondaryRoot.Position = CreateFloat3(shiftedSecondaryRoot);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() => ExecuteImportAsync(
+            client,
+            secondRunMetadata,
+            secondWorkDirectory.Path,
+            [CreateBundledTriangleCityObject("sibling-ambiguous-third", actualMeshCode: ThirdMeshCode, sourceFileRelativePath: ThirdSourceFile)]));
+        Assert.Contains("Append placement is ambiguous", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1653,27 +1549,6 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     SubmeshIndices: [0]),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
-    }
-
-    private static ResoniteConstructionCityObject CreateDynamicTerrainDemCityObject(
-        string objectIdentity,
-        string actualMeshCode = MeshCode,
-        string sourceFileRelativePath = PrimaryDemSourceFile,
-        ResoniteFloat3? worldPosition = null)
-    {
-        return CreateTerrainGridDemCityObject(objectIdentity, actualMeshCode, sourceFileRelativePath, worldPosition) with
-        {
-            DisplayName = $"DEM Dynamic Terrain {objectIdentity}",
-            Geometry = new ResoniteDynamicTerrainGeometry(
-                new ResoniteTriangleMeshGeometry(ResoniteLiveSceneImportTargetTestSupport.CreateTriangleMesh()),
-                new ResoniteTerrainGridGeometry(
-                    Width: 2,
-                    Height: 2,
-                    Size: new ResoniteFloat2(10.0, 10.0),
-                    MinHeight: 0.0,
-                    MaxHeight: 3.0,
-                    HeightSamples: [0.0, 1.0, 2.0, 3.0])),
-        };
     }
 
     private static ResoniteConstructionCityObject CreateVertexColorTriangleCityObject(


### PR DESCRIPTION
## Summary
- derive append source-root placement from the setup snapshot's observed non-Assets source roots instead of the completion anchor
- preserve run-scoped source roots while copying existing parent DEM root placement for overlapping appends
- apply only vertical terrain residual from observed DEM terrain to colocated non-DEM append roots, avoiding double horizontal correction

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false