### PR TITLE
Extract live-send run composition factories

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -211,8 +211,9 @@ internal sealed class DefaultSceneSinkFactory(
             new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
             new ResoniteQueuedCityObjectSender(
-                new DeterministicTerrainTextureAssetGenerator(),
-                serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>(),
+                new ResoniteQueuedTexturePreparer(
+                    new DeterministicTerrainTextureAssetGenerator(),
+                    serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>()),
                 serviceProvider.GetRequiredService<IResonitePreparedCityObjectImporter>()));
         return new ResoniteLiveSceneImportTarget(
             targetOptions,

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -205,7 +205,6 @@ internal sealed class DefaultSceneSinkFactory(
 
         IServiceProvider serviceProvider = scope.ServiceProvider;
         ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
-        IResoniteMaterialPlanning materialPlanning = serviceProvider.GetRequiredService<IResoniteMaterialPlanning>();
         IResoniteQueuedCityObjectEnqueuer queuedCityObjectEnqueuer = new ResoniteQueuedCityObjectEnqueuer();
         ResoniteLiveSendQueue queue = new(
             queuedCityObjectEnqueuer,
@@ -223,7 +222,7 @@ internal sealed class DefaultSceneSinkFactory(
                 serviceProvider.GetRequiredService<IResoniteLiveSendStartRequestFactory>(),
                 new ResoniteLiveSendRunStarter(
                     serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
-                    new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter),
+                    serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupPreparer>(),
                     serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
                     serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
                     new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupPreparer.cs
@@ -21,31 +21,35 @@ internal interface IResoniteCommonMaterialSetupPreparer
         ResoniteSceneSetupState setupState,
         CommonMaterialAssetCache materials,
         CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials,
+        Action<string>? progressReporter,
         CancellationToken cancellationToken);
 }
 
 internal sealed class ResoniteCommonMaterialSetupPreparer(
-    IResoniteMaterialPlanning materialPlanning,
-    Action<string>? progressReporter) : IResoniteCommonMaterialSetupPreparer
+    IResoniteMaterialPlanning materialPlanning) : IResoniteCommonMaterialSetupPreparer
 {
     public async Task PrepareAsync(
         IResoniteLinkClient client,
         ResoniteSceneSetupState setupState,
         CommonMaterialAssetCache materials,
         CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials,
+        Action<string>? progressReporter,
         CancellationToken cancellationToken)
     {
         CommonMaterialCatalog<ResoniteCommonMaterialPlan> commonMaterialPlans =
             ResoniteCommonMaterialPlans.CreateCatalogPlans(commonMaterials);
         if (commonMaterialPlans.Count == 0)
         {
-            ReportProgress(PlateauLog.Info("live", "No common material assets are required during scene setup."));
+            ReportProgress(
+                progressReporter,
+                PlateauLog.Info("live", "No common material assets are required during scene setup."));
             return;
         }
 
         Stopwatch stopwatch = Stopwatch.StartNew();
         int preparedCount = 0;
         ReportProgress(
+            progressReporter,
             PlateauLog.Info(
                 "live",
                 $"Preparing {commonMaterialPlans.Count} common material assets during scene setup before object streaming."));
@@ -72,6 +76,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
 
             Stopwatch materialStopwatch = Stopwatch.StartNew();
             ReportProgress(
+                progressReporter,
                 PlateauLog.Info(
                     "live",
                     $"Preparing common material asset {preparedCount + 1}/{commonMaterialPlans.Count}: "
@@ -95,6 +100,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
                     new CreatedMaterialAsset(existingComponent.Value, null)));
                 preparedCount++;
                 ReportProgress(
+                    progressReporter,
                     PlateauLog.Info(
                         "live",
                         $"Reused common material asset {preparedCount}/{commonMaterialPlans.Count}: "
@@ -135,6 +141,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
                 pendingMaterialComponent));
             preparedCount++;
             ReportProgress(
+                progressReporter,
                 PlateauLog.Info(
                     "live",
                     $"Planned common material asset {preparedCount}/{commonMaterialPlans.Count}: "
@@ -160,6 +167,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
             }
 
             ReportProgress(
+                progressReporter,
                 PlateauLog.Info(
                     "live",
                     $"Created {preparedMaterials.Count} common material assets in one setup component batch."));
@@ -171,6 +179,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
         }
 
         ReportProgress(
+            progressReporter,
             PlateauLog.Info(
                 "live",
                 $"Prepared {preparedCount} common material assets during scene setup in {stopwatch.Elapsed.TotalSeconds:F2}s."));
@@ -256,7 +265,9 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
         return (reusableSlotWithoutComponent, null);
     }
 
-    private void ReportProgress(string message)
+    private static void ReportProgress(
+        Action<string>? progressReporter,
+        string message)
     {
         progressReporter?.Invoke(message);
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLinkClientSessionFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLinkClientSessionFactory.cs
@@ -1,0 +1,31 @@
+using System;
+
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteClientSessionFactory
+{
+    ILiveSendClientSession Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        ResoniteLinkSendDiagnostics diagnostics);
+}
+
+internal sealed class ResoniteLinkClientSessionFactory(
+    Func<Action<string>?, IResoniteLinkClient> baseClientFactory) : IResoniteClientSessionFactory
+{
+    public ILiveSendClientSession Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        ResoniteLinkSendDiagnostics diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(diagnostics);
+
+        return ResoniteLinkTransportSessionFactory.Create(
+            options.Endpoint,
+            options.ConnectionCount,
+            diagnostics,
+            options.ProgressReporter,
+            baseClientFactory);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Net.Http;
+
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSceneImportDependencyFactory
+{
+    ResoniteLiveSceneImportDependencies Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        HttpClient terrainTextureAssetHttpClient);
+}
+
+internal sealed class ResoniteLiveSceneImportDependencyFactory(
+    IResoniteClientSessionFactory clientSessionFactory,
+    IResoniteLiveSendRunStarterFactory runStarterFactory,
+    IResoniteLiveSendStartRequestFactory startRequestFactory,
+    IResoniteLiveSendQueue queue)
+    : IResoniteLiveSceneImportDependencyFactory
+{
+    public ResoniteLiveSceneImportDependencies Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        HttpClient terrainTextureAssetHttpClient)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ResoniteLinkSendDiagnostics diagnostics = options.EnableSendMetrics
+            ? ResoniteLinkSendDiagnostics.CreateEnabled(options.ProgressReporter)
+            : ResoniteLinkSendDiagnostics.Disabled;
+
+        return new ResoniteLiveSceneImportDependencies(
+            clientSessionFactory.Create(options, diagnostics),
+            diagnostics,
+            startRequestFactory,
+            runStarterFactory.Create(terrainTextureAssetHttpClient, options),
+            queue);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportFactory.cs
@@ -1,0 +1,24 @@
+using System.Net.Http;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSceneImportFactory
+{
+    ResoniteLiveSceneImportTarget CreateTarget(
+        ResoniteLiveSceneImportTargetOptions options,
+        HttpClient terrainTextureAssetHttpClient);
+}
+
+internal sealed class ResoniteLiveSceneImportFactory(
+    IResoniteLiveSceneImportDependencyFactory dependencyFactory) : IResoniteLiveSceneImportFactory
+{
+    public ResoniteLiveSceneImportTarget CreateTarget(
+        ResoniteLiveSceneImportTargetOptions options,
+        HttpClient terrainTextureAssetHttpClient)
+    {
+        ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
+            options,
+            terrainTextureAssetHttpClient);
+        return new ResoniteLiveSceneImportTarget(options, dependencies);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -160,6 +160,7 @@ internal sealed class ResoniteLiveSendRunStarter(
             setupState,
             materials,
             request.CommonMaterials,
+            context.ProgressReporter,
             cancellationToken);
 
         ReportProgress(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -56,9 +56,11 @@ internal sealed class ResoniteLiveSendWorkerLauncherFactory(
         ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
         ArgumentNullException.ThrowIfNull(options);
 
-        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
+        ResoniteQueuedTexturePreparer texturePreparer = new(
             terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
-            datasetLicenseWriter,
+            datasetLicenseWriter);
+        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
+            texturePreparer,
             preparedCityObjectImporter);
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
         return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Net.Http;
+
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendRunStarterFactory
+{
+    IResoniteLiveSendRunStarter Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options);
+}
+
+internal sealed class ResoniteLiveSendRunStarterFactory(
+    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
+    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
+    ILiveSendRunPlanFactory runPlanFactory,
+    ILiveSendRunStateFactory runStateFactory,
+    IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory,
+    IResoniteSlotCreator slotCreator) : IResoniteLiveSendRunStarterFactory
+{
+    public IResoniteLiveSendRunStarter Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        return new ResoniteLiveSendRunStarter(
+            sceneSetupInterpreter,
+            commonMaterialSetupPreparer,
+            runPlanFactory,
+            runStateFactory,
+            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options),
+            slotCreator);
+    }
+}
+
+internal interface IResoniteLiveSendWorkerLauncherFactory
+{
+    IResoniteLiveSendWorkerLauncher Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options);
+}
+
+internal sealed class ResoniteLiveSendWorkerLauncherFactory(
+    ITerrainTextureAssetGeneratorFactory terrainTextureAssetGeneratorFactory,
+    IResoniteDatasetLicenseWriter datasetLicenseWriter,
+    IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteLiveSendWorkerLauncherFactory
+{
+    public IResoniteLiveSendWorkerLauncher Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
+            terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
+            datasetLicenseWriter,
+            preparedCityObjectImporter);
+        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
+        return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net.Http;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -26,8 +25,11 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteGeometryAssetPlanner, ResoniteGeometryAssetPlanner>();
         services.TryAddScoped<IResoniteMaterialPlanning, ResoniteMaterialPlanning>();
         services.TryAddScoped<IResoniteSceneMaterialPlanComposer, ResoniteSceneMaterialPlanComposer>();
+        services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
+        services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
+        services.TryAddScoped<IResoniteLiveSendWorkerLauncherFactory, ResoniteLiveSendWorkerLauncherFactory>();
         services.TryAddScoped<IResoniteLiveSendStartRequestFactory, ResoniteLiveSendStartRequestFactory>();
         services.TryAddScoped<IResonitePreparedCityObjectImporter, ResonitePreparedCityObjectImporter>();
         services.TryAddScoped<IResoniteQueuedCityObjectEnqueuer, ResoniteQueuedCityObjectEnqueuer>();
@@ -48,128 +50,5 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteLiveSceneImportFactory, ResoniteLiveSceneImportFactory>();
 
         return services;
-    }
-}
-
-internal interface IResoniteLiveSceneImportFactory
-{
-    ResoniteLiveSceneImportTarget CreateTarget(
-        ResoniteLiveSceneImportTargetOptions options,
-        HttpClient terrainTextureAssetHttpClient);
-}
-
-internal sealed class ResoniteLiveSceneImportFactory(
-    IResoniteLiveSceneImportDependencyFactory dependencyFactory) : IResoniteLiveSceneImportFactory
-{
-    public ResoniteLiveSceneImportTarget CreateTarget(
-        ResoniteLiveSceneImportTargetOptions options,
-        HttpClient terrainTextureAssetHttpClient)
-    {
-        ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
-            options,
-            terrainTextureAssetHttpClient);
-        return new ResoniteLiveSceneImportTarget(options, dependencies);
-    }
-}
-
-internal interface IResoniteLiveSceneImportDependencyFactory
-{
-    ResoniteLiveSceneImportDependencies Create(
-        ResoniteLiveSceneImportTargetOptions options,
-        HttpClient terrainTextureAssetHttpClient);
-}
-
-internal interface IResoniteClientSessionFactory
-{
-    ILiveSendClientSession Create(
-        ResoniteLiveSceneImportTargetOptions options,
-        ResoniteLinkSendDiagnostics diagnostics);
-}
-
-internal sealed class ResoniteLinkClientSessionFactory(
-    Func<Action<string>?, IResoniteLinkClient> baseClientFactory) : IResoniteClientSessionFactory
-{
-    public ILiveSendClientSession Create(
-        ResoniteLiveSceneImportTargetOptions options,
-        ResoniteLinkSendDiagnostics diagnostics)
-    {
-        ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(diagnostics);
-
-        return ResoniteLinkTransportSessionFactory.Create(
-            options.Endpoint,
-            options.ConnectionCount,
-            diagnostics,
-            options.ProgressReporter,
-            baseClientFactory);
-    }
-}
-
-internal interface ITerrainTextureAssetGeneratorFactory
-{
-    ITerrainTextureAssetGenerator Create(
-        HttpClient terrainTextureAssetHttpClient,
-        ResoniteLiveSceneImportTargetOptions options);
-}
-
-internal sealed class TerrainTextureAssetGeneratorFactory : ITerrainTextureAssetGeneratorFactory
-{
-    public ITerrainTextureAssetGenerator Create(
-        HttpClient terrainTextureAssetHttpClient,
-        ResoniteLiveSceneImportTargetOptions options)
-    {
-        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
-        ArgumentNullException.ThrowIfNull(options);
-        return new TerrainTextureAssetGenerator(
-            terrainTextureAssetHttpClient,
-            options.TerrainTileCacheRoot,
-            options.DisableTerrainTileCache);
-    }
-}
-
-internal sealed class ResoniteLiveSceneImportDependencyFactory(
-    IResoniteClientSessionFactory clientSessionFactory,
-    ITerrainTextureAssetGeneratorFactory terrainTextureAssetGeneratorFactory,
-    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
-    IResoniteDatasetLicenseWriter datasetLicenseWriter,
-    IResoniteMaterialPlanning materialPlanning,
-    ILiveSendRunPlanFactory runPlanFactory,
-    ILiveSendRunStateFactory runStateFactory,
-    IResoniteLiveSendStartRequestFactory startRequestFactory,
-    IResonitePreparedCityObjectImporter preparedCityObjectImporter,
-    IResoniteSlotCreator slotCreator,
-    IResoniteLiveSendQueue queue)
-    : IResoniteLiveSceneImportDependencyFactory
-{
-    public ResoniteLiveSceneImportDependencies Create(
-        ResoniteLiveSceneImportTargetOptions options,
-        HttpClient terrainTextureAssetHttpClient)
-    {
-        ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
-        ResoniteLinkSendDiagnostics diagnostics = options.EnableSendMetrics
-            ? ResoniteLinkSendDiagnostics.CreateEnabled(options.ProgressReporter)
-            : ResoniteLinkSendDiagnostics.Disabled;
-
-        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
-            terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
-            datasetLicenseWriter,
-            preparedCityObjectImporter);
-        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
-        ResoniteLiveSendWorkerLauncher workerLauncher = new(queuedCityObjectWorker);
-        ResoniteLiveSendRunStarter runStarter = new(
-            sceneSetupInterpreter,
-            new ResoniteCommonMaterialSetupPreparer(materialPlanning, options.ProgressReporter),
-            runPlanFactory,
-            runStateFactory,
-            workerLauncher,
-            slotCreator);
-
-        return new ResoniteLiveSceneImportDependencies(
-            clientSessionFactory.Create(options, diagnostics),
-            diagnostics,
-            startRequestFactory,
-            runStarter,
-            queue);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,14 +24,11 @@ internal interface IResoniteQueuedCityObjectSender
 }
 
 internal sealed class ResoniteQueuedCityObjectSender(
-    ITerrainTextureAssetGenerator terrainTextureAssetGenerator,
-    Execution.IResoniteDatasetLicenseWriter datasetLicenseWriter,
+    IResoniteQueuedTexturePreparer texturePreparer,
     IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteQueuedCityObjectSender
 {
-    private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator =
-        terrainTextureAssetGenerator ?? throw new ArgumentNullException(nameof(terrainTextureAssetGenerator));
-    private readonly Execution.IResoniteDatasetLicenseWriter datasetLicenseWriter =
-        datasetLicenseWriter ?? throw new ArgumentNullException(nameof(datasetLicenseWriter));
+    private readonly IResoniteQueuedTexturePreparer texturePreparer =
+        texturePreparer ?? throw new ArgumentNullException(nameof(texturePreparer));
     private readonly IResonitePreparedCityObjectImporter preparedCityObjectImporter =
         preparedCityObjectImporter ?? throw new ArgumentNullException(nameof(preparedCityObjectImporter));
 
@@ -181,34 +176,6 @@ internal sealed class ResoniteQueuedCityObjectSender(
             ResoniteCityObjectPreparation.ValidateTriangleMeshBindingsForImport(cityObject, dynamicTerrain.StaticMesh.Mesh);
         }
 
-        (string TerrainMeshCode, TerrainTextureOverlay TerrainOverlay)[] distinctTerrainOverlays = cityObject.Materials
-            .Select((material, materialIndex) => (Material: material, MaterialIndex: materialIndex))
-            .Where(static entry => entry.Material.TerrainOverlay is not null && entry.Material.TerrainMeshCode is not null)
-            .Select(entry => (
-                TerrainMeshCode: ResoniteTerrainOverlayMaterialContract.ValidateMeshCode(
-                    cityObject,
-                    entry.MaterialIndex,
-                    entry.Material,
-                    entry.Material.TerrainMeshCode!,
-                    entry.Material.TerrainOverlay!),
-                TerrainOverlay: entry.Material.TerrainOverlay!))
-            .Distinct()
-            .OrderBy(static entry => entry.TerrainMeshCode, StringComparer.Ordinal)
-            .ThenBy(static entry => entry.TerrainOverlay.PackageName, StringComparer.Ordinal)
-            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLatitude)
-            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLongitude)
-            .ToArray();
-
-        Task<PreparedTextureReference?>[] terrainOverlayTexturePreparationTasks = distinctTerrainOverlays
-            .Select(entry => PrepareTerrainOverlayTextureReferenceAsync(
-                state,
-                routedClient,
-                progressReporter,
-                entry.TerrainMeshCode,
-                entry.TerrainOverlay,
-                cancellationToken))
-            .ToArray();
-
         Task<PreparedConstructionGeometry> geometryPreparationTask = cityObject.Geometry switch
         {
             ResoniteTriangleMeshGeometry triangleMesh => Task.Run<PreparedConstructionGeometry>(
@@ -227,15 +194,12 @@ internal sealed class ResoniteQueuedCityObjectSender(
             _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
         };
         Stopwatch stopwatch = Stopwatch.StartNew();
-        PreparedTextureReference?[] preparedTextureResults = await Task.WhenAll(
-            terrainOverlayTexturePreparationTasks
-                .Concat(cityObject.Materials
-                    .Where(static material => material.TexturePayload is not null)
-                    .Select(PrepareDirectMaterialTextureReferenceAsync)
-                    .ToArray()));
-        PreparedTextureReference[] preparedTextures = preparedTextureResults
-            .OfType<PreparedTextureReference>()
-            .ToArray();
+        PreparedTextureReference[] preparedTextures = await texturePreparer.PrepareAsync(
+            state,
+            routedClient,
+            cityObject,
+            progressReporter,
+            cancellationToken);
         PreparedConstructionGeometry preparedGeometry = await geometryPreparationTask;
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay = preparedTextures
             .Where(static texture => texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
@@ -280,96 +244,6 @@ internal sealed class ResoniteQueuedCityObjectSender(
             preparedTextures);
     }
 
-    private async Task<PreparedTextureReference?> PrepareTerrainOverlayTextureReferenceAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient routedClient,
-        Action<string>? progressReporter,
-        string terrainMeshCode,
-        TerrainTextureOverlay terrainTextureOverlay,
-        CancellationToken cancellationToken)
-    {
-        GeneratedTerrainTexture terrainTexture = await terrainTextureAssetGenerator.EnsureTextureAsync(
-            terrainTextureOverlay,
-            cancellationToken);
-        TerrainTextureSource[] usedSources = GetTrackedTerrainTextureSources(terrainTexture, terrainTextureOverlay);
-        foreach (TerrainTextureSource usedSource in usedSources)
-        {
-            int useCount = state.DemSourceUseCounts.AddOrUpdate(
-                usedSource.IdentityKey,
-                1,
-                static (_, current) => checked(current + 1));
-            if (useCount == 1)
-            {
-                ReportProgress(
-                    progressReporter,
-                    PlateauLog.Info(
-                        "live",
-                        $"Resolved DEM terrain texture source for package '{terrainTextureOverlay.PackageName}' "
-                        + $"to {DescribeTerrainTextureSource(usedSource)}."));
-            }
-
-            if (IsGsiFallbackSource(usedSource))
-            {
-                await EnsureGsiFallbackLicenseAsync(state, routedClient, cancellationToken);
-            }
-        }
-
-        return new PreparedTextureReference(
-            TexturePayload: null,
-            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-            TextureImport: terrainTexture.TextureImport,
-            TerrainMeshCode: terrainMeshCode,
-            TerrainOverlay: terrainTextureOverlay,
-            GeneratedTerrainTexture: terrainTexture);
-    }
-
-    private static TerrainTextureSource[] GetTrackedTerrainTextureSources(
-        GeneratedTerrainTexture terrainTexture,
-        TerrainTextureOverlay terrainTextureOverlay)
-    {
-        if (terrainTexture.UsedSources is { Count: > 0 })
-        {
-            return terrainTexture.UsedSources
-                .Distinct()
-                .ToArray();
-        }
-
-        return
-        [
-            terrainTexture.UsedSource ?? terrainTextureOverlay.PrimarySource,
-        ];
-    }
-
-    private async Task EnsureGsiFallbackLicenseAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient routedClient,
-        CancellationToken cancellationToken)
-    {
-        if (Volatile.Read(ref state.GsiFallbackLicenseEnsured) != 0)
-        {
-            return;
-        }
-
-        await state.GsiFallbackLicenseGate.WaitAsync(cancellationToken);
-        try
-        {
-            if (state.GsiFallbackLicenseEnsured != 0)
-            {
-                return;
-            }
-
-            await datasetLicenseWriter.EnsureGsiFallbackLicenseAsync(
-                routedClient,
-                state.Context.DatasetRootSlot,
-                cancellationToken);
-            Volatile.Write(ref state.GsiFallbackLicenseEnsured, 1);
-        }
-        finally
-        {
-            state.GsiFallbackLicenseGate.Release();
-        }
-    }
-
     private static bool IsRecoverableCityObjectSendFailure(Exception exception)
     {
         return exception is ContinuableImportException
@@ -394,43 +268,6 @@ internal sealed class ResoniteQueuedCityObjectSender(
         }
 
         return null;
-    }
-
-    private static bool IsGsiFallbackSource(TerrainTextureSource source)
-    {
-        return DemTerrainTextureDefaults.IsGsiFallbackSource(source);
-    }
-
-    private static string DescribeTerrainTextureSource(TerrainTextureSource source)
-    {
-        return source switch
-        {
-            TerrainTextureGeoReferencedRasterSource rasterSource => string.Create(
-                CultureInfo.InvariantCulture,
-                $"GeoTIFF(path='{Path.GetFileName(rasterSource.SourcePath)}', crs='{rasterSource.Metadata?.CoordinateSystemIdentifier ?? "unknown"}')"),
-            TerrainTextureTileSource tileSource when IsGsiFallbackSource(tileSource) => string.Create(
-                CultureInfo.InvariantCulture,
-                $"GSI seamless photo tile(z={tileSource.ZoomLevel})"),
-            TerrainTextureTileSource tileSource => string.Create(
-                CultureInfo.InvariantCulture,
-                $"PLATEAU-Ortho tile(z={tileSource.ZoomLevel})"),
-            _ => source.GetType().Name,
-        };
-    }
-
-    private static Task<PreparedTextureReference?> PrepareDirectMaterialTextureReferenceAsync(
-        ResoniteMaterialBinding material)
-    {
-        ArgumentNullException.ThrowIfNull(material);
-        ArgumentNullException.ThrowIfNull(material.TexturePayload);
-
-        return Task.FromResult<PreparedTextureReference?>(
-            new PreparedTextureReference(
-                TexturePayload: material.TexturePayload,
-                TextureSourceKind: material.TextureSourceKind,
-                TextureImport: ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
-                TerrainMeshCode: null,
-                TerrainOverlay: null));
     }
 
     private static void ReportProgress(Action<string>? progressReporter, string message)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteQueuedTexturePreparer
