### PR TITLE
Use canonical CityGML reference system in parser

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDocumentReferenceSystemReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDocumentReferenceSystemReader.cs
@@ -11,7 +11,7 @@ internal static class CityGmlDocumentReferenceSystemReader
 {
     internal static readonly XNamespace Gml = "http://www.opengis.net/gml";
 
-    internal static async Task<LocalCityGmlObjectProjection.CoordinateReferenceSystem> ReadAsync(
+    internal static async Task<CoordinateReferenceSystem> ReadAsync(
         IPlateauDatasetContentSource datasetSource,
         string relativePath,
         CancellationToken cancellationToken)
@@ -29,12 +29,12 @@ internal static class CityGmlDocumentReferenceSystemReader
                 continue;
             }
 
-            return LocalCityGmlObjectProjection.CoordinateReferenceSystem.Parse(reader.GetAttribute("srsName"));
+            return CoordinateReferenceSystem.Parse(reader.GetAttribute("srsName"));
         }
 
         try
         {
-            return LocalCityGmlObjectProjection.CoordinateReferenceSystem.Parse((string?)null);
+            return CoordinateReferenceSystem.Parse((string?)null);
         }
         catch (PlateauImportValidationException)
         {

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSourceFileCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSourceFileCityObjectProjection.cs
@@ -14,7 +14,7 @@ internal static class CityGmlSourceFileCityObjectProjection
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         ICityGmlAppearanceStore appearanceStore,
         ICityGmlLodSelector lodSelector,
-        LocalCityGmlObjectProjection.CoordinateReferenceSystem coordinateReferenceSystem,
+        CoordinateReferenceSystem coordinateReferenceSystem,
         LodFilteringStrategy lodFilteringStrategy)
     {
         XElement? cityObjectElement = cityObjectMember.Elements().FirstOrDefault();
@@ -31,7 +31,7 @@ internal static class CityGmlSourceFileCityObjectProjection
             sourceFile.RequiresMeshCodeBoundsFilter,
             appearanceStore,
             lodSelector,
-            coordinateReferenceSystem,
+            coordinateReferenceSystem.ToProjectionModel(),
             sourceFile.RequiresMeshCodeBoundsFilter ? requestedMeshAreas : null,
             lodFilteringStrategy);
 

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileParser.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileParser.cs
@@ -70,7 +70,7 @@ internal static class LocalCityGmlSourceFileParser
 
         Stopwatch fileStopwatch = Stopwatch.StartNew();
         List<global::PlateauResoniteLink.Application.Importing.ParsedCityObject> cityObjects = [];
