### PR TITLE
Extract CityGML surface reader

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -121,7 +121,7 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
                     continue;
                 }
 
-                List<Float2> coordinates = LocalCityGmlObjectProjection.ParseTextureCoordinates(textureCoordinatesElement.Value);
+                List<Float2> coordinates = CityGmlCoordinateTextParser.ParseTextureCoordinates(textureCoordinatesElement.Value);
                 if (coordinates.Count > 0)
                 {
                     ringCoordinates[ringId] = coordinates;
@@ -330,7 +330,7 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
     {
         try
         {
-            return LocalCityGmlObjectProjection.ParseDoubles(value);
+            return CityGmlCoordinateTextParser.ParseDoubles(value);
         }
         catch (FormatException)
         {

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlCoordinateTextParser.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlCoordinateTextParser.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityGmlCoordinateTextParser
+{
+    internal static double[] ParseDoubles(string value)
+    {
+        return value
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
+            .Select(token => double.Parse(token, CultureInfo.InvariantCulture))
+            .ToArray();
+    }
+
+    internal static List<Float2> ParseTextureCoordinates(string value)
+    {
+        double[] ordinates = ParseDoubles(value);
+        List<Float2> coordinates = [];
+        for (int index = 0; index + 1 < ordinates.Length; index += 2)
+        {
+            coordinates.Add(new Float2(ordinates[index], ordinates[index + 1]));
+        }
+
+        if (coordinates.Count > 1 && AreSameUV(coordinates[0], coordinates[^1]))
+        {
+            coordinates.RemoveAt(coordinates.Count - 1);
+        }
+
+        return coordinates;
+    }
+
+    private static bool AreSameUV(Float2 left, Float2 right)
+    {
+        return Math.Abs(left.X - right.X) < 1e-8
+            && Math.Abs(left.Y - right.Y) < 1e-8;
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedSurfaceReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedSurfaceReader.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml.Linq;
+
+using ProjectionParsedRing = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedRing;
+using ProjectionParsedSurface = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedSurface;
+using ProjectionParsedSurfaceSemantic = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedSurfaceSemantic;
+using ProjectionGeodeticPoint = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.GeodeticPoint;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityGmlParsedSurfaceReader
+{
+    private static readonly XNamespace Gml = "http://www.opengis.net/gml";
+
+    internal static ProjectionParsedSurface? Parse(XElement polygonElement, ICityGmlAppearanceStore appearanceStore)
+    {
+        ArgumentNullException.ThrowIfNull(polygonElement);
+        ArgumentNullException.ThrowIfNull(appearanceStore);
+
+        XElement? exteriorRing = polygonElement
+            .Element(Gml + "exterior")
+            ?.Element(Gml + "LinearRing");
+        if (exteriorRing is null)
+        {
+            return null;
+        }
+
+        string polygonId = GetAttribute(polygonElement, Gml + "id") ?? CreateStableElementId("polygon", polygonElement);
+        CityGmlResolvedAppearance appearance = appearanceStore.Resolve(polygonId);
+        ProjectionParsedRing? exteriorParsedRing = ParseRing(
+            exteriorRing,
+            appearance.RingUvsByRingId,
+            fallbackRingId: polygonId);
+        if (exteriorParsedRing is null)
+        {
+            return null;
+        }
+
+        ProjectionParsedRing[] interiorRings = polygonElement
+            .Elements(Gml + "interior")
+            .Select(interiorElement => ParseRing(
+                interiorElement.Element(Gml + "LinearRing"),
+                appearance.RingUvsByRingId,
+                fallbackRingId: null))
+            .Where(static ring => ring is not null)
+            .Select(static ring => ring!)
+            .ToArray();
+
+        return new ProjectionParsedSurface(
+            PolygonId: polygonId,
+            Semantic: ParseSurfaceSemantic(polygonElement),
+            ExteriorRing: exteriorParsedRing,
+            InteriorRings: interiorRings,
+            BaseColor: ToInternalColor(appearance.BaseColor),
+            TexturePayload: appearance.TexturePayload,
+            OpticalProperties: CreateMaterialOpticalProperties(appearance.MaterialAttributes));
+    }
+
+    internal static ProjectionParsedSurface ApplyPackageDefaults(string packageName, ProjectionParsedSurface surface)
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+
+        return string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase)
+            && surface.TexturePayload is null
+            ? surface with { UsesGeneratedDemTexture = true }
+            : surface;
+    }
+
+    private static ProjectionParsedRing? ParseRing(
+        XElement? ringElement,
+        IReadOnlyDictionary<string, IReadOnlyList<Float2>>? ringUvsByRingId,
+        string? fallbackRingId)
+    {
+        if (ringElement is null)
+        {
+            return null;
+        }
+
+        string ringId = GetAttribute(ringElement, Gml + "id")
+            ?? fallbackRingId
+            ?? CreateStableElementId("ring", ringElement);
+        ProjectionGeodeticPoint[] vertices = ParseRingPoints(ringElement);
+        if (vertices.Length < 3)
+        {
+            return null;
+        }
+
+        IReadOnlyList<Float2>? uvs = null;
+        if (ringUvsByRingId is not null
+            && ringUvsByRingId.TryGetValue(ringId, out IReadOnlyList<Float2>? ringUvs)
+            && ringUvs.Count == vertices.Length)
+        {
+            uvs = ringUvs;
+        }
+
+        return new ProjectionParsedRing(ringId, vertices, uvs);
+    }
+
+    private static ProjectionGeodeticPoint[] ParseRingPoints(XElement ringElement)
+    {
+        List<double> ordinates = [];
+        XElement? posListElement = ringElement.Element(Gml + "posList");
+        if (posListElement is not null)
+        {
+            ordinates.AddRange(CityGmlCoordinateTextParser.ParseDoubles(posListElement.Value));
+        }
+        else
+        {
+            foreach (XElement posElement in ringElement.Elements(Gml + "pos"))
+            {
+                ordinates.AddRange(CityGmlCoordinateTextParser.ParseDoubles(posElement.Value));
+            }
+        }
+
+        List<ProjectionGeodeticPoint> points = [];
+        for (int index = 0; index + 2 < ordinates.Count; index += 3)
+        {
+            points.Add(new ProjectionGeodeticPoint(ordinates[index], ordinates[index + 1], ordinates[index + 2]));
+        }
+
+        if (points.Count > 1 && AreSamePoint(points[0], points[^1]))
+        {
+            points.RemoveAt(points.Count - 1);
+        }
+
+        return points.ToArray();
+    }
+
+    private static ProjectionParsedSurfaceSemantic ParseSurfaceSemantic(XElement polygonElement)
+    {
+        for (XElement? ancestor = polygonElement.Parent; ancestor is not null; ancestor = ancestor.Parent)
+        {
+            ProjectionParsedSurfaceSemantic semantic = ancestor.Name.LocalName switch
+            {
+                "WallSurface" or "InteriorWallSurface" => ProjectionParsedSurfaceSemantic.Wall,
+                "RoofSurface" => ProjectionParsedSurfaceSemantic.Roof,
+                "GroundSurface" => ProjectionParsedSurfaceSemantic.Ground,
+                "ClosureSurface" => ProjectionParsedSurfaceSemantic.Closure,
+                "OuterCeilingSurface" => ProjectionParsedSurfaceSemantic.OuterCeiling,
+                "OuterFloorSurface" => ProjectionParsedSurfaceSemantic.OuterFloor,
+                _ => ProjectionParsedSurfaceSemantic.Unknown,
+            };
+
+            if (semantic != ProjectionParsedSurfaceSemantic.Unknown)
+            {
+                return semantic;
+            }
+        }
+
+        return ProjectionParsedSurfaceSemantic.Unknown;
+    }
+
+    private static string CreateStableElementId(string prefix, XElement element)
+    {
+        byte[] payload = Encoding.UTF8.GetBytes(element.ToString(SaveOptions.DisableFormatting));
+        byte[] hash = SHA256.HashData(payload);
+        return string.Create(
+            System.Globalization.CultureInfo.InvariantCulture,
+            $"{prefix}_{Convert.ToHexString(hash.AsSpan(0, 12)).ToLowerInvariant()}");
+    }
+
+    private static MaterialOpticalProperties? CreateMaterialOpticalProperties(CityGmlMaterialAttributes? attributes)
+    {
+        if (attributes is null)
+        {
+            return null;
+        }
+
+        return new MaterialOpticalProperties(
+            DiffuseColor: ToInternalColor(attributes.DiffuseColor),
+            EmissiveColor: attributes.EmissiveColor is null ? null : ToInternalColor(attributes.EmissiveColor),
+            SpecularColor: attributes.SpecularColor is null ? null : ToInternalColor(attributes.SpecularColor),
+            AmbientIntensity: attributes.AmbientIntensity,
+            Shininess: attributes.Shininess,
+            Transparency: attributes.Transparency);
+    }
+
+    private static string? GetAttribute(XElement element, XName attributeName)
+    {
+        return element.Attribute(attributeName)?.Value;
+    }
+
+    private static bool AreSamePoint(ProjectionGeodeticPoint left, ProjectionGeodeticPoint right)
+    {
+        return Math.Abs(left.Latitude - right.Latitude) < 1e-8
+            && Math.Abs(left.Longitude - right.Longitude) < 1e-8
+            && Math.Abs(left.Altitude - right.Altitude) < 1e-8;
+    }
+
+    private static ColorRgba ToInternalColor(ColorRgba value) => new(value.R, value.G, value.B, value.A);
+}

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -107,10 +107,10 @@ internal static class LocalCityGmlObjectProjection
         }
 
         ParsedSurface[] surfaces = preferredSurfaceElements
-            .Select(surfaceElement => ParseSurface(surfaceElement, appearanceStore))
+            .Select(surfaceElement => CityGmlParsedSurfaceReader.Parse(surfaceElement, appearanceStore))
             .Where(static surface => surface is not null)
             .Select(static surface => surface!)
-            .Select(surface => ApplyPackageSurfaceDefaults(packageName, surface))
+            .Select(surface => CityGmlParsedSurfaceReader.ApplyPackageDefaults(packageName, surface))
             .OrderBy(static surface => CreateStableSurfaceSortKey(surface), StringComparer.Ordinal)
             .ToArray();
 
@@ -198,14 +198,6 @@ internal static class LocalCityGmlObjectProjection
                 .ToArray();
 
         return (selectedSurfaces, highestLod);
-    }
-
-    private static ParsedSurface ApplyPackageSurfaceDefaults(string packageName, ParsedSurface surface)
-    {
-        return string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase)
-            && surface.TexturePayload is null
-            ? surface with { UsesGeneratedDemTexture = true }
-            : surface;
     }
 
     private static int? GetSurfaceLodLevel(XElement surfaceElement, XElement cityObjectElement)
