### PR TITLE
Extract live send run startup

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -206,24 +206,26 @@ internal sealed class DefaultSceneSinkFactory(
         IServiceProvider serviceProvider = scope.ServiceProvider;
         ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
         IResoniteMaterialPlanning materialPlanning = serviceProvider.GetRequiredService<IResoniteMaterialPlanning>();
+        IResoniteQueuedCityObjectEnqueuer queuedCityObjectEnqueuer = new ResoniteQueuedCityObjectEnqueuer();
+        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
+            new ResoniteQueuedCityObjectSender(
+                new DeterministicTerrainTextureAssetGenerator(),
+                serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>(),
+                serviceProvider.GetRequiredService<IResonitePreparedCityObjectImporter>()));
         return new ResoniteLiveSceneImportTarget(
             targetOptions,
             new ResoniteLiveSceneImportDependencies(
                 new SingleRecordingClientSession(recordingClient),
                 diagnostics,
-                serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
-                new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter),
-                serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
-                serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
-                new ResoniteQueuedCityObjectWorker(
-                    new ResoniteQueuedCityObjectSender(
-                        new DeterministicTerrainTextureAssetGenerator(),
-                        serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>(),
-                        serviceProvider.GetRequiredService<IResonitePreparedCityObjectImporter>())),
-                new ResoniteQueuedCityObjectEnqueuer(),
-                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer()),
-                serviceProvider.GetRequiredService<IResoniteSlotCreator>(),
-                serviceProvider.GetRequiredService<IResoniteBufferedCityObjectBakerFactory>()));
+                new ResoniteLiveSendRunStarter(
+                    serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
+                    new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter),
+                    serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
+                    serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
+                    queuedCityObjectWorker,
+                    serviceProvider.GetRequiredService<IResoniteSlotCreator>()),
+                queuedCityObjectEnqueuer,
+                new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer)));
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
@@ -5,12 +5,6 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal sealed record ResoniteLiveSceneImportDependencies(
     ILiveSendClientSession ClientSession,
     ResoniteLinkSendDiagnostics Diagnostics,
-    Execution.IResoniteSceneSetupInterpreter SceneSetupInterpreter,
-    IResoniteCommonMaterialSetupPreparer CommonMaterialSetupPreparer,
-    ILiveSendRunPlanFactory RunPlanFactory,
-    ILiveSendRunStateFactory RunStateFactory,
-    IResoniteQueuedCityObjectWorker QueuedCityObjectWorker,
+    IResoniteLiveSendRunStarter RunStarter,
     IResoniteQueuedCityObjectEnqueuer QueuedCityObjectEnqueuer,
-    IResoniteLiveSendFinalizer Finalizer,
-    Execution.IResoniteSlotCreator SlotCreator,
-    IResoniteBufferedCityObjectBakerFactory CityObjectBakerFactory);
+    IResoniteLiveSendFinalizer Finalizer);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Domain.Importing;
-using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -16,20 +13,14 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 {
     private readonly Uri endpoint;
     private readonly int connectionCount;
-    private readonly IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer;
-    private readonly ILiveSendRunPlanFactory runPlanFactory;
-    private readonly ILiveSendRunStateFactory runStateFactory;
-    private readonly IResoniteQueuedCityObjectWorker queuedCityObjectWorker;
+    private readonly IResoniteLiveSendRunStarter runStarter;
     private readonly IResoniteQueuedCityObjectEnqueuer queuedCityObjectEnqueuer;
     private readonly IResoniteLiveSendFinalizer finalizer;
-    private readonly IResoniteSlotCreator slotCreator;
 #pragma warning disable CA1859
     private ILiveSendClientSession ClientSessionInternal { get; }
 #pragma warning restore CA1859
     private readonly Action<string>? progressReporter;
-#pragma warning disable CA1859
-    private readonly IResoniteSceneSetupInterpreter sceneSetupInterpreter;
-#pragma warning restore CA1859
+
     private int executionClaimed;
 
     internal ResoniteLiveSceneImportTarget(
@@ -39,7 +30,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(dependencies);
         ArgumentNullException.ThrowIfNull(dependencies.ClientSession);
-        ArgumentNullException.ThrowIfNull(dependencies.RunStateFactory);
+        ArgumentNullException.ThrowIfNull(dependencies.RunStarter);
 
         endpoint = options.Endpoint;
         connectionCount = options.ConnectionCount;
@@ -47,14 +38,9 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         Diagnostics = dependencies.Diagnostics;
         MeshBakeEnabled = options.EnableMeshBake;
         progressReporter = options.ProgressReporter;
-        sceneSetupInterpreter = dependencies.SceneSetupInterpreter;
-        commonMaterialSetupPreparer = dependencies.CommonMaterialSetupPreparer;
-        runPlanFactory = dependencies.RunPlanFactory;
-        runStateFactory = dependencies.RunStateFactory;
-        queuedCityObjectWorker = dependencies.QueuedCityObjectWorker;
+        runStarter = dependencies.RunStarter;
         queuedCityObjectEnqueuer = dependencies.QueuedCityObjectEnqueuer;
         finalizer = dependencies.Finalizer;
-        slotCreator = dependencies.SlotCreator;
         ClientSessionInternal = dependencies.ClientSession;
     }
 
@@ -136,154 +122,22 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         ArgumentNullException.ThrowIfNull(normalizedRequest);
         ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
 
-        LiveSendRunPlan runPlan = runPlanFactory.Create(
-            SetupInfo,
-            workRoot,
-            requestLocalOrigin,
-            MemoryProfile,
-            connectionCount,
-            MeshBakeEnabled);
-        ReportProgress(
-            PlateauLog.Info(
-                "live",
-                $"Initializing scene state for dataset '{SetupInfo.Dataset}' "
-                + $"mesh '{SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
-        Stopwatch connectionStopwatch = Stopwatch.StartNew();
-        ReportProgress(
-            PlateauLog.Info(
-                "live",
-                $"Connecting ResoniteLink connection pool to {endpoint} "
-                + $"with {connectionCount} available routed connection(s)."));
-        await ClientSessionInternal.EnsureConnectedAsync(
-            new LiveSendConnectionRequest(
-                normalizedRequest.Dataset,
-                normalizedRequest.MeshCode),
-            cancellationToken);
-        connectionStopwatch.Stop();
-        ReportProgress(
-            PlateauLog.Info(
-                "live",
-                $"ResoniteLink connection pool ready in {connectionStopwatch.Elapsed.TotalSeconds:F2}s "
-                + $"(dataset='{SetupInfo.Dataset}', mesh='{SetupInfo.MeshCode}')."));
-        IResoniteLinkClient routedClient = GetRoutedClient();
-        LiveSendProgressSink progress = new();
-        CommonMaterialAssetCache materials = new();
-        ReportProgress(
-            PlateauLog.Info(
-                "live",
-                "Reusing dataset content source provided by caller."));
-        ReportProgress(
-            PlateauLog.Info("live", "Setting up mutable helpers (baker)."));
-        ReportProgress(
-            PlateauLog.Info(
-                "live",
-                "Starting setup slot setup: dataset root, assets root, common assets root, location slot, and source-file root reference."));
-        Stopwatch setupStopwatch = Stopwatch.StartNew();
-        ResoniteSceneSetupState setupState = await sceneSetupInterpreter.SetupAsync(
-            routedClient,
-            runPlan.SetupInfo,
-            commonMaterials,
-            cancellationToken);
-        setupStopwatch.Stop();
-        ResoniteSharedSlotIndex placement = new(
-            setupState.DatasetRootSlot,
-            setupState.DatasetAssetsRootSlot,
-            runPlan.RequestLocalOrigin,
-            runPlan.SourceFileSlotNamesByRelativePath,
-            setupState.SceneAnchor,
-            slotCreator.CreateAsync);
-        placement.IndexSetupHierarchy(setupState);
-        ReportProgress(
-            PlateauLog.Info(
-                "live",
-                $"Scene setup complete in {setupStopwatch.Elapsed.TotalSeconds:F2}s "
-                + $"(dataset_root={setupState.DatasetRootSlot.SlotName}, assets_root={setupState.DatasetAssetsRootSlot.SlotName}, "
-                + $"common_root={setupState.CommonAssetsRootSlot.SlotName}, "
-                + $"dataset_root_existed={setupState.DatasetRootExisted}, "
-                + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
-                + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
-                + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
-        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
-        {
-            materials.CommonMaterialAssets.Set(materialAsset.Item);
-        }
-
-        foreach (string family in setupState.CommonMaterialFamilies)
-        {
-            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
-        }
-
-        if (setupState.CommonMaterialAssets.Count > 0)
-        {
-            progress.FirstCommonMaterialPrepLogged = setupState.CommonMaterialAssets.Count;
-            ReportProgress(
-                PlateauLog.Info(
-                    "live",
-                    $"Setup batch prepared {setupState.CommonMaterialAssets.Count} textureless common materials."));
-        }
-        else
-        {
-            ReportProgress(PlateauLog.Info("live", "Setup created common material slots; no textureless common material components were needed in setup batch."));
-        }
-
-        await commonMaterialSetupPreparer.PrepareAsync(
-            GetRoutedClient(),
-            setupState,
-            materials,
-            commonMaterials,
-            cancellationToken);
-
-        ReportProgress(
-            PlateauLog.Info(
-                "live",
-                "setup fixed dataset license metadata/component before city-object streaming starts."));
-        ReportProgress(
-            PlateauLog.Info(
-                "live",
-                $"Dataset metadata/license phase complete during setup. "
-                + $"Dataset root existed={setupState.DatasetRootExisted}."));
-        LiveSendQueuePlan runtimePlan = runPlan.Queue;
-        ReportProgress(
-            PlateauLog.Info(
-                "live",
-                $"Starting routed send workers (connection_pool={connectionCount})."));
-        progress.Reset();
-        LiveSendRunState state = runStateFactory.Create(
-            runPlan,
-            setupState,
-            progress,
-            materials,
-            placement,
-            cancellationToken);
-        ResoniteImportBudgetProfile resourceBudget = runPlan.ResourceBudget;
-        Stopwatch laneStartStopwatch = Stopwatch.StartNew();
-        Diagnostics.StartSendWindow(connectionCount);
-        state.Runtime.Start(queuedCityObjectWorker.CreateProcessingTasks(
-            state,
-            new LiveSendWorkerContext(
-                endpoint,
+        return await runStarter.StartAsync(
+            new LiveSendRunStartRequest(
+                SetupInfo,
+                workRoot,
+                commonMaterials,
+                normalizedRequest,
+                requestLocalOrigin,
+                MemoryProfile,
                 connectionCount,
-                GetRoutedClient,
+                MeshBakeEnabled),
+            new LiveSendRunStartContext(
+                endpoint,
+                ClientSessionInternal,
                 Diagnostics,
-                progressReporter)));
-        ReportProgress(
-            PlateauLog.Info(
-                "live",
-                $"Send lane tasks launched (connection budget={connectionCount}, "
-                + $"queue_capacity_total={runtimePlan.QueueCapacity}, "
-                + $"memory_budget_bytes={runtimePlan.MemoryBudgetBytes}, "
-                + $"memory_profile={resourceBudget.Name.ToString().ToLowerInvariant()}, "
-                + $"runtime_vram_budget_bytes={resourceBudget.RuntimeVramBudgetBytes})."));
-        laneStartStopwatch.Stop();
-        ReportProgress(
-            PlateauLog.Info(
-                "live",
-                $"Send workers ready against connection pool={connectionCount}."));
-        ReportProgress(
-            PlateauLog.Info(
-                "live",
-                $"Send lane startup phase complete in {laneStartStopwatch.Elapsed.TotalSeconds:F2}s."));
-        return state;
+                progressReporter),
+            cancellationToken);
     }
 
     public async ValueTask DisposeAsync()
@@ -312,11 +166,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         {
             await ClientSessionInternal.ResetClientsAsync();
         }
-    }
-
-    private void ReportProgress(string message)
-    {
-        progressReporter?.Invoke(message);
     }
 
     private IResoniteLinkClient GetRoutedClient()

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record LiveSendRunStartRequest(
+    ResoniteSceneSetupInfo SetupInfo,
+    string WorkRoot,
+    CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials,
+    PlateauImportRequest NormalizedRequest,
+    ResoniteLocalOrigin RequestLocalOrigin,
+    ResoniteImportMemoryProfile MemoryProfile,
+    int ConnectionCount,
+    bool MeshBakeEnabled);
+
+internal sealed record LiveSendRunStartContext(
+    Uri Endpoint,
+    ILiveSendClientSession ClientSession,
+    ResoniteLinkSendDiagnostics Diagnostics,
+    Action<string>? ProgressReporter);
+
+internal interface IResoniteLiveSendRunStarter
+{
+    Task<LiveSendRunState> StartAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteLiveSendRunStarter(
+    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
+    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
+    ILiveSendRunPlanFactory runPlanFactory,
+    ILiveSendRunStateFactory runStateFactory,
+    IResoniteQueuedCityObjectWorker queuedCityObjectWorker,
+    IResoniteSlotCreator slotCreator) : IResoniteLiveSendRunStarter
+{
+    public async Task<LiveSendRunState> StartAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(request.SetupInfo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkRoot);
+        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
+        ArgumentNullException.ThrowIfNull(request.NormalizedRequest);
+        ArgumentNullException.ThrowIfNull(context.Endpoint);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+        ArgumentNullException.ThrowIfNull(context.Diagnostics);
+
+        LiveSendRunPlan runPlan = runPlanFactory.Create(
+            request.SetupInfo,
+            request.WorkRoot,
+            request.RequestLocalOrigin,
+            request.MemoryProfile,
+            request.ConnectionCount,
+            request.MeshBakeEnabled);
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Initializing scene state for dataset '{request.SetupInfo.Dataset}' "
+                + $"mesh '{request.SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
+        Stopwatch connectionStopwatch = Stopwatch.StartNew();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Connecting ResoniteLink connection pool to {context.Endpoint} "
+                + $"with {request.ConnectionCount} available routed connection(s)."));
+        await context.ClientSession.EnsureConnectedAsync(
+            new LiveSendConnectionRequest(
+                request.NormalizedRequest.Dataset,
+                request.NormalizedRequest.MeshCode),
+            cancellationToken);
+        connectionStopwatch.Stop();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"ResoniteLink connection pool ready in {connectionStopwatch.Elapsed.TotalSeconds:F2}s "
+                + $"(dataset='{request.SetupInfo.Dataset}', mesh='{request.SetupInfo.MeshCode}')."));
+        LiveSendProgressSink progress = new();
+        CommonMaterialAssetCache materials = new();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "Reusing dataset content source provided by caller."));
+        ReportProgress(
+            context,
+            PlateauLog.Info("live", "Setting up mutable helpers (baker)."));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "Starting setup slot setup: dataset root, assets root, common assets root, location slot, and source-file root reference."));
+        Stopwatch setupStopwatch = Stopwatch.StartNew();
+        ResoniteSceneSetupState setupState = await sceneSetupInterpreter.SetupAsync(
+            GetRoutedClient(context),
+            runPlan.SetupInfo,
+            request.CommonMaterials,
+            cancellationToken);
+        setupStopwatch.Stop();
+        ResoniteSharedSlotIndex placement = new(
+            setupState.DatasetRootSlot,
+            setupState.DatasetAssetsRootSlot,
+            runPlan.RequestLocalOrigin,
+            runPlan.SourceFileSlotNamesByRelativePath,
+            setupState.SceneAnchor,
+            slotCreator.CreateAsync);
+        placement.IndexSetupHierarchy(setupState);
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Scene setup complete in {setupStopwatch.Elapsed.TotalSeconds:F2}s "
+                + $"(dataset_root={setupState.DatasetRootSlot.SlotName}, assets_root={setupState.DatasetAssetsRootSlot.SlotName}, "
+                + $"common_root={setupState.CommonAssetsRootSlot.SlotName}, "
+                + $"dataset_root_existed={setupState.DatasetRootExisted}, "
+                + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
+                + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
+                + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
+        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
+        {
+            materials.CommonMaterialAssets.Set(materialAsset.Item);
+        }
+
+        foreach (string family in setupState.CommonMaterialFamilies)
+        {
+            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
+        }
+
+        if (setupState.CommonMaterialAssets.Count > 0)
+        {
+            progress.FirstCommonMaterialPrepLogged = setupState.CommonMaterialAssets.Count;
+            ReportProgress(
+                context,
+                PlateauLog.Info(
+                    "live",
+                    $"Setup batch prepared {setupState.CommonMaterialAssets.Count} textureless common materials."));
+        }
+        else
+        {
+            ReportProgress(context, PlateauLog.Info("live", "Setup created common material slots; no textureless common material components were needed in setup batch."));
+        }
+
+        await commonMaterialSetupPreparer.PrepareAsync(
+            GetRoutedClient(context),
+            setupState,
+            materials,
+            request.CommonMaterials,
+            cancellationToken);
+
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "setup fixed dataset license metadata/component before city-object streaming starts."));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Dataset metadata/license phase complete during setup. "
+                + $"Dataset root existed={setupState.DatasetRootExisted}."));
+        LiveSendQueuePlan runtimePlan = runPlan.Queue;
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Starting routed send workers (connection_pool={request.ConnectionCount})."));
+        progress.Reset();
+        LiveSendRunState state = runStateFactory.Create(
+            runPlan,
+            setupState,
+            progress,
+            materials,
+            placement,
+            cancellationToken);
+        ResoniteImportBudgetProfile resourceBudget = runPlan.ResourceBudget;
+        Stopwatch laneStartStopwatch = Stopwatch.StartNew();
+        context.Diagnostics.StartSendWindow(request.ConnectionCount);
+        state.Runtime.Start(queuedCityObjectWorker.CreateProcessingTasks(
+            state,
+            new LiveSendWorkerContext(
+                context.Endpoint,
+                request.ConnectionCount,
+                () => GetRoutedClient(context),
+                context.Diagnostics,
+                context.ProgressReporter)));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Send lane tasks launched (connection budget={request.ConnectionCount}, "
+                + $"queue_capacity_total={runtimePlan.QueueCapacity}, "
+                + $"memory_budget_bytes={runtimePlan.MemoryBudgetBytes}, "
+                + $"memory_profile={resourceBudget.Name.ToString().ToLowerInvariant()}, "
+                + $"runtime_vram_budget_bytes={resourceBudget.RuntimeVramBudgetBytes})."));
+        laneStartStopwatch.Stop();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Send workers ready against connection pool={request.ConnectionCount}."));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Send lane startup phase complete in {laneStartStopwatch.Elapsed.TotalSeconds:F2}s."));
+        return state;
+    }
+
+    private static IResoniteLinkClient GetRoutedClient(LiveSendRunStartContext context)
+    {
+        return context.ClientSession.GetRequiredClient();
+    }
+
+    private static void ReportProgress(
+        LiveSendRunStartContext context,
+        string message)
+    {
+        context.ProgressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -133,8 +133,7 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
     ILiveSendRunPlanFactory runPlanFactory,
     ILiveSendRunStateFactory runStateFactory,
     IResonitePreparedCityObjectImporter preparedCityObjectImporter,
-    IResoniteSlotCreator slotCreator,
-    IResoniteBufferedCityObjectBakerFactory cityObjectBakerFactory)
+    IResoniteSlotCreator slotCreator)
     : IResoniteLiveSceneImportDependencyFactory
 {
     public ResoniteLiveSceneImportDependencies Create(
@@ -152,18 +151,20 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
             datasetLicenseWriter,
             preparedCityObjectImporter);
         ResoniteQueuedCityObjectEnqueuer queuedCityObjectEnqueuer = new();
-
-        return new ResoniteLiveSceneImportDependencies(
-            clientSessionFactory.Create(options, diagnostics),
-            diagnostics,
+        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
+        ResoniteLiveSendRunStarter runStarter = new(
             sceneSetupInterpreter,
             new ResoniteCommonMaterialSetupPreparer(materialPlanning, options.ProgressReporter),
             runPlanFactory,
             runStateFactory,
-            new ResoniteQueuedCityObjectWorker(queuedCityObjectSender),
+            queuedCityObjectWorker,
+            slotCreator);
+
+        return new ResoniteLiveSceneImportDependencies(
+            clientSessionFactory.Create(options, diagnostics),
+            diagnostics,
+            runStarter,
             queuedCityObjectEnqueuer,
-            new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer),
-            slotCreator,
-            cityObjectBakerFactory);
+            new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -21,9 +21,10 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     private static BundledDefaultMaterialAssetStore CreateBundledDefaultMaterialAssetStore() => new();
 
     private static ResoniteCommonMaterialSetupPreparer CreateCommonMaterialSetupPreparer(
-        IResoniteMaterialPlanning materialPlanning)
+        IResoniteMaterialPlanning materialPlanning,
+        Action<string>? progressReporter = null)
     {
-        return new ResoniteCommonMaterialSetupPreparer(materialPlanning, null);
+        return new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter);
     }
 
     private static LiveSendRunStateFactory CreateRunStateFactory()
