### PR TITLE
Centralize CityGML projection conversions

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlProjectionModelAdapter.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlProjectionModelAdapter.cs
@@ -4,12 +4,33 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal static class CityGmlProjectionModelAdapter
 {
+    internal static LocalCityGmlObjectProjection.ParsedRing ToProjectionModel(ParsedRing ring)
+    {
+        return new LocalCityGmlObjectProjection.ParsedRing(
+            ring.RingId,
+            ring.Vertices.Select(static point => point.ToProjectionModel()).ToArray(),
+            ring.UVs);
+    }
+
     internal static ParsedRing FromProjectionModel(LocalCityGmlObjectProjection.ParsedRing ring)
     {
         return new ParsedRing(
             ring.RingId,
             ring.Vertices.Select(GeodeticPoint.FromProjectionModel).ToArray(),
             ring.UVs);
+    }
+
+    internal static LocalCityGmlObjectProjection.ParsedSurface ToProjectionModel(ParsedSurface surface)
+    {
+        return new LocalCityGmlObjectProjection.ParsedSurface(
+            surface.PolygonId,
+            (LocalCityGmlObjectProjection.ParsedSurfaceSemantic)surface.Semantic,
+            ToProjectionModel(surface.ExteriorRing),
+            surface.InteriorRings.Select(ToProjectionModel).ToArray(),
+            surface.BaseColor,
+            surface.TexturePayload,
+            surface.UsesGeneratedDemTexture,
+            surface.OpticalProperties);
     }
 
     internal static ParsedSurface FromProjectionModel(LocalCityGmlObjectProjection.ParsedSurface surface)
@@ -23,6 +44,26 @@ internal static class CityGmlProjectionModelAdapter
             surface.TexturePayload,
             surface.UsesGeneratedDemTexture,
             surface.OpticalProperties);
+    }
+
+    internal static LocalCityGmlObjectProjection.ParsedCityObject ToProjectionModel(ParsedCityObject cityObject)
+    {
+        return new LocalCityGmlObjectProjection.ParsedCityObject(
+            cityObject.SlotKey,
+            cityObject.DisplayName,
+            cityObject.PackageName,
+            cityObject.ActualMeshCode,
+            cityObject.LodLevel,
+            cityObject.Surfaces.Select(ToProjectionModel).ToArray(),
+            cityObject.ReferenceSystem.ToProjectionModel(),
+            cityObject.SourceFileRelativePath,
+            cityObject.SharedAcrossMeshCodes,
+            cityObject.TerrainAligned,
+            cityObject.GeodeticOriginOverride?.ToProjectionModel(),
+            cityObject.FloorsAboveGround,
+            cityObject.MeasuredHeightMeters,
+            cityObject.BuildingAttributes,
+            cityObject.GeometryHeightMeters);
     }
 
     internal static ParsedCityObject FromProjectionModel(LocalCityGmlObjectProjection.ParsedCityObject cityObject)
@@ -45,17 +86,52 @@ internal static class CityGmlProjectionModelAdapter
             cityObject.GeometryHeightMeters);
     }
 
