### PR TITLE
Extract city object origin resolver

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityObjectOriginResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityObjectOriginResolver.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityObjectOriginResolver
+{
+    internal static GeodeticPoint Resolve(GeodeticPoint? originOverride, IEnumerable<GeodeticPoint> vertices)
+    {
+        if (originOverride is not null)
+        {
+            return originOverride;
+        }
+
+        List<GeodeticPoint> allPoints = vertices.ToList();
+        double minLatitude = allPoints.Min(static point => point.Latitude);
+        double maxLatitude = allPoints.Max(static point => point.Latitude);
+        double minLongitude = allPoints.Min(static point => point.Longitude);
+        double maxLongitude = allPoints.Max(static point => point.Longitude);
+        double minAltitude = allPoints.Min(static point => point.Altitude);
+
+        return new GeodeticPoint(
+            Latitude: (minLatitude + maxLatitude) / 2.0,
+            Longitude: (minLongitude + maxLongitude) / 2.0,
+            Altitude: minAltitude);
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -277,7 +277,7 @@ internal static class LocalCityGmlObjectProjection
             return [surface];
         }
 
-        GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        GeodeticPoint cityObjectOrigin = ResolveProjectionCityObjectOrigin(cityObject);
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
                 cityObjectOrigin.Latitude,
@@ -314,7 +314,7 @@ internal static class LocalCityGmlObjectProjection
             return [surface];
         }
 
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
                 cityObjectOrigin.Latitude,
@@ -928,7 +928,7 @@ internal static class LocalCityGmlObjectProjection
         {
             GeometryHeightMeters = geometryHeightMeters,
         };
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
 
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
@@ -1042,7 +1042,7 @@ internal static class LocalCityGmlObjectProjection
             return cityObject;
         }
 
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
         LocalCartesian cityObjectCartesian = new(
             cityObjectOrigin.Latitude,
             cityObjectOrigin.Longitude,
@@ -1475,46 +1475,24 @@ internal static class LocalCityGmlObjectProjection
             source.Altitude + ((target.Altitude - source.Altitude) * ratio));
     }
 
-    private static GeodeticPoint GetCityObjectOrigin(ParsedCityObject cityObject)
+    private static GeodeticPoint ResolveProjectionCityObjectOrigin(ParsedCityObject cityObject)
     {
-        if (cityObject.GeodeticOriginOverride is not null)
-        {
-            return cityObject.GeodeticOriginOverride;
-        }
-
-        List<GeodeticPoint> allPoints = cityObject.Surfaces.SelectMany(static surface => surface.Vertices).ToList();
-        double minLatitude = allPoints.Min(static point => point.Latitude);
-        double maxLatitude = allPoints.Max(static point => point.Latitude);
-        double minLongitude = allPoints.Min(static point => point.Longitude);
-        double maxLongitude = allPoints.Max(static point => point.Longitude);
-        double minAltitude = allPoints.Min(static point => point.Altitude);
-
-        return new GeodeticPoint(
-            Latitude: (minLatitude + maxLatitude) / 2.0,
-            Longitude: (minLongitude + maxLongitude) / 2.0,
-            Altitude: minAltitude);
+        return CityObjectOriginResolver.Resolve(
+                cityObject.GeodeticOriginOverride is null
+                    ? null
+                    : global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObject.GeodeticOriginOverride),
+                cityObject.Surfaces
+                    .SelectMany(static surface => surface.Vertices)
+                    .Select(static point => global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(point)))
+            .ToProjectionModel();
     }
 
