### PR TITLE
Extract prepared texture uploader

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -15,8 +15,6 @@ using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
-using ResoniteLink;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 public sealed class ResoniteLiveSceneImportTarget : ISceneSink
@@ -1089,7 +1087,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         IResoniteLinkClient routedClient = GetRoutedClient();
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay =
             CreatePreparedTerrainTextureDataByOverlay(preparedCityObject);
-        Task<UploadedTextureAssetSet> uploadedTextureAssetsTask = UploadPreparedTexturesAsync(
+        Task<ResoniteUploadedTextureAssetSet> uploadedTextureAssetsTask = ResonitePreparedTextureUploader.UploadAsync(
             state,
             routedClient,
             preparedCityObject,
@@ -1108,7 +1106,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         PlannedGeometryAsset plannedGeometryAsset;
         try
         {
-            UploadedTextureAssetSet uploadedTextureAssets = await uploadedTextureAssetsTask;
+            ResoniteUploadedTextureAssetSet uploadedTextureAssets = await uploadedTextureAssetsTask;
             materialStopwatch.Start();
             materialPlanningTask = PlanSceneMaterialPlanAsync(
                 state,
@@ -1177,246 +1175,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                     $"First city object imported after {GetSceneElapsedSeconds(state):F3}s: "
                     + $"{cityObject.DisplayName} ({cityObject.PackageName}/{cityObject.SlotKey})"));
         }
-    }
-
-    private static async Task<UploadedTextureAssetSet> UploadPreparedTexturesAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient importClient,
-        PreparedCityObject preparedCityObject,
-        Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay,
-        CancellationToken cancellationToken)
-    {
-        Dictionary<ResoniteTexturePayload, Uri> textureUrisByPayload = new(ResoniteTexturePayloadReferenceComparer.Instance);
-        Dictionary<TerrainTextureOverlay, Uri> terrainTextureUrisByOverlay = [];
-        Dictionary<string, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode = new(StringComparer.Ordinal);
-        HashSet<ResoniteTexturePayload> queuedPayloads = new(ResoniteTexturePayloadReferenceComparer.Instance);
-        List<(PreparedTextureReference Texture, Task<Uri> ImportTask)> textureImportTasks = [];
-        List<(PreparedTextureReference Texture, Task<SharedTerrainTextureAsset> ImportTask)> terrainTextureImportTasks = [];
-
-        foreach (PreparedTextureReference texture in preparedCityObject.Textures)
-        {
-            if (texture.TexturePayload is not null && !queuedPayloads.Add(texture.TexturePayload))
-            {
-                continue;
-            }
-
-            if (texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
-            {
-                string meshCode = ResolveTerrainTextureMeshCode(texture);
-                terrainTextureImportTasks.Add((
-                    texture,
-                    EnsureSharedTerrainTextureAssetAsync(
-                        state,
-                        importClient,
-                        meshCode,
-                        texture.TextureImport,
-                        cancellationToken)));
-                continue;
-            }
-
-            textureImportTasks.Add((
-                texture,
-                importClient.ImportTextureAsync(texture.TextureImport, cancellationToken)));
-        }
-
-        await Task.WhenAll(textureImportTasks.Select(static textureImport => textureImport.ImportTask));
-        await Task.WhenAll(terrainTextureImportTasks.Select(static textureImport => textureImport.ImportTask));
-
-        foreach ((PreparedTextureReference texture, Task<Uri> importTask) in textureImportTasks)
-        {
-            Uri textureUri = await importTask;
-            if (texture.TexturePayload is not null)
-            {
-                textureUrisByPayload.Add(texture.TexturePayload, textureUri);
-            }
-
-        }
-
-        foreach ((PreparedTextureReference texture, Task<SharedTerrainTextureAsset> importTask) in terrainTextureImportTasks)
-        {
-            SharedTerrainTextureAsset sharedTexture = await importTask;
-            string meshCode = ResolveTerrainTextureMeshCode(texture);
-            terrainTextureUrisByOverlay.Add(texture.TerrainOverlay!, sharedTexture.TextureUri);
-            terrainTexturePropertyBlockComponentsByMeshCode.TryAdd(meshCode, sharedTexture.MainTexturePropertyBlockComponent.Locator);
-        }
-
-        return new UploadedTextureAssetSet(
-            textureUrisByPayload,
-            terrainTextureUrisByOverlay,
-            terrainTexturePropertyBlockComponentsByMeshCode,
-            preparedTerrainTextureDataByOverlay);
-    }
-
-    private static Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient importClient,
-        string meshCode,
-        ResoniteTextureImport textureImport,
-        CancellationToken cancellationToken)
-    {
-        return state.TerrainTextures.AssetsByMeshCode.GetOrCreateAsync(
-            meshCode,
-            () => EnsureSharedTerrainTextureAssetCoreAsync(state, importClient, meshCode, textureImport, cancellationToken),
-            cancellationToken);
-    }
-
-    private static async Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetCoreAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient importClient,
-        string meshCode,
-        ResoniteTextureImport textureImport,
-        CancellationToken cancellationToken)
-    {
-        CreatedSlot terrainTexturesRoot = await state.Placement.GetOrCreateSharedChildSlotAsync(
-            importClient,
-            state.Context.DatasetAssetsRootSlot.Locator,
-            "Terrain Textures",
-            cancellationToken);
-        CreatedSlot meshSlot = await state.Placement.GetOrCreateSharedChildSlotAsync(
-            importClient,
-            terrainTexturesRoot.Locator,
-            meshCode,
-            cancellationToken);
-        SharedTerrainTextureAsset? existingTexture = await TryFindSharedTerrainTextureAssetAsync(
-            importClient,
-            meshSlot,
-            cancellationToken);
-        if (existingTexture is not null)
-        {
-            Uri refreshedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
-            await importClient.UpdateComponentAsync(
-                new ResoniteComponentUpdate
-                {
-                    Component = new ResoniteTransportComponentLocator(existingTexture.TextureComponent.Locator.Value),
-                    Members = ResoniteSceneMaterialConventions.CreateTextureMembers(
-                        refreshedTextureUri,
-                        ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride),
-                },
-                cancellationToken);
-            return existingTexture with
-            {
-                TextureUri = refreshedTextureUri,
-            };
-        }
-
-        Uri importedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
-        CreatedComponent textureComponent = await ResoniteMaterialPlanning.CreateComponentAsync(
-            importClient,
-            meshSlot.Locator,
-            "[FrooxEngine]FrooxEngine.StaticTexture2D",
-            ResoniteSceneMaterialConventions.CreateTextureMembers(
-                importedTextureUri,
-                ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride),
-            cancellationToken);
-        CreatedComponent propertyBlockComponent = await CreateTerrainMainTexturePropertyBlockAsync(
-            importClient,
-            meshSlot.Locator,
-            textureComponent.Locator,
-            cancellationToken);
-        return new SharedTerrainTextureAsset(
-            importedTextureUri,
-            textureComponent,
-            propertyBlockComponent);
-    }
-
-    private static async Task<SharedTerrainTextureAsset?> TryFindSharedTerrainTextureAssetAsync(
-        IResoniteLinkClient importClient,
-        CreatedSlot meshSlot,
-        CancellationToken cancellationToken)
-    {
-        Slot? slot = await importClient.GetSlotAsync(
-            new ResoniteTransportSlotLocator(meshSlot.Locator.Value),
-            depth: 0,
-            cancellationToken);
-        Component? textureComponent = slot?.Components?
-            .FirstOrDefault(IsSharedTerrainTextureComponent);
-        if (textureComponent?.ID is null
-            || textureComponent.Members["URL"] is not Field_Uri url)
-        {
-            return null;
-        }
-
-        if (url.Value is null)
-        {
-            return null;
-        }
-
-        CreatedComponent createdTextureComponent = new(new ResoniteComponentLocator(textureComponent.ID), textureComponent.ComponentType);
-        Component? propertyBlockComponent = slot?.Components?
-            .Where(component => IsSharedTerrainMainTexturePropertyBlockComponent(component, textureComponent.ID))
-            .OrderBy(static component => component.ID, StringComparer.Ordinal)
-            .FirstOrDefault();
-        CreatedComponent createdPropertyBlockComponent = propertyBlockComponent?.ID is null
-            ? await CreateTerrainMainTexturePropertyBlockAsync(
-                importClient,
-                meshSlot.Locator,
-                createdTextureComponent.Locator,
-                cancellationToken)
-            : new CreatedComponent(new ResoniteComponentLocator(propertyBlockComponent.ID), propertyBlockComponent.ComponentType);
-
-        return new SharedTerrainTextureAsset(
-            url.Value,
-            createdTextureComponent,
-            createdPropertyBlockComponent);
-    }
-
-    private static Task<CreatedComponent> CreateTerrainMainTexturePropertyBlockAsync(
-        IResoniteLinkClient importClient,
-        ResoniteSlotLocator meshSlot,
-        ResoniteComponentLocator textureComponent,
-        CancellationToken cancellationToken)
-    {
-        return ResoniteMaterialPlanning.CreateComponentAsync(
-            importClient,
-            meshSlot,
-            "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
-            new Dictionary<string, Member>(StringComparer.Ordinal)
-            {
-                ["Texture"] = new Reference
-                {
-                    TargetID = textureComponent.Value,
-                },
-            },
-            cancellationToken);
-    }
-
-    private static bool IsSharedTerrainMainTexturePropertyBlockComponent(Component component, string textureComponentId)
-    {
-        return string.Equals(
-                component.ComponentType,
-                "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
-                StringComparison.Ordinal)
-            && component.Members.TryGetValue("Texture", out Member? textureMember)
-            && textureMember is Reference { TargetID: string targetId }
-            && string.Equals(targetId, textureComponentId, StringComparison.Ordinal);
-    }
-
-    private static bool IsSharedTerrainTextureComponent(Component component)
-    {
-        return string.Equals(
-                component.ComponentType,
-                "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                StringComparison.Ordinal)
-            && component.Members.TryGetValue("URL", out Member? urlMember)
-            && urlMember is Field_Uri
-            && component.Members.TryGetValue("WrapModeU", out Member? wrapModeUMember)
-            && wrapModeUMember is Field_Enum { Value: "Clamp" }
-            && component.Members.TryGetValue("WrapModeV", out Member? wrapModeVMember)
-            && wrapModeVMember is Field_Enum { Value: "Clamp" };
-    }
-
-    private static string ResolveTerrainTextureMeshCode(PreparedTextureReference texture)
-    {
-        if (texture.TerrainMeshCode is not { Length: > 0 } meshCode
-            || meshCode.Length != 8
-            || !PlateauMeshCode.TryGetBounds(meshCode, out _))
-        {
-            throw new InvalidOperationException(
-                "Terrain texture overlay preparation requires a valid third-level mesh-code. "
-                + $"provided_mesh='{texture.TerrainMeshCode ?? "<null>"}'.");
-        }
-
-        return meshCode;
     }
 
     private static ResoniteMaterialBinding ValidateTerrainTextureMaterialContract(
@@ -1936,11 +1694,5 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         ArgumentNullException.ThrowIfNull(origin);
         return new ResoniteLocalOrigin(origin.Latitude, origin.Longitude, origin.Altitude);
     }
-
-    private sealed record UploadedTextureAssetSet(
-        Dictionary<ResoniteTexturePayload, Uri> TextureUrisByPayload,
-        Dictionary<TerrainTextureOverlay, Uri> TerrainTextureUrisByOverlay,
-        Dictionary<string, ResoniteComponentLocator> TerrainTexturePropertyBlockComponentsByMeshCode,
-        Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> GeneratedTerrainTexturesByOverlay);
 
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedTextureUploader.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedTextureUploader.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record ResoniteUploadedTextureAssetSet(
+    Dictionary<ResoniteTexturePayload, Uri> TextureUrisByPayload,
+    Dictionary<TerrainTextureOverlay, Uri> TerrainTextureUrisByOverlay,
+    Dictionary<string, ResoniteComponentLocator> TerrainTexturePropertyBlockComponentsByMeshCode,
+    Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> GeneratedTerrainTexturesByOverlay);
+
+internal static class ResonitePreparedTextureUploader
+{
+    public static async Task<ResoniteUploadedTextureAssetSet> UploadAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient importClient,
+        PreparedCityObject preparedCityObject,
+        Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay,
+        CancellationToken cancellationToken)
+    {
+        Dictionary<ResoniteTexturePayload, Uri> textureUrisByPayload = new(ResoniteTexturePayloadReferenceComparer.Instance);
+        Dictionary<TerrainTextureOverlay, Uri> terrainTextureUrisByOverlay = [];
+        Dictionary<string, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode = new(StringComparer.Ordinal);
+        HashSet<ResoniteTexturePayload> queuedPayloads = new(ResoniteTexturePayloadReferenceComparer.Instance);
+        List<(PreparedTextureReference Texture, Task<Uri> ImportTask)> textureImportTasks = [];
+        List<(PreparedTextureReference Texture, Task<SharedTerrainTextureAsset> ImportTask)> terrainTextureImportTasks = [];
+
+        foreach (PreparedTextureReference texture in preparedCityObject.Textures)
+        {
+            if (texture.TexturePayload is not null && !queuedPayloads.Add(texture.TexturePayload))
+            {
+                continue;
+            }
+
+            if (texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
+            {
+                string meshCode = ResolveTerrainTextureMeshCode(texture);
+                terrainTextureImportTasks.Add((
+                    texture,
+                    EnsureSharedTerrainTextureAssetAsync(
+                        state,
+                        importClient,
+                        meshCode,
+                        texture.TextureImport,
+                        cancellationToken)));
+                continue;
+            }
+
+            textureImportTasks.Add((
+                texture,
+                importClient.ImportTextureAsync(texture.TextureImport, cancellationToken)));
+        }
+
+        await Task.WhenAll(textureImportTasks.Select(static textureImport => textureImport.ImportTask));
+        await Task.WhenAll(terrainTextureImportTasks.Select(static textureImport => textureImport.ImportTask));
+
+        foreach ((PreparedTextureReference texture, Task<Uri> importTask) in textureImportTasks)
+        {
+            Uri textureUri = await importTask;
+            if (texture.TexturePayload is not null)
+            {
+                textureUrisByPayload.Add(texture.TexturePayload, textureUri);
+            }
+        }
+
+        foreach ((PreparedTextureReference texture, Task<SharedTerrainTextureAsset> importTask) in terrainTextureImportTasks)
+        {
+            SharedTerrainTextureAsset sharedTexture = await importTask;
+            string meshCode = ResolveTerrainTextureMeshCode(texture);
+            terrainTextureUrisByOverlay.Add(texture.TerrainOverlay!, sharedTexture.TextureUri);
+            terrainTexturePropertyBlockComponentsByMeshCode.TryAdd(meshCode, sharedTexture.MainTexturePropertyBlockComponent.Locator);
+        }
+
+        return new ResoniteUploadedTextureAssetSet(
+            textureUrisByPayload,
+            terrainTextureUrisByOverlay,
+            terrainTexturePropertyBlockComponentsByMeshCode,
+            preparedTerrainTextureDataByOverlay);
+    }
+
+    private static Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient importClient,
+        string meshCode,
+        ResoniteTextureImport textureImport,
+        CancellationToken cancellationToken)
+    {
+        return state.TerrainTextures.AssetsByMeshCode.GetOrCreateAsync(
+            meshCode,
+            () => EnsureSharedTerrainTextureAssetCoreAsync(state, importClient, meshCode, textureImport, cancellationToken),
+            cancellationToken);
+    }
+
+    private static async Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetCoreAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient importClient,
+        string meshCode,
+        ResoniteTextureImport textureImport,
+        CancellationToken cancellationToken)
+    {
+        CreatedSlot terrainTexturesRoot = await state.Placement.GetOrCreateSharedChildSlotAsync(
+            importClient,
+            state.Context.DatasetAssetsRootSlot.Locator,
+            "Terrain Textures",
+            cancellationToken);
+        CreatedSlot meshSlot = await state.Placement.GetOrCreateSharedChildSlotAsync(
+            importClient,
+            terrainTexturesRoot.Locator,
+            meshCode,
+            cancellationToken);
+        SharedTerrainTextureAsset? existingTexture = await TryFindSharedTerrainTextureAssetAsync(
+            importClient,
+            meshSlot,
+            cancellationToken);
+        if (existingTexture is not null)
+        {
+            Uri refreshedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
+            await importClient.UpdateComponentAsync(
+                new ResoniteComponentUpdate
+                {
+                    Component = new ResoniteTransportComponentLocator(existingTexture.TextureComponent.Locator.Value),
+                    Members = ResoniteSceneMaterialConventions.CreateTextureMembers(
+                        refreshedTextureUri,
+                        ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride),
+                },
+                cancellationToken);
+            return existingTexture with
+            {
+                TextureUri = refreshedTextureUri,
+            };
+        }
+
+        Uri importedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
+        CreatedComponent textureComponent = await ResoniteMaterialPlanning.CreateComponentAsync(
+            importClient,
+            meshSlot.Locator,
+            "[FrooxEngine]FrooxEngine.StaticTexture2D",
+            ResoniteSceneMaterialConventions.CreateTextureMembers(
+                importedTextureUri,
+                ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride),
+            cancellationToken);
+        CreatedComponent propertyBlockComponent = await CreateTerrainMainTexturePropertyBlockAsync(
+            importClient,
+            meshSlot.Locator,
+            textureComponent.Locator,
+            cancellationToken);
+        return new SharedTerrainTextureAsset(
+            importedTextureUri,
+            textureComponent,
+            propertyBlockComponent);
+    }
+
+    private static async Task<SharedTerrainTextureAsset?> TryFindSharedTerrainTextureAssetAsync(
+        IResoniteLinkClient importClient,
+        CreatedSlot meshSlot,
+        CancellationToken cancellationToken)
+    {
+        Slot? slot = await importClient.GetSlotAsync(
+            new ResoniteTransportSlotLocator(meshSlot.Locator.Value),
+            depth: 0,
+            cancellationToken);
+        Component? textureComponent = slot?.Components?
+            .FirstOrDefault(IsSharedTerrainTextureComponent);
+        if (textureComponent?.ID is null
+            || textureComponent.Members["URL"] is not Field_Uri url)
+        {
+            return null;
+        }
+
+        if (url.Value is null)
+        {
+            return null;
+        }
+
+        CreatedComponent createdTextureComponent = new(new ResoniteComponentLocator(textureComponent.ID), textureComponent.ComponentType);
+        Component? propertyBlockComponent = slot?.Components?
+            .Where(component => IsSharedTerrainMainTexturePropertyBlockComponent(component, textureComponent.ID))
+            .OrderBy(static component => component.ID, StringComparer.Ordinal)
+            .FirstOrDefault();
+        CreatedComponent createdPropertyBlockComponent = propertyBlockComponent?.ID is null
+            ? await CreateTerrainMainTexturePropertyBlockAsync(
+                importClient,
+                meshSlot.Locator,
+                createdTextureComponent.Locator,
+                cancellationToken)
+            : new CreatedComponent(new ResoniteComponentLocator(propertyBlockComponent.ID), propertyBlockComponent.ComponentType);
+
+        return new SharedTerrainTextureAsset(
+            url.Value,
+            createdTextureComponent,
+            createdPropertyBlockComponent);
+    }
+
+    private static Task<CreatedComponent> CreateTerrainMainTexturePropertyBlockAsync(
+        IResoniteLinkClient importClient,
+        ResoniteSlotLocator meshSlot,
+        ResoniteComponentLocator textureComponent,
+        CancellationToken cancellationToken)
+    {
+        return ResoniteMaterialPlanning.CreateComponentAsync(
+            importClient,
+            meshSlot,
+            "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
+            new Dictionary<string, Member>(StringComparer.Ordinal)
+            {
+                ["Texture"] = new Reference
+                {
+                    TargetID = textureComponent.Value,
+                },
+            },
+            cancellationToken);
+    }
+
+    private static bool IsSharedTerrainMainTexturePropertyBlockComponent(Component component, string textureComponentId)
+    {
+        return string.Equals(
+                component.ComponentType,
+                "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
+                StringComparison.Ordinal)
+            && component.Members.TryGetValue("Texture", out Member? textureMember)
+            && textureMember is Reference { TargetID: string targetId }
+            && string.Equals(targetId, textureComponentId, StringComparison.Ordinal);
+    }
+
+    private static bool IsSharedTerrainTextureComponent(Component component)
+    {
+        return string.Equals(
+                component.ComponentType,
+                "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                StringComparison.Ordinal)
+            && component.Members.TryGetValue("URL", out Member? urlMember)
+            && urlMember is Field_Uri
+            && component.Members.TryGetValue("WrapModeU", out Member? wrapModeUMember)
+            && wrapModeUMember is Field_Enum { Value: "Clamp" }
+            && component.Members.TryGetValue("WrapModeV", out Member? wrapModeVMember)
+            && wrapModeVMember is Field_Enum { Value: "Clamp" };
+    }
+
+    private static string ResolveTerrainTextureMeshCode(PreparedTextureReference texture)
+    {
+        if (texture.TerrainMeshCode is not { Length: > 0 } meshCode
+            || meshCode.Length != 8
+            || !PlateauMeshCode.TryGetBounds(meshCode, out _))
+        {
+            throw new InvalidOperationException(
+                "Terrain texture overlay preparation requires a valid third-level mesh-code. "
+                + $"provided_mesh='{texture.TerrainMeshCode ?? "<null>"}'.");
+        }
+
+        return meshCode;
+    }
+}


### PR DESCRIPTION
## Summary
- extract prepared texture upload orchestration out of `ResoniteLiveSceneImportTarget`
- keep shared terrain texture reuse/update logic behind `ResonitePreparedTextureUploader`
- leave the live scene import target focused on object import flow and material/geometry planning handoff

## Diff size
- Compared with `codex/refactor-city-object-workset-estimator`: 2 files changed, 263 insertions, 250 deletions

## Verification
- `dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --configuration Release --filter "FullyQualifiedName~ResoniteLiveSceneImportTargetTests.ExecuteAsyncUsesExistingSharedTerrainTextureComponentForDedicatedTerrainOverlayMaterial" --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (1 passed)
- `dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~ResoniteLiveSceneImportTargetTests.ExecuteAsyncSharesTerrainMainTextureComponentByThirdMeshCodeAcrossTerrainAndRoofWithoutOverlayUriOrRoleInKey" --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (1 passed)
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (802 passed)

## Note
- The first focused run initially hit a local disk-full condition under `C:\Users\esnya\AppData\Local\Temp\PlateauResoniteLink\default-materials`; generated build/temp artifacts were removed and the same affected tests passed afterward.