### PR TITLE
Extract DEM overlay coverage resolution

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
@@ -61,24 +61,15 @@ internal static class DemTerrainOverlayAssignment
                 }
 
                 GeographicRectangle surfaceBounds = GetSurfaceGeographicBounds(requestedMeshClippedSurface);
-                bool hasContainingOverlay = demTerrainTextureOverlays.Any(overlay =>
-                    surfaceBounds.MinLatitude >= overlay.GeographicBounds.MinLatitude
-                    && surfaceBounds.MaxLatitude <= overlay.GeographicBounds.MaxLatitude
-                    && surfaceBounds.MinLongitude >= overlay.GeographicBounds.MinLongitude
-                    && surfaceBounds.MaxLongitude <= overlay.GeographicBounds.MaxLongitude);
-                if (hasContainingOverlay)
+                TerrainOverlayCoverage coverage = ResolveTerrainOverlayCoverage(
+                    surfaceBounds,
+                    demTerrainTextureOverlays);
+                if (coverage.Kind == TerrainOverlayCoverageKind.Contained)
                 {
                     continue;
                 }
 
-                TerrainTextureOverlay[] candidateOverlays = demTerrainTextureOverlays
-                    .Where(overlay =>
-                        surfaceBounds.MaxLatitude >= overlay.GeographicBounds.MinLatitude
-                        && surfaceBounds.MinLatitude <= overlay.GeographicBounds.MaxLatitude
-                        && surfaceBounds.MaxLongitude >= overlay.GeographicBounds.MinLongitude
-                        && surfaceBounds.MinLongitude <= overlay.GeographicBounds.MaxLongitude)
-                    .ToArray();
-                if (candidateOverlays.Length == 0)
+                if (coverage.Kind == TerrainOverlayCoverageKind.None)
                 {
                     return false;
                 }