+{
+    Task<PreparedTextureReference[]> PrepareAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        ResoniteConstructionCityObject cityObject,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteQueuedTexturePreparer(
+    ITerrainTextureAssetGenerator terrainTextureAssetGenerator,
+    Execution.IResoniteDatasetLicenseWriter datasetLicenseWriter) : IResoniteQueuedTexturePreparer
+{
+    private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator =
+        terrainTextureAssetGenerator ?? throw new ArgumentNullException(nameof(terrainTextureAssetGenerator));
+    private readonly Execution.IResoniteDatasetLicenseWriter datasetLicenseWriter =
+        datasetLicenseWriter ?? throw new ArgumentNullException(nameof(datasetLicenseWriter));
+
+    public async Task<PreparedTextureReference[]> PrepareAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        ResoniteConstructionCityObject cityObject,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(routedClient);
+        ArgumentNullException.ThrowIfNull(cityObject);
+
+        (string TerrainMeshCode, TerrainTextureOverlay TerrainOverlay)[] distinctTerrainOverlays = cityObject.Materials
+            .Select((material, materialIndex) => (Material: material, MaterialIndex: materialIndex))
+            .Where(static entry => entry.Material.TerrainOverlay is not null && entry.Material.TerrainMeshCode is not null)
+            .Select(entry => (
+                TerrainMeshCode: ResoniteTerrainOverlayMaterialContract.ValidateMeshCode(
+                    cityObject,
+                    entry.MaterialIndex,
+                    entry.Material,
+                    entry.Material.TerrainMeshCode!,
+                    entry.Material.TerrainOverlay!),
+                TerrainOverlay: entry.Material.TerrainOverlay!))
+            .Distinct()
+            .OrderBy(static entry => entry.TerrainMeshCode, StringComparer.Ordinal)
+            .ThenBy(static entry => entry.TerrainOverlay.PackageName, StringComparer.Ordinal)
+            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLatitude)
+            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLongitude)
+            .ToArray();
+
+        Task<PreparedTextureReference?>[] terrainOverlayTexturePreparationTasks = distinctTerrainOverlays
+            .Select(entry => PrepareTerrainOverlayTextureReferenceAsync(
+                state,
+                routedClient,
+                progressReporter,
+                entry.TerrainMeshCode,
+                entry.TerrainOverlay,
+                cancellationToken))
+            .ToArray();
+        PreparedTextureReference?[] preparedTextureResults = await Task.WhenAll(
+            terrainOverlayTexturePreparationTasks
+                .Concat(cityObject.Materials
+                    .Where(static material => material.TexturePayload is not null)
+                    .Select(PrepareDirectMaterialTextureReferenceAsync)
+                    .ToArray()));
+        return preparedTextureResults
+            .OfType<PreparedTextureReference>()
+            .ToArray();
+    }
+
+    private async Task<PreparedTextureReference?> PrepareTerrainOverlayTextureReferenceAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        Action<string>? progressReporter,
+        string terrainMeshCode,
+        TerrainTextureOverlay terrainTextureOverlay,
+        CancellationToken cancellationToken)
+    {
+        GeneratedTerrainTexture terrainTexture = await terrainTextureAssetGenerator.EnsureTextureAsync(
+            terrainTextureOverlay,
+            cancellationToken);
+        TerrainTextureSource[] usedSources = GetTrackedTerrainTextureSources(terrainTexture, terrainTextureOverlay);
+        foreach (TerrainTextureSource usedSource in usedSources)
+        {
+            int useCount = state.DemSourceUseCounts.AddOrUpdate(
+                usedSource.IdentityKey,
+                1,
+                static (_, current) => checked(current + 1));
+            if (useCount == 1)
+            {
+                ReportProgress(
+                    progressReporter,
+                    PlateauLog.Info(
+                        "live",
+                        $"Resolved DEM terrain texture source for package '{terrainTextureOverlay.PackageName}' "
+                        + $"to {DescribeTerrainTextureSource(usedSource)}."));
+            }
+
+            if (IsGsiFallbackSource(usedSource))
+            {
+                await EnsureGsiFallbackLicenseAsync(state, routedClient, cancellationToken);
+            }
+        }
+
+        return new PreparedTextureReference(
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            TextureImport: terrainTexture.TextureImport,
+            TerrainMeshCode: terrainMeshCode,
+            TerrainOverlay: terrainTextureOverlay,
+            GeneratedTerrainTexture: terrainTexture);
+    }
+
+    private static TerrainTextureSource[] GetTrackedTerrainTextureSources(
+        GeneratedTerrainTexture terrainTexture,
+        TerrainTextureOverlay terrainTextureOverlay)
+    {
+        if (terrainTexture.UsedSources is { Count: > 0 })
+        {
+            return terrainTexture.UsedSources
+                .Distinct()
+                .ToArray();
+        }
+
+        return
+        [
+            terrainTexture.UsedSource ?? terrainTextureOverlay.PrimarySource,
+        ];
+    }
+
+    private async Task EnsureGsiFallbackLicenseAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref state.GsiFallbackLicenseEnsured) != 0)
+        {
+            return;
+        }
+
+        await state.GsiFallbackLicenseGate.WaitAsync(cancellationToken);
+        try
+        {
+            if (state.GsiFallbackLicenseEnsured != 0)
+            {
+                return;
+            }
+
+            await datasetLicenseWriter.EnsureGsiFallbackLicenseAsync(
+                routedClient,
+                state.Context.DatasetRootSlot,
+                cancellationToken);
+            Volatile.Write(ref state.GsiFallbackLicenseEnsured, 1);
+        }
+        finally
+        {
+            state.GsiFallbackLicenseGate.Release();
+        }
+    }
+
+    private static bool IsGsiFallbackSource(TerrainTextureSource source)
+    {
+        return DemTerrainTextureDefaults.IsGsiFallbackSource(source);
+    }
+
+    private static string DescribeTerrainTextureSource(TerrainTextureSource source)
+    {
+        return source switch
+        {
+            TerrainTextureGeoReferencedRasterSource rasterSource => string.Create(
+                CultureInfo.InvariantCulture,
+                $"GeoTIFF(path='{Path.GetFileName(rasterSource.SourcePath)}', crs='{rasterSource.Metadata?.CoordinateSystemIdentifier ?? "unknown"}')"),
+            TerrainTextureTileSource tileSource when IsGsiFallbackSource(tileSource) => string.Create(
+                CultureInfo.InvariantCulture,
+                $"GSI seamless photo tile(z={tileSource.ZoomLevel})"),
+            TerrainTextureTileSource tileSource => string.Create(
+                CultureInfo.InvariantCulture,
+                $"PLATEAU-Ortho tile(z={tileSource.ZoomLevel})"),
+            _ => source.GetType().Name,
+        };
+    }
+
+    private static Task<PreparedTextureReference?> PrepareDirectMaterialTextureReferenceAsync(
+        ResoniteMaterialBinding material)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+        ArgumentNullException.ThrowIfNull(material.TexturePayload);
+
+        return Task.FromResult<PreparedTextureReference?>(
+            new PreparedTextureReference(
+                TexturePayload: material.TexturePayload,
+                TextureSourceKind: material.TextureSourceKind,
+                TextureImport: ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
+                TerrainMeshCode: null,
+                TerrainOverlay: null));
+    }
+
+    private static void ReportProgress(Action<string>? progressReporter, string message)
+    {
+        progressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGeneratorFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGeneratorFactory.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Net.Http;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface ITerrainTextureAssetGeneratorFactory
+{
+    ITerrainTextureAssetGenerator Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options);
+}
+
+internal sealed class TerrainTextureAssetGeneratorFactory : ITerrainTextureAssetGeneratorFactory
+{
+    public ITerrainTextureAssetGenerator Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ArgumentNullException.ThrowIfNull(options);
+        return new TerrainTextureAssetGenerator(
+            terrainTextureAssetHttpClient,
+            options.TerrainTileCacheRoot,
+            options.DisableTerrainTileCache);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -48,8 +48,9 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     {
         return new ResoniteQueuedCityObjectWorker(
             new ResoniteQueuedCityObjectSender(
-                new TerrainTextureAssetGenerator(),
-                new ResoniteDatasetLicenseWriter(),
+                new ResoniteQueuedTexturePreparer(
+                    new TerrainTextureAssetGenerator(),
+                    new ResoniteDatasetLicenseWriter()),
                 CreatePreparedCityObjectImporter(materialPlanning)));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -21,10 +21,9 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     private static BundledDefaultMaterialAssetStore CreateBundledDefaultMaterialAssetStore() => new();
 
     private static ResoniteCommonMaterialSetupPreparer CreateCommonMaterialSetupPreparer(
-        IResoniteMaterialPlanning materialPlanning,
-        Action<string>? progressReporter = null)
+        IResoniteMaterialPlanning materialPlanning)
     {
-        return new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter);
+        return new ResoniteCommonMaterialSetupPreparer(materialPlanning);
     }
 
     private static LiveSendRunStateFactory CreateRunStateFactory()