+    internal static LocalCityGmlObjectProjection.SourceFileDescriptor ToProjectionModel(SourceFileDescriptor sourceFile)
+    {
+        return new LocalCityGmlObjectProjection.SourceFileDescriptor(
+            sourceFile.RelativePath,
+            sourceFile.PackageName,
+            sourceFile.MatchedMeshCode,
+            sourceFile.RequiresMeshCodeBoundsFilter);
+    }
+
+    internal static SourceFileDescriptor FromProjectionModel(LocalCityGmlObjectProjection.SourceFileDescriptor sourceFile)
+    {
+        return new SourceFileDescriptor(
+            sourceFile.RelativePath,
+            sourceFile.PackageName,
+            sourceFile.MatchedMeshCode,
+            sourceFile.RequiresMeshCodeBoundsFilter);
+    }
+
+    internal static LocalCityGmlObjectProjection.CachedSourceFileDescriptor ToProjectionModel(CachedSourceFileDescriptor sourceFile)
+    {
+        return new LocalCityGmlObjectProjection.CachedSourceFileDescriptor(
+            ToProjectionModel(sourceFile.SourceFile),
+            sourceFile.CityObjects.Select(ToProjectionModel).ToArray());
+    }
+
     internal static CachedSourceFileDescriptor FromProjectionModel(LocalCityGmlObjectProjection.CachedSourceFileDescriptor sourceFile)
     {
         return new CachedSourceFileDescriptor(
-            SourceFileDescriptor.FromProjectionModel(sourceFile.SourceFile),
+            FromProjectionModel(sourceFile.SourceFile),
             sourceFile.CityObjects.Select(FromProjectionModel).ToArray());
+    }
+
+    internal static LocalCityGmlObjectProjection.ParsedSourceFileResult ToProjectionModel(ParsedSourceFileResult sourceFile)
+    {
+        return new LocalCityGmlObjectProjection.ParsedSourceFileResult(
+            ToProjectionModel(sourceFile.SourceFile),
+            sourceFile.CityObjects.Select(ToProjectionModel).ToArray(),
+            sourceFile.ReferenceSystem?.ToProjectionModel(),
+            sourceFile.TerrainTriangles.Select(static triangle => triangle.ToProjectionModel()).ToArray(),
+            sourceFile.Elapsed);
     }
 
     internal static ParsedSourceFileResult FromProjectionModel(LocalCityGmlObjectProjection.ParsedSourceFileResult sourceFile)
     {
         return new ParsedSourceFileResult(
-            SourceFileDescriptor.FromProjectionModel(sourceFile.SourceFile),
+            FromProjectionModel(sourceFile.SourceFile),
             sourceFile.CityObjects.Select(FromProjectionModel).ToArray(),
             sourceFile.ReferenceSystem is null ? null : CoordinateReferenceSystem.FromProjectionModel(sourceFile.ReferenceSystem),
             sourceFile.TerrainTriangles.Select(TerrainHeightTriangle.FromProjectionModel).ToArray(),

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -700,14 +700,20 @@ internal static class LocalCityGmlObjectProjection
             return [surface];
         }
 
-        EdgePairSelection edgePair = SelectPrimaryRoadEdgePair(surface.ExteriorRing.ToProjectionModel(), positions);
+        EdgePairSelection edgePair = SelectPrimaryRoadEdgePair(
+            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface.ExteriorRing),
+            positions);
         double segmentLength = ComputeTerrainAlignedSegmentLength(edgePair.Width);
         if (edgePair.Length <= segmentLength + 1e-6)
         {
             return [surface];
         }
 
-        List<ParsedSurface> strips = CreateTerrainAlignedTransportationStrips(surface.ToProjectionModel(), positions, edgePair, segmentLength);
+        List<ParsedSurface> strips = CreateTerrainAlignedTransportationStrips(
+            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface),
+            positions,
+            edgePair,
+            segmentLength);
         return strips.Count > 0
             ? strips.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel).ToList()
             : [surface];
@@ -1287,7 +1293,7 @@ internal static class LocalCityGmlObjectProjection
         IDefaultMaterialResolver materialResolver)
     {
         double? geometryHeightMeters = cityObject.GeometryHeightMeters
-            ?? TryGetGeometryHeightMeters(cityObject.Surfaces.Select(static surface => surface.ToProjectionModel()));
+            ?? TryGetGeometryHeightMeters(cityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel));
         cityObject = ApplyGeneratedLod1Roof(cityObject) with
         {
             GeometryHeightMeters = geometryHeightMeters,
@@ -1307,7 +1313,7 @@ internal static class LocalCityGmlObjectProjection
             globalCartesian);
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
             cityObject.PackageName,