-        LocalCityGmlObjectProjection.CoordinateReferenceSystem? coordinateReferenceSystem = null;
+        CoordinateReferenceSystem? coordinateReferenceSystem = null;
         await foreach (global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject in StreamParsedCityObjectsCoreAsync(
                            sourceFile,
                            datasetSource,
@@ -107,7 +107,7 @@ internal static class LocalCityGmlSourceFileParser
         return new global::PlateauResoniteLink.Application.Importing.ParsedSourceFileResult(
             sourceFile,
             cityObjectArray,
-            coordinateReferenceSystem is null ? null : global::PlateauResoniteLink.Application.Importing.CoordinateReferenceSystem.FromProjectionModel(coordinateReferenceSystem),
+            coordinateReferenceSystem,
             terrainTriangles,
             fileStopwatch.Elapsed);
     }
@@ -142,7 +142,7 @@ internal static class LocalCityGmlSourceFileParser
         LodFilteringStrategy? lodFilteringStrategy,
         ICityGmlAppearanceStoreFactory appearanceStoreFactory,
         ICityGmlLodSelector lodSelector,
-        Action<LocalCityGmlObjectProjection.CoordinateReferenceSystem>? parsedReferenceSystem = null,
+        Action<CoordinateReferenceSystem>? parsedReferenceSystem = null,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         lodFilteringStrategy ??= new LodFilteringStrategy();
@@ -189,13 +189,13 @@ internal static class LocalCityGmlSourceFileParser
         LodFilteringStrategy? lodFilteringStrategy,
         ICityGmlAppearanceStoreFactory appearanceStoreFactory,
         ICityGmlLodSelector lodSelector,
-        Action<LocalCityGmlObjectProjection.CoordinateReferenceSystem>? parsedReferenceSystem,
+        Action<CoordinateReferenceSystem>? parsedReferenceSystem,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
     {
         lodFilteringStrategy ??= new LodFilteringStrategy();
         ICityGmlAppearanceStore appearanceStore = appearanceStoreFactory.Create(sourceFile.RelativePath, datasetSource);
-        LocalCityGmlObjectProjection.CoordinateReferenceSystem coordinateReferenceSystem =
-            LocalCityGmlObjectProjection.CoordinateReferenceSystem.Parse((string?)null);
+        CoordinateReferenceSystem coordinateReferenceSystem =
+            CoordinateReferenceSystem.Parse((string?)null);
 
         using XmlReader reader = XmlReader.Create(stream, CityGmlStreamingXmlReaderSettings.Create());
         while (await reader.ReadAsync())
@@ -210,7 +210,7 @@ internal static class LocalCityGmlSourceFileParser
                 && string.Equals(reader.LocalName, "Envelope", StringComparison.Ordinal))
             {
                 coordinateReferenceSystem =
-                    LocalCityGmlObjectProjection.CoordinateReferenceSystem.Parse(reader.GetAttribute("srsName"));
+                    CoordinateReferenceSystem.Parse(reader.GetAttribute("srsName"));
                 parsedReferenceSystem?.Invoke(coordinateReferenceSystem);
                 continue;
             }
@@ -283,14 +283,14 @@ internal static class LocalCityGmlSourceFileParser
         LodFilteringStrategy? lodFilteringStrategy,
         ICityGmlAppearanceStoreFactory appearanceStoreFactory,
         ICityGmlLodSelector lodSelector,
-        Action<LocalCityGmlObjectProjection.CoordinateReferenceSystem>? parsedReferenceSystem,
+        Action<CoordinateReferenceSystem>? parsedReferenceSystem,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
     {
         lodFilteringStrategy ??= new LodFilteringStrategy();
         await using Stream stream = await datasetSource.OpenReadAsync(sourceFile.RelativePath, cancellationToken);
         XDocument cityModel = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken);
-        LocalCityGmlObjectProjection.CoordinateReferenceSystem coordinateReferenceSystem =
-            LocalCityGmlObjectProjection.CoordinateReferenceSystem.Parse(cityModel);
+        CoordinateReferenceSystem coordinateReferenceSystem =
+            CoordinateReferenceSystem.Parse(cityModel);
         parsedReferenceSystem?.Invoke(coordinateReferenceSystem);
         ICityGmlAppearanceStore appearanceStore = appearanceStoreFactory.Create(sourceFile.RelativePath, datasetSource);
         appearanceStore.LoadFromDocument(cityModel);


### PR DESCRIPTION
## Summary
- make `CityGmlDocumentReferenceSystemReader` return the canonical application `CoordinateReferenceSystem`
- keep `LocalCityGmlSourceFileParser` callbacks and parsed source results on the canonical CRS model
- convert to the legacy projection CRS only at the projection adapter call site

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~LocalCityGmlSourceFileParserStreamingTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests|FullyQualifiedName~LocalCityGmlDocumentReaderTests|FullyQualifiedName~CityGml"`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- `git diff --check`
- `rg -n "LocalCityGmlObjectProjection\.CoordinateReferenceSystem" src/PlateauResoniteLink/Application/Importing/CityGmlDocumentReferenceSystemReader.cs src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileParser.cs src/PlateauResoniteLink/Application/Importing/CityGmlSourceFileCityObjectProjection.cs`

Note: while verifying, C: had only about 0.45GB free and build failed before tests due generated artifact copy failures. I removed ignored `.worktree/*/artifacts` outputs outside the active worktree, which restored about 35GB free, then reran build and tests successfully.