### PR TITLE
Extract CityGML mesh code bounds filter

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlMeshCodeBoundsFilter.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlMeshCodeBoundsFilter.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityGmlMeshCodeBoundsFilter
+{
+    private static readonly Regex ConcreteMeshCodeTokenRegex = new(
+        @"(?<!\d)(\d{8})(?!\d)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    internal static string ResolveActualMeshCode(
+        string packageName,
+        string displayName,
+        string objectId,
+        string fallbackActualMeshCode,
+        bool sharedAcrossMeshCodes)
+    {
+        return sharedAcrossMeshCodes && string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase)
+            ? ResolveConcreteActualMeshCode(displayName, objectId, fallbackActualMeshCode)
+            : fallbackActualMeshCode;
+    }
+
+    internal static bool IntersectsRequestedMeshCodeBounds(
+        string actualMeshCode,
+        bool sharedAcrossMeshCodes,
+        LocalCityGmlObjectProjection.CoordinateReferenceSystem coordinateReferenceSystem,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
+        IEnumerable<LocalCityGmlObjectProjection.ParsedSurface> surfaces)
+    {
+        if (requestedMeshCodeBounds is not { Count: > 0 }
+            || !coordinateReferenceSystem.IsGeographic)
+        {
+            return true;
+        }
+
+        if (sharedAcrossMeshCodes
+            && MeshCodeBounds.TryParse(actualMeshCode) is { } actualMeshCodeBounds)
+        {
+            return IntersectsMeshCodeBounds(actualMeshCodeBounds, requestedMeshCodeBounds);
+        }
+
+        return IntersectsMeshCodeBounds(surfaces, requestedMeshCodeBounds);
+    }
+
+    private static bool IntersectsMeshCodeBounds(
+        IEnumerable<LocalCityGmlObjectProjection.ParsedSurface> surfaces,
+        IReadOnlyList<MeshCodeBounds> meshCodeAreas)
+    {
+        List<LocalCityGmlObjectProjection.GeodeticPoint> vertices = surfaces
+            .SelectMany(static surface => surface.Vertices)
+            .ToList();
+
+        double minLatitude = vertices.Min(static point => point.Latitude);
+        double maxLatitude = vertices.Max(static point => point.Latitude);
+        double minLongitude = vertices.Min(static point => point.Longitude);
+        double maxLongitude = vertices.Max(static point => point.Longitude);
+
+        return IntersectsMeshCodeBounds(minLatitude, maxLatitude, minLongitude, maxLongitude, meshCodeAreas);
+    }
+
+    private static bool IntersectsMeshCodeBounds(
+        MeshCodeBounds meshCodeArea,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds)
+    {
+        return IntersectsMeshCodeBounds(
+            meshCodeArea.SouthLatitude,
+            meshCodeArea.NorthLatitude,
+            meshCodeArea.WestLongitude,
+            meshCodeArea.EastLongitude,
+            requestedMeshCodeBounds);
+    }
+
+    private static bool IntersectsMeshCodeBounds(
+        double minLatitude,
+        double maxLatitude,
+        double minLongitude,
+        double maxLongitude,
+        IReadOnlyList<MeshCodeBounds> meshCodeAreas)
+    {
+        const double overlapTolerance = 1e-10;
+
+        return meshCodeAreas.Any(meshCodeArea =>
+        {
+            double latitudeOverlap = Math.Min(maxLatitude, meshCodeArea.NorthLatitude)
+                - Math.Max(minLatitude, meshCodeArea.SouthLatitude);
+            if (latitudeOverlap <= overlapTolerance)
+            {
+                return false;
+            }
+
+            double longitudeOverlap = Math.Min(maxLongitude, meshCodeArea.EastLongitude)
+                - Math.Max(minLongitude, meshCodeArea.WestLongitude);
+            return longitudeOverlap > overlapTolerance;
+        });
+    }
+
+    private static string ResolveConcreteActualMeshCode(
+        string displayName,
+        string objectId,
+        string fallbackActualMeshCode)
+    {
+        return TryResolveConcreteMeshCode(displayName, out string? displayNameMeshCode)
+            ? displayNameMeshCode!
+            : TryResolveConcreteMeshCode(objectId, out string? objectIdMeshCode)
+                ? objectIdMeshCode!
+                : fallbackActualMeshCode;
+    }
+
+    private static bool TryResolveConcreteMeshCode(string value, out string? meshCode)
+    {
+        meshCode = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        Match match = ConcreteMeshCodeTokenRegex.Match(value);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        string candidate = match.Groups[1].Value;
+        if (!PlateauMeshCode.TryGetBounds(candidate, out _))
+        {
+            return false;
+        }
+
+        meshCode = candidate;
+        return true;
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -48,12 +47,6 @@ internal static class LocalCityGmlObjectProjection
     private static readonly XNamespace App = "http://www.opengis.net/citygml/appearance/2.0";
     private static readonly XNamespace Core = "http://www.opengis.net/citygml/2.0";
     private static readonly XNamespace Gml = "http://www.opengis.net/gml";
-    private static readonly Regex ConcreteMeshCodeTokenRegex = new(
-        @"(?<!\d)(\d{8})(?!\d)",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-
-
     internal static ParsedCityObject? ParseCityObject(
         XElement cityObjectElement,
         string packageName,
@@ -74,10 +67,12 @@ internal static class LocalCityGmlObjectProjection
             displayName = objectId;
         }
 
-        string resolvedActualMeshCode =
-            sharedAcrossMeshCodes && string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase)
-                ? ResolveConcreteActualMeshCode(displayName!, objectId, actualMeshCode)
-                : actualMeshCode;
+        string resolvedActualMeshCode = CityGmlMeshCodeBoundsFilter.ResolveActualMeshCode(
+            packageName,
+            displayName!,
+            objectId,
+            actualMeshCode,
+            sharedAcrossMeshCodes);
         BuildingAttributeContext buildingAttributes = BuildingAttributeParser.Parse(cityObjectElement);
         int? floorsAboveGround = BuildingAttributeQueries.TryGetKnownPositiveInteger(buildingAttributes.StoreysAboveGround);
         double? measuredHeightMeters = BuildingAttributeQueries.TryGetKnownPositiveMetric(buildingAttributes.MeasuredHeightMeters);
@@ -117,18 +112,14 @@ internal static class LocalCityGmlObjectProjection
             return null;
         }
 