@@ -50,6 +51,20 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
                 new TerrainTextureAssetGenerator(),
                 new ResoniteDatasetLicenseWriter(),
                 CreatePreparedCityObjectImporter(materialPlanning)));
+    }
+
+    private static ResoniteLiveSendRunStarter CreateRunStarter(
+        IResoniteMaterialPlanning materialPlanning,
+        IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null,
+        Action<string>? progressReporter = null)
+    {
+        return new ResoniteLiveSendRunStarter(
+            sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
+            CreateCommonMaterialSetupPreparer(materialPlanning, progressReporter),
+            new LiveSendRunPlanFactory(),
+            CreateRunStateFactory(),
+            CreateQueuedCityObjectWorker(materialPlanning),
+            new ResoniteSlotCreator());
     }
 
     [Fact]
@@ -94,15 +109,9 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             new ResoniteLiveSceneImportDependencies(
                 new DelegatingClientSession(),
                 diagnostics,
-                new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
-                CreateCommonMaterialSetupPreparer(materialPlanning),
-                new LiveSendRunPlanFactory(),
-                CreateRunStateFactory(),
-                CreateQueuedCityObjectWorker(materialPlanning),
+                CreateRunStarter(materialPlanning),
                 new ResoniteQueuedCityObjectEnqueuer(),
-                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer()),
-                new ResoniteSlotCreator(),
-                new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())));
+                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer())));
 
         Assert.Same(diagnostics, importTarget.Diagnostics);
     }