@@ -56,12 +55,11 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
 
     private static ResoniteLiveSendRunStarter CreateRunStarter(
         IResoniteMaterialPlanning materialPlanning,
-        IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null,
-        Action<string>? progressReporter = null)
+        IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null)
     {
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
-            CreateCommonMaterialSetupPreparer(materialPlanning, progressReporter),
+            CreateCommonMaterialSetupPreparer(materialPlanning),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
             new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -51,8 +51,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     {
         return new ResoniteQueuedCityObjectWorker(
             new ResoniteQueuedCityObjectSender(
-                new TerrainTextureAssetGenerator(),
-                new ResoniteDatasetLicenseWriter(),
+                new ResoniteQueuedTexturePreparer(
+                    new TerrainTextureAssetGenerator(),
+                    new ResoniteDatasetLicenseWriter()),
                 CreatePreparedCityObjectImporter(materialPlanning)));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -24,10 +24,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     private static BundledDefaultMaterialAssetStore CreateBundledDefaultMaterialAssetStore() => new();
 
     private static ResoniteCommonMaterialSetupPreparer CreateCommonMaterialSetupPreparer(
-        IResoniteMaterialPlanning materialPlanning,
-        Action<string>? progressReporter = null)
+        IResoniteMaterialPlanning materialPlanning)
     {
-        return new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter);
+        return new ResoniteCommonMaterialSetupPreparer(materialPlanning);
     }
 
     private static LiveSendRunStateFactory CreateRunStateFactory()
