### PR TITLE
Extract CityGML projection model adapter

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDocumentReferenceSystemReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDocumentReferenceSystemReader.cs
@@ -11,7 +11,7 @@ internal static class CityGmlDocumentReferenceSystemReader
 {
     internal static readonly XNamespace Gml = "http://www.opengis.net/gml";
 
-    internal static async Task<LocalCityGmlObjectProjection.CoordinateReferenceSystem> ReadAsync(
+    internal static async Task<CoordinateReferenceSystem> ReadAsync(
         IPlateauDatasetContentSource datasetSource,
         string relativePath,
         CancellationToken cancellationToken)
@@ -29,12 +29,12 @@ internal static class CityGmlDocumentReferenceSystemReader
                 continue;
             }
 
-            return LocalCityGmlObjectProjection.CoordinateReferenceSystem.Parse(reader.GetAttribute("srsName"));
+            return CoordinateReferenceSystem.Parse(reader.GetAttribute("srsName"));
         }
 
         try
         {
-            return LocalCityGmlObjectProjection.CoordinateReferenceSystem.Parse((string?)null);
+            return CoordinateReferenceSystem.Parse((string?)null);
         }
         catch (PlateauImportValidationException)
         {

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlProjectionModelAdapter.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlProjectionModelAdapter.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityGmlProjectionModelAdapter
+{
+    internal static ParsedRing FromProjectionModel(LocalCityGmlObjectProjection.ParsedRing ring)
+    {
+        return new ParsedRing(
+            ring.RingId,
+            ring.Vertices.Select(GeodeticPoint.FromProjectionModel).ToArray(),
+            ring.UVs);
+    }
+
+    internal static ParsedSurface FromProjectionModel(LocalCityGmlObjectProjection.ParsedSurface surface)
+    {
+        return new ParsedSurface(
+            surface.PolygonId,
+            (ParsedSurfaceSemantic)surface.Semantic,
+            FromProjectionModel(surface.ExteriorRing),
+            surface.InteriorRings.Select(FromProjectionModel).ToArray(),
+            new ColorRgba(surface.BaseColor.R, surface.BaseColor.G, surface.BaseColor.B, surface.BaseColor.A),
+            surface.TexturePayload,
+            surface.UsesGeneratedDemTexture,
+            surface.OpticalProperties);
+    }
+
+    internal static ParsedCityObject FromProjectionModel(LocalCityGmlObjectProjection.ParsedCityObject cityObject)
+    {
+        return new ParsedCityObject(
+            cityObject.SlotKey,
+            cityObject.DisplayName,
+            cityObject.PackageName,
+            cityObject.ActualMeshCode,
+            cityObject.LodLevel,
+            cityObject.Surfaces.Select(FromProjectionModel).ToArray(),
+            CoordinateReferenceSystem.FromProjectionModel(cityObject.ReferenceSystem),
+            cityObject.SourceFileRelativePath,
+            cityObject.SharedAcrossMeshCodes,
+            cityObject.TerrainAligned,
+            cityObject.GeodeticOriginOverride is null ? null : GeodeticPoint.FromProjectionModel(cityObject.GeodeticOriginOverride),
+            cityObject.FloorsAboveGround,
+            cityObject.MeasuredHeightMeters,
+            cityObject.BuildingAttributes,
+            cityObject.GeometryHeightMeters);
+    }
+
+    internal static CachedSourceFileDescriptor FromProjectionModel(LocalCityGmlObjectProjection.CachedSourceFileDescriptor sourceFile)
+    {
+        return new CachedSourceFileDescriptor(
+            SourceFileDescriptor.FromProjectionModel(sourceFile.SourceFile),
+            sourceFile.CityObjects.Select(FromProjectionModel).ToArray());
+    }
+
+    internal static ParsedSourceFileResult FromProjectionModel(LocalCityGmlObjectProjection.ParsedSourceFileResult sourceFile)
+    {
+        return new ParsedSourceFileResult(
+            SourceFileDescriptor.FromProjectionModel(sourceFile.SourceFile),
+            sourceFile.CityObjects.Select(FromProjectionModel).ToArray(),
+            sourceFile.ReferenceSystem is null ? null : CoordinateReferenceSystem.FromProjectionModel(sourceFile.ReferenceSystem),
+            sourceFile.TerrainTriangles.Select(TerrainHeightTriangle.FromProjectionModel).ToArray(),
+            sourceFile.Elapsed);
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSourceFileCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSourceFileCityObjectProjection.cs
@@ -14,7 +14,7 @@ internal static class CityGmlSourceFileCityObjectProjection
         IReadOnlyList<MeshCodeBounds> requestedMeshAreas,
         ICityGmlAppearanceStore appearanceStore,
         ICityGmlLodSelector lodSelector,
-        LocalCityGmlObjectProjection.CoordinateReferenceSystem coordinateReferenceSystem,
+        CoordinateReferenceSystem coordinateReferenceSystem,
         LodFilteringStrategy lodFilteringStrategy)
     {
         XElement? cityObjectElement = cityObjectMember.Elements().FirstOrDefault();
@@ -31,7 +31,7 @@ internal static class CityGmlSourceFileCityObjectProjection
             sourceFile.RequiresMeshCodeBoundsFilter,
             appearanceStore,
             lodSelector,
-            coordinateReferenceSystem,
+            coordinateReferenceSystem.ToProjectionModel(),
             sourceFile.RequiresMeshCodeBoundsFilter ? requestedMeshAreas : null,
             lodFilteringStrategy);
 

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSourceFileCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSourceFileCityObjectProjection.cs
@@ -35,6 +35,6 @@ internal static class CityGmlSourceFileCityObjectProjection
             sourceFile.RequiresMeshCodeBoundsFilter ? requestedMeshAreas : null,
             lodFilteringStrategy);
 
-        return cityObject is null ? null : ParsedCityObject.FromProjectionModel(cityObject);
+        return cityObject is null ? null : CityGmlProjectionModelAdapter.FromProjectionModel(cityObject);
     }
 }

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -623,7 +623,7 @@ internal static class LocalCityGmlObjectProjection
         MeshCodeBounds? fallbackBounds)
     {
         DemTerrainBounds? bounds = DemSourceDiscoverySupport.ResolveDemTerrainBounds(
-            demParsedSourceFiles.Select(global::PlateauResoniteLink.Application.Importing.ParsedSourceFileResult.FromProjectionModel),
+            demParsedSourceFiles.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel),
             fallbackBounds is null ? null : DemTerrainBounds.FromProjectionModel(fallbackBounds));
         return bounds?.ToProjectionModel();
     }
