### PR TITLE
Split non-DEM bake pipeline services

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/INonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/INonDemSourceFileBakeEmitter.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface INonDemSourceFileBakeEmitter
+{
+    Task<int> EmitAsync(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemBufferedCityObject> cityObjects,
+        int batchStartIndex,
+        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
+        CancellationToken cancellationToken);
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasBakeBudget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasBakeBudget.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal readonly record struct NonDemAtlasBakeBudget(
+    int MaxAtlasSize = NonDemAtlasBakeBudget.DefaultMaxAtlasSize,
+    int TilePaddingPixels = NonDemAtlasBakeBudget.DefaultTilePaddingPixels,
+    ResoniteImportBudgetProfile? ResourceBudget = null)
+{
+    public const int DefaultMaxAtlasSize = 4096;
+    public const int DefaultTilePaddingPixels = 2;
+
+    public int EffectiveMaxAtlasSize => Math.Max(1, Math.Min(MaxAtlasSize, ResourceBudget?.MaxAtlasSize ?? MaxAtlasSize));
+
+    public int EffectiveMaxAtlasTextureEdge
+    {
+        get
+        {
+            int profileMaxTileEdge = ResourceBudget?.MaxAtlasTextureEdge ?? EffectiveMaxAtlasSize;
+            return Math.Max(1, Math.Min(EffectiveMaxAtlasSize - (TilePaddingPixels * 2), profileMaxTileEdge));
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasBatchFitPolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasBatchFitPolicy.cs
@@ -3,7 +3,18 @@ using System.Linq;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed class NonDemAtlasBatchFitPolicy(NonDemAtlasLayoutFactory atlasLayoutFactory)
+internal interface INonDemAtlasBatchFitPolicy
+{
+    bool CanFitSingleCandidate(NonDemCityObjectBakeCandidate candidate);
+
+    bool CanAppendToAtlasBatch(
+        IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
+        NonDemCityObjectBakeCandidate candidate);
+
+    bool RequiresBakeEmission(NonDemCityObjectBakeCandidate candidate);
+}
+
+internal sealed class NonDemAtlasBatchFitPolicy(INonDemAtlasLayoutFactory atlasLayoutFactory) : INonDemAtlasBatchFitPolicy
 {
     public bool CanFitSingleCandidate(NonDemCityObjectBakeCandidate candidate)
     {
@@ -18,7 +29,7 @@ internal sealed class NonDemAtlasBatchFitPolicy(NonDemAtlasLayoutFactory atlasLa
         return atlasLayoutFactory.CanFit(candidateEntries);
     }
 
-    public static bool RequiresBakeEmission(NonDemCityObjectBakeCandidate candidate)
+    public bool RequiresBakeEmission(NonDemCityObjectBakeCandidate candidate)
     {
         return candidate.PreservedEntries.Any(static entry => entry.VertexColorOverride is not null);
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasBatchFitPolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasBatchFitPolicy.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemAtlasBatchFitPolicy(NonDemAtlasLayoutFactory atlasLayoutFactory)
+{
+    public bool CanFitSingleCandidate(NonDemCityObjectBakeCandidate candidate)
+    {
+        return candidate.AtlasEntries.Count == 0 || atlasLayoutFactory.CanFit(candidate.AtlasEntries);
+    }
+
+    public bool CanAppendToAtlasBatch(
+        IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
+        NonDemCityObjectBakeCandidate candidate)
+    {
+        List<NonDemAtlasBatchEntry> candidateEntries = [.. batchCandidates.SelectMany(static current => current.AtlasEntries), .. candidate.AtlasEntries];
+        return atlasLayoutFactory.CanFit(candidateEntries);
+    }
+
+    public static bool RequiresBakeEmission(NonDemCityObjectBakeCandidate candidate)
+    {
+        return candidate.PreservedEntries.Any(static entry => entry.VertexColorOverride is not null);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasImageRenderer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasImageRenderer.cs
@@ -6,7 +6,14 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed class NonDemAtlasImageRenderer(int tilePaddingPixels)
+internal interface INonDemAtlasImageRenderer
+{
+    void Draw(
+        Image<Rgba32> atlasImage,
+        IReadOnlyList<NonDemAtlasPlacement<NonDemAtlasBatchEntry>> placements);
+}
+
+internal sealed class NonDemAtlasImageRenderer(int tilePaddingPixels) : INonDemAtlasImageRenderer
 {
     public void Draw(
         Image<Rgba32> atlasImage,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasLayoutFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasLayoutFactory.cs
@@ -2,7 +2,16 @@ using System.Collections.Generic;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed class NonDemAtlasLayoutFactory(int atlasMaxSize, int tilePaddingPixels)
+internal interface INonDemAtlasLayoutFactory
+{
+    bool CanFit(IReadOnlyList<NonDemAtlasBatchEntry> entries);
+
+    bool TryCreate(
+        IReadOnlyList<NonDemAtlasBatchEntry> entries,
+        out NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout);
+}
+
+internal sealed class NonDemAtlasLayoutFactory(int atlasMaxSize, int tilePaddingPixels) : INonDemAtlasLayoutFactory
 {
     public bool CanFit(IReadOnlyList<NonDemAtlasBatchEntry> entries)
     {

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
@@ -11,9 +11,18 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
+internal interface INonDemAtlasOrPreservedEntryFactory
+{
+    Task<NonDemAtlasOrPreservedEntry> CreateAsync(
+        ResoniteConstructionCityObject cityObject,
+        ResoniteMeshSubmesh submesh,
+        ResoniteMaterialBinding material,
+        CancellationToken cancellationToken);
+}
+
 internal sealed class NonDemAtlasOrPreservedEntryFactory(
     ResoniteTextureImageLoader textureImageLoader,
-    int maxAtlasTextureEdge)
+    int maxAtlasTextureEdge) : INonDemAtlasOrPreservedEntryFactory
 {
     private readonly ResoniteTextureImageLoader textureImageLoader = textureImageLoader
         ?? throw new ArgumentNullException(nameof(textureImageLoader));

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemAtlasOrPreservedEntryFactory(
+    ResoniteTextureImageLoader textureImageLoader,
+    int maxAtlasTextureEdge)
+{
+    private readonly ResoniteTextureImageLoader textureImageLoader = textureImageLoader
+        ?? throw new ArgumentNullException(nameof(textureImageLoader));
+
+    public async Task<NonDemAtlasOrPreservedEntry> CreateAsync(
+        ResoniteConstructionCityObject cityObject,
+        ResoniteMeshSubmesh submesh,
+        ResoniteMaterialBinding material,
+        CancellationToken cancellationToken)
+    {
+        if (material.TexturePayload is null)
+        {
+            throw new InvalidOperationException("Non-DEM bake candidate material must have a texture payload.");
+        }
+
+        TextureUvRect uvBounds = ComputeUvBounds(cityObject.Mesh.Vertices, submesh);
+        using Image<Rgba32> sourceImage = await textureImageLoader.LoadAsync(
+            ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
+            cancellationToken);
+        Rgba32 detectedBackgroundColor = NonDemTextureImageProcessing.DetectRepresentativeBackgroundColor(sourceImage);
+        using Image<Rgba32> preparedSourceImage = sourceImage.Clone();
+        NonDemTextureImageProcessing.FillTransparentRgb(preparedSourceImage, detectedBackgroundColor);
+        if (NonDemTextureImageProcessing.TryGetUniformPixelColor(preparedSourceImage, out Rgba32 uniformDatasetColor))
+        {
+            Rgba32 tintedUniformColor = NonDemTextureImageProcessing.MultiplyPixel(
+                uniformDatasetColor,
+                NonDemTextureImageProcessing.ToPixel(material.BaseColor));
+            return new NonDemAtlasOrPreservedEntry(
+                AtlasEntry: null,
+                PreservedEntry: new NonDemPreservedSubmeshEntry(
+                    cityObject,
+                    submesh,
+                    CreateVertexColorMaterial(material, submesh.Index),
+                    NonDemTextureImageProcessing.ToColor(tintedUniformColor)));
+        }
+
+        int targetWidth = Math.Max(1, Math.Min(maxAtlasTextureEdge, (int)Math.Ceiling(sourceImage.Width * uvBounds.Width)));
+        int targetHeight = Math.Max(1, Math.Min(maxAtlasTextureEdge, (int)Math.Ceiling(sourceImage.Height * uvBounds.Height)));
+        using Image<Rgba32> bakedImage = NonDemTextureImageProcessing.BakeUsedUvRegion(
+            preparedSourceImage,
+            uvBounds,
+            targetWidth,
+            targetHeight);
+
+        NonDemTextureImageProcessing.ApplyBaseColor(bakedImage, material.BaseColor);
+        return new NonDemAtlasOrPreservedEntry(
+            AtlasEntry: new NonDemAtlasBatchEntry(
+                cityObject,
+                submesh,
+                material,
+                new NonDemMaterialAtlasTile(
+                    bakedImage.Clone(),
+                    NonDemTextureImageProcessing.MultiplyPixel(
+                        detectedBackgroundColor,
+                        NonDemTextureImageProcessing.ToPixel(material.BaseColor))),
+                uvBounds),
+            PreservedEntry: null);
+    }
+
+    private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)
+    {
+        return material with
+        {
+            MaterialType = ResoniteMaterialType.VertexColor,
+            BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            TexturePayload = null,
+            TextureSourceKind = ResoniteTextureSourceKind.Bundled,
+            TextureScale = null,
+            TextureOffset = null,
+            Family = null,
+            TerrainOverlay = null,
+            AssetScope = ResoniteMaterialAssetScope.Common,
+            SubmeshIndices = [submeshIndex],
+            CommonMaterial = material.DepthOffset is null
+                ? CommonMaterialCatalog.Create().VertexColor.Uv
+                : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv,
+        };
+    }
+
+    private static TextureUvRect ComputeUvBounds(
+        IReadOnlyList<ResoniteMeshVertex> vertices,
+        ResoniteMeshSubmesh submesh)
+    {
+        double minU = double.PositiveInfinity;
+        double minV = double.PositiveInfinity;
+        double maxU = double.NegativeInfinity;
+        double maxV = double.NegativeInfinity;
+
+        foreach (int sourceIndex in submesh.TriangleVertexIndices)
+        {
+            ResoniteFloat2 transformedUv = vertices[sourceIndex].UV0;
+            minU = Math.Min(minU, transformedUv.X);
+            minV = Math.Min(minV, transformedUv.Y);
+            maxU = Math.Max(maxU, transformedUv.X);
+            maxV = Math.Max(maxV, transformedUv.Y);
+        }
+
+        if (double.IsPositiveInfinity(minU) || double.IsPositiveInfinity(minV))
+        {
+            return TextureUvRect.Identity;
+        }
+
+        double width = Math.Max(1.0 / 1024.0, maxU - minU);
+        double height = Math.Max(1.0 / 1024.0, maxV - minV);
+        return new TextureUvRect(minU, minV, width, height);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemBakeCandidateImageDisposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemBakeCandidateImageDisposer.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface INonDemBakeCandidateImageDisposer
+{
+    void Dispose(NonDemCityObjectBakeCandidate candidate);
+
+    void Dispose(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates);
+}
+
+internal sealed class NonDemBakeCandidateImageDisposer : INonDemBakeCandidateImageDisposer
+{
+    public void Dispose(NonDemCityObjectBakeCandidate candidate)
+    {
+        Dispose([candidate]);
+    }
+
+    public void Dispose(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
+    {
+        foreach (Image<Rgba32> tileImage in candidates
+                     .SelectMany(static candidate => candidate.AtlasEntries)
+                     .Select(static entry => entry.Tile.Image)
+                     .Distinct())
+        {
+            tileImage.Dispose();
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record NonDemBakedGeometry(
+    ResoniteFloat3 Origin,
+    ResoniteImportedMesh Mesh,
+    IReadOnlyList<ResoniteMaterialBinding> Materials);
+
+internal interface INonDemBakedGeometryComposer
+{
+    NonDemBakedGeometry Compose(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
+        int batchIndex,
+        NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout,
+        Image<Rgba32>? atlasImage,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class NonDemBakedGeometryComposer : INonDemBakedGeometryComposer
+{
+    public NonDemBakedGeometry Compose(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
+        int batchIndex,
+        NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout,
+        Image<Rgba32>? atlasImage,
+        CancellationToken cancellationToken)
+    {
+        ResoniteFloat3 bakeOrigin = ComputeBakeOrigin(candidates);
+        List<ResoniteMeshVertex> vertices = [];
+        List<ResoniteMeshSubmesh> submeshes = [];
+        List<ResoniteMaterialBinding> materials = [];
+
+        if (layout is not null)
+        {
+            string textureIdentity = NonDemSourceFileBatching.CreateAtlasTextureIdentity(sourceFileKey, batchIndex);
+            List<int> atlasTriangleIndices = [];
+            foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in layout.Placements
+                         .OrderBy(static candidate => candidate.Entry.CityObject.SlotKey, StringComparer.Ordinal)
+                         .ThenBy(static candidate => candidate.Entry.Submesh.Index))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                AppendPlacementGeometry(vertices, atlasTriangleIndices, bakeOrigin, placement, layout.Width, layout.Height);
+            }
+
+            submeshes.Add(new ResoniteMeshSubmesh(0, atlasTriangleIndices));
+            materials.Add(
+                new ResoniteMaterialBinding(
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    TexturePayload: ResoniteTextureImportFactory.CreatePayloadFromImage(
+                        atlasImage ?? throw new InvalidOperationException("Non-DEM atlas image is required when an atlas layout exists."),
+                        identity: textureIdentity),
+                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv));
+        }
+
+        foreach (IGrouping<NonDemPreservedMaterialGroupingKey, NonDemOrderedPreservedSubmeshEntry> preservedGroup in candidates
+                     .SelectMany(static candidate => candidate.PreservedEntries)
+                     .Select(static (entry, order) => new NonDemOrderedPreservedSubmeshEntry(entry, order))
+                     .GroupBy(static entry => NonDemPreservedMaterialGrouping.CreateKey(entry.Entry.Material), NonDemPreservedMaterialGrouping.KeyComparer)
+                     .OrderBy(static group => group.Min(static entry => entry.Order)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            List<int> preservedTriangleIndices = [];
+            foreach (NonDemPreservedSubmeshEntry preservedEntry in preservedGroup
+                         .Select(static entry => entry.Entry)
+                         .OrderBy(static entry => entry.CityObject.SlotKey, StringComparer.Ordinal)
+                         .ThenBy(static entry => entry.Submesh.Index))
+            {
+                AppendOriginalGeometry(vertices, preservedTriangleIndices, bakeOrigin, preservedEntry);
+            }
+
+            if (preservedTriangleIndices.Count == 0)
+            {
+                continue;
+            }
+
+            int submeshIndex = submeshes.Count;
+            ResoniteMaterialBinding preservedMaterial = NonDemPreservedMaterialGrouping.NormalizeMaterial(preservedGroup.First().Entry.Material) with
+            {
+                SubmeshIndices = [submeshIndex],
+            };
+            submeshes.Add(new ResoniteMeshSubmesh(submeshIndex, preservedTriangleIndices));
+            materials.Add(preservedMaterial);
+        }
+
+        if (submeshes.Count == 0 || materials.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Non-DEM bake batch '{sourceFileKey.PackageName}:{sourceFileKey.ActualMeshCode}:LOD{sourceFileKey.LodLevel}' produced no materialized submesh.");
+        }
+
+        return new NonDemBakedGeometry(
+            bakeOrigin,
+            new ResoniteImportedMesh(vertices, submeshes),
+            materials);
+    }
+
+    private static void AppendPlacementGeometry(
+        List<ResoniteMeshVertex> vertices,
+        List<int> triangleIndices,
+        ResoniteFloat3 bakeOrigin,
+        NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement,
+        int atlasWidth,
+        int atlasHeight)
+    {
+        IReadOnlyList<ResoniteMeshVertex> sourceVertices = placement.Entry.CityObject.Mesh.Vertices;
+        ResoniteFloat3 cityObjectOffset = Subtract(placement.Entry.CityObject.Transform.Position, bakeOrigin);
+        NonDemAtlasRect innerRect = placement.InnerRect;
+
+        foreach (int sourceIndex in placement.Entry.Submesh.TriangleVertexIndices)
+        {
+            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
+            ResoniteFloat2 sourceUv = sourceVertex.UV0;
+            ResoniteFloat2 atlasUv = MapUvToAtlas(sourceUv, placement.Entry.UvBounds, innerRect, atlasWidth, atlasHeight);
+            vertices.Add(sourceVertex with
+            {
+                Position = Add(sourceVertex.Position, cityObjectOffset),
+                UV0 = atlasUv,
+            });
+            triangleIndices.Add(vertices.Count - 1);
+        }
+    }
+
+    private static void AppendOriginalGeometry(
+        List<ResoniteMeshVertex> vertices,
+        List<int> triangleIndices,
+        ResoniteFloat3 bakeOrigin,
+        NonDemPreservedSubmeshEntry preservedEntry)
+    {
+        IReadOnlyList<ResoniteMeshVertex> sourceVertices = preservedEntry.CityObject.Mesh.Vertices;
+        ResoniteFloat3 cityObjectOffset = Subtract(preservedEntry.CityObject.Transform.Position, bakeOrigin);
+        foreach (int sourceIndex in preservedEntry.Submesh.TriangleVertexIndices)
+        {
+            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
+            vertices.Add(sourceVertex with
+            {
+                Position = Add(sourceVertex.Position, cityObjectOffset),
+                Color = preservedEntry.VertexColorOverride ?? sourceVertex.Color,
+            });
+            triangleIndices.Add(vertices.Count - 1);
+        }
+    }
+
+    private static ResoniteFloat2 MapUvToAtlas(
+        ResoniteFloat2 sourceUv,
+        TextureUvRect uvBounds,
+        NonDemAtlasRect atlasRect,
+        double atlasWidth,
+        double atlasHeight)
+    {
+        TextureUvRect atlasUvRect = TextureUvRect.FromTopLeftPixelRect(
+            atlasRect.X,
+            atlasRect.Y,
+            atlasRect.Width,
+            atlasRect.Height,
+            (int)Math.Round(atlasWidth),
+            (int)Math.Round(atlasHeight));
+        ScalarPair remapped = TextureUvRect.RemapValue(
+            new ScalarPair(sourceUv.X, sourceUv.Y),
+            uvBounds,
+            atlasUvRect);
+        return new ResoniteFloat2(remapped.X, remapped.Y);
+    }
+
+    private static ResoniteFloat3 ComputeBakeOrigin(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
+    {
+        double minX = double.PositiveInfinity;
+        double minY = double.PositiveInfinity;
+        double minZ = double.PositiveInfinity;
+
+        foreach (ResoniteConstructionCityObject cityObject in candidates.Select(static candidate => candidate.CityObject))
+        {
+            foreach (ResoniteMeshVertex vertex in cityObject.Mesh.Vertices)
+            {
+                ResoniteFloat3 worldPosition = Add(vertex.Position, cityObject.Transform.Position);
+                minX = Math.Min(minX, worldPosition.X);
+                minY = Math.Min(minY, worldPosition.Y);
+                minZ = Math.Min(minZ, worldPosition.Z);
+            }
+        }
+
+        return double.IsPositiveInfinity(minX)
+            ? new ResoniteFloat3(0.0, 0.0, 0.0)
+            : new ResoniteFloat3(minX, minY, minZ);
+    }
+
+    private static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)
+    {
+        return new ResoniteFloat3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
+    }
+
+    private static ResoniteFloat3 Subtract(ResoniteFloat3 left, ResoniteFloat3 right)
+    {
+        return new ResoniteFloat3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
@@ -20,13 +20,13 @@ internal interface INonDemCityObjectBakeAssembler
 }
 
 internal sealed class NonDemCityObjectBakeAssembler(
-    NonDemAtlasLayoutFactory atlasLayoutFactory,
-    NonDemAtlasImageRenderer atlasImageRenderer,
+    INonDemAtlasLayoutFactory atlasLayoutFactory,
+    INonDemAtlasImageRenderer atlasImageRenderer,
     INonDemBakedGeometryComposer geometryComposer) : INonDemCityObjectBakeAssembler
 {
-    private readonly NonDemAtlasLayoutFactory atlasLayoutFactory = atlasLayoutFactory
+    private readonly INonDemAtlasLayoutFactory atlasLayoutFactory = atlasLayoutFactory
         ?? throw new ArgumentNullException(nameof(atlasLayoutFactory));
-    private readonly NonDemAtlasImageRenderer atlasImageRenderer = atlasImageRenderer
+    private readonly INonDemAtlasImageRenderer atlasImageRenderer = atlasImageRenderer
         ?? throw new ArgumentNullException(nameof(atlasImageRenderer));
     private readonly INonDemBakedGeometryComposer geometryComposer = geometryComposer
         ?? throw new ArgumentNullException(nameof(geometryComposer));

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
@@ -9,10 +9,20 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
+internal interface INonDemCityObjectBakeAssembler
+{
+    Task<ResoniteConstructionCityObject> BakeBatchAsync(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
+        int batchIndex,
+        bool preservePrimaryIdentity,
+        CancellationToken cancellationToken);
+}
+
 internal sealed class NonDemCityObjectBakeAssembler(
     NonDemAtlasLayoutFactory atlasLayoutFactory,
     NonDemAtlasImageRenderer atlasImageRenderer,
-    INonDemBakedGeometryComposer geometryComposer)
+    INonDemBakedGeometryComposer geometryComposer) : INonDemCityObjectBakeAssembler
 {
     private readonly NonDemAtlasLayoutFactory atlasLayoutFactory = atlasLayoutFactory
         ?? throw new ArgumentNullException(nameof(atlasLayoutFactory));

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
@@ -4,9 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Domain.Importing;
-
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -14,8 +11,16 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemCityObjectBakeAssembler(
     NonDemAtlasLayoutFactory atlasLayoutFactory,
-    NonDemAtlasImageRenderer atlasImageRenderer)
+    NonDemAtlasImageRenderer atlasImageRenderer,
+    INonDemBakedGeometryComposer geometryComposer)
 {
+    private readonly NonDemAtlasLayoutFactory atlasLayoutFactory = atlasLayoutFactory
+        ?? throw new ArgumentNullException(nameof(atlasLayoutFactory));
+    private readonly NonDemAtlasImageRenderer atlasImageRenderer = atlasImageRenderer
+        ?? throw new ArgumentNullException(nameof(atlasImageRenderer));
+    private readonly INonDemBakedGeometryComposer geometryComposer = geometryComposer
+        ?? throw new ArgumentNullException(nameof(geometryComposer));
+
     public Task<ResoniteConstructionCityObject> BakeBatchAsync(
         NonDemSourceFileBatchKey sourceFileKey,
         IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
@@ -51,69 +56,13 @@ internal sealed class NonDemCityObjectBakeAssembler(
             ? null
             : sourceFileKey.SourceFileRelativePath;
 
-        ResoniteFloat3 bakeOrigin = ComputeBakeOrigin(candidates);
-        List<ResoniteMeshVertex> vertices = [];
-        List<ResoniteMeshSubmesh> submeshes = [];
-        List<ResoniteMaterialBinding> materials = [];
-
-        if (layout is not null)
-        {
-            string textureIdentity = NonDemSourceFileBatching.CreateAtlasTextureIdentity(sourceFileKey, batchIndex);
-            List<int> atlasTriangleIndices = [];
-            foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in layout.Placements.OrderBy(static candidate => candidate.Entry.CityObject.SlotKey, StringComparer.Ordinal).ThenBy(static candidate => candidate.Entry.Submesh.Index))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                AppendPlacementGeometry(vertices, atlasTriangleIndices, bakeOrigin, placement, layout.Width, layout.Height);
-            }
-
-            submeshes.Add(new ResoniteMeshSubmesh(0, atlasTriangleIndices));
-            materials.Add(
-                new ResoniteMaterialBinding(
-                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-                    MaterialType: ResoniteMaterialType.Standard,
-                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-                    Projection: ResoniteMaterialProjection.Uv,
-                    DepthOffset: null,
-                    SubmeshIndices: [0],
-                    TexturePayload: ResoniteTextureImportFactory.CreatePayloadFromImage(atlasImage!, identity: textureIdentity),
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv));
-        }
-
-        foreach (IGrouping<NonDemPreservedMaterialGroupingKey, NonDemOrderedPreservedSubmeshEntry> preservedGroup in candidates
-                     .SelectMany(static candidate => candidate.PreservedEntries)
-                     .Select(static (entry, order) => new NonDemOrderedPreservedSubmeshEntry(entry, order))
-                     .GroupBy(static entry => NonDemPreservedMaterialGrouping.CreateKey(entry.Entry.Material), NonDemPreservedMaterialGrouping.KeyComparer)
-                     .OrderBy(static group => group.Min(static entry => entry.Order)))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            List<int> preservedTriangleIndices = [];
-            foreach (NonDemPreservedSubmeshEntry preservedEntry in preservedGroup
-                         .Select(static entry => entry.Entry)
-                         .OrderBy(static entry => entry.CityObject.SlotKey, StringComparer.Ordinal)
-                         .ThenBy(static entry => entry.Submesh.Index))
-            {
-                AppendOriginalGeometry(vertices, preservedTriangleIndices, bakeOrigin, preservedEntry);
-            }
-
-            if (preservedTriangleIndices.Count == 0)
-            {
-                continue;
-            }
-
-            int submeshIndex = submeshes.Count;
-            ResoniteMaterialBinding preservedMaterial = NonDemPreservedMaterialGrouping.NormalizeMaterial(preservedGroup.First().Entry.Material) with
-            {
-                SubmeshIndices = [submeshIndex],
-            };
-            submeshes.Add(new ResoniteMeshSubmesh(submeshIndex, preservedTriangleIndices));
-            materials.Add(preservedMaterial);
-        }
-
-        if (submeshes.Count == 0 || materials.Count == 0)
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM bake batch '{sourceFileKey.PackageName}:{sourceFileKey.ActualMeshCode}:LOD{sourceFileKey.LodLevel}' produced no materialized submesh.");
-        }
+        NonDemBakedGeometry geometry = geometryComposer.Compose(
+            sourceFileKey,
+            candidates,
+            batchIndex,
+            layout,
+            atlasImage,
+            cancellationToken);
 
         ResoniteConstructionCityObject bakedCityObject = new(
             SlotKey: slotKey,
@@ -121,110 +70,11 @@ internal sealed class NonDemCityObjectBakeAssembler(
             PackageName: firstCityObject.PackageName,
             ActualMeshCode: firstCityObject.ActualMeshCode,
             LodLevel: firstCityObject.LodLevel,
-            Transform: new ResoniteTransform(bakeOrigin),
-            Mesh: new ResoniteImportedMesh(vertices, submeshes),
-            Materials: materials,
+            Transform: new ResoniteTransform(geometry.Origin),
+            Mesh: geometry.Mesh,
+            Materials: geometry.Materials,
             CollisionEnabled: candidates.Any(static candidate => candidate.CityObject.CollisionEnabled),
             SourceFileRelativePath: sourceFileRelativePath);
         return Task.FromResult(bakedCityObject);
-    }
-
-    private static void AppendPlacementGeometry(
-        List<ResoniteMeshVertex> vertices,
-        List<int> triangleIndices,
-        ResoniteFloat3 bakeOrigin,
-        NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement,
-        int atlasWidth,
-        int atlasHeight)
-    {
-        IReadOnlyList<ResoniteMeshVertex> sourceVertices = placement.Entry.CityObject.Mesh.Vertices;
-        ResoniteFloat3 cityObjectOffset = Subtract(placement.Entry.CityObject.Transform.Position, bakeOrigin);
-        NonDemAtlasRect innerRect = placement.InnerRect;
-
-        foreach (int sourceIndex in placement.Entry.Submesh.TriangleVertexIndices)
-        {
-            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
-            ResoniteFloat2 sourceUv = sourceVertex.UV0;
-            ResoniteFloat2 atlasUv = MapUvToAtlas(sourceUv, placement.Entry.UvBounds, innerRect, atlasWidth, atlasHeight);
-            vertices.Add(sourceVertex with
-            {
-                Position = Add(sourceVertex.Position, cityObjectOffset),
-                UV0 = atlasUv,
-            });
-            triangleIndices.Add(vertices.Count - 1);
-        }
-    }
-
-    private static void AppendOriginalGeometry(
-        List<ResoniteMeshVertex> vertices,
-        List<int> triangleIndices,
-        ResoniteFloat3 bakeOrigin,
-        NonDemPreservedSubmeshEntry preservedEntry)
-    {
-        IReadOnlyList<ResoniteMeshVertex> sourceVertices = preservedEntry.CityObject.Mesh.Vertices;
-        ResoniteFloat3 cityObjectOffset = Subtract(preservedEntry.CityObject.Transform.Position, bakeOrigin);
-        foreach (int sourceIndex in preservedEntry.Submesh.TriangleVertexIndices)
-        {
-            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
-            vertices.Add(sourceVertex with
-            {
-                Position = Add(sourceVertex.Position, cityObjectOffset),
-                Color = preservedEntry.VertexColorOverride ?? sourceVertex.Color,
-            });
-            triangleIndices.Add(vertices.Count - 1);
-        }
-    }
-
-    private static ResoniteFloat2 MapUvToAtlas(
-        ResoniteFloat2 sourceUv,
-        TextureUvRect uvBounds,
-        NonDemAtlasRect atlasRect,
-        double atlasWidth,
-        double atlasHeight)
-    {
-        TextureUvRect atlasUvRect = TextureUvRect.FromTopLeftPixelRect(
-            atlasRect.X,
-            atlasRect.Y,
-            atlasRect.Width,
-            atlasRect.Height,
-            (int)Math.Round(atlasWidth),
-            (int)Math.Round(atlasHeight));
-        ScalarPair remapped = TextureUvRect.RemapValue(
-            new ScalarPair(sourceUv.X, sourceUv.Y),
-            uvBounds,
-            atlasUvRect);
-        return new ResoniteFloat2(remapped.X, remapped.Y);
-    }
-
-    private static ResoniteFloat3 ComputeBakeOrigin(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
-    {
-        double minX = double.PositiveInfinity;
-        double minY = double.PositiveInfinity;
-        double minZ = double.PositiveInfinity;
-
-        foreach (ResoniteConstructionCityObject cityObject in candidates.Select(static candidate => candidate.CityObject))
-        {
-            foreach (ResoniteMeshVertex vertex in cityObject.Mesh.Vertices)
-            {
-                ResoniteFloat3 worldPosition = Add(vertex.Position, cityObject.Transform.Position);
-                minX = Math.Min(minX, worldPosition.X);
-                minY = Math.Min(minY, worldPosition.Y);
-                minZ = Math.Min(minZ, worldPosition.Z);
-            }
-        }
-
-        return double.IsPositiveInfinity(minX)
-            ? new ResoniteFloat3(0.0, 0.0, 0.0)
-            : new ResoniteFloat3(minX, minY, minZ);
-    }
-
-    private static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)
-    {
-        return new ResoniteFloat3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
-    }
-
-    private static ResoniteFloat3 Subtract(ResoniteFloat3 left, ResoniteFloat3 right)
-    {
-        return new ResoniteFloat3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemCityObjectBakeAssembler(
+    NonDemAtlasLayoutFactory atlasLayoutFactory,
+    NonDemAtlasImageRenderer atlasImageRenderer)
+{
+    public Task<ResoniteConstructionCityObject> BakeBatchAsync(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
+        int batchIndex,
+        bool preservePrimaryIdentity,
+        CancellationToken cancellationToken)
+    {
+        List<NonDemAtlasBatchEntry> entries = candidates.SelectMany(static candidate => candidate.AtlasEntries).ToList();
+        NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout = null;
+        if (entries.Count > 0
+            && (!atlasLayoutFactory.TryCreate(entries, out layout) || layout is null))
+        {
+            throw new InvalidOperationException("Failed to create non-DEM atlas layout.");
+        }
+
+        using Image<Rgba32>? atlasImage = layout is null
+            ? null
+            : new Image<Rgba32>(layout.Width, layout.Height, new Rgba32(0, 0, 0, 0));
+        if (layout is not null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            atlasImageRenderer.Draw(atlasImage!, layout.Placements);
+        }
+
+        ResoniteConstructionCityObject firstCityObject = candidates[0].CityObject;
+        string slotKey = preservePrimaryIdentity
+            ? firstCityObject.SlotKey
+            : NonDemSourceFileBatching.CreateBatchSlotKey(sourceFileKey, batchIndex);
+        string displayName = preservePrimaryIdentity
+            ? firstCityObject.DisplayName
+            : NonDemSourceFileBatching.CreateBatchDisplayName(sourceFileKey, batchIndex, slotKey);
+        string? sourceFileRelativePath = string.IsNullOrWhiteSpace(firstCityObject.SourceFileRelativePath)
+            ? null
+            : sourceFileKey.SourceFileRelativePath;
+
+        ResoniteFloat3 bakeOrigin = ComputeBakeOrigin(candidates);
+        List<ResoniteMeshVertex> vertices = [];
+        List<ResoniteMeshSubmesh> submeshes = [];
+        List<ResoniteMaterialBinding> materials = [];
+
+        if (layout is not null)
+        {
+            string textureIdentity = NonDemSourceFileBatching.CreateAtlasTextureIdentity(sourceFileKey, batchIndex);
+            List<int> atlasTriangleIndices = [];
+            foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in layout.Placements.OrderBy(static candidate => candidate.Entry.CityObject.SlotKey, StringComparer.Ordinal).ThenBy(static candidate => candidate.Entry.Submesh.Index))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                AppendPlacementGeometry(vertices, atlasTriangleIndices, bakeOrigin, placement, layout.Width, layout.Height);
+            }
+
+            submeshes.Add(new ResoniteMeshSubmesh(0, atlasTriangleIndices));
+            materials.Add(
+                new ResoniteMaterialBinding(
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0],
+                    TexturePayload: ResoniteTextureImportFactory.CreatePayloadFromImage(atlasImage!, identity: textureIdentity),
+                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv));
+        }
+
+        foreach (IGrouping<NonDemPreservedMaterialGroupingKey, NonDemOrderedPreservedSubmeshEntry> preservedGroup in candidates
+                     .SelectMany(static candidate => candidate.PreservedEntries)
+                     .Select(static (entry, order) => new NonDemOrderedPreservedSubmeshEntry(entry, order))
+                     .GroupBy(static entry => NonDemPreservedMaterialGrouping.CreateKey(entry.Entry.Material), NonDemPreservedMaterialGrouping.KeyComparer)
+                     .OrderBy(static group => group.Min(static entry => entry.Order)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            List<int> preservedTriangleIndices = [];
+            foreach (NonDemPreservedSubmeshEntry preservedEntry in preservedGroup
+                         .Select(static entry => entry.Entry)
+                         .OrderBy(static entry => entry.CityObject.SlotKey, StringComparer.Ordinal)
+                         .ThenBy(static entry => entry.Submesh.Index))
+            {
+                AppendOriginalGeometry(vertices, preservedTriangleIndices, bakeOrigin, preservedEntry);
+            }
+
+            if (preservedTriangleIndices.Count == 0)
+            {
+                continue;
+            }
+
+            int submeshIndex = submeshes.Count;
+            ResoniteMaterialBinding preservedMaterial = NonDemPreservedMaterialGrouping.NormalizeMaterial(preservedGroup.First().Entry.Material) with
+            {
+                SubmeshIndices = [submeshIndex],
+            };
+            submeshes.Add(new ResoniteMeshSubmesh(submeshIndex, preservedTriangleIndices));
+            materials.Add(preservedMaterial);
+        }
+
+        if (submeshes.Count == 0 || materials.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Non-DEM bake batch '{sourceFileKey.PackageName}:{sourceFileKey.ActualMeshCode}:LOD{sourceFileKey.LodLevel}' produced no materialized submesh.");
+        }
+
+        ResoniteConstructionCityObject bakedCityObject = new(
+            SlotKey: slotKey,
+            DisplayName: displayName,
+            PackageName: firstCityObject.PackageName,
+            ActualMeshCode: firstCityObject.ActualMeshCode,
+            LodLevel: firstCityObject.LodLevel,
+            Transform: new ResoniteTransform(bakeOrigin),
+            Mesh: new ResoniteImportedMesh(vertices, submeshes),
+            Materials: materials,
+            CollisionEnabled: candidates.Any(static candidate => candidate.CityObject.CollisionEnabled),
+            SourceFileRelativePath: sourceFileRelativePath);
+        return Task.FromResult(bakedCityObject);
+    }
+
+    private static void AppendPlacementGeometry(
+        List<ResoniteMeshVertex> vertices,
+        List<int> triangleIndices,
+        ResoniteFloat3 bakeOrigin,
+        NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement,
+        int atlasWidth,
+        int atlasHeight)
+    {
+        IReadOnlyList<ResoniteMeshVertex> sourceVertices = placement.Entry.CityObject.Mesh.Vertices;
+        ResoniteFloat3 cityObjectOffset = Subtract(placement.Entry.CityObject.Transform.Position, bakeOrigin);
+        NonDemAtlasRect innerRect = placement.InnerRect;
+
+        foreach (int sourceIndex in placement.Entry.Submesh.TriangleVertexIndices)
+        {
+            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
+            ResoniteFloat2 sourceUv = sourceVertex.UV0;
+            ResoniteFloat2 atlasUv = MapUvToAtlas(sourceUv, placement.Entry.UvBounds, innerRect, atlasWidth, atlasHeight);
+            vertices.Add(sourceVertex with
+            {
+                Position = Add(sourceVertex.Position, cityObjectOffset),
+                UV0 = atlasUv,
+            });
+            triangleIndices.Add(vertices.Count - 1);
+        }
+    }
+
+    private static void AppendOriginalGeometry(
+        List<ResoniteMeshVertex> vertices,
+        List<int> triangleIndices,
+        ResoniteFloat3 bakeOrigin,
+        NonDemPreservedSubmeshEntry preservedEntry)
+    {
+        IReadOnlyList<ResoniteMeshVertex> sourceVertices = preservedEntry.CityObject.Mesh.Vertices;
+        ResoniteFloat3 cityObjectOffset = Subtract(preservedEntry.CityObject.Transform.Position, bakeOrigin);
+        foreach (int sourceIndex in preservedEntry.Submesh.TriangleVertexIndices)
+        {
+            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
+            vertices.Add(sourceVertex with
+            {
+                Position = Add(sourceVertex.Position, cityObjectOffset),
+                Color = preservedEntry.VertexColorOverride ?? sourceVertex.Color,
+            });
+            triangleIndices.Add(vertices.Count - 1);
+        }
+    }
+
+    private static ResoniteFloat2 MapUvToAtlas(
+        ResoniteFloat2 sourceUv,
+        TextureUvRect uvBounds,
+        NonDemAtlasRect atlasRect,
+        double atlasWidth,
+        double atlasHeight)
+    {
+        TextureUvRect atlasUvRect = TextureUvRect.FromTopLeftPixelRect(
+            atlasRect.X,
+            atlasRect.Y,
+            atlasRect.Width,
+            atlasRect.Height,
+            (int)Math.Round(atlasWidth),
+            (int)Math.Round(atlasHeight));
+        ScalarPair remapped = TextureUvRect.RemapValue(
+            new ScalarPair(sourceUv.X, sourceUv.Y),
+            uvBounds,
+            atlasUvRect);
+        return new ResoniteFloat2(remapped.X, remapped.Y);
+    }
+
+    private static ResoniteFloat3 ComputeBakeOrigin(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
+    {
+        double minX = double.PositiveInfinity;
+        double minY = double.PositiveInfinity;
+        double minZ = double.PositiveInfinity;
+
+        foreach (ResoniteConstructionCityObject cityObject in candidates.Select(static candidate => candidate.CityObject))
+        {
+            foreach (ResoniteMeshVertex vertex in cityObject.Mesh.Vertices)
+            {
+                ResoniteFloat3 worldPosition = Add(vertex.Position, cityObject.Transform.Position);
+                minX = Math.Min(minX, worldPosition.X);
+                minY = Math.Min(minY, worldPosition.Y);
+                minZ = Math.Min(minZ, worldPosition.Z);
+            }
+        }
+
+        return double.IsPositiveInfinity(minX)
+            ? new ResoniteFloat3(0.0, 0.0, 0.0)
+            : new ResoniteFloat3(minX, minY, minZ);
+    }
+
+    private static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)
+    {
+        return new ResoniteFloat3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
+    }
+
+    private static ResoniteFloat3 Subtract(ResoniteFloat3 left, ResoniteFloat3 right)
+    {
+        return new ResoniteFloat3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -6,8 +6,15 @@ using System.Threading.Tasks;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
+internal interface INonDemCityObjectBakeCandidateFactory
+{
+    Task<NonDemCityObjectBakeCandidate?> CreateAsync(
+        NonDemBufferedCityObject bufferedCityObject,
+        CancellationToken cancellationToken);
+}
+
 internal sealed class NonDemCityObjectBakeCandidateFactory(
-    NonDemAtlasOrPreservedEntryFactory entryFactory)
+    NonDemAtlasOrPreservedEntryFactory entryFactory) : INonDemCityObjectBakeCandidateFactory
 {
     private readonly NonDemAtlasOrPreservedEntryFactory entryFactory = entryFactory
         ?? throw new ArgumentNullException(nameof(entryFactory));

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -14,9 +14,9 @@ internal interface INonDemCityObjectBakeCandidateFactory
 }
 
 internal sealed class NonDemCityObjectBakeCandidateFactory(
-    NonDemAtlasOrPreservedEntryFactory entryFactory) : INonDemCityObjectBakeCandidateFactory
+    INonDemAtlasOrPreservedEntryFactory entryFactory) : INonDemCityObjectBakeCandidateFactory
 {
-    private readonly NonDemAtlasOrPreservedEntryFactory entryFactory = entryFactory
+    private readonly INonDemAtlasOrPreservedEntryFactory entryFactory = entryFactory
         ?? throw new ArgumentNullException(nameof(entryFactory));
 
     public async Task<NonDemCityObjectBakeCandidate?> CreateAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemCityObjectBakeCandidateFactory(
+    ResoniteTextureImageLoader textureImageLoader,
+    int maxAtlasTextureEdge)
+{
+    public async Task<NonDemCityObjectBakeCandidate?> CreateAsync(
+        NonDemBufferedCityObject bufferedCityObject,
+        CancellationToken cancellationToken)
+    {
+        ResoniteConstructionCityObject cityObject = bufferedCityObject.CityObject;
+        NonDemCityObjectBakePolicy policy = bufferedCityObject.Policy;
+        if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(cityObject, out _))
+        {
+            throw new InvalidOperationException(
+                $"Non-DEM bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
+        }
+
+        ResoniteConstructionCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
+        if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(normalizedCityObject, out Dictionary<int, ResoniteMaterialBinding>? materialBySubmeshIndex))
+        {
+            throw new InvalidOperationException(
+                $"Non-DEM bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
+        }
+
+        List<NonDemAtlasBatchEntry> atlasEntries = [];
+        List<NonDemPreservedSubmeshEntry> preservedEntries = [];
+        bool hadAtlasCandidateMaterial = false;
+        foreach (ResoniteMeshSubmesh submesh in normalizedCityObject.Mesh.Submeshes.OrderBy(static candidate => candidate.Index))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!materialBySubmeshIndex.TryGetValue(submesh.Index, out ResoniteMaterialBinding? material))
+            {
+                throw new InvalidOperationException(
+                    $"Non-DEM bake city object '{cityObject.DisplayName}' left submesh index {submesh.Index} without a material assignment.");
+            }
+
+            NonDemMaterialBakeCategory category = NonDemCityObjectBakeMaterialClassifier.Classify(material);
+            switch (category)
+            {
+                case NonDemMaterialBakeCategory.AtlasCandidate:
+                    hadAtlasCandidateMaterial = true;
+                    NonDemAtlasOrPreservedEntry bakeEntry = await CreateAtlasOrPreservedEntryAsync(
+                        normalizedCityObject,
+                        submesh,
+                        material,
+                        cancellationToken);
+                    if (bakeEntry.AtlasEntry is not null)
+                    {
+                        atlasEntries.Add(bakeEntry.AtlasEntry);
+                    }
+
+                    if (bakeEntry.PreservedEntry is not null)
+                    {
+                        preservedEntries.Add(bakeEntry.PreservedEntry);
+                    }
+
+                    break;
+                case NonDemMaterialBakeCategory.PreservedCommonMaterial when policy.PreserveCommonMaterials:
+                case NonDemMaterialBakeCategory.PreservedTextureless when policy.PreserveTexturelessMaterials:
+                case NonDemMaterialBakeCategory.PreservedVertexColor when policy.PreserveVertexColorMaterials:
+                case NonDemMaterialBakeCategory.PreservedOther:
+                    ResoniteMeshSubmesh normalizedSubmesh = normalizedCityObject.Mesh.Submeshes.Single(candidate => candidate.Index == submesh.Index);
+                    ResoniteMaterialBinding normalizedMaterial = normalizedCityObject.Materials.Single(candidate => candidate.SubmeshIndices.Contains(submesh.Index));
+                    preservedEntries.Add(new NonDemPreservedSubmeshEntry(normalizedCityObject, normalizedSubmesh, normalizedMaterial));
+                    break;
+            }
+        }
+
+        if (policy.RequireAtlasCandidateMaterial && !hadAtlasCandidateMaterial)
+        {
+            return null;
+        }
+
+        if (atlasEntries.Count == 0 && preservedEntries.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Non-DEM bake city object '{cityObject.DisplayName}' produced no atlas or preserved submesh candidate.");
+        }
+
+        return new NonDemCityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries);
+    }
+
+    private async Task<NonDemAtlasOrPreservedEntry> CreateAtlasOrPreservedEntryAsync(
+        ResoniteConstructionCityObject cityObject,
+        ResoniteMeshSubmesh submesh,
+        ResoniteMaterialBinding material,
+        CancellationToken cancellationToken)
+    {
+        if (material.TexturePayload is null)
+        {
+            throw new InvalidOperationException("Non-DEM bake candidate material must have a texture payload.");
+        }
+
+        TextureUvRect uvBounds = ComputeUvBounds(cityObject.Mesh.Vertices, submesh);
+        using Image<Rgba32> sourceImage = await textureImageLoader.LoadAsync(
+            ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
+            cancellationToken);
+        Rgba32 detectedBackgroundColor = NonDemTextureImageProcessing.DetectRepresentativeBackgroundColor(sourceImage);
+        using Image<Rgba32> preparedSourceImage = sourceImage.Clone();
+        NonDemTextureImageProcessing.FillTransparentRgb(preparedSourceImage, detectedBackgroundColor);
+        if (NonDemTextureImageProcessing.TryGetUniformPixelColor(preparedSourceImage, out Rgba32 uniformDatasetColor))
+        {
+            Rgba32 tintedUniformColor = NonDemTextureImageProcessing.MultiplyPixel(
+                uniformDatasetColor,
+                NonDemTextureImageProcessing.ToPixel(material.BaseColor));
+            return new NonDemAtlasOrPreservedEntry(
+                AtlasEntry: null,
+                PreservedEntry: new NonDemPreservedSubmeshEntry(
+                    cityObject,
+                    submesh,
+                    CreateVertexColorMaterial(material, submesh.Index),
+                    NonDemTextureImageProcessing.ToColor(tintedUniformColor)));
+        }
+
+        int targetWidth = Math.Max(1, Math.Min(maxAtlasTextureEdge, (int)Math.Ceiling(sourceImage.Width * uvBounds.Width)));
+        int targetHeight = Math.Max(1, Math.Min(maxAtlasTextureEdge, (int)Math.Ceiling(sourceImage.Height * uvBounds.Height)));
+        using Image<Rgba32> bakedImage = NonDemTextureImageProcessing.BakeUsedUvRegion(
+            preparedSourceImage,
+            uvBounds,
+            targetWidth,
+            targetHeight);
+
+        NonDemTextureImageProcessing.ApplyBaseColor(bakedImage, material.BaseColor);
+        return new NonDemAtlasOrPreservedEntry(
+            AtlasEntry: new NonDemAtlasBatchEntry(
+                cityObject,
+                submesh,
+                material,
+                new NonDemMaterialAtlasTile(
+                    bakedImage.Clone(),
+                    NonDemTextureImageProcessing.MultiplyPixel(
+                        detectedBackgroundColor,
+                        NonDemTextureImageProcessing.ToPixel(material.BaseColor))),
+                uvBounds),
+            PreservedEntry: null);
+    }
+
+    private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)
+    {
+        return material with
+        {
+            MaterialType = ResoniteMaterialType.VertexColor,
+            BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            TexturePayload = null,
+            TextureSourceKind = ResoniteTextureSourceKind.Bundled,
+            TextureScale = null,
+            TextureOffset = null,
+            Family = null,
+            TerrainOverlay = null,
+            AssetScope = ResoniteMaterialAssetScope.Common,
+            SubmeshIndices = [submeshIndex],
+            CommonMaterial = material.DepthOffset is null
+                ? CommonMaterialCatalog.Create().VertexColor.Uv
+                : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv,
+        };
+    }
+
+    private static TextureUvRect ComputeUvBounds(
+        IReadOnlyList<ResoniteMeshVertex> vertices,
+        ResoniteMeshSubmesh submesh)
+    {
+        double minU = double.PositiveInfinity;
+        double minV = double.PositiveInfinity;
+        double maxU = double.NegativeInfinity;
+        double maxV = double.NegativeInfinity;
+
+        foreach (int sourceIndex in submesh.TriangleVertexIndices)
+        {
+            ResoniteFloat2 transformedUv = vertices[sourceIndex].UV0;
+            minU = Math.Min(minU, transformedUv.X);
+            minV = Math.Min(minV, transformedUv.Y);
+            maxU = Math.Max(maxU, transformedUv.X);
+            maxV = Math.Max(maxV, transformedUv.Y);
+        }
+
+        if (double.IsPositiveInfinity(minU) || double.IsPositiveInfinity(minV))
+        {
+            return TextureUvRect.Identity;
+        }
+
+        double width = Math.Max(1.0 / 1024.0, maxU - minU);
+        double height = Math.Max(1.0 / 1024.0, maxV - minV);
+        return new TextureUvRect(minU, minV, width, height);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -4,18 +4,14 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Domain.Importing;
-
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemCityObjectBakeCandidateFactory(
-    ResoniteTextureImageLoader textureImageLoader,
-    int maxAtlasTextureEdge)
+    NonDemAtlasOrPreservedEntryFactory entryFactory)
 {
+    private readonly NonDemAtlasOrPreservedEntryFactory entryFactory = entryFactory
+        ?? throw new ArgumentNullException(nameof(entryFactory));
+
     public async Task<NonDemCityObjectBakeCandidate?> CreateAsync(
         NonDemBufferedCityObject bufferedCityObject,
         CancellationToken cancellationToken)
@@ -52,7 +48,7 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
             {
                 case NonDemMaterialBakeCategory.AtlasCandidate:
                     hadAtlasCandidateMaterial = true;
-                    NonDemAtlasOrPreservedEntry bakeEntry = await CreateAtlasOrPreservedEntryAsync(
+                    NonDemAtlasOrPreservedEntry bakeEntry = await entryFactory.CreateAsync(
                         normalizedCityObject,
                         submesh,
                         material,
@@ -91,108 +87,5 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
         }
 
         return new NonDemCityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries);
-    }
-
-    private async Task<NonDemAtlasOrPreservedEntry> CreateAtlasOrPreservedEntryAsync(
-        ResoniteConstructionCityObject cityObject,
-        ResoniteMeshSubmesh submesh,
-        ResoniteMaterialBinding material,
-        CancellationToken cancellationToken)
-    {
-        if (material.TexturePayload is null)
-        {
-            throw new InvalidOperationException("Non-DEM bake candidate material must have a texture payload.");
-        }
-
-        TextureUvRect uvBounds = ComputeUvBounds(cityObject.Mesh.Vertices, submesh);
-        using Image<Rgba32> sourceImage = await textureImageLoader.LoadAsync(
-            ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
-            cancellationToken);
-        Rgba32 detectedBackgroundColor = NonDemTextureImageProcessing.DetectRepresentativeBackgroundColor(sourceImage);
-        using Image<Rgba32> preparedSourceImage = sourceImage.Clone();
-        NonDemTextureImageProcessing.FillTransparentRgb(preparedSourceImage, detectedBackgroundColor);
-        if (NonDemTextureImageProcessing.TryGetUniformPixelColor(preparedSourceImage, out Rgba32 uniformDatasetColor))
-        {
-            Rgba32 tintedUniformColor = NonDemTextureImageProcessing.MultiplyPixel(
-                uniformDatasetColor,
-                NonDemTextureImageProcessing.ToPixel(material.BaseColor));
-            return new NonDemAtlasOrPreservedEntry(
-                AtlasEntry: null,
-                PreservedEntry: new NonDemPreservedSubmeshEntry(
-                    cityObject,
-                    submesh,
-                    CreateVertexColorMaterial(material, submesh.Index),
-                    NonDemTextureImageProcessing.ToColor(tintedUniformColor)));
-        }
-
-        int targetWidth = Math.Max(1, Math.Min(maxAtlasTextureEdge, (int)Math.Ceiling(sourceImage.Width * uvBounds.Width)));
-        int targetHeight = Math.Max(1, Math.Min(maxAtlasTextureEdge, (int)Math.Ceiling(sourceImage.Height * uvBounds.Height)));
-        using Image<Rgba32> bakedImage = NonDemTextureImageProcessing.BakeUsedUvRegion(
-            preparedSourceImage,
-            uvBounds,
-            targetWidth,
-            targetHeight);
-
-        NonDemTextureImageProcessing.ApplyBaseColor(bakedImage, material.BaseColor);
-        return new NonDemAtlasOrPreservedEntry(
-            AtlasEntry: new NonDemAtlasBatchEntry(
-                cityObject,
-                submesh,
-                material,
-                new NonDemMaterialAtlasTile(
-                    bakedImage.Clone(),
-                    NonDemTextureImageProcessing.MultiplyPixel(
-                        detectedBackgroundColor,
-                        NonDemTextureImageProcessing.ToPixel(material.BaseColor))),
-                uvBounds),
-            PreservedEntry: null);
-    }
-
-    private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)
-    {
-        return material with
-        {
-            MaterialType = ResoniteMaterialType.VertexColor,
-            BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-            TexturePayload = null,
-            TextureSourceKind = ResoniteTextureSourceKind.Bundled,
-            TextureScale = null,
-            TextureOffset = null,
-            Family = null,
-            TerrainOverlay = null,
-            AssetScope = ResoniteMaterialAssetScope.Common,
-            SubmeshIndices = [submeshIndex],
-            CommonMaterial = material.DepthOffset is null
-                ? CommonMaterialCatalog.Create().VertexColor.Uv
-                : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv,
-        };
-    }
-
-    private static TextureUvRect ComputeUvBounds(
-        IReadOnlyList<ResoniteMeshVertex> vertices,
-        ResoniteMeshSubmesh submesh)
-    {
-        double minU = double.PositiveInfinity;
-        double minV = double.PositiveInfinity;
-        double maxU = double.NegativeInfinity;
-        double maxV = double.NegativeInfinity;
-
-        foreach (int sourceIndex in submesh.TriangleVertexIndices)
-        {
-            ResoniteFloat2 transformedUv = vertices[sourceIndex].UV0;
-            minU = Math.Min(minU, transformedUv.X);
-            minV = Math.Min(minV, transformedUv.Y);
-            maxU = Math.Max(maxU, transformedUv.X);
-            maxV = Math.Max(maxV, transformedUv.Y);
-        }
-
-        if (double.IsPositiveInfinity(minU) || double.IsPositiveInfinity(minV))
-        {
-            return TextureUvRect.Identity;
-        }
-
-        double width = Math.Max(1.0 / 1024.0, maxU - minU);
-        double height = Math.Max(1.0 / 1024.0, maxV - minV);
-        return new TextureUvRect(minU, minV, width, height);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicyResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicyResolver.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface INonDemCityObjectBakePolicyResolver
+{
+    NonDemCityObjectBakePolicy? Resolve(ResoniteConstructionCityObject cityObject);
+}
+
+internal sealed class NonDemCityObjectBakePolicyResolver(
+    IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies) : INonDemCityObjectBakePolicyResolver
+{
+    private readonly IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies = bakePolicies
+        ?? throw new ArgumentNullException(nameof(bakePolicies));
+
+    public NonDemCityObjectBakePolicy? Resolve(ResoniteConstructionCityObject cityObject)
+    {
+        foreach (NonDemCityObjectBakePolicy policy in bakePolicies)
+        {
+            if (policy.CanBuffer(cityObject)
+                && NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(cityObject, policy))
+            {
+                return policy;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,8 +9,7 @@ internal sealed class NonDemCityObjectBaker(
     INonDemCityObjectBakePolicyResolver bakePolicyResolver,
     INonDemSourceFileBakeEmitter sourceFileBakeEmitter) : IResoniteBufferedCityObjectBaker
 {
-    private readonly Dictionary<NonDemSourceFileBatchKey, List<NonDemBufferedCityObject>> bufferedCityObjectsBySourceFile = [];
-    private readonly Dictionary<NonDemSourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
+    private readonly NonDemSourceFileBakeBuffer sourceFileBuffer = new();
     private readonly INonDemCityObjectBakePolicyResolver bakePolicyResolver = bakePolicyResolver
         ?? throw new ArgumentNullException(nameof(bakePolicyResolver));
     private readonly INonDemSourceFileBakeEmitter sourceFileBakeEmitter = sourceFileBakeEmitter
@@ -39,14 +37,7 @@ internal sealed class NonDemCityObjectBaker(
         cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(cityObject, policy);
         List<ResoniteConstructionCityObject> readyCityObjects = [];
-        NonDemBufferedCityObject bufferedCityObject = new(cityObject, policy);
-        if (!bufferedCityObjectsBySourceFile.TryGetValue(sourceFileKey, out List<NonDemBufferedCityObject>? bufferedCityObjects))
-        {
-            bufferedCityObjects = [];
-            bufferedCityObjectsBySourceFile.Add(sourceFileKey, bufferedCityObjects);
-        }
-
-        bufferedCityObjects.Add(bufferedCityObject);
+        sourceFileBuffer.Add(sourceFileKey, new NonDemBufferedCityObject(cityObject, policy));
         BakedInputCityObjectCount++;
         return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: true, readyCityObjects));
     }
@@ -70,15 +61,12 @@ internal sealed class NonDemCityObjectBaker(
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(onBakedCityObject);
-        if (bufferedCityObjectsBySourceFile.Count == 0)
+        if (sourceFileBuffer.IsEmpty)
         {
             return;
         }
 
-        NonDemSourceFileBatchKey[] orderedSourceFileKeys = bufferedCityObjectsBySourceFile.Keys
-            .OrderBy(static key => key, NonDemSourceFileBatching.KeyComparer)
-            .ToArray();
-        foreach (NonDemSourceFileBatchKey sourceFileKey in orderedSourceFileKeys)
+        foreach (NonDemSourceFileBatchKey sourceFileKey in sourceFileBuffer.SnapshotOrderedSourceFileKeys())
         {
             await EmitSourceFileAsync(sourceFileKey, onBakedCityObject, cancellationToken);
         }
@@ -89,19 +77,18 @@ internal sealed class NonDemCityObjectBaker(
         Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
         CancellationToken cancellationToken)
     {
-        if (!bufferedCityObjectsBySourceFile.Remove(sourceFileKey, out List<NonDemBufferedCityObject>? cityObjects))
+        if (!sourceFileBuffer.TryTake(sourceFileKey, out NonDemSourceFileBakeBufferEntry bufferEntry))
         {
             return;
         }
 
-        int batchStartIndex = nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey);
         int emittedCount = 0;
         try
         {
             await sourceFileBakeEmitter.EmitAsync(
-                sourceFileKey,
-                cityObjects,
-                batchStartIndex,
+                bufferEntry.SourceFileKey,
+                bufferEntry.CityObjects,
+                bufferEntry.BatchStartIndex,
                 async (bakedCityObject, callbackCancellationToken) =>
                 {
                     emittedCount++;
@@ -112,8 +99,7 @@ internal sealed class NonDemCityObjectBaker(
         }
         finally
         {
-            nextBatchIndexBySourceFile[sourceFileKey] = batchStartIndex + emittedCount;
-            cityObjects.Clear();
+            sourceFileBuffer.Complete(bufferEntry, emittedCount);
         }
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -141,6 +141,7 @@ internal sealed class NonDemCityObjectBaker(
         int batchIndex = batchStartIndex;
         bool preservePrimaryIdentity = cityObjects.Count == 1;
         NonDemCityObjectBakeCandidateFactory candidateFactory = CreateCandidateFactory();
+        NonDemAtlasBatchFitPolicy batchFitPolicy = CreateBatchFitPolicy();
 
         foreach (NonDemBufferedCityObject bufferedCityObject in cityObjects.OrderBy(
                      static bufferedCityObject => bufferedCityObject.CityObject.SlotKey,
@@ -153,7 +154,7 @@ internal sealed class NonDemCityObjectBaker(
                 continue;
             }
 
-            if (candidate.AtlasEntries.Count == 0 && !RequiresBakeEmission(candidate))
+            if (candidate.AtlasEntries.Count == 0 && !NonDemAtlasBatchFitPolicy.RequiresBakeEmission(candidate))
             {
                 passThroughCandidates.Add(candidate);
                 continue;
@@ -161,7 +162,7 @@ internal sealed class NonDemCityObjectBaker(
 
             if (currentAtlasBatch.Count == 0)
             {
-                if (CanFitSingleCandidate(candidate))
+                if (batchFitPolicy.CanFitSingleCandidate(candidate))
                 {
                     currentAtlasBatch.Add(candidate);
                 }
@@ -173,7 +174,7 @@ internal sealed class NonDemCityObjectBaker(
                 continue;
             }
 
-            if (CanAppendToAtlasBatch(currentAtlasBatch, candidate))
+            if (batchFitPolicy.CanAppendToAtlasBatch(currentAtlasBatch, candidate))
             {
                 currentAtlasBatch.Add(candidate);
                 continue;
@@ -188,7 +189,7 @@ internal sealed class NonDemCityObjectBaker(
                 cancellationToken);
             currentAtlasBatch.Clear();
 
-            if (CanFitSingleCandidate(candidate))
+            if (batchFitPolicy.CanFitSingleCandidate(candidate))
             {
                 currentAtlasBatch.Add(candidate);
             }
@@ -277,6 +278,11 @@ internal sealed class NonDemCityObjectBaker(
         return new NonDemCityObjectBakeCandidateFactory(textureImageLoader, EffectiveMaxAtlasTextureEdge);
     }
 
+    private NonDemAtlasBatchFitPolicy CreateBatchFitPolicy()
+    {
+        return new NonDemAtlasBatchFitPolicy(CreateAtlasLayoutFactory());
+    }
+
     private async Task EmitAtlasBatchAsync(
         NonDemSourceFileBatchKey sourceFileKey,
         IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
@@ -318,19 +324,6 @@ internal sealed class NonDemCityObjectBaker(
         }
     }
 
-    private bool CanFitSingleCandidate(NonDemCityObjectBakeCandidate candidate)
-    {
-        return candidate.AtlasEntries.Count == 0 || CreateAtlasLayoutFactory().CanFit(candidate.AtlasEntries);
-    }
-
-    private bool CanAppendToAtlasBatch(
-        IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
-        NonDemCityObjectBakeCandidate candidate)
-    {
-        List<NonDemAtlasBatchEntry> candidateEntries = [.. batchCandidates.SelectMany(static current => current.AtlasEntries), .. candidate.AtlasEntries];
-        return CreateAtlasLayoutFactory().CanFit(candidateEntries);
-    }
-
     private static void DisposeCandidateImages(NonDemCityObjectBakeCandidate candidate)
     {
         DisposeCandidateImages([candidate]);
@@ -346,10 +339,4 @@ internal sealed class NonDemCityObjectBaker(
             tileImage.Dispose();
         }
     }
-
-    private static bool RequiresBakeEmission(NonDemCityObjectBakeCandidate candidate)
-    {
-        return candidate.PreservedEntries.Any(static entry => entry.VertexColorOverride is not null);
-    }
-
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -4,9 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemCityObjectBaker(
@@ -111,131 +108,19 @@ internal sealed class NonDemCityObjectBaker(
             return;
         }
 
-        int emittedCount = 0;
         int batchStartIndex = nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey);
+        NonDemSourceFileBakeEmitter emitter = CreateSourceFileBakeEmitter();
 
-        await BakeSourceFileAsync(
+        int emittedCount = await emitter.EmitAsync(
             sourceFileKey,
             cityObjects,
             batchStartIndex,
-            (bakedCityObject, callbackCancellationToken) =>
-            {
-                emittedCount++;
-                return onBakedCityObject(bakedCityObject, callbackCancellationToken);
-            },
+            onBakedCityObject,
             cancellationToken);
 
+        BakedOutputCityObjectCount += emittedCount;
         nextBatchIndexBySourceFile[sourceFileKey] = batchStartIndex + emittedCount;
         cityObjects.Clear();
-    }
-
-    private async Task BakeSourceFileAsync(
-        NonDemSourceFileBatchKey sourceFileKey,
-        List<NonDemBufferedCityObject> cityObjects,
-        int batchStartIndex,
-        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
-        CancellationToken cancellationToken)
-    {
-        List<NonDemCityObjectBakeCandidate> passThroughCandidates = [];
-        List<NonDemCityObjectBakeCandidate> currentAtlasBatch = [];
-        int batchIndex = batchStartIndex;
-        bool preservePrimaryIdentity = cityObjects.Count == 1;
-        NonDemCityObjectBakeCandidateFactory candidateFactory = CreateCandidateFactory();
-        NonDemAtlasBatchFitPolicy batchFitPolicy = CreateBatchFitPolicy();
-
-        foreach (NonDemBufferedCityObject bufferedCityObject in cityObjects.OrderBy(
-                     static bufferedCityObject => bufferedCityObject.CityObject.SlotKey,
-                     StringComparer.Ordinal))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            NonDemCityObjectBakeCandidate? candidate = await candidateFactory.CreateAsync(bufferedCityObject, cancellationToken);
-            if (candidate is null)
-            {
-                continue;
-            }
-
-            if (candidate.AtlasEntries.Count == 0 && !NonDemAtlasBatchFitPolicy.RequiresBakeEmission(candidate))
-            {
-                passThroughCandidates.Add(candidate);
-                continue;
-            }
-
-            if (currentAtlasBatch.Count == 0)
-            {
-                if (batchFitPolicy.CanFitSingleCandidate(candidate))
-                {
-                    currentAtlasBatch.Add(candidate);
-                }
-                else
-                {
-                    await EmitFallbackCandidateAsync(candidate, onBakedCityObject, cancellationToken);
-                }
-
-                continue;
-            }
-
-            if (batchFitPolicy.CanAppendToAtlasBatch(currentAtlasBatch, candidate))
-            {
-                currentAtlasBatch.Add(candidate);
-                continue;
-            }
-
-            await EmitAtlasBatchAsync(
-                sourceFileKey,
-                currentAtlasBatch,
-                batchIndex++,
-                preservePrimaryIdentity && passThroughCandidates.Count == 0,
-                onBakedCityObject,
-                cancellationToken);
-            currentAtlasBatch.Clear();
-
-            if (batchFitPolicy.CanFitSingleCandidate(candidate))
-            {
-                currentAtlasBatch.Add(candidate);
-            }
-            else
-            {
-                await EmitFallbackCandidateAsync(candidate, onBakedCityObject, cancellationToken);
-            }
-        }
-
-        if (currentAtlasBatch.Count > 0)
-        {
-            await EmitAtlasBatchAsync(
-                sourceFileKey,
-                currentAtlasBatch,
-                batchIndex++,
-                preservePrimaryIdentity && passThroughCandidates.Count == 0,
-                onBakedCityObject,
-                cancellationToken);
-            currentAtlasBatch.Clear();
-        }
-
-        if (passThroughCandidates.Count == 1)
-        {
-            NonDemCityObjectBakeCandidate passThroughCandidate = passThroughCandidates[0];
-            BakedOutputCityObjectCount++;
-            await onBakedCityObject(passThroughCandidate.CityObject, cancellationToken);
-            DisposeCandidateImages(passThroughCandidate);
-        }
-        else if (passThroughCandidates.Count > 1)
-        {
-            try
-            {
-                ResoniteConstructionCityObject mergedPassThroughCityObject = await BakeBatchAsync(
-                    sourceFileKey,
-                    passThroughCandidates,
-                    batchIndex,
-                    preservePrimaryIdentity: false,
-                    cancellationToken);
-                BakedOutputCityObjectCount++;
-                await onBakedCityObject(mergedPassThroughCityObject, cancellationToken);
-            }
-            finally
-            {
-                DisposeCandidateImages(passThroughCandidates);
-            }
-        }
     }
 
     private NonDemCityObjectBakePolicy? ResolvePolicy(ResoniteConstructionCityObject cityObject)
@@ -250,22 +135,6 @@ internal sealed class NonDemCityObjectBaker(
         }
 
         return null;
-    }
-
-    private async Task<ResoniteConstructionCityObject> BakeBatchAsync(
-        NonDemSourceFileBatchKey sourceFileKey,
-        IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
-        int batchIndex,
-        bool preservePrimaryIdentity,
-        CancellationToken cancellationToken)
-    {
-        NonDemCityObjectBakeAssembler assembler = new(CreateAtlasLayoutFactory(), new NonDemAtlasImageRenderer(tilePaddingPixels));
-        return await assembler.BakeBatchAsync(
-            sourceFileKey,
-            candidates,
-            batchIndex,
-            preservePrimaryIdentity,
-            cancellationToken);
     }
 
     private NonDemAtlasLayoutFactory CreateAtlasLayoutFactory()
@@ -283,60 +152,11 @@ internal sealed class NonDemCityObjectBaker(
         return new NonDemAtlasBatchFitPolicy(CreateAtlasLayoutFactory());
     }
 
-    private async Task EmitAtlasBatchAsync(
-        NonDemSourceFileBatchKey sourceFileKey,
-        IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
-        int batchIndex,
-        bool preservePrimaryIdentity,
-        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
-        CancellationToken cancellationToken)
+    private NonDemSourceFileBakeEmitter CreateSourceFileBakeEmitter()
     {
-        try
-        {
-            ResoniteConstructionCityObject bakedCityObject = await BakeBatchAsync(
-                sourceFileKey,
-                batchCandidates,
-                batchIndex,
-                preservePrimaryIdentity,
-                cancellationToken);
-            BakedOutputCityObjectCount++;
-            await onBakedCityObject(bakedCityObject, cancellationToken);
-        }
-        finally
-        {
-            DisposeCandidateImages(batchCandidates);
-        }
-    }
-
-    private async Task EmitFallbackCandidateAsync(
-        NonDemCityObjectBakeCandidate fallbackCandidate,
-        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            BakedOutputCityObjectCount++;
-            await onBakedCityObject(fallbackCandidate.CityObject, cancellationToken);
-        }
-        finally
-        {
-            DisposeCandidateImages(fallbackCandidate);
-        }
-    }
-
-    private static void DisposeCandidateImages(NonDemCityObjectBakeCandidate candidate)
-    {
-        DisposeCandidateImages([candidate]);
-    }
-
-    private static void DisposeCandidateImages(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
-    {
-        foreach (Image<Rgba32> tileImage in candidates
-                     .SelectMany(static candidate => candidate.AtlasEntries)
-                     .Select(static entry => entry.Tile.Image)
-                     .Distinct())
-        {
-            tileImage.Dispose();
-        }
+        return new NonDemSourceFileBakeEmitter(
+            CreateCandidateFactory(),
+            new NonDemCityObjectBakeAssembler(CreateAtlasLayoutFactory(), new NonDemAtlasImageRenderer(tilePaddingPixels)),
+            CreateBatchFitPolicy());
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -4,9 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Domain.Importing;
-
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -261,199 +258,13 @@ internal sealed class NonDemCityObjectBaker(
         bool preservePrimaryIdentity,
         CancellationToken cancellationToken)
     {
-        List<NonDemAtlasBatchEntry> entries = candidates.SelectMany(static candidate => candidate.AtlasEntries).ToList();
-        NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout = null;
-        NonDemAtlasLayoutFactory atlasLayoutFactory = CreateAtlasLayoutFactory();
-        if (entries.Count > 0
-            && (!atlasLayoutFactory.TryCreate(entries, out layout) || layout is null))
-        {
-            throw new InvalidOperationException("Failed to create non-DEM atlas layout.");
-        }
-
-        using Image<Rgba32>? atlasImage = layout is null
-            ? null
-            : new Image<Rgba32>(layout.Width, layout.Height, new Rgba32(0, 0, 0, 0));
-        if (layout is not null)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            new NonDemAtlasImageRenderer(tilePaddingPixels).Draw(atlasImage!, layout.Placements);
-        }
-
-        ResoniteConstructionCityObject firstCityObject = candidates[0].CityObject;
-        string slotKey = preservePrimaryIdentity
-            ? firstCityObject.SlotKey
-            : NonDemSourceFileBatching.CreateBatchSlotKey(sourceFileKey, batchIndex);
-        string displayName = preservePrimaryIdentity
-            ? firstCityObject.DisplayName
-            : NonDemSourceFileBatching.CreateBatchDisplayName(sourceFileKey, batchIndex, slotKey);
-        string? sourceFileRelativePath = string.IsNullOrWhiteSpace(firstCityObject.SourceFileRelativePath)
-            ? null
-            : sourceFileKey.SourceFileRelativePath;
-
-        ResoniteFloat3 bakeOrigin = ComputeBakeOrigin(candidates);
-        List<ResoniteMeshVertex> vertices = [];
-        List<ResoniteMeshSubmesh> submeshes = [];
-        List<ResoniteMaterialBinding> materials = [];
-
-        if (layout is not null)
-        {
-            string textureIdentity = NonDemSourceFileBatching.CreateAtlasTextureIdentity(sourceFileKey, batchIndex);
-            List<int> atlasTriangleIndices = [];
-            foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in layout.Placements.OrderBy(static candidate => candidate.Entry.CityObject.SlotKey, StringComparer.Ordinal).ThenBy(static candidate => candidate.Entry.Submesh.Index))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                AppendPlacementGeometry(vertices, atlasTriangleIndices, bakeOrigin, placement, layout.Width, layout.Height);
-            }
-
-            submeshes.Add(new ResoniteMeshSubmesh(0, atlasTriangleIndices));
-            materials.Add(
-                new ResoniteMaterialBinding(
-                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-                    MaterialType: ResoniteMaterialType.Standard,
-                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-                    Projection: ResoniteMaterialProjection.Uv,
-                    DepthOffset: null,
-                    SubmeshIndices: [0],
-                    TexturePayload: ResoniteTextureImportFactory.CreatePayloadFromImage(atlasImage!, identity: textureIdentity),
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv));
-        }
-
-        foreach (IGrouping<NonDemPreservedMaterialGroupingKey, NonDemOrderedPreservedSubmeshEntry> preservedGroup in candidates
-                     .SelectMany(static candidate => candidate.PreservedEntries)
-                     .Select(static (entry, order) => new NonDemOrderedPreservedSubmeshEntry(entry, order))
-                     .GroupBy(static entry => NonDemPreservedMaterialGrouping.CreateKey(entry.Entry.Material), NonDemPreservedMaterialGrouping.KeyComparer)
-                     .OrderBy(static group => group.Min(static entry => entry.Order)))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            List<int> preservedTriangleIndices = [];
-            foreach (NonDemPreservedSubmeshEntry preservedEntry in preservedGroup
-                         .Select(static entry => entry.Entry)
-                         .OrderBy(static entry => entry.CityObject.SlotKey, StringComparer.Ordinal)
-                         .ThenBy(static entry => entry.Submesh.Index))
-            {
-                AppendOriginalGeometry(vertices, preservedTriangleIndices, bakeOrigin, preservedEntry);
-            }
-
-            if (preservedTriangleIndices.Count == 0)
-            {
-                continue;
-            }
-
-            int submeshIndex = submeshes.Count;
-            ResoniteMaterialBinding preservedMaterial = NonDemPreservedMaterialGrouping.NormalizeMaterial(preservedGroup.First().Entry.Material) with
-            {
-                SubmeshIndices = [submeshIndex],
-            };
-            submeshes.Add(new ResoniteMeshSubmesh(submeshIndex, preservedTriangleIndices));
-            materials.Add(preservedMaterial);
-        }
-
-        if (submeshes.Count == 0 || materials.Count == 0)
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM bake batch '{sourceFileKey.PackageName}:{sourceFileKey.ActualMeshCode}:LOD{sourceFileKey.LodLevel}' produced no materialized submesh.");
-        }
-
-        return new ResoniteConstructionCityObject(
-            SlotKey: slotKey,
-            DisplayName: displayName,
-            PackageName: firstCityObject.PackageName,
-            ActualMeshCode: firstCityObject.ActualMeshCode,
-            LodLevel: firstCityObject.LodLevel,
-            Transform: new ResoniteTransform(bakeOrigin),
-            Mesh: new ResoniteImportedMesh(vertices, submeshes),
-            Materials: materials,
-            CollisionEnabled: candidates.Any(static candidate => candidate.CityObject.CollisionEnabled),
-            SourceFileRelativePath: sourceFileRelativePath);
-    }
-
-    private static void AppendPlacementGeometry(
-        List<ResoniteMeshVertex> vertices,
-        List<int> triangleIndices,
-        ResoniteFloat3 bakeOrigin,
-        NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement,
-        int atlasWidth,
-        int atlasHeight)
-    {
-        IReadOnlyList<ResoniteMeshVertex> sourceVertices = placement.Entry.CityObject.Mesh.Vertices;
-        ResoniteFloat3 cityObjectOffset = Subtract(placement.Entry.CityObject.Transform.Position, bakeOrigin);
-        NonDemAtlasRect innerRect = placement.InnerRect;
-
-        foreach (int sourceIndex in placement.Entry.Submesh.TriangleVertexIndices)
-        {
-            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
-            ResoniteFloat2 sourceUv = sourceVertex.UV0;
-            ResoniteFloat2 atlasUv = MapUvToAtlas(sourceUv, placement.Entry.UvBounds, innerRect, atlasWidth, atlasHeight);
-            vertices.Add(sourceVertex with
-            {
-                Position = Add(sourceVertex.Position, cityObjectOffset),
-                UV0 = atlasUv,
-            });
-            triangleIndices.Add(vertices.Count - 1);
-        }
-    }
-
-    private static void AppendOriginalGeometry(
-        List<ResoniteMeshVertex> vertices,
-        List<int> triangleIndices,
-        ResoniteFloat3 bakeOrigin,
-        NonDemPreservedSubmeshEntry preservedEntry)
-    {
-        IReadOnlyList<ResoniteMeshVertex> sourceVertices = preservedEntry.CityObject.Mesh.Vertices;
-        ResoniteFloat3 cityObjectOffset = Subtract(preservedEntry.CityObject.Transform.Position, bakeOrigin);
-        foreach (int sourceIndex in preservedEntry.Submesh.TriangleVertexIndices)
-        {
-            ResoniteMeshVertex sourceVertex = sourceVertices[sourceIndex];
-            vertices.Add(sourceVertex with
-            {
-                Position = Add(sourceVertex.Position, cityObjectOffset),
-                Color = preservedEntry.VertexColorOverride ?? sourceVertex.Color,
-            });
-            triangleIndices.Add(vertices.Count - 1);
-        }
-    }
-
-    private static ResoniteFloat2 MapUvToAtlas(
-        ResoniteFloat2 sourceUv,
-        TextureUvRect uvBounds,
-        NonDemAtlasRect atlasRect,
-        double atlasWidth,
-        double atlasHeight)
-    {
-        TextureUvRect atlasUvRect = TextureUvRect.FromTopLeftPixelRect(
-            atlasRect.X,
-            atlasRect.Y,
-            atlasRect.Width,
-            atlasRect.Height,
-            (int)Math.Round(atlasWidth),
-            (int)Math.Round(atlasHeight));
-        ScalarPair remapped = TextureUvRect.RemapValue(
-            new ScalarPair(sourceUv.X, sourceUv.Y),
-            uvBounds,
-            atlasUvRect);
-        return new ResoniteFloat2(remapped.X, remapped.Y);
-    }
-
-    private static ResoniteFloat3 ComputeBakeOrigin(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
-    {
-        double minX = double.PositiveInfinity;
-        double minY = double.PositiveInfinity;
-        double minZ = double.PositiveInfinity;
-
-        foreach (ResoniteConstructionCityObject cityObject in candidates.Select(static candidate => candidate.CityObject))
-        {
-            foreach (ResoniteMeshVertex vertex in cityObject.Mesh.Vertices)
-            {
-                ResoniteFloat3 worldPosition = Add(vertex.Position, cityObject.Transform.Position);
-                minX = Math.Min(minX, worldPosition.X);
-                minY = Math.Min(minY, worldPosition.Y);
-                minZ = Math.Min(minZ, worldPosition.Z);
-            }
-        }
-
-        return double.IsPositiveInfinity(minX)
-            ? new ResoniteFloat3(0.0, 0.0, 0.0)
-            : new ResoniteFloat3(minX, minY, minZ);
+        NonDemCityObjectBakeAssembler assembler = new(CreateAtlasLayoutFactory(), new NonDemAtlasImageRenderer(tilePaddingPixels));
+        return await assembler.BakeBatchAsync(
+            sourceFileKey,
+            candidates,
+            batchIndex,
+            preservePrimaryIdentity,
+            cancellationToken);
     }
 
     private NonDemAtlasLayoutFactory CreateAtlasLayoutFactory()
@@ -464,16 +275,6 @@ internal sealed class NonDemCityObjectBaker(
     private NonDemCityObjectBakeCandidateFactory CreateCandidateFactory()
     {
         return new NonDemCityObjectBakeCandidateFactory(textureImageLoader, EffectiveMaxAtlasTextureEdge);
-    }
-
-    private static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)
-    {
-        return new ResoniteFloat3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
-    }
-
-    private static ResoniteFloat3 Subtract(ResoniteFloat3 left, ResoniteFloat3 right)
-    {
-        return new ResoniteFloat3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
     }
 
     private async Task EmitAtlasBatchAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -7,13 +7,13 @@ using System.Threading.Tasks;
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemCityObjectBaker(
-    IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies,
+    INonDemCityObjectBakePolicyResolver bakePolicyResolver,
     INonDemSourceFileBakeEmitter sourceFileBakeEmitter) : IResoniteBufferedCityObjectBaker
 {
     private readonly Dictionary<NonDemSourceFileBatchKey, List<NonDemBufferedCityObject>> bufferedCityObjectsBySourceFile = [];
     private readonly Dictionary<NonDemSourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
-    private readonly IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies = bakePolicies
-        ?? throw new ArgumentNullException(nameof(bakePolicies));
+    private readonly INonDemCityObjectBakePolicyResolver bakePolicyResolver = bakePolicyResolver
+        ?? throw new ArgumentNullException(nameof(bakePolicyResolver));
     private readonly INonDemSourceFileBakeEmitter sourceFileBakeEmitter = sourceFileBakeEmitter
         ?? throw new ArgumentNullException(nameof(sourceFileBakeEmitter));
 
@@ -30,7 +30,7 @@ internal sealed class NonDemCityObjectBaker(
         ArgumentNullException.ThrowIfNull(cityObject);
         cancellationToken.ThrowIfCancellationRequested();
 
-        NonDemCityObjectBakePolicy? policy = ResolvePolicy(cityObject);
+        NonDemCityObjectBakePolicy? policy = bakePolicyResolver.Resolve(cityObject);
         if (policy is null)
         {
             return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: false, []));
@@ -105,19 +105,5 @@ internal sealed class NonDemCityObjectBaker(
         BakedOutputCityObjectCount += emittedCount;
         nextBatchIndexBySourceFile[sourceFileKey] = batchStartIndex + emittedCount;
         cityObjects.Clear();
-    }
-
-    private NonDemCityObjectBakePolicy? ResolvePolicy(ResoniteConstructionCityObject cityObject)
-    {
-        foreach (NonDemCityObjectBakePolicy policy in bakePolicies)
-        {
-            if (policy.CanBuffer(cityObject)
-                && NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(cityObject, policy))
-            {
-                return policy;
-            }
-        }
-
-        return null;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -7,35 +7,21 @@ using System.Threading.Tasks;
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemCityObjectBaker(
-    ResoniteTextureImageLoader textureImageLoader,
     IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies,
-    int maxAtlasSize = 4096,
-    int tilePaddingPixels = 2,
-    ResoniteImportBudgetProfile? resourceBudget = null) : IResoniteBufferedCityObjectBaker
+    NonDemSourceFileBakeEmitter sourceFileBakeEmitter) : IResoniteBufferedCityObjectBaker
 {
-    internal const int DefaultMaxAtlasSize = 4096;
-    internal const int DefaultTilePaddingPixels = 2;
     private readonly Dictionary<NonDemSourceFileBatchKey, List<NonDemBufferedCityObject>> bufferedCityObjectsBySourceFile = [];
     private readonly Dictionary<NonDemSourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
     private readonly IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies = bakePolicies
         ?? throw new ArgumentNullException(nameof(bakePolicies));
+    private readonly NonDemSourceFileBakeEmitter sourceFileBakeEmitter = sourceFileBakeEmitter
+        ?? throw new ArgumentNullException(nameof(sourceFileBakeEmitter));
 
     public string Name => "AtlasBake";
 
     public int BakedInputCityObjectCount { get; private set; }
 
     public int BakedOutputCityObjectCount { get; private set; }
-
-    private int EffectiveMaxAtlasSize => Math.Max(1, Math.Min(maxAtlasSize, resourceBudget?.MaxAtlasSize ?? maxAtlasSize));
-
-    private int EffectiveMaxAtlasTextureEdge
-    {
-        get
-        {
-            int profileMaxTileEdge = resourceBudget?.MaxAtlasTextureEdge ?? EffectiveMaxAtlasSize;
-            return Math.Max(1, Math.Min(EffectiveMaxAtlasSize - (tilePaddingPixels * 2), profileMaxTileEdge));
-        }
-    }
 
     public ValueTask<BufferedCityObjectBufferResult> TryBufferAsync(
         ResoniteConstructionCityObject cityObject,
@@ -109,9 +95,7 @@ internal sealed class NonDemCityObjectBaker(
         }
 
         int batchStartIndex = nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey);
-        NonDemSourceFileBakeEmitter emitter = CreateSourceFileBakeEmitter();
-
-        int emittedCount = await emitter.EmitAsync(
+        int emittedCount = await sourceFileBakeEmitter.EmitAsync(
             sourceFileKey,
             cityObjects,
             batchStartIndex,
@@ -135,28 +119,5 @@ internal sealed class NonDemCityObjectBaker(
         }
 
         return null;
-    }
-
-    private NonDemAtlasLayoutFactory CreateAtlasLayoutFactory()
-    {
-        return new NonDemAtlasLayoutFactory(EffectiveMaxAtlasSize, tilePaddingPixels);
-    }
-
-    private NonDemCityObjectBakeCandidateFactory CreateCandidateFactory()
-    {
-        return new NonDemCityObjectBakeCandidateFactory(textureImageLoader, EffectiveMaxAtlasTextureEdge);
-    }
-
-    private NonDemAtlasBatchFitPolicy CreateBatchFitPolicy()
-    {
-        return new NonDemAtlasBatchFitPolicy(CreateAtlasLayoutFactory());
-    }
-
-    private NonDemSourceFileBakeEmitter CreateSourceFileBakeEmitter()
-    {
-        return new NonDemSourceFileBakeEmitter(
-            CreateCandidateFactory(),
-            new NonDemCityObjectBakeAssembler(CreateAtlasLayoutFactory(), new NonDemAtlasImageRenderer(tilePaddingPixels)),
-            CreateBatchFitPolicy());
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -95,14 +95,19 @@ internal sealed class NonDemCityObjectBaker(
         }
 
         int batchStartIndex = nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey);
-        int emittedCount = await sourceFileBakeEmitter.EmitAsync(
+        int emittedCount = 0;
+        await sourceFileBakeEmitter.EmitAsync(
             sourceFileKey,
             cityObjects,
             batchStartIndex,
-            onBakedCityObject,
+            async (bakedCityObject, callbackCancellationToken) =>
+            {
+                await onBakedCityObject(bakedCityObject, callbackCancellationToken);
+                emittedCount++;
+                BakedOutputCityObjectCount++;
+            },
             cancellationToken);
 
-        BakedOutputCityObjectCount += emittedCount;
         nextBatchIndexBySourceFile[sourceFileKey] = batchStartIndex + emittedCount;
         cityObjects.Clear();
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -143,13 +143,14 @@ internal sealed class NonDemCityObjectBaker(
         List<NonDemCityObjectBakeCandidate> currentAtlasBatch = [];
         int batchIndex = batchStartIndex;
         bool preservePrimaryIdentity = cityObjects.Count == 1;
+        NonDemCityObjectBakeCandidateFactory candidateFactory = CreateCandidateFactory();
 
         foreach (NonDemBufferedCityObject bufferedCityObject in cityObjects.OrderBy(
                      static bufferedCityObject => bufferedCityObject.CityObject.SlotKey,
                      StringComparer.Ordinal))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            NonDemCityObjectBakeCandidate? candidate = await CreateCandidateAsync(bufferedCityObject, cancellationToken);
+            NonDemCityObjectBakeCandidate? candidate = await candidateFactory.CreateAsync(bufferedCityObject, cancellationToken);
             if (candidate is null)
             {
                 continue;
@@ -251,141 +252,6 @@ internal sealed class NonDemCityObjectBaker(
         }
 
         return null;
-    }
-
-    private async Task<NonDemCityObjectBakeCandidate?> CreateCandidateAsync(
-        NonDemBufferedCityObject bufferedCityObject,
-        CancellationToken cancellationToken)
-    {
-        ResoniteConstructionCityObject cityObject = bufferedCityObject.CityObject;
-        NonDemCityObjectBakePolicy policy = bufferedCityObject.Policy;
-        if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(cityObject, out _))
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
-        }
-
-        ResoniteConstructionCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
-        if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(normalizedCityObject, out Dictionary<int, ResoniteMaterialBinding>? materialBySubmeshIndex))
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
-        }
-
-        List<NonDemAtlasBatchEntry> atlasEntries = [];
-        List<NonDemPreservedSubmeshEntry> preservedEntries = [];
-        bool hadAtlasCandidateMaterial = false;
-        foreach (ResoniteMeshSubmesh submesh in normalizedCityObject.Mesh.Submeshes.OrderBy(static candidate => candidate.Index))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (!materialBySubmeshIndex.TryGetValue(submesh.Index, out ResoniteMaterialBinding? material))
-            {
-                throw new InvalidOperationException(
-                    $"Non-DEM bake city object '{cityObject.DisplayName}' left submesh index {submesh.Index} without a material assignment.");
-            }
-
-            NonDemMaterialBakeCategory category = NonDemCityObjectBakeMaterialClassifier.Classify(material);
-            switch (category)
-            {
-                case NonDemMaterialBakeCategory.AtlasCandidate:
-                    hadAtlasCandidateMaterial = true;
-                    NonDemAtlasOrPreservedEntry bakeEntry = await CreateAtlasOrPreservedEntryAsync(
-                        normalizedCityObject,
-                        submesh,
-                        material,
-                        cancellationToken);
-                    if (bakeEntry.AtlasEntry is not null)
-                    {
-                        atlasEntries.Add(bakeEntry.AtlasEntry);
-                    }
-
-                    if (bakeEntry.PreservedEntry is not null)
-                    {
-                        preservedEntries.Add(bakeEntry.PreservedEntry);
-                    }
-
-                    break;
-                case NonDemMaterialBakeCategory.PreservedCommonMaterial when policy.PreserveCommonMaterials:
-                case NonDemMaterialBakeCategory.PreservedTextureless when policy.PreserveTexturelessMaterials:
-                case NonDemMaterialBakeCategory.PreservedVertexColor when policy.PreserveVertexColorMaterials:
-                case NonDemMaterialBakeCategory.PreservedOther:
-                    ResoniteMeshSubmesh normalizedSubmesh = normalizedCityObject.Mesh.Submeshes.Single(candidate => candidate.Index == submesh.Index);
-                    ResoniteMaterialBinding normalizedMaterial = normalizedCityObject.Materials.Single(candidate => candidate.SubmeshIndices.Contains(submesh.Index));
-                    preservedEntries.Add(new NonDemPreservedSubmeshEntry(normalizedCityObject, normalizedSubmesh, normalizedMaterial));
-                    break;
-            }
-        }
-
-        if (policy.RequireAtlasCandidateMaterial && !hadAtlasCandidateMaterial)
-        {
-            DisposeCandidateImages(new NonDemCityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries));
-            return null;
-        }
-
-        if (atlasEntries.Count == 0 && preservedEntries.Count == 0)
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM bake city object '{cityObject.DisplayName}' produced no atlas or preserved submesh candidate.");
-        }
-
-        return new NonDemCityObjectBakeCandidate(normalizedCityObject, atlasEntries, preservedEntries);
-    }
-
-    private async Task<NonDemAtlasOrPreservedEntry> CreateAtlasOrPreservedEntryAsync(
-        ResoniteConstructionCityObject cityObject,
-        ResoniteMeshSubmesh submesh,
-        ResoniteMaterialBinding material,
-        CancellationToken cancellationToken)
-    {
-        if (material.TexturePayload is null)
-        {
-            throw new InvalidOperationException("Non-DEM bake candidate material must have a texture payload.");
-        }
-
-        TextureUvRect uvBounds = ComputeUvBounds(cityObject.Mesh.Vertices, submesh, material);
-        using Image<Rgba32> sourceImage = await textureImageLoader.LoadAsync(
-            ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
-            cancellationToken);
-        Rgba32 detectedBackgroundColor = NonDemTextureImageProcessing.DetectRepresentativeBackgroundColor(sourceImage);
-        using Image<Rgba32> preparedSourceImage = sourceImage.Clone();
-        NonDemTextureImageProcessing.FillTransparentRgb(preparedSourceImage, detectedBackgroundColor);
-        if (NonDemTextureImageProcessing.TryGetUniformPixelColor(preparedSourceImage, out Rgba32 uniformDatasetColor))
-        {
-            Rgba32 tintedUniformColor = NonDemTextureImageProcessing.MultiplyPixel(
-                uniformDatasetColor,
-                NonDemTextureImageProcessing.ToPixel(material.BaseColor));
-            return new NonDemAtlasOrPreservedEntry(
-                AtlasEntry: null,
-                PreservedEntry: new NonDemPreservedSubmeshEntry(
-                    cityObject,
-                    submesh,
-                    CreateVertexColorMaterial(material, submesh.Index),
-                    NonDemTextureImageProcessing.ToColor(tintedUniformColor)));
-        }
-
-        int maxTileWidth = EffectiveMaxAtlasTextureEdge;
-        int maxTileHeight = EffectiveMaxAtlasTextureEdge;
-        int targetWidth = Math.Max(1, Math.Min(maxTileWidth, (int)Math.Ceiling(sourceImage.Width * uvBounds.Width)));
-        int targetHeight = Math.Max(1, Math.Min(maxTileHeight, (int)Math.Ceiling(sourceImage.Height * uvBounds.Height)));
-        using Image<Rgba32> bakedImage = NonDemTextureImageProcessing.BakeUsedUvRegion(
-            preparedSourceImage,
-            uvBounds,
-            targetWidth,
-            targetHeight);
-
-        NonDemTextureImageProcessing.ApplyBaseColor(bakedImage, material.BaseColor);
-        return new NonDemAtlasOrPreservedEntry(
-            AtlasEntry: new NonDemAtlasBatchEntry(
-                cityObject,
-                submesh,
-                material,
-                new NonDemMaterialAtlasTile(
-                    bakedImage.Clone(),
-                    NonDemTextureImageProcessing.MultiplyPixel(
-                        detectedBackgroundColor,
-                        NonDemTextureImageProcessing.ToPixel(material.BaseColor))),
-                uvBounds),
-            PreservedEntry: null);
     }
 
     private async Task<ResoniteConstructionCityObject> BakeBatchAsync(
@@ -595,24 +461,9 @@ internal sealed class NonDemCityObjectBaker(
         return new NonDemAtlasLayoutFactory(EffectiveMaxAtlasSize, tilePaddingPixels);
     }
 
-    private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)
+    private NonDemCityObjectBakeCandidateFactory CreateCandidateFactory()
     {
-        return material with
-        {
-            MaterialType = ResoniteMaterialType.VertexColor,
-            BaseColor = new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-            TexturePayload = null,
-            TextureSourceKind = ResoniteTextureSourceKind.Bundled,
-            TextureScale = null,
-            TextureOffset = null,
-            Family = null,
-            TerrainOverlay = null,
-            AssetScope = ResoniteMaterialAssetScope.Common,
-            SubmeshIndices = [submeshIndex],
-            CommonMaterial = material.DepthOffset is null
-                ? CommonMaterialCatalog.Create().VertexColor.Uv
-                : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv,
-        };
+        return new NonDemCityObjectBakeCandidateFactory(textureImageLoader, EffectiveMaxAtlasTextureEdge);
     }
 
     private static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)
@@ -623,35 +474,6 @@ internal sealed class NonDemCityObjectBaker(
     private static ResoniteFloat3 Subtract(ResoniteFloat3 left, ResoniteFloat3 right)
     {
         return new ResoniteFloat3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
-    }
-
-    private static TextureUvRect ComputeUvBounds(
-        IReadOnlyList<ResoniteMeshVertex> vertices,
-        ResoniteMeshSubmesh submesh,
-        ResoniteMaterialBinding material)
-    {
-        double minU = double.PositiveInfinity;
-        double minV = double.PositiveInfinity;
-        double maxU = double.NegativeInfinity;
-        double maxV = double.NegativeInfinity;
-
-        foreach (int sourceIndex in submesh.TriangleVertexIndices)
-        {
-            ResoniteFloat2 transformedUv = vertices[sourceIndex].UV0;
-            minU = Math.Min(minU, transformedUv.X);
-            minV = Math.Min(minV, transformedUv.Y);
-            maxU = Math.Max(maxU, transformedUv.X);
-            maxV = Math.Max(maxV, transformedUv.Y);
-        }
-
-        if (double.IsPositiveInfinity(minU) || double.IsPositiveInfinity(minV))
-        {
-            return TextureUvRect.Identity;
-        }
-
-        double width = Math.Max(1.0 / 1024.0, maxU - minU);
-        double height = Math.Max(1.0 / 1024.0, maxV - minV);
-        return new TextureUvRect(minU, minV, width, height);
     }
 
     private async Task EmitAtlasBatchAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -8,13 +8,13 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemCityObjectBaker(
     IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies,
-    NonDemSourceFileBakeEmitter sourceFileBakeEmitter) : IResoniteBufferedCityObjectBaker
+    INonDemSourceFileBakeEmitter sourceFileBakeEmitter) : IResoniteBufferedCityObjectBaker
 {
     private readonly Dictionary<NonDemSourceFileBatchKey, List<NonDemBufferedCityObject>> bufferedCityObjectsBySourceFile = [];
     private readonly Dictionary<NonDemSourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
     private readonly IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies = bakePolicies
         ?? throw new ArgumentNullException(nameof(bakePolicies));
-    private readonly NonDemSourceFileBakeEmitter sourceFileBakeEmitter = sourceFileBakeEmitter
+    private readonly INonDemSourceFileBakeEmitter sourceFileBakeEmitter = sourceFileBakeEmitter
         ?? throw new ArgumentNullException(nameof(sourceFileBakeEmitter));
 
     public string Name => "AtlasBake";

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -96,19 +96,24 @@ internal sealed class NonDemCityObjectBaker(
 
         int batchStartIndex = nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey);
         int emittedCount = 0;
-        await sourceFileBakeEmitter.EmitAsync(
-            sourceFileKey,
-            cityObjects,
-            batchStartIndex,
-            async (bakedCityObject, callbackCancellationToken) =>
-            {
-                await onBakedCityObject(bakedCityObject, callbackCancellationToken);
-                emittedCount++;
-                BakedOutputCityObjectCount++;
-            },
-            cancellationToken);
-
-        nextBatchIndexBySourceFile[sourceFileKey] = batchStartIndex + emittedCount;
-        cityObjects.Clear();
+        try
+        {
+            await sourceFileBakeEmitter.EmitAsync(
+                sourceFileKey,
+                cityObjects,
+                batchStartIndex,
+                async (bakedCityObject, callbackCancellationToken) =>
+                {
+                    emittedCount++;
+                    await onBakedCityObject(bakedCityObject, callbackCancellationToken);
+                    BakedOutputCityObjectCount++;
+                },
+                cancellationToken);
+        }
+        finally
+        {
+            nextBatchIndexBySourceFile[sourceFileKey] = batchStartIndex + emittedCount;
+            cityObjects.Clear();
+        }
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeBuffer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeBuffer.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemSourceFileBakeBuffer
+{
+    private readonly Dictionary<NonDemSourceFileBatchKey, List<NonDemBufferedCityObject>> bufferedCityObjectsBySourceFile = [];
+    private readonly Dictionary<NonDemSourceFileBatchKey, int> nextBatchIndexBySourceFile = [];
+
+    public bool IsEmpty => bufferedCityObjectsBySourceFile.Count == 0;
+
+    public void Add(
+        NonDemSourceFileBatchKey sourceFileKey,
+        NonDemBufferedCityObject bufferedCityObject)
+    {
+        if (!bufferedCityObjectsBySourceFile.TryGetValue(sourceFileKey, out List<NonDemBufferedCityObject>? bufferedCityObjects))
+        {
+            bufferedCityObjects = [];
+            bufferedCityObjectsBySourceFile.Add(sourceFileKey, bufferedCityObjects);
+        }
+
+        bufferedCityObjects.Add(bufferedCityObject);
+    }
+
+    public IReadOnlyList<NonDemSourceFileBatchKey> SnapshotOrderedSourceFileKeys()
+    {
+        return bufferedCityObjectsBySourceFile.Keys
+            .OrderBy(static key => key, NonDemSourceFileBatching.KeyComparer)
+            .ToArray();
+    }
+
+    public bool TryTake(
+        NonDemSourceFileBatchKey sourceFileKey,
+        out NonDemSourceFileBakeBufferEntry entry)
+    {
+        if (!bufferedCityObjectsBySourceFile.Remove(sourceFileKey, out List<NonDemBufferedCityObject>? cityObjects))
+        {
+            entry = default;
+            return false;
+        }
+
+        entry = new NonDemSourceFileBakeBufferEntry(
+            sourceFileKey,
+            cityObjects,
+            nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey));
+        return true;
+    }
+
+    public void Complete(
+        NonDemSourceFileBakeBufferEntry entry,
+        int reservedOutputCount)
+    {
+        nextBatchIndexBySourceFile[entry.SourceFileKey] = entry.BatchStartIndex + reservedOutputCount;
+        entry.CityObjects.Clear();
+    }
+}
+
+internal readonly record struct NonDemSourceFileBakeBufferEntry(
+    NonDemSourceFileBatchKey SourceFileKey,
+    List<NonDemBufferedCityObject> CityObjects,
+    int BatchStartIndex);

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemSourceFileBakeEmitter(
+    NonDemCityObjectBakeCandidateFactory candidateFactory,
+    NonDemCityObjectBakeAssembler assembler,
+    NonDemAtlasBatchFitPolicy batchFitPolicy)
+{
+    public async Task<int> EmitAsync(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemBufferedCityObject> cityObjects,
+        int batchStartIndex,
+        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
+        CancellationToken cancellationToken)
+    {
+        List<NonDemCityObjectBakeCandidate> passThroughCandidates = [];
+        List<NonDemCityObjectBakeCandidate> currentAtlasBatch = [];
+        int emittedCount = 0;
+        int batchIndex = batchStartIndex;
+        bool preservePrimaryIdentity = cityObjects.Count == 1;
+
+        foreach (NonDemBufferedCityObject bufferedCityObject in cityObjects.OrderBy(
+                     static bufferedCityObject => bufferedCityObject.CityObject.SlotKey,
+                     StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            NonDemCityObjectBakeCandidate? candidate = await candidateFactory.CreateAsync(bufferedCityObject, cancellationToken);
+            if (candidate is null)
+            {
+                continue;
+            }
+
+            if (candidate.AtlasEntries.Count == 0 && !NonDemAtlasBatchFitPolicy.RequiresBakeEmission(candidate))
+            {
+                passThroughCandidates.Add(candidate);
+                continue;
+            }
+
+            if (currentAtlasBatch.Count == 0)
+            {
+                if (batchFitPolicy.CanFitSingleCandidate(candidate))
+                {
+                    currentAtlasBatch.Add(candidate);
+                }
+                else
+                {
+                    emittedCount += await EmitFallbackCandidateAsync(candidate, onBakedCityObject, cancellationToken);
+                }
+
+                continue;
+            }
+
+            if (batchFitPolicy.CanAppendToAtlasBatch(currentAtlasBatch, candidate))
+            {
+                currentAtlasBatch.Add(candidate);
+                continue;
+            }
+
+            emittedCount += await EmitAtlasBatchAsync(
+                sourceFileKey,
+                currentAtlasBatch,
+                batchIndex++,
+                preservePrimaryIdentity && passThroughCandidates.Count == 0,
+                onBakedCityObject,
+                cancellationToken);
+            currentAtlasBatch.Clear();
+
+            if (batchFitPolicy.CanFitSingleCandidate(candidate))
+            {
+                currentAtlasBatch.Add(candidate);
+            }
+            else
+            {
+                emittedCount += await EmitFallbackCandidateAsync(candidate, onBakedCityObject, cancellationToken);
+            }
+        }
+
+        if (currentAtlasBatch.Count > 0)
+        {
+            emittedCount += await EmitAtlasBatchAsync(
+                sourceFileKey,
+                currentAtlasBatch,
+                batchIndex++,
+                preservePrimaryIdentity && passThroughCandidates.Count == 0,
+                onBakedCityObject,
+                cancellationToken);
+            currentAtlasBatch.Clear();
+        }
+
+        if (passThroughCandidates.Count == 1)
+        {
+            NonDemCityObjectBakeCandidate passThroughCandidate = passThroughCandidates[0];
+            await onBakedCityObject(passThroughCandidate.CityObject, cancellationToken);
+            DisposeCandidateImages(passThroughCandidate);
+            emittedCount++;
+        }
+        else if (passThroughCandidates.Count > 1)
+        {
+            try
+            {
+                ResoniteConstructionCityObject mergedPassThroughCityObject = await assembler.BakeBatchAsync(
+                    sourceFileKey,
+                    passThroughCandidates,
+                    batchIndex,
+                    preservePrimaryIdentity: false,
+                    cancellationToken);
+                await onBakedCityObject(mergedPassThroughCityObject, cancellationToken);
+                emittedCount++;
+            }
+            finally
+            {
+                DisposeCandidateImages(passThroughCandidates);
+            }
+        }
+
+        return emittedCount;
+    }
+
+    private async Task<int> EmitAtlasBatchAsync(
+        NonDemSourceFileBatchKey sourceFileKey,
+        IReadOnlyList<NonDemCityObjectBakeCandidate> batchCandidates,
+        int batchIndex,
+        bool preservePrimaryIdentity,
+        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            ResoniteConstructionCityObject bakedCityObject = await assembler.BakeBatchAsync(
+                sourceFileKey,
+                batchCandidates,
+                batchIndex,
+                preservePrimaryIdentity,
+                cancellationToken);
+            await onBakedCityObject(bakedCityObject, cancellationToken);
+            return 1;
+        }
+        finally
+        {
+            DisposeCandidateImages(batchCandidates);
+        }
+    }
+
+    private static async Task<int> EmitFallbackCandidateAsync(
+        NonDemCityObjectBakeCandidate fallbackCandidate,
+        Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await onBakedCityObject(fallbackCandidate.CityObject, cancellationToken);
+            return 1;
+        }
+        finally
+        {
+            DisposeCandidateImages(fallbackCandidate);
+        }
+    }
+
+    private static void DisposeCandidateImages(NonDemCityObjectBakeCandidate candidate)
+    {
+        DisposeCandidateImages([candidate]);
+    }
+
+    private static void DisposeCandidateImages(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
+    {
+        foreach (Image<Rgba32> tileImage in candidates
+                     .SelectMany(static candidate => candidate.AtlasEntries)
+                     .Select(static entry => entry.Tile.Image)
+                     .Distinct())
+        {
+            tileImage.Dispose();
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -4,16 +4,17 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemSourceFileBakeEmitter(
     NonDemCityObjectBakeCandidateFactory candidateFactory,
     NonDemCityObjectBakeAssembler assembler,
-    NonDemAtlasBatchFitPolicy batchFitPolicy) : INonDemSourceFileBakeEmitter
+    NonDemAtlasBatchFitPolicy batchFitPolicy,
+    INonDemBakeCandidateImageDisposer candidateImageDisposer) : INonDemSourceFileBakeEmitter
 {
+    private readonly INonDemBakeCandidateImageDisposer candidateImageDisposer = candidateImageDisposer
+        ?? throw new ArgumentNullException(nameof(candidateImageDisposer));
+
     public async Task<int> EmitAsync(
         NonDemSourceFileBatchKey sourceFileKey,
         IReadOnlyList<NonDemBufferedCityObject> cityObjects,
@@ -99,7 +100,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
         {
             NonDemCityObjectBakeCandidate passThroughCandidate = passThroughCandidates[0];
             await onBakedCityObject(passThroughCandidate.CityObject, cancellationToken);
-            DisposeCandidateImages(passThroughCandidate);
+            candidateImageDisposer.Dispose(passThroughCandidate);
             emittedCount++;
         }
         else if (passThroughCandidates.Count > 1)
@@ -117,7 +118,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
             }
             finally
             {
-                DisposeCandidateImages(passThroughCandidates);
+                candidateImageDisposer.Dispose(passThroughCandidates);
             }
         }
 
@@ -145,11 +146,11 @@ internal sealed class NonDemSourceFileBakeEmitter(
         }
         finally
         {
-            DisposeCandidateImages(batchCandidates);
+            candidateImageDisposer.Dispose(batchCandidates);
         }
     }
 
-    private static async Task<int> EmitFallbackCandidateAsync(
+    private async Task<int> EmitFallbackCandidateAsync(
         NonDemCityObjectBakeCandidate fallbackCandidate,
         Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
         CancellationToken cancellationToken)
@@ -161,23 +162,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
         }
         finally
         {
-            DisposeCandidateImages(fallbackCandidate);
-        }
-    }
-
-    private static void DisposeCandidateImages(NonDemCityObjectBakeCandidate candidate)
-    {
-        DisposeCandidateImages([candidate]);
-    }
-
-    private static void DisposeCandidateImages(IReadOnlyList<NonDemCityObjectBakeCandidate> candidates)
-    {
-        foreach (Image<Rgba32> tileImage in candidates
-                     .SelectMany(static candidate => candidate.AtlasEntries)
-                     .Select(static entry => entry.Tile.Image)
-                     .Distinct())
-        {
-            tileImage.Dispose();
+            candidateImageDisposer.Dispose(fallbackCandidate);
         }
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -12,7 +12,7 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal sealed class NonDemSourceFileBakeEmitter(
     NonDemCityObjectBakeCandidateFactory candidateFactory,
     NonDemCityObjectBakeAssembler assembler,
-    NonDemAtlasBatchFitPolicy batchFitPolicy)
+    NonDemAtlasBatchFitPolicy batchFitPolicy) : INonDemSourceFileBakeEmitter
 {
     public async Task<int> EmitAsync(
         NonDemSourceFileBatchKey sourceFileKey,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -7,11 +7,17 @@ using System.Threading.Tasks;
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class NonDemSourceFileBakeEmitter(
-    NonDemCityObjectBakeCandidateFactory candidateFactory,
-    NonDemCityObjectBakeAssembler assembler,
+    INonDemCityObjectBakeCandidateFactory candidateFactory,
+    INonDemCityObjectBakeAssembler assembler,
     NonDemAtlasBatchFitPolicy batchFitPolicy,
     INonDemBakeCandidateImageDisposer candidateImageDisposer) : INonDemSourceFileBakeEmitter
 {
+    private readonly INonDemCityObjectBakeCandidateFactory candidateFactory = candidateFactory
+        ?? throw new ArgumentNullException(nameof(candidateFactory));
+    private readonly INonDemCityObjectBakeAssembler assembler = assembler
+        ?? throw new ArgumentNullException(nameof(assembler));
+    private readonly NonDemAtlasBatchFitPolicy batchFitPolicy = batchFitPolicy
+        ?? throw new ArgumentNullException(nameof(batchFitPolicy));
     private readonly INonDemBakeCandidateImageDisposer candidateImageDisposer = candidateImageDisposer
         ?? throw new ArgumentNullException(nameof(candidateImageDisposer));
 

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -9,14 +9,14 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal sealed class NonDemSourceFileBakeEmitter(
     INonDemCityObjectBakeCandidateFactory candidateFactory,
     INonDemCityObjectBakeAssembler assembler,
-    NonDemAtlasBatchFitPolicy batchFitPolicy,
+    INonDemAtlasBatchFitPolicy batchFitPolicy,
     INonDemBakeCandidateImageDisposer candidateImageDisposer) : INonDemSourceFileBakeEmitter
 {
     private readonly INonDemCityObjectBakeCandidateFactory candidateFactory = candidateFactory
         ?? throw new ArgumentNullException(nameof(candidateFactory));
     private readonly INonDemCityObjectBakeAssembler assembler = assembler
         ?? throw new ArgumentNullException(nameof(assembler));
-    private readonly NonDemAtlasBatchFitPolicy batchFitPolicy = batchFitPolicy
+    private readonly INonDemAtlasBatchFitPolicy batchFitPolicy = batchFitPolicy
         ?? throw new ArgumentNullException(nameof(batchFitPolicy));
     private readonly INonDemBakeCandidateImageDisposer candidateImageDisposer = candidateImageDisposer
         ?? throw new ArgumentNullException(nameof(candidateImageDisposer));
@@ -45,7 +45,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
                 continue;
             }
 
-            if (candidate.AtlasEntries.Count == 0 && !NonDemAtlasBatchFitPolicy.RequiresBakeEmission(candidate))
+            if (candidate.AtlasEntries.Count == 0 && !batchFitPolicy.RequiresBakeEmission(candidate))
             {
                 passThroughCandidates.Add(candidate);
                 continue;

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -14,7 +14,8 @@ internal sealed class NonDemSourceFileBakeEmitterFactory(
                 new NonDemAtlasOrPreservedEntryFactory(textureImageLoader, atlasBudget.EffectiveMaxAtlasTextureEdge)),
             new NonDemCityObjectBakeAssembler(
                 layoutFactory,
-                new NonDemAtlasImageRenderer(atlasBudget.TilePaddingPixels)),
+                new NonDemAtlasImageRenderer(atlasBudget.TilePaddingPixels),
+                new NonDemBakedGeometryComposer()),
             new NonDemAtlasBatchFitPolicy(layoutFactory));
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -16,6 +16,7 @@ internal sealed class NonDemSourceFileBakeEmitterFactory(
                 layoutFactory,
                 new NonDemAtlasImageRenderer(atlasBudget.TilePaddingPixels),
                 new NonDemBakedGeometryComposer()),
-            new NonDemAtlasBatchFitPolicy(layoutFactory));
+            new NonDemAtlasBatchFitPolicy(layoutFactory),
+            new NonDemBakeCandidateImageDisposer());
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -1,0 +1,19 @@
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class NonDemSourceFileBakeEmitterFactory(
+    ResoniteTextureImageLoader textureImageLoader,
+    NonDemAtlasBakeBudget atlasBudget)
+{
+    public NonDemSourceFileBakeEmitter Create()
+    {
+        NonDemAtlasLayoutFactory layoutFactory = new(
+            atlasBudget.EffectiveMaxAtlasSize,
+            atlasBudget.TilePaddingPixels);
+        return new NonDemSourceFileBakeEmitter(
+            new NonDemCityObjectBakeCandidateFactory(textureImageLoader, atlasBudget.EffectiveMaxAtlasTextureEdge),
+            new NonDemCityObjectBakeAssembler(
+                layoutFactory,
+                new NonDemAtlasImageRenderer(atlasBudget.TilePaddingPixels)),
+            new NonDemAtlasBatchFitPolicy(layoutFactory));
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -1,10 +1,14 @@
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed class NonDemSourceFileBakeEmitterFactory(
-    ResoniteTextureImageLoader textureImageLoader,
-    NonDemAtlasBakeBudget atlasBudget)
+internal interface INonDemSourceFileBakeEmitterFactory
 {
-    public INonDemSourceFileBakeEmitter Create()
+    INonDemSourceFileBakeEmitter Create(NonDemAtlasBakeBudget atlasBudget);
+}
+
+internal sealed class NonDemSourceFileBakeEmitterFactory(
+    ResoniteTextureImageLoader textureImageLoader) : INonDemSourceFileBakeEmitterFactory
+{
+    public INonDemSourceFileBakeEmitter Create(NonDemAtlasBakeBudget atlasBudget)
     {
         NonDemAtlasLayoutFactory layoutFactory = new(
             atlasBudget.EffectiveMaxAtlasSize,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -10,7 +10,8 @@ internal sealed class NonDemSourceFileBakeEmitterFactory(
             atlasBudget.EffectiveMaxAtlasSize,
             atlasBudget.TilePaddingPixels);
         return new NonDemSourceFileBakeEmitter(
-            new NonDemCityObjectBakeCandidateFactory(textureImageLoader, atlasBudget.EffectiveMaxAtlasTextureEdge),
+            new NonDemCityObjectBakeCandidateFactory(
+                new NonDemAtlasOrPreservedEntryFactory(textureImageLoader, atlasBudget.EffectiveMaxAtlasTextureEdge)),
             new NonDemCityObjectBakeAssembler(
                 layoutFactory,
                 new NonDemAtlasImageRenderer(atlasBudget.TilePaddingPixels)),

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -4,7 +4,7 @@ internal sealed class NonDemSourceFileBakeEmitterFactory(
     ResoniteTextureImageLoader textureImageLoader,
     NonDemAtlasBakeBudget atlasBudget)
 {
-    public NonDemSourceFileBakeEmitter Create()
+    public INonDemSourceFileBakeEmitter Create()
     {
         NonDemAtlasLayoutFactory layoutFactory = new(
             atlasBudget.EffectiveMaxAtlasSize,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
@@ -10,14 +10,15 @@ internal interface IResoniteBufferedCityObjectBakerFactory
 }
 
 internal sealed class ResoniteBufferedCityObjectBakerFactory(
-    ResoniteTextureImageLoader textureImageLoader) : IResoniteBufferedCityObjectBakerFactory
+    INonDemSourceFileBakeEmitterFactory sourceFileBakeEmitterFactory) : IResoniteBufferedCityObjectBakerFactory
 {
+    private readonly INonDemSourceFileBakeEmitterFactory sourceFileBakeEmitterFactory = sourceFileBakeEmitterFactory
+        ?? throw new ArgumentNullException(nameof(sourceFileBakeEmitterFactory));
+
     public CompositeCityObjectBaker? Create(
         bool enableMeshBake,
         ResoniteImportBudgetProfile resourceBudget)
     {
-        ArgumentNullException.ThrowIfNull(textureImageLoader);
-
         _ = resourceBudget.Name switch
         {
             ResoniteImportMemoryProfile.Small or ResoniteImportMemoryProfile.Large => true,
@@ -28,9 +29,8 @@ internal sealed class ResoniteBufferedCityObjectBakerFactory(
             ? new CompositeCityObjectBaker(
                 new NonDemCityObjectBaker(
                     bakePolicyResolver: new NonDemCityObjectBakePolicyResolver(NonDemCityObjectBakePolicies.DefaultPolicies),
-                    sourceFileBakeEmitter: new NonDemSourceFileBakeEmitterFactory(
-                        textureImageLoader,
-                        new NonDemAtlasBakeBudget(ResourceBudget: resourceBudget)).Create()))
+                    sourceFileBakeEmitter: sourceFileBakeEmitterFactory.Create(
+                        new NonDemAtlasBakeBudget(ResourceBudget: resourceBudget))))
             : null;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
@@ -27,9 +27,10 @@ internal sealed class ResoniteBufferedCityObjectBakerFactory(
         return enableMeshBake
             ? new CompositeCityObjectBaker(
                 new NonDemCityObjectBaker(
-                    textureImageLoader,
                     bakePolicies: NonDemCityObjectBakePolicies.DefaultPolicies,
-                    resourceBudget: resourceBudget))
+                    sourceFileBakeEmitter: new NonDemSourceFileBakeEmitterFactory(
+                        textureImageLoader,
+                        new NonDemAtlasBakeBudget(ResourceBudget: resourceBudget)).Create()))
             : null;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteBufferedCityObjectBakerFactory.cs
@@ -27,7 +27,7 @@ internal sealed class ResoniteBufferedCityObjectBakerFactory(
         return enableMeshBake
             ? new CompositeCityObjectBaker(
                 new NonDemCityObjectBaker(
-                    bakePolicies: NonDemCityObjectBakePolicies.DefaultPolicies,
+                    bakePolicyResolver: new NonDemCityObjectBakePolicyResolver(NonDemCityObjectBakePolicies.DefaultPolicies),
                     sourceFileBakeEmitter: new NonDemSourceFileBakeEmitterFactory(
                         textureImageLoader,
                         new NonDemAtlasBakeBudget(ResourceBudget: resourceBudget)).Create()))

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
             _ => static progressReporter => new ResoniteLinkClient(progressReporter));
         services.TryAddScoped<BundledDefaultMaterialAssetStore>();
         services.TryAddScoped<ResoniteTextureImageLoader>();
+        services.TryAddScoped<INonDemSourceFileBakeEmitterFactory, NonDemSourceFileBakeEmitterFactory>();
         services.TryAddScoped<IResoniteBatchEmissionPlanner, ResoniteBatchEmissionPlanner>();
         services.TryAddScoped<IResoniteBufferedCityObjectBakerFactory, ResoniteBufferedCityObjectBakerFactory>();
         services.TryAddScoped<IResoniteGeometryAssetAssembler, ResoniteGeometryAssetAssembler>();

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -938,6 +938,42 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(512, atlasPayload.Height);
     }
 
+    [Fact]
+    public async Task FlushAllAsyncCountsOutputsAcceptedBeforeCallbackFailure()
+    {
+        NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 10, tilePaddingPixels: 0);
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-a",
+                CreateCheckerPayload("textures/a.png", new Rgba32(255, 0, 0, 255), new Rgba32(255, 255, 0, 255), 9, 3),
+                0,
+                "unit-a"));
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-b",
+                CreateCheckerPayload("textures/b.png", new Rgba32(0, 255, 0, 255), new Rgba32(0, 255, 255, 255), 9, 3),
+                2,
+                "unit-a"));
+
+        int callbackCount = 0;
+        await Assert.ThrowsAsync<InvalidOperationException>(() => baker.FlushAllAsync(
+            (_, _) =>
+            {
+                callbackCount++;
+                if (callbackCount == 2)
+                {
+                    throw new InvalidOperationException("stop after first accepted output");
+                }
+
+                return Task.CompletedTask;
+            }));
+
+        Assert.Equal(2, callbackCount);
+        Assert.Equal(1, baker.BakedOutputCityObjectCount);
+    }
+
     private static NonDemCityObjectBaker CreateBaker(
         int maxAtlasSize = NonDemAtlasBakeBudget.DefaultMaxAtlasSize,
         int tilePaddingPixels = NonDemAtlasBakeBudget.DefaultTilePaddingPixels,

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -981,8 +981,8 @@ public sealed class NonDemCityObjectBakerTests
         ResoniteImportBudgetProfile? resourceBudget = null)
     {
         INonDemSourceFileBakeEmitter sourceFileBakeEmitter = new NonDemSourceFileBakeEmitterFactory(
-            new ResoniteTextureImageLoader(),
-            new NonDemAtlasBakeBudget(maxAtlasSize, tilePaddingPixels, resourceBudget)).Create();
+            new ResoniteTextureImageLoader()).Create(
+            new NonDemAtlasBakeBudget(maxAtlasSize, tilePaddingPixels, resourceBudget));
         return new NonDemCityObjectBaker(
             new NonDemCityObjectBakePolicyResolver(bakePolicies ?? NonDemCityObjectBakePolicies.DefaultPolicies),
             sourceFileBakeEmitter);

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -974,6 +974,61 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(1, baker.BakedOutputCityObjectCount);
     }
 
+    [Fact]
+    public async Task FlushAllAsyncAdvancesBatchIdentityAfterCallbackFailure()
+    {
+        NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 16, tilePaddingPixels: 0);
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-a",
+                CreateCheckerPayload("textures/a.png", new Rgba32(255, 0, 0, 255), new Rgba32(255, 255, 0, 255), 9, 9),
+                0,
+                "unit-a"));
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-b",
+                CreateCheckerPayload("textures/b.png", new Rgba32(0, 255, 0, 255), new Rgba32(0, 255, 255, 255), 9, 9),
+                2,
+                "unit-a"));
+
+        int callbackCount = 0;
+        await Assert.ThrowsAsync<InvalidOperationException>(() => baker.FlushAllAsync(
+            (_, _) =>
+            {
+                callbackCount++;
+                if (callbackCount == 2)
+                {
+                    throw new InvalidOperationException("stop after second reserved output");
+                }
+
+                return Task.CompletedTask;
+            }));
+
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-c",
+                CreateCheckerPayload("textures/c.png", new Rgba32(0, 0, 255, 255), new Rgba32(255, 0, 255, 255), 4, 4),
+                4,
+                "unit-a"));
+        await AssertBufferedAsync(
+            baker,
+            CreateLod2Building(
+                "building-d",
+                CreateCheckerPayload("textures/d.png", new Rgba32(255, 255, 255, 255), new Rgba32(0, 0, 0, 255), 4, 4),
+                6,
+                "unit-a"));
+
+        ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
+
+        Assert.Equal("atlasbake-unit-a-bldg-lod2-3", cityObject.SlotKey);
+        Assert.Equal(
+            "atlastex-unit-a.gml-3",
+            Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Identity);
+    }
+
     private static NonDemCityObjectBaker CreateBaker(
         int maxAtlasSize = NonDemAtlasBakeBudget.DefaultMaxAtlasSize,
         int tilePaddingPixels = NonDemAtlasBakeBudget.DefaultTilePaddingPixels,

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -939,17 +939,17 @@ public sealed class NonDemCityObjectBakerTests
     }
 
     private static NonDemCityObjectBaker CreateBaker(
-        int maxAtlasSize = NonDemCityObjectBaker.DefaultMaxAtlasSize,
-        int tilePaddingPixels = NonDemCityObjectBaker.DefaultTilePaddingPixels,
+        int maxAtlasSize = NonDemAtlasBakeBudget.DefaultMaxAtlasSize,
+        int tilePaddingPixels = NonDemAtlasBakeBudget.DefaultTilePaddingPixels,
         IReadOnlyList<NonDemCityObjectBakePolicy>? bakePolicies = null,
         ResoniteImportBudgetProfile? resourceBudget = null)
     {
-        return new NonDemCityObjectBaker(
+        NonDemSourceFileBakeEmitter sourceFileBakeEmitter = new NonDemSourceFileBakeEmitterFactory(
             new ResoniteTextureImageLoader(),
+            new NonDemAtlasBakeBudget(maxAtlasSize, tilePaddingPixels, resourceBudget)).Create();
+        return new NonDemCityObjectBaker(
             bakePolicies ?? NonDemCityObjectBakePolicies.DefaultPolicies,
-            maxAtlasSize,
-            tilePaddingPixels,
-            resourceBudget);
+            sourceFileBakeEmitter);
     }
 
     private static async Task AssertBufferedAsync(NonDemCityObjectBaker baker, ResoniteConstructionCityObject cityObject)

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -944,7 +944,7 @@ public sealed class NonDemCityObjectBakerTests
         IReadOnlyList<NonDemCityObjectBakePolicy>? bakePolicies = null,
         ResoniteImportBudgetProfile? resourceBudget = null)
     {
-        NonDemSourceFileBakeEmitter sourceFileBakeEmitter = new NonDemSourceFileBakeEmitterFactory(
+        INonDemSourceFileBakeEmitter sourceFileBakeEmitter = new NonDemSourceFileBakeEmitterFactory(
             new ResoniteTextureImageLoader(),
             new NonDemAtlasBakeBudget(maxAtlasSize, tilePaddingPixels, resourceBudget)).Create();
         return new NonDemCityObjectBaker(

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -948,7 +948,7 @@ public sealed class NonDemCityObjectBakerTests
             new ResoniteTextureImageLoader(),
             new NonDemAtlasBakeBudget(maxAtlasSize, tilePaddingPixels, resourceBudget)).Create();
         return new NonDemCityObjectBaker(
-            bakePolicies ?? NonDemCityObjectBakePolicies.DefaultPolicies,
+            new NonDemCityObjectBakePolicyResolver(bakePolicies ?? NonDemCityObjectBakePolicies.DefaultPolicies),
             sourceFileBakeEmitter);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -30,7 +30,8 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     private static LiveSendRunStateFactory CreateRunStateFactory()
     {
         return new LiveSendRunStateFactory(
-            new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader()));
+            new ResoniteBufferedCityObjectBakerFactory(
+                new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader())));
     }
 
     private static ResonitePreparedCityObjectImporter CreatePreparedCityObjectImporter(
@@ -214,6 +215,29 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesPreservesPreRegisteredNonDemSourceFileBakeEmitterFactory()
+    {
+        RecordingNonDemSourceFileBakeEmitterFactory sourceFileBakeEmitterFactory = new();
+        ServiceProvider provider = new ServiceCollection()
+            .AddScoped<INonDemSourceFileBakeEmitterFactory>(_ => sourceFileBakeEmitterFactory)
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        CompositeCityObjectBaker? baker = scope.ServiceProvider
+            .GetRequiredService<IResoniteBufferedCityObjectBakerFactory>()
+            .Create(
+                enableMeshBake: true,
+                ResoniteImportBudgetProfiles.ForProfile(ResoniteImportMemoryProfile.Small));
+
+        Assert.NotNull(baker);
+        Assert.Equal(1, sourceFileBakeEmitterFactory.CreateCallCount);
+        ResoniteImportBudgetProfile? resourceBudget = sourceFileBakeEmitterFactory.LastBudget.ResourceBudget;
+        Assert.NotNull(resourceBudget);
+        Assert.Equal(ResoniteImportMemoryProfile.Small, resourceBudget.Name);
+    }
+
+    [Fact]
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The created target is disposed via await using in this test.")]
     public async Task AddResoniteLiveSendTargetServicesRegistersDefaultBaseClientFactory()
     {
@@ -359,6 +383,38 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         }
     }
 
+    private sealed class RecordingNonDemSourceFileBakeEmitterFactory : INonDemSourceFileBakeEmitterFactory
+    {
+        public int CreateCallCount { get; private set; }
+
+        public NonDemAtlasBakeBudget LastBudget { get; private set; }
+
+        public INonDemSourceFileBakeEmitter Create(NonDemAtlasBakeBudget atlasBudget)
+        {
+            CreateCallCount++;
+            LastBudget = atlasBudget;
+            return new RecordingNonDemSourceFileBakeEmitter();
+        }
+    }
+
+    private sealed class RecordingNonDemSourceFileBakeEmitter : INonDemSourceFileBakeEmitter
+    {
+        public Task<int> EmitAsync(
+            NonDemSourceFileBatchKey sourceFileKey,
+            IReadOnlyList<NonDemBufferedCityObject> cityObjects,
+            int batchStartIndex,
+            Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
+            CancellationToken cancellationToken)
+        {
+            _ = sourceFileKey;
+            _ = cityObjects;
+            _ = batchStartIndex;
+            _ = onBakedCityObject;
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new NotSupportedException("This test only verifies DI override preservation during baker creation.");
+        }
+    }
+
     private sealed class RecordingClientSessionFactory(
         Func<ILiveSendClientSession> createSession)
         : IResoniteClientSessionFactory
@@ -378,7 +434,8 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         int cityObjectCount,
         Func<int, ResoniteConstructionCityObject> createCityObject)
     {
-        ResoniteBufferedCityObjectBakerFactory factory = new(new ResoniteTextureImageLoader());
+        ResoniteBufferedCityObjectBakerFactory factory = new(
+            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()));
         CompositeCityObjectBaker baker = factory.Create(
                 enableMeshBake: true,
                 ResoniteImportBudgetProfiles.ForProfile(memoryProfile))

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -33,7 +33,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     private static LiveSendRunStateFactory CreateRunStateFactory()
     {
         return new LiveSendRunStateFactory(
-            new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader()));
+            new ResoniteBufferedCityObjectBakerFactory(
+                new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader())));
     }
 
     private static ResonitePreparedCityObjectImporter CreatePreparedCityObjectImporter(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -352,7 +352,9 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                         new ResoniteSceneAnchorResolver()),
                     new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter),
                     new LiveSendRunPlanFactory(),
-                    new LiveSendRunStateFactory(new ResoniteBufferedCityObjectBakerFactory(new ResoniteTextureImageLoader())),
+                    new LiveSendRunStateFactory(
+                        new ResoniteBufferedCityObjectBakerFactory(
+                            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
                     new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),
                     new ResoniteSlotCreator()),
                 queue));


### PR DESCRIPTION
## Summary
- move non-DEM bake candidate creation into a dedicated factory contract
- move atlas-or-preserved entry creation, texture baking, and uniform-texture vertex-color conversion into a dedicated factory contract
- move atlas layout, atlas rendering, and atlas batch-fit decisions behind dedicated service contracts
- move batch assembly into a dedicated assembler contract
- move baked mesh/material geometry composition behind a dedicated composer contract
- move source-file candidate batching and emission into a dedicated emitter contract
- move source-file buffering, flush ordering, and batch identity reservation into a dedicated buffer
- move candidate atlas image disposal behind a dedicated disposer contract
- move non-DEM source-file emitter construction behind a DI-registered factory contract
- move non-DEM bake policy selection into a dedicated resolver
- move atlas budget calculation and emitter composition out of NonDemCityObjectBaker
- keep NonDemCityObjectBaker focused on policy selection, buffering orchestration, callback accounting, and counters
- advance reserved non-DEM batch identities even when an output callback fails, while keeping accepted-output counts callback-completion based
- preserve atlas and preserved-material output behavior through existing behavior tests

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