@@ -308,15 +317,9 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             new ResoniteLiveSceneImportDependencies(
                 new DelegatingClientSession(),
                 diagnostics,
-                new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
-                CreateCommonMaterialSetupPreparer(materialPlanning),
-                new LiveSendRunPlanFactory(),
-                CreateRunStateFactory(),
-                CreateQueuedCityObjectWorker(materialPlanning),
+                CreateRunStarter(materialPlanning),
                 new ResoniteQueuedCityObjectEnqueuer(),
-                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer()),
-                new ResoniteSlotCreator(),
-                new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())));
+                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer())));
     }
 
     private sealed class RecordingTerrainTextureAssetGeneratorFactory : ITerrainTextureAssetGeneratorFactory

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -56,6 +56,20 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 CreatePreparedCityObjectImporter(materialPlanning)));
     }
 
+    private static ResoniteLiveSendRunStarter CreateRunStarter(
+        IResoniteMaterialPlanning materialPlanning,
+        IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null,
+        Action<string>? progressReporter = null)
+    {
+        return new ResoniteLiveSendRunStarter(
+            sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
+            CreateCommonMaterialSetupPreparer(materialPlanning, progressReporter),
+            new LiveSendRunPlanFactory(),
+            CreateRunStateFactory(),
+            CreateQueuedCityObjectWorker(materialPlanning),
+            new ResoniteSlotCreator());
+    }
+
     [Fact]
     public async Task ExecuteAsync_DelegatesNormalizedRequestsToInjectedSession()
     {
@@ -79,15 +93,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             new ResoniteLiveSceneImportDependencies(
                 session,
                 diagnostics,
-                new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
-                CreateCommonMaterialSetupPreparer(materialPlanning),
-                new LiveSendRunPlanFactory(),
-                CreateRunStateFactory(),
-                CreateQueuedCityObjectWorker(materialPlanning),
+                CreateRunStarter(materialPlanning),
                 new ResoniteQueuedCityObjectEnqueuer(),
-                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer()),
-                new ResoniteSlotCreator(),
-                new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())));
+                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer())));
 
         PlateauImportRequest normalizedRequest = new(
             Dataset: "tokyo23ku",
@@ -141,15 +149,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             new ResoniteLiveSceneImportDependencies(
                 session,
                 diagnostics,
-                new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
-                CreateCommonMaterialSetupPreparer(materialPlanning),
-                new LiveSendRunPlanFactory(),
-                CreateRunStateFactory(),
-                CreateQueuedCityObjectWorker(materialPlanning),
+                CreateRunStarter(materialPlanning),
                 new ResoniteQueuedCityObjectEnqueuer(),
-                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer()),
-                new ResoniteSlotCreator(),
-                new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())));
+                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer())));
 
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
@@ -194,15 +196,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             new ResoniteLiveSceneImportDependencies(
                 session,
                 diagnostics,
-                new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
-                CreateCommonMaterialSetupPreparer(materialPlanning),
-                new LiveSendRunPlanFactory(),
-                CreateRunStateFactory(),
-                CreateQueuedCityObjectWorker(materialPlanning),
+                CreateRunStarter(materialPlanning),
                 new ResoniteQueuedCityObjectEnqueuer(),
-                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer()),
-                new ResoniteSlotCreator(),
-                new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())));
+                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer())));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
             request,
