### PR TITLE
Extract non-DEM atlas layout packer

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -211,8 +211,9 @@ internal sealed class DefaultSceneSinkFactory(
             new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
             new ResoniteQueuedCityObjectSender(
-                new DeterministicTerrainTextureAssetGenerator(),
-                serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>(),
+                new ResoniteQueuedTexturePreparer(
+                    new DeterministicTerrainTextureAssetGenerator(),
+                    serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>()),
                 serviceProvider.GetRequiredService<IResonitePreparedCityObjectImporter>()));
         return new ResoniteLiveSceneImportTarget(
             targetOptions,

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -205,7 +205,6 @@ internal sealed class DefaultSceneSinkFactory(
 
         IServiceProvider serviceProvider = scope.ServiceProvider;
         ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
-        IResoniteMaterialPlanning materialPlanning = serviceProvider.GetRequiredService<IResoniteMaterialPlanning>();
         IResoniteQueuedCityObjectEnqueuer queuedCityObjectEnqueuer = new ResoniteQueuedCityObjectEnqueuer();
         ResoniteLiveSendQueue queue = new(
             queuedCityObjectEnqueuer,
@@ -223,7 +222,7 @@ internal sealed class DefaultSceneSinkFactory(
                 serviceProvider.GetRequiredService<IResoniteLiveSendStartRequestFactory>(),
                 new ResoniteLiveSendRunStarter(
                     serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
-                    new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter),
+                    serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupPreparer>(),
                     serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
                     serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
                     new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),

--- a/src/PlateauResoniteLink/Targets/Resonite/INonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/INonDemSourceFileBakeEmitter.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface INonDemSourceFileBakeEmitter
+{
+    Task<int> EmitAsync(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemBufferedCityObject> cityObjects,
+        int batchStartIndex,
+        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
+        CancellationToken cancellationToken);
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasBakeBudget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasBakeBudget.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal readonly record struct NonDemAtlasBakeBudget(
+    int MaxAtlasSize = NonDemAtlasBakeBudget.DefaultMaxAtlasSize,
+    int TilePaddingPixels = NonDemAtlasBakeBudget.DefaultTilePaddingPixels,
+    ResoniteImportBudgetProfile? ResourceBudget = null)
+{
+    public const int DefaultMaxAtlasSize = 4096;
+    public const int DefaultTilePaddingPixels = 2;
+
+    public int EffectiveMaxAtlasSize => Math.Max(1, Math.Min(MaxAtlasSize, ResourceBudget?.MaxAtlasSize ?? MaxAtlasSize));
+
+    public int EffectiveMaxAtlasTextureEdge
+    {
+        get
+        {
+            int profileMaxTileEdge = ResourceBudget?.MaxAtlasTextureEdge ?? EffectiveMaxAtlasSize;
+            return Math.Max(1, Math.Min(EffectiveMaxAtlasSize - (TilePaddingPixels * 2), profileMaxTileEdge));
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasBatchFitPolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasBatchFitPolicy.cs
@@ -3,7 +3,18 @@ using System.Linq;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed class NonDemAtlasBatchFitPolicy(NonDemAtlasLayoutFactory atlasLayoutFactory)
+internal interface INonDemAtlasBatchFitPolicy
+{
+    bool CanFitSingleCandidate(NonDemCityObjectBakeCandidate candidate);
+
+    bool CanAppendToAtlasBatch(
+        IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
+        NonDemCityObjectBakeCandidate candidate);
+
+    bool RequiresBakeEmission(NonDemCityObjectBakeCandidate candidate);
+}
+
+internal sealed class NonDemAtlasBatchFitPolicy(INonDemAtlasLayoutFactory atlasLayoutFactory) : INonDemAtlasBatchFitPolicy
 {
     public bool CanFitSingleCandidate(NonDemCityObjectBakeCandidate candidate)
     {
@@ -18,7 +29,7 @@ internal sealed class NonDemAtlasBatchFitPolicy(NonDemAtlasLayoutFactory atlasLa
         return atlasLayoutFactory.CanFit(candidateEntries);
     }
 
-    public static bool RequiresBakeEmission(NonDemCityObjectBakeCandidate candidate)
+    public bool RequiresBakeEmission(NonDemCityObjectBakeCandidate candidate)
     {
         return candidate.PreservedEntries.Any(static entry => entry.VertexColorOverride is not null);
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasBatchFitPolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasBatchFitPolicy.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemAtlasBatchFitPolicy(NonDemAtlasLayoutFactory atlasLayoutFactory)
+{
+    public bool CanFitSingleCandidate(NonDemCityObjectBakeCandidate candidate)
+    {
+        return candidate.AtlasEntries.Count == 0 || atlasLayoutFactory.CanFit(candidate.AtlasEntries);
+    }
+
+    public bool CanAppendToAtlasBatch(
+        IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
+        NonDemCityObjectBakeCandidate candidate)
+    {
+        List<NonDemAtlasBatchEntry> candidateEntries = [.. batchCandidates.SelectMany(static current => current.AtlasEntries), .. candidate.AtlasEntries];
+        return atlasLayoutFactory.CanFit(candidateEntries);
+    }
+
+    public static bool RequiresBakeEmission(NonDemCityObjectBakeCandidate candidate)
+    {
+        return candidate.PreservedEntries.Any(static entry => entry.VertexColorOverride is not null);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasImageRenderer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasImageRenderer.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemAtlasImageRenderer(int tilePaddingPixels)
+{
+    public void Draw(
+        Image<Rgba32> atlasImage,
+        IReadOnlyList<NonDemAtlasPlacement<NonDemAtlasBatchEntry>> placements)
+    {
+        bool[] atlasCoverage = new bool[atlasImage.Width * atlasImage.Height];
+        foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in placements)
+        {
+            DrawTile(atlasImage, atlasCoverage, placement);
+        }
+
+        FillUncoveredPixels(atlasImage, atlasCoverage, ComputeBackgroundColor(placements));
+    }
+
+    private void DrawTile(
+        Image<Rgba32> atlasImage,
+        bool[] atlasCoverage,
+        NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement)
+    {
+        for (int y = 0; y < placement.Entry.Tile.Image.Height; y++)
+        {
+            for (int x = 0; x < placement.Entry.Tile.Image.Width; x++)
+            {
+                SetPixel(
+                    atlasImage,
+                    atlasCoverage,
+                    placement.InnerRect.X + x,
+                    placement.InnerRect.Y + y,
+                    placement.Entry.Tile.Image[x, y]);
+            }
+        }
+
+        for (int y = 0; y < placement.Entry.Tile.Image.Height; y++)
+        {
+            Rgba32 leftEdge = atlasImage[placement.InnerRect.X, placement.InnerRect.Y + y];
+            Rgba32 rightEdge = atlasImage[placement.InnerRect.X + placement.InnerRect.Width - 1, placement.InnerRect.Y + y];
+            for (int pad = 1; pad <= tilePaddingPixels; pad++)
+            {
+                SetPixel(
+                    atlasImage,
+                    atlasCoverage,
+                    placement.InnerRect.X - pad,
+                    placement.InnerRect.Y + y,
+                    leftEdge);
+                SetPixel(
+                    atlasImage,
+                    atlasCoverage,
+                    placement.InnerRect.X + placement.InnerRect.Width - 1 + pad,
+                    placement.InnerRect.Y + y,
+                    rightEdge);
+            }
+        }
+
+        int fullWidth = placement.InnerRect.Width + (tilePaddingPixels * 2);
+        for (int pad = 1; pad <= tilePaddingPixels; pad++)
+        {
+            int sourceTopY = placement.InnerRect.Y;
+            int sourceBottomY = placement.InnerRect.Y + placement.InnerRect.Height - 1;
+            int targetTopY = placement.InnerRect.Y - pad;
+            int targetBottomY = placement.InnerRect.Y + placement.InnerRect.Height - 1 + pad;
+            for (int x = 0; x < fullWidth; x++)
+            {
+                int sampleX = placement.InnerRect.X - tilePaddingPixels + x;
+                SetPixel(
+                    atlasImage,
+                    atlasCoverage,
+                    sampleX,
+                    targetTopY,
+                    atlasImage[sampleX, sourceTopY]);
+                SetPixel(
+                    atlasImage,
+                    atlasCoverage,
+                    sampleX,
+                    targetBottomY,
+                    atlasImage[sampleX, sourceBottomY]);
+            }
+        }
+    }
+
+    private static Rgba32 ComputeBackgroundColor(
+        IReadOnlyList<NonDemAtlasPlacement<NonDemAtlasBatchEntry>> placements)
+    {
+        long sumR = 0;
+        long sumG = 0;
+        long sumB = 0;
+        long totalWeight = 0;
+        foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in placements)
+        {
+            long weight = Math.Max(1, placement.Entry.Tile.Image.Width * placement.Entry.Tile.Image.Height);
+            sumR += placement.Entry.Tile.BackgroundColor.R * weight;
+            sumG += placement.Entry.Tile.BackgroundColor.G * weight;
+            sumB += placement.Entry.Tile.BackgroundColor.B * weight;
+            totalWeight += weight;
+        }
+
+        if (totalWeight == 0)
+        {
+            return new Rgba32(255, 255, 255, 255);
+        }
+
+        return new Rgba32(
+            (byte)Math.Clamp(Math.Round(sumR / (double)totalWeight), 0.0, 255.0),
+            (byte)Math.Clamp(Math.Round(sumG / (double)totalWeight), 0.0, 255.0),
+            (byte)Math.Clamp(Math.Round(sumB / (double)totalWeight), 0.0, 255.0),
+            byte.MaxValue);
+    }
+
+    private static void FillUncoveredPixels(Image<Rgba32> atlasImage, bool[] atlasCoverage, Rgba32 backgroundColor)
+    {
+        for (int y = 0; y < atlasImage.Height; y++)
+        {
+            for (int x = 0; x < atlasImage.Width; x++)
+            {
+                int offset = (y * atlasImage.Width) + x;
+                if (atlasCoverage[offset])
+                {
+                    continue;
+                }
+
+                atlasImage[x, y] = backgroundColor;
+            }
+        }
+    }
+
+    private static void SetPixel(Image<Rgba32> atlasImage, bool[] atlasCoverage, int x, int y, Rgba32 pixel)
+    {
+        atlasImage[x, y] = pixel;
+        atlasCoverage[(y * atlasImage.Width) + x] = true;
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasImageRenderer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasImageRenderer.cs
@@ -6,7 +6,14 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed class NonDemAtlasImageRenderer(int tilePaddingPixels)
+internal interface INonDemAtlasImageRenderer
+{
+    void Draw(
+        Image<Rgba32> atlasImage,
+        IReadOnlyList<NonDemAtlasPlacement<NonDemAtlasBatchEntry>> placements);
+}
+
+internal sealed class NonDemAtlasImageRenderer(int tilePaddingPixels) : INonDemAtlasImageRenderer
 {
     public void Draw(
         Image<Rgba32> atlasImage,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasLayoutFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasLayoutFactory.cs
@@ -2,7 +2,16 @@ using System.Collections.Generic;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed class NonDemAtlasLayoutFactory(int atlasMaxSize, int tilePaddingPixels)
+internal interface INonDemAtlasLayoutFactory
+{
+    bool CanFit(IReadOnlyList<NonDemAtlasBatchEntry> entries);
+
+    bool TryCreate(
+        IReadOnlyList<NonDemAtlasBatchEntry> entries,
+        out NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout);
+}
+
+internal sealed class NonDemAtlasLayoutFactory(int atlasMaxSize, int tilePaddingPixels) : INonDemAtlasLayoutFactory
 {
     public bool CanFit(IReadOnlyList<NonDemAtlasBatchEntry> entries)
     {

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasLayoutFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasLayoutFactory.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemAtlasLayoutFactory(int atlasMaxSize, int tilePaddingPixels)
+{
+    public bool CanFit(IReadOnlyList<NonDemAtlasBatchEntry> entries)
+    {
+        return TryCreate(entries, out _);
+    }
+
+    public bool TryCreate(
+        IReadOnlyList<NonDemAtlasBatchEntry> entries,
+        out NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout)
+    {
+        NonDemAtlasLayoutPacker packer = new(atlasMaxSize, tilePaddingPixels);
+        return packer.TryCreate(
+            entries,
+            static entry => new NonDemAtlasTileSize(entry.Tile.Image.Width, entry.Tile.Image.Height),
+            out layout);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasLayoutPacker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasLayoutPacker.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemAtlasLayoutPacker(int atlasMaxSize, int tilePaddingPixels)
+{
+    public bool TryCreate<TEntry>(
+        IReadOnlyList<TEntry> entries,
+        Func<TEntry, NonDemAtlasTileSize> getTileSize,
+        out NonDemAtlasLayout<TEntry>? layout)
+    {
+        NonDemAtlasSizeRequirements requirements = ComputeSizeRequirements(entries, getTileSize);
+        if (!requirements.IsValid)
+        {
+            layout = null;
+            return false;
+        }
+
+        foreach (NonDemAtlasCanvasCandidate candidate in EnumerateCanvasCandidates(requirements))
+        {
+            if (TryCreateForCanvas(entries, getTileSize, candidate.Width, candidate.Height, out layout))
+            {
+                return true;
+            }
+        }
+
+        layout = null;
+        return false;
+    }
+
+    private bool TryCreateForCanvas<TEntry>(
+        IReadOnlyList<TEntry> entries,
+        Func<TEntry, NonDemAtlasTileSize> getTileSize,
+        int atlasWidth,
+        int atlasHeight,
+        out NonDemAtlasLayout<TEntry>? layout)
+    {
+        List<NonDemAtlasPlacement<TEntry>> placements = [];
+        List<NonDemAtlasRect> freeRectangles = [new NonDemAtlasRect(0, 0, atlasWidth, atlasHeight)];
+
+        foreach (TEntry entry in entries)
+        {
+            NonDemAtlasEntrySize entrySize = GetEntrySize(getTileSize(entry));
+            if (entrySize.PaddedWidth > atlasWidth || entrySize.PaddedHeight > atlasHeight)
+            {
+                layout = null;
+                return false;
+            }
+
+            if (!TryChooseFreeRectangle(freeRectangles, entrySize.PaddedWidth, entrySize.PaddedHeight, out NonDemAtlasRect selectedRect))
+            {
+                layout = null;
+                return false;
+            }
+
+            NonDemAtlasTileSize tileSize = getTileSize(entry);
+            NonDemAtlasRect outerRect = new(selectedRect.X, selectedRect.Y, entrySize.PaddedWidth, entrySize.PaddedHeight);
+            NonDemAtlasRect innerRect = new(selectedRect.X + tilePaddingPixels, selectedRect.Y + tilePaddingPixels, tileSize.Width, tileSize.Height);
+            placements.Add(new NonDemAtlasPlacement<TEntry>(entry, outerRect, innerRect));
+            SplitFreeRectangles(freeRectangles, outerRect);
+            PruneFreeRectangles(freeRectangles);
+        }
+
+        layout = new NonDemAtlasLayout<TEntry>(
+            atlasWidth,
+            atlasHeight,
+            placements);
+        return true;
+    }
+
+    private NonDemAtlasSizeRequirements ComputeSizeRequirements<TEntry>(
+        IReadOnlyList<TEntry> entries,
+        Func<TEntry, NonDemAtlasTileSize> getTileSize)
+    {
+        long requiredArea = 0;
+        int minWidth = 1;
+        int minHeight = 1;
+
+        foreach (TEntry entry in entries)
+        {
+            NonDemAtlasEntrySize entrySize = GetEntrySize(getTileSize(entry));
+            if (entrySize.PaddedWidth > atlasMaxSize || entrySize.PaddedHeight > atlasMaxSize)
+            {
+                return NonDemAtlasSizeRequirements.Invalid;
+            }
+
+            minWidth = Math.Max(minWidth, entrySize.PaddedWidth);
+            minHeight = Math.Max(minHeight, entrySize.PaddedHeight);
+            requiredArea += (long)entrySize.PaddedWidth * entrySize.PaddedHeight;
+        }
+
+        return new NonDemAtlasSizeRequirements(minWidth, minHeight, requiredArea);
+    }
+
+    private IEnumerable<NonDemAtlasCanvasCandidate> EnumerateCanvasCandidates(
+        NonDemAtlasSizeRequirements requirements)
+    {
+        List<int> widthCandidates = EnumeratePowerOfTwoEdges(requirements.MinWidth, atlasMaxSize).ToList();
+        List<int> heightCandidates = EnumeratePowerOfTwoEdges(requirements.MinHeight, atlasMaxSize).ToList();
+
+        return widthCandidates
+            .SelectMany(
+                width => heightCandidates,
+                (width, height) => new NonDemAtlasCanvasCandidate(width, height, requirements))
+            .OrderBy(static candidate => candidate.Area)
+            .ThenBy(static candidate => candidate.AreaSlack)
+            .ThenBy(static candidate => candidate.DimensionSlack)
+            .ThenBy(static candidate => candidate.Height)
+            .ThenBy(static candidate => candidate.Width);
+    }
+
+    private static IEnumerable<int> EnumeratePowerOfTwoEdges(int minimumEdge, int maxEdge)
+    {
+        if (minimumEdge > maxEdge)
+        {
+            yield break;
+        }
+
+        for (int edge = 1; edge > 0 && edge <= maxEdge; edge <<= 1)
+        {
+            if (edge >= minimumEdge)
+            {
+                yield return edge;
+            }
+        }
+    }
+
+    private NonDemAtlasEntrySize GetEntrySize(NonDemAtlasTileSize tileSize)
+    {
+        return new NonDemAtlasEntrySize(
+            tileSize.Width + (tilePaddingPixels * 2),
+            tileSize.Height + (tilePaddingPixels * 2));
+    }
+
+    private static bool TryChooseFreeRectangle(
+        IReadOnlyList<NonDemAtlasRect> freeRectangles,
+        int requiredWidth,
+        int requiredHeight,
+        out NonDemAtlasRect selectedRect)
+    {
+        selectedRect = default;
+        bool found = false;
+        int bestAreaFit = int.MaxValue;
+        int bestShortSideFit = int.MaxValue;
+
+        foreach (NonDemAtlasRect freeRect in freeRectangles)
+        {
+            if (requiredWidth > freeRect.Width || requiredHeight > freeRect.Height)
+            {
+                continue;
+            }
+
+            int areaFit = (freeRect.Width * freeRect.Height) - (requiredWidth * requiredHeight);
+            int shortSideFit = Math.Min(freeRect.Width - requiredWidth, freeRect.Height - requiredHeight);
+            if (areaFit < bestAreaFit
+                || (areaFit == bestAreaFit && shortSideFit < bestShortSideFit)
+                || (areaFit == bestAreaFit && shortSideFit == bestShortSideFit
+                    && (freeRect.Y < selectedRect.Y
+                        || (freeRect.Y == selectedRect.Y && freeRect.X < selectedRect.X))))
+            {
+                selectedRect = freeRect;
+                bestAreaFit = areaFit;
+                bestShortSideFit = shortSideFit;
+                found = true;
+            }
+        }
+
+        return found;
+    }
+
+    private static void SplitFreeRectangles(List<NonDemAtlasRect> freeRectangles, NonDemAtlasRect usedRect)
+    {
+        for (int index = freeRectangles.Count - 1; index >= 0; index--)
+        {
+            NonDemAtlasRect freeRect = freeRectangles[index];
+            if (!Intersects(freeRect, usedRect))
+            {
+                continue;
+            }
+
+            freeRectangles.RemoveAt(index);
+
+            if (usedRect.X > freeRect.X)
+            {
+                freeRectangles.Add(new NonDemAtlasRect(
+                    freeRect.X,
+                    freeRect.Y,
+                    usedRect.X - freeRect.X,
+                    freeRect.Height));
+            }
+
+            if (usedRect.X + usedRect.Width < freeRect.X + freeRect.Width)
+            {
+                freeRectangles.Add(new NonDemAtlasRect(
+                    usedRect.X + usedRect.Width,
+                    freeRect.Y,
+                    (freeRect.X + freeRect.Width) - (usedRect.X + usedRect.Width),
+                    freeRect.Height));
+            }
+
+            if (usedRect.Y > freeRect.Y)
+            {
+                freeRectangles.Add(new NonDemAtlasRect(
+                    freeRect.X,
+                    freeRect.Y,
+                    freeRect.Width,
+                    usedRect.Y - freeRect.Y));
+            }
+
+            if (usedRect.Y + usedRect.Height < freeRect.Y + freeRect.Height)
+            {
+                freeRectangles.Add(new NonDemAtlasRect(
+                    freeRect.X,
+                    usedRect.Y + usedRect.Height,
+                    freeRect.Width,
+                    (freeRect.Y + freeRect.Height) - usedRect.Y - usedRect.Height));
+            }
+        }
+    }
+
+    private static void PruneFreeRectangles(List<NonDemAtlasRect> freeRectangles)
+    {
+        for (int leftIndex = freeRectangles.Count - 1; leftIndex >= 0; leftIndex--)
+        {
+            NonDemAtlasRect left = freeRectangles[leftIndex];
+            for (int rightIndex = freeRectangles.Count - 1; rightIndex >= 0; rightIndex--)
+            {
+                if (leftIndex == rightIndex)
+                {
+                    continue;
+                }
+
+                NonDemAtlasRect right = freeRectangles[rightIndex];
+                if (Contains(right, left))
+                {
+                    freeRectangles.RemoveAt(leftIndex);
+                    break;
+                }
+            }
+        }
+    }
+
+    private static bool Intersects(NonDemAtlasRect left, NonDemAtlasRect right)
+    {
+        return left.X < right.X + right.Width
+            && left.X + left.Width > right.X
+            && left.Y < right.Y + right.Height
+            && left.Y + left.Height > right.Y;
+    }
+
+    private static bool Contains(NonDemAtlasRect outer, NonDemAtlasRect inner)
+    {
+        return inner.X >= outer.X
+            && inner.Y >= outer.Y
+            && inner.X + inner.Width <= outer.X + outer.Width
+            && inner.Y + inner.Height <= outer.Y + outer.Height;
+    }
+
+    private readonly record struct NonDemAtlasSizeRequirements(
+        int MinWidth,
+        int MinHeight,
+        long RequiredArea)
+    {
+        internal static NonDemAtlasSizeRequirements Invalid => new(0, 0, 0);
+
+        internal bool IsValid => MinWidth > 0 && MinHeight > 0;
+    }
+
+    private readonly record struct NonDemAtlasCanvasCandidate(
+        int Width,
+        int Height,
+        NonDemAtlasSizeRequirements Requirements)
+    {
+        internal long Area => (long)Width * Height;
+
+        internal long AreaSlack => Area - Requirements.RequiredArea;
+
+        internal int DimensionSlack => (Width - Requirements.MinWidth) + (Height - Requirements.MinHeight);
+    }
+
+    private readonly record struct NonDemAtlasEntrySize(
+        int PaddedWidth,
+        int PaddedHeight);
+}
+
+internal sealed record NonDemAtlasLayout<TEntry>(
+    int Width,
+    int Height,
+    IReadOnlyList<NonDemAtlasPlacement<TEntry>> Placements);
+
+internal sealed record NonDemAtlasPlacement<TEntry>(
+    TEntry Entry,
+    NonDemAtlasRect OuterRect,
+    NonDemAtlasRect InnerRect);
+
+internal readonly record struct NonDemAtlasRect(int X, int Y, int Width, int Height);
+
+internal readonly record struct NonDemAtlasTileSize(int Width, int Height);

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasLayoutPacker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasLayoutPacker.cs
@@ -42,7 +42,8 @@ internal sealed class NonDemAtlasLayoutPacker(int atlasMaxSize, int tilePaddingP
 
         foreach (TEntry entry in entries)
         {
-            NonDemAtlasEntrySize entrySize = GetEntrySize(getTileSize(entry));
+            NonDemAtlasTileSize tileSize = getTileSize(entry);
+            NonDemAtlasEntrySize entrySize = GetEntrySize(tileSize);
             if (entrySize.PaddedWidth > atlasWidth || entrySize.PaddedHeight > atlasHeight)
             {
                 layout = null;
@@ -55,7 +56,6 @@ internal sealed class NonDemAtlasLayoutPacker(int atlasMaxSize, int tilePaddingP
                 return false;
             }
 
-            NonDemAtlasTileSize tileSize = getTileSize(entry);
             NonDemAtlasRect outerRect = new(selectedRect.X, selectedRect.Y, entrySize.PaddedWidth, entrySize.PaddedHeight);
             NonDemAtlasRect innerRect = new(selectedRect.X + tilePaddingPixels, selectedRect.Y + tilePaddingPixels, tileSize.Width, tileSize.Height);
             placements.Add(new NonDemAtlasPlacement<TEntry>(entry, outerRect, innerRect));

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
@@ -11,9 +11,18 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
+internal interface INonDemAtlasOrPreservedEntryFactory
+{
+    Task<NonDemAtlasOrPreservedEntry> CreateAsync(
+        ResoniteConstructionCityObject cityObject,
+        ResoniteMeshSubmesh submesh,
+        ResoniteMaterialBinding material,
+        CancellationToken cancellationToken);
+}
+
 internal sealed class NonDemAtlasOrPreservedEntryFactory(
     ResoniteTextureImageLoader textureImageLoader,
-    int maxAtlasTextureEdge)
+    int maxAtlasTextureEdge) : INonDemAtlasOrPreservedEntryFactory
 {
     private readonly ResoniteTextureImageLoader textureImageLoader = textureImageLoader
         ?? throw new ArgumentNullException(nameof(textureImageLoader));

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemAtlasOrPreservedEntryFactory(
+    ResoniteTextureImageLoader textureImageLoader,
+    int maxAtlasTextureEdge)
+{
+    private readonly ResoniteTextureImageLoader textureImageLoader = textureImageLoader
+        ?? throw new ArgumentNullException(nameof(textureImageLoader));
+
+    public async Task<NonDemAtlasOrPreservedEntry> CreateAsync(
+        ResoniteConstructionCityObject cityObject,
+        ResoniteMeshSubmesh submesh,
+        ResoniteMaterialBinding material,
+        CancellationToken cancellationToken)
+    {
+        if (material.TexturePayload is null)
+        {
+            throw new InvalidOperationException("Non-DEM bake candidate material must have a texture payload.");
+        }
+
+        TextureUvRect uvBounds = ComputeUvBounds(cityObject.Mesh.Vertices, submesh);
+        using Image<Rgba32> sourceImage = await textureImageLoader.LoadAsync(
+            ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
+            cancellationToken);
+        Rgba32 detectedBackgroundColor = NonDemTextureImageProcessing.DetectRepresentativeBackgroundColor(sourceImage);
+        using Image<Rgba32> preparedSourceImage = sourceImage.Clone();
+        NonDemTextureImageProcessing.FillTransparentRgb(preparedSourceImage, detectedBackgroundColor);
+        if (NonDemTextureImageProcessing.TryGetUniformPixelColor(preparedSourceImage, out Rgba32 uniformDatasetColor))
+        {
+            Rgba32 tintedUniformColor = NonDemTextureImageProcessing.MultiplyPixel(
+                uniformDatasetColor,
+                NonDemTextureImageProcessing.ToPixel(material.BaseColor));
+            return new NonDemAtlasOrPreservedEntry(
+                AtlasEntry: null,
+                PreservedEntry: new NonDemPreservedSubmeshEntry(
+                    cityObject,
+                    submesh,
+                    CreateVertexColorMaterial(material, submesh.Index),
+                    NonDemTextureImageProcessing.ToColor(tintedUniformColor)));
+        }
+
+        int targetWidth = Math.Max(1, Math.Min(maxAtlasTextureEdge, (int)Math.Ceiling(sourceImage.Width * uvBounds.Width)));
+        int targetHeight = Math.Max(1, Math.Min(maxAtlasTextureEdge, (int)Math.Ceiling(sourceImage.Height * uvBounds.Height)));
+        using Image<Rgba32> bakedImage = NonDemTextureImageProcessing.BakeUsedUvRegion(
+            preparedSourceImage,
+            uvBounds,
+            targetWidth,
+            targetHeight);
+
+        NonDemTextureImageProcessing.ApplyBaseColor(bakedImage, material.BaseColor);
+        return new NonDemAtlasOrPreservedEntry(
+            AtlasEntry: new NonDemAtlasBatchEntry(
+                cityObject,
+                submesh,
+                material,
+                new NonDemMaterialAtlasTile(
+                    bakedImage.Clone(),
+                    NonDemTextureImageProcessing.MultiplyPixel(
+                        detectedBackgroundColor,
+                        NonDemTextureImageProcessing.ToPixel(material.BaseColor))),
+                uvBounds),
+            PreservedEntry: null);
+    }
+
+    private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)
+    {
+        return material with
+        {
+            MaterialType = ResoniteMaterialType.VertexColor,
+            BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            TexturePayload = null,
+            TextureSourceKind = ResoniteTextureSourceKind.Bundled,
+            TextureScale = null,
+            TextureOffset = null,
+            Family = null,
+            TerrainOverlay = null,
+            AssetScope = ResoniteMaterialAssetScope.Common,
+            SubmeshIndices = [submeshIndex],
+            CommonMaterial = material.DepthOffset is null
+                ? CommonMaterialCatalog.Create().VertexColor.Uv
+                : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv,
+        };
+    }
+
+    private static TextureUvRect ComputeUvBounds(
+        IReadOnlyList<ResoniteMeshVertex> vertices,
+        ResoniteMeshSubmesh submesh)
+    {
+        double minU = double.PositiveInfinity;
+        double minV = double.PositiveInfinity;
+        double maxU = double.NegativeInfinity;
+        double maxV = double.NegativeInfinity;
+
+        foreach (int sourceIndex in submesh.TriangleVertexIndices)
+        {
+            ResoniteFloat2 transformedUv = vertices[sourceIndex].UV0;
+            minU = Math.Min(minU, transformedUv.X);
+            minV = Math.Min(minV, transformedUv.Y);
+            maxU = Math.Max(maxU, transformedUv.X);
+            maxV = Math.Max(maxV, transformedUv.Y);
+        }
+
+        if (double.IsPositiveInfinity(minU) || double.IsPositiveInfinity(minV))
+        {
+            return TextureUvRect.Identity;
+        }
+
+        double width = Math.Max(1.0 / 1024.0, maxU - minU);
+        double height = Math.Max(1.0 / 1024.0, maxV - minV);
+        return new TextureUvRect(minU, minV, width, height);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemBakeCandidateImageDisposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemBakeCandidateImageDisposer.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface INonDemBakeCandidateImageDisposer
+{
+    void Dispose(NonDemCityObjectBakeCandidate candidate);
+
+    void Dispose(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates);
+}
+
+internal sealed class NonDemBakeCandidateImageDisposer : INonDemBakeCandidateImageDisposer
+{
+    public void Dispose(NonDemCityObjectBakeCandidate candidate)
+    {
+        Dispose([candidate]);
+    }
+
+    public void Dispose(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
+    {
+        foreach (Image<Rgba32> tileImage in candidates
+                     .SelectMany(static candidate => candidate.AtlasEntries)
+                     .Select(static entry => entry.Tile.Image)
+                     .Distinct())
+        {
+            tileImage.Dispose();
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record NonDemBakedGeometry(
+    ResoniteFloat3 Origin,
+    ResoniteImportedMesh Mesh,
+    IReadOnlyList<ResoniteMaterialBinding> Materials);
+
+internal interface INonDemBakedGeometryComposer
+{
+    NonDemBakedGeometry Compose(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
+        int batchIndex,
+        NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout,
+        Image<Rgba32>? atlasImage,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class NonDemBakedGeometryComposer : INonDemBakedGeometryComposer
+{
+    public NonDemBakedGeometry Compose(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
+        int batchIndex,
+        NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout,
+        Image<Rgba32>? atlasImage,
+        CancellationToken cancellationToken)
+    {
+        ResoniteFloat3 bakeOrigin = ComputeBakeOrigin(candidates);
+        List<ResoniteMeshVertex> vertices = [];
+        List<ResoniteMeshSubmesh> submeshes = [];
+        List<ResoniteMaterialBinding> materials = [];
+
+        if (layout is not null)
+        {
+            string textureIdentity = NonDemSourceFileBatching.CreateAtlasTextureIdentity(sourceFileKey, batchIndex);
+            List<int> atlasTriangleIndices = [];
+            foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in layout.Placements
+                         .OrderBy(static candidate => candidate.Entry.CityObject.SlotKey, StringComparer.Ordinal)
+                         .ThenBy(static candidate => candidate.Entry.Submesh.Index))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                AppendPlacementGeometry(vertices, atlasTriangleIndices, bakeOrigin, placement, layout.Width, layout.Height);
+            }
+
+            submeshes.Add(new ResoniteMeshSubmesh(0, atlasTriangleIndices));
+            materials.Add(
+                new ResoniteMaterialBinding(
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    TexturePayload: ResoniteTextureImportFactory.CreatePayloadFromImage(
+                        atlasImage ?? throw new InvalidOperationException("Non-DEM atlas image is required when an atlas layout exists."),
+                        identity: textureIdentity),
+                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv));
+        }
+
+        foreach (IGrouping<NonDemPreservedMaterialGroupingKey, NonDemOrderedPreservedSubmeshEntry> preservedGroup in candidates
+                     .SelectMany(static candidate => candidate.PreservedEntries)
+                     .Select(static (entry, order) => new NonDemOrderedPreservedSubmeshEntry(entry, order))
+                     .GroupBy(static entry => NonDemPreservedMaterialGrouping.CreateKey(entry.Entry.Material), NonDemPreservedMaterialGrouping.KeyComparer)
+                     .OrderBy(static group => group.Min(static entry => entry.Order)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            List<int> preservedTriangleIndices = [];
+            foreach (NonDemPreservedSubmeshEntry preservedEntry in preservedGroup
+                         .Select(static entry => entry.Entry)
+                         .OrderBy(static entry => entry.CityObject.SlotKey, StringComparer.Ordinal)
+                         .ThenBy(static entry => entry.Submesh.Index))
+            {
+                AppendOriginalGeometry(vertices, preservedTriangleIndices, bakeOrigin, preservedEntry);
+            }
+
+            if (preservedTriangleIndices.Count == 0)
+            {
+                continue;
+            }
+
+            int submeshIndex = submeshes.Count;
+            ResoniteMaterialBinding preservedMaterial = NonDemPreservedMaterialGrouping.NormalizeMaterial(preservedGroup.First().Entry.Material) with
+            {
+                SubmeshIndices = [submeshIndex],
+            };
+            submeshes.Add(new ResoniteMeshSubmesh(submeshIndex, preservedTriangleIndices));
+            materials.Add(preservedMaterial);
+        }
+
+        if (submeshes.Count == 0 || materials.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Non-DEM bake batch '{sourceFileKey.PackageName}:{sourceFileKey.ActualMeshCode}:LOD{sourceFileKey.LodLevel}' produced no materialized submesh.");
+        }
+
+        return new NonDemBakedGeometry(
+            bakeOrigin,
+            new ResoniteImportedMesh(vertices, submeshes),
+            materials);
+    }
+
+    private static void AppendPlacementGeometry(
+        List<ResoniteMeshVertex> vertices,
+        List<int> triangleIndices,
+        ResoniteFloat3 bakeOrigin,
+        NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement,
+        int atlasWidth,
+        int atlasHeight)
+    {
+        IReadOnlyList<ResoniteMeshVertex> sourceVertices = placement.Entry.CityObject.Mesh.Vertices;
+        ResoniteFloat3 cityObjectOffset = Subtract(placement.Entry.CityObject.Transform.Position, bakeOrigin);
+        NonDemAtlasRect innerRect = placement.InnerRect;
+
+        foreach (int sourceIndex in placement.Entry.Submesh.TriangleVertexIndices)
+        {
+            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
+            ResoniteFloat2 sourceUv = sourceVertex.UV0;
+            ResoniteFloat2 atlasUv = MapUvToAtlas(sourceUv, placement.Entry.UvBounds, innerRect, atlasWidth, atlasHeight);
+            vertices.Add(sourceVertex with
+            {
+                Position = Add(sourceVertex.Position, cityObjectOffset),
+                UV0 = atlasUv,
+            });
+            triangleIndices.Add(vertices.Count - 1);
+        }
+    }
+
+    private static void AppendOriginalGeometry(
+        List<ResoniteMeshVertex> vertices,
+        List<int> triangleIndices,
+        ResoniteFloat3 bakeOrigin,
+        NonDemPreservedSubmeshEntry preservedEntry)
+    {
+        IReadOnlyList<ResoniteMeshVertex> sourceVertices = preservedEntry.CityObject.Mesh.Vertices;
+        ResoniteFloat3 cityObjectOffset = Subtract(preservedEntry.CityObject.Transform.Position, bakeOrigin);
+        foreach (int sourceIndex in preservedEntry.Submesh.TriangleVertexIndices)
+        {
+            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
+            vertices.Add(sourceVertex with
+            {
+                Position = Add(sourceVertex.Position, cityObjectOffset),
+                Color = preservedEntry.VertexColorOverride ?? sourceVertex.Color,
+            });
+            triangleIndices.Add(vertices.Count - 1);
+        }
+    }
+
+    private static ResoniteFloat2 MapUvToAtlas(
+        ResoniteFloat2 sourceUv,
+        TextureUvRect uvBounds,
+        NonDemAtlasRect atlasRect,
+        double atlasWidth,
+        double atlasHeight)
+    {
+        TextureUvRect atlasUvRect = TextureUvRect.FromTopLeftPixelRect(
+            atlasRect.X,
+            atlasRect.Y,
+            atlasRect.Width,
+            atlasRect.Height,
+            (int)Math.Round(atlasWidth),
+            (int)Math.Round(atlasHeight));
+        ScalarPair remapped = TextureUvRect.RemapValue(
+            new ScalarPair(sourceUv.X, sourceUv.Y),
+            uvBounds,
+            atlasUvRect);
+        return new ResoniteFloat2(remapped.X, remapped.Y);
+    }
+
+    private static ResoniteFloat3 ComputeBakeOrigin(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
+    {
+        double minX = double.PositiveInfinity;
+        double minY = double.PositiveInfinity;
+        double minZ = double.PositiveInfinity;
+
+        foreach (ResoniteConstructionCityObject cityObject in candidates.Select(static candidate => candidate.CityObject))
+        {
+            foreach (ResoniteMeshVertex vertex in cityObject.Mesh.Vertices)
+            {
+                ResoniteFloat3 worldPosition = Add(vertex.Position, cityObject.Transform.Position);
+                minX = Math.Min(minX, worldPosition.X);
+                minY = Math.Min(minY, worldPosition.Y);
+                minZ = Math.Min(minZ, worldPosition.Z);
+            }
+        }
+
+        return double.IsPositiveInfinity(minX)
+            ? new ResoniteFloat3(0.0, 0.0, 0.0)
+            : new ResoniteFloat3(minX, minY, minZ);
+    }
+
+    private static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)
+    {
+        return new ResoniteFloat3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
+    }
+
+    private static ResoniteFloat3 Subtract(ResoniteFloat3 left, ResoniteFloat3 right)
+    {
+        return new ResoniteFloat3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
@@ -20,13 +20,13 @@ internal interface INonDemCityObjectBakeAssembler
 }
 
 internal sealed class NonDemCityObjectBakeAssembler(
-    NonDemAtlasLayoutFactory atlasLayoutFactory,
-    NonDemAtlasImageRenderer atlasImageRenderer,
+    INonDemAtlasLayoutFactory atlasLayoutFactory,
+    INonDemAtlasImageRenderer atlasImageRenderer,
     INonDemBakedGeometryComposer geometryComposer) : INonDemCityObjectBakeAssembler
 {
-    private readonly NonDemAtlasLayoutFactory atlasLayoutFactory = atlasLayoutFactory
+    private readonly INonDemAtlasLayoutFactory atlasLayoutFactory = atlasLayoutFactory
         ?? throw new ArgumentNullException(nameof(atlasLayoutFactory));
-    private readonly NonDemAtlasImageRenderer atlasImageRenderer = atlasImageRenderer
+    private readonly INonDemAtlasImageRenderer atlasImageRenderer = atlasImageRenderer
         ?? throw new ArgumentNullException(nameof(atlasImageRenderer));
     private readonly INonDemBakedGeometryComposer geometryComposer = geometryComposer
         ?? throw new ArgumentNullException(nameof(geometryComposer));

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
@@ -9,10 +9,20 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
+internal interface INonDemCityObjectBakeAssembler
+{
+    Task<ResoniteConstructionCityObject> BakeBatchAsync(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
+        int batchIndex,
+        bool preservePrimaryIdentity,
+        CancellationToken cancellationToken);
+}
+
 internal sealed class NonDemCityObjectBakeAssembler(
     NonDemAtlasLayoutFactory atlasLayoutFactory,
     NonDemAtlasImageRenderer atlasImageRenderer,
-    INonDemBakedGeometryComposer geometryComposer)
+    INonDemBakedGeometryComposer geometryComposer) : INonDemCityObjectBakeAssembler
 {
     private readonly NonDemAtlasLayoutFactory atlasLayoutFactory = atlasLayoutFactory
         ?? throw new ArgumentNullException(nameof(atlasLayoutFactory));

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
@@ -4,9 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Domain.Importing;
-
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -14,8 +11,16 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemCityObjectBakeAssembler(
     NonDemAtlasLayoutFactory atlasLayoutFactory,
-    NonDemAtlasImageRenderer atlasImageRenderer)
+    NonDemAtlasImageRenderer atlasImageRenderer,
+    INonDemBakedGeometryComposer geometryComposer)
 {
+    private readonly NonDemAtlasLayoutFactory atlasLayoutFactory = atlasLayoutFactory
+        ?? throw new ArgumentNullException(nameof(atlasLayoutFactory));
+    private readonly NonDemAtlasImageRenderer atlasImageRenderer = atlasImageRenderer
+        ?? throw new ArgumentNullException(nameof(atlasImageRenderer));
+    private readonly INonDemBakedGeometryComposer geometryComposer = geometryComposer
+        ?? throw new ArgumentNullException(nameof(geometryComposer));
+
     public Task<ResoniteConstructionCityObject> BakeBatchAsync(
         NonDemSourceFileBatchKey sourceFileKey,
         IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
@@ -51,69 +56,13 @@ internal sealed class NonDemCityObjectBakeAssembler(
             ? null
             : sourceFileKey.SourceFileRelativePath;
 
-        ResoniteFloat3 bakeOrigin = ComputeBakeOrigin(candidates);
-        List<ResoniteMeshVertex> vertices = [];
-        List<ResoniteMeshSubmesh> submeshes = [];
-        List<ResoniteMaterialBinding> materials = [];
-
-        if (layout is not null)
-        {
-            string textureIdentity = NonDemSourceFileBatching.CreateAtlasTextureIdentity(sourceFileKey, batchIndex);
-            List<int> atlasTriangleIndices = [];
-            foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in layout.Placements.OrderBy(static candidate => candidate.Entry.CityObject.SlotKey, StringComparer.Ordinal).ThenBy(static candidate => candidate.Entry.Submesh.Index))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                AppendPlacementGeometry(vertices, atlasTriangleIndices, bakeOrigin, placement, layout.Width, layout.Height);
-            }
-
-            submeshes.Add(new ResoniteMeshSubmesh(0, atlasTriangleIndices));
-            materials.Add(
-                new ResoniteMaterialBinding(
-                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-                    MaterialType: ResoniteMaterialType.Standard,
-                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-                    Projection: ResoniteMaterialProjection.Uv,
-                    DepthOffset: null,
-                    SubmeshIndices: [0],
-                    TexturePayload: ResoniteTextureImportFactory.CreatePayloadFromImage(atlasImage!, identity: textureIdentity),
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv));
-        }
-
-        foreach (IGrouping<NonDemPreservedMaterialGroupingKey, NonDemOrderedPreservedSubmeshEntry> preservedGroup in candidates
-                     .SelectMany(static candidate => candidate.PreservedEntries)
-                     .Select(static (entry, order) => new NonDemOrderedPreservedSubmeshEntry(entry, order))
-                     .GroupBy(static entry => NonDemPreservedMaterialGrouping.CreateKey(entry.Entry.Material), NonDemPreservedMaterialGrouping.KeyComparer)
-                     .OrderBy(static group => group.Min(static entry => entry.Order)))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            List<int> preservedTriangleIndices = [];
-            foreach (NonDemPreservedSubmeshEntry preservedEntry in preservedGroup
-                         .Select(static entry => entry.Entry)
-                         .OrderBy(static entry => entry.CityObject.SlotKey, StringComparer.Ordinal)
-                         .ThenBy(static entry => entry.Submesh.Index))
-            {
-                AppendOriginalGeometry(vertices, preservedTriangleIndices, bakeOrigin, preservedEntry);
-            }
-
-            if (preservedTriangleIndices.Count == 0)
-            {
-                continue;
-            }
-
-            int submeshIndex = submeshes.Count;
-            ResoniteMaterialBinding preservedMaterial = NonDemPreservedMaterialGrouping.NormalizeMaterial(preservedGroup.First().Entry.Material) with
-            {
-                SubmeshIndices = [submeshIndex],
-            };
-            submeshes.Add(new ResoniteMeshSubmesh(submeshIndex, preservedTriangleIndices));
-            materials.Add(preservedMaterial);
-        }
-
-        if (submeshes.Count == 0 || materials.Count == 0)
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM bake batch '{sourceFileKey.PackageName}:{sourceFileKey.ActualMeshCode}:LOD{sourceFileKey.LodLevel}' produced no materialized submesh.");
-        }
+        NonDemBakedGeometry geometry = geometryComposer.Compose(
+            sourceFileKey,
+            candidates,
+            batchIndex,
+            layout,
+            atlasImage,
+            cancellationToken);
 
         ResoniteConstructionCityObject bakedCityObject = new(
             SlotKey: slotKey,
@@ -121,110 +70,11 @@ internal sealed class NonDemCityObjectBakeAssembler(
             PackageName: firstCityObject.PackageName,
             ActualMeshCode: firstCityObject.ActualMeshCode,
             LodLevel: firstCityObject.LodLevel,
-            Transform: new ResoniteTransform(bakeOrigin),
-            Mesh: new ResoniteImportedMesh(vertices, submeshes),
-            Materials: materials,
+            Transform: new ResoniteTransform(geometry.Origin),
+            Mesh: geometry.Mesh,
+            Materials: geometry.Materials,
             CollisionEnabled: candidates.Any(static candidate => candidate.CityObject.CollisionEnabled),
             SourceFileRelativePath: sourceFileRelativePath);
         return Task.FromResult(bakedCityObject);
-    }
-
-    private static void AppendPlacementGeometry(
-        List<ResoniteMeshVertex> vertices,
-        List<int> triangleIndices,
-        ResoniteFloat3 bakeOrigin,
-        NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement,
-        int atlasWidth,
-        int atlasHeight)
-    {
-        IReadOnlyList<ResoniteMeshVertex> sourceVertices = placement.Entry.CityObject.Mesh.Vertices;
-        ResoniteFloat3 cityObjectOffset = Subtract(placement.Entry.CityObject.Transform.Position, bakeOrigin);
-        NonDemAtlasRect innerRect = placement.InnerRect;
-
-        foreach (int sourceIndex in placement.Entry.Submesh.TriangleVertexIndices)
-        {
-            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
-            ResoniteFloat2 sourceUv = sourceVertex.UV0;
-            ResoniteFloat2 atlasUv = MapUvToAtlas(sourceUv, placement.Entry.UvBounds, innerRect, atlasWidth, atlasHeight);
-            vertices.Add(sourceVertex with
-            {
-                Position = Add(sourceVertex.Position, cityObjectOffset),
-                UV0 = atlasUv,
-            });
-            triangleIndices.Add(vertices.Count - 1);
-        }
-    }
-
-    private static void AppendOriginalGeometry(
-        List<ResoniteMeshVertex> vertices,
-        List<int> triangleIndices,
-        ResoniteFloat3 bakeOrigin,
-        NonDemPreservedSubmeshEntry preservedEntry)
-    {
-        IReadOnlyList<ResoniteMeshVertex> sourceVertices = preservedEntry.CityObject.Mesh.Vertices;
-        ResoniteFloat3 cityObjectOffset = Subtract(preservedEntry.CityObject.Transform.Position, bakeOrigin);
-        foreach (int sourceIndex in preservedEntry.Submesh.TriangleVertexIndices)
-        {
-            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
-            vertices.Add(sourceVertex with
-            {
-                Position = Add(sourceVertex.Position, cityObjectOffset),
-                Color = preservedEntry.VertexColorOverride ?? sourceVertex.Color,
-            });
-            triangleIndices.Add(vertices.Count - 1);
-        }
-    }
-
-    private static ResoniteFloat2 MapUvToAtlas(
-        ResoniteFloat2 sourceUv,
-        TextureUvRect uvBounds,
-        NonDemAtlasRect atlasRect,
-        double atlasWidth,
-        double atlasHeight)
-    {
-        TextureUvRect atlasUvRect = TextureUvRect.FromTopLeftPixelRect(
-            atlasRect.X,
-            atlasRect.Y,
-            atlasRect.Width,
-            atlasRect.Height,
-            (int)Math.Round(atlasWidth),
-            (int)Math.Round(atlasHeight));
-        ScalarPair remapped = TextureUvRect.RemapValue(
-            new ScalarPair(sourceUv.X, sourceUv.Y),
-            uvBounds,
-            atlasUvRect);
-        return new ResoniteFloat2(remapped.X, remapped.Y);
-    }
-
-    private static ResoniteFloat3 ComputeBakeOrigin(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
-    {
-        double minX = double.PositiveInfinity;
-        double minY = double.PositiveInfinity;
-        double minZ = double.PositiveInfinity;
-
-        foreach (ResoniteConstructionCityObject cityObject in candidates.Select(static candidate => candidate.CityObject))
-        {
-            foreach (ResoniteMeshVertex vertex in cityObject.Mesh.Vertices)
-            {
-                ResoniteFloat3 worldPosition = Add(vertex.Position, cityObject.Transform.Position);
-                minX = Math.Min(minX, worldPosition.X);
-                minY = Math.Min(minY, worldPosition.Y);
-                minZ = Math.Min(minZ, worldPosition.Z);
-            }
-        }
-
-        return double.IsPositiveInfinity(minX)
-            ? new ResoniteFloat3(0.0, 0.0, 0.0)
-            : new ResoniteFloat3(minX, minY, minZ);
-    }
-
-    private static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)
-    {
-        return new ResoniteFloat3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
-    }
-
-    private static ResoniteFloat3 Subtract(ResoniteFloat3 left, ResoniteFloat3 right)
-    {
-        return new ResoniteFloat3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemCityObjectBakeAssembler(
+    NonDemAtlasLayoutFactory atlasLayoutFactory,
+    NonDemAtlasImageRenderer atlasImageRenderer)
+{
+    public Task<ResoniteConstructionCityObject> BakeBatchAsync(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
+        int batchIndex,
+        bool preservePrimaryIdentity,
+        CancellationToken cancellationToken)
+    {
+        List<NonDemAtlasBatchEntry> entries = candidates.SelectMany(static candidate => candidate.AtlasEntries).ToList();
+        NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout = null;
+        if (entries.Count > 0
+            && (!atlasLayoutFactory.TryCreate(entries, out layout) || layout is null))
+        {
+            throw new InvalidOperationException("Failed to create non-DEM atlas layout.");
+        }
+
+        using Image<Rgba32>? atlasImage = layout is null
+            ? null
+            : new Image<Rgba32>(layout.Width, layout.Height, new Rgba32(0, 0, 0, 0));
+        if (layout is not null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            atlasImageRenderer.Draw(atlasImage!, layout.Placements);
+        }
+
+        ResoniteConstructionCityObject firstCityObject = candidates[0].CityObject;
+        string slotKey = preservePrimaryIdentity
+            ? firstCityObject.SlotKey
+            : NonDemSourceFileBatching.CreateBatchSlotKey(sourceFileKey, batchIndex);
+        string displayName = preservePrimaryIdentity
+            ? firstCityObject.DisplayName
+            : NonDemSourceFileBatching.CreateBatchDisplayName(sourceFileKey, batchIndex, slotKey);
+        string? sourceFileRelativePath = string.IsNullOrWhiteSpace(firstCityObject.SourceFileRelativePath)
+            ? null
+            : sourceFileKey.SourceFileRelativePath;
+
+        ResoniteFloat3 bakeOrigin = ComputeBakeOrigin(candidates);
+        List<ResoniteMeshVertex> vertices = [];
+        List<ResoniteMeshSubmesh> submeshes = [];
+        List<ResoniteMaterialBinding> materials = [];
+
+        if (layout is not null)
+        {
+            string textureIdentity = NonDemSourceFileBatching.CreateAtlasTextureIdentity(sourceFileKey, batchIndex);
+            List<int> atlasTriangleIndices = [];
+            foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in layout.Placements.OrderBy(static candidate => candidate.Entry.CityObject.SlotKey, StringComparer.Ordinal).ThenBy(static candidate => candidate.Entry.Submesh.Index))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                AppendPlacementGeometry(vertices, atlasTriangleIndices, bakeOrigin, placement, layout.Width, layout.Height);
+            }
+
+            submeshes.Add(new ResoniteMeshSubmesh(0, atlasTriangleIndices));
+            materials.Add(
+                new ResoniteMaterialBinding(
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    TexturePayload: ResoniteTextureImportFactory.CreatePayloadFromImage(atlasImage!, identity: textureIdentity),
+                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv));
+        }
+
+        foreach (IGrouping<NonDemPreservedMaterialGroupingKey, NonDemOrderedPreservedSubmeshEntry> preservedGroup in candidates
+                     .SelectMany(static candidate => candidate.PreservedEntries)
+                     .Select(static (entry, order) => new NonDemOrderedPreservedSubmeshEntry(entry, order))
+                     .GroupBy(static entry => NonDemPreservedMaterialGrouping.CreateKey(entry.Entry.Material), NonDemPreservedMaterialGrouping.KeyComparer)
+                     .OrderBy(static group => group.Min(static entry => entry.Order)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            List<int> preservedTriangleIndices = [];
+            foreach (NonDemPreservedSubmeshEntry preservedEntry in preservedGroup
+                         .Select(static entry => entry.Entry)
+                         .OrderBy(static entry => entry.CityObject.SlotKey, StringComparer.Ordinal)
+                         .ThenBy(static entry => entry.Submesh.Index))
+            {
+                AppendOriginalGeometry(vertices, preservedTriangleIndices, bakeOrigin, preservedEntry);
+            }
+
+            if (preservedTriangleIndices.Count == 0)
+            {
+                continue;
+            }
+
+            int submeshIndex = submeshes.Count;
+            ResoniteMaterialBinding preservedMaterial = NonDemPreservedMaterialGrouping.NormalizeMaterial(preservedGroup.First().Entry.Material) with
+            {
+                SubmeshIndices = [submeshIndex],
+            };
+            submeshes.Add(new ResoniteMeshSubmesh(submeshIndex, preservedTriangleIndices));
+            materials.Add(preservedMaterial);
+        }
+
+        if (submeshes.Count == 0 || materials.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Non-DEM bake batch '{sourceFileKey.PackageName}:{sourceFileKey.ActualMeshCode}:LOD{sourceFileKey.LodLevel}' produced no materialized submesh.");
+        }
+
+        ResoniteConstructionCityObject bakedCityObject = new(
+            SlotKey: slotKey,
+            DisplayName: displayName,
+            PackageName: firstCityObject.PackageName,
+            ActualMeshCode: firstCityObject.ActualMeshCode,
+            LodLevel: firstCityObject.LodLevel,
+            Transform: new ResoniteTransform(bakeOrigin),
+            Mesh: new ResoniteImportedMesh(vertices, submeshes),
+            Materials: materials,
+            CollisionEnabled: candidates.Any(static candidate => candidate.CityObject.CollisionEnabled),
+            SourceFileRelativePath: sourceFileRelativePath);
+        return Task.FromResult(bakedCityObject);
+    }
+
+    private static void AppendPlacementGeometry(
+        List<ResoniteMeshVertex> vertices,
+        List<int> triangleIndices,
+        ResoniteFloat3 bakeOrigin,
+        NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement,
+        int atlasWidth,
+        int atlasHeight)
+    {
+        IReadOnlyList<ResoniteMeshVertex> sourceVertices = placement.Entry.CityObject.Mesh.Vertices;
+        ResoniteFloat3 cityObjectOffset = Subtract(placement.Entry.CityObject.Transform.Position, bakeOrigin);
+        NonDemAtlasRect innerRect = placement.InnerRect;
+
+        foreach (int sourceIndex in placement.Entry.Submesh.TriangleVertexIndices)
+        {
+            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
+            ResoniteFloat2 sourceUv = sourceVertex.UV0;
+            ResoniteFloat2 atlasUv = MapUvToAtlas(sourceUv, placement.Entry.UvBounds, innerRect, atlasWidth, atlasHeight);
+            vertices.Add(sourceVertex with
+            {
+                Position = Add(sourceVertex.Position, cityObjectOffset),
+                UV0 = atlasUv,
+            });
+            triangleIndices.Add(vertices.Count - 1);
+        }
+    }
+
+    private static void AppendOriginalGeometry(
+        List<ResoniteMeshVertex> vertices,
+        List<int> triangleIndices,
+        ResoniteFloat3 bakeOrigin,
+        NonDemPreservedSubmeshEntry preservedEntry)
+    {
+        IReadOnlyList<ResoniteMeshVertex> sourceVertices = preservedEntry.CityObject.Mesh.Vertices;
+        ResoniteFloat3 cityObjectOffset = Subtract(preservedEntry.CityObject.Transform.Position, bakeOrigin);
+        foreach (int sourceIndex in preservedEntry.Submesh.TriangleVertexIndices)
+        {
+            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
+            vertices.Add(sourceVertex with
+            {
+                Position = Add(sourceVertex.Position, cityObjectOffset),
+                Color = preservedEntry.VertexColorOverride ?? sourceVertex.Color,
+            });
+            triangleIndices.Add(vertices.Count - 1);
+        }
+    }
+
+    private static ResoniteFloat2 MapUvToAtlas(
+        ResoniteFloat2 sourceUv,
+        TextureUvRect uvBounds,
+        NonDemAtlasRect atlasRect,
+        double atlasWidth,
+        double atlasHeight)
+    {
+        TextureUvRect atlasUvRect = TextureUvRect.FromTopLeftPixelRect(
+            atlasRect.X,
+            atlasRect.Y,
+            atlasRect.Width,
+            atlasRect.Height,
+            (int)Math.Round(atlasWidth),
+            (int)Math.Round(atlasHeight));
+        ScalarPair remapped = TextureUvRect.RemapValue(
+            new ScalarPair(sourceUv.X, sourceUv.Y),
+            uvBounds,
+            atlasUvRect);
+        return new ResoniteFloat2(remapped.X, remapped.Y);
+    }
+
+    private static ResoniteFloat3 ComputeBakeOrigin(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
+    {
+        double minX = double.PositiveInfinity;
+        double minY = double.PositiveInfinity;
+        double minZ = double.PositiveInfinity;
+
+        foreach (ResoniteConstructionCityObject cityObject in candidates.Select(static candidate => candidate.CityObject))
+        {
+            foreach (ResoniteMeshVertex vertex in cityObject.Mesh.Vertices)
+            {
+                ResoniteFloat3 worldPosition = Add(vertex.Position, cityObject.Transform.Position);
+                minX = Math.Min(minX, worldPosition.X);
+                minY = Math.Min(minY, worldPosition.Y);
+                minZ = Math.Min(minZ, worldPosition.Z);
+            }
+        }
+
+        return double.IsPositiveInfinity(minX)
+            ? new ResoniteFloat3(0.0, 0.0, 0.0)
+            : new ResoniteFloat3(minX, minY, minZ);
+    }
+
+    private static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)
+    {
+        return new ResoniteFloat3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
+    }
+
+    private static ResoniteFloat3 Subtract(ResoniteFloat3 left, ResoniteFloat3 right)
+    {
+        return new ResoniteFloat3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -6,8 +6,15 @@ using System.Threading.Tasks;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
+internal interface INonDemCityObjectBakeCandidateFactory
+{
+    Task<NonDemCityObjectBakeCandidate?> CreateAsync(
+        NonDemBufferedCityObject bufferedCityObject,
+        CancellationToken cancellationToken);
+}
+
 internal sealed class NonDemCityObjectBakeCandidateFactory(
-    NonDemAtlasOrPreservedEntryFactory entryFactory)
+    NonDemAtlasOrPreservedEntryFactory entryFactory) : INonDemCityObjectBakeCandidateFactory
 {
     private readonly NonDemAtlasOrPreservedEntryFactory entryFactory = entryFactory
         ?? throw new ArgumentNullException(nameof(entryFactory));

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -14,9 +14,9 @@ internal interface INonDemCityObjectBakeCandidateFactory
 }
 
 internal sealed class NonDemCityObjectBakeCandidateFactory(
-    NonDemAtlasOrPreservedEntryFactory entryFactory) : INonDemCityObjectBakeCandidateFactory
+    INonDemAtlasOrPreservedEntryFactory entryFactory) : INonDemCityObjectBakeCandidateFactory
 {
-    private readonly NonDemAtlasOrPreservedEntryFactory entryFactory = entryFactory
+    private readonly INonDemAtlasOrPreservedEntryFactory entryFactory = entryFactory
         ?? throw new ArgumentNullException(nameof(entryFactory));
 
     public async Task<NonDemCityObjectBakeCandidate?> CreateAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemCityObjectBakeCandidateFactory(
+    ResoniteTextureImageLoader textureImageLoader,
+    int maxAtlasTextureEdge)
+{
+    public async Task<NonDemCityObjectBakeCandidate?> CreateAsync(
+        NonDemBufferedCityObject bufferedCityObject,
+        CancellationToken cancellationToken)
+    {
+        ResoniteConstructionCityObject cityObject = bufferedCityObject.CityObject;
+        NonDemCityObjectBakePolicy policy = bufferedCityObject.Policy;
+        if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(cityObject, out _))
+        {
+            throw new InvalidOperationException(
+                $"Non-DEM bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
+        }
+
+        ResoniteConstructionCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
+        if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(normalizedCityObject, out Dictionary<int, ResoniteMaterialBinding>? materialBySubmeshIndex))
+        {
+            throw new InvalidOperationException(
+                $"Non-DEM bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
+        }
+
+        List<NonDemAtlasBatchEntry> atlasEntries = [];
+        List<NonDemPreservedSubmeshEntry> preservedEntries = [];
+        bool hadAtlasCandidateMaterial = false;
+        foreach (ResoniteMeshSubmesh submesh in normalizedCityObject.Mesh.Submeshes.OrderBy(static candidate => candidate.Index))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!materialBySubmeshIndex.TryGetValue(submesh.Index, out ResoniteMaterialBinding? material))
+            {
+                throw new InvalidOperationException(
+                    $"Non-DEM bake city object '{cityObject.DisplayName}' left submesh index {submesh.Index} without a material assignment.");
+            }
+
+            NonDemMaterialBakeCategory category = NonDemCityObjectBakeMaterialClassifier.Classify(material);
+            switch (category)
+            {
+                case NonDemMaterialBakeCategory.AtlasCandidate:
+                    hadAtlasCandidateMaterial = true;
+                    NonDemAtlasOrPreservedEntry bakeEntry = await CreateAtlasOrPreservedEntryAsync(
+                        normalizedCityObject,
+                        submesh,
+                        material,
+                        cancellationToken);
+                    if (bakeEntry.AtlasEntry is not null)
+                    {
+                        atlasEntries.Add(bakeEntry.AtlasEntry);
+                    }
+
+                    if (bakeEntry.PreservedEntry is not null)
+                    {
+                        preservedEntries.Add(bakeEntry.PreservedEntry);
+                    }
+
+                    break;
+                case NonDemMaterialBakeCategory.PreservedCommonMaterial when policy.PreserveCommonMaterials:
+                case NonDemMaterialBakeCategory.PreservedTextureless when policy.PreserveTexturelessMaterials:
+                case NonDemMaterialBakeCategory.PreservedVertexColor when policy.PreserveVertexColorMaterials:
+                case NonDemMaterialBakeCategory.PreservedOther:
+                    ResoniteMeshSubmesh normalizedSubmesh = normalizedCityObject.Mesh.Submeshes.Single(candidate => candidate.Index == submesh.Index);
+                    ResoniteMaterialBinding normalizedMaterial = normalizedCityObject.Materials.Single(candidate => candidate.SubmeshIndices.Contains(submesh.Index));
+                    preservedEntries.Add(new NonDemPreservedSubmeshEntry(normalizedCityObject, normalizedSubmesh, normalizedMaterial));
+                    break;
+            }
+        }
+
+        if (policy.RequireAtlasCandidateMaterial && !hadAtlasCandidateMaterial)
+        {
+            return null;
+        }
+
+        if (atlasEntries.Count == 0 && preservedEntries.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Non-DEM bake city object '{cityObject.DisplayName}' produced no atlas or preserved submesh candidate.");
+        }
+
+        return new NonDemCityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries);
+    }
+
+    private async Task<NonDemAtlasOrPreservedEntry> CreateAtlasOrPreservedEntryAsync(
+        ResoniteConstructionCityObject cityObject,
+        ResoniteMeshSubmesh submesh,
+        ResoniteMaterialBinding material,
+        CancellationToken cancellationToken)
+    {
+        if (material.TexturePayload is null)
+        {
+            throw new InvalidOperationException("Non-DEM bake candidate material must have a texture payload.");
+        }
+
+        TextureUvRect uvBounds = ComputeUvBounds(cityObject.Mesh.Vertices, submesh);
+        using Image<Rgba32> sourceImage = await textureImageLoader.LoadAsync(
+            ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
+            cancellationToken);
+        Rgba32 detectedBackgroundColor = NonDemTextureImageProcessing.DetectRepresentativeBackgroundColor(sourceImage);
+        using Image<Rgba32> preparedSourceImage = sourceImage.Clone();
+        NonDemTextureImageProcessing.FillTransparentRgb(preparedSourceImage, detectedBackgroundColor);
+        if (NonDemTextureImageProcessing.TryGetUniformPixelColor(preparedSourceImage, out Rgba32 uniformDatasetColor))
+        {
+            Rgba32 tintedUniformColor = NonDemTextureImageProcessing.MultiplyPixel(
+                uniformDatasetColor,
+                NonDemTextureImageProcessing.ToPixel(material.BaseColor));
+            return new NonDemAtlasOrPreservedEntry(
+                AtlasEntry: null,
+                PreservedEntry: new NonDemPreservedSubmeshEntry(
+                    cityObject,
+                    submesh,
+                    CreateVertexColorMaterial(material, submesh.Index),
+                    NonDemTextureImageProcessing.ToColor(tintedUniformColor)));
+        }
+
+        int targetWidth = Math.Max(1, Math.Min(maxAtlasTextureEdge, (int)Math.Ceiling(sourceImage.Width * uvBounds.Width)));
+        int targetHeight = Math.Max(1, Math.Min(maxAtlasTextureEdge, (int)Math.Ceiling(sourceImage.Height * uvBounds.Height)));
+        using Image<Rgba32> bakedImage = NonDemTextureImageProcessing.BakeUsedUvRegion(
+            preparedSourceImage,
+            uvBounds,
+            targetWidth,
+            targetHeight);
+
+        NonDemTextureImageProcessing.ApplyBaseColor(bakedImage, material.BaseColor);
+        return new NonDemAtlasOrPreservedEntry(
+            AtlasEntry: new NonDemAtlasBatchEntry(
+                cityObject,
+                submesh,
+                material,
+                new NonDemMaterialAtlasTile(
+                    bakedImage.Clone(),
+                    NonDemTextureImageProcessing.MultiplyPixel(
+                        detectedBackgroundColor,
+                        NonDemTextureImageProcessing.ToPixel(material.BaseColor))),
+                uvBounds),
+            PreservedEntry: null);
+    }
+
+    private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)
+    {
+        return material with
+        {
+            MaterialType = ResoniteMaterialType.VertexColor,
+            BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            TexturePayload = null,
+            TextureSourceKind = ResoniteTextureSourceKind.Bundled,
+            TextureScale = null,
+            TextureOffset = null,
+            Family = null,
+            TerrainOverlay = null,
+            AssetScope = ResoniteMaterialAssetScope.Common,
+            SubmeshIndices = [submeshIndex],
+            CommonMaterial = material.DepthOffset is null
+                ? CommonMaterialCatalog.Create().VertexColor.Uv
+                : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv,
+        };
+    }
+
+    private static TextureUvRect ComputeUvBounds(
+        IReadOnlyList<ResoniteMeshVertex> vertices,
+        ResoniteMeshSubmesh submesh)
+    {
+        double minU = double.PositiveInfinity;
+        double minV = double.PositiveInfinity;
+        double maxU = double.NegativeInfinity;
+        double maxV = double.NegativeInfinity;
+
+        foreach (int sourceIndex in submesh.TriangleVertexIndices)
+        {
+            ResoniteFloat2 transformedUv = vertices[sourceIndex].UV0;
+            minU = Math.Min(minU, transformedUv.X);
+            minV = Math.Min(minV, transformedUv.Y);
+            maxU = Math.Max(maxU, transformedUv.X);
+            maxV = Math.Max(maxV, transformedUv.Y);
+        }
+
+        if (double.IsPositiveInfinity(minU) || double.IsPositiveInfinity(minV))
+        {
+            return TextureUvRect.Identity;
+        }
+
+        double width = Math.Max(1.0 / 1024.0, maxU - minU);
+        double height = Math.Max(1.0 / 1024.0, maxV - minV);
+        return new TextureUvRect(minU, minV, width, height);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -4,18 +4,14 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Domain.Importing;
-
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemCityObjectBakeCandidateFactory(
-    ResoniteTextureImageLoader textureImageLoader,
-    int maxAtlasTextureEdge)
+    NonDemAtlasOrPreservedEntryFactory entryFactory)
 {
+    private readonly NonDemAtlasOrPreservedEntryFactory entryFactory = entryFactory
+        ?? throw new ArgumentNullException(nameof(entryFactory));
+
     public async Task<NonDemCityObjectBakeCandidate?> CreateAsync(
         NonDemBufferedCityObject bufferedCityObject,
         CancellationToken cancellationToken)
@@ -52,7 +48,7 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
             {
                 case NonDemMaterialBakeCategory.AtlasCandidate:
                     hadAtlasCandidateMaterial = true;
-                    NonDemAtlasOrPreservedEntry bakeEntry = await CreateAtlasOrPreservedEntryAsync(
+                    NonDemAtlasOrPreservedEntry bakeEntry = await entryFactory.CreateAsync(
                         normalizedCityObject,
                         submesh,
                         material,
@@ -91,108 +87,5 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
         }
 
         return new NonDemCityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries);
-    }
-
-    private async Task<NonDemAtlasOrPreservedEntry> CreateAtlasOrPreservedEntryAsync(
-        ResoniteConstructionCityObject cityObject,
-        ResoniteMeshSubmesh submesh,
-        ResoniteMaterialBinding material,
-        CancellationToken cancellationToken)
-    {
-        if (material.TexturePayload is null)
-        {
-            throw new InvalidOperationException("Non-DEM bake candidate material must have a texture payload.");
-        }
-
-        TextureUvRect uvBounds = ComputeUvBounds(cityObject.Mesh.Vertices, submesh);
-        using Image<Rgba32> sourceImage = await textureImageLoader.LoadAsync(
-            ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
-            cancellationToken);
-        Rgba32 detectedBackgroundColor = NonDemTextureImageProcessing.DetectRepresentativeBackgroundColor(sourceImage);
-        using Image<Rgba32> preparedSourceImage = sourceImage.Clone();
-        NonDemTextureImageProcessing.FillTransparentRgb(preparedSourceImage, detectedBackgroundColor);
-        if (NonDemTextureImageProcessing.TryGetUniformPixelColor(preparedSourceImage, out Rgba32 uniformDatasetColor))
-        {
-            Rgba32 tintedUniformColor = NonDemTextureImageProcessing.MultiplyPixel(
-                uniformDatasetColor,
-                NonDemTextureImageProcessing.ToPixel(material.BaseColor));
-            return new NonDemAtlasOrPreservedEntry(
-                AtlasEntry: null,
-                PreservedEntry: new NonDemPreservedSubmeshEntry(
-                    cityObject,
-                    submesh,
-                    CreateVertexColorMaterial(material, submesh.Index),
-                    NonDemTextureImageProcessing.ToColor(tintedUniformColor)));
-        }
-
-        int targetWidth = Math.Max(1, Math.Min(maxAtlasTextureEdge, (int)Math.Ceiling(sourceImage.Width * uvBounds.Width)));
-        int targetHeight = Math.Max(1, Math.Min(maxAtlasTextureEdge, (int)Math.Ceiling(sourceImage.Height * uvBounds.Height)));
-        using Image<Rgba32> bakedImage = NonDemTextureImageProcessing.BakeUsedUvRegion(
-            preparedSourceImage,
-            uvBounds,
-            targetWidth,
-            targetHeight);
-
-        NonDemTextureImageProcessing.ApplyBaseColor(bakedImage, material.BaseColor);
-        return new NonDemAtlasOrPreservedEntry(
-            AtlasEntry: new NonDemAtlasBatchEntry(
-                cityObject,
-                submesh,
-                material,
-                new NonDemMaterialAtlasTile(
-                    bakedImage.Clone(),
-                    NonDemTextureImageProcessing.MultiplyPixel(
-                        detectedBackgroundColor,
-                        NonDemTextureImageProcessing.ToPixel(material.BaseColor))),
-                uvBounds),
-            PreservedEntry: null);
-    }
-
-    private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)
-    {
-        return material with
-        {
-            MaterialType = ResoniteMaterialType.VertexColor,
-            BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-            TexturePayload = null,
-            TextureSourceKind = ResoniteTextureSourceKind.Bundled,
-            TextureScale = null,
-            TextureOffset = null,
-            Family = null,
-            TerrainOverlay = null,
-            AssetScope = ResoniteMaterialAssetScope.Common,
-            SubmeshIndices = [submeshIndex],
-            CommonMaterial = material.DepthOffset is null
-                ? CommonMaterialCatalog.Create().VertexColor.Uv
-                : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv,
-        };
-    }
-
-    private static TextureUvRect ComputeUvBounds(
-        IReadOnlyList<ResoniteMeshVertex> vertices,
-        ResoniteMeshSubmesh submesh)
-    {
-        double minU = double.PositiveInfinity;
-        double minV = double.PositiveInfinity;
-        double maxU = double.NegativeInfinity;
-        double maxV = double.NegativeInfinity;
-
-        foreach (int sourceIndex in submesh.TriangleVertexIndices)
-        {
-            ResoniteFloat2 transformedUv = vertices[sourceIndex].UV0;
-            minU = Math.Min(minU, transformedUv.X);
-            minV = Math.Min(minV, transformedUv.Y);
-            maxU = Math.Max(maxU, transformedUv.X);
-            maxV = Math.Max(maxV, transformedUv.Y);
-        }
-
-        if (double.IsPositiveInfinity(minU) || double.IsPositiveInfinity(minV))
-        {
-            return TextureUvRect.Identity;
-        }
-
-        double width = Math.Max(1.0 / 1024.0, maxU - minU);
-        double height = Math.Max(1.0 / 1024.0, maxV - minV);
-        return new TextureUvRect(minU, minV, width, height);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeMaterialClassifier.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeMaterialClassifier.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal static class NonDemCityObjectBakeMaterialClassifier
+{
+    public static bool CanBufferCityObjectMaterials(
+        ResoniteConstructionCityObject cityObject,
+        NonDemCityObjectBakePolicy policy)
+    {
+        if (!TryCreateMaterialBySubmeshIndex(cityObject, out Dictionary<int, ResoniteMaterialBinding> materialBySubmeshIndex))
+        {
+            return false;
+        }
+
+        bool hasAtlasCandidateSubmesh = false;
+        foreach (ResoniteMeshSubmesh submesh in cityObject.Mesh.Submeshes)
+        {
+            if (!materialBySubmeshIndex.TryGetValue(submesh.Index, out ResoniteMaterialBinding? material))
+            {
+                return false;
+            }
+
+            NonDemMaterialBakeCategory category = Classify(material);
+            hasAtlasCandidateSubmesh |= category == NonDemMaterialBakeCategory.AtlasCandidate;
+            if (category == NonDemMaterialBakeCategory.PreservedCommonMaterial && !policy.PreserveCommonMaterials)
+            {
+                return false;
+            }
+
+            if (category == NonDemMaterialBakeCategory.PreservedVertexColor && !policy.PreserveVertexColorMaterials)
+            {
+                return false;
+            }
+
+            if (category == NonDemMaterialBakeCategory.PreservedTextureless && !policy.PreserveTexturelessMaterials)
+            {
+                return false;
+            }
+        }
+
+        return policy.RequireAtlasCandidateMaterial ? hasAtlasCandidateSubmesh : true;
+    }
+
+    public static bool TryCreateMaterialBySubmeshIndex(
+        ResoniteConstructionCityObject cityObject,
+        out Dictionary<int, ResoniteMaterialBinding> materialBySubmeshIndex)
+    {
+        materialBySubmeshIndex = [];
+        foreach (ResoniteMaterialBinding material in cityObject.Materials)
+        {
+            foreach (int submeshIndex in material.SubmeshIndices)
+            {
+                if (!materialBySubmeshIndex.TryAdd(submeshIndex, material))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public static NonDemMaterialBakeCategory Classify(ResoniteMaterialBinding material)
+    {
+        if (IsAtlasBakeCandidate(material))
+        {
+            return NonDemMaterialBakeCategory.AtlasCandidate;
+        }
+
+        if (material.MaterialType == ResoniteMaterialType.VertexColor)
+        {
+            return NonDemMaterialBakeCategory.PreservedVertexColor;
+        }
+
+        if (material.AssetScope == ResoniteMaterialAssetScope.Common
+            || !string.IsNullOrWhiteSpace(material.Family))
+        {
+            return CanPreserveAsCommonMaterial(material)
+                ? NonDemMaterialBakeCategory.PreservedCommonMaterial
+                : NonDemMaterialBakeCategory.PreservedOther;
+        }
+
+        if (material.TexturePayload is null)
+        {
+            return NonDemMaterialBakeCategory.PreservedTextureless;
+        }
+
+        return NonDemMaterialBakeCategory.PreservedOther;
+    }
+
+    private static bool IsAtlasBakeCandidate(ResoniteMaterialBinding material)
+    {
+        if (material.DepthOffset is not null
+            || material.Projection != ResoniteMaterialProjection.Uv
+            || material.AssetScope == ResoniteMaterialAssetScope.Common)
+        {
+            return false;
+        }
+
+        if (material.MaterialType != ResoniteMaterialType.Standard
+            || material.TexturePayload is null
+            || material.TextureSourceKind != ResoniteTextureSourceKind.Dataset)
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(material.Family))
+        {
+            return true;
+        }
+
+        return material.TerrainOverlay is null
+            && ResoniteMaterialSharing.CanUseSharedAlbedoOnlyMaterial(material);
+    }
+
+    private static bool CanPreserveAsCommonMaterial(ResoniteMaterialBinding material)
+    {
+        return material.CommonMaterial is not null;
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+using PlateauResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record NonDemMaterialAtlasTile(Image<Rgba32> Image, Rgba32 BackgroundColor);
+
+internal sealed record NonDemAtlasOrPreservedEntry(
+    NonDemAtlasBatchEntry? AtlasEntry,
+    NonDemPreservedSubmeshEntry? PreservedEntry);
+
+internal readonly record struct NonDemBufferedCityObject(
+    ResoniteConstructionCityObject CityObject,
+    NonDemCityObjectBakePolicy Policy);
+
+internal sealed record NonDemAtlasBatchEntry(
+    ResoniteConstructionCityObject CityObject,
+    ResoniteMeshSubmesh Submesh,
+    ResoniteMaterialBinding Material,
+    NonDemMaterialAtlasTile Tile,
+    TextureUvRect UvBounds);
+
+internal sealed record NonDemPreservedSubmeshEntry(
+    ResoniteConstructionCityObject CityObject,
+    ResoniteMeshSubmesh Submesh,
+    ResoniteMaterialBinding Material,
+    ResoniteColor? VertexColorOverride = null);
+
+internal sealed record NonDemOrderedPreservedSubmeshEntry(
+    NonDemPreservedSubmeshEntry Entry,
+    int Order);
+
+internal sealed record NonDemCityObjectBakeCandidate(
+    ResoniteConstructionCityObject CityObject,
+    IReadOnlyList<NonDemAtlasBatchEntry> AtlasEntries,
+    IReadOnlyList<NonDemPreservedSubmeshEntry> PreservedEntries);

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicyResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicyResolver.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface INonDemCityObjectBakePolicyResolver
+{
+    NonDemCityObjectBakePolicy? Resolve(ResoniteConstructionCityObject cityObject);
+}
+
+internal sealed class NonDemCityObjectBakePolicyResolver(
+    IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies) : INonDemCityObjectBakePolicyResolver
+{
+    private readonly IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies = bakePolicies
+        ?? throw new ArgumentNullException(nameof(bakePolicies));
+
+    public NonDemCityObjectBakePolicy? Resolve(ResoniteConstructionCityObject cityObject)
+    {
+        foreach (NonDemCityObjectBakePolicy policy in bakePolicies)
+        {
+            if (policy.CanBuffer(cityObject)
+                && NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(cityObject, policy))
+            {
+                return policy;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,8 +9,7 @@ internal sealed class NonDemCityObjectBaker(
     INonDemCityObjectBakePolicyResolver bakePolicyResolver,
     INonDemSourceFileBakeEmitter sourceFileBakeEmitter) : IResoniteBufferedCityObjectBaker
 {
-    private readonly Dictionary<NonDemSourceFileBatchKey, List<NonDemBufferedCityObject>> bufferedCityObjectsBySourceFile = [];
-    private readonly Dictionary<NonDemSourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
+    private readonly NonDemSourceFileBakeBuffer sourceFileBuffer = new();
     private readonly INonDemCityObjectBakePolicyResolver bakePolicyResolver = bakePolicyResolver
         ?? throw new ArgumentNullException(nameof(bakePolicyResolver));
     private readonly INonDemSourceFileBakeEmitter sourceFileBakeEmitter = sourceFileBakeEmitter
@@ -39,14 +37,7 @@ internal sealed class NonDemCityObjectBaker(
         cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(cityObject, policy);
         List<ResoniteConstructionCityObject> readyCityObjects = [];
-        NonDemBufferedCityObject bufferedCityObject = new(cityObject, policy);
-        if (!bufferedCityObjectsBySourceFile.TryGetValue(sourceFileKey, out List<NonDemBufferedCityObject>? bufferedCityObjects))
-        {
-            bufferedCityObjects = [];
-            bufferedCityObjectsBySourceFile.Add(sourceFileKey, bufferedCityObjects);
-        }
-
-        bufferedCityObjects.Add(bufferedCityObject);
+        sourceFileBuffer.Add(sourceFileKey, new NonDemBufferedCityObject(cityObject, policy));
         BakedInputCityObjectCount++;
         return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: true, readyCityObjects));
     }
@@ -70,15 +61,12 @@ internal sealed class NonDemCityObjectBaker(
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(onBakedCityObject);
-        if (bufferedCityObjectsBySourceFile.Count == 0)
+        if (sourceFileBuffer.IsEmpty)
         {
             return;
         }
 
-        NonDemSourceFileBatchKey[] orderedSourceFileKeys = bufferedCityObjectsBySourceFile.Keys
-            .OrderBy(static key => key, NonDemSourceFileBatching.KeyComparer)
-            .ToArray();
-        foreach (NonDemSourceFileBatchKey sourceFileKey in orderedSourceFileKeys)
+        foreach (NonDemSourceFileBatchKey sourceFileKey in sourceFileBuffer.SnapshotOrderedSourceFileKeys())
         {
             await EmitSourceFileAsync(sourceFileKey, onBakedCityObject, cancellationToken);
         }
@@ -89,19 +77,18 @@ internal sealed class NonDemCityObjectBaker(
         Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
         CancellationToken cancellationToken)
     {
-        if (!bufferedCityObjectsBySourceFile.Remove(sourceFileKey, out List<NonDemBufferedCityObject>? cityObjects))
+        if (!sourceFileBuffer.TryTake(sourceFileKey, out NonDemSourceFileBakeBufferEntry bufferEntry))
         {
             return;
         }
 
-        int batchStartIndex = nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey);
         int emittedCount = 0;
         try
         {
             await sourceFileBakeEmitter.EmitAsync(
-                sourceFileKey,
-                cityObjects,
-                batchStartIndex,
+                bufferEntry.SourceFileKey,
+                bufferEntry.CityObjects,
+                bufferEntry.BatchStartIndex,
                 async (bakedCityObject, callbackCancellationToken) =>
                 {
                     emittedCount++;
@@ -112,8 +99,7 @@ internal sealed class NonDemCityObjectBaker(
         }
         finally
         {
-            nextBatchIndexBySourceFile[sourceFileKey] = batchStartIndex + emittedCount;
-            cityObjects.Clear();
+            sourceFileBuffer.Complete(bufferEntry, emittedCount);
         }
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -141,6 +141,7 @@ internal sealed class NonDemCityObjectBaker(
         int batchIndex = batchStartIndex;
         bool preservePrimaryIdentity = cityObjects.Count == 1;
         NonDemCityObjectBakeCandidateFactory candidateFactory = CreateCandidateFactory();
+        NonDemAtlasBatchFitPolicy batchFitPolicy = CreateBatchFitPolicy();
 
         foreach (NonDemBufferedCityObject bufferedCityObject in cityObjects.OrderBy(
                      static bufferedCityObject => bufferedCityObject.CityObject.SlotKey,
@@ -153,7 +154,7 @@ internal sealed class NonDemCityObjectBaker(
                 continue;
             }
 
-            if (candidate.AtlasEntries.Count == 0 && !RequiresBakeEmission(candidate))
+            if (candidate.AtlasEntries.Count == 0 && !NonDemAtlasBatchFitPolicy.RequiresBakeEmission(candidate))
             {
                 passThroughCandidates.Add(candidate);
                 continue;
@@ -161,7 +162,7 @@ internal sealed class NonDemCityObjectBaker(
 
             if (currentAtlasBatch.Count == 0)
             {
-                if (CanFitSingleCandidate(candidate))
+                if (batchFitPolicy.CanFitSingleCandidate(candidate))
                 {
                     currentAtlasBatch.Add(candidate);
                 }
@@ -173,7 +174,7 @@ internal sealed class NonDemCityObjectBaker(
                 continue;
             }
 
-            if (CanAppendToAtlasBatch(currentAtlasBatch, candidate))
+            if (batchFitPolicy.CanAppendToAtlasBatch(currentAtlasBatch, candidate))
             {
                 currentAtlasBatch.Add(candidate);
                 continue;
@@ -188,7 +189,7 @@ internal sealed class NonDemCityObjectBaker(
                 cancellationToken);
             currentAtlasBatch.Clear();
 
-            if (CanFitSingleCandidate(candidate))
+            if (batchFitPolicy.CanFitSingleCandidate(candidate))
             {
                 currentAtlasBatch.Add(candidate);
             }
@@ -277,6 +278,11 @@ internal sealed class NonDemCityObjectBaker(
         return new NonDemCityObjectBakeCandidateFactory(textureImageLoader, EffectiveMaxAtlasTextureEdge);
     }
 
+    private NonDemAtlasBatchFitPolicy CreateBatchFitPolicy()
+    {
+        return new NonDemAtlasBatchFitPolicy(CreateAtlasLayoutFactory());
+    }
+
     private async Task EmitAtlasBatchAsync(
         NonDemSourceFileBatchKey sourceFileKey,
         IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
@@ -318,19 +324,6 @@ internal sealed class NonDemCityObjectBaker(
         }
     }
 
-    private bool CanFitSingleCandidate(NonDemCityObjectBakeCandidate candidate)
-    {
-        return candidate.AtlasEntries.Count == 0 || CreateAtlasLayoutFactory().CanFit(candidate.AtlasEntries);
-    }
-
-    private bool CanAppendToAtlasBatch(
-        IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
-        NonDemCityObjectBakeCandidate candidate)
-    {
-        List<NonDemAtlasBatchEntry> candidateEntries = [.. batchCandidates.SelectMany(static current => current.AtlasEntries), .. candidate.AtlasEntries];
-        return CreateAtlasLayoutFactory().CanFit(candidateEntries);
-    }
-
     private static void DisposeCandidateImages(NonDemCityObjectBakeCandidate candidate)
     {
         DisposeCandidateImages([candidate]);
@@ -346,10 +339,4 @@ internal sealed class NonDemCityObjectBaker(
             tileImage.Dispose();
         }
     }
-
-    private static bool RequiresBakeEmission(NonDemCityObjectBakeCandidate candidate)
-    {
-        return candidate.PreservedEntries.Any(static entry => entry.VertexColorOverride is not null);
-    }
-
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -4,9 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemCityObjectBaker(
@@ -111,131 +108,19 @@ internal sealed class NonDemCityObjectBaker(
             return;
         }
 
-        int emittedCount = 0;
         int batchStartIndex = nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey);
+        NonDemSourceFileBakeEmitter emitter = CreateSourceFileBakeEmitter();
 
-        await BakeSourceFileAsync(
+        int emittedCount = await emitter.EmitAsync(
             sourceFileKey,
             cityObjects,
             batchStartIndex,
-            (bakedCityObject, callbackCancellationToken) =>
-            {
-                emittedCount++;
-                return onBakedCityObject(bakedCityObject, callbackCancellationToken);
-            },
+            onBakedCityObject,
             cancellationToken);
 
+        BakedOutputCityObjectCount += emittedCount;
         nextBatchIndexBySourceFile[sourceFileKey] = batchStartIndex + emittedCount;
         cityObjects.Clear();
-    }
-
-    private async Task BakeSourceFileAsync(
-        NonDemSourceFileBatchKey sourceFileKey,
-        List<NonDemBufferedCityObject> cityObjects,
-        int batchStartIndex,
-        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
-        CancellationToken cancellationToken)
-    {
-        List<NonDemCityObjectBakeCandidate> passThroughCandidates = [];
-        List<NonDemCityObjectBakeCandidate> currentAtlasBatch = [];
-        int batchIndex = batchStartIndex;
-        bool preservePrimaryIdentity = cityObjects.Count == 1;
-        NonDemCityObjectBakeCandidateFactory candidateFactory = CreateCandidateFactory();
-        NonDemAtlasBatchFitPolicy batchFitPolicy = CreateBatchFitPolicy();
-
-        foreach (NonDemBufferedCityObject bufferedCityObject in cityObjects.OrderBy(
-                     static bufferedCityObject => bufferedCityObject.CityObject.SlotKey,
-                     StringComparer.Ordinal))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            NonDemCityObjectBakeCandidate? candidate = await candidateFactory.CreateAsync(bufferedCityObject, cancellationToken);
-            if (candidate is null)
-            {
-                continue;
-            }
-
-            if (candidate.AtlasEntries.Count == 0 && !NonDemAtlasBatchFitPolicy.RequiresBakeEmission(candidate))
-            {
-                passThroughCandidates.Add(candidate);
-                continue;
-            }
-
-            if (currentAtlasBatch.Count == 0)
-            {
-                if (batchFitPolicy.CanFitSingleCandidate(candidate))
-                {
-                    currentAtlasBatch.Add(candidate);
-                }
-                else
-                {
-                    await EmitFallbackCandidateAsync(candidate, onBakedCityObject, cancellationToken);
-                }
-
-                continue;
-            }
-
-            if (batchFitPolicy.CanAppendToAtlasBatch(currentAtlasBatch, candidate))
-            {
-                currentAtlasBatch.Add(candidate);
-                continue;
-            }
-
-            await EmitAtlasBatchAsync(
-                sourceFileKey,
-                currentAtlasBatch,
-                batchIndex++,
-                preservePrimaryIdentity && passThroughCandidates.Count == 0,
-                onBakedCityObject,
-                cancellationToken);
-            currentAtlasBatch.Clear();
-
-            if (batchFitPolicy.CanFitSingleCandidate(candidate))
-            {
-                currentAtlasBatch.Add(candidate);
-            }
-            else
-            {
-                await EmitFallbackCandidateAsync(candidate, onBakedCityObject, cancellationToken);
-            }
-        }
-
-        if (currentAtlasBatch.Count > 0)
-        {
-            await EmitAtlasBatchAsync(
-                sourceFileKey,
-                currentAtlasBatch,
-                batchIndex++,
-                preservePrimaryIdentity && passThroughCandidates.Count == 0,
-                onBakedCityObject,
-                cancellationToken);
-            currentAtlasBatch.Clear();
-        }
-
-        if (passThroughCandidates.Count == 1)
-        {
-            NonDemCityObjectBakeCandidate passThroughCandidate = passThroughCandidates[0];
-            BakedOutputCityObjectCount++;
-            await onBakedCityObject(passThroughCandidate.CityObject, cancellationToken);
-            DisposeCandidateImages(passThroughCandidate);
-        }
-        else if (passThroughCandidates.Count > 1)
-        {
-            try
-            {
-                ResoniteConstructionCityObject mergedPassThroughCityObject = await BakeBatchAsync(
-                    sourceFileKey,
-                    passThroughCandidates,
-                    batchIndex,
-                    preservePrimaryIdentity: false,
-                    cancellationToken);
-                BakedOutputCityObjectCount++;
-                await onBakedCityObject(mergedPassThroughCityObject, cancellationToken);
-            }
-            finally
-            {
-                DisposeCandidateImages(passThroughCandidates);
-            }
-        }
     }
 
     private NonDemCityObjectBakePolicy? ResolvePolicy(ResoniteConstructionCityObject cityObject)
@@ -250,22 +135,6 @@ internal sealed class NonDemCityObjectBaker(
         }
 
         return null;
-    }
-
-    private async Task<ResoniteConstructionCityObject> BakeBatchAsync(
-        NonDemSourceFileBatchKey sourceFileKey,
-        IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
-        int batchIndex,
-        bool preservePrimaryIdentity,
-        CancellationToken cancellationToken)
-    {
-        NonDemCityObjectBakeAssembler assembler = new(CreateAtlasLayoutFactory(), new NonDemAtlasImageRenderer(tilePaddingPixels));
-        return await assembler.BakeBatchAsync(
-            sourceFileKey,
-            candidates,
-            batchIndex,
-            preservePrimaryIdentity,
-            cancellationToken);
     }
 
     private NonDemAtlasLayoutFactory CreateAtlasLayoutFactory()
@@ -283,60 +152,11 @@ internal sealed class NonDemCityObjectBaker(
         return new NonDemAtlasBatchFitPolicy(CreateAtlasLayoutFactory());
     }
 
-    private async Task EmitAtlasBatchAsync(
-        NonDemSourceFileBatchKey sourceFileKey,
-        IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
-        int batchIndex,
-        bool preservePrimaryIdentity,
-        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
-        CancellationToken cancellationToken)
+    private NonDemSourceFileBakeEmitter CreateSourceFileBakeEmitter()
     {
-        try
-        {
-            ResoniteConstructionCityObject bakedCityObject = await BakeBatchAsync(
-                sourceFileKey,
-                batchCandidates,
-                batchIndex,
-                preservePrimaryIdentity,
-                cancellationToken);
-            BakedOutputCityObjectCount++;
-            await onBakedCityObject(bakedCityObject, cancellationToken);
-        }
-        finally
-        {
-            DisposeCandidateImages(batchCandidates);
-        }
-    }
-
-    private async Task EmitFallbackCandidateAsync(
-        NonDemCityObjectBakeCandidate fallbackCandidate,
-        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            BakedOutputCityObjectCount++;
-            await onBakedCityObject(fallbackCandidate.CityObject, cancellationToken);
-        }
-        finally
-        {
-            DisposeCandidateImages(fallbackCandidate);
-        }
-    }
-
-    private static void DisposeCandidateImages(NonDemCityObjectBakeCandidate candidate)
-    {
-        DisposeCandidateImages([candidate]);
-    }
-
-    private static void DisposeCandidateImages(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
-    {
-        foreach (Image<Rgba32> tileImage in candidates
-                     .SelectMany(static candidate => candidate.AtlasEntries)
-                     .Select(static entry => entry.Tile.Image)
-                     .Distinct())
-        {
-            tileImage.Dispose();
-        }
+        return new NonDemSourceFileBakeEmitter(
+            CreateCandidateFactory(),
+            new NonDemCityObjectBakeAssembler(CreateAtlasLayoutFactory(), new NonDemAtlasImageRenderer(tilePaddingPixels)),
+            CreateBatchFitPolicy());
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -4,9 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Domain.Importing;
-
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -261,199 +258,13 @@ internal sealed class NonDemCityObjectBaker(
         bool preservePrimaryIdentity,
         CancellationToken cancellationToken)
     {
-        List<NonDemAtlasBatchEntry> entries = candidates.SelectMany(static candidate => candidate.AtlasEntries).ToList();
-        NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout = null;
-        NonDemAtlasLayoutFactory atlasLayoutFactory = CreateAtlasLayoutFactory();
-        if (entries.Count > 0
-            && (!atlasLayoutFactory.TryCreate(entries, out layout) || layout is null))
-        {
-            throw new InvalidOperationException("Failed to create non-DEM atlas layout.");
-        }
-
-        using Image<Rgba32>? atlasImage = layout is null
-            ? null
-            : new Image<Rgba32>(layout.Width, layout.Height, new Rgba32(0, 0, 0, 0));
-        if (layout is not null)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            new NonDemAtlasImageRenderer(tilePaddingPixels).Draw(atlasImage!, layout.Placements);
-        }
-
-        ResoniteConstructionCityObject firstCityObject = candidates[0].CityObject;
-        string slotKey = preservePrimaryIdentity
-            ? firstCityObject.SlotKey
-            : NonDemSourceFileBatching.CreateBatchSlotKey(sourceFileKey, batchIndex);
-        string displayName = preservePrimaryIdentity
-            ? firstCityObject.DisplayName
-            : NonDemSourceFileBatching.CreateBatchDisplayName(sourceFileKey, batchIndex, slotKey);
-        string? sourceFileRelativePath = string.IsNullOrWhiteSpace(firstCityObject.SourceFileRelativePath)
-            ? null
-            : sourceFileKey.SourceFileRelativePath;
-
-        ResoniteFloat3 bakeOrigin = ComputeBakeOrigin(candidates);
-        List<ResoniteMeshVertex> vertices = [];
-        List<ResoniteMeshSubmesh> submeshes = [];
-        List<ResoniteMaterialBinding> materials = [];
-
-        if (layout is not null)
-        {
-            string textureIdentity = NonDemSourceFileBatching.CreateAtlasTextureIdentity(sourceFileKey, batchIndex);
-            List<int> atlasTriangleIndices = [];
-            foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in layout.Placements.OrderBy(static candidate => candidate.Entry.CityObject.SlotKey, StringComparer.Ordinal).ThenBy(static candidate => candidate.Entry.Submesh.Index))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                AppendPlacementGeometry(vertices, atlasTriangleIndices, bakeOrigin, placement, layout.Width, layout.Height);
-            }
-
-            submeshes.Add(new ResoniteMeshSubmesh(0, atlasTriangleIndices));
-            materials.Add(
-                new ResoniteMaterialBinding(
-                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-                    MaterialType: ResoniteMaterialType.Standard,
-                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-                    Projection: ResoniteMaterialProjection.Uv,
-                    DepthOffset: null,
-                    SubmeshIndices: [0],
-                    TexturePayload: ResoniteTextureImportFactory.CreatePayloadFromImage(atlasImage!, identity: textureIdentity),
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv));
-        }
-
-        foreach (IGrouping<NonDemPreservedMaterialGroupingKey, NonDemOrderedPreservedSubmeshEntry> preservedGroup in candidates
-                     .SelectMany(static candidate => candidate.PreservedEntries)
-                     .Select(static (entry, order) => new NonDemOrderedPreservedSubmeshEntry(entry, order))
-                     .GroupBy(static entry => NonDemPreservedMaterialGrouping.CreateKey(entry.Entry.Material), NonDemPreservedMaterialGrouping.KeyComparer)
-                     .OrderBy(static group => group.Min(static entry => entry.Order)))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            List<int> preservedTriangleIndices = [];
-            foreach (NonDemPreservedSubmeshEntry preservedEntry in preservedGroup
-                         .Select(static entry => entry.Entry)
-                         .OrderBy(static entry => entry.CityObject.SlotKey, StringComparer.Ordinal)
-                         .ThenBy(static entry => entry.Submesh.Index))
-            {
-                AppendOriginalGeometry(vertices, preservedTriangleIndices, bakeOrigin, preservedEntry);
-            }
-
-            if (preservedTriangleIndices.Count == 0)
-            {
-                continue;
-            }
-
-            int submeshIndex = submeshes.Count;
-            ResoniteMaterialBinding preservedMaterial = NonDemPreservedMaterialGrouping.NormalizeMaterial(preservedGroup.First().Entry.Material) with
-            {
-                SubmeshIndices = [submeshIndex],
-            };
-            submeshes.Add(new ResoniteMeshSubmesh(submeshIndex, preservedTriangleIndices));
-            materials.Add(preservedMaterial);
-        }
-
-        if (submeshes.Count == 0 || materials.Count == 0)
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM bake batch '{sourceFileKey.PackageName}:{sourceFileKey.ActualMeshCode}:LOD{sourceFileKey.LodLevel}' produced no materialized submesh.");
-        }
-
-        return new ResoniteConstructionCityObject(
-            SlotKey: slotKey,
-            DisplayName: displayName,
-            PackageName: firstCityObject.PackageName,
-            ActualMeshCode: firstCityObject.ActualMeshCode,
-            LodLevel: firstCityObject.LodLevel,
-            Transform: new ResoniteTransform(bakeOrigin),
-            Mesh: new ResoniteImportedMesh(vertices, submeshes),
-            Materials: materials,
-            CollisionEnabled: candidates.Any(static candidate => candidate.CityObject.CollisionEnabled),
-            SourceFileRelativePath: sourceFileRelativePath);
-    }
-
-    private static void AppendPlacementGeometry(
-        List<ResoniteMeshVertex> vertices,
-        List<int> triangleIndices,
-        ResoniteFloat3 bakeOrigin,
-        NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement,
-        int atlasWidth,
-        int atlasHeight)
-    {
-        IReadOnlyList<ResoniteMeshVertex> sourceVertices = placement.Entry.CityObject.Mesh.Vertices;
-        ResoniteFloat3 cityObjectOffset = Subtract(placement.Entry.CityObject.Transform.Position, bakeOrigin);
-        NonDemAtlasRect innerRect = placement.InnerRect;
-
-        foreach (int sourceIndex in placement.Entry.Submesh.TriangleVertexIndices)
-        {
-            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
-            ResoniteFloat2 sourceUv = sourceVertex.UV0;
-            ResoniteFloat2 atlasUv = MapUvToAtlas(sourceUv, placement.Entry.UvBounds, innerRect, atlasWidth, atlasHeight);
-            vertices.Add(sourceVertex with
-            {
-                Position = Add(sourceVertex.Position, cityObjectOffset),
-                UV0 = atlasUv,
-            });
-            triangleIndices.Add(vertices.Count - 1);
-        }
-    }
-
-    private static void AppendOriginalGeometry(
-        List<ResoniteMeshVertex> vertices,
-        List<int> triangleIndices,
-        ResoniteFloat3 bakeOrigin,
-        NonDemPreservedSubmeshEntry preservedEntry)
-    {
-        IReadOnlyList<ResoniteMeshVertex> sourceVertices = preservedEntry.CityObject.Mesh.Vertices;
-        ResoniteFloat3 cityObjectOffset = Subtract(preservedEntry.CityObject.Transform.Position, bakeOrigin);
-        foreach (int sourceIndex in preservedEntry.Submesh.TriangleVertexIndices)
-        {
-            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
-            vertices.Add(sourceVertex with
-            {
-                Position = Add(sourceVertex.Position, cityObjectOffset),
-                Color = preservedEntry.VertexColorOverride ?? sourceVertex.Color,
-            });
-            triangleIndices.Add(vertices.Count - 1);
-        }
-    }
-
-    private static ResoniteFloat2 MapUvToAtlas(
-        ResoniteFloat2 sourceUv,
-        TextureUvRect uvBounds,
-        NonDemAtlasRect atlasRect,
-        double atlasWidth,
-        double atlasHeight)
-    {
-        TextureUvRect atlasUvRect = TextureUvRect.FromTopLeftPixelRect(
-            atlasRect.X,
-            atlasRect.Y,
-            atlasRect.Width,
-            atlasRect.Height,
-            (int)Math.Round(atlasWidth),
-            (int)Math.Round(atlasHeight));
-        ScalarPair remapped = TextureUvRect.RemapValue(
-            new ScalarPair(sourceUv.X, sourceUv.Y),
-            uvBounds,
-            atlasUvRect);
-        return new ResoniteFloat2(remapped.X, remapped.Y);
-    }
-
-    private static ResoniteFloat3 ComputeBakeOrigin(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
-    {
-        double minX = double.PositiveInfinity;
-        double minY = double.PositiveInfinity;
-        double minZ = double.PositiveInfinity;
-
-        foreach (ResoniteConstructionCityObject cityObject in candidates.Select(static candidate => candidate.CityObject))
-        {
-            foreach (ResoniteMeshVertex vertex in cityObject.Mesh.Vertices)
-            {
-                ResoniteFloat3 worldPosition = Add(vertex.Position, cityObject.Transform.Position);
-                minX = Math.Min(minX, worldPosition.X);
-                minY = Math.Min(minY, worldPosition.Y);
-                minZ = Math.Min(minZ, worldPosition.Z);
-            }
-        }
-
-        return double.IsPositiveInfinity(minX)
-            ? new ResoniteFloat3(0.0, 0.0, 0.0)
-            : new ResoniteFloat3(minX, minY, minZ);
+        NonDemCityObjectBakeAssembler assembler = new(CreateAtlasLayoutFactory(), new NonDemAtlasImageRenderer(tilePaddingPixels));
+        return await assembler.BakeBatchAsync(
+            sourceFileKey,
+            candidates,
+            batchIndex,
+            preservePrimaryIdentity,
+            cancellationToken);
     }
 
     private NonDemAtlasLayoutFactory CreateAtlasLayoutFactory()
@@ -464,16 +275,6 @@ internal sealed class NonDemCityObjectBaker(
     private NonDemCityObjectBakeCandidateFactory CreateCandidateFactory()
     {
         return new NonDemCityObjectBakeCandidateFactory(textureImageLoader, EffectiveMaxAtlasTextureEdge);
-    }
-
-    private static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)
-    {
-        return new ResoniteFloat3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
-    }
-
-    private static ResoniteFloat3 Subtract(ResoniteFloat3 left, ResoniteFloat3 right)
-    {
-        return new ResoniteFloat3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
     }
 
     private async Task EmitAtlasBatchAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -248,7 +248,8 @@ internal sealed class NonDemCityObjectBaker(
     {
         foreach (NonDemCityObjectBakePolicy policy in bakePolicies)
         {
-            if (policy.CanBuffer(cityObject) && CanBufferCityObjectMaterials(cityObject, policy))
+            if (policy.CanBuffer(cityObject)
+                && NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(cityObject, policy))
             {
                 return policy;
             }
@@ -263,14 +264,14 @@ internal sealed class NonDemCityObjectBaker(
     {
         ResoniteConstructionCityObject cityObject = bufferedCityObject.CityObject;
         NonDemCityObjectBakePolicy policy = bufferedCityObject.Policy;
-        if (!TryCreateMaterialBySubmeshIndex(cityObject, out _))
+        if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(cityObject, out _))
         {
             throw new InvalidOperationException(
                 $"Non-DEM bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
         }
 
         ResoniteConstructionCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
-        if (!TryCreateMaterialBySubmeshIndex(normalizedCityObject, out Dictionary<int, ResoniteMaterialBinding>? materialBySubmeshIndex))
+        if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(normalizedCityObject, out Dictionary<int, ResoniteMaterialBinding>? materialBySubmeshIndex))
         {
             throw new InvalidOperationException(
                 $"Non-DEM bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
@@ -288,7 +289,7 @@ internal sealed class NonDemCityObjectBaker(
                     $"Non-DEM bake city object '{cityObject.DisplayName}' left submesh index {submesh.Index} without a material assignment.");
             }
 
-            NonDemMaterialBakeCategory category = ClassifyMaterial(material);
+            NonDemMaterialBakeCategory category = NonDemCityObjectBakeMaterialClassifier.Classify(material);
             switch (category)
             {
                 case NonDemMaterialBakeCategory.AtlasCandidate:
@@ -381,121 +382,6 @@ internal sealed class NonDemCityObjectBaker(
                     MultiplyPixel(detectedBackgroundColor, ToPixel(material.BaseColor))),
                 uvBounds),
             PreservedEntry: null);
-    }
-
-    private static bool CanBufferCityObjectMaterials(
-        ResoniteConstructionCityObject cityObject,
-        NonDemCityObjectBakePolicy policy)
-    {
-        if (!TryCreateMaterialBySubmeshIndex(cityObject, out Dictionary<int, ResoniteMaterialBinding> materialBySubmeshIndex))
-        {
-            return false;
-        }
-
-        bool hasAtlasCandidateSubmesh = false;
-        foreach (ResoniteMeshSubmesh submesh in cityObject.Mesh.Submeshes)
-        {
-            if (!materialBySubmeshIndex.TryGetValue(submesh.Index, out ResoniteMaterialBinding? material))
-            {
-                return false;
-            }
-
-            NonDemMaterialBakeCategory category = ClassifyMaterial(material);
-            hasAtlasCandidateSubmesh |= category == NonDemMaterialBakeCategory.AtlasCandidate;
-            if (category == NonDemMaterialBakeCategory.PreservedCommonMaterial && !policy.PreserveCommonMaterials)
-            {
-                return false;
-            }
-
-            if (category == NonDemMaterialBakeCategory.PreservedVertexColor && !policy.PreserveVertexColorMaterials)
-            {
-                return false;
-            }
-
-            if (category == NonDemMaterialBakeCategory.PreservedTextureless && !policy.PreserveTexturelessMaterials)
-            {
-                return false;
-            }
-        }
-
-        return policy.RequireAtlasCandidateMaterial ? hasAtlasCandidateSubmesh : true;
-    }
-
-    private static bool TryCreateMaterialBySubmeshIndex(
-        ResoniteConstructionCityObject cityObject,
-        out Dictionary<int, ResoniteMaterialBinding> materialBySubmeshIndex)
-    {
-        materialBySubmeshIndex = [];
-        foreach (ResoniteMaterialBinding material in cityObject.Materials)
-        {
-            foreach (int submeshIndex in material.SubmeshIndices)
-            {
-                if (!materialBySubmeshIndex.TryAdd(submeshIndex, material))
-                {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
-    private static bool IsAtlasBakeCandidate(ResoniteMaterialBinding material)
-    {
-        if (material.DepthOffset is not null
-            || material.Projection != ResoniteMaterialProjection.Uv
-            || material.AssetScope == ResoniteMaterialAssetScope.Common)
-        {
-            return false;
-        }
-
-        if (material.MaterialType != ResoniteMaterialType.Standard
-            || material.TexturePayload is null
-            || material.TextureSourceKind != ResoniteTextureSourceKind.Dataset)
-        {
-            return false;
-        }
-
-        if (string.IsNullOrWhiteSpace(material.Family))
-        {
-            return true;
-        }
-
-        return material.TerrainOverlay is null
-            && ResoniteMaterialSharing.CanUseSharedAlbedoOnlyMaterial(material);
-    }
-
-    private static NonDemMaterialBakeCategory ClassifyMaterial(ResoniteMaterialBinding material)
-    {
-        if (IsAtlasBakeCandidate(material))
-        {
-            return NonDemMaterialBakeCategory.AtlasCandidate;
-        }
-
-        if (material.MaterialType == ResoniteMaterialType.VertexColor)
-        {
-            return NonDemMaterialBakeCategory.PreservedVertexColor;
-        }
-
-        if (material.AssetScope == ResoniteMaterialAssetScope.Common
-            || !string.IsNullOrWhiteSpace(material.Family))
-        {
-            return CanPreserveAsCommonMaterial(material)
-                ? NonDemMaterialBakeCategory.PreservedCommonMaterial
-                : NonDemMaterialBakeCategory.PreservedOther;
-        }
-
-        if (material.TexturePayload is null)
-        {
-            return NonDemMaterialBakeCategory.PreservedTextureless;
-        }
-
-        return NonDemMaterialBakeCategory.PreservedOther;
-    }
-
-    private static bool CanPreserveAsCommonMaterial(ResoniteMaterialBinding material)
-    {
-        return material.CommonMaterial is not null;
     }
 
     private AtlasBatchPlan CreateAtlasCandidateBatches(

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -543,7 +543,7 @@ internal sealed class NonDemCityObjectBaker(
         CancellationToken cancellationToken)
     {
         List<AtlasBatchEntry> entries = candidates.SelectMany(static candidate => candidate.AtlasEntries).ToList();
-        AtlasLayout? layout = null;
+        NonDemAtlasLayout<AtlasBatchEntry>? layout = null;
         if (entries.Count > 0
             && (!TryCreateAtlasLayout(entries, out layout) || layout is null))
         {
@@ -558,7 +558,7 @@ internal sealed class NonDemCityObjectBaker(
             : new bool[layout.Width * layout.Height];
         if (layout is not null)
         {
-            foreach (AtlasPlacement placement in layout.Placements)
+            foreach (NonDemAtlasPlacement<AtlasBatchEntry> placement in layout.Placements)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 DrawAtlasTile(atlasImage!, atlasCoverage!, layout.Width, placement);
@@ -590,7 +590,7 @@ internal sealed class NonDemCityObjectBaker(
         {
             string textureIdentity = CreateAtlasTextureIdentity(sourceFileKey, batchIndex);
             List<int> atlasTriangleIndices = [];
-            foreach (AtlasPlacement placement in layout.Placements.OrderBy(static candidate => candidate.Entry.CityObject.SlotKey, StringComparer.Ordinal).ThenBy(static candidate => candidate.Entry.Submesh.Index))
+            foreach (NonDemAtlasPlacement<AtlasBatchEntry> placement in layout.Placements.OrderBy(static candidate => candidate.Entry.CityObject.SlotKey, StringComparer.Ordinal).ThenBy(static candidate => candidate.Entry.Submesh.Index))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 AppendPlacementGeometry(vertices, atlasTriangleIndices, bakeOrigin, placement, layout.Width, layout.Height);
@@ -662,13 +662,13 @@ internal sealed class NonDemCityObjectBaker(
         List<ResoniteMeshVertex> vertices,
         List<int> triangleIndices,
         ResoniteFloat3 bakeOrigin,
-        AtlasPlacement placement,
+        NonDemAtlasPlacement<AtlasBatchEntry> placement,
         int atlasWidth,
         int atlasHeight)
     {
         IReadOnlyList<ResoniteMeshVertex> sourceVertices = placement.Entry.CityObject.Mesh.Vertices;
         ResoniteFloat3 cityObjectOffset = Subtract(placement.Entry.CityObject.Transform.Position, bakeOrigin);
-        Rect innerRect = placement.InnerRect;
+        NonDemAtlasRect innerRect = placement.InnerRect;
 
         foreach (int sourceIndex in placement.Entry.Submesh.TriangleVertexIndices)
         {
@@ -707,7 +707,7 @@ internal sealed class NonDemCityObjectBaker(
     private static ResoniteFloat2 MapUvToAtlas(
         ResoniteFloat2 sourceUv,
         TextureUvRect uvBounds,
-        Rect atlasRect,
+        NonDemAtlasRect atlasRect,
         double atlasWidth,
         double atlasHeight)
     {
@@ -747,7 +747,7 @@ internal sealed class NonDemCityObjectBaker(
             : new ResoniteFloat3(minX, minY, minZ);
     }
 
-    private void DrawAtlasTile(Image<Rgba32> atlasImage, bool[] atlasCoverage, int atlasWidth, AtlasPlacement placement)
+    private void DrawAtlasTile(Image<Rgba32> atlasImage, bool[] atlasCoverage, int atlasWidth, NonDemAtlasPlacement<AtlasBatchEntry> placement)
     {
         for (int y = 0; y < placement.Entry.Tile.Image.Height; y++)
         {
@@ -816,253 +816,13 @@ internal sealed class NonDemCityObjectBaker(
 
     private bool TryCreateAtlasLayout(
         IReadOnlyList<AtlasBatchEntry> entries,
-        out AtlasLayout? layout)
+        out NonDemAtlasLayout<AtlasBatchEntry>? layout)
     {
-        int atlasMaxSize = EffectiveMaxAtlasSize;
-        AtlasSizeRequirements requirements = ComputeAtlasSizeRequirements(entries, atlasMaxSize);
-        if (!requirements.IsValid)
-        {
-            layout = null;
-            return false;
-        }
-
-        foreach (AtlasCanvasCandidate candidate in EnumerateAtlasCanvasCandidates(requirements, atlasMaxSize))
-        {
-            if (TryCreateAtlasLayoutForCanvas(entries, candidate.Width, candidate.Height, out layout))
-            {
-                return true;
-            }
-        }
-
-        layout = null;
-        return false;
-    }
-
-    private bool TryCreateAtlasLayoutForCanvas(
-        IReadOnlyList<AtlasBatchEntry> entries,
-        int atlasWidth,
-        int atlasHeight,
-        out AtlasLayout? layout)
-    {
-        List<AtlasPlacement> placements = [];
-        List<Rect> freeRectangles = [new Rect(0, 0, atlasWidth, atlasHeight)];
-
-        foreach (AtlasBatchEntry entry in entries)
-        {
-            AtlasEntrySize entrySize = GetAtlasEntrySize(entry);
-            if (entrySize.PaddedWidth > atlasWidth || entrySize.PaddedHeight > atlasHeight)
-            {
-                layout = null;
-                return false;
-            }
-
-            if (!TryChooseFreeRectangle(freeRectangles, entrySize.PaddedWidth, entrySize.PaddedHeight, out Rect selectedRect))
-            {
-                layout = null;
-                return false;
-            }
-
-            Rect outerRect = new(selectedRect.X, selectedRect.Y, entrySize.PaddedWidth, entrySize.PaddedHeight);
-            Rect innerRect = new(selectedRect.X + tilePaddingPixels, selectedRect.Y + tilePaddingPixels, entry.Tile.Image.Width, entry.Tile.Image.Height);
-            placements.Add(new AtlasPlacement(entry, outerRect, innerRect));
-            SplitFreeRectangles(freeRectangles, outerRect);
-            PruneFreeRectangles(freeRectangles);
-        }
-
-        layout = new AtlasLayout(
-            atlasWidth,
-            atlasHeight,
-            placements);
-        return true;
-    }
-
-    private AtlasSizeRequirements ComputeAtlasSizeRequirements(
-        IReadOnlyList<AtlasBatchEntry> entries,
-        int atlasMaxSize)
-    {
-        long requiredArea = 0;
-        int minWidth = 1;
-        int minHeight = 1;
-
-        foreach (AtlasBatchEntry entry in entries)
-        {
-            AtlasEntrySize entrySize = GetAtlasEntrySize(entry);
-            if (entrySize.PaddedWidth > atlasMaxSize || entrySize.PaddedHeight > atlasMaxSize)
-            {
-                return AtlasSizeRequirements.Invalid;
-            }
-
-            minWidth = Math.Max(minWidth, entrySize.PaddedWidth);
-            minHeight = Math.Max(minHeight, entrySize.PaddedHeight);
-            requiredArea += (long)entrySize.PaddedWidth * entrySize.PaddedHeight;
-        }
-
-        return new AtlasSizeRequirements(minWidth, minHeight, requiredArea);
-    }
-
-    private static IEnumerable<AtlasCanvasCandidate> EnumerateAtlasCanvasCandidates(
-        AtlasSizeRequirements requirements,
-        int atlasMaxSize)
-    {
-        List<int> widthCandidates = EnumeratePowerOfTwoEdges(requirements.MinWidth, atlasMaxSize).ToList();
-        List<int> heightCandidates = EnumeratePowerOfTwoEdges(requirements.MinHeight, atlasMaxSize).ToList();
-
-        return widthCandidates
-            .SelectMany(
-                width => heightCandidates,
-                (width, height) => new AtlasCanvasCandidate(width, height, requirements))
-            .OrderBy(static candidate => candidate.Area)
-            .ThenBy(static candidate => candidate.AreaSlack)
-            .ThenBy(static candidate => candidate.DimensionSlack)
-            .ThenBy(static candidate => candidate.Height)
-            .ThenBy(static candidate => candidate.Width);
-    }
-
-    private static IEnumerable<int> EnumeratePowerOfTwoEdges(int minimumEdge, int maxEdge)
-    {
-        if (minimumEdge > maxEdge)
-        {
-            yield break;
-        }
-
-        for (int edge = 1; edge > 0 && edge <= maxEdge; edge <<= 1)
-        {
-            if (edge >= minimumEdge)
-            {
-                yield return edge;
-            }
-        }
-    }
-
-    private AtlasEntrySize GetAtlasEntrySize(AtlasBatchEntry entry)
-    {
-        return new AtlasEntrySize(
-            entry.Tile.Image.Width + (tilePaddingPixels * 2),
-            entry.Tile.Image.Height + (tilePaddingPixels * 2));
-    }
-
-    private static bool TryChooseFreeRectangle(
-        IReadOnlyList<Rect> freeRectangles,
-        int requiredWidth,
-        int requiredHeight,
-        out Rect selectedRect)
-    {
-        selectedRect = default;
-        bool found = false;
-        int bestAreaFit = int.MaxValue;
-        int bestShortSideFit = int.MaxValue;
-
-        foreach (Rect freeRect in freeRectangles)
-        {
-            if (requiredWidth > freeRect.Width || requiredHeight > freeRect.Height)
-            {
-                continue;
-            }
-
-            int areaFit = (freeRect.Width * freeRect.Height) - (requiredWidth * requiredHeight);
-            int shortSideFit = Math.Min(freeRect.Width - requiredWidth, freeRect.Height - requiredHeight);
-            if (areaFit < bestAreaFit
-                || (areaFit == bestAreaFit && shortSideFit < bestShortSideFit)
-                || (areaFit == bestAreaFit && shortSideFit == bestShortSideFit
-                    && (freeRect.Y < selectedRect.Y
-                        || (freeRect.Y == selectedRect.Y && freeRect.X < selectedRect.X))))
-            {
-                selectedRect = freeRect;
-                bestAreaFit = areaFit;
-                bestShortSideFit = shortSideFit;
-                found = true;
-            }
-        }
-
-        return found;
-    }
-
-    private static void SplitFreeRectangles(List<Rect> freeRectangles, Rect usedRect)
-    {
-        for (int index = freeRectangles.Count - 1; index >= 0; index--)
-        {
-            Rect freeRect = freeRectangles[index];
-            if (!Intersects(freeRect, usedRect))
-            {
-                continue;
-            }
-
-            freeRectangles.RemoveAt(index);
-
-            if (usedRect.X > freeRect.X)
-            {
-                freeRectangles.Add(new Rect(
-                    freeRect.X,
-                    freeRect.Y,
-                    usedRect.X - freeRect.X,
-                    freeRect.Height));
-            }
-
-            if (usedRect.X + usedRect.Width < freeRect.X + freeRect.Width)
-            {
-                freeRectangles.Add(new Rect(
-                    usedRect.X + usedRect.Width,
-                    freeRect.Y,
-                    (freeRect.X + freeRect.Width) - (usedRect.X + usedRect.Width),
-                    freeRect.Height));
-            }
-
-            if (usedRect.Y > freeRect.Y)
-            {
-                freeRectangles.Add(new Rect(
-                    freeRect.X,
-                    freeRect.Y,
-                    freeRect.Width,
-                    usedRect.Y - freeRect.Y));
-            }
-
-            if (usedRect.Y + usedRect.Height < freeRect.Y + freeRect.Height)
-            {
-                freeRectangles.Add(new Rect(
-                    freeRect.X,
-                    usedRect.Y + usedRect.Height,
-                    freeRect.Width,
-                    (freeRect.Y + freeRect.Height) - (usedRect.Y + usedRect.Height)));
-            }
-        }
-    }
-
-    private static void PruneFreeRectangles(List<Rect> freeRectangles)
-    {
-        for (int leftIndex = freeRectangles.Count - 1; leftIndex >= 0; leftIndex--)
-        {
-            Rect left = freeRectangles[leftIndex];
-            for (int rightIndex = freeRectangles.Count - 1; rightIndex >= 0; rightIndex--)
-            {
-                if (leftIndex == rightIndex)
-                {
-                    continue;
-                }
-
-                Rect right = freeRectangles[rightIndex];
-                if (Contains(right, left))
-                {
-                    freeRectangles.RemoveAt(leftIndex);
-                    break;
-                }
-            }
-        }
-    }
-
-    private static bool Intersects(Rect left, Rect right)
-    {
-        return left.X < right.X + right.Width
-            && left.X + left.Width > right.X
-            && left.Y < right.Y + right.Height
-            && left.Y + left.Height > right.Y;
-    }
-
-    private static bool Contains(Rect outer, Rect inner)
-    {
-        return inner.X >= outer.X
-            && inner.Y >= outer.Y
-            && inner.X + inner.Width <= outer.X + outer.Width
-            && inner.Y + inner.Height <= outer.Y + outer.Height;
+        NonDemAtlasLayoutPacker packer = new(EffectiveMaxAtlasSize, tilePaddingPixels);
+        return packer.TryCreate(
+            entries,
+            static entry => new NonDemAtlasTileSize(entry.Tile.Image.Width, entry.Tile.Image.Height),
+            out layout);
     }
 
     private static void ApplyBaseColor(Image<Rgba32> image, ResoniteColor color)
@@ -1404,13 +1164,13 @@ internal sealed class NonDemCityObjectBaker(
         return (byte)Math.Clamp(Math.Round(blended), 0.0, 255.0);
     }
 
-    private static Rgba32 ComputeAtlasBackgroundColor(IReadOnlyList<AtlasPlacement> placements)
+    private static Rgba32 ComputeAtlasBackgroundColor(IReadOnlyList<NonDemAtlasPlacement<AtlasBatchEntry>> placements)
     {
         long sumR = 0;
         long sumG = 0;
         long sumB = 0;
         long totalWeight = 0;
-        foreach (AtlasPlacement placement in placements)
+        foreach (NonDemAtlasPlacement<AtlasBatchEntry> placement in placements)
         {
             long weight = Math.Max(1, placement.Entry.Tile.Image.Width * placement.Entry.Tile.Image.Height);
             sumR += placement.Entry.Tile.BackgroundColor.R * weight;
@@ -1669,44 +1429,6 @@ internal sealed class NonDemCityObjectBaker(
     private sealed record AtlasBatchPlan(
         IReadOnlyList<IReadOnlyList<CityObjectBakeCandidate>> Batches,
         IReadOnlyList<CityObjectBakeCandidate> FallbackCandidates);
-
-    private sealed record AtlasLayout(
-        int Width,
-        int Height,
-        IReadOnlyList<AtlasPlacement> Placements);
-
-    private readonly record struct AtlasSizeRequirements(
-        int MinWidth,
-        int MinHeight,
-        long RequiredArea)
-    {
-        internal static AtlasSizeRequirements Invalid => new(0, 0, 0);
-
-        internal bool IsValid => MinWidth > 0 && MinHeight > 0;
-    }
-
-    private readonly record struct AtlasCanvasCandidate(
-        int Width,
-        int Height,
-        AtlasSizeRequirements Requirements)
-    {
-        internal long Area => (long)Width * Height;
-
-        internal long AreaSlack => Area - Requirements.RequiredArea;
-
-        internal int DimensionSlack => (Width - Requirements.MinWidth) + (Height - Requirements.MinHeight);
-    }
-
-    private readonly record struct AtlasEntrySize(
-        int PaddedWidth,
-        int PaddedHeight);
-
-    private sealed record AtlasPlacement(
-        AtlasBatchEntry Entry,
-        Rect OuterRect,
-        Rect InnerRect);
-
-    private readonly record struct Rect(int X, int Y, int Width, int Height);
 
     private readonly record struct SourceFileBatchKey(
         string ActualMeshCode,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -23,8 +23,6 @@ internal sealed class NonDemCityObjectBaker(
 {
     internal const int DefaultMaxAtlasSize = 4096;
     internal const int DefaultTilePaddingPixels = 2;
-    private const byte BackgroundDetectionAlphaThreshold = 16;
-
     private readonly Dictionary<SourceFileBatchKey, List<BufferedCityObject>> bufferedCityObjectsBySourceFile = [];
     private readonly Dictionary<SourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
     private readonly IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies = bakePolicies
@@ -350,27 +348,34 @@ internal sealed class NonDemCityObjectBaker(
         using Image<Rgba32> sourceImage = await textureImageLoader.LoadAsync(
             ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
             cancellationToken);
-        Rgba32 detectedBackgroundColor = DetectRepresentativeBackgroundColor(sourceImage);
+        Rgba32 detectedBackgroundColor = NonDemTextureImageProcessing.DetectRepresentativeBackgroundColor(sourceImage);
         using Image<Rgba32> preparedSourceImage = sourceImage.Clone();
-        FillTransparentRgb(preparedSourceImage, detectedBackgroundColor);
-        if (TryGetUniformPixelColor(preparedSourceImage, out Rgba32 uniformDatasetColor))
+        NonDemTextureImageProcessing.FillTransparentRgb(preparedSourceImage, detectedBackgroundColor);
+        if (NonDemTextureImageProcessing.TryGetUniformPixelColor(preparedSourceImage, out Rgba32 uniformDatasetColor))
         {
+            Rgba32 tintedUniformColor = NonDemTextureImageProcessing.MultiplyPixel(
+                uniformDatasetColor,
+                NonDemTextureImageProcessing.ToPixel(material.BaseColor));
             return new AtlasOrPreservedEntry(
                 AtlasEntry: null,
                 PreservedEntry: new PreservedSubmeshEntry(
                     cityObject,
                     submesh,
                     CreateVertexColorMaterial(material, submesh.Index),
-                    ToColor(MultiplyPixel(uniformDatasetColor, ToPixel(material.BaseColor)))));
+                    NonDemTextureImageProcessing.ToColor(tintedUniformColor)));
         }
 
         int maxTileWidth = EffectiveMaxAtlasTextureEdge;
         int maxTileHeight = EffectiveMaxAtlasTextureEdge;
         int targetWidth = Math.Max(1, Math.Min(maxTileWidth, (int)Math.Ceiling(sourceImage.Width * uvBounds.Width)));
         int targetHeight = Math.Max(1, Math.Min(maxTileHeight, (int)Math.Ceiling(sourceImage.Height * uvBounds.Height)));
-        using Image<Rgba32> bakedImage = BakeUsedUvRegion(preparedSourceImage, uvBounds, targetWidth, targetHeight);
+        using Image<Rgba32> bakedImage = NonDemTextureImageProcessing.BakeUsedUvRegion(
+            preparedSourceImage,
+            uvBounds,
+            targetWidth,
+            targetHeight);
 
-        ApplyBaseColor(bakedImage, material.BaseColor);
+        NonDemTextureImageProcessing.ApplyBaseColor(bakedImage, material.BaseColor);
         return new AtlasOrPreservedEntry(
             AtlasEntry: new AtlasBatchEntry(
                 cityObject,
@@ -378,7 +383,9 @@ internal sealed class NonDemCityObjectBaker(
                 material,
                 new MaterialAtlasTile(
                     bakedImage.Clone(),
-                    MultiplyPixel(detectedBackgroundColor, ToPixel(material.BaseColor))),
+                    NonDemTextureImageProcessing.MultiplyPixel(
+                        detectedBackgroundColor,
+                        NonDemTextureImageProcessing.ToPixel(material.BaseColor))),
                 uvBounds),
             PreservedEntry: null);
     }
@@ -710,55 +717,6 @@ internal sealed class NonDemCityObjectBaker(
             out layout);
     }
 
-    private static void ApplyBaseColor(Image<Rgba32> image, ResoniteColor color)
-    {
-        Rgba32 tint = ToPixel(color);
-        for (int y = 0; y < image.Height; y++)
-        {
-            for (int x = 0; x < image.Width; x++)
-            {
-                Rgba32 pixel = image[x, y];
-                image[x, y] = new Rgba32(
-                    MultiplyChannel(pixel.R, tint.R),
-                    MultiplyChannel(pixel.G, tint.G),
-                    MultiplyChannel(pixel.B, tint.B),
-                    MultiplyChannel(pixel.A, tint.A));
-            }
-        }
-    }
-
-    private static byte MultiplyChannel(byte left, byte right)
-    {
-        return (byte)Math.Clamp((left * right + 127) / 255, 0, 255);
-    }
-
-    private static Rgba32 MultiplyPixel(Rgba32 left, Rgba32 right)
-    {
-        return new Rgba32(
-            MultiplyChannel(left.R, right.R),
-            MultiplyChannel(left.G, right.G),
-            MultiplyChannel(left.B, right.B),
-            MultiplyChannel(left.A, right.A));
-    }
-
-    private static Rgba32 ToPixel(ResoniteColor color)
-    {
-        return new Rgba32(
-            (byte)Math.Round(Math.Clamp(color.R, 0.0, 1.0) * 255.0),
-            (byte)Math.Round(Math.Clamp(color.G, 0.0, 1.0) * 255.0),
-            (byte)Math.Round(Math.Clamp(color.B, 0.0, 1.0) * 255.0),
-            (byte)Math.Round(Math.Clamp(color.A, 0.0, 1.0) * 255.0));
-    }
-
-    private static ResoniteColor ToColor(Rgba32 color)
-    {
-        return new ResoniteColor(
-            color.R / 255.0,
-            color.G / 255.0,
-            color.B / 255.0,
-            color.A / 255.0);
-    }
-
     private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)
     {
         return material with
@@ -862,193 +820,6 @@ internal sealed class NonDemCityObjectBaker(
         return new TextureUvRect(minU, minV, width, height);
     }
 
-    private static Image<Rgba32> BakeUsedUvRegion(
-        Image<Rgba32> sourceImage,
-        TextureUvRect uvBounds,
-        int targetWidth,
-        int targetHeight)
-    {
-        Image<Rgba32> bakedImage = new(targetWidth, targetHeight);
-        for (int y = 0; y < targetHeight; y++)
-        {
-            double normalizedV = 1.0 - ((y + 0.5) / targetHeight);
-            for (int x = 0; x < targetWidth; x++)
-            {
-                double normalizedU = (x + 0.5) / targetWidth;
-                ScalarPair sourceUv = uvBounds.DenormalizeValue(normalizedU, normalizedV);
-                bakedImage[x, y] = SampleWrappedPixelBilinear(sourceImage, sourceUv.X, sourceUv.Y);
-            }
-        }
-
-        return bakedImage;
-    }
-
-    private static Rgba32 DetectRepresentativeBackgroundColor(Image<Rgba32> image)
-    {
-        if (TryAverageBoundaryOpaquePixels(image, out Rgba32 boundaryAverage))
-        {
-            return boundaryAverage;
-        }
-
-        if (TryAverageOpaquePixels(image, out Rgba32 opaqueAverage))
-        {
-            return opaqueAverage;
-        }
-
-        if (TryAverageAllPixels(image, out Rgba32 allPixelAverage))
-        {
-            return new Rgba32(allPixelAverage.R, allPixelAverage.G, allPixelAverage.B, byte.MaxValue);
-        }
-
-        return new Rgba32(255, 255, 255, 255);
-    }
-
-    private static void FillTransparentRgb(Image<Rgba32> image, Rgba32 backgroundColor)
-    {
-        for (int y = 0; y < image.Height; y++)
-        {
-            for (int x = 0; x < image.Width; x++)
-            {
-                Rgba32 pixel = image[x, y];
-                if (pixel.A == byte.MaxValue)
-                {
-                    continue;
-                }
-
-                double alpha = pixel.A / 255.0;
-                image[x, y] = new Rgba32(
-                    BlendBackgroundChannel(pixel.R, backgroundColor.R, alpha),
-                    BlendBackgroundChannel(pixel.G, backgroundColor.G, alpha),
-                    BlendBackgroundChannel(pixel.B, backgroundColor.B, alpha),
-                    pixel.A);
-            }
-        }
-    }
-
-    private static bool TryGetUniformPixelColor(Image<Rgba32> image, out Rgba32 color)
-    {
-        color = default;
-        if (image.Width <= 0 || image.Height <= 0)
-        {
-            return false;
-        }
-
-        Rgba32 firstPixel = image[0, 0];
-        for (int y = 0; y < image.Height; y++)
-        {
-            for (int x = 0; x < image.Width; x++)
-            {
-                if (!image[x, y].Equals(firstPixel))
-                {
-                    return false;
-                }
-            }
-        }
-
-        color = firstPixel;
-        return true;
-    }
-
-    private static bool TryAverageBoundaryOpaquePixels(Image<Rgba32> image, out Rgba32 color)
-    {
-        long sumR = 0;
-        long sumG = 0;
-        long sumB = 0;
-        long count = 0;
-        for (int y = 0; y < image.Height; y++)
-        {
-            for (int x = 0; x < image.Width; x++)
-            {
-                Rgba32 pixel = image[x, y];
-                if (pixel.A <= BackgroundDetectionAlphaThreshold || !TouchesTransparentNeighbor(image, x, y))
-                {
-                    continue;
-                }
-
-                sumR += pixel.R;
-                sumG += pixel.G;
-                sumB += pixel.B;
-                count++;
-            }
-        }
-
-        color = count == 0
-            ? default
-            : new Rgba32(
-                (byte)Math.Clamp(Math.Round(sumR / (double)count), 0.0, 255.0),
-                (byte)Math.Clamp(Math.Round(sumG / (double)count), 0.0, 255.0),
-                (byte)Math.Clamp(Math.Round(sumB / (double)count), 0.0, 255.0),
-                byte.MaxValue);
-        return count > 0;
-    }
-
-    private static bool TouchesTransparentNeighbor(Image<Rgba32> image, int x, int y)
-    {
-        return IsTransparentOrOutOfBounds(image, x - 1, y)
-            || IsTransparentOrOutOfBounds(image, x + 1, y)
-            || IsTransparentOrOutOfBounds(image, x, y - 1)
-            || IsTransparentOrOutOfBounds(image, x, y + 1);
-    }
-
-    private static bool IsTransparentOrOutOfBounds(Image<Rgba32> image, int x, int y)
-    {
-        if (x < 0 || y < 0 || x >= image.Width || y >= image.Height)
-        {
-            return true;
-        }
-
-        return image[x, y].A <= BackgroundDetectionAlphaThreshold;
-    }
-
-    private static bool TryAverageOpaquePixels(Image<Rgba32> image, out Rgba32 color)
-    {
-        return TryAveragePixels(image, static pixel => pixel.A > BackgroundDetectionAlphaThreshold, out color);
-    }
-
-    private static bool TryAverageAllPixels(Image<Rgba32> image, out Rgba32 color)
-    {
-        return TryAveragePixels(image, static _ => true, out color);
-    }
-
-    private static bool TryAveragePixels(Image<Rgba32> image, Func<Rgba32, bool> predicate, out Rgba32 color)
-    {
-        long sumR = 0;
-        long sumG = 0;
-        long sumB = 0;
-        long count = 0;
-        for (int y = 0; y < image.Height; y++)
-        {
-            for (int x = 0; x < image.Width; x++)
-            {
-                Rgba32 pixel = image[x, y];
-                if (!predicate(pixel))
-                {
-                    continue;
-                }
-
-                sumR += pixel.R;
-                sumG += pixel.G;
-                sumB += pixel.B;
-                count++;
-            }
-        }
-
-        color = count == 0
-            ? default
-            : new Rgba32(
-                (byte)Math.Clamp(Math.Round(sumR / (double)count), 0.0, 255.0),
-                (byte)Math.Clamp(Math.Round(sumG / (double)count), 0.0, 255.0),
-                (byte)Math.Clamp(Math.Round(sumB / (double)count), 0.0, 255.0),
-                byte.MaxValue);
-        return count > 0;
-    }
-
-    private static byte BlendBackgroundChannel(byte foreground, byte background, double alpha)
-    {
-        double blended = (foreground * alpha) + (background * (1.0 - alpha));
-        return (byte)Math.Clamp(Math.Round(blended), 0.0, 255.0);
-    }
-
     private static Rgba32 ComputeAtlasBackgroundColor(IReadOnlyList<NonDemAtlasPlacement<AtlasBatchEntry>> placements)
     {
         long sumR = 0;
@@ -1097,67 +868,6 @@ internal sealed class NonDemCityObjectBaker(
     {
         atlasImage[x, y] = pixel;
         atlasCoverage[(y * atlasWidth) + x] = true;
-    }
-
-    private static Rgba32 SampleWrappedPixelBilinear(Image<Rgba32> sourceImage, double u, double v)
-    {
-        double wrappedU = WrapUvCoordinate(u);
-        double wrappedV = WrapUvCoordinate(v);
-        double sourceX = (wrappedU * sourceImage.Width) - 0.5;
-        double sourceY = ((1.0 - wrappedV) * sourceImage.Height) - 0.5;
-        int x0 = (int)Math.Floor(sourceX);
-        int y0 = (int)Math.Floor(sourceY);
-        int x1 = x0 + 1;
-        int y1 = y0 + 1;
-        double tx = sourceX - x0;
-        double ty = sourceY - y0;
-
-        Rgba32 topLeft = sourceImage[WrapPixelCoordinate(x0, sourceImage.Width), WrapPixelCoordinate(y0, sourceImage.Height)];
-        Rgba32 topRight = sourceImage[WrapPixelCoordinate(x1, sourceImage.Width), WrapPixelCoordinate(y0, sourceImage.Height)];
-        Rgba32 bottomLeft = sourceImage[WrapPixelCoordinate(x0, sourceImage.Width), WrapPixelCoordinate(y1, sourceImage.Height)];
-        Rgba32 bottomRight = sourceImage[WrapPixelCoordinate(x1, sourceImage.Width), WrapPixelCoordinate(y1, sourceImage.Height)];
-        return LerpPixels(topLeft, topRight, bottomLeft, bottomRight, tx, ty);
-    }
-
-    private static double WrapUvCoordinate(double value)
-    {
-        double wrapped = value - Math.Floor(value);
-        return wrapped >= 1.0 ? 0.0 : wrapped;
-    }
-
-    private static int WrapPixelCoordinate(int value, int length)
-    {
-        int wrapped = value % length;
-        return wrapped < 0 ? wrapped + length : wrapped;
-    }
-
-    private static Rgba32 LerpPixels(
-        Rgba32 topLeft,
-        Rgba32 topRight,
-        Rgba32 bottomLeft,
-        Rgba32 bottomRight,
-        double tx,
-        double ty)
-    {
-        return new Rgba32(
-            LerpChannel(topLeft.R, topRight.R, bottomLeft.R, bottomRight.R, tx, ty),
-            LerpChannel(topLeft.G, topRight.G, bottomLeft.G, bottomRight.G, tx, ty),
-            LerpChannel(topLeft.B, topRight.B, bottomLeft.B, bottomRight.B, tx, ty),
-            LerpChannel(topLeft.A, topRight.A, bottomLeft.A, bottomRight.A, tx, ty));
-    }
-
-    private static byte LerpChannel(
-        byte topLeft,
-        byte topRight,
-        byte bottomLeft,
-        byte bottomRight,
-        double tx,
-        double ty)
-    {
-        double top = topLeft + ((topRight - topLeft) * tx);
-        double bottom = bottomLeft + ((bottomRight - bottomLeft) * tx);
-        double value = top + ((bottom - top) * ty);
-        return (byte)Math.Clamp(Math.Round(value), 0.0, 255.0);
     }
 
     private async Task EmitAtlasBatchAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -407,21 +407,10 @@ internal sealed class NonDemCityObjectBaker(
         using Image<Rgba32>? atlasImage = layout is null
             ? null
             : new Image<Rgba32>(layout.Width, layout.Height, new Rgba32(0, 0, 0, 0));
-        bool[]? atlasCoverage = layout is null
-            ? null
-            : new bool[layout.Width * layout.Height];
         if (layout is not null)
         {
-            foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in layout.Placements)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                DrawAtlasTile(atlasImage!, atlasCoverage!, layout.Width, placement);
-            }
-
-            FillUncoveredAtlasPixels(
-                atlasImage!,
-                atlasCoverage!,
-                ComputeAtlasBackgroundColor(layout.Placements));
+            cancellationToken.ThrowIfCancellationRequested();
+            new NonDemAtlasImageRenderer(tilePaddingPixels).Draw(atlasImage!, layout.Placements);
         }
 
         ResoniteConstructionCityObject firstCityObject = candidates[0].CityObject;
@@ -601,73 +590,6 @@ internal sealed class NonDemCityObjectBaker(
             : new ResoniteFloat3(minX, minY, minZ);
     }
 
-    private void DrawAtlasTile(Image<Rgba32> atlasImage, bool[] atlasCoverage, int atlasWidth, NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement)
-    {
-        for (int y = 0; y < placement.Entry.Tile.Image.Height; y++)
-        {
-            for (int x = 0; x < placement.Entry.Tile.Image.Width; x++)
-            {
-                SetAtlasPixel(
-                    atlasImage,
-                    atlasCoverage,
-                    atlasWidth,
-                    placement.InnerRect.X + x,
-                    placement.InnerRect.Y + y,
-                    placement.Entry.Tile.Image[x, y]);
-            }
-        }
-
-        for (int y = 0; y < placement.Entry.Tile.Image.Height; y++)
-        {
-            Rgba32 leftEdge = atlasImage[placement.InnerRect.X, placement.InnerRect.Y + y];
-            Rgba32 rightEdge = atlasImage[placement.InnerRect.X + placement.InnerRect.Width - 1, placement.InnerRect.Y + y];
-            for (int pad = 1; pad <= tilePaddingPixels; pad++)
-            {
-                SetAtlasPixel(
-                    atlasImage,
-                    atlasCoverage,
-                    atlasWidth,
-                    placement.InnerRect.X - pad,
-                    placement.InnerRect.Y + y,
-                    leftEdge);
-                SetAtlasPixel(
-                    atlasImage,
-                    atlasCoverage,
-                    atlasWidth,
-                    placement.InnerRect.X + placement.InnerRect.Width - 1 + pad,
-                    placement.InnerRect.Y + y,
-                    rightEdge);
-            }
-        }
-
-        int fullWidth = placement.InnerRect.Width + (tilePaddingPixels * 2);
-        for (int pad = 1; pad <= tilePaddingPixels; pad++)
-        {
-            int sourceTopY = placement.InnerRect.Y;
-            int sourceBottomY = placement.InnerRect.Y + placement.InnerRect.Height - 1;
-            int targetTopY = placement.InnerRect.Y - pad;
-            int targetBottomY = placement.InnerRect.Y + placement.InnerRect.Height - 1 + pad;
-            for (int x = 0; x < fullWidth; x++)
-            {
-                int sampleX = placement.InnerRect.X - tilePaddingPixels + x;
-                SetAtlasPixel(
-                    atlasImage,
-                    atlasCoverage,
-                    atlasWidth,
-                    sampleX,
-                    targetTopY,
-                    atlasImage[sampleX, sourceTopY]);
-                SetAtlasPixel(
-                    atlasImage,
-                    atlasCoverage,
-                    atlasWidth,
-                    sampleX,
-                    targetBottomY,
-                    atlasImage[sampleX, sourceBottomY]);
-            }
-        }
-    }
-
     private NonDemAtlasLayoutFactory CreateAtlasLayoutFactory()
     {
         return new NonDemAtlasLayoutFactory(EffectiveMaxAtlasSize, tilePaddingPixels);
@@ -730,56 +652,6 @@ internal sealed class NonDemCityObjectBaker(
         double width = Math.Max(1.0 / 1024.0, maxU - minU);
         double height = Math.Max(1.0 / 1024.0, maxV - minV);
         return new TextureUvRect(minU, minV, width, height);
-    }
-
-    private static Rgba32 ComputeAtlasBackgroundColor(IReadOnlyList<NonDemAtlasPlacement<NonDemAtlasBatchEntry>> placements)
-    {
-        long sumR = 0;
-        long sumG = 0;
-        long sumB = 0;
-        long totalWeight = 0;
-        foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in placements)
-        {
-            long weight = Math.Max(1, placement.Entry.Tile.Image.Width * placement.Entry.Tile.Image.Height);
-            sumR += placement.Entry.Tile.BackgroundColor.R * weight;
-            sumG += placement.Entry.Tile.BackgroundColor.G * weight;
-            sumB += placement.Entry.Tile.BackgroundColor.B * weight;
-            totalWeight += weight;
-        }
-
-        if (totalWeight == 0)
-        {
-            return new Rgba32(255, 255, 255, 255);
-        }
-
-        return new Rgba32(
-            (byte)Math.Clamp(Math.Round(sumR / (double)totalWeight), 0.0, 255.0),
-            (byte)Math.Clamp(Math.Round(sumG / (double)totalWeight), 0.0, 255.0),
-            (byte)Math.Clamp(Math.Round(sumB / (double)totalWeight), 0.0, 255.0),
-            byte.MaxValue);
-    }
-
-    private static void FillUncoveredAtlasPixels(Image<Rgba32> atlasImage, bool[] atlasCoverage, Rgba32 backgroundColor)
-    {
-        for (int y = 0; y < atlasImage.Height; y++)
-        {
-            for (int x = 0; x < atlasImage.Width; x++)
-            {
-                int offset = (y * atlasImage.Width) + x;
-                if (atlasCoverage[offset])
-                {
-                    continue;
-                }
-
-                atlasImage[x, y] = backgroundColor;
-            }
-        }
-    }
-
-    private static void SetAtlasPixel(Image<Rgba32> atlasImage, bool[] atlasCoverage, int atlasWidth, int x, int y, Rgba32 pixel)
-    {
-        atlasImage[x, y] = pixel;
-        atlasCoverage[(y * atlasWidth) + x] = true;
     }
 
     private async Task EmitAtlasBatchAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -7,13 +7,13 @@ using System.Threading.Tasks;
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemCityObjectBaker(
-    IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies,
+    INonDemCityObjectBakePolicyResolver bakePolicyResolver,
     INonDemSourceFileBakeEmitter sourceFileBakeEmitter) : IResoniteBufferedCityObjectBaker
 {
     private readonly Dictionary<NonDemSourceFileBatchKey, List<NonDemBufferedCityObject>> bufferedCityObjectsBySourceFile = [];
     private readonly Dictionary<NonDemSourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
-    private readonly IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies = bakePolicies
-        ?? throw new ArgumentNullException(nameof(bakePolicies));
+    private readonly INonDemCityObjectBakePolicyResolver bakePolicyResolver = bakePolicyResolver
+        ?? throw new ArgumentNullException(nameof(bakePolicyResolver));
     private readonly INonDemSourceFileBakeEmitter sourceFileBakeEmitter = sourceFileBakeEmitter
         ?? throw new ArgumentNullException(nameof(sourceFileBakeEmitter));
 
@@ -30,7 +30,7 @@ internal sealed class NonDemCityObjectBaker(
         ArgumentNullException.ThrowIfNull(cityObject);
         cancellationToken.ThrowIfCancellationRequested();
 
-        NonDemCityObjectBakePolicy? policy = ResolvePolicy(cityObject);
+        NonDemCityObjectBakePolicy? policy = bakePolicyResolver.Resolve(cityObject);
         if (policy is null)
         {
             return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: false, []));
@@ -105,19 +105,5 @@ internal sealed class NonDemCityObjectBaker(
         BakedOutputCityObjectCount += emittedCount;
         nextBatchIndexBySourceFile[sourceFileKey] = batchStartIndex + emittedCount;
         cityObjects.Clear();
-    }
-
-    private NonDemCityObjectBakePolicy? ResolvePolicy(ResoniteConstructionCityObject cityObject)
-    {
-        foreach (NonDemCityObjectBakePolicy policy in bakePolicies)
-        {
-            if (policy.CanBuffer(cityObject)
-                && NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(cityObject, policy))
-            {
-                return policy;
-            }
-        }
-
-        return null;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -21,7 +21,7 @@ internal sealed class NonDemCityObjectBaker(
 {
     internal const int DefaultMaxAtlasSize = 4096;
     internal const int DefaultTilePaddingPixels = 2;
-    private readonly Dictionary<NonDemSourceFileBatchKey, List<BufferedCityObject>> bufferedCityObjectsBySourceFile = [];
+    private readonly Dictionary<NonDemSourceFileBatchKey, List<NonDemBufferedCityObject>> bufferedCityObjectsBySourceFile = [];
     private readonly Dictionary<NonDemSourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
     private readonly IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies = bakePolicies
         ?? throw new ArgumentNullException(nameof(bakePolicies));
@@ -59,8 +59,8 @@ internal sealed class NonDemCityObjectBaker(
         cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(cityObject, policy);
         List<ResoniteConstructionCityObject> readyCityObjects = [];
-        BufferedCityObject bufferedCityObject = new(cityObject, policy);
-        if (!bufferedCityObjectsBySourceFile.TryGetValue(sourceFileKey, out List<BufferedCityObject>? bufferedCityObjects))
+        NonDemBufferedCityObject bufferedCityObject = new(cityObject, policy);
+        if (!bufferedCityObjectsBySourceFile.TryGetValue(sourceFileKey, out List<NonDemBufferedCityObject>? bufferedCityObjects))
         {
             bufferedCityObjects = [];
             bufferedCityObjectsBySourceFile.Add(sourceFileKey, bufferedCityObjects);
@@ -109,7 +109,7 @@ internal sealed class NonDemCityObjectBaker(
         Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
         CancellationToken cancellationToken)
     {
-        if (!bufferedCityObjectsBySourceFile.Remove(sourceFileKey, out List<BufferedCityObject>? cityObjects))
+        if (!bufferedCityObjectsBySourceFile.Remove(sourceFileKey, out List<NonDemBufferedCityObject>? cityObjects))
         {
             return;
         }
@@ -134,22 +134,22 @@ internal sealed class NonDemCityObjectBaker(
 
     private async Task BakeSourceFileAsync(
         NonDemSourceFileBatchKey sourceFileKey,
-        IReadOnlyList<BufferedCityObject> cityObjects,
+        List<NonDemBufferedCityObject> cityObjects,
         int batchStartIndex,
         Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
         CancellationToken cancellationToken)
     {
-        List<CityObjectBakeCandidate> passThroughCandidates = [];
-        List<CityObjectBakeCandidate> currentAtlasBatch = [];
+        List<NonDemCityObjectBakeCandidate> passThroughCandidates = [];
+        List<NonDemCityObjectBakeCandidate> currentAtlasBatch = [];
         int batchIndex = batchStartIndex;
         bool preservePrimaryIdentity = cityObjects.Count == 1;
 
-        foreach (BufferedCityObject bufferedCityObject in cityObjects.OrderBy(
+        foreach (NonDemBufferedCityObject bufferedCityObject in cityObjects.OrderBy(
                      static bufferedCityObject => bufferedCityObject.CityObject.SlotKey,
                      StringComparer.Ordinal))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            CityObjectBakeCandidate? candidate = await CreateCandidateAsync(bufferedCityObject, cancellationToken);
+            NonDemCityObjectBakeCandidate? candidate = await CreateCandidateAsync(bufferedCityObject, cancellationToken);
             if (candidate is null)
             {
                 continue;
@@ -214,7 +214,7 @@ internal sealed class NonDemCityObjectBaker(
 
         if (passThroughCandidates.Count == 1)
         {
-            CityObjectBakeCandidate passThroughCandidate = passThroughCandidates[0];
+            NonDemCityObjectBakeCandidate passThroughCandidate = passThroughCandidates[0];
             BakedOutputCityObjectCount++;
             await onBakedCityObject(passThroughCandidate.CityObject, cancellationToken);
             DisposeCandidateImages(passThroughCandidate);
@@ -253,8 +253,8 @@ internal sealed class NonDemCityObjectBaker(
         return null;
     }
 
-    private async Task<CityObjectBakeCandidate?> CreateCandidateAsync(
-        BufferedCityObject bufferedCityObject,
+    private async Task<NonDemCityObjectBakeCandidate?> CreateCandidateAsync(
+        NonDemBufferedCityObject bufferedCityObject,
         CancellationToken cancellationToken)
     {
         ResoniteConstructionCityObject cityObject = bufferedCityObject.CityObject;
@@ -272,8 +272,8 @@ internal sealed class NonDemCityObjectBaker(
                 $"Non-DEM bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
         }
 
-        List<AtlasBatchEntry> atlasEntries = [];
-        List<PreservedSubmeshEntry> preservedEntries = [];
+        List<NonDemAtlasBatchEntry> atlasEntries = [];
+        List<NonDemPreservedSubmeshEntry> preservedEntries = [];
         bool hadAtlasCandidateMaterial = false;
         foreach (ResoniteMeshSubmesh submesh in normalizedCityObject.Mesh.Submeshes.OrderBy(static candidate => candidate.Index))
         {
@@ -289,7 +289,7 @@ internal sealed class NonDemCityObjectBaker(
             {
                 case NonDemMaterialBakeCategory.AtlasCandidate:
                     hadAtlasCandidateMaterial = true;
-                    AtlasOrPreservedEntry bakeEntry = await CreateAtlasOrPreservedEntryAsync(
+                    NonDemAtlasOrPreservedEntry bakeEntry = await CreateAtlasOrPreservedEntryAsync(
                         normalizedCityObject,
                         submesh,
                         material,
@@ -311,14 +311,14 @@ internal sealed class NonDemCityObjectBaker(
                 case NonDemMaterialBakeCategory.PreservedOther:
                     ResoniteMeshSubmesh normalizedSubmesh = normalizedCityObject.Mesh.Submeshes.Single(candidate => candidate.Index == submesh.Index);
                     ResoniteMaterialBinding normalizedMaterial = normalizedCityObject.Materials.Single(candidate => candidate.SubmeshIndices.Contains(submesh.Index));
-                    preservedEntries.Add(new PreservedSubmeshEntry(normalizedCityObject, normalizedSubmesh, normalizedMaterial));
+                    preservedEntries.Add(new NonDemPreservedSubmeshEntry(normalizedCityObject, normalizedSubmesh, normalizedMaterial));
                     break;
             }
         }
 
         if (policy.RequireAtlasCandidateMaterial && !hadAtlasCandidateMaterial)
         {
-            DisposeCandidateImages(new CityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries));
+            DisposeCandidateImages(new NonDemCityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries));
             return null;
         }
 
@@ -328,10 +328,10 @@ internal sealed class NonDemCityObjectBaker(
                 $"Non-DEM bake city object '{cityObject.DisplayName}' produced no atlas or preserved submesh candidate.");
         }
 
-        return new CityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries);
+        return new NonDemCityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries);
     }
 
-    private async Task<AtlasOrPreservedEntry> CreateAtlasOrPreservedEntryAsync(
+    private async Task<NonDemAtlasOrPreservedEntry> CreateAtlasOrPreservedEntryAsync(
         ResoniteConstructionCityObject cityObject,
         ResoniteMeshSubmesh submesh,
         ResoniteMaterialBinding material,
@@ -354,9 +354,9 @@ internal sealed class NonDemCityObjectBaker(
             Rgba32 tintedUniformColor = NonDemTextureImageProcessing.MultiplyPixel(
                 uniformDatasetColor,
                 NonDemTextureImageProcessing.ToPixel(material.BaseColor));
-            return new AtlasOrPreservedEntry(
+            return new NonDemAtlasOrPreservedEntry(
                 AtlasEntry: null,
-                PreservedEntry: new PreservedSubmeshEntry(
+                PreservedEntry: new NonDemPreservedSubmeshEntry(
                     cityObject,
                     submesh,
                     CreateVertexColorMaterial(material, submesh.Index),
@@ -374,12 +374,12 @@ internal sealed class NonDemCityObjectBaker(
             targetHeight);
 
         NonDemTextureImageProcessing.ApplyBaseColor(bakedImage, material.BaseColor);
-        return new AtlasOrPreservedEntry(
-            AtlasEntry: new AtlasBatchEntry(
+        return new NonDemAtlasOrPreservedEntry(
+            AtlasEntry: new NonDemAtlasBatchEntry(
                 cityObject,
                 submesh,
                 material,
-                new MaterialAtlasTile(
+                new NonDemMaterialAtlasTile(
                     bakedImage.Clone(),
                     NonDemTextureImageProcessing.MultiplyPixel(
                         detectedBackgroundColor,
@@ -388,54 +388,18 @@ internal sealed class NonDemCityObjectBaker(
             PreservedEntry: null);
     }
 
-    private AtlasBatchPlan CreateAtlasCandidateBatches(
-        IReadOnlyList<CityObjectBakeCandidate> candidates)
-    {
-        List<IReadOnlyList<CityObjectBakeCandidate>> batches = [];
-        List<CityObjectBakeCandidate> fallbackCandidates = [];
-        List<CityObjectBakeCandidate> pending = candidates
-            .OrderByDescending(static candidate => candidate.AtlasEntries.Sum(entry => entry.Tile.Image.Width * entry.Tile.Image.Height))
-            .ThenBy(static candidate => candidate.CityObject.SlotKey, StringComparer.Ordinal)
-            .ToList();
-
-        while (pending.Count > 0)
-        {
-            List<CityObjectBakeCandidate> currentBatch = [];
-            foreach (CityObjectBakeCandidate candidate in pending.ToArray())
-            {
-                List<AtlasBatchEntry> candidateEntries = [.. currentBatch.SelectMany(static current => current.AtlasEntries), .. candidate.AtlasEntries];
-                if (TryCreateAtlasLayout(candidateEntries, out _))
-                {
-                    currentBatch.Add(candidate);
-                    pending.Remove(candidate);
-                }
-            }
-
-            if (currentBatch.Count == 0)
-            {
-                CityObjectBakeCandidate oversizedCandidate = pending[0];
-                pending.RemoveAt(0);
-                fallbackCandidates.Add(oversizedCandidate);
-                continue;
-            }
-
-            batches.Add(currentBatch);
-        }
-
-        return new AtlasBatchPlan(batches, fallbackCandidates);
-    }
-
     private async Task<ResoniteConstructionCityObject> BakeBatchAsync(
         NonDemSourceFileBatchKey sourceFileKey,
-        IReadOnlyList<CityObjectBakeCandidate> candidates,
+        IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
         int batchIndex,
         bool preservePrimaryIdentity,
         CancellationToken cancellationToken)
     {
-        List<AtlasBatchEntry> entries = candidates.SelectMany(static candidate => candidate.AtlasEntries).ToList();
-        NonDemAtlasLayout<AtlasBatchEntry>? layout = null;
+        List<NonDemAtlasBatchEntry> entries = candidates.SelectMany(static candidate => candidate.AtlasEntries).ToList();
+        NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout = null;
+        NonDemAtlasLayoutFactory atlasLayoutFactory = CreateAtlasLayoutFactory();
         if (entries.Count > 0
-            && (!TryCreateAtlasLayout(entries, out layout) || layout is null))
+            && (!atlasLayoutFactory.TryCreate(entries, out layout) || layout is null))
         {
             throw new InvalidOperationException("Failed to create non-DEM atlas layout.");
         }
@@ -448,7 +412,7 @@ internal sealed class NonDemCityObjectBaker(
             : new bool[layout.Width * layout.Height];
         if (layout is not null)
         {
-            foreach (NonDemAtlasPlacement<AtlasBatchEntry> placement in layout.Placements)
+            foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in layout.Placements)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 DrawAtlasTile(atlasImage!, atlasCoverage!, layout.Width, placement);
@@ -480,7 +444,7 @@ internal sealed class NonDemCityObjectBaker(
         {
             string textureIdentity = NonDemSourceFileBatching.CreateAtlasTextureIdentity(sourceFileKey, batchIndex);
             List<int> atlasTriangleIndices = [];
-            foreach (NonDemAtlasPlacement<AtlasBatchEntry> placement in layout.Placements.OrderBy(static candidate => candidate.Entry.CityObject.SlotKey, StringComparer.Ordinal).ThenBy(static candidate => candidate.Entry.Submesh.Index))
+            foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in layout.Placements.OrderBy(static candidate => candidate.Entry.CityObject.SlotKey, StringComparer.Ordinal).ThenBy(static candidate => candidate.Entry.Submesh.Index))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 AppendPlacementGeometry(vertices, atlasTriangleIndices, bakeOrigin, placement, layout.Width, layout.Height);
@@ -499,15 +463,15 @@ internal sealed class NonDemCityObjectBaker(
                     CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv));
         }
 
-        foreach (IGrouping<NonDemPreservedMaterialGroupingKey, OrderedPreservedSubmeshEntry> preservedGroup in candidates
+        foreach (IGrouping<NonDemPreservedMaterialGroupingKey, NonDemOrderedPreservedSubmeshEntry> preservedGroup in candidates
                      .SelectMany(static candidate => candidate.PreservedEntries)
-                     .Select(static (entry, order) => new OrderedPreservedSubmeshEntry(entry, order))
+                     .Select(static (entry, order) => new NonDemOrderedPreservedSubmeshEntry(entry, order))
                      .GroupBy(static entry => NonDemPreservedMaterialGrouping.CreateKey(entry.Entry.Material), NonDemPreservedMaterialGrouping.KeyComparer)
                      .OrderBy(static group => group.Min(static entry => entry.Order)))
         {
             cancellationToken.ThrowIfCancellationRequested();
             List<int> preservedTriangleIndices = [];
-            foreach (PreservedSubmeshEntry preservedEntry in preservedGroup
+            foreach (NonDemPreservedSubmeshEntry preservedEntry in preservedGroup
                          .Select(static entry => entry.Entry)
                          .OrderBy(static entry => entry.CityObject.SlotKey, StringComparer.Ordinal)
                          .ThenBy(static entry => entry.Submesh.Index))
@@ -552,7 +516,7 @@ internal sealed class NonDemCityObjectBaker(
         List<ResoniteMeshVertex> vertices,
         List<int> triangleIndices,
         ResoniteFloat3 bakeOrigin,
-        NonDemAtlasPlacement<AtlasBatchEntry> placement,
+        NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement,
         int atlasWidth,
         int atlasHeight)
     {
@@ -578,7 +542,7 @@ internal sealed class NonDemCityObjectBaker(
         List<ResoniteMeshVertex> vertices,
         List<int> triangleIndices,
         ResoniteFloat3 bakeOrigin,
-        PreservedSubmeshEntry preservedEntry)
+        NonDemPreservedSubmeshEntry preservedEntry)
     {
         IReadOnlyList<ResoniteMeshVertex> sourceVertices = preservedEntry.CityObject.Mesh.Vertices;
         ResoniteFloat3 cityObjectOffset = Subtract(preservedEntry.CityObject.Transform.Position, bakeOrigin);
@@ -615,7 +579,7 @@ internal sealed class NonDemCityObjectBaker(
         return new ResoniteFloat2(remapped.X, remapped.Y);
     }
 
-    private static ResoniteFloat3 ComputeBakeOrigin(IReadOnlyList<CityObjectBakeCandidate> candidates)
+    private static ResoniteFloat3 ComputeBakeOrigin(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
     {
         double minX = double.PositiveInfinity;
         double minY = double.PositiveInfinity;
@@ -637,7 +601,7 @@ internal sealed class NonDemCityObjectBaker(
             : new ResoniteFloat3(minX, minY, minZ);
     }
 
-    private void DrawAtlasTile(Image<Rgba32> atlasImage, bool[] atlasCoverage, int atlasWidth, NonDemAtlasPlacement<AtlasBatchEntry> placement)
+    private void DrawAtlasTile(Image<Rgba32> atlasImage, bool[] atlasCoverage, int atlasWidth, NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement)
     {
         for (int y = 0; y < placement.Entry.Tile.Image.Height; y++)
         {
@@ -704,15 +668,9 @@ internal sealed class NonDemCityObjectBaker(
         }
     }
 
-    private bool TryCreateAtlasLayout(
-        IReadOnlyList<AtlasBatchEntry> entries,
-        out NonDemAtlasLayout<AtlasBatchEntry>? layout)
+    private NonDemAtlasLayoutFactory CreateAtlasLayoutFactory()
     {
-        NonDemAtlasLayoutPacker packer = new(EffectiveMaxAtlasSize, tilePaddingPixels);
-        return packer.TryCreate(
-            entries,
-            static entry => new NonDemAtlasTileSize(entry.Tile.Image.Width, entry.Tile.Image.Height),
-            out layout);
+        return new NonDemAtlasLayoutFactory(EffectiveMaxAtlasSize, tilePaddingPixels);
     }
 
     private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)
@@ -774,13 +732,13 @@ internal sealed class NonDemCityObjectBaker(
         return new TextureUvRect(minU, minV, width, height);
     }
 
-    private static Rgba32 ComputeAtlasBackgroundColor(IReadOnlyList<NonDemAtlasPlacement<AtlasBatchEntry>> placements)
+    private static Rgba32 ComputeAtlasBackgroundColor(IReadOnlyList<NonDemAtlasPlacement<NonDemAtlasBatchEntry>> placements)
     {
         long sumR = 0;
         long sumG = 0;
         long sumB = 0;
         long totalWeight = 0;
-        foreach (NonDemAtlasPlacement<AtlasBatchEntry> placement in placements)
+        foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in placements)
         {
             long weight = Math.Max(1, placement.Entry.Tile.Image.Width * placement.Entry.Tile.Image.Height);
             sumR += placement.Entry.Tile.BackgroundColor.R * weight;
@@ -826,7 +784,7 @@ internal sealed class NonDemCityObjectBaker(
 
     private async Task EmitAtlasBatchAsync(
         NonDemSourceFileBatchKey sourceFileKey,
-        IReadOnlyList<CityObjectBakeCandidate> batchCandidates,
+        IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
         int batchIndex,
         bool preservePrimaryIdentity,
         Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
@@ -850,7 +808,7 @@ internal sealed class NonDemCityObjectBaker(
     }
 
     private async Task EmitFallbackCandidateAsync(
-        CityObjectBakeCandidate fallbackCandidate,
+        NonDemCityObjectBakeCandidate fallbackCandidate,
         Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
         CancellationToken cancellationToken)
     {
@@ -865,25 +823,25 @@ internal sealed class NonDemCityObjectBaker(
         }
     }
 
-    private bool CanFitSingleCandidate(CityObjectBakeCandidate candidate)
+    private bool CanFitSingleCandidate(NonDemCityObjectBakeCandidate candidate)
     {
-        return candidate.AtlasEntries.Count == 0 || TryCreateAtlasLayout(candidate.AtlasEntries, out _);
+        return candidate.AtlasEntries.Count == 0 || CreateAtlasLayoutFactory().CanFit(candidate.AtlasEntries);
     }
 
     private bool CanAppendToAtlasBatch(
-        IReadOnlyList<CityObjectBakeCandidate> batchCandidates,
-        CityObjectBakeCandidate candidate)
+        IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
+        NonDemCityObjectBakeCandidate candidate)
     {
-        List<AtlasBatchEntry> candidateEntries = [.. batchCandidates.SelectMany(static current => current.AtlasEntries), .. candidate.AtlasEntries];
-        return TryCreateAtlasLayout(candidateEntries, out _);
+        List<NonDemAtlasBatchEntry> candidateEntries = [.. batchCandidates.SelectMany(static current => current.AtlasEntries), .. candidate.AtlasEntries];
+        return CreateAtlasLayoutFactory().CanFit(candidateEntries);
     }
 
-    private static void DisposeCandidateImages(CityObjectBakeCandidate candidate)
+    private static void DisposeCandidateImages(NonDemCityObjectBakeCandidate candidate)
     {
         DisposeCandidateImages([candidate]);
     }
 
-    private static void DisposeCandidateImages(IReadOnlyList<CityObjectBakeCandidate> candidates)
+    private static void DisposeCandidateImages(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
     {
         foreach (Image<Rgba32> tileImage in candidates
                      .SelectMany(static candidate => candidate.AtlasEntries)
@@ -894,45 +852,9 @@ internal sealed class NonDemCityObjectBaker(
         }
     }
 
-    private sealed record MaterialAtlasTile(Image<Rgba32> Image, Rgba32 BackgroundColor);
-
-    private sealed record AtlasOrPreservedEntry(
-        AtlasBatchEntry? AtlasEntry,
-        PreservedSubmeshEntry? PreservedEntry);
-
-    private readonly record struct BufferedCityObject(
-        ResoniteConstructionCityObject CityObject,
-        NonDemCityObjectBakePolicy Policy);
-
-    private sealed record AtlasBatchEntry(
-        ResoniteConstructionCityObject CityObject,
-        ResoniteMeshSubmesh Submesh,
-        ResoniteMaterialBinding Material,
-        MaterialAtlasTile Tile,
-        TextureUvRect UvBounds);
-
-    private sealed record PreservedSubmeshEntry(
-        ResoniteConstructionCityObject CityObject,
-        ResoniteMeshSubmesh Submesh,
-        ResoniteMaterialBinding Material,
-        ResoniteColor? VertexColorOverride = null);
-
-    private sealed record OrderedPreservedSubmeshEntry(
-        PreservedSubmeshEntry Entry,
-        int Order);
-
-    private sealed record CityObjectBakeCandidate(
-        ResoniteConstructionCityObject CityObject,
-        IReadOnlyList<AtlasBatchEntry> AtlasEntries,
-        IReadOnlyList<PreservedSubmeshEntry> PreservedEntries);
-
-    private static bool RequiresBakeEmission(CityObjectBakeCandidate candidate)
+    private static bool RequiresBakeEmission(NonDemCityObjectBakeCandidate candidate)
     {
         return candidate.PreservedEntries.Any(static entry => entry.VertexColorOverride is not null);
     }
-
-    private sealed record AtlasBatchPlan(
-        IReadOnlyList<IReadOnlyList<CityObjectBakeCandidate>> Batches,
-        IReadOnlyList<CityObjectBakeCandidate> FallbackCandidates);
 
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -495,10 +494,10 @@ internal sealed class NonDemCityObjectBaker(
                     CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv));
         }
 
-        foreach (IGrouping<PreservedMaterialGroupingKey, OrderedPreservedSubmeshEntry> preservedGroup in candidates
+        foreach (IGrouping<NonDemPreservedMaterialGroupingKey, OrderedPreservedSubmeshEntry> preservedGroup in candidates
                      .SelectMany(static candidate => candidate.PreservedEntries)
                      .Select(static (entry, order) => new OrderedPreservedSubmeshEntry(entry, order))
-                     .GroupBy(static entry => CreatePreservedMaterialGroupingKey(entry.Entry.Material), PreservedMaterialGroupingKeyComparer.Instance)
+                     .GroupBy(static entry => NonDemPreservedMaterialGrouping.CreateKey(entry.Entry.Material), NonDemPreservedMaterialGrouping.KeyComparer)
                      .OrderBy(static group => group.Min(static entry => entry.Order)))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -517,7 +516,7 @@ internal sealed class NonDemCityObjectBaker(
             }
 
             int submeshIndex = submeshes.Count;
-            ResoniteMaterialBinding preservedMaterial = NormalizePreservedMaterial(preservedGroup.First().Entry.Material) with
+            ResoniteMaterialBinding preservedMaterial = NonDemPreservedMaterialGrouping.NormalizeMaterial(preservedGroup.First().Entry.Material) with
             {
                 SubmeshIndices = [submeshIndex],
             };
@@ -1161,50 +1160,6 @@ internal sealed class NonDemCityObjectBaker(
         return (byte)Math.Clamp(Math.Round(value), 0.0, 255.0);
     }
 
-    private static PreservedMaterialGroupingKey CreatePreservedMaterialGroupingKey(ResoniteMaterialBinding material)
-    {
-        ResoniteMaterialBinding normalizedMaterial = NormalizePreservedMaterial(material);
-        if (normalizedMaterial.CommonMaterial is not null)
-        {
-            return new PreservedMaterialGroupingKey(
-                normalizedMaterial.CommonMaterial,
-                new ResoniteColor(0.0, 0.0, 0.0, 0.0),
-                default,
-                normalizedMaterial.TexturePayload,
-                normalizedMaterial.TextureSourceKind,
-                normalizedMaterial.TerrainOverlay,
-                default,
-                default,
-                default,
-                default,
-                default,
-                default,
-                default,
-                normalizedMaterial.TerrainMeshCode);
-        }
-
-        return new PreservedMaterialGroupingKey(
-            null,
-            normalizedMaterial.BaseColor,
-            normalizedMaterial.MaterialType,
-            normalizedMaterial.TexturePayload,
-            normalizedMaterial.TextureSourceKind,
-            normalizedMaterial.TerrainOverlay,
-            normalizedMaterial.Projection,
-            normalizedMaterial.DepthOffset,
-            normalizedMaterial.TextureScale,
-            normalizedMaterial.TextureOffset,
-            normalizedMaterial.AssetScope,
-            normalizedMaterial.Family,
-            normalizedMaterial.BundledVariantIndex,
-            normalizedMaterial.TerrainMeshCode);
-    }
-
-    private static ResoniteMaterialBinding NormalizePreservedMaterial(ResoniteMaterialBinding material)
-    {
-        return ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
-    }
-
     private async Task EmitAtlasBatchAsync(
         SourceFileBatchKey sourceFileKey,
         IReadOnlyList<CityObjectBakeCandidate> batchCandidates,
@@ -1323,22 +1278,6 @@ internal sealed class NonDemCityObjectBaker(
         string PolicyContext,
         string SourceFileRelativePath);
 
-    private readonly record struct PreservedMaterialGroupingKey(
-        DefaultCommonMaterialMember? CommonMaterial,
-        ResoniteColor BaseColor,
-        ResoniteMaterialType MaterialType,
-        ResoniteTexturePayload? TexturePayload,
-        ResoniteTextureSourceKind TextureSourceKind,
-        TerrainTextureOverlay? TerrainOverlay,
-        ResoniteMaterialProjection Projection,
-        ResoniteMaterialDepthOffset? DepthOffset,
-        ResoniteFloat2? TextureScale,
-        ResoniteFloat2? TextureOffset,
-        ResoniteMaterialAssetScope AssetScope,
-        string? Family,
-        int? BundledVariantIndex,
-        string? TerrainMeshCode);
-
     private sealed class SourceFileBatchKeyComparer : IComparer<SourceFileBatchKey>
     {
         internal static readonly SourceFileBatchKeyComparer Instance = new();
@@ -1379,75 +1318,4 @@ internal sealed class NonDemCityObjectBaker(
         }
     }
 
-    private sealed class PreservedMaterialGroupingKeyComparer :
-        IEqualityComparer<PreservedMaterialGroupingKey>
-    {
-        internal static readonly PreservedMaterialGroupingKeyComparer Instance = new();
-
-        public bool Equals(PreservedMaterialGroupingKey x, PreservedMaterialGroupingKey y)
-        {
-            if (!EqualityComparer<DefaultCommonMaterialMember?>.Default.Equals(x.CommonMaterial, y.CommonMaterial))
-            {
-                return false;
-            }
-
-            if (x.CommonMaterial is not null)
-            {
-                return ReferenceEquals(x.TexturePayload, y.TexturePayload)
-                    && x.TextureSourceKind == y.TextureSourceKind
-                    && EqualityComparer<TerrainTextureOverlay?>.Default.Equals(x.TerrainOverlay, y.TerrainOverlay)
-                    && string.Equals(x.TerrainMeshCode, y.TerrainMeshCode, StringComparison.Ordinal);
-            }
-
-            return x.BaseColor == y.BaseColor
-                && x.MaterialType == y.MaterialType
-                && ReferenceEquals(x.TexturePayload, y.TexturePayload)
-                && x.TextureSourceKind == y.TextureSourceKind
-                && EqualityComparer<TerrainTextureOverlay?>.Default.Equals(x.TerrainOverlay, y.TerrainOverlay)
-                && x.Projection == y.Projection
-                && EqualityComparer<ResoniteMaterialDepthOffset?>.Default.Equals(x.DepthOffset, y.DepthOffset)
-                && EqualityComparer<ResoniteFloat2?>.Default.Equals(x.TextureScale, y.TextureScale)
-                && EqualityComparer<ResoniteFloat2?>.Default.Equals(x.TextureOffset, y.TextureOffset)
-                && x.AssetScope == y.AssetScope
-                && string.Equals(x.Family, y.Family, StringComparison.Ordinal)
-                && x.BundledVariantIndex == y.BundledVariantIndex
-                && string.Equals(x.TerrainMeshCode, y.TerrainMeshCode, StringComparison.Ordinal);
-        }
-
-        public int GetHashCode(PreservedMaterialGroupingKey obj)
-        {
-            HashCode hash = new();
-            hash.Add(obj.CommonMaterial);
-            if (obj.CommonMaterial is not null)
-            {
-                if (obj.TexturePayload is not null)
-                {
-                    hash.Add(RuntimeHelpers.GetHashCode(obj.TexturePayload));
-                }
-                hash.Add(obj.TextureSourceKind);
-                hash.Add(obj.TerrainOverlay);
-                hash.Add(obj.TerrainMeshCode, StringComparer.Ordinal);
-                return hash.ToHashCode();
-            }
-
-            hash.Add(obj.BaseColor);
-            hash.Add(obj.MaterialType);
-            if (obj.TexturePayload is not null)
-            {
-                hash.Add(RuntimeHelpers.GetHashCode(obj.TexturePayload));
-            }
-            hash.Add(obj.TextureSourceKind);
-            hash.Add(obj.TerrainOverlay);
-            hash.Add(obj.Projection);
-            hash.Add(obj.DepthOffset);
-            hash.Add(obj.TextureScale);
-            hash.Add(obj.TextureOffset);
-            hash.Add(obj.AssetScope);
-            hash.Add(obj.Family, StringComparer.Ordinal);
-            hash.Add(obj.BundledVariantIndex);
-            hash.Add(obj.TerrainMeshCode, StringComparer.Ordinal);
-            return hash.ToHashCode();
-        }
-
-    }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -7,35 +7,21 @@ using System.Threading.Tasks;
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemCityObjectBaker(
-    ResoniteTextureImageLoader textureImageLoader,
     IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies,
-    int maxAtlasSize = 4096,
-    int tilePaddingPixels = 2,
-    ResoniteImportBudgetProfile? resourceBudget = null) : IResoniteBufferedCityObjectBaker
+    NonDemSourceFileBakeEmitter sourceFileBakeEmitter) : IResoniteBufferedCityObjectBaker
 {
-    internal const int DefaultMaxAtlasSize = 4096;
-    internal const int DefaultTilePaddingPixels = 2;
     private readonly Dictionary<NonDemSourceFileBatchKey, List<NonDemBufferedCityObject>> bufferedCityObjectsBySourceFile = [];
     private readonly Dictionary<NonDemSourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
     private readonly IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies = bakePolicies
         ?? throw new ArgumentNullException(nameof(bakePolicies));
+    private readonly NonDemSourceFileBakeEmitter sourceFileBakeEmitter = sourceFileBakeEmitter
+        ?? throw new ArgumentNullException(nameof(sourceFileBakeEmitter));
 
     public string Name => "AtlasBake";
 
     public int BakedInputCityObjectCount { get; private set; }
 
     public int BakedOutputCityObjectCount { get; private set; }
-
-    private int EffectiveMaxAtlasSize => Math.Max(1, Math.Min(maxAtlasSize, resourceBudget?.MaxAtlasSize ?? maxAtlasSize));
-
-    private int EffectiveMaxAtlasTextureEdge
-    {
-        get
-        {
-            int profileMaxTileEdge = resourceBudget?.MaxAtlasTextureEdge ?? EffectiveMaxAtlasSize;
-            return Math.Max(1, Math.Min(EffectiveMaxAtlasSize - (tilePaddingPixels * 2), profileMaxTileEdge));
-        }
-    }
 
     public ValueTask<BufferedCityObjectBufferResult> TryBufferAsync(
         ResoniteConstructionCityObject cityObject,
@@ -109,9 +95,7 @@ internal sealed class NonDemCityObjectBaker(
         }
 
         int batchStartIndex = nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey);
-        NonDemSourceFileBakeEmitter emitter = CreateSourceFileBakeEmitter();
-
-        int emittedCount = await emitter.EmitAsync(
+        int emittedCount = await sourceFileBakeEmitter.EmitAsync(
             sourceFileKey,
             cityObjects,
             batchStartIndex,
@@ -135,28 +119,5 @@ internal sealed class NonDemCityObjectBaker(
         }
 
         return null;
-    }
-
-    private NonDemAtlasLayoutFactory CreateAtlasLayoutFactory()
-    {
-        return new NonDemAtlasLayoutFactory(EffectiveMaxAtlasSize, tilePaddingPixels);
-    }
-
-    private NonDemCityObjectBakeCandidateFactory CreateCandidateFactory()
-    {
-        return new NonDemCityObjectBakeCandidateFactory(textureImageLoader, EffectiveMaxAtlasTextureEdge);
-    }
-
-    private NonDemAtlasBatchFitPolicy CreateBatchFitPolicy()
-    {
-        return new NonDemAtlasBatchFitPolicy(CreateAtlasLayoutFactory());
-    }
-
-    private NonDemSourceFileBakeEmitter CreateSourceFileBakeEmitter()
-    {
-        return new NonDemSourceFileBakeEmitter(
-            CreateCandidateFactory(),
-            new NonDemCityObjectBakeAssembler(CreateAtlasLayoutFactory(), new NonDemAtlasImageRenderer(tilePaddingPixels)),
-            CreateBatchFitPolicy());
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -95,14 +95,19 @@ internal sealed class NonDemCityObjectBaker(
         }
 
         int batchStartIndex = nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey);
-        int emittedCount = await sourceFileBakeEmitter.EmitAsync(
+        int emittedCount = 0;
+        await sourceFileBakeEmitter.EmitAsync(
             sourceFileKey,
             cityObjects,
             batchStartIndex,
-            onBakedCityObject,
+            async (bakedCityObject, callbackCancellationToken) =>
+            {
+                await onBakedCityObject(bakedCityObject, callbackCancellationToken);
+                emittedCount++;
+                BakedOutputCityObjectCount++;
+            },
             cancellationToken);
 
-        BakedOutputCityObjectCount += emittedCount;
         nextBatchIndexBySourceFile[sourceFileKey] = batchStartIndex + emittedCount;
         cityObjects.Clear();
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -143,13 +143,14 @@ internal sealed class NonDemCityObjectBaker(
         List<NonDemCityObjectBakeCandidate> currentAtlasBatch = [];
         int batchIndex = batchStartIndex;
         bool preservePrimaryIdentity = cityObjects.Count == 1;
+        NonDemCityObjectBakeCandidateFactory candidateFactory = CreateCandidateFactory();
 
         foreach (NonDemBufferedCityObject bufferedCityObject in cityObjects.OrderBy(
                      static bufferedCityObject => bufferedCityObject.CityObject.SlotKey,
                      StringComparer.Ordinal))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            NonDemCityObjectBakeCandidate? candidate = await CreateCandidateAsync(bufferedCityObject, cancellationToken);
+            NonDemCityObjectBakeCandidate? candidate = await candidateFactory.CreateAsync(bufferedCityObject, cancellationToken);
             if (candidate is null)
             {
                 continue;
@@ -251,141 +252,6 @@ internal sealed class NonDemCityObjectBaker(
         }
 
         return null;
-    }
-
-    private async Task<NonDemCityObjectBakeCandidate?> CreateCandidateAsync(
-        NonDemBufferedCityObject bufferedCityObject,
-        CancellationToken cancellationToken)
-    {
-        ResoniteConstructionCityObject cityObject = bufferedCityObject.CityObject;
-        NonDemCityObjectBakePolicy policy = bufferedCityObject.Policy;
-        if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(cityObject, out _))
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
-        }
-
-        ResoniteConstructionCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
-        if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(normalizedCityObject, out Dictionary<int, ResoniteMaterialBinding>? materialBySubmeshIndex))
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
-        }
-
-        List<NonDemAtlasBatchEntry> atlasEntries = [];
-        List<NonDemPreservedSubmeshEntry> preservedEntries = [];
-        bool hadAtlasCandidateMaterial = false;
-        foreach (ResoniteMeshSubmesh submesh in normalizedCityObject.Mesh.Submeshes.OrderBy(static candidate => candidate.Index))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (!materialBySubmeshIndex.TryGetValue(submesh.Index, out ResoniteMaterialBinding? material))
-            {
-                throw new InvalidOperationException(
-                    $"Non-DEM bake city object '{cityObject.DisplayName}' left submesh index {submesh.Index} without a material assignment.");
-            }
-
-            NonDemMaterialBakeCategory category = NonDemCityObjectBakeMaterialClassifier.Classify(material);
-            switch (category)
-            {
-                case NonDemMaterialBakeCategory.AtlasCandidate:
-                    hadAtlasCandidateMaterial = true;
-                    NonDemAtlasOrPreservedEntry bakeEntry = await CreateAtlasOrPreservedEntryAsync(
-                        normalizedCityObject,
-                        submesh,
-                        material,
-                        cancellationToken);
-                    if (bakeEntry.AtlasEntry is not null)
-                    {
-                        atlasEntries.Add(bakeEntry.AtlasEntry);
-                    }
-
-                    if (bakeEntry.PreservedEntry is not null)
-                    {
-                        preservedEntries.Add(bakeEntry.PreservedEntry);
-                    }
-
-                    break;
-                case NonDemMaterialBakeCategory.PreservedCommonMaterial when policy.PreserveCommonMaterials:
-                case NonDemMaterialBakeCategory.PreservedTextureless when policy.PreserveTexturelessMaterials:
-                case NonDemMaterialBakeCategory.PreservedVertexColor when policy.PreserveVertexColorMaterials:
-                case NonDemMaterialBakeCategory.PreservedOther:
-                    ResoniteMeshSubmesh normalizedSubmesh = normalizedCityObject.Mesh.Submeshes.Single(candidate => candidate.Index == submesh.Index);
-                    ResoniteMaterialBinding normalizedMaterial = normalizedCityObject.Materials.Single(candidate => candidate.SubmeshIndices.Contains(submesh.Index));
-                    preservedEntries.Add(new NonDemPreservedSubmeshEntry(normalizedCityObject, normalizedSubmesh, normalizedMaterial));
-                    break;
-            }
-        }
-
-        if (policy.RequireAtlasCandidateMaterial && !hadAtlasCandidateMaterial)
-        {
-            DisposeCandidateImages(new NonDemCityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries));
-            return null;
-        }
-
-        if (atlasEntries.Count == 0 && preservedEntries.Count == 0)
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM bake city object '{cityObject.DisplayName}' produced no atlas or preserved submesh candidate.");
-        }
-
-        return new NonDemCityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries);
-    }
-
-    private async Task<NonDemAtlasOrPreservedEntry> CreateAtlasOrPreservedEntryAsync(
-        ResoniteConstructionCityObject cityObject,
-        ResoniteMeshSubmesh submesh,
-        ResoniteMaterialBinding material,
-        CancellationToken cancellationToken)
-    {
-        if (material.TexturePayload is null)
-        {
-            throw new InvalidOperationException("Non-DEM bake candidate material must have a texture payload.");
-        }
-
-        TextureUvRect uvBounds = ComputeUvBounds(cityObject.Mesh.Vertices, submesh, material);
-        using Image<Rgba32> sourceImage = await textureImageLoader.LoadAsync(
-            ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
-            cancellationToken);
-        Rgba32 detectedBackgroundColor = NonDemTextureImageProcessing.DetectRepresentativeBackgroundColor(sourceImage);
-        using Image<Rgba32> preparedSourceImage = sourceImage.Clone();
-        NonDemTextureImageProcessing.FillTransparentRgb(preparedSourceImage, detectedBackgroundColor);
-        if (NonDemTextureImageProcessing.TryGetUniformPixelColor(preparedSourceImage, out Rgba32 uniformDatasetColor))
-        {
-            Rgba32 tintedUniformColor = NonDemTextureImageProcessing.MultiplyPixel(
-                uniformDatasetColor,
-                NonDemTextureImageProcessing.ToPixel(material.BaseColor));
-            return new NonDemAtlasOrPreservedEntry(
-                AtlasEntry: null,
-                PreservedEntry: new NonDemPreservedSubmeshEntry(
-                    cityObject,
-                    submesh,
-                    CreateVertexColorMaterial(material, submesh.Index),
-                    NonDemTextureImageProcessing.ToColor(tintedUniformColor)));
-        }
-
-        int maxTileWidth = EffectiveMaxAtlasTextureEdge;
-        int maxTileHeight = EffectiveMaxAtlasTextureEdge;
-        int targetWidth = Math.Max(1, Math.Min(maxTileWidth, (int)Math.Ceiling(sourceImage.Width * uvBounds.Width)));
-        int targetHeight = Math.Max(1, Math.Min(maxTileHeight, (int)Math.Ceiling(sourceImage.Height * uvBounds.Height)));
-        using Image<Rgba32> bakedImage = NonDemTextureImageProcessing.BakeUsedUvRegion(
-            preparedSourceImage,
-            uvBounds,
-            targetWidth,
-            targetHeight);
-
-        NonDemTextureImageProcessing.ApplyBaseColor(bakedImage, material.BaseColor);
-        return new NonDemAtlasOrPreservedEntry(
-            AtlasEntry: new NonDemAtlasBatchEntry(
-                cityObject,
-                submesh,
-                material,
-                new NonDemMaterialAtlasTile(
-                    bakedImage.Clone(),
-                    NonDemTextureImageProcessing.MultiplyPixel(
-                        detectedBackgroundColor,
-                        NonDemTextureImageProcessing.ToPixel(material.BaseColor))),
-                uvBounds),
-            PreservedEntry: null);
     }
 
     private async Task<ResoniteConstructionCityObject> BakeBatchAsync(
@@ -595,24 +461,9 @@ internal sealed class NonDemCityObjectBaker(
         return new NonDemAtlasLayoutFactory(EffectiveMaxAtlasSize, tilePaddingPixels);
     }
 
-    private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)
+    private NonDemCityObjectBakeCandidateFactory CreateCandidateFactory()
     {
-        return material with
-        {
-            MaterialType = ResoniteMaterialType.VertexColor,
-            BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-            TexturePayload = null,
-            TextureSourceKind = ResoniteTextureSourceKind.Bundled,
-            TextureScale = null,
-            TextureOffset = null,
-            Family = null,
-            TerrainOverlay = null,
-            AssetScope = ResoniteMaterialAssetScope.Common,
-            SubmeshIndices = [submeshIndex],
-            CommonMaterial = material.DepthOffset is null
-                ? CommonMaterialCatalog.Create().VertexColor.Uv
-                : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv,
-        };
+        return new NonDemCityObjectBakeCandidateFactory(textureImageLoader, EffectiveMaxAtlasTextureEdge);
     }
 
     private static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)
@@ -623,35 +474,6 @@ internal sealed class NonDemCityObjectBaker(
     private static ResoniteFloat3 Subtract(ResoniteFloat3 left, ResoniteFloat3 right)
     {
         return new ResoniteFloat3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
-    }
-
-    private static TextureUvRect ComputeUvBounds(
-        IReadOnlyList<ResoniteMeshVertex> vertices,
-        ResoniteMeshSubmesh submesh,
-        ResoniteMaterialBinding material)
-    {
-        double minU = double.PositiveInfinity;
-        double minV = double.PositiveInfinity;
-        double maxU = double.NegativeInfinity;
-        double maxV = double.NegativeInfinity;
-
-        foreach (int sourceIndex in submesh.TriangleVertexIndices)
-        {
-            ResoniteFloat2 transformedUv = vertices[sourceIndex].UV0;
-            minU = Math.Min(minU, transformedUv.X);
-            minV = Math.Min(minV, transformedUv.Y);
-            maxU = Math.Max(maxU, transformedUv.X);
-            maxV = Math.Max(maxV, transformedUv.Y);
-        }
-
-        if (double.IsPositiveInfinity(minU) || double.IsPositiveInfinity(minV))
-        {
-            return TextureUvRect.Identity;
-        }
-
-        double width = Math.Max(1.0 / 1024.0, maxU - minU);
-        double height = Math.Max(1.0 / 1024.0, maxV - minV);
-        return new TextureUvRect(minU, minV, width, height);
     }
 
     private async Task EmitAtlasBatchAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -8,13 +8,13 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemCityObjectBaker(
     IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies,
-    NonDemSourceFileBakeEmitter sourceFileBakeEmitter) : IResoniteBufferedCityObjectBaker
+    INonDemSourceFileBakeEmitter sourceFileBakeEmitter) : IResoniteBufferedCityObjectBaker
 {
     private readonly Dictionary<NonDemSourceFileBatchKey, List<NonDemBufferedCityObject>> bufferedCityObjectsBySourceFile = [];
     private readonly Dictionary<NonDemSourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
     private readonly IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies = bakePolicies
         ?? throw new ArgumentNullException(nameof(bakePolicies));
-    private readonly NonDemSourceFileBakeEmitter sourceFileBakeEmitter = sourceFileBakeEmitter
+    private readonly INonDemSourceFileBakeEmitter sourceFileBakeEmitter = sourceFileBakeEmitter
         ?? throw new ArgumentNullException(nameof(sourceFileBakeEmitter));
 
     public string Name => "AtlasBake";

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -96,19 +96,24 @@ internal sealed class NonDemCityObjectBaker(
 
         int batchStartIndex = nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey);
         int emittedCount = 0;
-        await sourceFileBakeEmitter.EmitAsync(
-            sourceFileKey,
-            cityObjects,
-            batchStartIndex,
-            async (bakedCityObject, callbackCancellationToken) =>
-            {
-                await onBakedCityObject(bakedCityObject, callbackCancellationToken);
-                emittedCount++;
-                BakedOutputCityObjectCount++;
-            },
-            cancellationToken);
-
-        nextBatchIndexBySourceFile[sourceFileKey] = batchStartIndex + emittedCount;
-        cityObjects.Clear();
+        try
+        {
+            await sourceFileBakeEmitter.EmitAsync(
+                sourceFileKey,
+                cityObjects,
+                batchStartIndex,
+                async (bakedCityObject, callbackCancellationToken) =>
+                {
+                    emittedCount++;
+                    await onBakedCityObject(bakedCityObject, callbackCancellationToken);
+                    BakedOutputCityObjectCount++;
+                },
+                cancellationToken);
+        }
+        finally
+        {
+            nextBatchIndexBySourceFile[sourceFileKey] = batchStartIndex + emittedCount;
+            cityObjects.Clear();
+        }
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,8 +21,8 @@ internal sealed class NonDemCityObjectBaker(
 {
     internal const int DefaultMaxAtlasSize = 4096;
     internal const int DefaultTilePaddingPixels = 2;
-    private readonly Dictionary<SourceFileBatchKey, List<BufferedCityObject>> bufferedCityObjectsBySourceFile = [];
-    private readonly Dictionary<SourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
+    private readonly Dictionary<NonDemSourceFileBatchKey, List<BufferedCityObject>> bufferedCityObjectsBySourceFile = [];
+    private readonly Dictionary<NonDemSourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
     private readonly IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies = bakePolicies
         ?? throw new ArgumentNullException(nameof(bakePolicies));
 
@@ -59,7 +57,7 @@ internal sealed class NonDemCityObjectBaker(
         }
 
         cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
-        SourceFileBatchKey sourceFileKey = CreateSourceFileKey(cityObject, policy);
+        NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(cityObject, policy);
         List<ResoniteConstructionCityObject> readyCityObjects = [];
         BufferedCityObject bufferedCityObject = new(cityObject, policy);
         if (!bufferedCityObjectsBySourceFile.TryGetValue(sourceFileKey, out List<BufferedCityObject>? bufferedCityObjects))
@@ -97,17 +95,17 @@ internal sealed class NonDemCityObjectBaker(
             return;
         }
 
-        SourceFileBatchKey[] orderedSourceFileKeys = bufferedCityObjectsBySourceFile.Keys
-            .OrderBy(static key => key, SourceFileBatchKeyComparer.Instance)
+        NonDemSourceFileBatchKey[] orderedSourceFileKeys = bufferedCityObjectsBySourceFile.Keys
+            .OrderBy(static key => key, NonDemSourceFileBatching.KeyComparer)
             .ToArray();
-        foreach (SourceFileBatchKey sourceFileKey in orderedSourceFileKeys)
+        foreach (NonDemSourceFileBatchKey sourceFileKey in orderedSourceFileKeys)
         {
             await EmitSourceFileAsync(sourceFileKey, onBakedCityObject, cancellationToken);
         }
     }
 
     private async Task EmitSourceFileAsync(
-        SourceFileBatchKey sourceFileKey,
+        NonDemSourceFileBatchKey sourceFileKey,
         Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
         CancellationToken cancellationToken)
     {
@@ -135,7 +133,7 @@ internal sealed class NonDemCityObjectBaker(
     }
 
     private async Task BakeSourceFileAsync(
-        SourceFileBatchKey sourceFileKey,
+        NonDemSourceFileBatchKey sourceFileKey,
         IReadOnlyList<BufferedCityObject> cityObjects,
         int batchStartIndex,
         Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
@@ -428,7 +426,7 @@ internal sealed class NonDemCityObjectBaker(
     }
 
     private async Task<ResoniteConstructionCityObject> BakeBatchAsync(
-        SourceFileBatchKey sourceFileKey,
+        NonDemSourceFileBatchKey sourceFileKey,
         IReadOnlyList<CityObjectBakeCandidate> candidates,
         int batchIndex,
         bool preservePrimaryIdentity,
@@ -465,10 +463,10 @@ internal sealed class NonDemCityObjectBaker(
         ResoniteConstructionCityObject firstCityObject = candidates[0].CityObject;
         string slotKey = preservePrimaryIdentity
             ? firstCityObject.SlotKey
-            : CreateBatchSlotKey(sourceFileKey, batchIndex);
+            : NonDemSourceFileBatching.CreateBatchSlotKey(sourceFileKey, batchIndex);
         string displayName = preservePrimaryIdentity
             ? firstCityObject.DisplayName
-            : CreateBatchDisplayName(sourceFileKey, batchIndex, slotKey);
+            : NonDemSourceFileBatching.CreateBatchDisplayName(sourceFileKey, batchIndex, slotKey);
         string? sourceFileRelativePath = string.IsNullOrWhiteSpace(firstCityObject.SourceFileRelativePath)
             ? null
             : sourceFileKey.SourceFileRelativePath;
@@ -480,7 +478,7 @@ internal sealed class NonDemCityObjectBaker(
 
         if (layout is not null)
         {
-            string textureIdentity = CreateAtlasTextureIdentity(sourceFileKey, batchIndex);
+            string textureIdentity = NonDemSourceFileBatching.CreateAtlasTextureIdentity(sourceFileKey, batchIndex);
             List<int> atlasTriangleIndices = [];
             foreach (NonDemAtlasPlacement<AtlasBatchEntry> placement in layout.Placements.OrderBy(static candidate => candidate.Entry.CityObject.SlotKey, StringComparer.Ordinal).ThenBy(static candidate => candidate.Entry.Submesh.Index))
             {
@@ -737,50 +735,6 @@ internal sealed class NonDemCityObjectBaker(
         };
     }
 
-    private static SourceFileBatchKey CreateSourceFileKey(
-        ResoniteConstructionCityObject cityObject,
-        NonDemCityObjectBakePolicy policy)
-    {
-        string context = policy.Name;
-        string? sourceFileRelativePath = string.IsNullOrWhiteSpace(cityObject.SourceFileRelativePath) ? null : cityObject.SourceFileRelativePath;
-        if (sourceFileRelativePath is null)
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM batch candidate '{cityObject.DisplayName}' did not provide source scope. "
-                + "source-file-owned batching requires SourceFileRelativePath.");
-        }
-
-        return new SourceFileBatchKey(
-            cityObject.ActualMeshCode,
-            cityObject.PackageName.ToLowerInvariant(),
-            cityObject.LodLevel,
-            context,
-            SourceFileRelativePath: sourceFileRelativePath);
-    }
-
-    private static string CreateBatchSlotKey(SourceFileBatchKey sourceFileKey, int batchIndex)
-    {
-        string lodToken = sourceFileKey.LodLevel?.ToString(CultureInfo.InvariantCulture) ?? "none";
-        return string.Create(
-            CultureInfo.InvariantCulture,
-            $"atlasbake-{Path.GetFileNameWithoutExtension(sourceFileKey.SourceFileRelativePath)}-{sourceFileKey.PackageName}-lod{lodToken}-{batchIndex + 1}");
-    }
-
-    private static string CreateBatchDisplayName(SourceFileBatchKey sourceFileKey, int batchIndex, string batchSlotKey)
-    {
-        string lodToken = sourceFileKey.LodLevel?.ToString(CultureInfo.InvariantCulture) ?? "none";
-        return string.Create(
-            CultureInfo.InvariantCulture,
-            $"AtlasBake {sourceFileKey.PackageName} LOD{lodToken} #{batchIndex + 1} [{batchSlotKey}]");
-    }
-
-    private static string CreateAtlasTextureIdentity(SourceFileBatchKey sourceFileKey, int batchIndex)
-    {
-        return string.Create(
-            CultureInfo.InvariantCulture,
-            $"atlastex-{sourceFileKey.SourceFileRelativePath}-{batchIndex + 1}");
-    }
-
     private static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)
     {
         return new ResoniteFloat3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
@@ -871,7 +825,7 @@ internal sealed class NonDemCityObjectBaker(
     }
 
     private async Task EmitAtlasBatchAsync(
-        SourceFileBatchKey sourceFileKey,
+        NonDemSourceFileBatchKey sourceFileKey,
         IReadOnlyList<CityObjectBakeCandidate> batchCandidates,
         int batchIndex,
         bool preservePrimaryIdentity,
@@ -980,52 +934,5 @@ internal sealed class NonDemCityObjectBaker(
     private sealed record AtlasBatchPlan(
         IReadOnlyList<IReadOnlyList<CityObjectBakeCandidate>> Batches,
         IReadOnlyList<CityObjectBakeCandidate> FallbackCandidates);
-
-    private readonly record struct SourceFileBatchKey(
-        string ActualMeshCode,
-        string PackageName,
-        int? LodLevel,
-        string PolicyContext,
-        string SourceFileRelativePath);
-
-    private sealed class SourceFileBatchKeyComparer : IComparer<SourceFileBatchKey>
-    {
-        internal static readonly SourceFileBatchKeyComparer Instance = new();
-
-        public int Compare(SourceFileBatchKey x, SourceFileBatchKey y)
-        {
-            int compare = string.CompareOrdinal(x.ActualMeshCode, y.ActualMeshCode);
-            if (compare != 0)
-            {
-                return compare;
-            }
-
-            compare = string.CompareOrdinal(x.PackageName, y.PackageName);
-            if (compare != 0)
-            {
-                return compare;
-            }
-
-            compare = Nullable.Compare(x.LodLevel, y.LodLevel);
-            if (compare != 0)
-            {
-                return compare;
-            }
-
-            compare = string.CompareOrdinal(x.PolicyContext, y.PolicyContext);
-            if (compare != 0)
-            {
-                return compare;
-            }
-
-            compare = string.CompareOrdinal(x.SourceFileRelativePath, y.SourceFileRelativePath);
-            if (compare != 0)
-            {
-                return compare;
-            }
-
-            return 0;
-        }
-    }
 
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemPreservedMaterialGrouping.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemPreservedMaterialGrouping.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal static class NonDemPreservedMaterialGrouping
+{
+    public static IEqualityComparer<NonDemPreservedMaterialGroupingKey> KeyComparer { get; } =
+        new PreservedMaterialGroupingKeyComparer();
+
+    public static NonDemPreservedMaterialGroupingKey CreateKey(ResoniteMaterialBinding material)
+    {
+        ResoniteMaterialBinding normalizedMaterial = NormalizeMaterial(material);
+        if (normalizedMaterial.CommonMaterial is not null)
+        {
+            return new NonDemPreservedMaterialGroupingKey(
+                normalizedMaterial.CommonMaterial,
+                new ResoniteColor(0.0, 0.0, 0.0, 0.0),
+                default,
+                normalizedMaterial.TexturePayload,
+                normalizedMaterial.TextureSourceKind,
+                normalizedMaterial.TerrainOverlay,
+                default,
+                default,
+                default,
+                default,
+                default,
+                default,
+                default,
+                normalizedMaterial.TerrainMeshCode);
+        }
+
+        return new NonDemPreservedMaterialGroupingKey(
+            null,
+            normalizedMaterial.BaseColor,
+            normalizedMaterial.MaterialType,
+            normalizedMaterial.TexturePayload,
+            normalizedMaterial.TextureSourceKind,
+            normalizedMaterial.TerrainOverlay,
+            normalizedMaterial.Projection,
+            normalizedMaterial.DepthOffset,
+            normalizedMaterial.TextureScale,
+            normalizedMaterial.TextureOffset,
+            normalizedMaterial.AssetScope,
+            normalizedMaterial.Family,
+            normalizedMaterial.BundledVariantIndex,
+            normalizedMaterial.TerrainMeshCode);
+    }
+
+    public static ResoniteMaterialBinding NormalizeMaterial(ResoniteMaterialBinding material)
+    {
+        return ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
+    }
+
+    private sealed class PreservedMaterialGroupingKeyComparer :
+        IEqualityComparer<NonDemPreservedMaterialGroupingKey>
+    {
+        public bool Equals(NonDemPreservedMaterialGroupingKey x, NonDemPreservedMaterialGroupingKey y)
+        {
+            if (!EqualityComparer<DefaultCommonMaterialMember?>.Default.Equals(x.CommonMaterial, y.CommonMaterial))
+            {
+                return false;
+            }
+
+            if (x.CommonMaterial is not null)
+            {
+                return ReferenceEquals(x.TexturePayload, y.TexturePayload)
+                    && x.TextureSourceKind == y.TextureSourceKind
+                    && EqualityComparer<TerrainTextureOverlay?>.Default.Equals(x.TerrainOverlay, y.TerrainOverlay)
+                    && string.Equals(x.TerrainMeshCode, y.TerrainMeshCode, StringComparison.Ordinal);
+            }
+
+            return x.BaseColor == y.BaseColor
+                && x.MaterialType == y.MaterialType
+                && ReferenceEquals(x.TexturePayload, y.TexturePayload)
+                && x.TextureSourceKind == y.TextureSourceKind
+                && EqualityComparer<TerrainTextureOverlay?>.Default.Equals(x.TerrainOverlay, y.TerrainOverlay)
+                && x.Projection == y.Projection
+                && EqualityComparer<ResoniteMaterialDepthOffset?>.Default.Equals(x.DepthOffset, y.DepthOffset)
+                && EqualityComparer<ResoniteFloat2?>.Default.Equals(x.TextureScale, y.TextureScale)
+                && EqualityComparer<ResoniteFloat2?>.Default.Equals(x.TextureOffset, y.TextureOffset)
+                && x.AssetScope == y.AssetScope
+                && string.Equals(x.Family, y.Family, StringComparison.Ordinal)
+                && x.BundledVariantIndex == y.BundledVariantIndex
+                && string.Equals(x.TerrainMeshCode, y.TerrainMeshCode, StringComparison.Ordinal);
+        }
+
+        public int GetHashCode(NonDemPreservedMaterialGroupingKey obj)
+        {
+            HashCode hash = new();
+            hash.Add(obj.CommonMaterial);
+            if (obj.CommonMaterial is not null)
+            {
+                if (obj.TexturePayload is not null)
+                {
+                    hash.Add(RuntimeHelpers.GetHashCode(obj.TexturePayload));
+                }
+
+                hash.Add(obj.TextureSourceKind);
+                hash.Add(obj.TerrainOverlay);
+                hash.Add(obj.TerrainMeshCode, StringComparer.Ordinal);
+                return hash.ToHashCode();
+            }
+
+            hash.Add(obj.BaseColor);
+            hash.Add(obj.MaterialType);
+            if (obj.TexturePayload is not null)
+            {
+                hash.Add(RuntimeHelpers.GetHashCode(obj.TexturePayload));
+            }
+
+            hash.Add(obj.TextureSourceKind);
+            hash.Add(obj.TerrainOverlay);
+            hash.Add(obj.Projection);
+            hash.Add(obj.DepthOffset);
+            hash.Add(obj.TextureScale);
+            hash.Add(obj.TextureOffset);
+            hash.Add(obj.AssetScope);
+            hash.Add(obj.Family, StringComparer.Ordinal);
+            hash.Add(obj.BundledVariantIndex);
+            hash.Add(obj.TerrainMeshCode, StringComparer.Ordinal);
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemPreservedMaterialGrouping.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemPreservedMaterialGrouping.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
@@ -68,7 +67,7 @@ internal static class NonDemPreservedMaterialGrouping
 
             if (x.CommonMaterial is not null)
             {
-                return ReferenceEquals(x.TexturePayload, y.TexturePayload)
+                return ResoniteTexturePayloadReferenceComparer.Instance.Equals(x.TexturePayload, y.TexturePayload)
                     && x.TextureSourceKind == y.TextureSourceKind
                     && EqualityComparer<TerrainTextureOverlay?>.Default.Equals(x.TerrainOverlay, y.TerrainOverlay)
                     && string.Equals(x.TerrainMeshCode, y.TerrainMeshCode, StringComparison.Ordinal);
@@ -76,7 +75,7 @@ internal static class NonDemPreservedMaterialGrouping
 
             return x.BaseColor == y.BaseColor
                 && x.MaterialType == y.MaterialType
-                && ReferenceEquals(x.TexturePayload, y.TexturePayload)
+                && ResoniteTexturePayloadReferenceComparer.Instance.Equals(x.TexturePayload, y.TexturePayload)
                 && x.TextureSourceKind == y.TextureSourceKind
                 && EqualityComparer<TerrainTextureOverlay?>.Default.Equals(x.TerrainOverlay, y.TerrainOverlay)
                 && x.Projection == y.Projection
@@ -95,11 +94,7 @@ internal static class NonDemPreservedMaterialGrouping
             hash.Add(obj.CommonMaterial);
             if (obj.CommonMaterial is not null)
             {
-                if (obj.TexturePayload is not null)
-                {
-                    hash.Add(RuntimeHelpers.GetHashCode(obj.TexturePayload));
-                }
-
+                AddTexturePayloadHash(ref hash, obj.TexturePayload);
                 hash.Add(obj.TextureSourceKind);
                 hash.Add(obj.TerrainOverlay);
                 hash.Add(obj.TerrainMeshCode, StringComparer.Ordinal);
@@ -108,11 +103,7 @@ internal static class NonDemPreservedMaterialGrouping
 
             hash.Add(obj.BaseColor);
             hash.Add(obj.MaterialType);
-            if (obj.TexturePayload is not null)
-            {
-                hash.Add(RuntimeHelpers.GetHashCode(obj.TexturePayload));
-            }
-
+            AddTexturePayloadHash(ref hash, obj.TexturePayload);
             hash.Add(obj.TextureSourceKind);
             hash.Add(obj.TerrainOverlay);
             hash.Add(obj.Projection);
@@ -124,6 +115,13 @@ internal static class NonDemPreservedMaterialGrouping
             hash.Add(obj.BundledVariantIndex);
             hash.Add(obj.TerrainMeshCode, StringComparer.Ordinal);
             return hash.ToHashCode();
+        }
+
+        private static void AddTexturePayloadHash(ref HashCode hash, ResoniteTexturePayload? texturePayload)
+        {
+            hash.Add(texturePayload is null
+                ? 0
+                : ResoniteTexturePayloadReferenceComparer.Instance.GetHashCode(texturePayload));
         }
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemPreservedMaterialGroupingKey.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemPreservedMaterialGroupingKey.cs
@@ -1,0 +1,20 @@
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal readonly record struct NonDemPreservedMaterialGroupingKey(
+    DefaultCommonMaterialMember? CommonMaterial,
+    ResoniteColor BaseColor,
+    ResoniteMaterialType MaterialType,
+    ResoniteTexturePayload? TexturePayload,
+    ResoniteTextureSourceKind TextureSourceKind,
+    TerrainTextureOverlay? TerrainOverlay,
+    ResoniteMaterialProjection Projection,
+    ResoniteMaterialDepthOffset? DepthOffset,
+    ResoniteFloat2? TextureScale,
+    ResoniteFloat2? TextureOffset,
+    ResoniteMaterialAssetScope AssetScope,
+    string? Family,
+    int? BundledVariantIndex,
+    string? TerrainMeshCode);

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeBuffer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeBuffer.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemSourceFileBakeBuffer
+{
+    private readonly Dictionary<NonDemSourceFileBatchKey, List<NonDemBufferedCityObject>> bufferedCityObjectsBySourceFile = [];
+    private readonly Dictionary<NonDemSourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
+
+    public bool IsEmpty => bufferedCityObjectsBySourceFile.Count == 0;
+
+    public void Add(
+        NonDemSourceFileBatchKey sourceFileKey,
+        NonDemBufferedCityObject bufferedCityObject)
+    {
+        if (!bufferedCityObjectsBySourceFile.TryGetValue(sourceFileKey, out List<NonDemBufferedCityObject>? bufferedCityObjects))
+        {
+            bufferedCityObjects = [];
+            bufferedCityObjectsBySourceFile.Add(sourceFileKey, bufferedCityObjects);
+        }
+
+        bufferedCityObjects.Add(bufferedCityObject);
+    }
+
+    public IReadOnlyList<NonDemSourceFileBatchKey> SnapshotOrderedSourceFileKeys()
+    {
+        return bufferedCityObjectsBySourceFile.Keys
+            .OrderBy(static key => key, NonDemSourceFileBatching.KeyComparer)
+            .ToArray();
+    }
+
+    public bool TryTake(
+        NonDemSourceFileBatchKey sourceFileKey,
+        out NonDemSourceFileBakeBufferEntry entry)
+    {
+        if (!bufferedCityObjectsBySourceFile.Remove(sourceFileKey, out List<NonDemBufferedCityObject>? cityObjects))
+        {
+            entry = default;
+            return false;
+        }
+
+        entry = new NonDemSourceFileBakeBufferEntry(
+            sourceFileKey,
+            cityObjects,
+            nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey));
+        return true;
+    }
+
+    public void Complete(
+        NonDemSourceFileBakeBufferEntry entry,
+        int reservedOutputCount)
+    {
+        nextBatchIndexBySourceFile[entry.SourceFileKey] = entry.BatchStartIndex + reservedOutputCount;
+        entry.CityObjects.Clear();
+    }
+}
+
+internal readonly record struct NonDemSourceFileBakeBufferEntry(
+    NonDemSourceFileBatchKey SourceFileKey,
+    List<NonDemBufferedCityObject> CityObjects,
+    int BatchStartIndex);

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemSourceFileBakeEmitter(
+    NonDemCityObjectBakeCandidateFactory candidateFactory,
+    NonDemCityObjectBakeAssembler assembler,
+    NonDemAtlasBatchFitPolicy batchFitPolicy)
+{
+    public async Task<int> EmitAsync(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemBufferedCityObject> cityObjects,
+        int batchStartIndex,
+        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
+        CancellationToken cancellationToken)
+    {
+        List<NonDemCityObjectBakeCandidate> passThroughCandidates = [];
+        List<NonDemCityObjectBakeCandidate> currentAtlasBatch = [];
+        int emittedCount = 0;
+        int batchIndex = batchStartIndex;
+        bool preservePrimaryIdentity = cityObjects.Count == 1;
+
+        foreach (NonDemBufferedCityObject bufferedCityObject in cityObjects.OrderBy(
+                     static bufferedCityObject => bufferedCityObject.CityObject.SlotKey,
+                     StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            NonDemCityObjectBakeCandidate? candidate = await candidateFactory.CreateAsync(bufferedCityObject, cancellationToken);
+            if (candidate is null)
+            {
+                continue;
+            }
+
+            if (candidate.AtlasEntries.Count == 0 && !NonDemAtlasBatchFitPolicy.RequiresBakeEmission(candidate))
+            {
+                passThroughCandidates.Add(candidate);
+                continue;
+            }
+
+            if (currentAtlasBatch.Count == 0)
+            {
+                if (batchFitPolicy.CanFitSingleCandidate(candidate))
+                {
+                    currentAtlasBatch.Add(candidate);
+                }
+                else
+                {
+                    emittedCount += await EmitFallbackCandidateAsync(candidate, onBakedCityObject, cancellationToken);
+                }
+
+                continue;
+            }
+
+            if (batchFitPolicy.CanAppendToAtlasBatch(currentAtlasBatch, candidate))
+            {
+                currentAtlasBatch.Add(candidate);
+                continue;
+            }
+
+            emittedCount += await EmitAtlasBatchAsync(
+                sourceFileKey,
+                currentAtlasBatch,
+                batchIndex++,
+                preservePrimaryIdentity && passThroughCandidates.Count == 0,
+                onBakedCityObject,
+                cancellationToken);
+            currentAtlasBatch.Clear();
+
+            if (batchFitPolicy.CanFitSingleCandidate(candidate))
+            {
+                currentAtlasBatch.Add(candidate);
+            }
+            else
+            {
+                emittedCount += await EmitFallbackCandidateAsync(candidate, onBakedCityObject, cancellationToken);
+            }
+        }
+
+        if (currentAtlasBatch.Count > 0)
+        {
+            emittedCount += await EmitAtlasBatchAsync(
+                sourceFileKey,
+                currentAtlasBatch,
+                batchIndex++,
+                preservePrimaryIdentity && passThroughCandidates.Count == 0,
+                onBakedCityObject,
+                cancellationToken);
+            currentAtlasBatch.Clear();
+        }
+
+        if (passThroughCandidates.Count == 1)
+        {
+            NonDemCityObjectBakeCandidate passThroughCandidate = passThroughCandidates[0];
+            await onBakedCityObject(passThroughCandidate.CityObject, cancellationToken);
+            DisposeCandidateImages(passThroughCandidate);
+            emittedCount++;
+        }
+        else if (passThroughCandidates.Count > 1)
+        {
+            try
+            {
+                ResoniteConstructionCityObject mergedPassThroughCityObject = await assembler.BakeBatchAsync(
+                    sourceFileKey,
+                    passThroughCandidates,
+                    batchIndex,
+                    preservePrimaryIdentity: false,
+                    cancellationToken);
+                await onBakedCityObject(mergedPassThroughCityObject, cancellationToken);
+                emittedCount++;
+            }
+            finally
+            {
+                DisposeCandidateImages(passThroughCandidates);
+            }
+        }
+
+        return emittedCount;
+    }
+
+    private async Task<int> EmitAtlasBatchAsync(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
+        int batchIndex,
+        bool preservePrimaryIdentity,
+        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            ResoniteConstructionCityObject bakedCityObject = await assembler.BakeBatchAsync(
+                sourceFileKey,
+                batchCandidates,
+                batchIndex,
+                preservePrimaryIdentity,
+                cancellationToken);
+            await onBakedCityObject(bakedCityObject, cancellationToken);
+            return 1;
+        }
+        finally
+        {
+            DisposeCandidateImages(batchCandidates);
+        }
+    }
+
+    private static async Task<int> EmitFallbackCandidateAsync(
+        NonDemCityObjectBakeCandidate fallbackCandidate,
+        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await onBakedCityObject(fallbackCandidate.CityObject, cancellationToken);
+            return 1;
+        }
+        finally
+        {
+            DisposeCandidateImages(fallbackCandidate);
+        }
+    }
+
+    private static void DisposeCandidateImages(NonDemCityObjectBakeCandidate candidate)
+    {
+        DisposeCandidateImages([candidate]);
+    }
+
+    private static void DisposeCandidateImages(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
+    {
+        foreach (Image<Rgba32> tileImage in candidates
+                     .SelectMany(static candidate => candidate.AtlasEntries)
+                     .Select(static entry => entry.Tile.Image)
+                     .Distinct())
+        {
+            tileImage.Dispose();
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -4,16 +4,17 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemSourceFileBakeEmitter(
     NonDemCityObjectBakeCandidateFactory candidateFactory,
     NonDemCityObjectBakeAssembler assembler,
-    NonDemAtlasBatchFitPolicy batchFitPolicy) : INonDemSourceFileBakeEmitter
+    NonDemAtlasBatchFitPolicy batchFitPolicy,
+    INonDemBakeCandidateImageDisposer candidateImageDisposer) : INonDemSourceFileBakeEmitter
 {
+    private readonly INonDemBakeCandidateImageDisposer candidateImageDisposer = candidateImageDisposer
+        ?? throw new ArgumentNullException(nameof(candidateImageDisposer));
+
     public async Task<int> EmitAsync(
         NonDemSourceFileBatchKey sourceFileKey,
         IReadOnlyList<NonDemBufferedCityObject> cityObjects,
@@ -99,7 +100,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
         {
             NonDemCityObjectBakeCandidate passThroughCandidate = passThroughCandidates[0];
             await onBakedCityObject(passThroughCandidate.CityObject, cancellationToken);
-            DisposeCandidateImages(passThroughCandidate);
+            candidateImageDisposer.Dispose(passThroughCandidate);
             emittedCount++;
         }
         else if (passThroughCandidates.Count > 1)
@@ -117,7 +118,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
             }
             finally
             {
-                DisposeCandidateImages(passThroughCandidates);
+                candidateImageDisposer.Dispose(passThroughCandidates);
             }
         }
 
@@ -145,11 +146,11 @@ internal sealed class NonDemSourceFileBakeEmitter(
         }
         finally
         {
-            DisposeCandidateImages(batchCandidates);
+            candidateImageDisposer.Dispose(batchCandidates);
         }
     }
 
-    private static async Task<int> EmitFallbackCandidateAsync(
+    private async Task<int> EmitFallbackCandidateAsync(
         NonDemCityObjectBakeCandidate fallbackCandidate,
         Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
         CancellationToken cancellationToken)
@@ -161,23 +162,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
         }
         finally
         {
-            DisposeCandidateImages(fallbackCandidate);
-        }
-    }
-
-    private static void DisposeCandidateImages(NonDemCityObjectBakeCandidate candidate)
-    {
-        DisposeCandidateImages([candidate]);
-    }
-
-    private static void DisposeCandidateImages(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
-    {
-        foreach (Image<Rgba32> tileImage in candidates
-                     .SelectMany(static candidate => candidate.AtlasEntries)
-                     .Select(static entry => entry.Tile.Image)
-                     .Distinct())
-        {
-            tileImage.Dispose();
+            candidateImageDisposer.Dispose(fallbackCandidate);
         }
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -12,7 +12,7 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal sealed class NonDemSourceFileBakeEmitter(
     NonDemCityObjectBakeCandidateFactory candidateFactory,
     NonDemCityObjectBakeAssembler assembler,
-    NonDemAtlasBatchFitPolicy batchFitPolicy)
+    NonDemAtlasBatchFitPolicy batchFitPolicy) : INonDemSourceFileBakeEmitter
 {
     public async Task<int> EmitAsync(
         NonDemSourceFileBatchKey sourceFileKey,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -7,11 +7,17 @@ using System.Threading.Tasks;
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemSourceFileBakeEmitter(
-    NonDemCityObjectBakeCandidateFactory candidateFactory,
-    NonDemCityObjectBakeAssembler assembler,
+    INonDemCityObjectBakeCandidateFactory candidateFactory,
+    INonDemCityObjectBakeAssembler assembler,
     NonDemAtlasBatchFitPolicy batchFitPolicy,
     INonDemBakeCandidateImageDisposer candidateImageDisposer) : INonDemSourceFileBakeEmitter
 {
+    private readonly INonDemCityObjectBakeCandidateFactory candidateFactory = candidateFactory
+        ?? throw new ArgumentNullException(nameof(candidateFactory));
+    private readonly INonDemCityObjectBakeAssembler assembler = assembler
+        ?? throw new ArgumentNullException(nameof(assembler));
+    private readonly NonDemAtlasBatchFitPolicy batchFitPolicy = batchFitPolicy
+        ?? throw new ArgumentNullException(nameof(batchFitPolicy));
     private readonly INonDemBakeCandidateImageDisposer candidateImageDisposer = candidateImageDisposer
         ?? throw new ArgumentNullException(nameof(candidateImageDisposer));
 

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -9,14 +9,14 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal sealed class NonDemSourceFileBakeEmitter(
     INonDemCityObjectBakeCandidateFactory candidateFactory,
     INonDemCityObjectBakeAssembler assembler,
-    NonDemAtlasBatchFitPolicy batchFitPolicy,
+    INonDemAtlasBatchFitPolicy batchFitPolicy,
     INonDemBakeCandidateImageDisposer candidateImageDisposer) : INonDemSourceFileBakeEmitter
 {
     private readonly INonDemCityObjectBakeCandidateFactory candidateFactory = candidateFactory
         ?? throw new ArgumentNullException(nameof(candidateFactory));
     private readonly INonDemCityObjectBakeAssembler assembler = assembler
         ?? throw new ArgumentNullException(nameof(assembler));
-    private readonly NonDemAtlasBatchFitPolicy batchFitPolicy = batchFitPolicy
+    private readonly INonDemAtlasBatchFitPolicy batchFitPolicy = batchFitPolicy
         ?? throw new ArgumentNullException(nameof(batchFitPolicy));
     private readonly INonDemBakeCandidateImageDisposer candidateImageDisposer = candidateImageDisposer
         ?? throw new ArgumentNullException(nameof(candidateImageDisposer));
@@ -45,7 +45,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
                 continue;
             }
 
-            if (candidate.AtlasEntries.Count == 0 && !NonDemAtlasBatchFitPolicy.RequiresBakeEmission(candidate))
+            if (candidate.AtlasEntries.Count == 0 && !batchFitPolicy.RequiresBakeEmission(candidate))
             {
                 passThroughCandidates.Add(candidate);
                 continue;

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -14,7 +14,8 @@ internal sealed class NonDemSourceFileBakeEmitterFactory(
                 new NonDemAtlasOrPreservedEntryFactory(textureImageLoader, atlasBudget.EffectiveMaxAtlasTextureEdge)),
             new NonDemCityObjectBakeAssembler(
                 layoutFactory,
-                new NonDemAtlasImageRenderer(atlasBudget.TilePaddingPixels)),
+                new NonDemAtlasImageRenderer(atlasBudget.TilePaddingPixels),
+                new NonDemBakedGeometryComposer()),
             new NonDemAtlasBatchFitPolicy(layoutFactory));
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -16,6 +16,7 @@ internal sealed class NonDemSourceFileBakeEmitterFactory(
                 layoutFactory,
                 new NonDemAtlasImageRenderer(atlasBudget.TilePaddingPixels),
                 new NonDemBakedGeometryComposer()),
-            new NonDemAtlasBatchFitPolicy(layoutFactory));
+            new NonDemAtlasBatchFitPolicy(layoutFactory),
+            new NonDemBakeCandidateImageDisposer());
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -1,0 +1,19 @@
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemSourceFileBakeEmitterFactory(
+    ResoniteTextureImageLoader textureImageLoader,
+    NonDemAtlasBakeBudget atlasBudget)
+{
+    public NonDemSourceFileBakeEmitter Create()
+    {
+        NonDemAtlasLayoutFactory layoutFactory = new(
+            atlasBudget.EffectiveMaxAtlasSize,
+            atlasBudget.TilePaddingPixels);
+        return new NonDemSourceFileBakeEmitter(
+            new NonDemCityObjectBakeCandidateFactory(textureImageLoader, atlasBudget.EffectiveMaxAtlasTextureEdge),
+            new NonDemCityObjectBakeAssembler(
+                layoutFactory,
+                new NonDemAtlasImageRenderer(atlasBudget.TilePaddingPixels)),
+            new NonDemAtlasBatchFitPolicy(layoutFactory));
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -1,10 +1,14 @@
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed class NonDemSourceFileBakeEmitterFactory(
-    ResoniteTextureImageLoader textureImageLoader,
-    NonDemAtlasBakeBudget atlasBudget)
+internal interface INonDemSourceFileBakeEmitterFactory
 {
-    public INonDemSourceFileBakeEmitter Create()
+    INonDemSourceFileBakeEmitter Create(NonDemAtlasBakeBudget atlasBudget);
+}
+
+internal sealed class NonDemSourceFileBakeEmitterFactory(
+    ResoniteTextureImageLoader textureImageLoader) : INonDemSourceFileBakeEmitterFactory
+{
+    public INonDemSourceFileBakeEmitter Create(NonDemAtlasBakeBudget atlasBudget)
     {
         NonDemAtlasLayoutFactory layoutFactory = new(
             atlasBudget.EffectiveMaxAtlasSize,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -10,7 +10,8 @@ internal sealed class NonDemSourceFileBakeEmitterFactory(
             atlasBudget.EffectiveMaxAtlasSize,
             atlasBudget.TilePaddingPixels);
         return new NonDemSourceFileBakeEmitter(
-            new NonDemCityObjectBakeCandidateFactory(textureImageLoader, atlasBudget.EffectiveMaxAtlasTextureEdge),
+            new NonDemCityObjectBakeCandidateFactory(
+                new NonDemAtlasOrPreservedEntryFactory(textureImageLoader, atlasBudget.EffectiveMaxAtlasTextureEdge)),
             new NonDemCityObjectBakeAssembler(
                 layoutFactory,
                 new NonDemAtlasImageRenderer(atlasBudget.TilePaddingPixels)),

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -4,7 +4,7 @@ internal sealed class NonDemSourceFileBakeEmitterFactory(
     ResoniteTextureImageLoader textureImageLoader,
     NonDemAtlasBakeBudget atlasBudget)
 {
-    public NonDemSourceFileBakeEmitter Create()
+    public INonDemSourceFileBakeEmitter Create()
     {
         NonDemAtlasLayoutFactory layoutFactory = new(
             atlasBudget.EffectiveMaxAtlasSize,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBatchKey.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBatchKey.cs
@@ -1,0 +1,8 @@
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal readonly record struct NonDemSourceFileBatchKey(
+    string ActualMeshCode,
+    string PackageName,
+    int? LodLevel,
+    string PolicyContext,
+    string SourceFileRelativePath);

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBatching.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBatching.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal static class NonDemSourceFileBatching
+{
+    public static IComparer<NonDemSourceFileBatchKey> KeyComparer { get; } = new SourceFileBatchKeyComparer();
+
+    public static NonDemSourceFileBatchKey CreateKey(
+        ResoniteConstructionCityObject cityObject,
+        NonDemCityObjectBakePolicy policy)
+    {
+        string context = policy.Name;
+        string? sourceFileRelativePath = string.IsNullOrWhiteSpace(cityObject.SourceFileRelativePath) ? null : cityObject.SourceFileRelativePath;
+        if (sourceFileRelativePath is null)
+        {
+            throw new InvalidOperationException(
+                $"Non-DEM batch candidate '{cityObject.DisplayName}' did not provide source scope. "
+                + "source-file-owned batching requires SourceFileRelativePath.");
+        }
+
+        return new NonDemSourceFileBatchKey(
+            cityObject.ActualMeshCode,
+            cityObject.PackageName.ToLowerInvariant(),
+            cityObject.LodLevel,
+            context,
+            SourceFileRelativePath: sourceFileRelativePath);
+    }
+
+    public static string CreateBatchSlotKey(NonDemSourceFileBatchKey sourceFileKey, int batchIndex)
+    {
+        string lodToken = sourceFileKey.LodLevel?.ToString(CultureInfo.InvariantCulture) ?? "none";
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"atlasbake-{Path.GetFileNameWithoutExtension(sourceFileKey.SourceFileRelativePath)}-{sourceFileKey.PackageName}-lod{lodToken}-{batchIndex + 1}");
+    }
+
+    public static string CreateBatchDisplayName(NonDemSourceFileBatchKey sourceFileKey, int batchIndex, string batchSlotKey)
+    {
+        string lodToken = sourceFileKey.LodLevel?.ToString(CultureInfo.InvariantCulture) ?? "none";
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"AtlasBake {sourceFileKey.PackageName} LOD{lodToken} #{batchIndex + 1} [{batchSlotKey}]");
+    }
+
+    public static string CreateAtlasTextureIdentity(NonDemSourceFileBatchKey sourceFileKey, int batchIndex)
+    {
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"atlastex-{sourceFileKey.SourceFileRelativePath}-{batchIndex + 1}");
+    }
+
+    private sealed class SourceFileBatchKeyComparer : IComparer<NonDemSourceFileBatchKey>
+    {
+        public int Compare(NonDemSourceFileBatchKey x, NonDemSourceFileBatchKey y)
+        {
+            int compare = string.CompareOrdinal(x.ActualMeshCode, y.ActualMeshCode);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.CompareOrdinal(x.PackageName, y.PackageName);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = Nullable.Compare(x.LodLevel, y.LodLevel);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.CompareOrdinal(x.PolicyContext, y.PolicyContext);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.CompareOrdinal(x.SourceFileRelativePath, y.SourceFileRelativePath);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemTextureImageProcessing.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemTextureImageProcessing.cs
@@ -1,0 +1,310 @@
+using System;
+
+using PlateauResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal static class NonDemTextureImageProcessing
+{
+    private const byte BackgroundDetectionAlphaThreshold = 16;
+
+    public static void ApplyBaseColor(Image<Rgba32> image, ResoniteColor color)
+    {
+        Rgba32 tint = ToPixel(color);
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                Rgba32 pixel = image[x, y];
+                image[x, y] = new Rgba32(
+                    MultiplyChannel(pixel.R, tint.R),
+                    MultiplyChannel(pixel.G, tint.G),
+                    MultiplyChannel(pixel.B, tint.B),
+                    MultiplyChannel(pixel.A, tint.A));
+            }
+        }
+    }
+
+    public static Rgba32 MultiplyPixel(Rgba32 left, Rgba32 right)
+    {
+        return new Rgba32(
+            MultiplyChannel(left.R, right.R),
+            MultiplyChannel(left.G, right.G),
+            MultiplyChannel(left.B, right.B),
+            MultiplyChannel(left.A, right.A));
+    }
+
+    public static Rgba32 ToPixel(ResoniteColor color)
+    {
+        return new Rgba32(
+            (byte)Math.Round(Math.Clamp(color.R, 0.0, 1.0) * 255.0),
+            (byte)Math.Round(Math.Clamp(color.G, 0.0, 1.0) * 255.0),
+            (byte)Math.Round(Math.Clamp(color.B, 0.0, 1.0) * 255.0),
+            (byte)Math.Round(Math.Clamp(color.A, 0.0, 1.0) * 255.0));
+    }
+
+    public static ResoniteColor ToColor(Rgba32 color)
+    {
+        return new ResoniteColor(
+            color.R / 255.0,
+            color.G / 255.0,
+            color.B / 255.0,
+            color.A / 255.0);
+    }
+
+    public static Image<Rgba32> BakeUsedUvRegion(
+        Image<Rgba32> sourceImage,
+        TextureUvRect uvBounds,
+        int targetWidth,
+        int targetHeight)
+    {
+        Image<Rgba32> bakedImage = new(targetWidth, targetHeight);
+        for (int y = 0; y < targetHeight; y++)
+        {
+            double normalizedV = 1.0 - ((y + 0.5) / targetHeight);
+            for (int x = 0; x < targetWidth; x++)
+            {
+                double normalizedU = (x + 0.5) / targetWidth;
+                ScalarPair sourceUv = uvBounds.DenormalizeValue(normalizedU, normalizedV);
+                bakedImage[x, y] = SampleWrappedPixelBilinear(sourceImage, sourceUv.X, sourceUv.Y);
+            }
+        }
+
+        return bakedImage;
+    }
+
+    public static Rgba32 DetectRepresentativeBackgroundColor(Image<Rgba32> image)
+    {
+        if (TryAverageBoundaryOpaquePixels(image, out Rgba32 boundaryAverage))
+        {
+            return boundaryAverage;
+        }
+
+        if (TryAverageOpaquePixels(image, out Rgba32 opaqueAverage))
+        {
+            return opaqueAverage;
+        }
+
+        if (TryAverageAllPixels(image, out Rgba32 allPixelAverage))
+        {
+            return new Rgba32(allPixelAverage.R, allPixelAverage.G, allPixelAverage.B, byte.MaxValue);
+        }
+
+        return new Rgba32(255, 255, 255, 255);
+    }
+
+    public static void FillTransparentRgb(Image<Rgba32> image, Rgba32 backgroundColor)
+    {
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                Rgba32 pixel = image[x, y];
+                if (pixel.A == byte.MaxValue)
+                {
+                    continue;
+                }
+
+                double alpha = pixel.A / 255.0;
+                image[x, y] = new Rgba32(
+                    BlendBackgroundChannel(pixel.R, backgroundColor.R, alpha),
+                    BlendBackgroundChannel(pixel.G, backgroundColor.G, alpha),
+                    BlendBackgroundChannel(pixel.B, backgroundColor.B, alpha),
+                    pixel.A);
+            }
+        }
+    }
+
+    public static bool TryGetUniformPixelColor(Image<Rgba32> image, out Rgba32 color)
+    {
+        color = default;
+        if (image.Width <= 0 || image.Height <= 0)
+        {
+            return false;
+        }
+
+        Rgba32 firstPixel = image[0, 0];
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                if (!image[x, y].Equals(firstPixel))
+                {
+                    return false;
+                }
+            }
+        }
+
+        color = firstPixel;
+        return true;
+    }
+
+    private static byte MultiplyChannel(byte left, byte right)
+    {
+        return (byte)Math.Clamp((left * right + 127) / 255, 0, 255);
+    }
+
+    private static bool TryAverageBoundaryOpaquePixels(Image<Rgba32> image, out Rgba32 color)
+    {
+        long sumR = 0;
+        long sumG = 0;
+        long sumB = 0;
+        long count = 0;
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                Rgba32 pixel = image[x, y];
+                if (pixel.A <= BackgroundDetectionAlphaThreshold || !TouchesTransparentNeighbor(image, x, y))
+                {
+                    continue;
+                }
+
+                sumR += pixel.R;
+                sumG += pixel.G;
+                sumB += pixel.B;
+                count++;
+            }
+        }
+
+        color = count == 0
+            ? default
+            : new Rgba32(
+                (byte)Math.Clamp(Math.Round(sumR / (double)count), 0.0, 255.0),
+                (byte)Math.Clamp(Math.Round(sumG / (double)count), 0.0, 255.0),
+                (byte)Math.Clamp(Math.Round(sumB / (double)count), 0.0, 255.0),
+                byte.MaxValue);
+        return count > 0;
+    }
+
+    private static bool TouchesTransparentNeighbor(Image<Rgba32> image, int x, int y)
+    {
+        return IsTransparentOrOutOfBounds(image, x - 1, y)
+            || IsTransparentOrOutOfBounds(image, x + 1, y)
+            || IsTransparentOrOutOfBounds(image, x, y - 1)
+            || IsTransparentOrOutOfBounds(image, x, y + 1);
+    }
+
+    private static bool IsTransparentOrOutOfBounds(Image<Rgba32> image, int x, int y)
+    {
+        if (x < 0 || y < 0 || x >= image.Width || y >= image.Height)
+        {
+            return true;
+        }
+
+        return image[x, y].A <= BackgroundDetectionAlphaThreshold;
+    }
+
+    private static bool TryAverageOpaquePixels(Image<Rgba32> image, out Rgba32 color)
+    {
+        return TryAveragePixels(image, static pixel => pixel.A > BackgroundDetectionAlphaThreshold, out color);
+    }
+
+    private static bool TryAverageAllPixels(Image<Rgba32> image, out Rgba32 color)
+    {
+        return TryAveragePixels(image, static _ => true, out color);
+    }
+
+    private static bool TryAveragePixels(Image<Rgba32> image, Func<Rgba32, bool> predicate, out Rgba32 color)
+    {
+        long sumR = 0;
+        long sumG = 0;
+        long sumB = 0;
+        long count = 0;
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                Rgba32 pixel = image[x, y];
+                if (!predicate(pixel))
+                {
+                    continue;
+                }
+
+                sumR += pixel.R;
+                sumG += pixel.G;
+                sumB += pixel.B;
+                count++;
+            }
+        }
+
+        color = count == 0
+            ? default
+            : new Rgba32(
+                (byte)Math.Clamp(Math.Round(sumR / (double)count), 0.0, 255.0),
+                (byte)Math.Clamp(Math.Round(sumG / (double)count), 0.0, 255.0),
+                (byte)Math.Clamp(Math.Round(sumB / (double)count), 0.0, 255.0),
+                byte.MaxValue);
+        return count > 0;
+    }
+
+    private static byte BlendBackgroundChannel(byte foreground, byte background, double alpha)
+    {
+        double blended = (foreground * alpha) + (background * (1.0 - alpha));
+        return (byte)Math.Clamp(Math.Round(blended), 0.0, 255.0);
+    }
+
+    private static Rgba32 SampleWrappedPixelBilinear(Image<Rgba32> sourceImage, double u, double v)
+    {
+        double wrappedU = WrapUvCoordinate(u);
+        double wrappedV = WrapUvCoordinate(v);
+        double sourceX = (wrappedU * sourceImage.Width) - 0.5;
+        double sourceY = ((1.0 - wrappedV) * sourceImage.Height) - 0.5;
+        int x0 = (int)Math.Floor(sourceX);
+        int y0 = (int)Math.Floor(sourceY);
+        int x1 = x0 + 1;
+        int y1 = y0 + 1;
+        double tx = sourceX - x0;
+        double ty = sourceY - y0;
+
+        Rgba32 topLeft = sourceImage[WrapPixelCoordinate(x0, sourceImage.Width), WrapPixelCoordinate(y0, sourceImage.Height)];
+        Rgba32 topRight = sourceImage[WrapPixelCoordinate(x1, sourceImage.Width), WrapPixelCoordinate(y0, sourceImage.Height)];
+        Rgba32 bottomLeft = sourceImage[WrapPixelCoordinate(x0, sourceImage.Width), WrapPixelCoordinate(y1, sourceImage.Height)];
+        Rgba32 bottomRight = sourceImage[WrapPixelCoordinate(x1, sourceImage.Width), WrapPixelCoordinate(y1, sourceImage.Height)];
+        return LerpPixels(topLeft, topRight, bottomLeft, bottomRight, tx, ty);
+    }
+
+    private static double WrapUvCoordinate(double value)
+    {
+        double wrapped = value - Math.Floor(value);
+        return wrapped >= 1.0 ? 0.0 : wrapped;
+    }
+
+    private static int WrapPixelCoordinate(int value, int length)
+    {
+        int wrapped = value % length;
+        return wrapped < 0 ? wrapped + length : wrapped;
+    }
+
+    private static Rgba32 LerpPixels(
+        Rgba32 topLeft,
+        Rgba32 topRight,
+        Rgba32 bottomLeft,
+        Rgba32 bottomRight,
+        double tx,
+        double ty)
+    {
+        return new Rgba32(
+            LerpChannel(topLeft.R, topRight.R, bottomLeft.R, bottomRight.R, tx, ty),
+            LerpChannel(topLeft.G, topRight.G, bottomLeft.G, bottomRight.G, tx, ty),
+            LerpChannel(topLeft.B, topRight.B, bottomLeft.B, bottomRight.B, tx, ty),
+            LerpChannel(topLeft.A, topRight.A, bottomLeft.A, bottomRight.A, tx, ty));
+    }
+
+    private static byte LerpChannel(
+        byte topLeft,
+        byte topRight,
+        byte bottomLeft,
+        byte bottomRight,
+        double tx,
+        double ty)
+    {
+        double top = topLeft + ((topRight - topLeft) * tx);
+        double bottom = bottomLeft + ((bottomRight - bottomLeft) * tx);
+        double value = top + ((bottom - top) * ty);
+        return (byte)Math.Clamp(Math.Round(value), 0.0, 255.0);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
@@ -10,14 +10,15 @@ internal interface IResoniteBufferedCityObjectBakerFactory
 }
 
 internal sealed class ResoniteBufferedCityObjectBakerFactory(
-    ResoniteTextureImageLoader textureImageLoader) : IResoniteBufferedCityObjectBakerFactory
+    INonDemSourceFileBakeEmitterFactory sourceFileBakeEmitterFactory) : IResoniteBufferedCityObjectBakerFactory
 {
+    private readonly INonDemSourceFileBakeEmitterFactory sourceFileBakeEmitterFactory = sourceFileBakeEmitterFactory
+        ?? throw new ArgumentNullException(nameof(sourceFileBakeEmitterFactory));
+
     public CompositeCityObjectBaker? Create(
         bool enableMeshBake,
         ResoniteImportBudgetProfile resourceBudget)
     {
-        ArgumentNullException.ThrowIfNull(textureImageLoader);
-
         _ = resourceBudget.Name switch
         {
             ResoniteImportMemoryProfile.Small or ResoniteImportMemoryProfile.Large => true,
@@ -28,9 +29,8 @@ internal sealed class ResoniteBufferedCityObjectBakerFactory(
             ? new CompositeCityObjectBaker(
                 new NonDemCityObjectBaker(
                     bakePolicyResolver: new NonDemCityObjectBakePolicyResolver(NonDemCityObjectBakePolicies.DefaultPolicies),
-                    sourceFileBakeEmitter: new NonDemSourceFileBakeEmitterFactory(
-                        textureImageLoader,
-                        new NonDemAtlasBakeBudget(ResourceBudget: resourceBudget)).Create()))
+                    sourceFileBakeEmitter: sourceFileBakeEmitterFactory.Create(
+                        new NonDemAtlasBakeBudget(ResourceBudget: resourceBudget))))
             : null;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
@@ -27,9 +27,10 @@ internal sealed class ResoniteBufferedCityObjectBakerFactory(
         return enableMeshBake
             ? new CompositeCityObjectBaker(
                 new NonDemCityObjectBaker(
-                    textureImageLoader,
                     bakePolicies: NonDemCityObjectBakePolicies.DefaultPolicies,
-                    resourceBudget: resourceBudget))
+                    sourceFileBakeEmitter: new NonDemSourceFileBakeEmitterFactory(
+                        textureImageLoader,
+                        new NonDemAtlasBakeBudget(ResourceBudget: resourceBudget)).Create()))
             : null;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
@@ -27,7 +27,7 @@ internal sealed class ResoniteBufferedCityObjectBakerFactory(
         return enableMeshBake
             ? new CompositeCityObjectBaker(
                 new NonDemCityObjectBaker(
-                    bakePolicies: NonDemCityObjectBakePolicies.DefaultPolicies,
+                    bakePolicyResolver: new NonDemCityObjectBakePolicyResolver(NonDemCityObjectBakePolicies.DefaultPolicies),
                     sourceFileBakeEmitter: new NonDemSourceFileBakeEmitterFactory(
                         textureImageLoader,
                         new NonDemAtlasBakeBudget(ResourceBudget: resourceBudget)).Create()))

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupPreparer.cs
@@ -21,31 +21,35 @@ internal interface IResoniteCommonMaterialSetupPreparer
         ResoniteSceneSetupState setupState,
         CommonMaterialAssetCache materials,
         CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials,
+        Action<string>? progressReporter,
         CancellationToken cancellationToken);
 }
 
 internal sealed class ResoniteCommonMaterialSetupPreparer(
-    IResoniteMaterialPlanning materialPlanning,
-    Action<string>? progressReporter) : IResoniteCommonMaterialSetupPreparer
+    IResoniteMaterialPlanning materialPlanning) : IResoniteCommonMaterialSetupPreparer
 {
     public async Task PrepareAsync(
         IResoniteLinkClient client,
         ResoniteSceneSetupState setupState,
         CommonMaterialAssetCache materials,
         CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials,
+        Action<string>? progressReporter,
         CancellationToken cancellationToken)
     {
         CommonMaterialCatalog<ResoniteCommonMaterialPlan> commonMaterialPlans =
             ResoniteCommonMaterialPlans.CreateCatalogPlans(commonMaterials);
         if (commonMaterialPlans.Count == 0)
         {
-            ReportProgress(PlateauLog.Info("live", "No common material assets are required during scene setup."));
+            ReportProgress(
+                progressReporter,
+                PlateauLog.Info("live", "No common material assets are required during scene setup."));
             return;
         }
 
         Stopwatch stopwatch = Stopwatch.StartNew();
         int preparedCount = 0;
         ReportProgress(
+            progressReporter,
             PlateauLog.Info(
                 "live",
                 $"Preparing {commonMaterialPlans.Count} common material assets during scene setup before object streaming."));
@@ -72,6 +76,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
 
             Stopwatch materialStopwatch = Stopwatch.StartNew();
             ReportProgress(
+                progressReporter,
                 PlateauLog.Info(
                     "live",
                     $"Preparing common material asset {preparedCount + 1}/{commonMaterialPlans.Count}: "
@@ -95,6 +100,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
                     new CreatedMaterialAsset(existingComponent.Value, null)));
                 preparedCount++;
                 ReportProgress(
+                    progressReporter,
                     PlateauLog.Info(
                         "live",
                         $"Reused common material asset {preparedCount}/{commonMaterialPlans.Count}: "
@@ -135,6 +141,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
                 pendingMaterialComponent));
             preparedCount++;
             ReportProgress(
+                progressReporter,
                 PlateauLog.Info(
                     "live",
                     $"Planned common material asset {preparedCount}/{commonMaterialPlans.Count}: "
@@ -160,6 +167,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
             }
 
             ReportProgress(
+                progressReporter,
                 PlateauLog.Info(
                     "live",
                     $"Created {preparedMaterials.Count} common material assets in one setup component batch."));
@@ -171,6 +179,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
         }
 
         ReportProgress(
+            progressReporter,
             PlateauLog.Info(
                 "live",
                 $"Prepared {preparedCount} common material assets during scene setup in {stopwatch.Elapsed.TotalSeconds:F2}s."));
@@ -256,7 +265,9 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
         return (reusableSlotWithoutComponent, null);
     }
 
-    private void ReportProgress(string message)
+    private static void ReportProgress(
+        Action<string>? progressReporter,
+        string message)
     {
         progressReporter?.Invoke(message);
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLinkClientSessionFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLinkClientSessionFactory.cs
@@ -1,0 +1,31 @@
+using System;
+
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteClientSessionFactory
+{
+    ILiveSendClientSession Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        ResoniteLinkSendDiagnostics diagnostics);
+}
+
+internal sealed class ResoniteLinkClientSessionFactory(
+    Func<Action<string>?, IResoniteLinkClient> baseClientFactory) : IResoniteClientSessionFactory
+{
+    public ILiveSendClientSession Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        ResoniteLinkSendDiagnostics diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(diagnostics);
+
+        return ResoniteLinkTransportSessionFactory.Create(
+            options.Endpoint,
+            options.ConnectionCount,
+            diagnostics,
+            options.ProgressReporter,
+            baseClientFactory);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Net.Http;
+
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSceneImportDependencyFactory
+{
+    ResoniteLiveSceneImportDependencies Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        HttpClient terrainTextureAssetHttpClient);
+}
+
+internal sealed class ResoniteLiveSceneImportDependencyFactory(
+    IResoniteClientSessionFactory clientSessionFactory,
+    IResoniteLiveSendRunStarterFactory runStarterFactory,
+    IResoniteLiveSendStartRequestFactory startRequestFactory,
+    IResoniteLiveSendQueue queue)
+    : IResoniteLiveSceneImportDependencyFactory
+{
+    public ResoniteLiveSceneImportDependencies Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        HttpClient terrainTextureAssetHttpClient)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ResoniteLinkSendDiagnostics diagnostics = options.EnableSendMetrics
+            ? ResoniteLinkSendDiagnostics.CreateEnabled(options.ProgressReporter)
+            : ResoniteLinkSendDiagnostics.Disabled;
+
+        return new ResoniteLiveSceneImportDependencies(
+            clientSessionFactory.Create(options, diagnostics),
+            diagnostics,
+            startRequestFactory,
+            runStarterFactory.Create(terrainTextureAssetHttpClient, options),
+            queue);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportFactory.cs
@@ -1,0 +1,24 @@
+using System.Net.Http;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSceneImportFactory
+{
+    ResoniteLiveSceneImportTarget CreateTarget(
+        ResoniteLiveSceneImportTargetOptions options,
+        HttpClient terrainTextureAssetHttpClient);
+}
+
+internal sealed class ResoniteLiveSceneImportFactory(
+    IResoniteLiveSceneImportDependencyFactory dependencyFactory) : IResoniteLiveSceneImportFactory
+{
+    public ResoniteLiveSceneImportTarget CreateTarget(
+        ResoniteLiveSceneImportTargetOptions options,
+        HttpClient terrainTextureAssetHttpClient)
+    {
+        ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
+            options,
+            terrainTextureAssetHttpClient);
+        return new ResoniteLiveSceneImportTarget(options, dependencies);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -160,6 +160,7 @@ internal sealed class ResoniteLiveSendRunStarter(
             setupState,
             materials,
             request.CommonMaterials,
+            context.ProgressReporter,
             cancellationToken);
 
         ReportProgress(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -56,9 +56,11 @@ internal sealed class ResoniteLiveSendWorkerLauncherFactory(
         ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
         ArgumentNullException.ThrowIfNull(options);
 
-        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
+        ResoniteQueuedTexturePreparer texturePreparer = new(
             terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
-            datasetLicenseWriter,
+            datasetLicenseWriter);
+        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
+            texturePreparer,
             preparedCityObjectImporter);
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
         return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Net.Http;
+
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendRunStarterFactory
+{
+    IResoniteLiveSendRunStarter Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options);
+}
+
+internal sealed class ResoniteLiveSendRunStarterFactory(
+    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
+    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
+    ILiveSendRunPlanFactory runPlanFactory,
+    ILiveSendRunStateFactory runStateFactory,
+    IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory,
+    IResoniteSlotCreator slotCreator) : IResoniteLiveSendRunStarterFactory
+{
+    public IResoniteLiveSendRunStarter Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        return new ResoniteLiveSendRunStarter(
+            sceneSetupInterpreter,
+            commonMaterialSetupPreparer,
+            runPlanFactory,
+            runStateFactory,
+            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options),
+            slotCreator);
+    }
+}
+
+internal interface IResoniteLiveSendWorkerLauncherFactory
+{
+    IResoniteLiveSendWorkerLauncher Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options);
+}
+
+internal sealed class ResoniteLiveSendWorkerLauncherFactory(
+    ITerrainTextureAssetGeneratorFactory terrainTextureAssetGeneratorFactory,
+    IResoniteDatasetLicenseWriter datasetLicenseWriter,
+    IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteLiveSendWorkerLauncherFactory
+{
+    public IResoniteLiveSendWorkerLauncher Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
+            terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
+            datasetLicenseWriter,
+            preparedCityObjectImporter);
+        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
+        return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net.Http;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -26,8 +25,11 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteGeometryAssetPlanner, ResoniteGeometryAssetPlanner>();
         services.TryAddScoped<IResoniteMaterialPlanning, ResoniteMaterialPlanning>();
         services.TryAddScoped<IResoniteSceneMaterialPlanComposer, ResoniteSceneMaterialPlanComposer>();
+        services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
+        services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
+        services.TryAddScoped<IResoniteLiveSendWorkerLauncherFactory, ResoniteLiveSendWorkerLauncherFactory>();
         services.TryAddScoped<IResoniteLiveSendStartRequestFactory, ResoniteLiveSendStartRequestFactory>();
         services.TryAddScoped<IResonitePreparedCityObjectImporter, ResonitePreparedCityObjectImporter>();
         services.TryAddScoped<IResoniteQueuedCityObjectEnqueuer, ResoniteQueuedCityObjectEnqueuer>();
@@ -48,128 +50,5 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteLiveSceneImportFactory, ResoniteLiveSceneImportFactory>();
 
         return services;
-    }
-}
-
-internal interface IResoniteLiveSceneImportFactory
-{
-    ResoniteLiveSceneImportTarget CreateTarget(
-        ResoniteLiveSceneImportTargetOptions options,
-        HttpClient terrainTextureAssetHttpClient);
-}
-
-internal sealed class ResoniteLiveSceneImportFactory(
-    IResoniteLiveSceneImportDependencyFactory dependencyFactory) : IResoniteLiveSceneImportFactory
-{
-    public ResoniteLiveSceneImportTarget CreateTarget(
-        ResoniteLiveSceneImportTargetOptions options,
-        HttpClient terrainTextureAssetHttpClient)
-    {
-        ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
-            options,
-            terrainTextureAssetHttpClient);
-        return new ResoniteLiveSceneImportTarget(options, dependencies);
-    }
-}
-
-internal interface IResoniteLiveSceneImportDependencyFactory
-{
-    ResoniteLiveSceneImportDependencies Create(
-        ResoniteLiveSceneImportTargetOptions options,
-        HttpClient terrainTextureAssetHttpClient);
-}
-
-internal interface IResoniteClientSessionFactory
-{
-    ILiveSendClientSession Create(
-        ResoniteLiveSceneImportTargetOptions options,
-        ResoniteLinkSendDiagnostics diagnostics);
-}
-
-internal sealed class ResoniteLinkClientSessionFactory(
-    Func<Action<string>?, IResoniteLinkClient> baseClientFactory) : IResoniteClientSessionFactory
-{
-    public ILiveSendClientSession Create(
-        ResoniteLiveSceneImportTargetOptions options,
-        ResoniteLinkSendDiagnostics diagnostics)
-    {
-        ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(diagnostics);
-
-        return ResoniteLinkTransportSessionFactory.Create(
-            options.Endpoint,
-            options.ConnectionCount,
-            diagnostics,
-            options.ProgressReporter,
-            baseClientFactory);
-    }
-}
-
-internal interface ITerrainTextureAssetGeneratorFactory
-{
-    ITerrainTextureAssetGenerator Create(
-        HttpClient terrainTextureAssetHttpClient,
-        ResoniteLiveSceneImportTargetOptions options);
-}
-
-internal sealed class TerrainTextureAssetGeneratorFactory : ITerrainTextureAssetGeneratorFactory
-{
-    public ITerrainTextureAssetGenerator Create(
-        HttpClient terrainTextureAssetHttpClient,
-        ResoniteLiveSceneImportTargetOptions options)
-    {
-        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
-        ArgumentNullException.ThrowIfNull(options);
-        return new TerrainTextureAssetGenerator(
-            terrainTextureAssetHttpClient,
-            options.TerrainTileCacheRoot,
-            options.DisableTerrainTileCache);
-    }
-}
-
-internal sealed class ResoniteLiveSceneImportDependencyFactory(
-    IResoniteClientSessionFactory clientSessionFactory,
-    ITerrainTextureAssetGeneratorFactory terrainTextureAssetGeneratorFactory,
-    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
-    IResoniteDatasetLicenseWriter datasetLicenseWriter,
-    IResoniteMaterialPlanning materialPlanning,
-    ILiveSendRunPlanFactory runPlanFactory,
-    ILiveSendRunStateFactory runStateFactory,
-    IResoniteLiveSendStartRequestFactory startRequestFactory,
-    IResonitePreparedCityObjectImporter preparedCityObjectImporter,
-    IResoniteSlotCreator slotCreator,
-    IResoniteLiveSendQueue queue)
-    : IResoniteLiveSceneImportDependencyFactory
-{
-    public ResoniteLiveSceneImportDependencies Create(
-        ResoniteLiveSceneImportTargetOptions options,
-        HttpClient terrainTextureAssetHttpClient)
-    {
-        ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
-        ResoniteLinkSendDiagnostics diagnostics = options.EnableSendMetrics
-            ? ResoniteLinkSendDiagnostics.CreateEnabled(options.ProgressReporter)
-            : ResoniteLinkSendDiagnostics.Disabled;
-
-        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
-            terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
-            datasetLicenseWriter,
-            preparedCityObjectImporter);
-        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
-        ResoniteLiveSendWorkerLauncher workerLauncher = new(queuedCityObjectWorker);
-        ResoniteLiveSendRunStarter runStarter = new(
-            sceneSetupInterpreter,
-            new ResoniteCommonMaterialSetupPreparer(materialPlanning, options.ProgressReporter),
-            runPlanFactory,
-            runStateFactory,
-            workerLauncher,
-            slotCreator);
-
-        return new ResoniteLiveSceneImportDependencies(
-            clientSessionFactory.Create(options, diagnostics),
-            diagnostics,
-            startRequestFactory,
-            runStarter,
-            queue);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
             _ => static progressReporter => new ResoniteLinkClient(progressReporter));
         services.TryAddScoped<BundledDefaultMaterialAssetStore>();
         services.TryAddScoped<ResoniteTextureImageLoader>();
+        services.TryAddScoped<INonDemSourceFileBakeEmitterFactory, NonDemSourceFileBakeEmitterFactory>();
         services.TryAddScoped<IResoniteBatchEmissionPlanner, ResoniteBatchEmissionPlanner>();
         services.TryAddScoped<IResoniteBufferedCityObjectBakerFactory, ResoniteBufferedCityObjectBakerFactory>();
         services.TryAddScoped<IResoniteGeometryAssetAssembler, ResoniteGeometryAssetAssembler>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,14 +24,11 @@ internal interface IResoniteQueuedCityObjectSender
 }
 
 internal sealed class ResoniteQueuedCityObjectSender(
-    ITerrainTextureAssetGenerator terrainTextureAssetGenerator,
-    Execution.IResoniteDatasetLicenseWriter datasetLicenseWriter,
+    IResoniteQueuedTexturePreparer texturePreparer,
     IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteQueuedCityObjectSender
 {
-    private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator =
-        terrainTextureAssetGenerator ?? throw new ArgumentNullException(nameof(terrainTextureAssetGenerator));
-    private readonly Execution.IResoniteDatasetLicenseWriter datasetLicenseWriter =
-        datasetLicenseWriter ?? throw new ArgumentNullException(nameof(datasetLicenseWriter));
+    private readonly IResoniteQueuedTexturePreparer texturePreparer =
+        texturePreparer ?? throw new ArgumentNullException(nameof(texturePreparer));
     private readonly IResonitePreparedCityObjectImporter preparedCityObjectImporter =
         preparedCityObjectImporter ?? throw new ArgumentNullException(nameof(preparedCityObjectImporter));
 
@@ -181,34 +176,6 @@ internal sealed class ResoniteQueuedCityObjectSender(
             ResoniteCityObjectPreparation.ValidateTriangleMeshBindingsForImport(cityObject, dynamicTerrain.StaticMesh.Mesh);
         }
 
-        (string TerrainMeshCode, TerrainTextureOverlay TerrainOverlay)[] distinctTerrainOverlays = cityObject.Materials
-            .Select((material, materialIndex) => (Material: material, MaterialIndex: materialIndex))
-            .Where(static entry => entry.Material.TerrainOverlay is not null && entry.Material.TerrainMeshCode is not null)
-            .Select(entry => (
-                TerrainMeshCode: ResoniteTerrainOverlayMaterialContract.ValidateMeshCode(
-                    cityObject,
-                    entry.MaterialIndex,
-                    entry.Material,
-                    entry.Material.TerrainMeshCode!,
-                    entry.Material.TerrainOverlay!),
-                TerrainOverlay: entry.Material.TerrainOverlay!))
-            .Distinct()
-            .OrderBy(static entry => entry.TerrainMeshCode, StringComparer.Ordinal)
-            .ThenBy(static entry => entry.TerrainOverlay.PackageName, StringComparer.Ordinal)
-            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLatitude)
-            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLongitude)
-            .ToArray();
-
-        Task<PreparedTextureReference?>[] terrainOverlayTexturePreparationTasks = distinctTerrainOverlays
-            .Select(entry => PrepareTerrainOverlayTextureReferenceAsync(
-                state,
-                routedClient,
-                progressReporter,
-                entry.TerrainMeshCode,
-                entry.TerrainOverlay,
-                cancellationToken))
-            .ToArray();
-
         Task<PreparedConstructionGeometry> geometryPreparationTask = cityObject.Geometry switch
         {
             ResoniteTriangleMeshGeometry triangleMesh => Task.Run<PreparedConstructionGeometry>(
@@ -227,15 +194,12 @@ internal sealed class ResoniteQueuedCityObjectSender(
             _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
         };
         Stopwatch stopwatch = Stopwatch.StartNew();
-        PreparedTextureReference?[] preparedTextureResults = await Task.WhenAll(
-            terrainOverlayTexturePreparationTasks
-                .Concat(cityObject.Materials
-                    .Where(static material => material.TexturePayload is not null)
-                    .Select(PrepareDirectMaterialTextureReferenceAsync)
-                    .ToArray()));
-        PreparedTextureReference[] preparedTextures = preparedTextureResults
-            .OfType<PreparedTextureReference>()
-            .ToArray();
+        PreparedTextureReference[] preparedTextures = await texturePreparer.PrepareAsync(
+            state,
+            routedClient,
+            cityObject,
+            progressReporter,
+            cancellationToken);
         PreparedConstructionGeometry preparedGeometry = await geometryPreparationTask;
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay = preparedTextures
             .Where(static texture => texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
@@ -280,96 +244,6 @@ internal sealed class ResoniteQueuedCityObjectSender(
             preparedTextures);
     }
 
-    private async Task<PreparedTextureReference?> PrepareTerrainOverlayTextureReferenceAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient routedClient,
-        Action<string>? progressReporter,
-        string terrainMeshCode,
-        TerrainTextureOverlay terrainTextureOverlay,
-        CancellationToken cancellationToken)
-    {
-        GeneratedTerrainTexture terrainTexture = await terrainTextureAssetGenerator.EnsureTextureAsync(
-            terrainTextureOverlay,
-            cancellationToken);
-        TerrainTextureSource[] usedSources = GetTrackedTerrainTextureSources(terrainTexture, terrainTextureOverlay);
-        foreach (TerrainTextureSource usedSource in usedSources)
-        {
-            int useCount = state.DemSourceUseCounts.AddOrUpdate(
-                usedSource.IdentityKey,
-                1,
-                static (_, current) => checked(current + 1));
-            if (useCount == 1)
-            {
-                ReportProgress(
-                    progressReporter,
-                    PlateauLog.Info(
-                        "live",
-                        $"Resolved DEM terrain texture source for package '{terrainTextureOverlay.PackageName}' "
-                        + $"to {DescribeTerrainTextureSource(usedSource)}."));
-            }
-
-            if (IsGsiFallbackSource(usedSource))
-            {
-                await EnsureGsiFallbackLicenseAsync(state, routedClient, cancellationToken);
-            }
-        }
-
-        return new PreparedTextureReference(
-            TexturePayload: null,
-            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-            TextureImport: terrainTexture.TextureImport,
-            TerrainMeshCode: terrainMeshCode,
-            TerrainOverlay: terrainTextureOverlay,
-            GeneratedTerrainTexture: terrainTexture);
-    }
-
-    private static TerrainTextureSource[] GetTrackedTerrainTextureSources(
-        GeneratedTerrainTexture terrainTexture,
-        TerrainTextureOverlay terrainTextureOverlay)
-    {
-        if (terrainTexture.UsedSources is { Count: > 0 })
-        {
-            return terrainTexture.UsedSources
-                .Distinct()
-                .ToArray();
-        }
-
-        return
-        [
-            terrainTexture.UsedSource ?? terrainTextureOverlay.PrimarySource,
-        ];
-    }
-
-    private async Task EnsureGsiFallbackLicenseAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient routedClient,
-        CancellationToken cancellationToken)
-    {
-        if (Volatile.Read(ref state.GsiFallbackLicenseEnsured) != 0)
-        {
-            return;
-        }
-
-        await state.GsiFallbackLicenseGate.WaitAsync(cancellationToken);
-        try
-        {
-            if (state.GsiFallbackLicenseEnsured != 0)
-            {
-                return;
-            }
-
-            await datasetLicenseWriter.EnsureGsiFallbackLicenseAsync(
-                routedClient,
-                state.Context.DatasetRootSlot,
-                cancellationToken);
-            Volatile.Write(ref state.GsiFallbackLicenseEnsured, 1);
-        }
-        finally
-        {
-            state.GsiFallbackLicenseGate.Release();
-        }
-    }
-
     private static bool IsRecoverableCityObjectSendFailure(Exception exception)
     {
         return exception is ContinuableImportException
@@ -394,43 +268,6 @@ internal sealed class ResoniteQueuedCityObjectSender(
         }
 
         return null;
-    }
-
-    private static bool IsGsiFallbackSource(TerrainTextureSource source)
-    {
-        return DemTerrainTextureDefaults.IsGsiFallbackSource(source);
-    }
-
-    private static string DescribeTerrainTextureSource(TerrainTextureSource source)
-    {
-        return source switch
-        {
-            TerrainTextureGeoReferencedRasterSource rasterSource => string.Create(
-                CultureInfo.InvariantCulture,
-                $"GeoTIFF(path='{Path.GetFileName(rasterSource.SourcePath)}', crs='{rasterSource.Metadata?.CoordinateSystemIdentifier ?? "unknown"}')"),
-            TerrainTextureTileSource tileSource when IsGsiFallbackSource(tileSource) => string.Create(
-                CultureInfo.InvariantCulture,
-                $"GSI seamless photo tile(z={tileSource.ZoomLevel})"),
-            TerrainTextureTileSource tileSource => string.Create(
-                CultureInfo.InvariantCulture,
-                $"PLATEAU-Ortho tile(z={tileSource.ZoomLevel})"),
-            _ => source.GetType().Name,
-        };
-    }
-
-    private static Task<PreparedTextureReference?> PrepareDirectMaterialTextureReferenceAsync(
-        ResoniteMaterialBinding material)
-    {
-        ArgumentNullException.ThrowIfNull(material);
-        ArgumentNullException.ThrowIfNull(material.TexturePayload);
-
-        return Task.FromResult<PreparedTextureReference?>(
-            new PreparedTextureReference(
-                TexturePayload: material.TexturePayload,
-                TextureSourceKind: material.TextureSourceKind,
-                TextureImport: ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
-                TerrainMeshCode: null,
-                TerrainOverlay: null));
     }
 
     private static void ReportProgress(Action<string>? progressReporter, string message)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteQueuedTexturePreparer
+{
+    Task<PreparedTextureReference[]> PrepareAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        ResoniteConstructionCityObject cityObject,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteQueuedTexturePreparer(
+    ITerrainTextureAssetGenerator terrainTextureAssetGenerator,
+    Execution.IResoniteDatasetLicenseWriter datasetLicenseWriter) : IResoniteQueuedTexturePreparer
+{
+    private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator =
+        terrainTextureAssetGenerator ?? throw new ArgumentNullException(nameof(terrainTextureAssetGenerator));
+    private readonly Execution.IResoniteDatasetLicenseWriter datasetLicenseWriter =
+        datasetLicenseWriter ?? throw new ArgumentNullException(nameof(datasetLicenseWriter));
+
+    public async Task<PreparedTextureReference[]> PrepareAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        ResoniteConstructionCityObject cityObject,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(routedClient);
+        ArgumentNullException.ThrowIfNull(cityObject);
+
+        (string TerrainMeshCode, TerrainTextureOverlay TerrainOverlay)[] distinctTerrainOverlays = cityObject.Materials
+            .Select((material, materialIndex) => (Material: material, MaterialIndex: materialIndex))
+            .Where(static entry => entry.Material.TerrainOverlay is not null && entry.Material.TerrainMeshCode is not null)
+            .Select(entry => (
+                TerrainMeshCode: ResoniteTerrainOverlayMaterialContract.ValidateMeshCode(
+                    cityObject,
+                    entry.MaterialIndex,
+                    entry.Material,
+                    entry.Material.TerrainMeshCode!,
+                    entry.Material.TerrainOverlay!),
+                TerrainOverlay: entry.Material.TerrainOverlay!))
+            .Distinct()
+            .OrderBy(static entry => entry.TerrainMeshCode, StringComparer.Ordinal)
+            .ThenBy(static entry => entry.TerrainOverlay.PackageName, StringComparer.Ordinal)
+            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLatitude)
+            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLongitude)
+            .ToArray();
+
+        Task<PreparedTextureReference?>[] terrainOverlayTexturePreparationTasks = distinctTerrainOverlays
+            .Select(entry => PrepareTerrainOverlayTextureReferenceAsync(
+                state,
+                routedClient,
+                progressReporter,
+                entry.TerrainMeshCode,
+                entry.TerrainOverlay,
+                cancellationToken))
+            .ToArray();
+        PreparedTextureReference?[] preparedTextureResults = await Task.WhenAll(
+            terrainOverlayTexturePreparationTasks
+                .Concat(cityObject.Materials
+                    .Where(static material => material.TexturePayload is not null)
+                    .Select(PrepareDirectMaterialTextureReferenceAsync)
+                    .ToArray()));
+        return preparedTextureResults
+            .OfType<PreparedTextureReference>()
+            .ToArray();
+    }
+
+    private async Task<PreparedTextureReference?> PrepareTerrainOverlayTextureReferenceAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        Action<string>? progressReporter,
+        string terrainMeshCode,
+        TerrainTextureOverlay terrainTextureOverlay,
+        CancellationToken cancellationToken)
+    {
+        GeneratedTerrainTexture terrainTexture = await terrainTextureAssetGenerator.EnsureTextureAsync(
+            terrainTextureOverlay,
+            cancellationToken);
+        TerrainTextureSource[] usedSources = GetTrackedTerrainTextureSources(terrainTexture, terrainTextureOverlay);
+        foreach (TerrainTextureSource usedSource in usedSources)
+        {
+            int useCount = state.DemSourceUseCounts.AddOrUpdate(
+                usedSource.IdentityKey,
+                1,
+                static (_, current) => checked(current + 1));
+            if (useCount == 1)
+            {
+                ReportProgress(
+                    progressReporter,
+                    PlateauLog.Info(
+                        "live",
+                        $"Resolved DEM terrain texture source for package '{terrainTextureOverlay.PackageName}' "
+                        + $"to {DescribeTerrainTextureSource(usedSource)}."));
+            }
+
+            if (IsGsiFallbackSource(usedSource))
+            {
+                await EnsureGsiFallbackLicenseAsync(state, routedClient, cancellationToken);
+            }
+        }
+
+        return new PreparedTextureReference(
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            TextureImport: terrainTexture.TextureImport,
+            TerrainMeshCode: terrainMeshCode,
+            TerrainOverlay: terrainTextureOverlay,
+            GeneratedTerrainTexture: terrainTexture);
+    }
+
+    private static TerrainTextureSource[] GetTrackedTerrainTextureSources(
+        GeneratedTerrainTexture terrainTexture,
+        TerrainTextureOverlay terrainTextureOverlay)
+    {
+        if (terrainTexture.UsedSources is { Count: > 0 })
+        {
+            return terrainTexture.UsedSources
+                .Distinct()
+                .ToArray();
+        }
+
+        return
+        [
+            terrainTexture.UsedSource ?? terrainTextureOverlay.PrimarySource,
+        ];
+    }
+
+    private async Task EnsureGsiFallbackLicenseAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref state.GsiFallbackLicenseEnsured) != 0)
+        {
+            return;
+        }
+
+        await state.GsiFallbackLicenseGate.WaitAsync(cancellationToken);
+        try
+        {
+            if (state.GsiFallbackLicenseEnsured != 0)
+            {
+                return;
+            }
+
+            await datasetLicenseWriter.EnsureGsiFallbackLicenseAsync(
+                routedClient,
+                state.Context.DatasetRootSlot,
+                cancellationToken);
+            Volatile.Write(ref state.GsiFallbackLicenseEnsured, 1);
+        }
+        finally
+        {
+            state.GsiFallbackLicenseGate.Release();
+        }
+    }
+
+    private static bool IsGsiFallbackSource(TerrainTextureSource source)
+    {
+        return DemTerrainTextureDefaults.IsGsiFallbackSource(source);
+    }
+
+    private static string DescribeTerrainTextureSource(TerrainTextureSource source)
+    {
+        return source switch
+        {
+            TerrainTextureGeoReferencedRasterSource rasterSource => string.Create(
+                CultureInfo.InvariantCulture,
+                $"GeoTIFF(path='{Path.GetFileName(rasterSource.SourcePath)}', crs='{rasterSource.Metadata?.CoordinateSystemIdentifier ?? "unknown"}')"),
+            TerrainTextureTileSource tileSource when IsGsiFallbackSource(tileSource) => string.Create(
+                CultureInfo.InvariantCulture,
+                $"GSI seamless photo tile(z={tileSource.ZoomLevel})"),
+            TerrainTextureTileSource tileSource => string.Create(
+                CultureInfo.InvariantCulture,
+                $"PLATEAU-Ortho tile(z={tileSource.ZoomLevel})"),
+            _ => source.GetType().Name,
+        };
+    }
+
+    private static Task<PreparedTextureReference?> PrepareDirectMaterialTextureReferenceAsync(
+        ResoniteMaterialBinding material)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+        ArgumentNullException.ThrowIfNull(material.TexturePayload);
+
+        return Task.FromResult<PreparedTextureReference?>(
+            new PreparedTextureReference(
+                TexturePayload: material.TexturePayload,
+                TextureSourceKind: material.TextureSourceKind,
+                TextureImport: ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
+                TerrainMeshCode: null,
+                TerrainOverlay: null));
+    }
+
+    private static void ReportProgress(Action<string>? progressReporter, string message)
+    {
+        progressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGeneratorFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGeneratorFactory.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Net.Http;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface ITerrainTextureAssetGeneratorFactory
+{
+    ITerrainTextureAssetGenerator Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options);
+}
+
+internal sealed class TerrainTextureAssetGeneratorFactory : ITerrainTextureAssetGeneratorFactory
+{
+    public ITerrainTextureAssetGenerator Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ArgumentNullException.ThrowIfNull(options);
+        return new TerrainTextureAssetGenerator(
+            terrainTextureAssetHttpClient,
+            options.TerrainTileCacheRoot,
+            options.DisableTerrainTileCache);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemAtlasLayoutPackerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemAtlasLayoutPackerTests.cs
@@ -1,0 +1,55 @@
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class NonDemAtlasLayoutPackerTests
+{
+    [Fact]
+    public void TryCreateUsesSmallestPowerOfTwoCanvasThatFitsPaddedTiles()
+    {
+        NonDemAtlasLayoutPacker packer = new(atlasMaxSize: 16, tilePaddingPixels: 1);
+
+        bool created = packer.TryCreate(
+            [
+                new Tile("a", 2, 2),
+                new Tile("b", 2, 2),
+            ],
+            static tile => new NonDemAtlasTileSize(tile.Width, tile.Height),
+            out NonDemAtlasLayout<Tile>? layout);
+
+        Assert.True(created);
+        Assert.NotNull(layout);
+        Assert.Equal(8, layout.Width);
+        Assert.Equal(4, layout.Height);
+        Assert.Collection(
+            layout.Placements,
+            placement =>
+            {
+                Assert.Equal("a", placement.Entry.Id);
+                Assert.Equal(new NonDemAtlasRect(0, 0, 4, 4), placement.OuterRect);
+                Assert.Equal(new NonDemAtlasRect(1, 1, 2, 2), placement.InnerRect);
+            },
+            placement =>
+            {
+                Assert.Equal("b", placement.Entry.Id);
+                Assert.Equal(new NonDemAtlasRect(4, 0, 4, 4), placement.OuterRect);
+                Assert.Equal(new NonDemAtlasRect(5, 1, 2, 2), placement.InnerRect);
+            });
+    }
+
+    [Fact]
+    public void TryCreateRejectsTileWhosePaddedSizeExceedsAtlas()
+    {
+        NonDemAtlasLayoutPacker packer = new(atlasMaxSize: 4, tilePaddingPixels: 1);
+
+        bool created = packer.TryCreate(
+            [new Tile("oversized", 3, 3)],
+            static tile => new NonDemAtlasTileSize(tile.Width, tile.Height),
+            out NonDemAtlasLayout<Tile>? layout);
+
+        Assert.False(created);
+        Assert.Null(layout);
+    }
+
+    private sealed record Tile(string Id, int Width, int Height);
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class NonDemCityObjectBakeMaterialClassifierTests
+{
+    [Fact]
+    public void ClassifySeparatesAtlasCandidateFromPreservedMaterialKinds()
+    {
+        Assert.Equal(
+            NonDemMaterialBakeCategory.AtlasCandidate,
+            NonDemCityObjectBakeMaterialClassifier.Classify(CreateDatasetTextureMaterial()));
+        Assert.Equal(
+            NonDemMaterialBakeCategory.PreservedVertexColor,
+            NonDemCityObjectBakeMaterialClassifier.Classify(CreateTexturelessMaterial() with { MaterialType = ResoniteMaterialType.VertexColor }));
+        Assert.Equal(
+            NonDemMaterialBakeCategory.PreservedCommonMaterial,
+            NonDemCityObjectBakeMaterialClassifier.Classify(CreateTexturelessMaterial() with
+            {
+                AssetScope = ResoniteMaterialAssetScope.Common,
+                CommonMaterial = CommonMaterialCatalog.Create().Generic.Uv,
+            }));
+        Assert.Equal(
+            NonDemMaterialBakeCategory.PreservedTextureless,
+            NonDemCityObjectBakeMaterialClassifier.Classify(CreateTexturelessMaterial()));
+        Assert.Equal(
+            NonDemMaterialBakeCategory.PreservedOther,
+            NonDemCityObjectBakeMaterialClassifier.Classify(CreateDatasetTextureMaterial() with
+            {
+                Projection = ResoniteMaterialProjection.Triplanar,
+            }));
+    }
+
+    [Fact]
+    public void CanBufferCityObjectMaterialsHonorsRequiredAtlasCandidateAndPreservationFlags()
+    {
+        NonDemCityObjectBakePolicy requireAtlasCandidate = NonDemCityObjectBakePolicies.Default with
+        {
+            RequireAtlasCandidateMaterial = true,
+            PreserveTexturelessMaterials = true,
+        };
+
+        Assert.False(NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(
+            CreateCityObject([CreateTexturelessMaterial()]),
+            requireAtlasCandidate));
+        Assert.True(NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(
+            CreateCityObject([CreateDatasetTextureMaterial()]),
+            requireAtlasCandidate));
+        Assert.False(NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(
+            CreateCityObject([CreateTexturelessMaterial()]),
+            requireAtlasCandidate with
+            {
+                RequireAtlasCandidateMaterial = false,
+                PreserveTexturelessMaterials = false,
+            }));
+    }
+
+    [Fact]
+    public void TryCreateMaterialBySubmeshIndexRejectsDuplicateSubmeshAssignments()
+    {
+        ResoniteConstructionCityObject cityObject = CreateCityObject(
+            [
+                CreateDatasetTextureMaterial(),
+                CreateTexturelessMaterial(),
+            ]);
+
+        Assert.False(NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(
+            cityObject,
+            out _));
+    }
+
+    private static ResoniteConstructionCityObject CreateCityObject(IReadOnlyList<ResoniteMaterialBinding> materials)
+    {
+        return new ResoniteConstructionCityObject(
+            "object",
+            "object",
+            "bldg",
+            "53394525",
+            LodLevel: 2,
+            new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            new ResoniteImportedMesh(
+                [
+                    new ResoniteMeshVertex(
+                        new ResoniteFloat3(0.0, 0.0, 0.0),
+                        new ResoniteFloat3(0.0, 1.0, 0.0),
+                        new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(
+                        new ResoniteFloat3(1.0, 0.0, 0.0),
+                        new ResoniteFloat3(0.0, 1.0, 0.0),
+                        new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(
+                        new ResoniteFloat3(0.0, 0.0, 1.0),
+                        new ResoniteFloat3(0.0, 1.0, 0.0),
+                        new ResoniteFloat2(0.0, 1.0)),
+                ],
+                [new ResoniteMeshSubmesh(0, [0, 1, 2])]),
+            materials);
+    }
+
+    private static ResoniteMaterialBinding CreateDatasetTextureMaterial()
+    {
+        return CreateTexturelessMaterial() with
+        {
+            TexturePayload = new ResoniteTexturePayload(
+                width: 1,
+                height: 1,
+                colorProfile: null,
+                binaryPayload: [255, 255, 255, 255],
+                identity: "dataset.png"),
+            TextureSourceKind = ResoniteTextureSourceKind.Dataset,
+        };
+    }
+
+    private static ResoniteMaterialBinding CreateTexturelessMaterial()
+    {
+        return new ResoniteMaterialBinding(
+            new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            ResoniteTextureSourceKind.Bundled,
+            ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0]);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -938,6 +938,42 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(512, atlasPayload.Height);
     }
 
+    [Fact]
+    public async Task FlushAllAsyncCountsOutputsAcceptedBeforeCallbackFailure()
+    {
+        NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 10, tilePaddingPixels: 0);
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-a",
+                CreateCheckerPayload("textures/a.png", new Rgba32(255, 0, 0, 255), new Rgba32(255, 255, 0, 255), 9, 3),
+                0,
+                "unit-a"));
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-b",
+                CreateCheckerPayload("textures/b.png", new Rgba32(0, 255, 0, 255), new Rgba32(0, 255, 255, 255), 9, 3),
+                2,
+                "unit-a"));
+
+        int callbackCount = 0;
+        await Assert.ThrowsAsync<InvalidOperationException>(() => baker.FlushAllAsync(
+            (_, _) =>
+            {
+                callbackCount++;
+                if (callbackCount == 2)
+                {
+                    throw new InvalidOperationException("stop after first accepted output");
+                }
+
+                return Task.CompletedTask;
+            }));
+
+        Assert.Equal(2, callbackCount);
+        Assert.Equal(1, baker.BakedOutputCityObjectCount);
+    }
+
     private static NonDemCityObjectBaker CreateBaker(
         int maxAtlasSize = NonDemAtlasBakeBudget.DefaultMaxAtlasSize,
         int tilePaddingPixels = NonDemAtlasBakeBudget.DefaultTilePaddingPixels,

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -981,8 +981,8 @@ public sealed class NonDemCityObjectBakerTests
         ResoniteImportBudgetProfile? resourceBudget = null)
     {
         INonDemSourceFileBakeEmitter sourceFileBakeEmitter = new NonDemSourceFileBakeEmitterFactory(
-            new ResoniteTextureImageLoader(),
-            new NonDemAtlasBakeBudget(maxAtlasSize, tilePaddingPixels, resourceBudget)).Create();
+            new ResoniteTextureImageLoader()).Create(
+            new NonDemAtlasBakeBudget(maxAtlasSize, tilePaddingPixels, resourceBudget));
         return new NonDemCityObjectBaker(
             new NonDemCityObjectBakePolicyResolver(bakePolicies ?? NonDemCityObjectBakePolicies.DefaultPolicies),
             sourceFileBakeEmitter);

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -974,6 +974,61 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(1, baker.BakedOutputCityObjectCount);
     }
 
+    [Fact]
+    public async Task FlushAllAsyncAdvancesBatchIdentityAfterCallbackFailure()
+    {
+        NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 16, tilePaddingPixels: 0);
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-a",
+                CreateCheckerPayload("textures/a.png", new Rgba32(255, 0, 0, 255), new Rgba32(255, 255, 0, 255), 9, 9),
+                0,
+                "unit-a"));
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-b",
+                CreateCheckerPayload("textures/b.png", new Rgba32(0, 255, 0, 255), new Rgba32(0, 255, 255, 255), 9, 9),
+                2,
+                "unit-a"));
+
+        int callbackCount = 0;
+        await Assert.ThrowsAsync<InvalidOperationException>(() => baker.FlushAllAsync(
+            (_, _) =>
+            {
+                callbackCount++;
+                if (callbackCount == 2)
+                {
+                    throw new InvalidOperationException("stop after second reserved output");
+                }
+
+                return Task.CompletedTask;
+            }));
+
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-c",
+                CreateCheckerPayload("textures/c.png", new Rgba32(0, 0, 255, 255), new Rgba32(255, 0, 255, 255), 4, 4),
+                4,
+                "unit-a"));
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-d",
+                CreateCheckerPayload("textures/d.png", new Rgba32(255, 255, 255, 255), new Rgba32(0, 0, 0, 255), 4, 4),
+                6,
+                "unit-a"));
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+
+        Assert.Equal("atlasbake-unit-a-bldg-lod2-3", cityObject.SlotKey);
+        Assert.Equal(
+            "atlastex-unit-a.gml-3",
+            Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Identity);
+    }
+
     private static NonDemCityObjectBaker CreateBaker(
         int maxAtlasSize = NonDemAtlasBakeBudget.DefaultMaxAtlasSize,
         int tilePaddingPixels = NonDemAtlasBakeBudget.DefaultTilePaddingPixels,

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -939,17 +939,17 @@ public sealed class NonDemCityObjectBakerTests
     }
 
     private static NonDemCityObjectBaker CreateBaker(
-        int maxAtlasSize = NonDemCityObjectBaker.DefaultMaxAtlasSize,
-        int tilePaddingPixels = NonDemCityObjectBaker.DefaultTilePaddingPixels,
+        int maxAtlasSize = NonDemAtlasBakeBudget.DefaultMaxAtlasSize,
+        int tilePaddingPixels = NonDemAtlasBakeBudget.DefaultTilePaddingPixels,
         IReadOnlyList<NonDemCityObjectBakePolicy>? bakePolicies = null,
         ResoniteImportBudgetProfile? resourceBudget = null)
     {
-        return new NonDemCityObjectBaker(
+        NonDemSourceFileBakeEmitter sourceFileBakeEmitter = new NonDemSourceFileBakeEmitterFactory(
             new ResoniteTextureImageLoader(),
+            new NonDemAtlasBakeBudget(maxAtlasSize, tilePaddingPixels, resourceBudget)).Create();
+        return new NonDemCityObjectBaker(
             bakePolicies ?? NonDemCityObjectBakePolicies.DefaultPolicies,
-            maxAtlasSize,
-            tilePaddingPixels,
-            resourceBudget);
+            sourceFileBakeEmitter);
     }
 
     private static async Task AssertBufferedAsync(NonDemCityObjectBaker baker, ResoniteConstructionCityObject cityObject)

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -944,7 +944,7 @@ public sealed class NonDemCityObjectBakerTests
         IReadOnlyList<NonDemCityObjectBakePolicy>? bakePolicies = null,
         ResoniteImportBudgetProfile? resourceBudget = null)
     {
-        NonDemSourceFileBakeEmitter sourceFileBakeEmitter = new NonDemSourceFileBakeEmitterFactory(
+        INonDemSourceFileBakeEmitter sourceFileBakeEmitter = new NonDemSourceFileBakeEmitterFactory(
             new ResoniteTextureImageLoader(),
             new NonDemAtlasBakeBudget(maxAtlasSize, tilePaddingPixels, resourceBudget)).Create();
         return new NonDemCityObjectBaker(

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -948,7 +948,7 @@ public sealed class NonDemCityObjectBakerTests
             new ResoniteTextureImageLoader(),
             new NonDemAtlasBakeBudget(maxAtlasSize, tilePaddingPixels, resourceBudget)).Create();
         return new NonDemCityObjectBaker(
-            bakePolicies ?? NonDemCityObjectBakePolicies.DefaultPolicies,
+            new NonDemCityObjectBakePolicyResolver(bakePolicies ?? NonDemCityObjectBakePolicies.DefaultPolicies),
             sourceFileBakeEmitter);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
@@ -1,0 +1,73 @@
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class NonDemPreservedMaterialGroupingTests
+{
+    [Fact]
+    public void CreateKeyIgnoresCommonMaterialTintButKeepsTextureReference()
+    {
+        ResoniteMaterialBinding commonMaterial = CreateTexturelessMaterial() with
+        {
+            AssetScope = ResoniteMaterialAssetScope.Common,
+            CommonMaterial = CommonMaterialCatalog.Create().Generic.Uv,
+        };
+        ResoniteTexturePayload texture = new(
+            width: 1,
+            height: 1,
+            colorProfile: null,
+            binaryPayload: [255, 255, 255, 255],
+            identity: "shared.png");
+
+        NonDemPreservedMaterialGroupingKey first = NonDemPreservedMaterialGrouping.CreateKey(commonMaterial with
+        {
+            BaseColor = new ResoniteColor(1.0, 0.0, 0.0, 1.0),
+            TexturePayload = texture,
+        });
+        NonDemPreservedMaterialGroupingKey second = NonDemPreservedMaterialGrouping.CreateKey(commonMaterial with
+        {
+            BaseColor = new ResoniteColor(0.0, 0.0, 1.0, 1.0),
+            TexturePayload = texture,
+        });
+        NonDemPreservedMaterialGroupingKey differentTexture = NonDemPreservedMaterialGrouping.CreateKey(commonMaterial with
+        {
+            TexturePayload = new ResoniteTexturePayload(
+                width: 1,
+                height: 1,
+                colorProfile: null,
+                binaryPayload: [255, 255, 255, 255],
+                identity: "shared.png"),
+        });
+
+        Assert.True(NonDemPreservedMaterialGrouping.KeyComparer.Equals(first, second));
+        Assert.False(NonDemPreservedMaterialGrouping.KeyComparer.Equals(first, differentTexture));
+    }
+
+    [Fact]
+    public void CreateKeyKeepsDedicatedMaterialTintDistinct()
+    {
+        NonDemPreservedMaterialGroupingKey red = NonDemPreservedMaterialGrouping.CreateKey(CreateTexturelessMaterial() with
+        {
+            BaseColor = new ResoniteColor(1.0, 0.0, 0.0, 1.0),
+        });
+        NonDemPreservedMaterialGroupingKey blue = NonDemPreservedMaterialGrouping.CreateKey(CreateTexturelessMaterial() with
+        {
+            BaseColor = new ResoniteColor(0.0, 0.0, 1.0, 1.0),
+        });
+
+        Assert.False(NonDemPreservedMaterialGrouping.KeyComparer.Equals(red, blue));
+    }
+
+    private static ResoniteMaterialBinding CreateTexturelessMaterial()
+    {
+        return new ResoniteMaterialBinding(
+            new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            ResoniteTextureSourceKind.Bundled,
+            ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0]);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemSourceFileBatchingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemSourceFileBatchingTests.cs
@@ -1,0 +1,87 @@
+using System;
+
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class NonDemSourceFileBatchingTests
+{
+    [Fact]
+    public void CreateKeyNormalizesPackageNameAndRequiresSourceFileScope()
+    {
+        ResoniteConstructionCityObject cityObject = CreateCityObject() with
+        {
+            PackageName = "BLDG",
+            SourceFileRelativePath = "udx/bldg/53394525_bldg_6697_op.gml",
+        };
+
+        NonDemSourceFileBatchKey key = NonDemSourceFileBatching.CreateKey(
+            cityObject,
+            NonDemCityObjectBakePolicies.Default);
+
+        Assert.Equal("bldg", key.PackageName);
+        Assert.Equal("udx/bldg/53394525_bldg_6697_op.gml", key.SourceFileRelativePath);
+        Assert.Throws<InvalidOperationException>(() => NonDemSourceFileBatching.CreateKey(
+            cityObject with { SourceFileRelativePath = null },
+            NonDemCityObjectBakePolicies.Default));
+    }
+
+    [Fact]
+    public void CreateBatchNamesUseStableSourceFileAndLodTokens()
+    {
+        NonDemSourceFileBatchKey key = new(
+            ActualMeshCode: "53394525",
+            PackageName: "bldg",
+            LodLevel: 2,
+            PolicyContext: "default",
+            SourceFileRelativePath: "udx/bldg/53394525_bldg_6697_op.gml");
+
+        string slotKey = NonDemSourceFileBatching.CreateBatchSlotKey(key, batchIndex: 1);
+        string displayName = NonDemSourceFileBatching.CreateBatchDisplayName(key, batchIndex: 1, slotKey);
+
+        Assert.Equal("atlasbake-53394525_bldg_6697_op-bldg-lod2-2", slotKey);
+        Assert.Equal("AtlasBake bldg LOD2 #2 [atlasbake-53394525_bldg_6697_op-bldg-lod2-2]", displayName);
+        Assert.Equal(
+            "atlastex-udx/bldg/53394525_bldg_6697_op.gml-2",
+            NonDemSourceFileBatching.CreateAtlasTextureIdentity(key, batchIndex: 1));
+    }
+
+    [Fact]
+    public void KeyComparerOrdersByMeshPackageLodPolicyAndSourceFile()
+    {
+        NonDemSourceFileBatchKey first = new("53394525", "bldg", 1, "a", "a.gml");
+        NonDemSourceFileBatchKey second = new("53394525", "bldg", 2, "a", "a.gml");
+
+        Assert.True(NonDemSourceFileBatching.KeyComparer.Compare(first, second) < 0);
+        Assert.True(NonDemSourceFileBatching.KeyComparer.Compare(second, first) > 0);
+        Assert.Equal(0, NonDemSourceFileBatching.KeyComparer.Compare(first, first));
+    }
+
+    private static ResoniteConstructionCityObject CreateCityObject()
+    {
+        return new ResoniteConstructionCityObject(
+            "object",
+            "object",
+            "bldg",
+            "53394525",
+            LodLevel: 2,
+            new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            new ResoniteImportedMesh(
+                [
+                    new ResoniteMeshVertex(
+                        new ResoniteFloat3(0.0, 0.0, 0.0),
+                        new ResoniteFloat3(0.0, 1.0, 0.0),
+                        new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(
+                        new ResoniteFloat3(1.0, 0.0, 0.0),
+                        new ResoniteFloat3(0.0, 1.0, 0.0),
+                        new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(
+                        new ResoniteFloat3(0.0, 0.0, 1.0),
+                        new ResoniteFloat3(0.0, 1.0, 0.0),
+                        new ResoniteFloat2(0.0, 1.0)),
+                ],
+                [new ResoniteMeshSubmesh(0, [0, 1, 2])]),
+            []);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemTextureImageProcessingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemTextureImageProcessingTests.cs
@@ -1,0 +1,51 @@
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class NonDemTextureImageProcessingTests
+{
+    [Fact]
+    public void DetectRepresentativeBackgroundColorAveragesOpaqueBoundaryPixels()
+    {
+        using Image<Rgba32> image = new(3, 1);
+        image[0, 0] = new Rgba32(10, 20, 30, 255);
+        image[1, 0] = new Rgba32(200, 210, 220, 255);
+        image[2, 0] = new Rgba32(0, 0, 0, 0);
+
+        Rgba32 color = NonDemTextureImageProcessing.DetectRepresentativeBackgroundColor(image);
+
+        Assert.Equal(new Rgba32(105, 115, 125, 255), color);
+    }
+
+    [Fact]
+    public void FillTransparentRgbBlendsTransparentPixelsTowardBackground()
+    {
+        using Image<Rgba32> image = new(1, 1);
+        image[0, 0] = new Rgba32(100, 50, 0, 128);
+
+        NonDemTextureImageProcessing.FillTransparentRgb(image, new Rgba32(200, 250, 100, 255));
+
+        Assert.Equal(new Rgba32(150, 150, 50, 128), image[0, 0]);
+    }
+
+    [Fact]
+    public void BakeUsedUvRegionSamplesWrappedUvRegion()
+    {
+        using Image<Rgba32> image = new(2, 1);
+        image[0, 0] = new Rgba32(0, 0, 0, 255);
+        image[1, 0] = new Rgba32(255, 0, 0, 255);
+
+        using Image<Rgba32> baked = NonDemTextureImageProcessing.BakeUsedUvRegion(
+            image,
+            new TextureUvRect(0.5, 0.0, 1.0, 1.0),
+            targetWidth: 2,
+            targetHeight: 1);
+
+        Assert.Equal(new Rgba32(255, 0, 0, 255), baked[0, 0]);
+        Assert.Equal(new Rgba32(0, 0, 0, 255), baked[1, 0]);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -30,7 +30,8 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     private static LiveSendRunStateFactory CreateRunStateFactory()
     {
         return new LiveSendRunStateFactory(
-            new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader()));
+            new ResoniteBufferedCityObjectBakerFactory(
+                new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader())));
     }
 
     private static ResonitePreparedCityObjectImporter CreatePreparedCityObjectImporter(
@@ -214,6 +215,29 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesPreservesPreRegisteredNonDemSourceFileBakeEmitterFactory()
+    {
+        RecordingNonDemSourceFileBakeEmitterFactory sourceFileBakeEmitterFactory = new();
+        ServiceProvider provider = new ServiceCollection()
+            .AddScoped<INonDemSourceFileBakeEmitterFactory>(_ => sourceFileBakeEmitterFactory)
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        CompositeCityObjectBaker? baker = scope.ServiceProvider
+            .GetRequiredService<IResoniteBufferedCityObjectBakerFactory>()
+            .Create(
+                enableMeshBake: true,
+                ResoniteImportBudgetProfiles.ForProfile(ResoniteImportMemoryProfile.Small));
+
+        Assert.NotNull(baker);
+        Assert.Equal(1, sourceFileBakeEmitterFactory.CreateCallCount);
+        ResoniteImportBudgetProfile? resourceBudget = sourceFileBakeEmitterFactory.LastBudget.ResourceBudget;
+        Assert.NotNull(resourceBudget);
+        Assert.Equal(ResoniteImportMemoryProfile.Small, resourceBudget.Name);
+    }
+
+    [Fact]
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The created target is disposed via await using in this test.")]
     public async Task AddResoniteLiveSendTargetServicesRegistersDefaultBaseClientFactory()
     {
@@ -359,6 +383,38 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         }
     }
 
+    private sealed class RecordingNonDemSourceFileBakeEmitterFactory : INonDemSourceFileBakeEmitterFactory
+    {
+        public int CreateCallCount { get; private set; }
+
+        public NonDemAtlasBakeBudget LastBudget { get; private set; }
+
+        public INonDemSourceFileBakeEmitter Create(NonDemAtlasBakeBudget atlasBudget)
+        {
+            CreateCallCount++;
+            LastBudget = atlasBudget;
+            return new RecordingNonDemSourceFileBakeEmitter();
+        }
+    }
+
+    private sealed class RecordingNonDemSourceFileBakeEmitter : INonDemSourceFileBakeEmitter
+    {
+        public Task<int> EmitAsync(
+            NonDemSourceFileBatchKey sourceFileKey,
+            IReadOnlyList<NonDemBufferedCityObject> cityObjects,
+            int batchStartIndex,
+            Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
+            CancellationToken cancellationToken)
+        {
+            _ = sourceFileKey;
+            _ = cityObjects;
+            _ = batchStartIndex;
+            _ = onBakedCityObject;
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new NotSupportedException("This test only verifies DI override preservation during baker creation.");
+        }
+    }
+
     private sealed class RecordingClientSessionFactory(
         Func<ILiveSendClientSession> createSession)
         : IResoniteClientSessionFactory
@@ -378,7 +434,8 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         int cityObjectCount,
         Func<int, ResoniteConstructionCityObject> createCityObject)
     {
-        ResoniteBufferedCityObjectBakerFactory factory = new(new ResoniteTextureImageLoader());
+        ResoniteBufferedCityObjectBakerFactory factory = new(
+            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()));
         CompositeCityObjectBaker baker = factory.Create(
                 enableMeshBake: true,
                 ResoniteImportBudgetProfiles.ForProfile(memoryProfile))

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -48,8 +48,9 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     {
         return new ResoniteQueuedCityObjectWorker(
             new ResoniteQueuedCityObjectSender(
-                new TerrainTextureAssetGenerator(),
-                new ResoniteDatasetLicenseWriter(),
+                new ResoniteQueuedTexturePreparer(
+                    new TerrainTextureAssetGenerator(),
+                    new ResoniteDatasetLicenseWriter()),
                 CreatePreparedCityObjectImporter(materialPlanning)));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -21,10 +21,9 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     private static BundledDefaultMaterialAssetStore CreateBundledDefaultMaterialAssetStore() => new();
 
     private static ResoniteCommonMaterialSetupPreparer CreateCommonMaterialSetupPreparer(
-        IResoniteMaterialPlanning materialPlanning,
-        Action<string>? progressReporter = null)
+        IResoniteMaterialPlanning materialPlanning)
     {
-        return new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter);
+        return new ResoniteCommonMaterialSetupPreparer(materialPlanning);
     }
 
     private static LiveSendRunStateFactory CreateRunStateFactory()
@@ -56,12 +55,11 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
 
     private static ResoniteLiveSendRunStarter CreateRunStarter(
         IResoniteMaterialPlanning materialPlanning,
-        IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null,
-        Action<string>? progressReporter = null)
+        IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null)
     {
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
-            CreateCommonMaterialSetupPreparer(materialPlanning, progressReporter),
+            CreateCommonMaterialSetupPreparer(materialPlanning),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
             new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -51,8 +51,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     {
         return new ResoniteQueuedCityObjectWorker(
             new ResoniteQueuedCityObjectSender(
-                new TerrainTextureAssetGenerator(),
-                new ResoniteDatasetLicenseWriter(),
+                new ResoniteQueuedTexturePreparer(
+                    new TerrainTextureAssetGenerator(),
+                    new ResoniteDatasetLicenseWriter()),
                 CreatePreparedCityObjectImporter(materialPlanning)));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -24,10 +24,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     private static BundledDefaultMaterialAssetStore CreateBundledDefaultMaterialAssetStore() => new();
 
     private static ResoniteCommonMaterialSetupPreparer CreateCommonMaterialSetupPreparer(
-        IResoniteMaterialPlanning materialPlanning,
-        Action<string>? progressReporter = null)
+        IResoniteMaterialPlanning materialPlanning)
     {
-        return new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter);
+        return new ResoniteCommonMaterialSetupPreparer(materialPlanning);
     }
 
     private static LiveSendRunStateFactory CreateRunStateFactory()
@@ -59,12 +58,11 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
 
     private static ResoniteLiveSendRunStarter CreateRunStarter(
         IResoniteMaterialPlanning materialPlanning,
-        IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null,
-        Action<string>? progressReporter = null)
+        IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null)
     {
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
-            CreateCommonMaterialSetupPreparer(materialPlanning, progressReporter),
+            CreateCommonMaterialSetupPreparer(materialPlanning),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
             new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),
@@ -399,7 +397,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 session,
                 ResoniteLinkSendDiagnostics.Disabled,
                 new ResoniteLiveSendStartRequestFactory(),
-                CreateRunStarter(materialPlanning, progressReporter: progressMessages.Add),
+                CreateRunStarter(materialPlanning),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -33,7 +33,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     private static LiveSendRunStateFactory CreateRunStateFactory()
     {
         return new LiveSendRunStateFactory(
-            new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader()));
+            new ResoniteBufferedCityObjectBakerFactory(
+                new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader())));
     }
 
     private static ResonitePreparedCityObjectImporter CreatePreparedCityObjectImporter(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -325,8 +325,9 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
             new ResoniteQueuedCityObjectSender(
-                terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
-                new ResoniteDatasetLicenseWriter(),
+                new ResoniteQueuedTexturePreparer(
+                    terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
+                    new ResoniteDatasetLicenseWriter()),
                 new ResonitePreparedCityObjectImporter(
                     new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
                     new ResoniteSceneMaterialPlanComposer(materialPlanning),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -350,7 +350,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                     new ResoniteSceneSetupInterpreter(
                         new ResoniteSceneSlotLocator(),
                         new ResoniteSceneAnchorResolver()),
-                    new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter),
+                    new ResoniteCommonMaterialSetupPreparer(materialPlanning),
                     new LiveSendRunPlanFactory(),
                     new LiveSendRunStateFactory(
                         new ResoniteBufferedCityObjectBakerFactory(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -352,7 +352,9 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                         new ResoniteSceneAnchorResolver()),
                     new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter),
                     new LiveSendRunPlanFactory(),
-                    new LiveSendRunStateFactory(new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())),
+                    new LiveSendRunStateFactory(
+                        new ResoniteBufferedCityObjectBakerFactory(
+                            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
                     new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),
                     new ResoniteSlotCreator()),
                 queue));


### PR DESCRIPTION
## Summary
- extract non-DEM atlas rectangle packing into NonDemAtlasLayoutPacker
- keep NonDemCityObjectBaker focused on bake candidate/material/geometry emission work
- add layout packer tests for power-of-two canvas selection and oversized tile rejection

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false