-        if (requestedMeshCodeBounds is not null
-            && requestedMeshCodeBounds.Count > 0
-            && coordinateReferenceSystem.IsGeographic)
+        if (!CityGmlMeshCodeBoundsFilter.IntersectsRequestedMeshCodeBounds(
+                resolvedActualMeshCode,
+                sharedAcrossMeshCodes,
+                coordinateReferenceSystem,
+                requestedMeshCodeBounds,
+                surfaces))
         {
-            bool intersectsRequestedMeshCodeBounds = sharedAcrossMeshCodes
-                && TryCreateMeshCodeBounds(resolvedActualMeshCode, out MeshCodeBounds? resolvedActualMeshCodeBounds)
-                    ? IntersectsMeshCodeBounds(resolvedActualMeshCodeBounds!, requestedMeshCodeBounds)
-                    : IntersectsMeshCodeBounds(surfaces, requestedMeshCodeBounds);
-            if (!intersectsRequestedMeshCodeBounds)
-            {
-                return null;
-            }
+            return null;
         }
 
         string fileStem = Path.GetFileNameWithoutExtension(relativeSourceFile);
@@ -233,94 +224,6 @@ internal static class LocalCityGmlObjectProjection
                 NumberStyles.None,
                 CultureInfo.InvariantCulture,
                 out lodLevel);
