### PR TITLE
Remove partial regex holders

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSourceMeshCodeAnchor.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSourceMeshCodeAnchor.cs
@@ -13,7 +13,7 @@ internal static class ResoniteSourceMeshCodeAnchor
 {
     private static readonly Regex MeshCodeRegex = new(
         @"(?<!\d)(\d{8}|\d{6})(?!\d)",
-        RegexOptions.CultureInvariant,
+        RegexOptions.CultureInvariant | RegexOptions.Compiled,
         TimeSpan.FromSeconds(1));
 
     public static bool TryGetConcreteMeshCode(string value, out string meshCode)
@@ -24,7 +24,16 @@ internal static class ResoniteSourceMeshCodeAnchor
             return false;
         }
 
-        Match[] matches = MeshCodeRegex.Matches(value).Cast<Match>().ToArray();
+        Match[] matches;
+        try
+        {
+            matches = MeshCodeRegex.Matches(value).Cast<Match>().ToArray();
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return false;
+        }
+
         foreach (Match match in matches.OrderByDescending(static entry => entry.Value.Length).ThenByDescending(static entry => entry.Index))
         {
             if (PlateauMeshCode.TryGetGeodeticCenter(match.Value, out _))

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSourceMeshCodeAnchor.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSourceMeshCodeAnchor.cs
@@ -9,10 +9,12 @@ using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal static partial class ResoniteSourceMeshCodeAnchor
+internal static class ResoniteSourceMeshCodeAnchor
 {
-    [GeneratedRegex(@"(?<!\d)(\d{8}|\d{6})(?!\d)", RegexOptions.CultureInvariant)]
-    private static partial Regex MeshCodeRegex();
+    private static readonly Regex MeshCodeRegex = new(
+        @"(?<!\d)(\d{8}|\d{6})(?!\d)",
+        RegexOptions.CultureInvariant,
+        TimeSpan.FromSeconds(1));
 
     public static bool TryGetConcreteMeshCode(string value, out string meshCode)
     {
@@ -22,7 +24,7 @@ internal static partial class ResoniteSourceMeshCodeAnchor
             return false;
         }
 
-        Match[] matches = MeshCodeRegex().Matches(value).Cast<Match>().ToArray();
+        Match[] matches = MeshCodeRegex.Matches(value).Cast<Match>().ToArray();
         foreach (Match match in matches.OrderByDescending(static entry => entry.Value.Length).ThenByDescending(static entry => entry.Index))
         {
             if (PlateauMeshCode.TryGetGeodeticCenter(match.Value, out _))

--- a/tests/PlateauResoniteLink.Tests/Docs/LiveSendDocumentationContractTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Docs/LiveSendDocumentationContractTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 
@@ -5,8 +6,13 @@ using System.Text.RegularExpressions;
 
 namespace PlateauResoniteLink.Tests.Docs;
 
-public sealed partial class LiveSendDocumentationContractTests
+public sealed class LiveSendDocumentationContractTests
 {
+    private static readonly Regex HeadingRegex = new(
+        "^## .+$",
+        RegexOptions.Multiline,
+        TimeSpan.FromSeconds(1));
+
     [Fact]
     public void EnglishAndJapaneseMirrorsKeepMatchingMajorHeadings()
     {
@@ -21,12 +27,9 @@ public sealed partial class LiveSendDocumentationContractTests
 
     private static string[] GetHeadings(string markdown)
     {
-        return HeadingRegex()
+        return HeadingRegex
             .Matches(markdown)
             .Select(match => match.Value)
             .ToArray();
     }
-
-    [GeneratedRegex("^## .+$", RegexOptions.Multiline)]
-    private static partial Regex HeadingRegex();
 }


### PR DESCRIPTION
## Summary
- remove `partial` type usage that was only required by `GeneratedRegex`
- keep regex ownership explicit with static readonly instances and timeouts
- leave remaining `partial` text occurrences as fixture filenames only

## Diff size
- Compared with `codex/refactor-scene-material-plan-composer`: 2 files changed, 14 insertions, 9 deletions

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (802 passed)