### PR TITLE
Extract live send start request factory

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -220,6 +220,7 @@ internal sealed class DefaultSceneSinkFactory(
             new ResoniteLiveSceneImportDependencies(
                 new SingleRecordingClientSession(recordingClient),
                 diagnostics,
+                serviceProvider.GetRequiredService<IResoniteLiveSendStartRequestFactory>(),
                 new ResoniteLiveSendRunStarter(
                     serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
                     new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter),

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
@@ -5,5 +5,6 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal sealed record ResoniteLiveSceneImportDependencies(
     ILiveSendClientSession ClientSession,
     ResoniteLinkSendDiagnostics Diagnostics,
+    IResoniteLiveSendStartRequestFactory StartRequestFactory,
     IResoniteLiveSendRunStarter RunStarter,
     IResoniteLiveSendQueue Queue);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -13,6 +12,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 {
     private readonly Uri endpoint;
     private readonly int connectionCount;
+    private readonly IResoniteLiveSendStartRequestFactory startRequestFactory;
     private readonly IResoniteLiveSendRunStarter runStarter;
     private readonly IResoniteLiveSendQueue queue;
 #pragma warning disable CA1859
@@ -29,6 +29,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(dependencies);
         ArgumentNullException.ThrowIfNull(dependencies.ClientSession);
+        ArgumentNullException.ThrowIfNull(dependencies.StartRequestFactory);
         ArgumentNullException.ThrowIfNull(dependencies.RunStarter);
         ArgumentNullException.ThrowIfNull(dependencies.Queue);
 
@@ -38,6 +39,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         Diagnostics = dependencies.Diagnostics;
         MeshBakeEnabled = options.EnableMeshBake;
         progressReporter = options.ProgressReporter;
+        startRequestFactory = dependencies.StartRequestFactory;
         runStarter = dependencies.RunStarter;
         queue = dependencies.Queue;
         ClientSessionInternal = dependencies.ClientSession;
@@ -67,13 +69,13 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 
         try
         {
-            SceneImportRequest request = plan.SceneImportRequest;
-            state = await CreateRunStateAsync(
-                CreateSceneSetupInfo(request),
-                request.WorkRoot,
-                request.CommonMaterials,
-                plan.NormalizedRequest,
-                CreateLocalOrigin(plan.SceneImportRequest.Metadata.GeodeticOrigin),
+            state = await runStarter.StartAsync(
+                startRequestFactory.Create(
+                    plan,
+                    MemoryProfile,
+                    connectionCount,
+                    MeshBakeEnabled),
+                CreateRunStartContext(),
                 cancellationToken);
 
             await foreach (ImportedObjectUnit objectUnit in objectUnits.WithCancellation(cancellationToken))
@@ -106,37 +108,6 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 Volatile.Write(ref executionClaimed, 0);
             }
         }
-    }
-
-    private async Task<LiveSendRunState> CreateRunStateAsync(
-        ResoniteSceneSetupInfo SetupInfo,
-        string workRoot,
-        CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials,
-        PlateauImportRequest normalizedRequest,
-        ResoniteLocalOrigin requestLocalOrigin,
-        CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(SetupInfo);
-        ArgumentNullException.ThrowIfNull(commonMaterials);
-        ArgumentNullException.ThrowIfNull(normalizedRequest);
-        ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
-
-        return await runStarter.StartAsync(
-            new LiveSendRunStartRequest(
-                SetupInfo,
-                workRoot,
-                commonMaterials,
-                normalizedRequest,
-                requestLocalOrigin,
-                MemoryProfile,
-                connectionCount,
-                MeshBakeEnabled),
-            new LiveSendRunStartContext(
-                endpoint,
-                ClientSessionInternal,
-                Diagnostics,
-                progressReporter),
-            cancellationToken);
     }
 
     public async ValueTask DisposeAsync()
@@ -189,26 +160,13 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
             progressReporter);
     }
 
