### PR TITLE
Extract observed source root placement resolver

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -9,7 +9,7 @@ namespace PlateauResoniteLink.Targets.Resonite.Execution;
 internal interface IResoniteBatchEmissionPlanner
 {
     PlannedBatchEmission Create(
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots,
+        ResoniteObjectSlotHierarchy objectSlots,
         PlannedSceneObjectEmission emissionPlan);
 }
 
@@ -29,7 +29,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         "[FrooxEngine]FrooxEngine.BooleanAssetDriver<[FrooxEngine]FrooxEngine.Mesh>";
 
     public PlannedBatchEmission Create(
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots,
+        ResoniteObjectSlotHierarchy objectSlots,
         PlannedSceneObjectEmission emissionPlan)
     {
         ArgumentNullException.ThrowIfNull(objectSlots);
@@ -252,7 +252,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         List<PlannedBatchSlotEmission> slotEmissions,
         List<PlannedBatchComponentEmission> componentEmissions,
         List<BatchPlanSlotLocator> slotResolutionTargets,
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots,
+        ResoniteObjectSlotHierarchy objectSlots,
         string terrainGridAssetSlotName,
         ResoniteTerrainGridGeometry geometry,
         Uri heightTextureUri,

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendQueuedCityObject.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendQueuedCityObject.cs
@@ -6,5 +6,5 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed record LiveSendQueuedCityObject(
     ResoniteConstructionCityObject CityObject,
-    Task<ResoniteSharedSlotIndex.ObjectSlotHierarchy> ObjectHierarchyTask,
+    Task<ResoniteObjectSlotHierarchy> ObjectHierarchyTask,
     AsyncWeightedGate.Lease MemoryLease);

--- a/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootPlacementResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootPlacementResolver.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal static class ObservedSourceRootPlacementResolver
+{
+    private const double StrictPlacementEquivalenceTolerance = 0.001;
+    private const double SiblingProjectionDriftTolerance = 0.25;
+
+    public static ObservedSourceRootPlacement? TryResolve(
+        string sourceFileSlotName,
+        string rootMeshCode,
+        IReadOnlyList<Slot> directSourceRoots)
+    {
+        ObservedSourceRootPlacement[] exactSourceRoots = directSourceRoots
+            .Where(slot => string.Equals(slot.Name?.Value, sourceFileSlotName, StringComparison.Ordinal))
+            .Select(slot => new ObservedSourceRootPlacement(
+                GetSlotPositionOrDefault(slot),
+                ReferenceMeshCode: rootMeshCode,
+                SlotId: slot.ID ?? string.Empty))
+            .ToArray();
+        if (exactSourceRoots.Length > 0)
+        {
+            return SelectDeterministicObservedPlacement(
+                exactSourceRoots,
+                $"Dataset root contains multiple observed source roots named '{sourceFileSlotName}' with different placements. Append placement is ambiguous.",
+                StrictPlacementEquivalenceTolerance);
+        }
+
+        ObservedSourceRootPlacement[] ancestorCandidates = directSourceRoots
+            .Select(static slot => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name?.Value ?? string.Empty, out string meshCode)
+                ? (Slot: slot, MeshCode: meshCode)
+                : default)
+            .Where(candidate => candidate.Slot is not null
+                && rootMeshCode.StartsWith(candidate.MeshCode, StringComparison.Ordinal))
+            .Select(candidate => new ObservedSourceRootPlacement(
+                ResonitePlacementPolicy.Add(
+                    GetSlotPositionOrDefault(candidate.Slot),
+                    ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
+                ReferenceMeshCode: candidate.MeshCode,
+                SlotId: candidate.Slot.ID ?? string.Empty))
+            .OrderByDescending(static candidate => candidate.ReferenceMeshCode.Length)
+            .ToArray();
+        if (ancestorCandidates.Length == 0)
+        {
+            ObservedSourceRootPlacement[] observedMeshCodeRoots = directSourceRoots
+                .Select(static slot => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name?.Value ?? string.Empty, out string meshCode)
+                    ? (Slot: slot, MeshCode: meshCode)
+                    : default)
+                .Where(static candidate => candidate.Slot is not null)
+                .Select(candidate => new ObservedSourceRootPlacement(
+                    ResonitePlacementPolicy.Add(
+                        GetSlotPositionOrDefault(candidate.Slot),
+                        ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
+                    ReferenceMeshCode: candidate.MeshCode,
+                    SlotId: candidate.Slot.ID ?? string.Empty))
+                .ToArray();
+            return observedMeshCodeRoots.Length == 0
+                ? null
+                : SelectDeterministicObservedPlacement(
+                    observedMeshCodeRoots,
+                    $"Dataset root contains multiple observed source roots that resolve different placements for mesh-code '{rootMeshCode}'. Append placement is ambiguous.",
+                    SiblingProjectionDriftTolerance);
+        }
+
+        int bestLength = ancestorCandidates[0].ReferenceMeshCode.Length;
+        ObservedSourceRootPlacement[] bestCandidates = ancestorCandidates
+            .Where(candidate => candidate.ReferenceMeshCode.Length == bestLength)
+            .ToArray();
+        return SelectDeterministicObservedPlacement(
+            bestCandidates,
+            $"Dataset root contains multiple observed source roots for mesh-code '{bestCandidates[0].ReferenceMeshCode}' with different placements. Append placement is ambiguous.",
+            StrictPlacementEquivalenceTolerance);
+    }
+
+    private static ObservedSourceRootPlacement SelectDeterministicObservedPlacement(
+        IReadOnlyCollection<ObservedSourceRootPlacement> candidates,
+        string ambiguousMessage,
+        double tolerance)
+    {
+        ObservedSourceRootPlacement selected = candidates
+            .OrderBy(static candidate => candidate.ReferenceMeshCode, StringComparer.Ordinal)
+            .ThenBy(static candidate => candidate.SlotId, StringComparer.Ordinal)
+            .First();
+        if (candidates.Any(candidate => !AreEquivalentPositions(candidate.Position, selected.Position, tolerance)))
+        {
+            throw new InvalidOperationException(ambiguousMessage);
+        }
+
+        return selected;
+    }
+
+    private static bool AreEquivalentPositions(ResoniteFloat3 left, ResoniteFloat3 right, double tolerance)
+    {
+        return Math.Abs(left.X - right.X) <= tolerance
+            && Math.Abs(left.Y - right.Y) <= tolerance
+            && Math.Abs(left.Z - right.Z) <= tolerance;
+    }
+
+    private static ResoniteFloat3 GetSlotPositionOrDefault(Slot slot)
+    {
+        if (slot.Position is not Field_float3 position)
+        {
+            return new ResoniteFloat3(0.0, 0.0, 0.0);
+        }
+
+        return new ResoniteFloat3(position.Value.x, position.Value.y, position.Value.z);
+    }
+}
+
+internal readonly record struct ObservedSourceRootPlacement(
+    ResoniteFloat3 Position,
+    string ReferenceMeshCode,
+    string SlotId);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteObjectSlotHierarchy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteObjectSlotHierarchy.cs
@@ -1,0 +1,8 @@
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record ResoniteObjectSlotHierarchy(
+    CreatedSlot AssetLodSlot,
+    CreatedSlot LodSlot,
+    string CityObjectSlotName,
+    ResoniteFloat3 CityObjectLocalPosition,
+    ResoniteFloatQ? CityObjectRotation);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedCityObjectImporter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedCityObjectImporter.cs
@@ -50,7 +50,7 @@ internal sealed class ResonitePreparedCityObjectImporter(
         Stopwatch cityObjectStopwatch = Stopwatch.StartNew();
         ReportImportStep(progressReporter, cityObject, "Creating object slot hierarchy.");
         Stopwatch slotHierarchyStopwatch = Stopwatch.StartNew();
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = await AwaitWithSlowCityObjectWarningAsync(
+        ResoniteObjectSlotHierarchy objectSlots = await AwaitWithSlowCityObjectWarningAsync(
             queuedCityObject.ObjectHierarchyTask,
             cancellationToken);
         slotHierarchyStopwatch.Stop();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectEnqueuer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectEnqueuer.cs
@@ -129,7 +129,7 @@ internal sealed class ResoniteQueuedCityObjectEnqueuer : IResoniteQueuedCityObje
         AsyncWeightedGate.Lease cityObjectMemoryLease = await runtime.AcquireCityObjectMemoryAsync(
             estimatedWorksetBytes,
             cancellationToken);
-        Task<ResoniteSharedSlotIndex.ObjectSlotHierarchy> objectHierarchyTask = state.Placement.CreateObjectHierarchyTask(
+        Task<ResoniteObjectSlotHierarchy> objectHierarchyTask = state.Placement.CreateObjectHierarchyTask(
             context.GetRoutedClient(),
             cityObject,
             runtime.ProcessingCancellationToken,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -1,14 +1,10 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
-
-using ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
@@ -23,26 +19,12 @@ internal sealed class ResoniteSharedSlotIndex(
     private readonly AsyncCompletedResultCache<SharedSlotIndexKey, CreatedSlot> sharedSlotCache = new();
     private readonly AsyncCompletedResultCache<SharedSlotIndexKey, CreatedSlot> runScopedSourceFileRootCache = new();
     private readonly AsyncCompletedResultCache<CanonicalParentSourceFile, CanonicalParentScope> canonicalParentScopeCache = new();
-    private readonly ConcurrentDictionary<string, byte> createdSlotIds = new(StringComparer.Ordinal);
-    private readonly ConcurrentDictionary<SharedSlotIndexKey, CreatedSlot> sharedSlotIndex = new();
-    private readonly ConcurrentDictionary<string, Slot> observedSlotSnapshotsById = new(StringComparer.Ordinal);
-    private Slot[]? observedDatasetSourceRoots;
+    private readonly ResoniteSlotSnapshotIndex slotSnapshotIndex = new(datasetRootSlot);
     public SceneAnchor? SceneAnchor { get; private set; } = initialSceneAnchor;
 
     public void IndexSetupHierarchy(ResoniteSceneSetupState setupState)
     {
-        observedDatasetSourceRoots = null;
-        if (setupState.DatasetRootSnapshot is not null)
-        {
-            observedSlotSnapshotsById.Clear();
-            IndexObservedSlotSnapshot(setupState.DatasetRootSnapshot);
-        }
-        else
-        {
-            IndexCreatedSharedSlot(ResoniteSlotLocator.Root, setupState.DatasetRootSlot);
-        }
-
-        IndexCreatedSharedSlot(setupState.DatasetRootSlot.Locator, setupState.DatasetAssetsRootSlot);
+        slotSnapshotIndex.IndexSetupHierarchy(setupState);
     }
 
     public Task<ObjectSlotHierarchy> CreateObjectHierarchyTask(
@@ -186,8 +168,8 @@ internal sealed class ResoniteSharedSlotIndex(
             async ct =>
             {
                 CreatedSlot createdSlot = await createSlotAsync(client, parent, slotName, position, null, ct);
-                createdSlotIds[createdSlot.Locator.Value] = 0;
-                return IndexCreatedSharedSlot(parent, createdSlot, position);
+                slotSnapshotIndex.MarkCreated(createdSlot);
+                return slotSnapshotIndex.IndexCreatedSharedSlot(parent, createdSlot, position);
             },
             cancellationToken);
     }
@@ -203,57 +185,18 @@ internal sealed class ResoniteSharedSlotIndex(
         CreatedSlot? indexedSlot = TryGetIndexedSharedChildSlot(parent, slotName);
         if (indexedSlot is not null)
         {
-            createdSlotIds[indexedSlot.Value.Locator.Value] = 0;
+            slotSnapshotIndex.MarkCreated(indexedSlot.Value);
             return indexedSlot.Value;
         }
 
         CreatedSlot createdSlot = await createSlotAsync(client, parent, slotName, position, rotation, cancellationToken);
-        createdSlotIds[createdSlot.Locator.Value] = 0;
-        return IndexCreatedSharedSlot(parent, createdSlot, position);
-    }
-
-    private void IndexObservedSlotSnapshot(Slot slot)
-    {
-        if (string.IsNullOrWhiteSpace(slot.ID))
-        {
-            return;
-        }
-
-        observedSlotSnapshotsById[slot.ID] = slot;
-        if (slot.Children is null || slot.Children.Count == 0)
-        {
-            return;
-        }
-
-        foreach (Slot child in slot.Children)
-        {
-            if (!string.IsNullOrWhiteSpace(child.ID) && !string.IsNullOrWhiteSpace(child.Name?.Value))
-            {
-                sharedSlotIndex[new SharedSlotIndexKey(slot.ID!, child.Name!.Value)] = new CreatedSlot(new ResoniteSlotLocator(child.ID!), child.Name.Value);
-            }
-
-            IndexObservedSlotSnapshot(child);
-        }
+        slotSnapshotIndex.MarkCreated(createdSlot);
+        return slotSnapshotIndex.IndexCreatedSharedSlot(parent, createdSlot, position);
     }
 
     private CreatedSlot? TryGetIndexedSharedChildSlot(ResoniteSlotLocator parent, string slotName)
     {
-        return sharedSlotIndex.TryGetValue(new SharedSlotIndexKey(parent.Value, slotName), out CreatedSlot createdSlot)
-            ? createdSlot
-            : null;
-    }
-
-    private CreatedSlot IndexCreatedSharedSlot(ResoniteSlotLocator parent, CreatedSlot createdSlot, ResoniteFloat3? position = null)
-    {
-        sharedSlotIndex[new SharedSlotIndexKey(parent.Value, createdSlot.SlotName)] = createdSlot;
-        observedSlotSnapshotsById[createdSlot.Locator.Value] = new Slot
-        {
-            ID = createdSlot.Locator.Value,
-            Name = new Field_string { Value = createdSlot.SlotName },
-            Parent = new Reference { TargetID = parent.Value },
-            Position = position is null ? null : CreateFloat3(position),
-        };
-        return createdSlot;
+        return slotSnapshotIndex.TryGetSharedChildSlot(parent, slotName);
     }
 
     private SourceRootPlacement ResolveSourceRootPlacement(
@@ -265,33 +208,7 @@ internal sealed class ResoniteSharedSlotIndex(
             rootMeshCode,
             requestLocalOrigin,
             SceneAnchor,
-            GetObservedDatasetSourceRoots());
-    }
-
-    private IEnumerable<Slot> EnumerateObservedDatasetSourceRoots()
-    {
-        return observedSlotSnapshotsById.Values
-            .Where(slot => string.Equals(slot.Parent?.TargetID, datasetRootSlot.Locator.Value, StringComparison.Ordinal))
-            .Where(slot => string.IsNullOrWhiteSpace(slot.ID) || !createdSlotIds.ContainsKey(slot.ID!))
-            .Where(static slot => !string.Equals(slot.Name?.Value, "Assets", StringComparison.Ordinal));
-    }
-
-    private Slot[] GetObservedDatasetSourceRoots()
-    {
-        return observedDatasetSourceRoots ??= EnumerateObservedDatasetSourceRoots().ToArray();
-    }
-
-    private static Field_float3 CreateFloat3(ResoniteFloat3 value)
-    {
-        return new Field_float3
-        {
-            Value = new float3
-            {
-                x = (float)value.X,
-                y = (float)value.Y,
-                z = (float)value.Z,
-            },
-        };
+            slotSnapshotIndex.GetObservedDatasetSourceRoots());
     }
 
     internal sealed record ObjectSlotHierarchy(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -27,7 +27,7 @@ internal sealed class ResoniteSharedSlotIndex(
         slotSnapshotIndex.IndexSetupHierarchy(setupState);
     }
 
-    public Task<ObjectSlotHierarchy> CreateObjectHierarchyTask(
+    public Task<ResoniteObjectSlotHierarchy> CreateObjectHierarchyTask(
         IResoniteLinkClient client,
         ResoniteConstructionCityObject cityObject,
         CancellationToken processingCancellationToken,
@@ -49,7 +49,7 @@ internal sealed class ResoniteSharedSlotIndex(
         return GetOrCreateSharedChildSlotByIdAsync(client, parent, slotName, null, null, cancellationToken);
     }
 
-    private async Task<ObjectSlotHierarchy> CreateObjectHierarchyWithLinkedCancellationAsync(
+    private async Task<ResoniteObjectSlotHierarchy> CreateObjectHierarchyWithLinkedCancellationAsync(
         IResoniteLinkClient client,
         ResoniteConstructionCityObject cityObject,
         CancellationToken processingCancellationToken,
@@ -61,7 +61,7 @@ internal sealed class ResoniteSharedSlotIndex(
         return await CreateObjectSlotHierarchyAsync(client, cityObject, linkedCancellation.Token);
     }
 
-    private async Task<ObjectSlotHierarchy> CreateObjectSlotHierarchyAsync(
+    private async Task<ResoniteObjectSlotHierarchy> CreateObjectSlotHierarchyAsync(
         IResoniteLinkClient client,
         ResoniteConstructionCityObject cityObject,
         CancellationToken cancellationToken)
@@ -74,7 +74,7 @@ internal sealed class ResoniteSharedSlotIndex(
             new CanonicalParentSourceFile(sourceFileRelativePath, rootMeshCode, cityObject.LodLevel),
             ct => CreateCanonicalParentScopeAsync(client, sourceFileSlotName, rootMeshCode, cityObject.LodLevel, sourceRootPlacement.RootPosition, ct),
             cancellationToken);
-        return new ObjectSlotHierarchy(
+        return new ResoniteObjectSlotHierarchy(
             parentScope.AssetLodSlot,
             parentScope.LodSlot,
             cityObject.DisplayName,
@@ -210,13 +210,6 @@ internal sealed class ResoniteSharedSlotIndex(
             SceneAnchor,
             slotSnapshotIndex.GetObservedDatasetSourceRoots());
     }
-
-    internal sealed record ObjectSlotHierarchy(
-        CreatedSlot AssetLodSlot,
-        CreatedSlot LodSlot,
-        string CityObjectSlotName,
-        ResoniteFloat3 CityObjectLocalPosition,
-        ResoniteFloatQ? CityObjectRotation);
 
     private sealed record CanonicalParentScope(
         CreatedSlot SourceFileSlot,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -20,9 +20,6 @@ internal sealed class ResoniteSharedSlotIndex(
     SceneAnchor? initialSceneAnchor,
     Func<IResoniteLinkClient, ResoniteSlotLocator, string, ResoniteFloat3?, ResoniteFloatQ?, CancellationToken, Task<CreatedSlot>> createSlotAsync)
 {
-    private const double StrictPlacementEquivalenceTolerance = 0.001;
-    private const double SiblingProjectionDriftTolerance = 0.25;
-
     private readonly AsyncCompletedResultCache<SharedSlotIndexKey, CreatedSlot> sharedSlotCache = new();
     private readonly AsyncCompletedResultCache<SharedSlotIndexKey, CreatedSlot> runScopedSourceFileRootCache = new();
     private readonly AsyncCompletedResultCache<CanonicalParentSourceFile, CanonicalParentScope> canonicalParentScopeCache = new();
@@ -285,66 +282,10 @@ internal sealed class ResoniteSharedSlotIndex(
         string sourceFileSlotName,
         string rootMeshCode)
     {
-        Slot[] directSourceRoots = GetObservedDatasetSourceRoots();
-        ObservedSourceRootPlacement[] exactSourceRoots = directSourceRoots
-            .Where(slot => string.Equals(slot.Name?.Value, sourceFileSlotName, StringComparison.Ordinal))
-            .Select(slot => new ObservedSourceRootPlacement(
-                GetSlotPositionOrDefault(slot),
-                ReferenceMeshCode: rootMeshCode,
-                SlotId: slot.ID ?? string.Empty))
-            .ToArray();
-        if (exactSourceRoots.Length > 0)
-        {
-            return SelectDeterministicObservedPlacement(
-                exactSourceRoots,
-                $"Dataset root contains multiple observed source roots named '{sourceFileSlotName}' with different placements. Append placement is ambiguous.",
-                StrictPlacementEquivalenceTolerance);
-        }
-
-        ObservedSourceRootPlacement[] ancestorCandidates = directSourceRoots
-            .Select(static slot => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name?.Value ?? string.Empty, out string meshCode)
-                ? (Slot: slot, MeshCode: meshCode)
-                : default)
-            .Where(candidate => candidate.Slot is not null
-                && rootMeshCode.StartsWith(candidate.MeshCode, StringComparison.Ordinal))
-            .Select(candidate => new ObservedSourceRootPlacement(
-                ResonitePlacementPolicy.Add(
-                    GetSlotPositionOrDefault(candidate.Slot),
-                    ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
-                ReferenceMeshCode: candidate.MeshCode,
-                SlotId: candidate.Slot.ID ?? string.Empty))
-            .OrderByDescending(static candidate => candidate.ReferenceMeshCode.Length)
-            .ToArray();
-        if (ancestorCandidates.Length == 0)
-        {
-            ObservedSourceRootPlacement[] observedMeshCodeRoots = directSourceRoots
-                .Select(static slot => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name?.Value ?? string.Empty, out string meshCode)
-                    ? (Slot: slot, MeshCode: meshCode)
-                    : default)
-                .Where(static candidate => candidate.Slot is not null)
-                .Select(candidate => new ObservedSourceRootPlacement(
-                    ResonitePlacementPolicy.Add(
-                        GetSlotPositionOrDefault(candidate.Slot),
-                        ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
-                    ReferenceMeshCode: candidate.MeshCode,
-                    SlotId: candidate.Slot.ID ?? string.Empty))
-                .ToArray();
-            return observedMeshCodeRoots.Length == 0
-                ? null
-                : SelectDeterministicObservedPlacement(
-                    observedMeshCodeRoots,
-                    $"Dataset root contains multiple observed source roots that resolve different placements for mesh-code '{rootMeshCode}'. Append placement is ambiguous.",
-                    SiblingProjectionDriftTolerance);
-        }
-
-        int bestLength = ancestorCandidates[0].ReferenceMeshCode.Length;
-        ObservedSourceRootPlacement[] bestCandidates = ancestorCandidates
-            .Where(candidate => candidate.ReferenceMeshCode.Length == bestLength)
-            .ToArray();
-        return SelectDeterministicObservedPlacement(
-            bestCandidates,
-            $"Dataset root contains multiple observed source roots for mesh-code '{bestCandidates[0].ReferenceMeshCode}' with different placements. Append placement is ambiguous.",
-            StrictPlacementEquivalenceTolerance);
+        return ObservedSourceRootPlacementResolver.TryResolve(
+            sourceFileSlotName,
+            rootMeshCode,
+            GetObservedDatasetSourceRoots());
     }
 
     private IEnumerable<Slot> EnumerateObservedDatasetSourceRoots()
@@ -360,30 +301,6 @@ internal sealed class ResoniteSharedSlotIndex(
         return observedDatasetSourceRoots ??= EnumerateObservedDatasetSourceRoots().ToArray();
     }
 
-    private static ObservedSourceRootPlacement SelectDeterministicObservedPlacement(
-        IReadOnlyCollection<ObservedSourceRootPlacement> candidates,
-        string ambiguousMessage,
-        double tolerance)
-    {
-        ObservedSourceRootPlacement selected = candidates
-            .OrderBy(static candidate => candidate.ReferenceMeshCode, StringComparer.Ordinal)
-            .ThenBy(static candidate => candidate.SlotId, StringComparer.Ordinal)
-            .First();
-        if (candidates.Any(candidate => !AreEquivalentPositions(candidate.Position, selected.Position, tolerance)))
-        {
-            throw new InvalidOperationException(ambiguousMessage);
-        }
-
-        return selected;
-    }
-
-    private static bool AreEquivalentPositions(ResoniteFloat3 left, ResoniteFloat3 right, double tolerance)
-    {
-        return Math.Abs(left.X - right.X) <= tolerance
-            && Math.Abs(left.Y - right.Y) <= tolerance
-            && Math.Abs(left.Z - right.Z) <= tolerance;
-    }
-
     private static Field_float3 CreateFloat3(ResoniteFloat3 value)
     {
         return new Field_float3
@@ -395,16 +312,6 @@ internal sealed class ResoniteSharedSlotIndex(
                 z = (float)value.Z,
             },
         };
-    }
-
-    private static ResoniteFloat3 GetSlotPositionOrDefault(Slot slot)
-    {
-        if (slot.Position is not Field_float3 position)
-        {
-            return new ResoniteFloat3(0.0, 0.0, 0.0);
-        }
-
-        return new ResoniteFloat3(position.Value.x, position.Value.y, position.Value.z);
     }
 
     internal sealed record ObjectSlotHierarchy(
@@ -423,11 +330,6 @@ internal sealed class ResoniteSharedSlotIndex(
     private readonly record struct SourceRootPlacement(
         ResoniteFloat3 RootPosition,
         ResoniteFloat3 LocalPositionReferenceRoot);
-
-    private readonly record struct ObservedSourceRootPlacement(
-        ResoniteFloat3 Position,
-        string ReferenceMeshCode,
-        string SlotId);
 
     private readonly record struct CanonicalParentSourceFile(
         string SourceFileRelativePath,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -260,31 +260,11 @@ internal sealed class ResoniteSharedSlotIndex(
         string sourceFileSlotName,
         string rootMeshCode)
     {
-        ObservedSourceRootPlacement? observedRootPlacement = TryResolveObservedSourceRootPosition(sourceFileSlotName, rootMeshCode);
-        ResoniteFloat3 rootPosition = observedRootPlacement?.Position
-            ?? ResolveDatasetRootAnchoredSourceRootPosition(rootMeshCode)
-            ?? ResonitePlacementPolicy.ResolveMeshRootPosition(requestLocalOrigin, rootMeshCode);
-
-        return new SourceRootPlacement(rootPosition, rootPosition);
-    }
-
-    private ResoniteFloat3? ResolveDatasetRootAnchoredSourceRootPosition(string rootMeshCode)
-    {
-        if (SceneAnchor is not { ReferenceSourceFileRoot: null } anchor)
-        {
-            return null;
-        }
-
-        return ResonitePlacementPolicy.ComputeMeshCodeOffset(anchor.MeshCode, rootMeshCode);
-    }
-
-    private ObservedSourceRootPlacement? TryResolveObservedSourceRootPosition(
-        string sourceFileSlotName,
-        string rootMeshCode)
-    {
-        return ObservedSourceRootPlacementResolver.TryResolve(
+        return SourceRootPlacementResolver.Resolve(
             sourceFileSlotName,
             rootMeshCode,
+            requestLocalOrigin,
+            SceneAnchor,
             GetObservedDatasetSourceRoots());
     }
 
@@ -326,10 +306,6 @@ internal sealed class ResoniteSharedSlotIndex(
         CreatedSlot AssetSourceFileSlot,
         CreatedSlot LodSlot,
         CreatedSlot AssetLodSlot);
-
-    private readonly record struct SourceRootPlacement(
-        ResoniteFloat3 RootPosition,
-        ResoniteFloat3 LocalPositionReferenceRoot);
 
     private readonly record struct CanonicalParentSourceFile(
         string SourceFileRelativePath,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSlotSnapshotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSlotSnapshotIndex.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class ResoniteSlotSnapshotIndex(CreatedSlot datasetRootSlot)
+{
+    private readonly ConcurrentDictionary<string, byte> createdSlotIds = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<SlotIndexKey, CreatedSlot> sharedSlotIndex = new();
+    private readonly ConcurrentDictionary<string, Slot> observedSlotSnapshotsById = new(StringComparer.Ordinal);
+    private Slot[]? observedDatasetSourceRoots;
+
+    public void IndexSetupHierarchy(ResoniteSceneSetupState setupState)
+    {
+        observedDatasetSourceRoots = null;
+        if (setupState.DatasetRootSnapshot is not null)
+        {
+            observedSlotSnapshotsById.Clear();
+            IndexObservedSlotSnapshot(setupState.DatasetRootSnapshot);
+        }
+        else
+        {
+            IndexCreatedSharedSlot(ResoniteSlotLocator.Root, setupState.DatasetRootSlot);
+        }
+
+        IndexCreatedSharedSlot(setupState.DatasetRootSlot.Locator, setupState.DatasetAssetsRootSlot);
+    }
+
+    public CreatedSlot? TryGetSharedChildSlot(ResoniteSlotLocator parent, string slotName)
+    {
+        return sharedSlotIndex.TryGetValue(new SlotIndexKey(parent.Value, slotName), out CreatedSlot createdSlot)
+            ? createdSlot
+            : null;
+    }
+
+    public CreatedSlot IndexCreatedSharedSlot(ResoniteSlotLocator parent, CreatedSlot createdSlot, ResoniteFloat3? position = null)
+    {
+        sharedSlotIndex[new SlotIndexKey(parent.Value, createdSlot.SlotName)] = createdSlot;
+        observedSlotSnapshotsById[createdSlot.Locator.Value] = new Slot
+        {
+            ID = createdSlot.Locator.Value,
+            Name = new Field_string { Value = createdSlot.SlotName },
+            Parent = new Reference { TargetID = parent.Value },
+            Position = position is null ? null : CreateFloat3(position),
+        };
+        return createdSlot;
+    }
+
+    public void MarkCreated(CreatedSlot createdSlot)
+    {
+        createdSlotIds[createdSlot.Locator.Value] = 0;
+    }
+
+    public IReadOnlyList<Slot> GetObservedDatasetSourceRoots()
+    {
+        return observedDatasetSourceRoots ??= EnumerateObservedDatasetSourceRoots().ToArray();
+    }
+
+    private void IndexObservedSlotSnapshot(Slot slot)
+    {
+        if (string.IsNullOrWhiteSpace(slot.ID))
+        {
+            return;
+        }
+
+        observedSlotSnapshotsById[slot.ID] = slot;
+        if (slot.Children is null || slot.Children.Count == 0)
+        {
+            return;
+        }
+
+        foreach (Slot child in slot.Children)
+        {
+            if (!string.IsNullOrWhiteSpace(child.ID) && !string.IsNullOrWhiteSpace(child.Name?.Value))
+            {
+                sharedSlotIndex[new SlotIndexKey(slot.ID!, child.Name!.Value)] = new CreatedSlot(new ResoniteSlotLocator(child.ID!), child.Name.Value);
+            }
+
+            IndexObservedSlotSnapshot(child);
+        }
+    }
+
+    private IEnumerable<Slot> EnumerateObservedDatasetSourceRoots()
+    {
+        return observedSlotSnapshotsById.Values
+            .Where(slot => string.Equals(slot.Parent?.TargetID, datasetRootSlot.Locator.Value, StringComparison.Ordinal))
+            .Where(slot => string.IsNullOrWhiteSpace(slot.ID) || !createdSlotIds.ContainsKey(slot.ID!))
+            .Where(static slot => !string.Equals(slot.Name?.Value, "Assets", StringComparison.Ordinal));
+    }
+
+    private static Field_float3 CreateFloat3(ResoniteFloat3 value)
+    {
+        return new Field_float3
+        {
+            Value = new float3
+            {
+                x = (float)value.X,
+                y = (float)value.Y,
+                z = (float)value.Z,
+            },
+        };
+    }
+
+    private readonly record struct SlotIndexKey(
+        string ParentSlotId,
+        string SlotName);
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/SourceRootPlacementResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SourceRootPlacementResolver.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal static class SourceRootPlacementResolver
+{
+    public static SourceRootPlacement Resolve(
+        string sourceFileSlotName,
+        string rootMeshCode,
+        ResoniteLocalOrigin requestLocalOrigin,
+        SceneAnchor? sceneAnchor,
+        IReadOnlyList<Slot> observedDatasetSourceRoots)
+    {
+        ObservedSourceRootPlacement? observedRootPlacement = ObservedSourceRootPlacementResolver.TryResolve(
+            sourceFileSlotName,
+            rootMeshCode,
+            observedDatasetSourceRoots);
+        ResoniteFloat3 rootPosition = observedRootPlacement?.Position
+            ?? ResolveDatasetRootAnchoredSourceRootPosition(sceneAnchor, rootMeshCode)
+            ?? ResonitePlacementPolicy.ResolveMeshRootPosition(requestLocalOrigin, rootMeshCode);
+
+        return new SourceRootPlacement(rootPosition, rootPosition);
+    }
+
+    private static ResoniteFloat3? ResolveDatasetRootAnchoredSourceRootPosition(
+        SceneAnchor? sceneAnchor,
+        string rootMeshCode)
+    {
+        if (sceneAnchor is not { ReferenceSourceFileRoot: null } anchor)
+        {
+            return null;
+        }
+
+        return ResonitePlacementPolicy.ComputeMeshCodeOffset(anchor.MeshCode, rootMeshCode);
+    }
+}
+
+internal readonly record struct SourceRootPlacement(
+    ResoniteFloat3 RootPosition,
+    ResoniteFloat3 LocalPositionReferenceRoot);

--- a/tests/PlateauResoniteLink.Tests/Targets/ObservedSourceRootPlacementResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ObservedSourceRootPlacementResolverTests.cs
@@ -1,0 +1,62 @@
+using System;
+
+using PlateauResoniteLink.Targets.Resonite;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class ObservedSourceRootPlacementResolverTests
+{
+    [Fact]
+    public void TryResolveUsesExactSourceFileRootNameBeforeMeshCodeProjection()
+    {
+        ObservedSourceRootPlacement? placement = ObservedSourceRootPlacementResolver.TryResolve(
+            "plateau_tokyo23ku_bldg_53394525",
+            "53394525",
+            [
+                CreateSlot("sibling-root", "plateau_tokyo23ku_bldg_53394526", new ResoniteFloat3(20.0, 1.0, 30.0)),
+                CreateSlot("exact-root", "plateau_tokyo23ku_bldg_53394525", new ResoniteFloat3(2.0, 3.0, 4.0)),
+            ]);
+
+        Assert.Equal(new ResoniteFloat3(2.0, 3.0, 4.0), placement?.Position);
+        Assert.Equal("53394525", placement?.ReferenceMeshCode);
+        Assert.Equal("exact-root", placement?.SlotId);
+    }
+
+    [Fact]
+    public void TryResolveRejectsDuplicateExactSourceFileRootsWithDifferentPlacements()
+    {
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => ObservedSourceRootPlacementResolver.TryResolve(
+                "plateau_tokyo23ku_bldg_53394525",
+                "53394525",
+                [
+                    CreateSlot("first-root", "plateau_tokyo23ku_bldg_53394525", new ResoniteFloat3(0.0, 0.0, 0.0)),
+                    CreateSlot("second-root", "plateau_tokyo23ku_bldg_53394525", new ResoniteFloat3(1.0, 0.0, 0.0)),
+                ]));
+
+        Assert.Contains(
+            "multiple observed source roots named 'plateau_tokyo23ku_bldg_53394525'",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    private static Slot CreateSlot(string id, string name, ResoniteFloat3 position)
+    {
+        return new Slot
+        {
+            ID = id,
+            Name = new Field_string { Value = name },
+            Position = new Field_float3
+            {
+                Value = new float3
+                {
+                    x = (float)position.X,
+                    y = (float)position.Y,
+                    z = (float)position.Z,
+                },
+            },
+        };
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -37,7 +37,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     [Fact]
     public void CreatePlannedBatchEmission_CreatesTerrainGridPlanWithPlannedTextureReference()
     {
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
+        ResoniteObjectSlotHierarchy objectSlots = new(
             new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Terrain Grid Object",
@@ -135,7 +135,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     [Fact]
     public void CreatePlannedBatchEmission_CreatesDynamicTerrainPlanWithGridAsFalseFallback()
     {
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
+        ResoniteObjectSlotHierarchy objectSlots = new(
             new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Dynamic Terrain Object",
@@ -219,7 +219,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     [Fact]
     public void CreatePlannedBatchEmission_CarriesTerrainGridUvMembers()
     {
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
+        ResoniteObjectSlotHierarchy objectSlots = new(
             new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Terrain Grid Object",
@@ -265,7 +265,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     [Fact]
     public void CreatePlannedBatchEmission_UsesReusableTargetsAndPlansDedicatedMaterialComponents()
     {
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
+        ResoniteObjectSlotHierarchy objectSlots = new(
             new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Triangle Object",
@@ -333,7 +333,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     [Fact]
     public void CreatePlannedBatchEmission_UsesMeshAssetContainerWhenDedicatedMaterialSlotIsNotPreserved()
     {
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
+        ResoniteObjectSlotHierarchy objectSlots = new(
             new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Triangle Object",
@@ -420,7 +420,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     [Fact]
     public void CreatePlannedBatchEmission_UsesMainTexturePropertyBlockForRendererOverride()
     {
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
+        ResoniteObjectSlotHierarchy objectSlots = new(
             new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Triangle Object",
@@ -477,7 +477,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     [Fact]
     public void CreatePlannedBatchEmission_ClampsTerrainMainTextureOverride()
     {
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
+        ResoniteObjectSlotHierarchy objectSlots = new(
             new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Triangle Object",
@@ -516,7 +516,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     [Fact]
     public void CreatePlannedBatchEmission_UsesSharedTerrainPropertyBlockWhenProvided()
     {
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
+        ResoniteObjectSlotHierarchy objectSlots = new(
             new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Triangle Object",
@@ -562,7 +562,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     [Fact]
     public void CreatePlannedBatchEmission_UsesDistinctOverrideComponentIdsForSharedMaterialOverrides()
     {
-        ResoniteSharedSlotIndex.ObjectSlotHierarchy objectSlots = new(
+        ResoniteObjectSlotHierarchy objectSlots = new(
             new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Triangle Object",

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSlotSnapshotIndexTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSlotSnapshotIndexTests.cs
@@ -1,0 +1,72 @@
+using System.Linq;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class ResoniteSlotSnapshotIndexTests
+{
+    [Fact]
+    public void IndexSetupHierarchyIndexesObservedChildrenAndFiltersCreatedSourceRoots()
+    {
+        CreatedSlot datasetRoot = new(new ResoniteSlotLocator("dataset-root"), "PLATEAU tokyo23ku");
+        CreatedSlot assetsRoot = new(new ResoniteSlotLocator("assets-root"), "Assets");
+        ResoniteSlotSnapshotIndex index = new(datasetRoot);
+
+        index.IndexSetupHierarchy(new ResoniteSceneSetupState(
+            datasetRoot,
+            assetsRoot,
+            new CreatedSlot(new ResoniteSlotLocator("common-root"), "Common Materials"),
+            DatasetRootExisted: true,
+            new SceneAnchor(
+                datasetRoot.Locator,
+                "53394525",
+                new ResoniteFloat3(0.0, 0.0, 0.0),
+                ReferenceSourceFileRoot: null),
+            CreateSlot(
+                "dataset-root",
+                "PLATEAU tokyo23ku",
+                null,
+                [
+                    CreateSlot("existing-root", "plateau_tokyo23ku_bldg_53394525", "dataset-root"),
+                    CreateSlot("assets-root", "Assets", "dataset-root"),
+                ]),
+            CommonMaterialCatalog.Create().Map(static member => new ResoniteCommonMaterialAsset(
+                member,
+                SceneImportContractMapper.ToInternal(member.CreateBinding([0])),
+                default)),
+            []));
+
+        CreatedSlot? existingRoot = index.TryGetSharedChildSlot(
+            datasetRoot.Locator,
+            "plateau_tokyo23ku_bldg_53394525");
+        Assert.Equal("existing-root", existingRoot?.Locator.Value);
+        Assert.Equal("assets-root", index.TryGetSharedChildSlot(datasetRoot.Locator, "Assets")?.Locator.Value);
+
+        CreatedSlot createdRoot = new(new ResoniteSlotLocator("created-root"), "plateau_tokyo23ku_bldg_53394526");
+        index.MarkCreated(createdRoot);
+        index.IndexCreatedSharedSlot(datasetRoot.Locator, createdRoot, new ResoniteFloat3(1.0, 2.0, 3.0));
+
+        Slot observedRoot = Assert.Single(index.GetObservedDatasetSourceRoots());
+        Assert.Equal("existing-root", observedRoot.ID);
+    }
+
+    private static Slot CreateSlot(
+        string id,
+        string name,
+        string? parentId = null,
+        Slot[]? children = null)
+    {
+        return new Slot
+        {
+            ID = id,
+            Name = new Field_string { Value = name },
+            Parent = parentId is null ? null : new Reference { TargetID = parentId },
+            Children = children?.ToList(),
+        };
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/SourceRootPlacementResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SourceRootPlacementResolverTests.cs
@@ -1,0 +1,69 @@
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class SourceRootPlacementResolverTests
+{
+    [Fact]
+    public void ResolveUsesObservedRootBeforeSceneAnchorFallback()
+    {
+        SourceRootPlacement placement = SourceRootPlacementResolver.Resolve(
+            "plateau_tokyo23ku_bldg_53394525",
+            "53394525",
+            new ResoniteLocalOrigin(35.0, 139.0, 0.0),
+            new SceneAnchor(
+                new ResoniteSlotLocator("dataset-root"),
+                "53394526",
+                new ResoniteFloat3(0.0, 0.0, 0.0),
+                ReferenceSourceFileRoot: null),
+            [
+                CreateSlot(
+                    "source-root",
+                    "plateau_tokyo23ku_bldg_53394525",
+                    new ResoniteFloat3(4.0, 5.0, 6.0)),
+            ]);
+
+        Assert.Equal(new ResoniteFloat3(4.0, 5.0, 6.0), placement.RootPosition);
+        Assert.Equal(placement.RootPosition, placement.LocalPositionReferenceRoot);
+    }
+
+    [Fact]
+    public void ResolveUsesDatasetRootAnchorWhenNoObservedRootExists()
+    {
+        SourceRootPlacement placement = SourceRootPlacementResolver.Resolve(
+            "plateau_tokyo23ku_bldg_53394525",
+            "53394525",
+            new ResoniteLocalOrigin(35.0, 139.0, 0.0),
+            new SceneAnchor(
+                new ResoniteSlotLocator("dataset-root"),
+                "53394524",
+                new ResoniteFloat3(0.0, 0.0, 0.0),
+                ReferenceSourceFileRoot: null),
+            []);
+
+        Assert.Equal(
+            ResonitePlacementPolicy.ComputeMeshCodeOffset("53394524", "53394525"),
+            placement.RootPosition);
+    }
+
+    private static Slot CreateSlot(string id, string name, ResoniteFloat3 position)
+    {
+        return new Slot
+        {
+            ID = id,
+            Name = new Field_string { Value = name },
+            Position = new Field_float3
+            {
+                Value = new float3
+                {
+                    x = (float)position.X,
+                    y = (float)position.Y,
+                    z = (float)position.Z,
+                },
+            },
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Move observed source root placement selection out of ResoniteSharedSlotIndex.
- Keep ResoniteSharedSlotIndex focused on slot indexing/caching and hierarchy creation.
- Add focused resolver tests for exact observed roots and ambiguous duplicate placements.

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false