@@ -632,7 +632,7 @@ internal static class LocalCityGmlObjectProjection
         IEnumerable<ParsedCityObject> cityObjects)
     {
         return DemSourceDiscoverySupport.CreateTerrainHeightTriangles(
-                cityObjects.Select(global::PlateauResoniteLink.Application.Importing.ParsedCityObject.FromProjectionModel))
+                cityObjects.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel))
             .Select(static triangle => triangle.ToProjectionModel())
             .ToArray();
     }
@@ -709,7 +709,7 @@ internal static class LocalCityGmlObjectProjection
 
         List<ParsedSurface> strips = CreateTerrainAlignedTransportationStrips(surface.ToProjectionModel(), positions, edgePair, segmentLength);
         return strips.Count > 0
-            ? strips.Select(global::PlateauResoniteLink.Application.Importing.ParsedSurface.FromProjectionModel).ToList()
+            ? strips.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel).ToList()
             : [surface];
     }
 
@@ -2392,7 +2392,7 @@ internal static class LocalCityGmlObjectProjection
                 surface.ToProjectionModel(),
                 cityObjectOrigin.ToProjectionModel(),
                 cityObjectCartesian)
-            .Select(global::PlateauResoniteLink.Application.Importing.ParsedSurface.FromProjectionModel)
+            .Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel)
             .ToList();
     }
 
@@ -4081,7 +4081,7 @@ internal static class LocalCityGmlObjectProjection
                         subdividedCityObject.Surfaces.Select(static surface => surface.ToProjectionModel()).ToArray(),
                         terrainHeightSampler,
                         ref terrainAligned)
-                    .Select(global::PlateauResoniteLink.Application.Importing.ParsedSurface.FromProjectionModel)
+                    .Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel)
                     .ToArray()
                 : ConformSurfacesToTerrain(
                         subdividedCityObject.PackageName,
@@ -4090,7 +4090,7 @@ internal static class LocalCityGmlObjectProjection
                         cityObjectOrigin.ToProjectionModel(),
                         cityObjectCartesian,
                         ref terrainAligned)
-                    .Select(global::PlateauResoniteLink.Application.Importing.ParsedSurface.FromProjectionModel)
+                    .Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel)
                     .ToArray();
 
         return terrainAligned
@@ -5515,7 +5515,7 @@ internal static class LocalCityGmlObjectProjection
         }
 
         TextureUvRect? occupiedUvRect = DemTerrainOverlayAssignment.TryCreateTerrainGridOccupiedUvRect(
-            global::PlateauResoniteLink.Application.Importing.ParsedCityObject.FromProjectionModel(cityObject),
+            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(cityObject),
             representativeSurface,
             demTerrainTextureOverlay,
             demObjectBounds);

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedObjectModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedObjectModels.cs
@@ -16,13 +16,6 @@ internal sealed record ParsedRing(
             UVs);
     }
 
