### PR TITLE
Make live send runtime cancellation synchronous

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendQueuedCityObject.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendQueuedCityObject.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record LiveSendQueuedCityObject(
+    ResoniteConstructionCityObject CityObject,
+    Task<ResoniteSharedSlotIndex.ObjectSlotHierarchy> ObjectHierarchyTask,
+    AsyncWeightedGate.Lease MemoryLease);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -344,11 +344,11 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 
     private async Task ProcessQueuedCityObjectsAsync(
         LiveSendRunState state,
-        ChannelReader<QueuedCityObject> reader,
+        ChannelReader<LiveSendQueuedCityObject> reader,
         int laneIndex,
         CancellationToken cancellationToken)
     {
-        QueuedCityObject? currentCityObject = null;
+        LiveSendQueuedCityObject? currentCityObject = null;
         try
         {
             if (Interlocked.CompareExchange(ref state.Progress.FirstCityObjectStreamingStartedLogged, 1, 0) == 0)
@@ -359,7 +359,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                         $"City-object send pipeline is active and waiting for queue on lane {laneIndex + 1}/{connectionCount}."));
             }
 
-            await foreach (QueuedCityObject queuedCityObject in reader.ReadAllAsync(cancellationToken))
+            await foreach (LiveSendQueuedCityObject queuedCityObject in reader.ReadAllAsync(cancellationToken))
             {
                 currentCityObject = queuedCityObject;
                 if (Interlocked.CompareExchange(ref state.Progress.FirstCityObjectDequeuedLogged, 1, 0) == 0)
@@ -406,7 +406,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 
     private async Task ProcessQueuedCityObjectsOnLaneAsync(
         LiveSendRunState state,
-        ChannelReader<QueuedCityObject> reader,
+        ChannelReader<LiveSendQueuedCityObject> reader,
         int laneIndex,
         CancellationToken cancellationToken)
     {
@@ -636,7 +636,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         Justification = "Live send should log and skip individual city object send failures while keeping the lane alive.")]
     private async Task ProcessQueuedCityObjectAsync(
         LiveSendRunState state,
-        QueuedCityObject queuedCityObject,
+        LiveSendQueuedCityObject queuedCityObject,
         CancellationToken cancellationToken)
     {
         Interlocked.Increment(ref state.Progress.AttemptedCityObjectCount);
@@ -736,7 +736,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         try
         {
             await runtime.WriteAsync(
-                new QueuedCityObject(cityObject, objectHierarchyTask, cityObjectMemoryLease),
+                new LiveSendQueuedCityObject(cityObject, objectHierarchyTask, cityObjectMemoryLease),
                 enqueueCancellation.Token);
         }
         catch (OperationCanceledException) when (runtime.IsCancellationRequested)
@@ -1364,7 +1364,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 
     private async Task ImportPreparedCityObjectAsync(
         LiveSendRunState state,
-        QueuedCityObject queuedCityObject,
+        LiveSendQueuedCityObject queuedCityObject,
         PreparedCityObject preparedCityObject,
         CancellationToken cancellationToken)
     {
@@ -2311,11 +2311,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         ArgumentNullException.ThrowIfNull(origin);
         return new ResoniteLocalOrigin(origin.Latitude, origin.Longitude, origin.Altitude);
     }
-
-    internal sealed record QueuedCityObject(
-        ResoniteConstructionCityObject CityObject,
-        Task<ResoniteSharedSlotIndex.ObjectSlotHierarchy> ObjectHierarchyTask,
-        AsyncWeightedGate.Lease MemoryLease);
 
     private sealed record UploadedTextureAssetSet(
         Dictionary<ResoniteTexturePayload, Uri> TextureUrisByPayload,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendExecutionRuntime.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendExecutionRuntime.cs
@@ -108,6 +108,9 @@ internal sealed class LiveSendExecutionRuntime : IAsyncDisposable
         {
             processingCancellationSource.Cancel();
         }
+        catch (AggregateException)
+        {
+        }
         catch (ObjectDisposedException)
         {
         }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendExecutionRuntime.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendExecutionRuntime.cs
@@ -106,7 +106,7 @@ internal sealed class LiveSendExecutionRuntime : IAsyncDisposable
     {
         try
         {
-            _ = processingCancellationSource.CancelAsync();
+            processingCancellationSource.Cancel();
         }
         catch (ObjectDisposedException)
         {

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendExecutionRuntime.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendExecutionRuntime.cs
@@ -11,7 +11,7 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class LiveSendExecutionRuntime : IAsyncDisposable
 {
-    private readonly Channel<ResoniteLiveSceneImportTarget.QueuedCityObject> cityObjectChannel;
+    private readonly Channel<LiveSendQueuedCityObject> cityObjectChannel;
     private readonly CancellationTokenSource processingCancellationSource;
     private readonly TaskCompletionSource<Exception> firstProcessingFailureSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly AsyncWeightedGate cityObjectMemoryGate;
@@ -22,7 +22,7 @@ internal sealed class LiveSendExecutionRuntime : IAsyncDisposable
     {
         ArgumentNullException.ThrowIfNull(plan);
 
-        cityObjectChannel = Channel.CreateBounded<ResoniteLiveSceneImportTarget.QueuedCityObject>(
+        cityObjectChannel = Channel.CreateBounded<LiveSendQueuedCityObject>(
             new BoundedChannelOptions(plan.QueueCapacity)
             {
                 SingleReader = false,
@@ -33,7 +33,7 @@ internal sealed class LiveSendExecutionRuntime : IAsyncDisposable
         cityObjectMemoryGate = new AsyncWeightedGate(plan.MemoryBudgetBytes);
     }
 
-    public ChannelReader<ResoniteLiveSceneImportTarget.QueuedCityObject> Reader => cityObjectChannel.Reader;
+    public ChannelReader<LiveSendQueuedCityObject> Reader => cityObjectChannel.Reader;
 
     public CancellationToken ProcessingCancellationToken => processingCancellationSource.Token;
 
@@ -54,7 +54,7 @@ internal sealed class LiveSendExecutionRuntime : IAsyncDisposable
         return cityObjectMemoryGate.AcquireAsync(estimatedWorksetBytes, cancellationToken);
     }
 
-    public ValueTask WriteAsync(ResoniteLiveSceneImportTarget.QueuedCityObject queuedCityObject, CancellationToken cancellationToken)
+    public ValueTask WriteAsync(LiveSendQueuedCityObject queuedCityObject, CancellationToken cancellationToken)
     {
         return cityObjectChannel.Writer.WriteAsync(queuedCityObject, cancellationToken);
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/LiveSendExecutionRuntimeTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/LiveSendExecutionRuntimeTests.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class LiveSendExecutionRuntimeTests
+{
+    [Fact]
+    public async Task CancelRunsRegisteredCancellationCallbacksBeforeReturning()
+    {
+        await using LiveSendExecutionRuntime runtime = new(
+            new LiveSendQueuePlan(
+                ConnectionCount: 1,
+                QueueCapacity: 1,
+                MemoryBudgetBytes: 1),
+            CancellationToken.None);
+        bool callbackRan = false;
+        using CancellationTokenRegistration _ = runtime.ProcessingCancellationToken.Register(
+            () => callbackRan = true);
+
+        runtime.Cancel();
+
+        Assert.True(runtime.IsCancellationRequested);
+        Assert.True(callbackRan);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/LiveSendExecutionRuntimeTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/LiveSendExecutionRuntimeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,5 +25,41 @@ public sealed class LiveSendExecutionRuntimeTests
 
         Assert.True(runtime.IsCancellationRequested);
         Assert.True(callbackRan);
+    }
+
+    [Fact]
+    public async Task AwaitCompletionAsyncPreservesProcessingFailureWhenCancellationCallbackThrows()
+    {
+        await using LiveSendExecutionRuntime runtime = new(
+            new LiveSendQueuePlan(
+                ConnectionCount: 1,
+                QueueCapacity: 1,
+                MemoryBudgetBytes: 1),
+            CancellationToken.None);
+        using CancellationTokenRegistration _ = runtime.ProcessingCancellationToken.Register(
+            static () => throw new InvalidOperationException("cancel-callback-failed"));
+        InvalidOperationException expectedFailure = new("processing-failed");
+
+        runtime.Start([Task.Delay(Timeout.Infinite, runtime.ProcessingCancellationToken)]);
+        runtime.TryMarkFailure(expectedFailure);
+
+        InvalidOperationException actualFailure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => runtime.AwaitCompletionAsync(CancellationToken.None));
+        Assert.Same(expectedFailure, actualFailure);
+    }
+
+    [Fact]
+    public async Task DisposeAsyncDoesNotThrowWhenCancellationCallbackThrows()
+    {
+        LiveSendExecutionRuntime runtime = new(
+            new LiveSendQueuePlan(
+                ConnectionCount: 1,
+                QueueCapacity: 1,
+                MemoryBudgetBytes: 1),
+            CancellationToken.None);
+        using CancellationTokenRegistration _ = runtime.ProcessingCancellationToken.Register(
+            static () => throw new InvalidOperationException("cancel-callback-failed"));
+
+        await runtime.DisposeAsync();
     }
 }


### PR DESCRIPTION
## Summary
- make LiveSendExecutionRuntime.Cancel run cancellation synchronously so registered callbacks complete before the method returns
- add a focused behavior test for the cancellation callback contract

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false