-            cityObject.Surfaces.Select(static surface => surface.ToProjectionModel()),
+            cityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel),
             cityObjectOrigin.ToProjectionModel(),
             cityObjectCartesian);
         List<MeshVertex> vertices = [];
@@ -1350,7 +1356,7 @@ internal static class LocalCityGmlObjectProjection
             List<int> indices = [];
             FacadeUvProjectionContext? facadeUvProjectionContext = TryCreateFacadeUvProjectionContext(
                 cityObject.PackageName,
-                cityObject.Surfaces.Select(static surface => surface.ToProjectionModel()),
+                cityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel),
                 cityObjectOrigin.ToProjectionModel(),
                 cityObjectCartesian);
 
@@ -1400,7 +1406,8 @@ internal static class LocalCityGmlObjectProjection
         if (!IsBuildingPackage(cityObject.PackageName)
             || cityObject.LodLevel != 1
             || !cityObject.ReferenceSystem.IsGeographic
-            || cityObject.Surfaces.Any(static surface => IsGeneratedLod1RoofSurface(surface.ToProjectionModel())))
+            || cityObject.Surfaces.Any(static surface => IsGeneratedLod1RoofSurface(
+                global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface))))
         {
             return cityObject;
         }
@@ -1446,7 +1453,10 @@ internal static class LocalCityGmlObjectProjection
     {
         footprint = null;
         SurfaceProjectionInfo[] surfaceInfos = cityObject.Surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface.ToProjectionModel(), cityObjectOrigin.ToProjectionModel(), cityObjectCartesian))
+            .Select(surface => CreateSurfaceProjectionInfo(
+                global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface),
+                cityObjectOrigin.ToProjectionModel(),
+                cityObjectCartesian))
             .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
             .ToArray();
         if (surfaceInfos.Length == 0)
@@ -2074,7 +2084,7 @@ internal static class LocalCityGmlObjectProjection
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
-        ParsedSurface projectionSurface = surface.ToProjectionModel();
+        ParsedSurface projectionSurface = global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface);
         if (projectionSurface.UsesGeneratedDemTexture)
         {
             return new ResolvedSurfaceMaterial(
@@ -2389,7 +2399,7 @@ internal static class LocalCityGmlObjectProjection
         LocalCartesian? cityObjectCartesian)
     {
         return CreateGeneratedRoadMarkingSurfaces(
-                surface.ToProjectionModel(),
+                global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface),
                 cityObjectOrigin.ToProjectionModel(),
                 cityObjectCartesian)
             .Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel)
@@ -3809,7 +3819,8 @@ internal static class LocalCityGmlObjectProjection
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(materialResolver);
 
-        double? geometryHeightMeters = TryGetGeometryHeightMeters(parsedCityObject.Surfaces.Select(static surface => surface.ToProjectionModel()));
+        double? geometryHeightMeters = TryGetGeometryHeightMeters(
+            parsedCityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel));
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject terrainAlignedParsedCityObject =
             ApplyGeneratedLod1Roof(ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler)) with
             {
@@ -3923,7 +3934,8 @@ internal static class LocalCityGmlObjectProjection
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(materialResolver);
 
-        double? geometryHeightMeters = TryGetGeometryHeightMeters(parsedCityObject.Surfaces.Select(static surface => surface.ToProjectionModel()));
+        double? geometryHeightMeters = TryGetGeometryHeightMeters(
+            parsedCityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel));
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject terrainAlignedParsedCityObject =
             ApplyGeneratedLod1Roof(ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler)) with
             {
@@ -4078,14 +4090,14 @@ internal static class LocalCityGmlObjectProjection
         global::PlateauResoniteLink.Application.Importing.ParsedSurface[] conformedSurfaces =
             PlateauPackageCatalog.IsRoadPackage(subdividedCityObject.PackageName)
                 ? ConformRoadSurfacesToTerrainWithFallback(
-                        subdividedCityObject.Surfaces.Select(static surface => surface.ToProjectionModel()).ToArray(),
+                        subdividedCityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel).ToArray(),
                         terrainHeightSampler,
                         ref terrainAligned)
                     .Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel)
                     .ToArray()
                 : ConformSurfacesToTerrain(
                         subdividedCityObject.PackageName,
-                        subdividedCityObject.Surfaces.Select(static surface => surface.ToProjectionModel()).ToArray(),
+                        subdividedCityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel).ToArray(),
                         terrainHeightSampler,
                         cityObjectOrigin.ToProjectionModel(),
                         cityObjectCartesian,