-    internal static ParsedRing FromProjectionModel(LocalCityGmlObjectProjection.ParsedRing ring)
-    {
-        return new ParsedRing(
-            ring.RingId,
-            ring.Vertices.Select(GeodeticPoint.FromProjectionModel).ToArray(),
-            ring.UVs);
-    }
 }
 
 internal enum ParsedSurfaceSemantic
@@ -62,18 +55,6 @@ internal sealed record ParsedSurface(
             OpticalProperties);
     }
 
-    internal static ParsedSurface FromProjectionModel(LocalCityGmlObjectProjection.ParsedSurface surface)
-    {
-        return new ParsedSurface(
-            surface.PolygonId,
-            (ParsedSurfaceSemantic)surface.Semantic,
-            ParsedRing.FromProjectionModel(surface.ExteriorRing),
-            surface.InteriorRings.Select(ParsedRing.FromProjectionModel).ToArray(),
-            new ColorRgba(surface.BaseColor.R, surface.BaseColor.G, surface.BaseColor.B, surface.BaseColor.A),
-            surface.TexturePayload,
-            surface.UsesGeneratedDemTexture,
-            surface.OpticalProperties);
-    }
 }
 
 internal sealed record ParsedCityObject(
@@ -113,23 +94,4 @@ internal sealed record ParsedCityObject(
             GeometryHeightMeters);
     }
 
-    internal static ParsedCityObject FromProjectionModel(LocalCityGmlObjectProjection.ParsedCityObject cityObject)
-    {
-        return new ParsedCityObject(
-            cityObject.SlotKey,
-            cityObject.DisplayName,
-            cityObject.PackageName,
-            cityObject.ActualMeshCode,
-            cityObject.LodLevel,
-            cityObject.Surfaces.Select(ParsedSurface.FromProjectionModel).ToArray(),
-            CoordinateReferenceSystem.FromProjectionModel(cityObject.ReferenceSystem),
-            cityObject.SourceFileRelativePath,
-            cityObject.SharedAcrossMeshCodes,
-            cityObject.TerrainAligned,
-            cityObject.GeodeticOriginOverride is null ? null : GeodeticPoint.FromProjectionModel(cityObject.GeodeticOriginOverride),
-            cityObject.FloorsAboveGround,
-            cityObject.MeasuredHeightMeters,
-            cityObject.BuildingAttributes,
-            cityObject.GeometryHeightMeters);
-    }
 }

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedSourceFileModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedSourceFileModels.cs
@@ -46,12 +46,6 @@ internal sealed record CachedSourceFileDescriptor(
             CityObjects.Select(static cityObject => cityObject.ToProjectionModel()).ToArray());
     }
 
-    internal static CachedSourceFileDescriptor FromProjectionModel(LocalCityGmlObjectProjection.CachedSourceFileDescriptor sourceFile)
-    {
-        return new CachedSourceFileDescriptor(
-            SourceFileDescriptor.FromProjectionModel(sourceFile.SourceFile),
-            sourceFile.CityObjects.Select(ParsedCityObject.FromProjectionModel).ToArray());
-    }
 }
 
 internal sealed class SourceFilePipeline
@@ -117,13 +111,4 @@ internal sealed record ParsedSourceFileResult(
             Elapsed);
     }
 
-    internal static ParsedSourceFileResult FromProjectionModel(LocalCityGmlObjectProjection.ParsedSourceFileResult sourceFile)
-    {
-        return new ParsedSourceFileResult(
-            SourceFileDescriptor.FromProjectionModel(sourceFile.SourceFile),
-            sourceFile.CityObjects.Select(ParsedCityObject.FromProjectionModel).ToArray(),
-            sourceFile.ReferenceSystem is null ? null : CoordinateReferenceSystem.FromProjectionModel(sourceFile.ReferenceSystem),
-            sourceFile.TerrainTriangles.Select(TerrainHeightTriangle.FromProjectionModel).ToArray(),
-            sourceFile.Elapsed);
-    }
 }

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileParser.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileParser.cs
@@ -70,7 +70,7 @@ internal static class LocalCityGmlSourceFileParser
 
         Stopwatch fileStopwatch = Stopwatch.StartNew();
         List<global::PlateauResoniteLink.Application.Importing.ParsedCityObject> cityObjects = [];
-        LocalCityGmlObjectProjection.CoordinateReferenceSystem? coordinateReferenceSystem = null;
+        CoordinateReferenceSystem? coordinateReferenceSystem = null;
         await foreach (global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject in StreamParsedCityObjectsCoreAsync(
                            sourceFile,
                            datasetSource,
@@ -107,7 +107,7 @@ internal static class LocalCityGmlSourceFileParser
         return new global::PlateauResoniteLink.Application.Importing.ParsedSourceFileResult(
             sourceFile,
             cityObjectArray,
-            coordinateReferenceSystem is null ? null : global::PlateauResoniteLink.Application.Importing.CoordinateReferenceSystem.FromProjectionModel(coordinateReferenceSystem),
+            coordinateReferenceSystem,
             terrainTriangles,
             fileStopwatch.Elapsed);
     }
@@ -142,7 +142,7 @@ internal static class LocalCityGmlSourceFileParser
         LodFilteringStrategy? lodFilteringStrategy,
         ICityGmlAppearanceStoreFactory appearanceStoreFactory,
         ICityGmlLodSelector lodSelector,
-        Action<LocalCityGmlObjectProjection.CoordinateReferenceSystem>? parsedReferenceSystem = null,
+        Action<CoordinateReferenceSystem>? parsedReferenceSystem = null,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         lodFilteringStrategy ??= new LodFilteringStrategy();
@@ -189,13 +189,13 @@ internal static class LocalCityGmlSourceFileParser
         LodFilteringStrategy? lodFilteringStrategy,
         ICityGmlAppearanceStoreFactory appearanceStoreFactory,
         ICityGmlLodSelector lodSelector,
-        Action<LocalCityGmlObjectProjection.CoordinateReferenceSystem>? parsedReferenceSystem,
+        Action<CoordinateReferenceSystem>? parsedReferenceSystem,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
     {
         lodFilteringStrategy ??= new LodFilteringStrategy();
         ICityGmlAppearanceStore appearanceStore = appearanceStoreFactory.Create(sourceFile.RelativePath, datasetSource);
-        LocalCityGmlObjectProjection.CoordinateReferenceSystem coordinateReferenceSystem =
-            LocalCityGmlObjectProjection.CoordinateReferenceSystem.Parse((string?)null);
+        CoordinateReferenceSystem coordinateReferenceSystem =
+            CoordinateReferenceSystem.Parse((string?)null);
 
         using XmlReader reader = XmlReader.Create(stream, CityGmlStreamingXmlReaderSettings.Create());
         while (await reader.ReadAsync())
@@ -210,7 +210,7 @@ internal static class LocalCityGmlSourceFileParser
                 && string.Equals(reader.LocalName, "Envelope", StringComparison.Ordinal))
             {
                 coordinateReferenceSystem =
-                    LocalCityGmlObjectProjection.CoordinateReferenceSystem.Parse(reader.GetAttribute("srsName"));
+                    CoordinateReferenceSystem.Parse(reader.GetAttribute("srsName"));
                 parsedReferenceSystem?.Invoke(coordinateReferenceSystem);
                 continue;
             }
@@ -283,14 +283,14 @@ internal static class LocalCityGmlSourceFileParser
         LodFilteringStrategy? lodFilteringStrategy,
         ICityGmlAppearanceStoreFactory appearanceStoreFactory,
         ICityGmlLodSelector lodSelector,
-        Action<LocalCityGmlObjectProjection.CoordinateReferenceSystem>? parsedReferenceSystem,
+        Action<CoordinateReferenceSystem>? parsedReferenceSystem,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
     {
         lodFilteringStrategy ??= new LodFilteringStrategy();
         await using Stream stream = await datasetSource.OpenReadAsync(sourceFile.RelativePath, cancellationToken);
         XDocument cityModel = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken);
-        LocalCityGmlObjectProjection.CoordinateReferenceSystem coordinateReferenceSystem =
-            LocalCityGmlObjectProjection.CoordinateReferenceSystem.Parse(cityModel);
+        CoordinateReferenceSystem coordinateReferenceSystem =
+            CoordinateReferenceSystem.Parse(cityModel);
         parsedReferenceSystem?.Invoke(coordinateReferenceSystem);
         ICityGmlAppearanceStore appearanceStore = appearanceStoreFactory.Create(sourceFile.RelativePath, datasetSource);
         appearanceStore.LoadFromDocument(cityModel);


### PR DESCRIPTION
## Summary
- move CityGML projection-model-to-application-model conversion into `CityGmlProjectionModelAdapter`
- remove `FromProjectionModel` conversion factories from parsed CityGML result records
- keep projection compatibility at adapter call sites without introducing `partial` boundaries

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~LocalCityGmlSourceFileParserStreamingTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests|FullyQualifiedName~LocalCityGmlDocumentReaderTests|FullyQualifiedName~CityGml"`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- `git diff --check`
- `rg -n "ParsedCityObject\.FromProjectionModel|ParsedSurface\.FromProjectionModel|ParsedRing\.FromProjectionModel|CachedSourceFileDescriptor\.FromProjectionModel|ParsedSourceFileResult\.FromProjectionModel" src tests`

Note: one full-test rerun briefly hit `DemTerrainGeoReferencedRasterCatalogTests.TryResolveRasterSourceAsyncEvictsFaultedBackgroundTaskAfterCanceledWaiter`; that same test passed when run directly, and the following full run passed 756/756.