@@ -59,12 +58,11 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
 
     private static ResoniteLiveSendRunStarter CreateRunStarter(
         IResoniteMaterialPlanning materialPlanning,
-        IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null,
-        Action<string>? progressReporter = null)
+        IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null)
     {
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
-            CreateCommonMaterialSetupPreparer(materialPlanning, progressReporter),
+            CreateCommonMaterialSetupPreparer(materialPlanning),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
             new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),
@@ -399,7 +397,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 session,
                 ResoniteLinkSendDiagnostics.Disabled,
                 new ResoniteLiveSendStartRequestFactory(),
-                CreateRunStarter(materialPlanning, progressReporter: progressMessages.Add),
+                CreateRunStarter(materialPlanning),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -325,8 +325,9 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
             new ResoniteQueuedCityObjectSender(
-                terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
-                new ResoniteDatasetLicenseWriter(),
+                new ResoniteQueuedTexturePreparer(
+                    terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
+                    new ResoniteDatasetLicenseWriter()),
                 new ResonitePreparedCityObjectImporter(
                     new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
                     new ResoniteSceneMaterialPlanComposer(materialPlanning),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -350,7 +350,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                     new ResoniteSceneSetupInterpreter(
                         new ResoniteSceneSlotLocator(),
                         new ResoniteSceneAnchorResolver()),
-                    new ResoniteCommonMaterialSetupPreparer(materialPlanning, progressReporter),
+                    new ResoniteCommonMaterialSetupPreparer(materialPlanning),
                     new LiveSendRunPlanFactory(),
                     new LiveSendRunStateFactory(
                         new ResoniteBufferedCityObjectBakerFactory(


### PR DESCRIPTION
## Summary
- move live-send target, dependency, client-session, terrain-texture, and run-starter composition out of the service registration file
- keep runtime option-dependent run starter and worker launcher construction behind focused factories
- pass common-material setup progress reporting through the run context instead of storing per-run state in the setup preparer

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false