@@ -284,15 +280,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             new ResoniteLiveSceneImportDependencies(
                 session,
                 ResoniteLinkSendDiagnostics.Disabled,
-                new MissingCommonMaterialSetupInterpreter(),
-                CreateCommonMaterialSetupPreparer(materialPlanning),
-                new LiveSendRunPlanFactory(),
-                CreateRunStateFactory(),
-                CreateQueuedCityObjectWorker(materialPlanning),
+                CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter()),
                 new ResoniteQueuedCityObjectEnqueuer(),
-                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer()),
-                new ResoniteSlotCreator(),
-                new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())));
+                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer())));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
             request,
@@ -334,15 +324,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             new ResoniteLiveSceneImportDependencies(
                 session,
                 ResoniteLinkSendDiagnostics.Disabled,
-                new MissingCommonMaterialSetupInterpreter(),
-                CreateCommonMaterialSetupPreparer(materialPlanning),
-                new LiveSendRunPlanFactory(),
-                CreateRunStateFactory(),
-                CreateQueuedCityObjectWorker(materialPlanning),
+                CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter()),
                 new ResoniteQueuedCityObjectEnqueuer(),
-                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer()),
-                new ResoniteSlotCreator(),
-                new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())));
+                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer())));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
             request,
@@ -407,15 +391,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             new ResoniteLiveSceneImportDependencies(
                 session,
                 ResoniteLinkSendDiagnostics.Disabled,
-                new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
-                CreateCommonMaterialSetupPreparer(materialPlanning, progressMessages.Add),
-                new LiveSendRunPlanFactory(),
-                CreateRunStateFactory(),
-                CreateQueuedCityObjectWorker(materialPlanning),
+                CreateRunStarter(materialPlanning, progressReporter: progressMessages.Add),
                 new ResoniteQueuedCityObjectEnqueuer(),
-                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer()),
-                new ResoniteSlotCreator(),
-                new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())));
+                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer())));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
             request,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -295,6 +295,16 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
     {
         ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
         ResoniteMaterialPlanning materialPlanning = new(CreateBundledDefaultMaterialAssetStore());
+        IResoniteQueuedCityObjectEnqueuer queuedCityObjectEnqueuer = new ResoniteQueuedCityObjectEnqueuer();
+        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
+            new ResoniteQueuedCityObjectSender(
+                terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
+                new ResoniteDatasetLicenseWriter(),
+                new ResonitePreparedCityObjectImporter(
+                    new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
+                    new ResoniteSceneMaterialPlanComposer(materialPlanning),
+                    new ResoniteBatchEmissionPlanner(),
+                    new PlannedBatchEmissionInterpreter())));
         return new ResoniteLiveSceneImportTarget(
             new ResoniteLiveSceneImportTargetOptions(
                 new Uri("ws://localhost:12345/"),
@@ -308,25 +318,17 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             new ResoniteLiveSceneImportDependencies(
                 session ?? new DelegatingClientSession(routedClient),
                 diagnostics,
-                new ResoniteSceneSetupInterpreter(
-                    new ResoniteSceneSlotLocator(),
-                    new ResoniteSceneAnchorResolver()),
-                new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter),
-                new LiveSendRunPlanFactory(),
-                new LiveSendRunStateFactory(new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())),
-                new ResoniteQueuedCityObjectWorker(
-                    new ResoniteQueuedCityObjectSender(
-                        terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
-                        new ResoniteDatasetLicenseWriter(),
-                        new ResonitePreparedCityObjectImporter(
-                            new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
-                            new ResoniteSceneMaterialPlanComposer(materialPlanning),
-                            new ResoniteBatchEmissionPlanner(),
-                            new PlannedBatchEmissionInterpreter()))),
-                new ResoniteQueuedCityObjectEnqueuer(),
-                new ResoniteLiveSendFinalizer(new ResoniteQueuedCityObjectEnqueuer()),
-                new ResoniteSlotCreator(),
-                new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())));
+                new ResoniteLiveSendRunStarter(
+                    new ResoniteSceneSetupInterpreter(
+                        new ResoniteSceneSlotLocator(),
+                        new ResoniteSceneAnchorResolver()),
+                    new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter),
+                    new LiveSendRunPlanFactory(),
+                    new LiveSendRunStateFactory(new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())),
+                    queuedCityObjectWorker,
+                    new ResoniteSlotCreator()),
+                queuedCityObjectEnqueuer,
+                new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer)));
     }
 
     private static async IAsyncEnumerable<ImportedObjectUnit> CreateImportedObjectUnitsAsync(


### PR DESCRIPTION
## Summary
- extract live-send connection, setup, common-material preparation, and worker startup into an injected run starter
- narrow ResoniteLiveSceneImportTarget to execution claiming, enqueueing, finalization, and resource release
- update manual dependency construction in CLI/test support to use the startup boundary

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