@@ -4212,7 +4224,9 @@ internal static class LocalCityGmlObjectProjection
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
-        ParsedSurface[] projectionSurfaces = cityObject.Surfaces.Select(static surface => surface.ToProjectionModel()).ToArray();
+        ParsedSurface[] projectionSurfaces = cityObject.Surfaces
+            .Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel)
+            .ToArray();
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
             cityObject.PackageName,
             projectionSurfaces,
@@ -4873,7 +4887,9 @@ internal static class LocalCityGmlObjectProjection
         IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
         IDefaultMaterialResolver materialResolver)
     {
-        ParsedSurface[] projectionSurfaces = cityObject.Surfaces.Select(static surface => surface.ToProjectionModel()).ToArray();
+        ParsedSurface[] projectionSurfaces = cityObject.Surfaces
+            .Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel)
+            .ToArray();
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
             cityObject.PackageName,
             projectionSurfaces,
@@ -5396,7 +5412,7 @@ internal static class LocalCityGmlObjectProjection
         return surface.TexturePayload is null
             && !surface.UsesGeneratedDemTexture
             && IsRoofTerrainTextureSurface(
-                surface.ToProjectionModel(),
+                global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface),
                 cityObjectMinAltitude,
                 cityObjectOrigin.ToProjectionModel(),
                 cityObjectCartesian);

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedObjectModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedObjectModels.cs
@@ -6,17 +6,7 @@ namespace PlateauResoniteLink.Application.Importing;
 internal sealed record ParsedRing(
     string RingId,
     GeodeticPoint[] Vertices,
-    IReadOnlyList<Float2>? UVs)
-{
-    internal LocalCityGmlObjectProjection.ParsedRing ToProjectionModel()
-    {
-        return new LocalCityGmlObjectProjection.ParsedRing(
-            RingId,
-            Vertices.Select(static point => point.ToProjectionModel()).ToArray(),
-            UVs);
-    }
-
-}
+    IReadOnlyList<Float2>? UVs);
 
 internal enum ParsedSurfaceSemantic
 {
@@ -41,20 +31,6 @@ internal sealed record ParsedSurface(
 {
     public IEnumerable<GeodeticPoint> Vertices =>
         ExteriorRing.Vertices.Concat(InteriorRings.SelectMany(static ring => ring.Vertices));
-
-    internal LocalCityGmlObjectProjection.ParsedSurface ToProjectionModel()
-    {
-        return new LocalCityGmlObjectProjection.ParsedSurface(
-            PolygonId,
-            (LocalCityGmlObjectProjection.ParsedSurfaceSemantic)Semantic,
-            ExteriorRing.ToProjectionModel(),
-            InteriorRings.Select(static ring => ring.ToProjectionModel()).ToArray(),
-            BaseColor,
-            TexturePayload,
-            UsesGeneratedDemTexture,
-            OpticalProperties);
-    }
-
 }
 
 internal sealed record ParsedCityObject(
@@ -72,26 +48,4 @@ internal sealed record ParsedCityObject(
     int? FloorsAboveGround = null,
     double? MeasuredHeightMeters = null,
     BuildingAttributeContext? BuildingAttributes = null,
-    double? GeometryHeightMeters = null)
-{
-    internal LocalCityGmlObjectProjection.ParsedCityObject ToProjectionModel()
-    {
-        return new LocalCityGmlObjectProjection.ParsedCityObject(
-            SlotKey,
-            DisplayName,
-            PackageName,
-            ActualMeshCode,
-            LodLevel,
-            Surfaces.Select(static surface => surface.ToProjectionModel()).ToArray(),
-            ReferenceSystem.ToProjectionModel(),
-            SourceFileRelativePath,
-            SharedAcrossMeshCodes,
-            TerrainAligned,
-            GeodeticOriginOverride?.ToProjectionModel(),
-            FloorsAboveGround,
-            MeasuredHeightMeters,
-            BuildingAttributes,
-            GeometryHeightMeters);
-    }
-
-}
+    double? GeometryHeightMeters = null);

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedSourceFileModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedSourceFileModels.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,26 +9,7 @@ internal sealed record SourceFileDescriptor(
     string RelativePath,
     string PackageName,
     string MatchedMeshCode,
-    bool RequiresMeshCodeBoundsFilter)
-{
-    internal LocalCityGmlObjectProjection.SourceFileDescriptor ToProjectionModel()
-    {
-        return new LocalCityGmlObjectProjection.SourceFileDescriptor(
-            RelativePath,
-            PackageName,
-            MatchedMeshCode,
-            RequiresMeshCodeBoundsFilter);
-    }
-
-    internal static SourceFileDescriptor FromProjectionModel(LocalCityGmlObjectProjection.SourceFileDescriptor sourceFile)
-    {
-        return new SourceFileDescriptor(
-            sourceFile.RelativePath,
-            sourceFile.PackageName,
-            sourceFile.MatchedMeshCode,
-            sourceFile.RequiresMeshCodeBoundsFilter);
-    }
-}
+    bool RequiresMeshCodeBoundsFilter);
 
 internal sealed record CachedSourceFileDescriptor(
     SourceFileDescriptor SourceFile,
@@ -38,14 +18,6 @@ internal sealed record CachedSourceFileDescriptor(
     public string RelativePath => SourceFile.RelativePath;
 
     public string PackageName => SourceFile.PackageName;
-
-    internal LocalCityGmlObjectProjection.CachedSourceFileDescriptor ToProjectionModel()
-    {
-        return new LocalCityGmlObjectProjection.CachedSourceFileDescriptor(
-            SourceFile.ToProjectionModel(),
-            CityObjects.Select(static cityObject => cityObject.ToProjectionModel()).ToArray());
-    }
-
 }
 
 internal sealed class SourceFilePipeline
@@ -99,16 +71,4 @@ internal sealed record ParsedSourceFileResult(
     ParsedCityObject[] CityObjects,
     CoordinateReferenceSystem? ReferenceSystem,
     TerrainHeightTriangle[] TerrainTriangles,
-    TimeSpan Elapsed)
-{
-    internal LocalCityGmlObjectProjection.ParsedSourceFileResult ToProjectionModel()
-    {
-        return new LocalCityGmlObjectProjection.ParsedSourceFileResult(
-            SourceFile.ToProjectionModel(),
-            CityObjects.Select(static cityObject => cityObject.ToProjectionModel()).ToArray(),
-            ReferenceSystem?.ToProjectionModel(),
-            TerrainTriangles.Select(static triangle => triangle.ToProjectionModel()).ToArray(),
-            Elapsed);
-    }
-
-}
+    TimeSpan Elapsed);

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
@@ -314,7 +314,7 @@ public sealed class DemTerrainOverlayAssignmentTests
             Sources: [new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", 18)]);
         GeographicRectangle objectBounds = GetSurfaceBounds(surface);
         LocalCityGmlObjectProjection.ResolvedSurfaceMaterial material = new(
-            surface.ToProjectionModel(),
+            CityGmlProjectionModelAdapter.ToProjectionModel(surface),
             new ResolvedMaterial(
                 MaterialType.Standard,
                 TexturePayload: null,

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -1936,7 +1936,14 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjectionForTest(
             "bldg",
-            [wallSurface.ToProjectionModel(), roofSurface.ToProjectionModel(), groundSurface.ToProjectionModel(), reversedGroundSurface.ToProjectionModel(), outerFloorSurface.ToProjectionModel(), highOuterFloorSurface.ToProjectionModel()],
+            [
+                CityGmlProjectionModelAdapter.ToProjectionModel(wallSurface),
+                CityGmlProjectionModelAdapter.ToProjectionModel(roofSurface),
+                CityGmlProjectionModelAdapter.ToProjectionModel(groundSurface),
+                CityGmlProjectionModelAdapter.ToProjectionModel(reversedGroundSurface),
+                CityGmlProjectionModelAdapter.ToProjectionModel(outerFloorSurface),
+                CityGmlProjectionModelAdapter.ToProjectionModel(highOuterFloorSurface),
+            ],
             origin,
             cartesian);
 
@@ -1983,7 +1990,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjectionForTest(
             "tran",
-            [groundSurface.ToProjectionModel()],
+            [CityGmlProjectionModelAdapter.ToProjectionModel(groundSurface)],
             origin,
             cartesian);
 
@@ -2041,7 +2048,12 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjectionForTest(
             "bldg",
-            [wallSurface.ToProjectionModel(), bottomSurface.ToProjectionModel(), reversedBottomSurface.ToProjectionModel(), roofSurface.ToProjectionModel()],
+            [
+                CityGmlProjectionModelAdapter.ToProjectionModel(wallSurface),
+                CityGmlProjectionModelAdapter.ToProjectionModel(bottomSurface),
+                CityGmlProjectionModelAdapter.ToProjectionModel(reversedBottomSurface),
+                CityGmlProjectionModelAdapter.ToProjectionModel(roofSurface),
+            ],
             origin,
             cartesian);
 
@@ -2086,7 +2098,10 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjectionForTest(
             "bldg",
-            [bottomSurface.ToProjectionModel(), highDownwardRoofSurface.ToProjectionModel()],
+            [
+                CityGmlProjectionModelAdapter.ToProjectionModel(bottomSurface),
+                CityGmlProjectionModelAdapter.ToProjectionModel(highDownwardRoofSurface),
+            ],
             origin,
             cartesian);
 
@@ -2112,7 +2127,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjectionForTest(
             "bldg",
-            [onlySurface.ToProjectionModel()],
+            [CityGmlProjectionModelAdapter.ToProjectionModel(onlySurface)],
             origin,
             cartesian);
 
@@ -2168,7 +2183,12 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjectionForTest(
             "bldg",
-            [wallSurface.ToProjectionModel(), exactBoundaryBottomSurface.ToProjectionModel(), aboveBoundaryBottomSurface.ToProjectionModel(), roofSurface.ToProjectionModel()],
+            [
+                CityGmlProjectionModelAdapter.ToProjectionModel(wallSurface),
+                CityGmlProjectionModelAdapter.ToProjectionModel(exactBoundaryBottomSurface),
+                CityGmlProjectionModelAdapter.ToProjectionModel(aboveBoundaryBottomSurface),
+                CityGmlProjectionModelAdapter.ToProjectionModel(roofSurface),
+            ],
             origin,
             cartesian);
 


### PR DESCRIPTION
## Summary
- add `ToProjectionModel` conversions to `CityGmlProjectionModelAdapter` so CityGML projection compatibility is centralized in one adapter
- remove projection conversion methods from parsed CityGML records
- update projection and focused tests to use the adapter explicitly, without adding partial boundaries

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~LocalCityGmlSourceFileParserStreamingTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests|FullyQualifiedName~LocalCityGmlDocumentReaderTests|FullyQualifiedName~CityGml|FullyQualifiedName~DemTerrainOverlayAssignmentTests"`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- `git diff --check`
- `rg -n "internal .*ToProjectionModel\(|static .*FromProjectionModel\(|\.ToProjectionModel\(\)" src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedObjectModels.cs src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedSourceFileModels.cs tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs`