### PR TITLE
Run live target tests in parallel

### DIFF
--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -17,7 +17,6 @@ using ResoniteLink;
 
 namespace PlateauResoniteLink.Tests.Targets;
 
-[Collection(BundledCompanionTextureIsolationGroup.Name)]
 [Trait("Category", "Slow")]
 public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
 {

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -529,8 +529,3 @@ internal sealed class DelegatingClientSession(
         ConnectedClient = null;
     }
 }
-[CollectionDefinition(BundledCompanionTextureIsolationGroup.Name, DisableParallelization = true)]
-public sealed class BundledCompanionTextureIsolationGroup
-{
-    public const string Name = "BundledCompanionTextureIsolation";
-}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -20,7 +20,6 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Tests.Targets;
 
-[Collection(BundledCompanionTextureIsolationGroup.Name)]
 [Trait("Category", "Slow")]
 public sealed class ResoniteLiveSceneImportTargetTests
 {


### PR DESCRIPTION
## Summary
- remove the shared non-parallel xUnit collection from the live target test classes
- rely on BundledDefaultMaterialAssetStore locking instead of serializing unrelated tests
- reduce the slow live-target test segment while preserving the same behavioral assertions

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- Measure-Command { dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --configuration Release --no-build --filter "FullyQualifiedName~ResoniteLiveSceneImportTargetTests|FullyQualifiedName~ResoniteLiveSceneImportTargetAssetReuseTests" --verbosity quiet } | Select-Object TotalSeconds
  - before: 212.62s
  - after: 133.09s
- dotnet format whitespace . --folder --verify-no-changes
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
  - 756 passed, 2.3097 minutes
- git diff --check