-    }
-
-    private static bool IntersectsMeshCodeBounds(
-        IEnumerable<ParsedSurface> surfaces,
-        IReadOnlyList<MeshCodeBounds> meshCodeAreas)
-    {
-        List<GeodeticPoint> vertices = surfaces
-            .SelectMany(static surface => surface.Vertices)
-            .ToList();
-
-        double minLatitude = vertices.Min(static point => point.Latitude);
-        double maxLatitude = vertices.Max(static point => point.Latitude);
-        double minLongitude = vertices.Min(static point => point.Longitude);
-        double maxLongitude = vertices.Max(static point => point.Longitude);
-
-        return IntersectsMeshCodeBounds(minLatitude, maxLatitude, minLongitude, maxLongitude, meshCodeAreas);
-    }
-
-    private static bool IntersectsMeshCodeBounds(
-        MeshCodeBounds meshCodeArea,
-        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds)
-    {
-        return IntersectsMeshCodeBounds(
-            meshCodeArea.SouthLatitude,
-            meshCodeArea.NorthLatitude,
-            meshCodeArea.WestLongitude,
-            meshCodeArea.EastLongitude,
-            requestedMeshCodeBounds);
-    }
-
-    private static bool IntersectsMeshCodeBounds(
-        double minLatitude,
-        double maxLatitude,
-        double minLongitude,
-        double maxLongitude,
-        IReadOnlyList<MeshCodeBounds> meshCodeAreas)
-    {
-        const double overlapTolerance = 1e-10;
-
-        return meshCodeAreas.Any(meshCodeArea =>
-        {
-            double latitudeOverlap = Math.Min(maxLatitude, meshCodeArea.NorthLatitude)
-                - Math.Max(minLatitude, meshCodeArea.SouthLatitude);
-            if (latitudeOverlap <= overlapTolerance)
-            {
-                return false;
-            }
-
-            double longitudeOverlap = Math.Min(maxLongitude, meshCodeArea.EastLongitude)
-                - Math.Max(minLongitude, meshCodeArea.WestLongitude);
-            return longitudeOverlap > overlapTolerance;
-        });
-    }
-
-    private static string ResolveConcreteActualMeshCode(
-        string displayName,
-        string objectId,
-        string fallbackActualMeshCode)
-    {
-        return TryResolveConcreteMeshCode(displayName, out string? displayNameMeshCode)
-            ? displayNameMeshCode!
-            : TryResolveConcreteMeshCode(objectId, out string? objectIdMeshCode)
-                ? objectIdMeshCode!
-                : fallbackActualMeshCode;
-    }
-
-    private static bool TryResolveConcreteMeshCode(string value, out string? meshCode)
-    {
-        meshCode = null;
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return false;
-        }
-
-        Match match = ConcreteMeshCodeTokenRegex.Match(value);
-        if (!match.Success)
-        {
-            return false;
-        }
-
-        string candidate = match.Groups[1].Value;
-        if (!PlateauMeshCode.TryGetBounds(candidate, out _))
-        {
-            return false;
-        }
-
-        meshCode = candidate;
-        return true;
     }
 
     private static bool TryCreateMeshCodeBounds(string meshCode, out MeshCodeBounds? meshCodeArea)

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlMeshCodeBoundsFilterTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlMeshCodeBoundsFilterTests.cs
@@ -1,0 +1,97 @@
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class CityGmlMeshCodeBoundsFilterTests
+{
+    [Fact]
+    public void ResolveActualMeshCodeUsesConcreteDemMeshCodeFromDisplayName()
+    {
+        string actualMeshCode = CityGmlMeshCodeBoundsFilter.ResolveActualMeshCode(
+            "dem",
+            "parent relief 53394525",
+            "dem-parent",
+            fallbackActualMeshCode: "533945",
+            sharedAcrossMeshCodes: true);
+
+        Assert.Equal("53394525", actualMeshCode);
+    }
+
+    [Fact]
+    public void ResolveActualMeshCodeKeepsFallbackForNonDemSharedFile()
+    {
+        string actualMeshCode = CityGmlMeshCodeBoundsFilter.ResolveActualMeshCode(
+            "bldg",
+            "building 53394525",
+            "bldg-1",
+            fallbackActualMeshCode: "533945",
+            sharedAcrossMeshCodes: true);
+
+        Assert.Equal("533945", actualMeshCode);
+    }
+
+    [Fact]
+    public void IntersectsRequestedMeshCodeBoundsUsesActualMeshCodeForSharedObjects()
+    {
+        LocalCityGmlObjectProjection.ParsedSurface surfaceOutsideRequest = CreateSurfaceAtMeshCenter("53394600");
+
+        bool intersects = CityGmlMeshCodeBoundsFilter.IntersectsRequestedMeshCodeBounds(
+            actualMeshCode: "53394525",
+            sharedAcrossMeshCodes: true,
+            coordinateReferenceSystem: LocalCityGmlObjectProjection.CoordinateReferenceSystem.Parse("EPSG:4326"),
+            requestedMeshCodeBounds: [MeshCodeBounds.TryParse("53394525")!],
+            surfaces: [surfaceOutsideRequest]);
+
+        Assert.True(intersects);
+    }
+
+    [Fact]
+    public void IntersectsRequestedMeshCodeBoundsUsesSurfaceBoundsForNonSharedObjects()
+    {
+        LocalCityGmlObjectProjection.ParsedSurface surfaceOutsideRequest = CreateSurfaceAtMeshCenter("53394600");
+
+        bool intersects = CityGmlMeshCodeBoundsFilter.IntersectsRequestedMeshCodeBounds(
+            actualMeshCode: "53394525",
+            sharedAcrossMeshCodes: false,
+            coordinateReferenceSystem: LocalCityGmlObjectProjection.CoordinateReferenceSystem.Parse("EPSG:4326"),
+            requestedMeshCodeBounds: [MeshCodeBounds.TryParse("53394525")!],
+            surfaces: [surfaceOutsideRequest]);
+
+        Assert.False(intersects);
+    }
+
+    [Fact]
+    public void IntersectsRequestedMeshCodeBoundsSkipsFilteringForLocalCartesianReferenceSystem()
+    {
+        LocalCityGmlObjectProjection.ParsedSurface surfaceOutsideRequest = CreateSurfaceAtMeshCenter("53394600");
+
+        bool intersects = CityGmlMeshCodeBoundsFilter.IntersectsRequestedMeshCodeBounds(
+            actualMeshCode: "53394525",
+            sharedAcrossMeshCodes: false,
+            coordinateReferenceSystem: LocalCityGmlObjectProjection.CoordinateReferenceSystem.Parse((string?)null),
+            requestedMeshCodeBounds: [MeshCodeBounds.TryParse("53394525")!],
+            surfaces: [surfaceOutsideRequest]);
+
+        Assert.True(intersects);
+    }
+
+    private static LocalCityGmlObjectProjection.ParsedSurface CreateSurfaceAtMeshCenter(string meshCode)
+    {
+        Assert.True(PlateauMeshCode.TryGetBounds(
+            meshCode,
+            out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds));
+
+        double latitude = (bounds.SouthLatitude + bounds.NorthLatitude) / 2.0;
+        double longitude = (bounds.WestLongitude + bounds.EastLongitude) / 2.0;
+        LocalCityGmlObjectProjection.GeodeticPoint point = new(latitude, longitude, 0.0);
+
+        return new LocalCityGmlObjectProjection.ParsedSurface(
+            "polygon",
+            LocalCityGmlObjectProjection.ParsedSurfaceSemantic.Ground,
+            new LocalCityGmlObjectProjection.ParsedRing("ring", [point, point, point], UVs: null),
+            InteriorRings: [],
+            new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null);
+    }
+}


### PR DESCRIPTION
## Summary
- extract CityGML actual mesh-code resolution and requested mesh bounds filtering from LocalCityGmlObjectProjection
- keep ParseCityObject behavior for shared DEM objects, geographic CRS filtering, and surface-bounds fallback
- add focused tests for mesh-code resolution, shared-vs-non-shared bounds checks, and non-geographic skip behavior

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~CityGmlMeshCodeBoundsFilterTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests|FullyQualifiedName~LocalCityGmlSourceFileParserStreamingTests"
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- git diff --check

## Notes
- No partial type introduced for this boundary extraction.
- The first build attempt hit local disk exhaustion from accumulated worktree artifacts. After deleting generated .worktree/*/artifacts outputs and rerunning restore, the documented verification sequence passed.