@@ -564,15 +556,6 @@ internal static class LocalCityGmlObjectProjection
         return metric.Kind == BuildingMetricValueKind.Known && metric.Value is > 0.0
             ? metric.Value
             : null;
-    }
-
-    private static string CreateStableElementId(string prefix, XElement element)
-    {
-        byte[] payload = Encoding.UTF8.GetBytes(element.ToString(SaveOptions.DisableFormatting));
-        byte[] hash = SHA256.HashData(payload);
-        return string.Create(
-            CultureInfo.InvariantCulture,
-            $"{prefix}_{Convert.ToHexString(hash.AsSpan(0, 12)).ToLowerInvariant()}");
     }
 
     private static string CreateStableSurfaceSortKey(ParsedSurface surface)
@@ -1247,107 +1230,6 @@ internal static class LocalCityGmlObjectProjection
     {
         Float3? normal = ComputePolygonNormal(positions);
         return normal is not null && Math.Abs(normal.Y) >= 0.7;
-    }
-
-    private static ParsedSurface? ParseSurface(XElement polygonElement, ICityGmlAppearanceStore appearanceStore)
-    {
-        XElement? exteriorRing = polygonElement
-            .Element(Gml + "exterior")
-            ?.Element(Gml + "LinearRing");
-        if (exteriorRing is null)
-        {
-            return null;
-        }
-
-        string polygonId = GetAttribute(polygonElement, Gml + "id") ?? CreateStableElementId("polygon", polygonElement);
-        CityGmlResolvedAppearance appearance = appearanceStore.Resolve(polygonId);
-        ParsedRing? exteriorParsedRing = ParseRing(
-            exteriorRing,
-            appearance.RingUvsByRingId,
-            fallbackRingId: polygonId);
-        if (exteriorParsedRing is null)
-        {
-            return null;
-        }
-
-        ParsedRing[] interiorRings = polygonElement
-            .Elements(Gml + "interior")
-            .Select(interiorElement => ParseRing(
-                interiorElement.Element(Gml + "LinearRing"),
-                appearance.RingUvsByRingId,
-                fallbackRingId: null))
-            .Where(static ring => ring is not null)
-            .Select(static ring => ring!)
-            .ToArray();
-
-        return new ParsedSurface(
-            PolygonId: polygonId,
-            Semantic: ParseSurfaceSemantic(polygonElement),
-            ExteriorRing: exteriorParsedRing,
-            InteriorRings: interiorRings,
-            BaseColor: ToInternalColor(appearance.BaseColor),
-            TexturePayload: appearance.TexturePayload,
-            OpticalProperties: CreateMaterialOpticalProperties(appearance.MaterialAttributes));
-    }
-
-    private static ParsedRing? ParseRing(
-        XElement? ringElement,
-        IReadOnlyDictionary<string, IReadOnlyList<Float2>>? ringUvsByRingId,
-        string? fallbackRingId)
-    {
-        if (ringElement is null)
-        {
-            return null;
-        }
-
-        string ringId = GetAttribute(ringElement, Gml + "id")
-            ?? fallbackRingId
-            ?? CreateStableElementId("ring", ringElement);
-        GeodeticPoint[] vertices = ParseRingPoints(ringElement);
-        if (vertices.Length < 3)
-        {
-            return null;
-        }
-
-        IReadOnlyList<Float2>? uvs = null;
-        if (ringUvsByRingId is not null
-            && ringUvsByRingId.TryGetValue(ringId, out IReadOnlyList<Float2>? ringUvs)
-            && ringUvs.Count == vertices.Length)
-        {
-            uvs = ringUvs;
-        }
-
-        return new ParsedRing(ringId, vertices, uvs);
-    }
-
-    private static GeodeticPoint[] ParseRingPoints(XElement ringElement)
-    {
-        List<double> ordinates = [];
-        XElement? posListElement = ringElement.Element(Gml + "posList");
-        if (posListElement is not null)
-        {
-            ordinates.AddRange(ParseDoubles(posListElement.Value));
-        }
-        else
-        {
-            foreach (XElement posElement in ringElement.Elements(Gml + "pos"))
-            {
-                ordinates.AddRange(ParseDoubles(posElement.Value));
-            }
-        }
-
-        List<GeodeticPoint> points = [];
-        for (int index = 0; index + 2 < ordinates.Count; index += 3)
-        {
-            points.Add(new GeodeticPoint(ordinates[index], ordinates[index + 1], ordinates[index + 2]));
-        }
-
-        if (points.Count > 1 && AreSamePoint(points[0], points[^1]))
-        {
-            points.RemoveAt(points.Count - 1);
-        }
-
-        return points.ToArray();
     }
 
     private static GeodeticPoint ComputeGlobalOrigin(IEnumerable<ParsedCityObject> cityObjects)
