### PR TITLE
Extract city object altitude metrics resolver

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityObjectAltitudeMetricsResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityObjectAltitudeMetricsResolver.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityObjectAltitudeMetricsResolver
+{
+    internal static double GetMinimumAltitude(IEnumerable<GeodeticPoint> vertices)
+    {
+        return GetMinimumAltitude(vertices, static vertex => vertex.Altitude);
+    }
+
+    internal static double GetMinimumAltitude<TPoint>(
+        IEnumerable<TPoint> vertices,
+        Func<TPoint, double> altitudeSelector)
+    {
+        bool hasVertex = false;
+        double minAltitude = double.PositiveInfinity;
+        foreach (TPoint vertex in vertices)
+        {
+            hasVertex = true;
+            minAltitude = double.Min(minAltitude, altitudeSelector(vertex));
+        }
+
+        if (!hasVertex)
+        {
+            throw new InvalidOperationException("Sequence contains no elements.");
+        }
+
+        return minAltitude;
+    }
+
+    internal static double? TryGetGeometryHeightMeters(IEnumerable<GeodeticPoint> vertices)
+    {
+        return TryGetGeometryHeightMeters(vertices, static vertex => vertex.Altitude);
+    }
+
+    internal static double? TryGetGeometryHeightMeters<TPoint>(
+        IEnumerable<TPoint> vertices,
+        Func<TPoint, double> altitudeSelector)
+    {
+        double minAltitude = double.PositiveInfinity;
+        double maxAltitude = double.NegativeInfinity;
+        foreach (TPoint vertex in vertices)
+        {
+            double altitude = altitudeSelector(vertex);
+            minAltitude = double.Min(minAltitude, altitude);
+            maxAltitude = double.Max(maxAltitude, altitude);
+        }
+
+        if (double.IsInfinity(minAltitude) || double.IsInfinity(maxAltitude))
+        {
+            return null;
+        }
+
+        double height = maxAltitude - minAltitude;
+        return height > 0.0 ? height : null;
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/CityObjectGeographicBoundsResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityObjectGeographicBoundsResolver.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityObjectGeographicBoundsResolver
+{
+    internal static GeographicRectangle Resolve(IEnumerable<GeodeticPoint> vertices)
+    {
+        List<GeodeticPoint> allPoints = vertices.ToList();
+        return new GeographicRectangle(
+            MinLatitude: allPoints.Min(static point => point.Latitude),
+            MaxLatitude: allPoints.Max(static point => point.Latitude),
+            MinLongitude: allPoints.Min(static point => point.Longitude),
+            MaxLongitude: allPoints.Max(static point => point.Longitude));
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/CityObjectGeographicBoundsResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityObjectGeographicBoundsResolver.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using PlateauResoniteLink.Domain.Importing;
 
@@ -9,11 +9,67 @@ internal static class CityObjectGeographicBoundsResolver
 {
     internal static GeographicRectangle Resolve(IEnumerable<GeodeticPoint> vertices)
     {
-        List<GeodeticPoint> allPoints = vertices.ToList();
+        return Resolve(
+            vertices,
+            static point => point.Latitude,
+            static point => point.Longitude);
+    }
+
+    internal static GeographicRectangle Resolve<TPoint>(
+        IEnumerable<TPoint> vertices,
+        Func<TPoint, double> latitudeSelector,
+        Func<TPoint, double> longitudeSelector)
+    {
+        double minLatitude = 0.0;
+        double maxLatitude = 0.0;
+        double minLongitude = 0.0;
+        double maxLongitude = 0.0;
+        bool hasPoint = false;
+
+        foreach (TPoint point in vertices)
+        {
+            double latitude = latitudeSelector(point);
+            double longitude = longitudeSelector(point);
+            if (!hasPoint)
+            {
+                minLatitude = latitude;
+                maxLatitude = latitude;
+                minLongitude = longitude;
+                maxLongitude = longitude;
+                hasPoint = true;
+                continue;
+            }
+
+            minLatitude = double.Min(minLatitude, latitude);
+            maxLatitude = MaxLikeEnumerable(maxLatitude, latitude);
+            minLongitude = double.Min(minLongitude, longitude);
+            maxLongitude = MaxLikeEnumerable(maxLongitude, longitude);
+        }
+
+        if (!hasPoint)
+        {
+            throw new InvalidOperationException("Sequence contains no elements.");
+        }
+
         return new GeographicRectangle(
-            MinLatitude: allPoints.Min(static point => point.Latitude),
-            MaxLatitude: allPoints.Max(static point => point.Latitude),
-            MinLongitude: allPoints.Min(static point => point.Longitude),
-            MaxLongitude: allPoints.Max(static point => point.Longitude));
+            MinLatitude: minLatitude,
+            MaxLatitude: maxLatitude,
+            MinLongitude: minLongitude,
+            MaxLongitude: maxLongitude);
+    }
+
+    private static double MaxLikeEnumerable(double current, double candidate)
+    {
+        if (double.IsNaN(candidate))
+        {
+            return current;
+        }
+
+        if (double.IsNaN(current) || candidate > current)
+        {
+            return candidate;
+        }
+
+        return current;
     }
 }

--- a/src/PlateauResoniteLink/Application/Importing/CityObjectOriginResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityObjectOriginResolver.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace PlateauResoniteLink.Application.Importing;
 
@@ -7,21 +7,82 @@ internal static class CityObjectOriginResolver
 {
     internal static GeodeticPoint Resolve(GeodeticPoint? originOverride, IEnumerable<GeodeticPoint> vertices)
     {
+        return Resolve(
+            originOverride,
+            vertices,
+            static point => point.Latitude,
+            static point => point.Longitude,
+            static point => point.Altitude,
+            static (latitude, longitude, altitude) => new GeodeticPoint(latitude, longitude, altitude));
+    }
+
+    internal static TOrigin Resolve<TPoint, TOrigin>(
+        TOrigin? originOverride,
+        IEnumerable<TPoint> vertices,
+        Func<TPoint, double> latitudeSelector,
+        Func<TPoint, double> longitudeSelector,
+        Func<TPoint, double> altitudeSelector,
+        Func<double, double, double, TOrigin> createOrigin)
+        where TOrigin : class
+    {
         if (originOverride is not null)
         {
             return originOverride;
         }
 
-        List<GeodeticPoint> allPoints = vertices.ToList();
-        double minLatitude = allPoints.Min(static point => point.Latitude);
-        double maxLatitude = allPoints.Max(static point => point.Latitude);
-        double minLongitude = allPoints.Min(static point => point.Longitude);
-        double maxLongitude = allPoints.Max(static point => point.Longitude);
-        double minAltitude = allPoints.Min(static point => point.Altitude);
+        double minLatitude = 0.0;
+        double maxLatitude = 0.0;
+        double minLongitude = 0.0;
+        double maxLongitude = 0.0;
+        double minAltitude = 0.0;
+        bool hasPoint = false;
 
-        return new GeodeticPoint(
-            Latitude: (minLatitude + maxLatitude) / 2.0,
-            Longitude: (minLongitude + maxLongitude) / 2.0,
-            Altitude: minAltitude);
+        foreach (TPoint point in vertices)
+        {
+            double latitude = latitudeSelector(point);
+            double longitude = longitudeSelector(point);
+            double altitude = altitudeSelector(point);
+            if (!hasPoint)
+            {
+                minLatitude = latitude;
+                maxLatitude = latitude;
+                minLongitude = longitude;
+                maxLongitude = longitude;
+                minAltitude = altitude;
+                hasPoint = true;
+                continue;
+            }
+
+            minLatitude = double.Min(minLatitude, latitude);
+            maxLatitude = MaxLikeEnumerable(maxLatitude, latitude);
+            minLongitude = double.Min(minLongitude, longitude);
+            maxLongitude = MaxLikeEnumerable(maxLongitude, longitude);
+            minAltitude = double.Min(minAltitude, altitude);
+        }
+
+        if (!hasPoint)
+        {
+            throw new InvalidOperationException("Sequence contains no elements.");
+        }
+
+        return createOrigin(
+            (minLatitude + maxLatitude) / 2.0,
+            (minLongitude + maxLongitude) / 2.0,
+            minAltitude);
+    }
+
+    private static double MaxLikeEnumerable(double current, double candidate)
+    {
+        if (double.IsNaN(candidate))
+        {
+            return current;
+        }
+
+        if (double.IsNaN(current) || candidate > current)
+        {
+            return candidate;
+        }
+
+        return current;
     }
 }

--- a/src/PlateauResoniteLink/Application/Importing/CityObjectOriginResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityObjectOriginResolver.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityObjectOriginResolver
+{
+    internal static GeodeticPoint Resolve(GeodeticPoint? originOverride, IEnumerable<GeodeticPoint> vertices)
+    {
+        if (originOverride is not null)
+        {
+            return originOverride;
+        }
+
+        List<GeodeticPoint> allPoints = vertices.ToList();
+        double minLatitude = allPoints.Min(static point => point.Latitude);
+        double maxLatitude = allPoints.Max(static point => point.Latitude);
+        double minLongitude = allPoints.Min(static point => point.Longitude);
+        double maxLongitude = allPoints.Max(static point => point.Longitude);
+        double minAltitude = allPoints.Min(static point => point.Altitude);
+
+        return new GeodeticPoint(
+            Latitude: (minLatitude + maxLatitude) / 2.0,
+            Longitude: (minLongitude + maxLongitude) / 2.0,
+            Altitude: minAltitude);
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1476,13 +1476,12 @@ internal static class LocalCityGmlObjectProjection
     private static GeodeticPoint ResolveProjectionCityObjectOrigin(ParsedCityObject cityObject)
     {
         return CityObjectOriginResolver.Resolve(
-                cityObject.GeodeticOriginOverride is null
-                    ? null
-                    : global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObject.GeodeticOriginOverride),
-                cityObject.Surfaces
-                    .SelectMany(static surface => surface.Vertices)
-                    .Select(static point => global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(point)))
-            .ToProjectionModel();
+            cityObject.GeodeticOriginOverride,
+            cityObject.Surfaces.SelectMany(static surface => surface.Vertices),
+            static point => point.Latitude,
+            static point => point.Longitude,
+            static point => point.Altitude,
+            static (latitude, longitude, altitude) => new GeodeticPoint(latitude, longitude, altitude));
     }
 
     private static global::PlateauResoniteLink.Application.Importing.GeodeticPoint ResolveParsedCityObjectOrigin(
@@ -1505,13 +1504,6 @@ internal static class LocalCityGmlObjectProjection
     {
         return CityObjectAltitudeMetricsResolver.GetMinimumAltitude(
             surfaces.SelectMany(static surface => surface.Vertices));
-    }
-
-    private static double? ResolveProjectionGeometryHeightMeters(IEnumerable<ParsedSurface> surfaces)
-    {
-        return CityObjectAltitudeMetricsResolver.TryGetGeometryHeightMeters(
-            surfaces.SelectMany(static surface => surface.Vertices),
-            static point => point.Altitude);
     }
 
     private static double? ResolveParsedGeometryHeightMeters(
@@ -2816,15 +2808,10 @@ internal static class LocalCityGmlObjectProjection
             $"{FormatRounded(value.R)}-{FormatRounded(value.G)}-{FormatRounded(value.B)}-{FormatRounded(value.A)}");
 
     private static string FormatBounds(GeographicRectangle bounds) =>
-        string.Create(
-            CultureInfo.InvariantCulture,
-            $"{FormatRounded(bounds.MinLatitude)}-{FormatRounded(bounds.MaxLatitude)}-{FormatRounded(bounds.MinLongitude)}-{FormatRounded(bounds.MaxLongitude)}");
+        TerrainOverlayDiagnostics.FormatBounds(bounds);
 
-    private static string FormatRounded(double value)
-    {
-        double rounded = Math.Round(value, 6, MidpointRounding.AwayFromZero);
-        return (rounded == 0.0 ? 0.0 : rounded).ToString("0.######", CultureInfo.InvariantCulture);
-    }
+    private static string FormatRounded(double value) =>
+        TerrainOverlayDiagnostics.FormatRounded(value);
 
     private static bool ShouldPreferUvProjection(
         string packageName,
@@ -4393,22 +4380,12 @@ internal static class LocalCityGmlObjectProjection
         IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
         TerrainTextureOverlay? terrainOverlay)
     {
-        string requestedMeshCodeBoundsSummary = requestedMeshCodeBounds is { Count: > 0 }
-            ? string.Join(
-                ",",
-                requestedMeshCodeBounds.Select(static area => string.Create(
-                    CultureInfo.InvariantCulture,
-                    $"{FormatRounded(area.SouthLatitude)}-{FormatRounded(area.NorthLatitude)}-{FormatRounded(area.WestLongitude)}-{FormatRounded(area.EastLongitude)}")))
-            : "<none>";
-        string overlaySummary = terrainOverlay is null
-            ? "<null>"
-            : string.Create(
-                CultureInfo.InvariantCulture,
-                $"package='{terrainOverlay.PackageName}', bounds='{FormatBounds(terrainOverlay.GeographicBounds)}', sources='{terrainOverlay.SourceDescriptorKey}'");
-        return new InvalidOperationException(
-            $"Terrain overlay material requires a third-level mesh-code that matches the overlay geographic bounds. "
-            + $"phase='{phase}', actual_mesh_code='{actualMeshCode}', requested_mesh_code='{requestedMeshCode}', "
-            + $"requested_mesh_code_bounds='{requestedMeshCodeBoundsSummary}', overlay={overlaySummary}.");
+        return TerrainOverlayDiagnostics.CreateMeshCodeMismatchException(
+            phase,
+            actualMeshCode,
+            requestedMeshCode,
+            requestedMeshCodeBounds,
+            terrainOverlay);
     }
 
     private static IEnumerable<(global::PlateauResoniteLink.Application.Importing.ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> SplitParsedCityObjectForTerrainProjection(

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -968,7 +968,7 @@ internal static class LocalCityGmlObjectProjection
 
         IGrouping<MaterialGroupingKey, ResolvedSurfaceMaterial>[] materialGroups = resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateMaterialGroupingKey(
+                resolvedSurface => MaterialGroupingPolicy.CreateKey(
                     cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
@@ -2772,56 +2772,6 @@ internal static class LocalCityGmlObjectProjection
             cartesian);
     }
 
-    private static MaterialGroupingKey CreateMaterialGroupingKey(
-        string actualMeshCode,
-        ResolvedMaterial material,
-        MaterialDepthOffset? depthOffset,
-        Float2? textureScale,
-        ColorRgba color,
-        Float2? textureOffset = null)
-    {
-        if (material.TerrainOverlay is not null)
-        {
-            if (TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, material.TerrainOverlay) is null)
-            {
-                throw CreateTerrainOverlayMeshCodeMismatchException(
-                    "material-grouping",
-                    actualMeshCode,
-                    actualMeshCode,
-                    requestedMeshCodeBounds: null,
-                    material.TerrainOverlay);
-            }
-
-            return new MaterialGroupingKey(
-                material.MaterialType,
-                TexturePayloadIdentity: null,
-                material.TextureSourceKind,
-                material.Projection,
-                depthOffset,
-                IsIdentityTextureScale(textureScale) ? null : textureScale,
-                Family: null,
-                BaseColor: null,
-                IsZeroTextureOffset(textureOffset) ? null : textureOffset,
-                MaterialReuseScope.PerObject,
-                material.BundledVariantIndex,
-                TerrainOverlay: null);
-        }
-
-        return new MaterialGroupingKey(
-            material.MaterialType,
-            material.TexturePayload?.Identity,
-            material.TextureSourceKind,
-            material.Projection,
-            depthOffset,
-            textureScale,
-            material.Family,
-            color,
-            textureOffset,
-            material.ReuseScope,
-            material.BundledVariantIndex,
-            material.TerrainOverlay);
-    }
-
     private static string CreateTerrainOverlayToken(TerrainTextureOverlay terrainOverlay)
     {
         return string.Create(
@@ -2874,20 +2824,6 @@ internal static class LocalCityGmlObjectProjection
     {
         double rounded = Math.Round(value, 6, MidpointRounding.AwayFromZero);
         return (rounded == 0.0 ? 0.0 : rounded).ToString("0.######", CultureInfo.InvariantCulture);
-    }
-
-    private static bool IsZeroTextureOffset(Float2? textureOffset)
-    {
-        return textureOffset is null
-            || (Math.Abs(textureOffset.X) < 1e-9
-                && Math.Abs(textureOffset.Y) < 1e-9);
-    }
-
-    private static bool IsIdentityTextureScale(Float2? textureScale)
-    {
-        return textureScale is null
-            || (Math.Abs(textureScale.X - 1.0) < 1e-9
-                && Math.Abs(textureScale.Y - 1.0) < 1e-9);
     }
 
     private static bool ShouldPreferUvProjection(
@@ -3657,7 +3593,7 @@ internal static class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateMaterialGroupingKey(
+                resolvedSurface => MaterialGroupingPolicy.CreateKey(
                     cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
@@ -3709,7 +3645,7 @@ internal static class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateMaterialGroupingKey(
+                resolvedSurface => MaterialGroupingPolicy.CreateKey(
                     cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
@@ -4306,7 +4242,7 @@ internal static class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateMaterialGroupingKey(
+                resolvedSurface => MaterialGroupingPolicy.CreateKey(
                     TerrainOverlayMeshCodeResolver.ResolveMaterialMeshCodeSource(
                         cityObject.ActualMeshCode,
                         requestedMeshCode,
@@ -4368,7 +4304,7 @@ internal static class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateMaterialGroupingKey(
+                resolvedSurface => MaterialGroupingPolicy.CreateKey(
                     TerrainOverlayMeshCodeResolver.ResolveMaterialMeshCodeSource(
                         cityObject.ActualMeshCode,
                         requestedMeshCode,
@@ -5634,20 +5570,6 @@ internal static class LocalCityGmlObjectProjection
         double GeometryHeightMeters,
         BuildingAttributeContext Attributes,
         bool FirstEdgeIsLongAxis);
-
-    private sealed record MaterialGroupingKey(
-        MaterialType MaterialType,
-        string? TexturePayloadIdentity,
-        TextureSourceKind TextureSourceKind,
-        MaterialProjection Projection,
-        MaterialDepthOffset? DepthOffset,
-        Float2? TextureScale,
-        string? Family,
-        ColorRgba? BaseColor,
-        Float2? TextureOffset,
-        MaterialReuseScope ReuseScope,
-        int? BundledVariantIndex,
-        TerrainTextureOverlay? TerrainOverlay);
 
     private sealed record TessellatedVertex(
         Float3 Position,

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -4884,7 +4884,7 @@ internal static class LocalCityGmlObjectProjection
             return null;
         }
 
-        return GetCityObjectGeographicBounds(cityObject);
+        return ResolveProjectionCityObjectGeographicBounds(cityObject);
     }
 
     private static GeographicRectangle? TryGetDemObjectGeographicBounds(
@@ -4897,7 +4897,7 @@ internal static class LocalCityGmlObjectProjection
             return null;
         }
 
-        return GetCityObjectGeographicBounds(cityObject);
+        return ResolveParsedCityObjectGeographicBounds(cityObject);
     }
 
     private static DemTerrainGridBounds CreateDemTerrainGridBounds(
@@ -4920,7 +4920,7 @@ internal static class LocalCityGmlObjectProjection
         }
 
         GeographicRectangle clippedBounds = IntersectGeographicBounds(
-            GetCityObjectGeographicBounds(cityObject),
+            ResolveProjectionCityObjectGeographicBounds(cityObject),
             demTerrainTextureOverlay.GeographicBounds);
         double referenceLatitude = cityObjectOrigin.Latitude;
         double referenceLongitude = cityObjectOrigin.Longitude;
@@ -4978,7 +4978,7 @@ internal static class LocalCityGmlObjectProjection
         }
 
         GeographicRectangle clippedBounds = IntersectGeographicBounds(
-            GetCityObjectGeographicBounds(cityObject),
+            ResolveParsedCityObjectGeographicBounds(cityObject),
             demTerrainTextureOverlay.GeographicBounds);
         double referenceLatitude = cityObjectOrigin.Latitude;
         double referenceLongitude = cityObjectOrigin.Longitude;
@@ -5016,26 +5016,19 @@ internal static class LocalCityGmlObjectProjection
         return new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ);
     }
 
-    private static GeographicRectangle GetCityObjectGeographicBounds(ParsedCityObject cityObject)
+    private static GeographicRectangle ResolveProjectionCityObjectGeographicBounds(ParsedCityObject cityObject)
     {
-        List<GeodeticPoint> vertices = cityObject.Surfaces.SelectMany(static surface => surface.Vertices).ToList();
-        return new GeographicRectangle(
-            MinLatitude: vertices.Min(static point => point.Latitude),
-            MaxLatitude: vertices.Max(static point => point.Latitude),
-            MinLongitude: vertices.Min(static point => point.Longitude),
-            MaxLongitude: vertices.Max(static point => point.Longitude));
+        return CityObjectGeographicBoundsResolver.Resolve(
+            cityObject.Surfaces
+                .SelectMany(static surface => surface.Vertices)
+                .Select(static point => global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(point)));
     }
 
-    private static GeographicRectangle GetCityObjectGeographicBounds(
+    private static GeographicRectangle ResolveParsedCityObjectGeographicBounds(
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject)
     {
-        List<global::PlateauResoniteLink.Application.Importing.GeodeticPoint> vertices =
-            cityObject.Surfaces.SelectMany(static surface => surface.Vertices).ToList();
-        return new GeographicRectangle(
-            MinLatitude: vertices.Min(static point => point.Latitude),
-            MaxLatitude: vertices.Max(static point => point.Latitude),
-            MinLongitude: vertices.Min(static point => point.Longitude),
-            MaxLongitude: vertices.Max(static point => point.Longitude));
+        return CityObjectGeographicBoundsResolver.Resolve(
+            cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
     }
 
     private static GeographicRectangle IntersectGeographicBounds(

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -277,7 +277,7 @@ internal static class LocalCityGmlObjectProjection
             return [surface];
         }
 
-        GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        GeodeticPoint cityObjectOrigin = ResolveProjectionCityObjectOrigin(cityObject);
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
                 cityObjectOrigin.Latitude,
@@ -314,7 +314,7 @@ internal static class LocalCityGmlObjectProjection
             return [surface];
         }
 
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
                 cityObjectOrigin.Latitude,
@@ -928,7 +928,7 @@ internal static class LocalCityGmlObjectProjection
         {
             GeometryHeightMeters = geometryHeightMeters,
         };
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
 
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
@@ -1042,7 +1042,7 @@ internal static class LocalCityGmlObjectProjection
             return cityObject;
         }
 
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
         LocalCartesian cityObjectCartesian = new(
             cityObjectOrigin.Latitude,
             cityObjectOrigin.Longitude,
@@ -1475,46 +1475,24 @@ internal static class LocalCityGmlObjectProjection
             source.Altitude + ((target.Altitude - source.Altitude) * ratio));
     }
 
-    private static GeodeticPoint GetCityObjectOrigin(ParsedCityObject cityObject)
+    private static GeodeticPoint ResolveProjectionCityObjectOrigin(ParsedCityObject cityObject)
     {
-        if (cityObject.GeodeticOriginOverride is not null)
-        {
-            return cityObject.GeodeticOriginOverride;
-        }
-
-        List<GeodeticPoint> allPoints = cityObject.Surfaces.SelectMany(static surface => surface.Vertices).ToList();
-        double minLatitude = allPoints.Min(static point => point.Latitude);
-        double maxLatitude = allPoints.Max(static point => point.Latitude);
-        double minLongitude = allPoints.Min(static point => point.Longitude);
-        double maxLongitude = allPoints.Max(static point => point.Longitude);
-        double minAltitude = allPoints.Min(static point => point.Altitude);
-
-        return new GeodeticPoint(
-            Latitude: (minLatitude + maxLatitude) / 2.0,
-            Longitude: (minLongitude + maxLongitude) / 2.0,
-            Altitude: minAltitude);
+        return CityObjectOriginResolver.Resolve(
+                cityObject.GeodeticOriginOverride is null
+                    ? null
+                    : global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObject.GeodeticOriginOverride),
+                cityObject.Surfaces
+                    .SelectMany(static surface => surface.Vertices)
+                    .Select(static point => global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(point)))
+            .ToProjectionModel();
     }
 
-    private static global::PlateauResoniteLink.Application.Importing.GeodeticPoint GetCityObjectOrigin(
+    private static global::PlateauResoniteLink.Application.Importing.GeodeticPoint ResolveParsedCityObjectOrigin(
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject)
     {
-        if (cityObject.GeodeticOriginOverride is not null)
-        {
-            return cityObject.GeodeticOriginOverride;
-        }
-
-        List<global::PlateauResoniteLink.Application.Importing.GeodeticPoint> allPoints =
-            cityObject.Surfaces.SelectMany(static surface => surface.Vertices).ToList();
-        double minLatitude = allPoints.Min(static point => point.Latitude);
-        double maxLatitude = allPoints.Max(static point => point.Latitude);
-        double minLongitude = allPoints.Min(static point => point.Longitude);
-        double maxLongitude = allPoints.Max(static point => point.Longitude);
-        double minAltitude = allPoints.Min(static point => point.Altitude);
-
-        return new global::PlateauResoniteLink.Application.Importing.GeodeticPoint(
-            Latitude: (minLatitude + maxLatitude) / 2.0,
-            Longitude: (minLongitude + maxLongitude) / 2.0,
-            Altitude: minAltitude);
+        return CityObjectOriginResolver.Resolve(
+            cityObject.GeodeticOriginOverride,
+            cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
     }
 
     private static ResolvedSurfaceMaterial ResolveSurfaceMaterial(
@@ -3350,7 +3328,7 @@ internal static class LocalCityGmlObjectProjection
                 projectedCityObjects.Add(cityObject);
             }
 
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint markingOrigin = GetCityObjectOrigin(splitCityObject.CityObject);
+            global::PlateauResoniteLink.Application.Importing.GeodeticPoint markingOrigin = ResolveParsedCityObjectOrigin(splitCityObject.CityObject);
             LocalCartesian? markingCartesian = splitCityObject.CityObject.ReferenceSystem.IsGeographic
                 ? new LocalCartesian(
                     markingOrigin.Latitude,
@@ -3444,7 +3422,7 @@ internal static class LocalCityGmlObjectProjection
                     splitCityObject.Overlay);
             }
 
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(splitCityObject.CityObject);
+            global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(splitCityObject.CityObject);
             LocalCartesian? cityObjectCartesian = splitCityObject.CityObject.ReferenceSystem.IsGeographic
                 ? new LocalCartesian(
                     cityObjectOrigin.Latitude,
@@ -3561,7 +3539,7 @@ internal static class LocalCityGmlObjectProjection
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject subdividedCityObject =
             SubdivideTerrainAlignedCityObject(parsedCityObject);
         bool terrainAligned = false;
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(subdividedCityObject);
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(subdividedCityObject);
         LocalCartesian? cityObjectCartesian = subdividedCityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
                 cityObjectOrigin.Latitude,
@@ -3972,7 +3950,7 @@ internal static class LocalCityGmlObjectProjection
     {
         heightMapCityObject = null;
 
-        GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        GeodeticPoint cityObjectOrigin = ResolveProjectionCityObjectOrigin(cityObject);
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
                 cityObjectOrigin.Latitude,
@@ -4143,7 +4121,7 @@ internal static class LocalCityGmlObjectProjection
             return false;
         }
 
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
                 cityObjectOrigin.Latitude,
@@ -4552,7 +4530,7 @@ internal static class LocalCityGmlObjectProjection
             yield break;
         }
 
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
                 cityObjectOrigin.Latitude,

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -923,7 +923,7 @@ internal static class LocalCityGmlObjectProjection
         IDefaultMaterialResolver materialResolver)
     {
         double? geometryHeightMeters = cityObject.GeometryHeightMeters
-            ?? TryGetGeometryHeightMeters(cityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel));
+            ?? ResolveParsedGeometryHeightMeters(cityObject.Surfaces);
         cityObject = ApplyGeneratedLod1Roof(cityObject) with
         {
             GeometryHeightMeters = geometryHeightMeters,
@@ -950,9 +950,7 @@ internal static class LocalCityGmlObjectProjection
         List<MeshSubmesh> submeshes = [];
         List<MaterialBinding> materials = [];
         DemUvProjection? demUvProjection = TryCreateDemUvProjection(cityObject.ActualMeshCode, demTerrainTextureOverlay);
-        double cityObjectMinAltitude = cityObject.Surfaces
-            .SelectMany(static surface => surface.Vertices)
-            .Min(static vertex => vertex.Altitude);
+        double cityObjectMinAltitude = ResolveParsedMinimumAltitude(cityObject.Surfaces);
 
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
@@ -1495,6 +1493,34 @@ internal static class LocalCityGmlObjectProjection
             cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
     }
 
+    private static double ResolveProjectionMinimumAltitude(IEnumerable<ParsedSurface> surfaces)
+    {
+        return CityObjectAltitudeMetricsResolver.GetMinimumAltitude(
+            surfaces.SelectMany(static surface => surface.Vertices),
+            static point => point.Altitude);
+    }
+
+    private static double ResolveParsedMinimumAltitude(
+        IEnumerable<global::PlateauResoniteLink.Application.Importing.ParsedSurface> surfaces)
+    {
+        return CityObjectAltitudeMetricsResolver.GetMinimumAltitude(
+            surfaces.SelectMany(static surface => surface.Vertices));
+    }
+
+    private static double? ResolveProjectionGeometryHeightMeters(IEnumerable<ParsedSurface> surfaces)
+    {
+        return CityObjectAltitudeMetricsResolver.TryGetGeometryHeightMeters(
+            surfaces.SelectMany(static surface => surface.Vertices),
+            static point => point.Altitude);
+    }
+
+    private static double? ResolveParsedGeometryHeightMeters(
+        IEnumerable<global::PlateauResoniteLink.Application.Importing.ParsedSurface> surfaces)
+    {
+        return CityObjectAltitudeMetricsResolver.TryGetGeometryHeightMeters(
+            surfaces.SelectMany(static surface => surface.Vertices));
+    }
+
     private static ResolvedSurfaceMaterial ResolveSurfaceMaterial(
         ParsedCityObject cityObject,
         GeodeticPoint cityObjectOrigin,
@@ -1718,28 +1744,6 @@ internal static class LocalCityGmlObjectProjection
             ? DefaultTerrainAlignedMaterialDepthOffset
             : null;
         return new ResolvedSurfaceMaterial(projectionSurface, resolvedMaterial, depthOffset);
-    }
-
-    private static double? TryGetGeometryHeightMeters(IEnumerable<ParsedSurface> surfaces)
-    {
-        double minAltitude = double.PositiveInfinity;
-        double maxAltitude = double.NegativeInfinity;
-        foreach (ParsedSurface surface in surfaces)
-        {
-            foreach (GeodeticPoint vertex in surface.Vertices)
-            {
-                minAltitude = Math.Min(minAltitude, vertex.Altitude);
-                maxAltitude = Math.Max(maxAltitude, vertex.Altitude);
-            }
-        }
-
-        if (double.IsInfinity(minAltitude) || double.IsInfinity(maxAltitude))
-        {
-            return null;
-        }
-
-        double height = maxAltitude - minAltitude;
-        return height > 0.0 ? height : null;
     }
 
     private static ResolvedMaterial? TryCreateRoofTerrainTextureMaterial(
@@ -3279,8 +3283,7 @@ internal static class LocalCityGmlObjectProjection
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(materialResolver);
 
-        double? geometryHeightMeters = TryGetGeometryHeightMeters(
-            parsedCityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel));
+        double? geometryHeightMeters = ResolveParsedGeometryHeightMeters(parsedCityObject.Surfaces);
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject terrainAlignedParsedCityObject =
             ApplyGeneratedLod1Roof(ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler)) with
             {
@@ -3394,8 +3397,7 @@ internal static class LocalCityGmlObjectProjection
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(materialResolver);
 
-        double? geometryHeightMeters = TryGetGeometryHeightMeters(
-            parsedCityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel));
+        double? geometryHeightMeters = ResolveParsedGeometryHeightMeters(parsedCityObject.Surfaces);
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject terrainAlignedParsedCityObject =
             ApplyGeneratedLod1Roof(ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler)) with
             {
@@ -3638,9 +3640,7 @@ internal static class LocalCityGmlObjectProjection
             cityObject.Surfaces,
             cityObjectOrigin,
             cityObjectCartesian);
-        double cityObjectMinAltitude = cityObject.Surfaces
-            .SelectMany(static surface => surface.Vertices)
-            .Min(static vertex => vertex.Altitude);
+        double cityObjectMinAltitude = ResolveProjectionMinimumAltitude(cityObject.Surfaces);
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
             .. cityObject.Surfaces
@@ -3692,9 +3692,7 @@ internal static class LocalCityGmlObjectProjection
             projectionSurfaces,
             cityObjectOrigin.ToProjectionModel(),
             cityObjectCartesian);
-        double cityObjectMinAltitude = projectionSurfaces
-            .SelectMany(static surface => surface.Vertices)
-            .Min(static vertex => vertex.Altitude);
+        double cityObjectMinAltitude = ResolveProjectionMinimumAltitude(projectionSurfaces);
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
             .. cityObject.Surfaces
@@ -4291,9 +4289,7 @@ internal static class LocalCityGmlObjectProjection
             cityObject.Surfaces,
             cityObjectOrigin,
             cityObjectCartesian);
-        double cityObjectMinAltitude = cityObject.Surfaces
-            .SelectMany(static surface => surface.Vertices)
-            .Min(static vertex => vertex.Altitude);
+        double cityObjectMinAltitude = ResolveProjectionMinimumAltitude(cityObject.Surfaces);
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
             .. cityObject.Surfaces
@@ -4355,9 +4351,7 @@ internal static class LocalCityGmlObjectProjection
             projectionSurfaces,
             cityObjectOrigin.ToProjectionModel(),
             cityObjectCartesian);
-        double cityObjectMinAltitude = projectionSurfaces
-            .SelectMany(static surface => surface.Vertices)
-            .Min(static vertex => vertex.Altitude);
+        double cityObjectMinAltitude = ResolveProjectionMinimumAltitude(projectionSurfaces);
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
             .. cityObject.Surfaces
@@ -4548,7 +4542,7 @@ internal static class LocalCityGmlObjectProjection
             yield break;
         }
 
-        double cityObjectMinAltitude = cityObjectVertices.Min(static vertex => vertex.Altitude);
+        double cityObjectMinAltitude = CityObjectAltitudeMetricsResolver.GetMinimumAltitude(cityObjectVertices);
 
         List<global::PlateauResoniteLink.Application.Importing.ParsedSurface> untexturedSurfaces = [];
         List<(global::PlateauResoniteLink.Application.Importing.ParsedSurface Surface, TerrainTextureOverlay Overlay)> terrainOverlaySurfaces = [];
@@ -4809,9 +4803,7 @@ internal static class LocalCityGmlObjectProjection
         }
 
         GeographicRectangle? demObjectBounds = TryGetDemObjectGeographicBounds(cityObject, demTerrainTextureOverlay);
-        double cityObjectMinAltitude = cityObject.Surfaces
-            .SelectMany(static surface => surface.Vertices)
-            .Min(static vertex => vertex.Altitude);
+        double cityObjectMinAltitude = ResolveProjectionMinimumAltitude(cityObject.Surfaces);
         ResolvedSurfaceMaterial? representativeSurface = cityObject.Surfaces
             .Select(surface => ResolveSurfaceMaterial(
                 cityObject,
@@ -4848,9 +4840,7 @@ internal static class LocalCityGmlObjectProjection
         }
 
         GeographicRectangle? demObjectBounds = TryGetDemObjectGeographicBounds(cityObject, demTerrainTextureOverlay);
-        double cityObjectMinAltitude = cityObject.Surfaces
-            .SelectMany(static surface => surface.Vertices)
-            .Min(static vertex => vertex.Altitude);
+        double cityObjectMinAltitude = ResolveParsedMinimumAltitude(cityObject.Surfaces);
         ResolvedSurfaceMaterial? representativeSurface = cityObject.Surfaces
             .Select(surface => ResolveSurfaceMaterial(
                 cityObject,

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -5019,9 +5019,9 @@ internal static class LocalCityGmlObjectProjection
     private static GeographicRectangle ResolveProjectionCityObjectGeographicBounds(ParsedCityObject cityObject)
     {
         return CityObjectGeographicBoundsResolver.Resolve(
-            cityObject.Surfaces
-                .SelectMany(static surface => surface.Vertices)
-                .Select(static point => global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(point)));
+            cityObject.Surfaces.SelectMany(static surface => surface.Vertices),
+            static point => point.Latitude,
+            static point => point.Longitude);
     }
 
     private static GeographicRectangle ResolveParsedCityObjectGeographicBounds(

--- a/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Globalization;
 
 using PlateauResoniteLink.Domain.Importing;
 
@@ -19,8 +18,11 @@ internal static class MaterialGroupingPolicy
         {
             if (TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, material.TerrainOverlay) is null)
             {
-                throw CreateTerrainOverlayMeshCodeMismatchException(
+                throw TerrainOverlayDiagnostics.CreateMeshCodeMismatchException(
+                    "material-grouping",
                     actualMeshCode,
+                    actualMeshCode,
+                    requestedMeshCodeBounds: null,
                     material.TerrainOverlay);
             }
 
@@ -52,31 +54,6 @@ internal static class MaterialGroupingPolicy
             material.ReuseScope,
             material.BundledVariantIndex,
             material.TerrainOverlay);
-    }
-
-    private static InvalidOperationException CreateTerrainOverlayMeshCodeMismatchException(
-        string actualMeshCode,
-        TerrainTextureOverlay terrainOverlay)
-    {
-        string overlaySummary = string.Create(
-            CultureInfo.InvariantCulture,
-            $"package='{terrainOverlay.PackageName}', bounds='{FormatBounds(terrainOverlay.GeographicBounds)}', sources='{terrainOverlay.SourceDescriptorKey}'");
-
-        return new InvalidOperationException(
-            $"Terrain overlay material requires a third-level mesh-code that matches the overlay geographic bounds. "
-            + $"phase='material-grouping', actual_mesh_code='{actualMeshCode}', requested_mesh_code='{actualMeshCode}', "
-            + $"requested_mesh_code_bounds='<none>', overlay={overlaySummary}.");
-    }
-
-    private static string FormatBounds(GeographicRectangle bounds) =>
-        string.Create(
-            CultureInfo.InvariantCulture,
-            $"{FormatRounded(bounds.MinLatitude)}-{FormatRounded(bounds.MaxLatitude)}-{FormatRounded(bounds.MinLongitude)}-{FormatRounded(bounds.MaxLongitude)}");
-
-    private static string FormatRounded(double value)
-    {
-        double rounded = Math.Round(value, 6, MidpointRounding.AwayFromZero);
-        return (rounded == 0.0 ? 0.0 : rounded).ToString("0.######", CultureInfo.InvariantCulture);
     }
 
     private static bool IsZeroTextureOffset(Float2? textureOffset)

--- a/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
@@ -21,7 +21,7 @@ internal static class MaterialGroupingPolicy
                 throw TerrainOverlayDiagnostics.CreateMeshCodeMismatchException(
                     "material-grouping",
                     actualMeshCode,
-                    actualMeshCode,
+                    requestedMeshCode: null,
                     requestedMeshCodeBounds: null,
                     material.TerrainOverlay);
             }

--- a/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Globalization;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class MaterialGroupingPolicy
+{
+    internal static MaterialGroupingKey CreateKey(
+        string actualMeshCode,
+        ResolvedMaterial material,
+        MaterialDepthOffset? depthOffset,
+        Float2? textureScale,
+        ColorRgba color,
+        Float2? textureOffset = null)
+    {
+        if (material.TerrainOverlay is not null)
+        {
+            if (TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, material.TerrainOverlay) is null)
+            {
+                throw CreateTerrainOverlayMeshCodeMismatchException(
+                    actualMeshCode,
+                    material.TerrainOverlay);
+            }
+
+            return new MaterialGroupingKey(
+                material.MaterialType,
+                TexturePayloadIdentity: null,
+                material.TextureSourceKind,
+                material.Projection,
+                depthOffset,
+                IsIdentityTextureScale(textureScale) ? null : textureScale,
+                Family: null,
+                BaseColor: null,
+                IsZeroTextureOffset(textureOffset) ? null : textureOffset,
+                MaterialReuseScope.PerObject,
+                material.BundledVariantIndex,
+                TerrainOverlay: null);
+        }
+
+        return new MaterialGroupingKey(
+            material.MaterialType,
+            material.TexturePayload?.Identity,
+            material.TextureSourceKind,
+            material.Projection,
+            depthOffset,
+            textureScale,
+            material.Family,
+            color,
+            textureOffset,
+            material.ReuseScope,
+            material.BundledVariantIndex,
+            material.TerrainOverlay);
+    }
+
+    private static InvalidOperationException CreateTerrainOverlayMeshCodeMismatchException(
+        string actualMeshCode,
+        TerrainTextureOverlay terrainOverlay)
+    {
+        string overlaySummary = string.Create(
+            CultureInfo.InvariantCulture,
+            $"package='{terrainOverlay.PackageName}', bounds='{FormatBounds(terrainOverlay.GeographicBounds)}', sources='{terrainOverlay.SourceDescriptorKey}'");
+
+        return new InvalidOperationException(
+            $"Terrain overlay material requires a third-level mesh-code that matches the overlay geographic bounds. "
+            + $"phase='material-grouping', actual_mesh_code='{actualMeshCode}', requested_mesh_code='{actualMeshCode}', "
+            + $"requested_mesh_code_bounds='<none>', overlay={overlaySummary}.");
+    }
+
+    private static string FormatBounds(GeographicRectangle bounds) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"{FormatRounded(bounds.MinLatitude)}-{FormatRounded(bounds.MaxLatitude)}-{FormatRounded(bounds.MinLongitude)}-{FormatRounded(bounds.MaxLongitude)}");
+
+    private static string FormatRounded(double value)
+    {
+        double rounded = Math.Round(value, 6, MidpointRounding.AwayFromZero);
+        return (rounded == 0.0 ? 0.0 : rounded).ToString("0.######", CultureInfo.InvariantCulture);
+    }
+
+    private static bool IsZeroTextureOffset(Float2? textureOffset)
+    {
+        return textureOffset is null
+            || (Math.Abs(textureOffset.X) < 1e-9
+                && Math.Abs(textureOffset.Y) < 1e-9);
+    }
+
+    private static bool IsIdentityTextureScale(Float2? textureScale)
+    {
+        return textureScale is null
+            || (Math.Abs(textureScale.X - 1.0) < 1e-9
+                && Math.Abs(textureScale.Y - 1.0) < 1e-9);
+    }
+}
+
+internal sealed record MaterialGroupingKey(
+    MaterialType MaterialType,
+    string? TexturePayloadIdentity,
+    TextureSourceKind TextureSourceKind,
+    MaterialProjection Projection,
+    MaterialDepthOffset? DepthOffset,
+    Float2? TextureScale,
+    string? Family,
+    ColorRgba? BaseColor,
+    Float2? TextureOffset,
+    MaterialReuseScope ReuseScope,
+    int? BundledVariantIndex,
+    TerrainTextureOverlay? TerrainOverlay);

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayDiagnostics.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayDiagnostics.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class TerrainOverlayDiagnostics
+{
+    internal static InvalidOperationException CreateMeshCodeMismatchException(
+        string phase,
+        string actualMeshCode,
+        string requestedMeshCode,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
+        TerrainTextureOverlay? terrainOverlay)
+    {
+        string requestedMeshCodeBoundsSummary = requestedMeshCodeBounds is { Count: > 0 }
+            ? string.Join(
+                ",",
+                requestedMeshCodeBounds.Select(static area => string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{FormatRounded(area.SouthLatitude)}-{FormatRounded(area.NorthLatitude)}-{FormatRounded(area.WestLongitude)}-{FormatRounded(area.EastLongitude)}")))
+            : "<none>";
+        return new InvalidOperationException(
+            $"Terrain overlay material requires a third-level mesh-code that matches the overlay geographic bounds. "
+            + $"phase='{phase}', actual_mesh_code='{actualMeshCode}', requested_mesh_code='{requestedMeshCode}', "
+            + $"requested_mesh_code_bounds='{requestedMeshCodeBoundsSummary}', overlay={FormatOverlay(terrainOverlay)}.");
+    }
+
+    internal static string FormatBounds(GeographicRectangle bounds) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"{FormatRounded(bounds.MinLatitude)}-{FormatRounded(bounds.MaxLatitude)}-{FormatRounded(bounds.MinLongitude)}-{FormatRounded(bounds.MaxLongitude)}");
+
+    private static string FormatOverlay(TerrainTextureOverlay? terrainOverlay)
+    {
+        return terrainOverlay is null
+            ? "<null>"
+            : string.Create(
+                CultureInfo.InvariantCulture,
+                $"package='{terrainOverlay.PackageName}', bounds='{FormatBounds(terrainOverlay.GeographicBounds)}', sources='{terrainOverlay.SourceDescriptorKey}'");
+    }
+
+    internal static string FormatRounded(double value)
+    {
+        double rounded = Math.Round(value, 6, MidpointRounding.AwayFromZero);
+        return (rounded == 0.0 ? 0.0 : rounded).ToString("0.######", CultureInfo.InvariantCulture);
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayDiagnostics.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayDiagnostics.cs
@@ -12,7 +12,7 @@ internal static class TerrainOverlayDiagnostics
     internal static InvalidOperationException CreateMeshCodeMismatchException(
         string phase,
         string actualMeshCode,
-        string requestedMeshCode,
+        string? requestedMeshCode,
         IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
         TerrainTextureOverlay? terrainOverlay)
     {
@@ -23,9 +23,12 @@ internal static class TerrainOverlayDiagnostics
                     CultureInfo.InvariantCulture,
                     $"{FormatRounded(area.SouthLatitude)}-{FormatRounded(area.NorthLatitude)}-{FormatRounded(area.WestLongitude)}-{FormatRounded(area.EastLongitude)}")))
             : "<none>";
+        string requestedMeshCodeSummary = requestedMeshCode is null
+            ? string.Empty
+            : string.Create(CultureInfo.InvariantCulture, $"requested_mesh_code='{requestedMeshCode}', ");
         return new InvalidOperationException(
             $"Terrain overlay material requires a third-level mesh-code that matches the overlay geographic bounds. "
-            + $"phase='{phase}', actual_mesh_code='{actualMeshCode}', requested_mesh_code='{requestedMeshCode}', "
+            + $"phase='{phase}', actual_mesh_code='{actualMeshCode}', {requestedMeshCodeSummary}"
             + $"requested_mesh_code_bounds='{requestedMeshCodeBoundsSummary}', overlay={FormatOverlay(terrainOverlay)}.");
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityObjectAltitudeMetricsResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityObjectAltitudeMetricsResolverTests.cs
@@ -1,0 +1,76 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class CityObjectAltitudeMetricsResolverTests
+{
+    [Fact]
+    public void GetMinimumAltitudeReturnsLowestVertexAltitude()
+    {
+        double minAltitude = CityObjectAltitudeMetricsResolver.GetMinimumAltitude(
+            [
+                new GeodeticPoint(35.0, 139.0, 12.0),
+                new GeodeticPoint(35.1, 139.1, -2.5),
+                new GeodeticPoint(35.2, 139.2, 8.0),
+            ]);
+
+        Assert.Equal(-2.5, minAltitude, 12);
+    }
+
+    [Fact]
+    public void GetMinimumAltitudeRejectsEmptyGeometry()
+    {
+        Assert.Throws<InvalidOperationException>(
+            static () => CityObjectAltitudeMetricsResolver.GetMinimumAltitude([]));
+    }
+
+    [Fact]
+    public void GetMinimumAltitudePreservesEnumerableFloatingPointNaNBehavior()
+    {
+        double minAltitude = CityObjectAltitudeMetricsResolver.GetMinimumAltitude(
+            [
+                new GeodeticPoint(35.0, 139.0, 12.0),
+                new GeodeticPoint(35.1, 139.1, double.NaN),
+                new GeodeticPoint(35.2, 139.2, -2.5),
+            ]);
+
+        Assert.True(double.IsNaN(minAltitude));
+    }
+
+    [Fact]
+    public void TryGetGeometryHeightMetersReturnsPositiveAltitudeSpan()
+    {
+        double? height = CityObjectAltitudeMetricsResolver.TryGetGeometryHeightMeters(
+            [
+                new GeodeticPoint(35.0, 139.0, 12.0),
+                new GeodeticPoint(35.1, 139.1, -2.5),
+                new GeodeticPoint(35.2, 139.2, 8.0),
+            ]);
+
+        Assert.Equal(14.5, height!.Value, 12);
+    }
+
+    [Fact]
+    public void TryGetGeometryHeightMetersReturnsNullForFlatOrEmptyGeometry()
+    {
+        Assert.Null(CityObjectAltitudeMetricsResolver.TryGetGeometryHeightMeters([]));
+        Assert.Null(CityObjectAltitudeMetricsResolver.TryGetGeometryHeightMeters(
+            [
+                new GeodeticPoint(35.0, 139.0, 12.0),
+                new GeodeticPoint(35.1, 139.1, 12.0),
+            ]));
+    }
+
+    [Fact]
+    public void TryGetGeometryHeightMetersPreservesMathNaNBehavior()
+    {
+        Assert.Null(CityObjectAltitudeMetricsResolver.TryGetGeometryHeightMeters(
+            [
+                new GeodeticPoint(35.0, 139.0, 12.0),
+                new GeodeticPoint(35.1, 139.1, double.NaN),
+                new GeodeticPoint(35.2, 139.2, -2.5),
+            ]));
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityObjectGeographicBoundsResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityObjectGeographicBoundsResolverTests.cs
@@ -1,0 +1,23 @@
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class CityObjectGeographicBoundsResolverTests
+{
+    [Fact]
+    public void ResolveComputesLatitudeAndLongitudeExtents()
+    {
+        GeographicRectangle bounds = CityObjectGeographicBoundsResolver.Resolve(
+            [
+                new GeodeticPoint(35.2, 139.1, 20.0),
+                new GeodeticPoint(35.0, 139.4, 10.0),
+                new GeodeticPoint(35.1, 139.0, 30.0),
+            ]);
+
+        Assert.Equal(35.0, bounds.MinLatitude, 12);
+        Assert.Equal(35.2, bounds.MaxLatitude, 12);
+        Assert.Equal(139.0, bounds.MinLongitude, 12);
+        Assert.Equal(139.4, bounds.MaxLongitude, 12);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityObjectGeographicBoundsResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityObjectGeographicBoundsResolverTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 
@@ -18,6 +20,28 @@ public sealed class CityObjectGeographicBoundsResolverTests
         Assert.Equal(35.0, bounds.MinLatitude, 12);
         Assert.Equal(35.2, bounds.MaxLatitude, 12);
         Assert.Equal(139.0, bounds.MinLongitude, 12);
+        Assert.Equal(139.4, bounds.MaxLongitude, 12);
+    }
+
+    [Fact]
+    public void ResolveRejectsEmptyGeometry()
+    {
+        Assert.Throws<InvalidOperationException>(
+            static () => CityObjectGeographicBoundsResolver.Resolve([]));
+    }
+
+    [Fact]
+    public void ResolvePreservesEnumerableFloatingPointNaNBehavior()
+    {
+        GeographicRectangle bounds = CityObjectGeographicBoundsResolver.Resolve(
+            [
+                new GeodeticPoint(double.NaN, double.NaN, 0.0),
+                new GeodeticPoint(35.2, 139.4, 0.0),
+            ]);
+
+        Assert.True(double.IsNaN(bounds.MinLatitude));
+        Assert.Equal(35.2, bounds.MaxLatitude, 12);
+        Assert.True(double.IsNaN(bounds.MinLongitude));
         Assert.Equal(139.4, bounds.MaxLongitude, 12);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityObjectOriginResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityObjectOriginResolverTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using PlateauResoniteLink.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.Profiles;
@@ -31,6 +33,48 @@ public sealed class CityObjectOriginResolverTests
         Assert.Equal(3.0, origin.Altitude, 12);
     }
 
+    [Fact]
+    public void ResolveRejectsEmptyGeometry()
+    {
+        Assert.Throws<InvalidOperationException>(
+            static () => CityObjectOriginResolver.Resolve(
+                originOverride: null,
+                []));
+    }
+
+    [Fact]
+    public void ResolvePreservesEnumerableFloatingPointNaNBehavior()
+    {
+        GeodeticPoint origin = CityObjectOriginResolver.Resolve(
+            originOverride: null,
+            CreateVertices(
+                new GeodeticPoint(double.NaN, double.NaN, 12.0),
+                new GeodeticPoint(35.2, 139.4, double.NaN),
+                new GeodeticPoint(35.0, 139.0, 3.0)));
+
+        Assert.True(double.IsNaN(origin.Latitude));
+        Assert.True(double.IsNaN(origin.Longitude));
+        Assert.True(double.IsNaN(origin.Altitude));
+    }
+
+    [Fact]
+    public void ResolveSupportsSelectorInput()
+    {
+        TestPoint origin = CityObjectOriginResolver.Resolve(
+            originOverride: null,
+            [
+                new TestPoint(35.0, 139.0, 5.0),
+                new TestPoint(35.2, 139.4, 7.0),
+                new TestPoint(35.1, 139.1, 3.0),
+            ],
+            static point => point.Latitude,
+            static point => point.Longitude,
+            static point => point.Altitude,
+            static (latitude, longitude, altitude) => new TestPoint(latitude, longitude, altitude));
+
+        Assert.Equal(new TestPoint(35.1, 139.2, 3.0), origin);
+    }
+
     private static GeodeticPoint[] CreateVertices(params GeodeticPoint[] vertices)
     {
         if (vertices.Length > 0)
@@ -45,4 +89,6 @@ public sealed class CityObjectOriginResolverTests
             new GeodeticPoint(35.1, 139.1, 0.0),
         ];
     }
+
+    private sealed record TestPoint(double Latitude, double Longitude, double Altitude);
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityObjectOriginResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityObjectOriginResolverTests.cs
@@ -1,0 +1,48 @@
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class CityObjectOriginResolverTests
+{
+    [Fact]
+    public void ResolveUsesOriginOverride()
+    {
+        GeodeticPoint overrideOrigin = new(36.0, 140.0, 12.0);
+
+        GeodeticPoint origin = CityObjectOriginResolver.Resolve(
+            overrideOrigin,
+            CreateVertices());
+
+        Assert.Equal(overrideOrigin, origin);
+    }
+
+    [Fact]
+    public void ResolveComputesBoundingCenterAtMinimumAltitude()
+    {
+        GeodeticPoint origin = CityObjectOriginResolver.Resolve(
+            originOverride: null,
+            CreateVertices(
+                new GeodeticPoint(35.0, 139.0, 5.0),
+                new GeodeticPoint(35.2, 139.4, 7.0),
+                new GeodeticPoint(35.1, 139.1, 3.0)));
+
+        Assert.Equal(35.1, origin.Latitude, 12);
+        Assert.Equal(139.2, origin.Longitude, 12);
+        Assert.Equal(3.0, origin.Altitude, 12);
+    }
+
+    private static GeodeticPoint[] CreateVertices(params GeodeticPoint[] vertices)
+    {
+        if (vertices.Length > 0)
+        {
+            return vertices;
+        }
+
+        return
+        [
+            new GeodeticPoint(35.0, 139.0, 0.0),
+            new GeodeticPoint(35.0, 139.1, 0.0),
+            new GeodeticPoint(35.1, 139.1, 0.0),
+        ];
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
@@ -142,13 +142,17 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await firstCall);
         datasetSource.ReleaseEnsureLocalFile.TrySetResult();
         await datasetSource.BackgroundCompletion.Task.WaitAsync(CancellationToken.None);
-        await Task.Delay(10);
 
-        await Assert.ThrowsAnyAsync<IOException>(async () => await catalog.TryResolveRasterSourceAsync(
-            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", bounds),
-            "dem-fallback",
-            bounds,
-            CancellationToken.None));
+        for (int attempt = 0; attempt < 10 && datasetSource.EnsureLocalFileCallCount < 2; attempt++)
+        {
+            await Assert.ThrowsAnyAsync<IOException>(async () => await catalog.TryResolveRasterSourceAsync(
+                new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", bounds),
+                "dem-fallback",
+                bounds,
+                CancellationToken.None));
+            await Task.Yield();
+        }
+
         Assert.Equal(2, datasetSource.EnsureLocalFileCallCount);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/MaterialGroupingPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/MaterialGroupingPolicyTests.cs
@@ -1,0 +1,179 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class MaterialGroupingPolicyTests
+{
+    [Fact]
+    public void CreateKeyGroupsMatchingNonOverlayMaterials()
+    {
+        ResolvedMaterial material = new(
+            MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind.Dataset,
+            MaterialProjection.Uv,
+            Family: "facade",
+            TextureScale: new Float2(2.0, 3.0),
+            MaterialReuseScope.Shared,
+            BundledVariantIndex: 7,
+            TextureOffset: new Float2(0.25, 0.5));
+        ColorRgba color = new(0.1, 0.2, 0.3, 1.0);
+
+        MaterialGroupingKey first = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: new MaterialDepthOffset(1.0, 2.0),
+            textureScale: material.TextureScale,
+            color,
+            textureOffset: material.TextureOffset);
+        MaterialGroupingKey second = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: new MaterialDepthOffset(1.0, 2.0),
+            textureScale: material.TextureScale,
+            color,
+            textureOffset: material.TextureOffset);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void CreateKeySeparatesNonOverlayMaterialsWhenGroupingInputsDiffer()
+    {
+        ResolvedMaterial material = new(
+            MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind.Dataset,
+            MaterialProjection.Uv,
+            Family: "facade",
+            TextureScale: null,
+            MaterialReuseScope.Shared);
+
+        MaterialGroupingKey first = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: null,
+            textureScale: null,
+            color: new ColorRgba(0.1, 0.2, 0.3, 1.0));
+        MaterialGroupingKey second = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: null,
+            textureScale: null,
+            color: new ColorRgba(0.2, 0.2, 0.3, 1.0));
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void CreateKeyGroupsTerrainOverlayMaterialsWhenTransformsAreNoOp()
+    {
+        TerrainTextureOverlay overlay = CreateOverlay("53394525");
+        ResolvedMaterial material = new(
+            MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind.Bundled,
+            MaterialProjection.Uv,
+            Family: "terrain",
+            TextureScale: new Float2(1.0, 1.0),
+            MaterialReuseScope.Shared,
+            TerrainOverlay: overlay,
+            TextureOffset: new Float2(0.0, 0.0));
+
+        MaterialGroupingKey explicitNoOp = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: null,
+            textureScale: material.TextureScale,
+            color: new ColorRgba(0.1, 0.2, 0.3, 1.0),
+            textureOffset: material.TextureOffset);
+        MaterialGroupingKey implicitNoOp = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: null,
+            textureScale: null,
+            color: new ColorRgba(0.8, 0.7, 0.6, 1.0),
+            textureOffset: null);
+
+        Assert.Equal(explicitNoOp, implicitNoOp);
+    }
+
+    [Fact]
+    public void CreateKeySeparatesTerrainOverlayMaterialsWhenTransformChanges()
+    {
+        TerrainTextureOverlay overlay = CreateOverlay("53394525");
+        ResolvedMaterial material = new(
+            MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind.Bundled,
+            MaterialProjection.Uv,
+            Family: "terrain",
+            TextureScale: null,
+            MaterialReuseScope.Shared,
+            TerrainOverlay: overlay);
+
+        MaterialGroupingKey first = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: null,
+            textureScale: null,
+            color: new ColorRgba(0.1, 0.2, 0.3, 1.0),
+            textureOffset: null);
+        MaterialGroupingKey second = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: null,
+            textureScale: new Float2(2.0, 1.0),
+            color: new ColorRgba(0.8, 0.7, 0.6, 1.0),
+            textureOffset: null);
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void CreateKeyRejectsTerrainOverlayThatDoesNotMatchActualMeshCode()
+    {
+        TerrainTextureOverlay overlay = CreateOverlay("53394525");
+        ResolvedMaterial material = new(
+            MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind.Bundled,
+            MaterialProjection.Uv,
+            Family: null,
+            TextureScale: null,
+            MaterialReuseScope.Shared,
+            TerrainOverlay: overlay);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => MaterialGroupingPolicy.CreateKey(
+                "53394600",
+                material,
+                depthOffset: null,
+                textureScale: null,
+                color: new ColorRgba(1.0, 1.0, 1.0, 1.0)));
+
+        Assert.Contains("phase='material-grouping'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("actual_mesh_code='53394600'", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static TerrainTextureOverlay CreateOverlay(string meshCode)
+    {
+        Assert.True(PlateauMeshCode.TryGetBounds(
+            meshCode,
+            out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds));
+
+        return new TerrainTextureOverlay(
+            PackageName: "dem",
+            UrlTemplate: $"https://terrain.example/{meshCode}/{{z}}/{{x}}/{{y}}.png",
+            ZoomLevel: 18,
+            GeographicBounds: new GeographicRectangle(
+                bounds.SouthLatitude,
+                bounds.NorthLatitude,
+                bounds.WestLongitude,
+                bounds.EastLongitude),
+            MaxTextureSize: 2048);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/MaterialGroupingPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/MaterialGroupingPolicyTests.cs
@@ -157,6 +157,7 @@ public sealed class MaterialGroupingPolicyTests
 
         Assert.Contains("phase='material-grouping'", exception.Message, StringComparison.Ordinal);
         Assert.Contains("actual_mesh_code='53394600'", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("requested_mesh_code=", exception.Message, StringComparison.Ordinal);
     }
 
     private static TerrainTextureOverlay CreateOverlay(string meshCode)


### PR DESCRIPTION
## Summary
- extract city object altitude min/height calculations into `CityObjectAltitudeMetricsResolver`
- keep projection-model vertices streamed through altitude selectors instead of allocating neutral point copies
- cover empty, flat, and NaN altitude behavior so the refactor preserves existing semantics

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`