-    private static global::PlateauResoniteLink.Application.Importing.GeodeticPoint GetCityObjectOrigin(
+    private static global::PlateauResoniteLink.Application.Importing.GeodeticPoint ResolveParsedCityObjectOrigin(
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject)
     {
-        if (cityObject.GeodeticOriginOverride is not null)
-        {
-            return cityObject.GeodeticOriginOverride;
-        }
-
-        List<global::PlateauResoniteLink.Application.Importing.GeodeticPoint> allPoints =
-            cityObject.Surfaces.SelectMany(static surface => surface.Vertices).ToList();
-        double minLatitude = allPoints.Min(static point => point.Latitude);
-        double maxLatitude = allPoints.Max(static point => point.Latitude);
-        double minLongitude = allPoints.Min(static point => point.Longitude);
-        double maxLongitude = allPoints.Max(static point => point.Longitude);
-        double minAltitude = allPoints.Min(static point => point.Altitude);
-
-        return new global::PlateauResoniteLink.Application.Importing.GeodeticPoint(
-            Latitude: (minLatitude + maxLatitude) / 2.0,
-            Longitude: (minLongitude + maxLongitude) / 2.0,
-            Altitude: minAltitude);
+        return CityObjectOriginResolver.Resolve(
+            cityObject.GeodeticOriginOverride,
+            cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
     }
 
     private static ResolvedSurfaceMaterial ResolveSurfaceMaterial(
@@ -3350,7 +3328,7 @@ internal static class LocalCityGmlObjectProjection
                 projectedCityObjects.Add(cityObject);
             }
 
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint markingOrigin = GetCityObjectOrigin(splitCityObject.CityObject);
+            global::PlateauResoniteLink.Application.Importing.GeodeticPoint markingOrigin = ResolveParsedCityObjectOrigin(splitCityObject.CityObject);
             LocalCartesian? markingCartesian = splitCityObject.CityObject.ReferenceSystem.IsGeographic
                 ? new LocalCartesian(
                     markingOrigin.Latitude,
@@ -3444,7 +3422,7 @@ internal static class LocalCityGmlObjectProjection
                     splitCityObject.Overlay);
             }
 
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(splitCityObject.CityObject);
+            global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(splitCityObject.CityObject);
             LocalCartesian? cityObjectCartesian = splitCityObject.CityObject.ReferenceSystem.IsGeographic
                 ? new LocalCartesian(
                     cityObjectOrigin.Latitude,
@@ -3561,7 +3539,7 @@ internal static class LocalCityGmlObjectProjection
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject subdividedCityObject =
             SubdivideTerrainAlignedCityObject(parsedCityObject);
         bool terrainAligned = false;
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(subdividedCityObject);
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(subdividedCityObject);
         LocalCartesian? cityObjectCartesian = subdividedCityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
                 cityObjectOrigin.Latitude,
@@ -3972,7 +3950,7 @@ internal static class LocalCityGmlObjectProjection
     {
         heightMapCityObject = null;
 
-        GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        GeodeticPoint cityObjectOrigin = ResolveProjectionCityObjectOrigin(cityObject);
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
                 cityObjectOrigin.Latitude,
@@ -4143,7 +4121,7 @@ internal static class LocalCityGmlObjectProjection
             return false;
         }
 
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
                 cityObjectOrigin.Latitude,
@@ -4552,7 +4530,7 @@ internal static class LocalCityGmlObjectProjection
             yield break;
         }
 
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
                 cityObjectOrigin.Latitude,

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityObjectOriginResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityObjectOriginResolverTests.cs
@@ -1,0 +1,48 @@
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class CityObjectOriginResolverTests
+{
+    [Fact]
+    public void ResolveUsesOriginOverride()
+    {
+        GeodeticPoint overrideOrigin = new(36.0, 140.0, 12.0);
+
+        GeodeticPoint origin = CityObjectOriginResolver.Resolve(
+            overrideOrigin,
+            CreateVertices());
+
+        Assert.Equal(overrideOrigin, origin);
+    }
+
+    [Fact]
+    public void ResolveComputesBoundingCenterAtMinimumAltitude()
+    {
+        GeodeticPoint origin = CityObjectOriginResolver.Resolve(
+            originOverride: null,
+            CreateVertices(
+                new GeodeticPoint(35.0, 139.0, 5.0),
+                new GeodeticPoint(35.2, 139.4, 7.0),
+                new GeodeticPoint(35.1, 139.1, 3.0)));
+
+        Assert.Equal(35.1, origin.Latitude, 12);
+        Assert.Equal(139.2, origin.Longitude, 12);
+        Assert.Equal(3.0, origin.Altitude, 12);
+    }
+
+    private static GeodeticPoint[] CreateVertices(params GeodeticPoint[] vertices)
+    {
+        if (vertices.Length > 0)
+        {
+            return vertices;
+        }
+
+        return
+        [
+            new GeodeticPoint(35.0, 139.0, 0.0),
+            new GeodeticPoint(35.0, 139.1, 0.0),
+            new GeodeticPoint(35.1, 139.1, 0.0),
+        ];
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
@@ -142,13 +142,17 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await firstCall);
         datasetSource.ReleaseEnsureLocalFile.TrySetResult();
         await datasetSource.BackgroundCompletion.Task.WaitAsync(CancellationToken.None);
-        await Task.Delay(10);
 
-        await Assert.ThrowsAnyAsync<IOException>(async () => await catalog.TryResolveRasterSourceAsync(
-            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", bounds),
-            "dem-fallback",
-            bounds,
-            CancellationToken.None));
+        for (int attempt = 0; attempt < 10 && datasetSource.EnsureLocalFileCallCount < 2; attempt++)
+        {
+            await Assert.ThrowsAnyAsync<IOException>(async () => await catalog.TryResolveRasterSourceAsync(
+                new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", bounds),
+                "dem-fallback",
+                bounds,
+                CancellationToken.None));
+            await Task.Yield();
+        }
+
         Assert.Equal(2, datasetSource.EnsureLocalFileCallCount);
     }
 


### PR DESCRIPTION
## Summary
- Extract city object origin calculation into `CityObjectOriginResolver` over neutral geodetic points.
- Keep LocalCityGmlObjectProjection model conversion at the caller boundary instead of exposing old nested model overloads.
- Replace a timing-based DEM raster catalog test wait with bounded retry so the behavior spec is stable under full-suite load.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`

## PR gate checked before creation
- #213: mergeable, CI success, no review threads/comments, bot THUMBS_UP.