@@ -3572,30 +3454,6 @@ internal static class LocalCityGmlObjectProjection
         return IsFacadeSurface(surface, cityObjectOrigin, cityObjectCartesian);
     }
 
-    private static ParsedSurfaceSemantic ParseSurfaceSemantic(XElement polygonElement)
-    {
-        for (XElement? ancestor = polygonElement.Parent; ancestor is not null; ancestor = ancestor.Parent)
-        {
-            ParsedSurfaceSemantic semantic = ancestor.Name.LocalName switch
-            {
-                "WallSurface" or "InteriorWallSurface" => ParsedSurfaceSemantic.Wall,
-                "RoofSurface" => ParsedSurfaceSemantic.Roof,
-                "GroundSurface" => ParsedSurfaceSemantic.Ground,
-                "ClosureSurface" => ParsedSurfaceSemantic.Closure,
-                "OuterCeilingSurface" => ParsedSurfaceSemantic.OuterCeiling,
-                "OuterFloorSurface" => ParsedSurfaceSemantic.OuterFloor,
-                _ => ParsedSurfaceSemantic.Unknown,
-            };
-
-            if (semantic != ParsedSurfaceSemantic.Unknown)
-            {
-                return semantic;
-            }
-        }
-
-        return ParsedSurfaceSemantic.Unknown;
-    }
-
     private static DefaultMaterialSurfaceRole ToDefaultMaterialSurfaceRole(ParsedSurfaceSemantic semantic)
     {
         return semantic switch
@@ -3831,31 +3689,6 @@ internal static class LocalCityGmlObjectProjection
         return element.Attribute(attributeName)?.Value;
     }
 
