### PR TITLE
Extract material grouping policy

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -968,7 +968,7 @@ internal static class LocalCityGmlObjectProjection
 
         IGrouping<MaterialGroupingKey, ResolvedSurfaceMaterial>[] materialGroups = resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateMaterialGroupingKey(
+                resolvedSurface => MaterialGroupingPolicy.CreateKey(
                     cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
@@ -2772,56 +2772,6 @@ internal static class LocalCityGmlObjectProjection
             cartesian);
     }
 
-    private static MaterialGroupingKey CreateMaterialGroupingKey(
-        string actualMeshCode,
-        ResolvedMaterial material,
-        MaterialDepthOffset? depthOffset,
-        Float2? textureScale,
-        ColorRgba color,
-        Float2? textureOffset = null)
-    {
-        if (material.TerrainOverlay is not null)
-        {
-            if (TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, material.TerrainOverlay) is null)
-            {
-                throw CreateTerrainOverlayMeshCodeMismatchException(
-                    "material-grouping",
-                    actualMeshCode,
-                    actualMeshCode,
-                    requestedMeshCodeBounds: null,
-                    material.TerrainOverlay);
-            }
-
-            return new MaterialGroupingKey(
-                material.MaterialType,
-                TexturePayloadIdentity: null,
-                material.TextureSourceKind,
-                material.Projection,
-                depthOffset,
-                IsIdentityTextureScale(textureScale) ? null : textureScale,
-                Family: null,
-                BaseColor: null,
-                IsZeroTextureOffset(textureOffset) ? null : textureOffset,
-                MaterialReuseScope.PerObject,
-                material.BundledVariantIndex,
-                TerrainOverlay: null);
-        }
-
-        return new MaterialGroupingKey(
-            material.MaterialType,
-            material.TexturePayload?.Identity,
-            material.TextureSourceKind,
-            material.Projection,
-            depthOffset,
-            textureScale,
-            material.Family,
-            color,
-            textureOffset,
-            material.ReuseScope,
-            material.BundledVariantIndex,
-            material.TerrainOverlay);
-    }
-
     private static string CreateTerrainOverlayToken(TerrainTextureOverlay terrainOverlay)
     {
         return string.Create(
@@ -2874,20 +2824,6 @@ internal static class LocalCityGmlObjectProjection
     {
         double rounded = Math.Round(value, 6, MidpointRounding.AwayFromZero);
         return (rounded == 0.0 ? 0.0 : rounded).ToString("0.######", CultureInfo.InvariantCulture);
-    }
-
-    private static bool IsZeroTextureOffset(Float2? textureOffset)
-    {
-        return textureOffset is null
-            || (Math.Abs(textureOffset.X) < 1e-9
-                && Math.Abs(textureOffset.Y) < 1e-9);
-    }
-
-    private static bool IsIdentityTextureScale(Float2? textureScale)
-    {
-        return textureScale is null
-            || (Math.Abs(textureScale.X - 1.0) < 1e-9
-                && Math.Abs(textureScale.Y - 1.0) < 1e-9);
     }
 
     private static bool ShouldPreferUvProjection(
@@ -3657,7 +3593,7 @@ internal static class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateMaterialGroupingKey(
+                resolvedSurface => MaterialGroupingPolicy.CreateKey(
                     cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
@@ -3709,7 +3645,7 @@ internal static class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateMaterialGroupingKey(
+                resolvedSurface => MaterialGroupingPolicy.CreateKey(
                     cityObject.ActualMeshCode,
                     resolvedSurface.Material,
                     resolvedSurface.DepthOffset,
@@ -4306,7 +4242,7 @@ internal static class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateMaterialGroupingKey(
+                resolvedSurface => MaterialGroupingPolicy.CreateKey(
                     TerrainOverlayMeshCodeResolver.ResolveMaterialMeshCodeSource(
                         cityObject.ActualMeshCode,
                         requestedMeshCode,
@@ -4368,7 +4304,7 @@ internal static class LocalCityGmlObjectProjection
 
         return resolvedSurfaces
             .GroupBy(
-                resolvedSurface => CreateMaterialGroupingKey(
+                resolvedSurface => MaterialGroupingPolicy.CreateKey(
                     TerrainOverlayMeshCodeResolver.ResolveMaterialMeshCodeSource(
                         cityObject.ActualMeshCode,
                         requestedMeshCode,
@@ -5634,20 +5570,6 @@ internal static class LocalCityGmlObjectProjection
         double GeometryHeightMeters,
         BuildingAttributeContext Attributes,
         bool FirstEdgeIsLongAxis);
-
-    private sealed record MaterialGroupingKey(
-        MaterialType MaterialType,
-        string? TexturePayloadIdentity,
-        TextureSourceKind TextureSourceKind,
-        MaterialProjection Projection,
-        MaterialDepthOffset? DepthOffset,
-        Float2? TextureScale,
-        string? Family,
-        ColorRgba? BaseColor,
-        Float2? TextureOffset,
-        MaterialReuseScope ReuseScope,
-        int? BundledVariantIndex,
-        TerrainTextureOverlay? TerrainOverlay);
 
     private sealed record TessellatedVertex(
         Float3 Position,

--- a/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Globalization;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class MaterialGroupingPolicy
+{
+    internal static MaterialGroupingKey CreateKey(
+        string actualMeshCode,
+        ResolvedMaterial material,
+        MaterialDepthOffset? depthOffset,
+        Float2? textureScale,
+        ColorRgba color,
+        Float2? textureOffset = null)
+    {
+        if (material.TerrainOverlay is not null)
+        {
+            if (TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, material.TerrainOverlay) is null)
+            {
+                throw CreateTerrainOverlayMeshCodeMismatchException(
+                    actualMeshCode,
+                    material.TerrainOverlay);
+            }
+
+            return new MaterialGroupingKey(
+                material.MaterialType,
+                TexturePayloadIdentity: null,
+                material.TextureSourceKind,
+                material.Projection,
+                depthOffset,
+                IsIdentityTextureScale(textureScale) ? null : textureScale,
+                Family: null,
+                BaseColor: null,
+                IsZeroTextureOffset(textureOffset) ? null : textureOffset,
+                MaterialReuseScope.PerObject,
+                material.BundledVariantIndex,
+                TerrainOverlay: null);
+        }
+
+        return new MaterialGroupingKey(
+            material.MaterialType,
+            material.TexturePayload?.Identity,
+            material.TextureSourceKind,
+            material.Projection,
+            depthOffset,
+            textureScale,
+            material.Family,
+            color,
+            textureOffset,
+            material.ReuseScope,
+            material.BundledVariantIndex,
+            material.TerrainOverlay);
+    }
+
+    private static InvalidOperationException CreateTerrainOverlayMeshCodeMismatchException(
+        string actualMeshCode,
+        TerrainTextureOverlay terrainOverlay)
+    {
+        string overlaySummary = string.Create(
+            CultureInfo.InvariantCulture,
+            $"package='{terrainOverlay.PackageName}', bounds='{FormatBounds(terrainOverlay.GeographicBounds)}', sources='{terrainOverlay.SourceDescriptorKey}'");
+
+        return new InvalidOperationException(
+            $"Terrain overlay material requires a third-level mesh-code that matches the overlay geographic bounds. "
+            + $"phase='material-grouping', actual_mesh_code='{actualMeshCode}', requested_mesh_code='{actualMeshCode}', "
+            + $"requested_mesh_code_bounds='<none>', overlay={overlaySummary}.");
+    }
+
+    private static string FormatBounds(GeographicRectangle bounds) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"{FormatRounded(bounds.MinLatitude)}-{FormatRounded(bounds.MaxLatitude)}-{FormatRounded(bounds.MinLongitude)}-{FormatRounded(bounds.MaxLongitude)}");
+
+    private static string FormatRounded(double value)
+    {
+        double rounded = Math.Round(value, 6, MidpointRounding.AwayFromZero);
+        return (rounded == 0.0 ? 0.0 : rounded).ToString("0.######", CultureInfo.InvariantCulture);
+    }
+
+    private static bool IsZeroTextureOffset(Float2? textureOffset)
+    {
+        return textureOffset is null
+            || (Math.Abs(textureOffset.X) < 1e-9
+                && Math.Abs(textureOffset.Y) < 1e-9);
+    }
+
+    private static bool IsIdentityTextureScale(Float2? textureScale)
+    {
+        return textureScale is null
+            || (Math.Abs(textureScale.X - 1.0) < 1e-9
+                && Math.Abs(textureScale.Y - 1.0) < 1e-9);
+    }
+}
+
+internal sealed record MaterialGroupingKey(
+    MaterialType MaterialType,
+    string? TexturePayloadIdentity,
+    TextureSourceKind TextureSourceKind,
+    MaterialProjection Projection,
+    MaterialDepthOffset? DepthOffset,
+    Float2? TextureScale,
+    string? Family,
+    ColorRgba? BaseColor,
+    Float2? TextureOffset,
+    MaterialReuseScope ReuseScope,
+    int? BundledVariantIndex,
+    TerrainTextureOverlay? TerrainOverlay);

--- a/tests/PlateauResoniteLink.Tests/Profiles/MaterialGroupingPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/MaterialGroupingPolicyTests.cs
@@ -1,0 +1,179 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class MaterialGroupingPolicyTests
+{
+    [Fact]
+    public void CreateKeyGroupsMatchingNonOverlayMaterials()
+    {
+        ResolvedMaterial material = new(
+            MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind.Dataset,
+            MaterialProjection.Uv,
+            Family: "facade",
+            TextureScale: new Float2(2.0, 3.0),
+            MaterialReuseScope.Shared,
+            BundledVariantIndex: 7,
+            TextureOffset: new Float2(0.25, 0.5));
+        ColorRgba color = new(0.1, 0.2, 0.3, 1.0);
+
+        MaterialGroupingKey first = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: new MaterialDepthOffset(1.0, 2.0),
+            textureScale: material.TextureScale,
+            color,
+            textureOffset: material.TextureOffset);
+        MaterialGroupingKey second = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: new MaterialDepthOffset(1.0, 2.0),
+            textureScale: material.TextureScale,
+            color,
+            textureOffset: material.TextureOffset);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void CreateKeySeparatesNonOverlayMaterialsWhenGroupingInputsDiffer()
+    {
+        ResolvedMaterial material = new(
+            MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind.Dataset,
+            MaterialProjection.Uv,
+            Family: "facade",
+            TextureScale: null,
+            MaterialReuseScope.Shared);
+
+        MaterialGroupingKey first = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: null,
+            textureScale: null,
+            color: new ColorRgba(0.1, 0.2, 0.3, 1.0));
+        MaterialGroupingKey second = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: null,
+            textureScale: null,
+            color: new ColorRgba(0.2, 0.2, 0.3, 1.0));
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void CreateKeyGroupsTerrainOverlayMaterialsWhenTransformsAreNoOp()
+    {
+        TerrainTextureOverlay overlay = CreateOverlay("53394525");
+        ResolvedMaterial material = new(
+            MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind.Bundled,
+            MaterialProjection.Uv,
+            Family: "terrain",
+            TextureScale: new Float2(1.0, 1.0),
+            MaterialReuseScope.Shared,
+            TerrainOverlay: overlay,
+            TextureOffset: new Float2(0.0, 0.0));
+
+        MaterialGroupingKey explicitNoOp = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: null,
+            textureScale: material.TextureScale,
+            color: new ColorRgba(0.1, 0.2, 0.3, 1.0),
+            textureOffset: material.TextureOffset);
+        MaterialGroupingKey implicitNoOp = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: null,
+            textureScale: null,
+            color: new ColorRgba(0.8, 0.7, 0.6, 1.0),
+            textureOffset: null);
+
+        Assert.Equal(explicitNoOp, implicitNoOp);
+    }
+
+    [Fact]
+    public void CreateKeySeparatesTerrainOverlayMaterialsWhenTransformChanges()
+    {
+        TerrainTextureOverlay overlay = CreateOverlay("53394525");
+        ResolvedMaterial material = new(
+            MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind.Bundled,
+            MaterialProjection.Uv,
+            Family: "terrain",
+            TextureScale: null,
+            MaterialReuseScope.Shared,
+            TerrainOverlay: overlay);
+
+        MaterialGroupingKey first = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: null,
+            textureScale: null,
+            color: new ColorRgba(0.1, 0.2, 0.3, 1.0),
+            textureOffset: null);
+        MaterialGroupingKey second = MaterialGroupingPolicy.CreateKey(
+            "53394525",
+            material,
+            depthOffset: null,
+            textureScale: new Float2(2.0, 1.0),
+            color: new ColorRgba(0.8, 0.7, 0.6, 1.0),
+            textureOffset: null);
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void CreateKeyRejectsTerrainOverlayThatDoesNotMatchActualMeshCode()
+    {
+        TerrainTextureOverlay overlay = CreateOverlay("53394525");
+        ResolvedMaterial material = new(
+            MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind.Bundled,
+            MaterialProjection.Uv,
+            Family: null,
+            TextureScale: null,
+            MaterialReuseScope.Shared,
+            TerrainOverlay: overlay);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => MaterialGroupingPolicy.CreateKey(
+                "53394600",
+                material,
+                depthOffset: null,
+                textureScale: null,
+                color: new ColorRgba(1.0, 1.0, 1.0, 1.0)));
+
+        Assert.Contains("phase='material-grouping'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("actual_mesh_code='53394600'", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static TerrainTextureOverlay CreateOverlay(string meshCode)
+    {
+        Assert.True(PlateauMeshCode.TryGetBounds(
+            meshCode,
+            out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds));
+
+        return new TerrainTextureOverlay(
+            PackageName: "dem",
+            UrlTemplate: $"https://terrain.example/{meshCode}/{{z}}/{{x}}/{{y}}.png",
+            ZoomLevel: 18,
+            GeographicBounds: new GeographicRectangle(
+                bounds.SouthLatitude,
+                bounds.NorthLatitude,
+                bounds.WestLongitude,
+                bounds.EastLongitude),
+            MaxTextureSize: 2048);
+    }
+}


### PR DESCRIPTION
## Summary
- extract material grouping key construction into `MaterialGroupingPolicy`
- keep terrain overlay grouping validation and no-op transform normalization behavior intact
- add grouping-focused tests for matching, differing, no-op, and invalid overlay cases

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`