### PR TITLE
Extract live send worker launcher

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -226,7 +226,7 @@ internal sealed class DefaultSceneSinkFactory(
                     new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter),
                     serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
                     serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
-                    queuedCityObjectWorker,
+                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),
                     serviceProvider.GetRequiredService<IResoniteSlotCreator>()),
                 queue));
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -40,7 +40,7 @@ internal sealed class ResoniteLiveSendRunStarter(
     IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
     ILiveSendRunPlanFactory runPlanFactory,
     ILiveSendRunStateFactory runStateFactory,
-    IResoniteQueuedCityObjectWorker queuedCityObjectWorker,
+    IResoniteLiveSendWorkerLauncher workerLauncher,
     IResoniteSlotCreator slotCreator) : IResoniteLiveSendRunStarter
 {
     public async Task<LiveSendRunState> StartAsync(
@@ -173,13 +173,6 @@ internal sealed class ResoniteLiveSendRunStarter(
                 "live",
                 $"Dataset metadata/license phase complete during setup. "
                 + $"Dataset root existed={setupState.DatasetRootExisted}."));
-        LiveSendQueuePlan runtimePlan = runPlan.Queue;
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Starting routed send workers (connection_pool={request.ConnectionCount})."));
-        progress.Reset();
         LiveSendRunState state = runStateFactory.Create(
             runPlan,
             setupState,
@@ -187,37 +180,13 @@ internal sealed class ResoniteLiveSendRunStarter(
             materials,
             placement,
             cancellationToken);
-        ResoniteImportBudgetProfile resourceBudget = runPlan.ResourceBudget;
-        Stopwatch laneStartStopwatch = Stopwatch.StartNew();
-        context.Diagnostics.StartSendWindow(request.ConnectionCount);
-        state.Runtime.Start(queuedCityObjectWorker.CreateProcessingTasks(
-            state,
-            new LiveSendWorkerContext(
-                context.Endpoint,
-                request.ConnectionCount,
-                () => GetRoutedClient(context),
-                context.Diagnostics,
-                context.ProgressReporter)));
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Send lane tasks launched (connection budget={request.ConnectionCount}, "
-                + $"queue_capacity_total={runtimePlan.QueueCapacity}, "
-                + $"memory_budget_bytes={runtimePlan.MemoryBudgetBytes}, "
-                + $"memory_profile={resourceBudget.Name.ToString().ToLowerInvariant()}, "
-                + $"runtime_vram_budget_bytes={resourceBudget.RuntimeVramBudgetBytes})."));
-        laneStartStopwatch.Stop();
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Send workers ready against connection pool={request.ConnectionCount}."));
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Send lane startup phase complete in {laneStartStopwatch.Elapsed.TotalSeconds:F2}s."));
+        workerLauncher.Launch(
+            new LiveSendWorkerLaunchRequest(
+                state,
+                runPlan.Queue,
+                runPlan.ResourceBudget,
+                request.ConnectionCount),
+            context);
         return state;
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -184,8 +184,7 @@ internal sealed class ResoniteLiveSendRunStarter(
             new LiveSendWorkerLaunchRequest(
                 state,
                 runPlan.Queue,
-                runPlan.ResourceBudget,
-                request.ConnectionCount),
+                runPlan.ResourceBudget),
             context);
         return state;
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -155,12 +155,13 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
             datasetLicenseWriter,
             preparedCityObjectImporter);
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
+        ResoniteLiveSendWorkerLauncher workerLauncher = new(queuedCityObjectWorker);
         ResoniteLiveSendRunStarter runStarter = new(
             sceneSetupInterpreter,
             new ResoniteCommonMaterialSetupPreparer(materialPlanning, options.ProgressReporter),
             runPlanFactory,
             runStateFactory,
-            queuedCityObjectWorker,
+            workerLauncher,
             slotCreator);
 
         return new ResoniteLiveSceneImportDependencies(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
@@ -22,6 +22,9 @@ internal interface IResoniteLiveSendWorkerLauncher
 internal sealed class ResoniteLiveSendWorkerLauncher(
     IResoniteQueuedCityObjectWorker queuedCityObjectWorker) : IResoniteLiveSendWorkerLauncher
 {
+    private readonly IResoniteQueuedCityObjectWorker queuedCityObjectWorker =
+        queuedCityObjectWorker ?? throw new ArgumentNullException(nameof(queuedCityObjectWorker));
+
     public void Launch(
         LiveSendWorkerLaunchRequest request,
         LiveSendRunStartContext context)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
@@ -9,8 +9,7 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal sealed record LiveSendWorkerLaunchRequest(
     LiveSendRunState State,
     LiveSendQueuePlan QueuePlan,
-    ResoniteImportBudgetProfile ResourceBudget,
-    int ConnectionCount);
+    ResoniteImportBudgetProfile ResourceBudget);
 
 internal interface IResoniteLiveSendWorkerLauncher
 {
@@ -37,21 +36,22 @@ internal sealed class ResoniteLiveSendWorkerLauncher(
         ArgumentNullException.ThrowIfNull(context.Endpoint);
         ArgumentNullException.ThrowIfNull(context.ClientSession);
         ArgumentNullException.ThrowIfNull(context.Diagnostics);
-        ArgumentOutOfRangeException.ThrowIfLessThan(request.ConnectionCount, 1);
+        int connectionCount = request.QueuePlan.ConnectionCount;
+        ArgumentOutOfRangeException.ThrowIfLessThan(connectionCount, 1);
 
         ReportProgress(
             context,
             PlateauLog.Info(
                 "live",
-                $"Starting routed send workers (connection_pool={request.ConnectionCount})."));
+                $"Starting routed send workers (connection_pool={connectionCount})."));
         request.State.Progress.Reset();
         Stopwatch laneStartStopwatch = Stopwatch.StartNew();
-        context.Diagnostics.StartSendWindow(request.ConnectionCount);
+        context.Diagnostics.StartSendWindow(connectionCount);
         request.State.Runtime.Start(queuedCityObjectWorker.CreateProcessingTasks(
             request.State,
             new LiveSendWorkerContext(
                 context.Endpoint,
-                request.ConnectionCount,
+                connectionCount,
                 () => GetRoutedClient(context),
                 context.Diagnostics,
                 context.ProgressReporter)));
@@ -59,7 +59,7 @@ internal sealed class ResoniteLiveSendWorkerLauncher(
             context,
             PlateauLog.Info(
                 "live",
-                $"Send lane tasks launched (connection budget={request.ConnectionCount}, "
+                $"Send lane tasks launched (connection budget={connectionCount}, "
                 + $"queue_capacity_total={request.QueuePlan.QueueCapacity}, "
                 + $"memory_budget_bytes={request.QueuePlan.MemoryBudgetBytes}, "
                 + $"memory_profile={request.ResourceBudget.Name.ToString().ToLowerInvariant()}, "
@@ -69,7 +69,7 @@ internal sealed class ResoniteLiveSendWorkerLauncher(
             context,
             PlateauLog.Info(
                 "live",
-                $"Send workers ready against connection pool={request.ConnectionCount}."));
+                $"Send workers ready against connection pool={connectionCount}."));
         ReportProgress(
             context,
             PlateauLog.Info(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Diagnostics;
+
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record LiveSendWorkerLaunchRequest(
+    LiveSendRunState State,
+    LiveSendQueuePlan QueuePlan,
+    ResoniteImportBudgetProfile ResourceBudget,
+    int ConnectionCount);
+
+internal interface IResoniteLiveSendWorkerLauncher
+{
+    void Launch(
+        LiveSendWorkerLaunchRequest request,
+        LiveSendRunStartContext context);
+}
+
+internal sealed class ResoniteLiveSendWorkerLauncher(
+    IResoniteQueuedCityObjectWorker queuedCityObjectWorker) : IResoniteLiveSendWorkerLauncher
+{
+    public void Launch(
+        LiveSendWorkerLaunchRequest request,
+        LiveSendRunStartContext context)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.State);
+        ArgumentNullException.ThrowIfNull(request.QueuePlan);
+        ArgumentNullException.ThrowIfNull(request.ResourceBudget);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.Endpoint);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+        ArgumentNullException.ThrowIfNull(context.Diagnostics);
+        ArgumentOutOfRangeException.ThrowIfLessThan(request.ConnectionCount, 1);
+
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Starting routed send workers (connection_pool={request.ConnectionCount})."));
+        request.State.Progress.Reset();
+        Stopwatch laneStartStopwatch = Stopwatch.StartNew();
+        context.Diagnostics.StartSendWindow(request.ConnectionCount);
+        request.State.Runtime.Start(queuedCityObjectWorker.CreateProcessingTasks(
+            request.State,
+            new LiveSendWorkerContext(
+                context.Endpoint,
+                request.ConnectionCount,
+                () => GetRoutedClient(context),
+                context.Diagnostics,
+                context.ProgressReporter)));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Send lane tasks launched (connection budget={request.ConnectionCount}, "
+                + $"queue_capacity_total={request.QueuePlan.QueueCapacity}, "
+                + $"memory_budget_bytes={request.QueuePlan.MemoryBudgetBytes}, "
+                + $"memory_profile={request.ResourceBudget.Name.ToString().ToLowerInvariant()}, "
+                + $"runtime_vram_budget_bytes={request.ResourceBudget.RuntimeVramBudgetBytes})."));
+        laneStartStopwatch.Stop();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Send workers ready against connection pool={request.ConnectionCount}."));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Send lane startup phase complete in {laneStartStopwatch.Elapsed.TotalSeconds:F2}s."));
+    }
+
+    private static IResoniteLinkClient GetRoutedClient(LiveSendRunStartContext context)
+    {
+        return context.ClientSession.GetRequiredClient();
+    }
+
+    private static void ReportProgress(
+        LiveSendRunStartContext context,
+        string message)
+    {
+        context.ProgressReporter?.Invoke(message);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -63,7 +63,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             CreateCommonMaterialSetupPreparer(materialPlanning, progressReporter),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
-            CreateQueuedCityObjectWorker(materialPlanning),
+            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),
             new ResoniteSlotCreator());
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -66,7 +66,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             CreateCommonMaterialSetupPreparer(materialPlanning, progressReporter),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
-            CreateQueuedCityObjectWorker(materialPlanning),
+            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),
             new ResoniteSlotCreator());
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -329,7 +329,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                     new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter),
                     new LiveSendRunPlanFactory(),
                     new LiveSendRunStateFactory(new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())),
-                    queuedCityObjectWorker,
+                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),
                     new ResoniteSlotCreator()),
                 queue));
     }


### PR DESCRIPTION
## Summary
- extract routed send worker startup from ResoniteLiveSendRunStarter into a dedicated launcher
- keep diagnostics send-window start, worker task creation, and worker startup progress logging together
- update manual CLI/test composition for the new worker-launch boundary

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