-    private static ResoniteSceneSetupInfo CreateSceneSetupInfo(SceneImportRequest request)
+    private LiveSendRunStartContext CreateRunStartContext()
     {
-        ArgumentNullException.ThrowIfNull(request);
-
-        return new ResoniteSceneSetupInfo(
-            request.Metadata.Request.Dataset,
-            request.Metadata.Request.MeshCode,
-            request.Metadata.SourceDataset.SourceFiles,
-            request.Metadata.SourceDataset.SelectedMeshCodes ?? [],
-            new ResoniteLicenseAttributionMetadata(
-                request.Metadata.Attribution.DatasetLicense.RequireCredit,
-                request.Metadata.Attribution.DatasetLicense.CreditText,
-                request.Metadata.Attribution.DatasetLicense.LicenseName,
-                request.Metadata.Attribution.DatasetLicense.LicenseUrl));
-    }
-
-    private static ResoniteLocalOrigin CreateLocalOrigin(GeodeticOrigin origin)
-    {
-        ArgumentNullException.ThrowIfNull(origin);
-        return new ResoniteLocalOrigin(origin.Latitude, origin.Longitude, origin.Altitude);
+        return new LiveSendRunStartContext(
+            endpoint,
+            ClientSessionInternal,
+            Diagnostics,
+            progressReporter);
     }
 
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendStartRequestFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendStartRequestFactory.cs
@@ -1,0 +1,60 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendStartRequestFactory
+{
+    LiveSendRunStartRequest Create(
+        SceneImportExecutionPlan plan,
+        ResoniteImportMemoryProfile memoryProfile,
+        int connectionCount,
+        bool meshBakeEnabled);
+}
+
+internal sealed class ResoniteLiveSendStartRequestFactory : IResoniteLiveSendStartRequestFactory
+{
+    public LiveSendRunStartRequest Create(
+        SceneImportExecutionPlan plan,
+        ResoniteImportMemoryProfile memoryProfile,
+        int connectionCount,
+        bool meshBakeEnabled)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentOutOfRangeException.ThrowIfLessThan(connectionCount, 1);
+
+        SceneImportRequest request = plan.SceneImportRequest;
+        return new LiveSendRunStartRequest(
+            CreateSceneSetupInfo(request),
+            request.WorkRoot,
+            request.CommonMaterials,
+            plan.NormalizedRequest,
+            CreateLocalOrigin(request.Metadata.GeodeticOrigin),
+            memoryProfile,
+            connectionCount,
+            meshBakeEnabled);
+    }
+
+    private static ResoniteSceneSetupInfo CreateSceneSetupInfo(SceneImportRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return new ResoniteSceneSetupInfo(
+            request.Metadata.Request.Dataset,
+            request.Metadata.Request.MeshCode,
+            request.Metadata.SourceDataset.SourceFiles,
+            request.Metadata.SourceDataset.SelectedMeshCodes ?? [],
+            new ResoniteLicenseAttributionMetadata(
+                request.Metadata.Attribution.DatasetLicense.RequireCredit,
+                request.Metadata.Attribution.DatasetLicense.CreditText,
+                request.Metadata.Attribution.DatasetLicense.LicenseName,
+                request.Metadata.Attribution.DatasetLicense.LicenseUrl));
+    }
+
+    private static ResoniteLocalOrigin CreateLocalOrigin(GeodeticOrigin origin)
+    {
+        ArgumentNullException.ThrowIfNull(origin);
+        return new ResoniteLocalOrigin(origin.Latitude, origin.Longitude, origin.Altitude);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteSceneMaterialPlanComposer, ResoniteSceneMaterialPlanComposer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
+        services.TryAddScoped<IResoniteLiveSendStartRequestFactory, ResoniteLiveSendStartRequestFactory>();
         services.TryAddScoped<IResonitePreparedCityObjectImporter, ResonitePreparedCityObjectImporter>();
         services.TryAddScoped<IResoniteQueuedCityObjectEnqueuer, ResoniteQueuedCityObjectEnqueuer>();
         services.TryAddScoped<IResoniteLiveSendFinalizer, ResoniteLiveSendFinalizer>();
@@ -133,6 +134,7 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
     IResoniteMaterialPlanning materialPlanning,
     ILiveSendRunPlanFactory runPlanFactory,
     ILiveSendRunStateFactory runStateFactory,
+    IResoniteLiveSendStartRequestFactory startRequestFactory,
     IResonitePreparedCityObjectImporter preparedCityObjectImporter,
     IResoniteSlotCreator slotCreator,
     IResoniteLiveSendQueue queue)
@@ -164,6 +166,7 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
         return new ResoniteLiveSceneImportDependencies(
             clientSessionFactory.Create(options, diagnostics),
             diagnostics,
+            startRequestFactory,
             runStarter,
             queue);
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -115,6 +115,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             new ResoniteLiveSceneImportDependencies(
                 new DelegatingClientSession(),
                 diagnostics,
+                new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
                 CreateQueue()));
 
@@ -322,6 +323,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             new ResoniteLiveSceneImportDependencies(
                 new DelegatingClientSession(),
                 diagnostics,
+                new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
                 CreateQueue()));
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -99,6 +99,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             new ResoniteLiveSceneImportDependencies(
                 session,
                 diagnostics,
+                new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
                 CreateQueue()));
 
@@ -154,6 +155,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             new ResoniteLiveSceneImportDependencies(
                 session,
                 diagnostics,
+                new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
                 CreateQueue()));
 
@@ -200,6 +202,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             new ResoniteLiveSceneImportDependencies(
                 session,
                 diagnostics,
+                new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
@@ -283,6 +286,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             new ResoniteLiveSceneImportDependencies(
                 session,
                 ResoniteLinkSendDiagnostics.Disabled,
+                new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter()),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
@@ -326,6 +330,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             new ResoniteLiveSceneImportDependencies(
                 session,
                 ResoniteLinkSendDiagnostics.Disabled,
+                new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter()),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
@@ -392,6 +397,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             new ResoniteLiveSceneImportDependencies(
                 session,
                 ResoniteLinkSendDiagnostics.Disabled,
+                new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning, progressReporter: progressMessages.Add),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -321,6 +321,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             new ResoniteLiveSceneImportDependencies(
                 session ?? new DelegatingClientSession(routedClient),
                 diagnostics,
+                new ResoniteLiveSendStartRequestFactory(),
                 new ResoniteLiveSendRunStarter(
                     new ResoniteSceneSetupInterpreter(
                         new ResoniteSceneSlotLocator(),


### PR DESCRIPTION
## Summary
- extract live-send start request construction from ResoniteLiveSceneImportTarget into an injected factory
- keep scene setup metadata and local-origin projection as a pure target-edge transform
- update DI and manual test/CLI composition for the new start-request boundary

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