@@ -86,7 +77,7 @@ internal static class DemTerrainOverlayAssignment
                 IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> clippedSurfaces =
                     DemTerrainOverlaySurfaceClipper.ClipGeneratedSurfaceToOverlays(
                         requestedMeshClippedSurface,
-                        candidateOverlays);
+                        coverage.IntersectingOverlays);
                 if (clippedSurfaces.Count == 0)
                 {
                     return false;
@@ -190,25 +181,16 @@ internal static class DemTerrainOverlayAssignment
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 GeographicRectangle surfaceBounds = GetSurfaceGeographicBounds(requestedMeshClippedSurface);
-                TerrainTextureOverlay? containingOverlay = demTerrainTextureOverlays.FirstOrDefault(overlay =>
-                    surfaceBounds.MinLatitude >= overlay.GeographicBounds.MinLatitude
-                    && surfaceBounds.MaxLatitude <= overlay.GeographicBounds.MaxLatitude
-                    && surfaceBounds.MinLongitude >= overlay.GeographicBounds.MinLongitude
-                    && surfaceBounds.MaxLongitude <= overlay.GeographicBounds.MaxLongitude);
-                if (containingOverlay is not null)
+                TerrainOverlayCoverage coverage = ResolveTerrainOverlayCoverage(
+                    surfaceBounds,
+                    demTerrainTextureOverlays);
+                if (coverage.Kind == TerrainOverlayCoverageKind.Contained)
                 {
-                    splitGeneratedSurfaces.Add((requestedMeshClippedSurface, containingOverlay));
+                    splitGeneratedSurfaces.Add((requestedMeshClippedSurface, coverage.ContainingOverlay!));
                     continue;
                 }
 
-                TerrainTextureOverlay[] candidateOverlays = demTerrainTextureOverlays
-                    .Where(overlay =>
-                        surfaceBounds.MaxLatitude >= overlay.GeographicBounds.MinLatitude
-                        && surfaceBounds.MinLatitude <= overlay.GeographicBounds.MaxLatitude
-                        && surfaceBounds.MaxLongitude >= overlay.GeographicBounds.MinLongitude
-                        && surfaceBounds.MinLongitude <= overlay.GeographicBounds.MaxLongitude)
-                    .ToArray();
-                if (candidateOverlays.Length == 0)
+                if (coverage.Kind == TerrainOverlayCoverageKind.None)
                 {
                     throw new InvalidOperationException(
                         $"Mesh-code-bounds-clipped DEM surface '{requestedMeshClippedSurface.PolygonId}' has no matching terrain overlay coverage.");
@@ -217,7 +199,7 @@ internal static class DemTerrainOverlayAssignment
                 IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> clippedSurfaces =
                     DemTerrainOverlaySurfaceClipper.ClipGeneratedSurfaceToOverlays(
                         requestedMeshClippedSurface,
-                        candidateOverlays,
+                        coverage.IntersectingOverlays,
                         progressReporter,
                         cancellationToken);
                 if (clippedSurfaces.Count == 0)
@@ -334,6 +316,45 @@ internal static class DemTerrainOverlayAssignment
         return DemTerrainOverlaySurfaceClipper.ClipGeneratedSurfaceToBounds(
             generatedSurface,
             requestedMeshBounds).ToArray();
+    }
+
+    private static TerrainOverlayCoverage ResolveTerrainOverlayCoverage(
+        GeographicRectangle surfaceBounds,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays)
+    {
+        TerrainTextureOverlay? containingOverlay = demTerrainTextureOverlays.FirstOrDefault(overlay =>
+            Contains(overlay.GeographicBounds, surfaceBounds));
+        if (containingOverlay is not null)
+        {
+            return TerrainOverlayCoverage.Contained(containingOverlay);
+        }
+
+        TerrainTextureOverlay[] intersectingOverlays = demTerrainTextureOverlays
+            .Where(overlay => Intersects(overlay.GeographicBounds, surfaceBounds))
+            .ToArray();
+        return intersectingOverlays.Length == 0
+            ? TerrainOverlayCoverage.None
+            : TerrainOverlayCoverage.Intersecting(intersectingOverlays);
+    }
+
+    private static bool Contains(
+        GeographicRectangle container,
+        GeographicRectangle subject)
+    {
+        return subject.MinLatitude >= container.MinLatitude
+            && subject.MaxLatitude <= container.MaxLatitude
+            && subject.MinLongitude >= container.MinLongitude
+            && subject.MaxLongitude <= container.MaxLongitude;
+    }
+
+    private static bool Intersects(
+        GeographicRectangle left,
+        GeographicRectangle right)
+    {
+        return right.MaxLatitude >= left.MinLatitude
+            && right.MinLatitude <= left.MaxLatitude
+            && right.MaxLongitude >= left.MinLongitude
+            && right.MinLongitude <= left.MaxLongitude;
     }
 
     public static (Float2? TextureScale, Float2? TextureOffset) TryCreateTerrainGridTextureTransform(
@@ -702,6 +723,40 @@ internal static class DemTerrainOverlayAssignment
     private readonly record struct ProjectedPoint(double X, double Y);
 
     private readonly record struct SurfaceMetrics(double AreaSquareMeters, double EstimatedThicknessMeters);
+
+    private readonly record struct TerrainOverlayCoverage(
+        TerrainOverlayCoverageKind Kind,
+        TerrainTextureOverlay? ContainingOverlay,
+        IReadOnlyList<TerrainTextureOverlay> IntersectingOverlays)
+    {
+        public static TerrainOverlayCoverage None { get; } = new(
+            TerrainOverlayCoverageKind.None,
+            ContainingOverlay: null,
+            IntersectingOverlays: []);
+
+        public static TerrainOverlayCoverage Contained(TerrainTextureOverlay containingOverlay)
+        {
+            return new TerrainOverlayCoverage(
+                TerrainOverlayCoverageKind.Contained,
+                containingOverlay,
+                IntersectingOverlays: []);
+        }
+
+        public static TerrainOverlayCoverage Intersecting(IReadOnlyList<TerrainTextureOverlay> intersectingOverlays)
+        {
+            return new TerrainOverlayCoverage(
+                TerrainOverlayCoverageKind.Intersecting,
+                ContainingOverlay: null,
+                intersectingOverlays);
+        }
+    }
+
+    private enum TerrainOverlayCoverageKind
+    {
+        None,
+        Contained,
+        Intersecting,
+    }
 
     private readonly record struct GroupMetrics(
         TerrainTextureOverlay Overlay,

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
@@ -269,6 +269,63 @@ public sealed class DemTerrainOverlayAssignmentTests
     }
 
     [Fact]
+    public void HasOverlayCoverageReturnsTrueWhenRequestedMeshExcludesGeneratedSurface()
+    {
+        ParsedCityObject cityObject = CreateCityObject(
+            CreateGeneratedSurface(
+                "dem-outside-request",
+                [
+                    new GeodeticPoint(35.0000, 139.0000, 0.0),
+                    new GeodeticPoint(35.0100, 139.0000, 1.0),
+                    new GeodeticPoint(35.0100, 139.0200, 2.0),
+                ]));
+        TerrainTextureOverlay[] overlays =
+        [
+            CreateOverlay(139.0000, 139.0200),
+        ];
+        MeshCodeBounds[] requestedMeshCodeBounds =
+        [
+            new(35.0000, 35.0200, 139.0300, 139.0400),
+        ];
+
+        bool hasCoverage = DemTerrainOverlayAssignment.HasOverlayCoverage(
+            cityObject,
+            overlays,
+            requestedMeshCodeBounds);
+
+        Assert.True(hasCoverage);
+    }
+
+    [Fact]
+    public void SplitParsedCityObjectSkipsGeneratedSurfaceWhenRequestedMeshExcludesIt()
+    {
+        ParsedSurface surface = CreateGeneratedSurface(
+            "dem-outside-request",
+            [
+                new GeodeticPoint(35.0000, 139.0000, 0.0),
+                new GeodeticPoint(35.0100, 139.0000, 1.0),
+                new GeodeticPoint(35.0100, 139.0200, 2.0),
+            ]);
+        ParsedCityObject cityObject = CreateCityObject(surface);
+        TerrainTextureOverlay[] overlays =
+        [
+            CreateOverlay(139.0000, 139.0200),
+        ];
+        MeshCodeBounds[] requestedMeshCodeBounds =
+        [
+            new(35.0000, 35.0200, 139.0300, 139.0400),
+        ];
+
+        (ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)[] results =
+            DemTerrainOverlayAssignment.SplitParsedCityObject(
+                cityObject,
+                overlays,
+                requestedMeshCodeBounds).ToArray();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
     public void SplitParsedCityObjectClipsSharedDemToRequestedMeshEvenWhenNoOverlaysExist()
     {
         ParsedSurface surface = CreateGeneratedSurface(


### PR DESCRIPTION
## Summary
- Extract DEM terrain overlay coverage resolution into a single private value-based path
- Share the same contained/intersecting/none decision between coverage probing and split execution
- Add requested-mesh clipping tests for generated surfaces that are excluded before overlay matching

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