-    internal static double[] ParseDoubles(string value)
-    {
-        return value
-            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
-            .Select(token => double.Parse(token, CultureInfo.InvariantCulture))
-            .ToArray();
-    }
-
-    internal static List<Float2> ParseTextureCoordinates(string value)
-    {
-        double[] ordinates = ParseDoubles(value);
-        List<Float2> coordinates = [];
-        for (int index = 0; index + 1 < ordinates.Length; index += 2)
-        {
-            coordinates.Add(new Float2(ordinates[index], ordinates[index + 1]));
-        }
-
-        if (coordinates.Count > 1 && AreSameUV(coordinates[0], coordinates[^1]))
-        {
-            coordinates.RemoveAt(coordinates.Count - 1);
-        }
-
-        return coordinates;
-    }
-
     private static bool AreSamePoint(GeodeticPoint left, GeodeticPoint right)
     {
         return Math.Abs(left.Latitude - right.Latitude) < 1e-8
@@ -3889,12 +3722,6 @@ internal static class LocalCityGmlObjectProjection
         return new Float2(
             source.X + ((target.X - source.X) * ratio),
             source.Y + ((target.Y - source.Y) * ratio));
-    }
-
-    private static bool AreSameUV(Float2 left, Float2 right)
-    {
-        return Math.Abs(left.X - right.X) < 1e-8
-            && Math.Abs(left.Y - right.Y) < 1e-8;
     }
 
     private static bool HasExplicitMaterialColor(ColorRgba color)
@@ -5649,22 +5476,6 @@ internal static class LocalCityGmlObjectProjection
     private static Float2 ToInternalFloat2(Float2 value) => new(value.X, value.Y);
 
     private static ColorRgba ToInternalColor(ColorRgba value) => new(value.R, value.G, value.B, value.A);
-
-    private static MaterialOpticalProperties? CreateMaterialOpticalProperties(CityGmlMaterialAttributes? attributes)
-    {
-        if (attributes is null)
-        {
-            return null;
-        }
-
-        return new MaterialOpticalProperties(
-            DiffuseColor: ToInternalColor(attributes.DiffuseColor),
-            EmissiveColor: attributes.EmissiveColor is null ? null : ToInternalColor(attributes.EmissiveColor),
-            SpecularColor: attributes.SpecularColor is null ? null : ToInternalColor(attributes.SpecularColor),
-            AmbientIntensity: attributes.AmbientIntensity,
-            Shininess: attributes.Shininess,
-            Transparency: attributes.Transparency);
-    }
 
     private static Float3 ToContractFloat3(Float3 value) => new(value.X, value.Y, value.Z);
 


### PR DESCRIPTION
## Summary
- move CityGML polygon/ring and texture-coordinate parsing out of LocalCityGmlObjectProjection
- keep package-specific surface defaults behind a focused CityGML surface reader
- remove parsing helpers from the projection type so projection retains less XML parsing responsibility

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --configuration Release --no-build --filter "FullyQualifiedName~LocalCityGmlSourceFileParserStreamingTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests|FullyQualifiedName~CanonicalSceneDumpSinkTests|FullyQualifiedName~ResoniteSemanticGateTests" --verbosity normal
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- git diff --check