### PR TITLE
Extract queued texture preparation

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -211,8 +211,9 @@ internal sealed class DefaultSceneSinkFactory(
             new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
             new ResoniteQueuedCityObjectSender(
-                new DeterministicTerrainTextureAssetGenerator(),
-                serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>(),
+                new ResoniteQueuedTexturePreparer(
+                    new DeterministicTerrainTextureAssetGenerator(),
+                    serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>()),
                 serviceProvider.GetRequiredService<IResonitePreparedCityObjectImporter>()));
         return new ResoniteLiveSceneImportTarget(
             targetOptions,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -56,9 +56,11 @@ internal sealed class ResoniteLiveSendWorkerLauncherFactory(
         ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
         ArgumentNullException.ThrowIfNull(options);
 
-        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
+        ResoniteQueuedTexturePreparer texturePreparer = new(
             terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
-            datasetLicenseWriter,
+            datasetLicenseWriter);
+        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
+            texturePreparer,
             preparedCityObjectImporter);
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
         return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,14 +24,11 @@ internal interface IResoniteQueuedCityObjectSender
 }
 
 internal sealed class ResoniteQueuedCityObjectSender(
-    ITerrainTextureAssetGenerator terrainTextureAssetGenerator,
-    Execution.IResoniteDatasetLicenseWriter datasetLicenseWriter,
+    IResoniteQueuedTexturePreparer texturePreparer,
     IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteQueuedCityObjectSender
 {
-    private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator =
-        terrainTextureAssetGenerator ?? throw new ArgumentNullException(nameof(terrainTextureAssetGenerator));
-    private readonly Execution.IResoniteDatasetLicenseWriter datasetLicenseWriter =
-        datasetLicenseWriter ?? throw new ArgumentNullException(nameof(datasetLicenseWriter));
+    private readonly IResoniteQueuedTexturePreparer texturePreparer =
+        texturePreparer ?? throw new ArgumentNullException(nameof(texturePreparer));
     private readonly IResonitePreparedCityObjectImporter preparedCityObjectImporter =
         preparedCityObjectImporter ?? throw new ArgumentNullException(nameof(preparedCityObjectImporter));
 
@@ -181,34 +176,6 @@ internal sealed class ResoniteQueuedCityObjectSender(
             ResoniteCityObjectPreparation.ValidateTriangleMeshBindingsForImport(cityObject, dynamicTerrain.StaticMesh.Mesh);
         }
 
-        (string TerrainMeshCode, TerrainTextureOverlay TerrainOverlay)[] distinctTerrainOverlays = cityObject.Materials
-            .Select((material, materialIndex) => (Material: material, MaterialIndex: materialIndex))
-            .Where(static entry => entry.Material.TerrainOverlay is not null && entry.Material.TerrainMeshCode is not null)
-            .Select(entry => (
-                TerrainMeshCode: ResoniteTerrainOverlayMaterialContract.ValidateMeshCode(
-                    cityObject,
-                    entry.MaterialIndex,
-                    entry.Material,
-                    entry.Material.TerrainMeshCode!,
-                    entry.Material.TerrainOverlay!),
-                TerrainOverlay: entry.Material.TerrainOverlay!))
-            .Distinct()
-            .OrderBy(static entry => entry.TerrainMeshCode, StringComparer.Ordinal)
-            .ThenBy(static entry => entry.TerrainOverlay.PackageName, StringComparer.Ordinal)
-            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLatitude)
-            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLongitude)
-            .ToArray();
-
-        Task<PreparedTextureReference?>[] terrainOverlayTexturePreparationTasks = distinctTerrainOverlays
-            .Select(entry => PrepareTerrainOverlayTextureReferenceAsync(
-                state,
-                routedClient,
-                progressReporter,
-                entry.TerrainMeshCode,
-                entry.TerrainOverlay,
-                cancellationToken))
-            .ToArray();
-
         Task<PreparedConstructionGeometry> geometryPreparationTask = cityObject.Geometry switch
         {
             ResoniteTriangleMeshGeometry triangleMesh => Task.Run<PreparedConstructionGeometry>(
@@ -227,15 +194,12 @@ internal sealed class ResoniteQueuedCityObjectSender(
             _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
         };
         Stopwatch stopwatch = Stopwatch.StartNew();
-        PreparedTextureReference?[] preparedTextureResults = await Task.WhenAll(
-            terrainOverlayTexturePreparationTasks
-                .Concat(cityObject.Materials
-                    .Where(static material => material.TexturePayload is not null)
-                    .Select(PrepareDirectMaterialTextureReferenceAsync)
-                    .ToArray()));
-        PreparedTextureReference[] preparedTextures = preparedTextureResults
-            .OfType<PreparedTextureReference>()
-            .ToArray();
+        PreparedTextureReference[] preparedTextures = await texturePreparer.PrepareAsync(
+            state,
+            routedClient,
+            cityObject,
+            progressReporter,
+            cancellationToken);
         PreparedConstructionGeometry preparedGeometry = await geometryPreparationTask;
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay = preparedTextures
             .Where(static texture => texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
@@ -280,96 +244,6 @@ internal sealed class ResoniteQueuedCityObjectSender(
             preparedTextures);
     }
 
-    private async Task<PreparedTextureReference?> PrepareTerrainOverlayTextureReferenceAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient routedClient,
-        Action<string>? progressReporter,
-        string terrainMeshCode,
-        TerrainTextureOverlay terrainTextureOverlay,
-        CancellationToken cancellationToken)
-    {
-        GeneratedTerrainTexture terrainTexture = await terrainTextureAssetGenerator.EnsureTextureAsync(
-            terrainTextureOverlay,
-            cancellationToken);
-        TerrainTextureSource[] usedSources = GetTrackedTerrainTextureSources(terrainTexture, terrainTextureOverlay);
-        foreach (TerrainTextureSource usedSource in usedSources)
-        {
-            int useCount = state.DemSourceUseCounts.AddOrUpdate(
-                usedSource.IdentityKey,
-                1,
-                static (_, current) => checked(current + 1));
-            if (useCount == 1)
-            {
-                ReportProgress(
-                    progressReporter,
-                    PlateauLog.Info(
-                        "live",
-                        $"Resolved DEM terrain texture source for package '{terrainTextureOverlay.PackageName}' "
-                        + $"to {DescribeTerrainTextureSource(usedSource)}."));
-            }
-
-            if (IsGsiFallbackSource(usedSource))
-            {
-                await EnsureGsiFallbackLicenseAsync(state, routedClient, cancellationToken);
-            }
-        }
-
-        return new PreparedTextureReference(
-            TexturePayload: null,
-            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-            TextureImport: terrainTexture.TextureImport,
-            TerrainMeshCode: terrainMeshCode,
-            TerrainOverlay: terrainTextureOverlay,
-            GeneratedTerrainTexture: terrainTexture);
-    }
-
-    private static TerrainTextureSource[] GetTrackedTerrainTextureSources(
-        GeneratedTerrainTexture terrainTexture,
-        TerrainTextureOverlay terrainTextureOverlay)
-    {
-        if (terrainTexture.UsedSources is { Count: > 0 })
-        {
-            return terrainTexture.UsedSources
-                .Distinct()
-                .ToArray();
-        }
-
-        return
-        [
-            terrainTexture.UsedSource ?? terrainTextureOverlay.PrimarySource,
-        ];
-    }
-
-    private async Task EnsureGsiFallbackLicenseAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient routedClient,
-        CancellationToken cancellationToken)
-    {
-        if (Volatile.Read(ref state.GsiFallbackLicenseEnsured) != 0)
-        {
-            return;
-        }
-
-        await state.GsiFallbackLicenseGate.WaitAsync(cancellationToken);
-        try
-        {
-            if (state.GsiFallbackLicenseEnsured != 0)
-            {
-                return;
-            }
-
-            await datasetLicenseWriter.EnsureGsiFallbackLicenseAsync(
-                routedClient,
-                state.Context.DatasetRootSlot,
-                cancellationToken);
-            Volatile.Write(ref state.GsiFallbackLicenseEnsured, 1);
-        }
-        finally
-        {
-            state.GsiFallbackLicenseGate.Release();
-        }
-    }
-
     private static bool IsRecoverableCityObjectSendFailure(Exception exception)
     {
         return exception is ContinuableImportException
@@ -394,43 +268,6 @@ internal sealed class ResoniteQueuedCityObjectSender(
         }
 
         return null;
-    }
-
-    private static bool IsGsiFallbackSource(TerrainTextureSource source)
-    {
-        return DemTerrainTextureDefaults.IsGsiFallbackSource(source);
-    }
-
-    private static string DescribeTerrainTextureSource(TerrainTextureSource source)
-    {
-        return source switch
-        {
-            TerrainTextureGeoReferencedRasterSource rasterSource => string.Create(
-                CultureInfo.InvariantCulture,
-                $"GeoTIFF(path='{Path.GetFileName(rasterSource.SourcePath)}', crs='{rasterSource.Metadata?.CoordinateSystemIdentifier ?? "unknown"}')"),
-            TerrainTextureTileSource tileSource when IsGsiFallbackSource(tileSource) => string.Create(
-                CultureInfo.InvariantCulture,
-                $"GSI seamless photo tile(z={tileSource.ZoomLevel})"),
-            TerrainTextureTileSource tileSource => string.Create(
-                CultureInfo.InvariantCulture,
-                $"PLATEAU-Ortho tile(z={tileSource.ZoomLevel})"),
-            _ => source.GetType().Name,
-        };
-    }
-
-    private static Task<PreparedTextureReference?> PrepareDirectMaterialTextureReferenceAsync(
-        ResoniteMaterialBinding material)
-    {
-        ArgumentNullException.ThrowIfNull(material);
-        ArgumentNullException.ThrowIfNull(material.TexturePayload);
-
-        return Task.FromResult<PreparedTextureReference?>(
-            new PreparedTextureReference(
-                TexturePayload: material.TexturePayload,
-                TextureSourceKind: material.TextureSourceKind,
-                TextureImport: ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
-                TerrainMeshCode: null,
-                TerrainOverlay: null));
     }
 
     private static void ReportProgress(Action<string>? progressReporter, string message)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteQueuedTexturePreparer
+{
+    Task<PreparedTextureReference[]> PrepareAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        ResoniteConstructionCityObject cityObject,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteQueuedTexturePreparer(
+    ITerrainTextureAssetGenerator terrainTextureAssetGenerator,
+    Execution.IResoniteDatasetLicenseWriter datasetLicenseWriter) : IResoniteQueuedTexturePreparer
+{
+    private readonly ITerrainTextureAssetGenerator terrainTextureAssetGenerator =
+        terrainTextureAssetGenerator ?? throw new ArgumentNullException(nameof(terrainTextureAssetGenerator));
+    private readonly Execution.IResoniteDatasetLicenseWriter datasetLicenseWriter =
+        datasetLicenseWriter ?? throw new ArgumentNullException(nameof(datasetLicenseWriter));
+
+    public async Task<PreparedTextureReference[]> PrepareAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        ResoniteConstructionCityObject cityObject,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(routedClient);
+        ArgumentNullException.ThrowIfNull(cityObject);
+
+        (string TerrainMeshCode, TerrainTextureOverlay TerrainOverlay)[] distinctTerrainOverlays = cityObject.Materials
+            .Select((material, materialIndex) => (Material: material, MaterialIndex: materialIndex))
+            .Where(static entry => entry.Material.TerrainOverlay is not null && entry.Material.TerrainMeshCode is not null)
+            .Select(entry => (
+                TerrainMeshCode: ResoniteTerrainOverlayMaterialContract.ValidateMeshCode(
+                    cityObject,
+                    entry.MaterialIndex,
+                    entry.Material,
+                    entry.Material.TerrainMeshCode!,
+                    entry.Material.TerrainOverlay!),
+                TerrainOverlay: entry.Material.TerrainOverlay!))
+            .Distinct()
+            .OrderBy(static entry => entry.TerrainMeshCode, StringComparer.Ordinal)
+            .ThenBy(static entry => entry.TerrainOverlay.PackageName, StringComparer.Ordinal)
+            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLatitude)
+            .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLongitude)
+            .ToArray();
+
+        Task<PreparedTextureReference?>[] terrainOverlayTexturePreparationTasks = distinctTerrainOverlays
+            .Select(entry => PrepareTerrainOverlayTextureReferenceAsync(
+                state,
+                routedClient,
+                progressReporter,
+                entry.TerrainMeshCode,
+                entry.TerrainOverlay,
+                cancellationToken))
+            .ToArray();
+        PreparedTextureReference?[] preparedTextureResults = await Task.WhenAll(
+            terrainOverlayTexturePreparationTasks
+                .Concat(cityObject.Materials
+                    .Where(static material => material.TexturePayload is not null)
+                    .Select(PrepareDirectMaterialTextureReferenceAsync)
+                    .ToArray()));
+        return preparedTextureResults
+            .OfType<PreparedTextureReference>()
+            .ToArray();
+    }
+
+    private async Task<PreparedTextureReference?> PrepareTerrainOverlayTextureReferenceAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        Action<string>? progressReporter,
+        string terrainMeshCode,
+        TerrainTextureOverlay terrainTextureOverlay,
+        CancellationToken cancellationToken)
+    {
+        GeneratedTerrainTexture terrainTexture = await terrainTextureAssetGenerator.EnsureTextureAsync(
+            terrainTextureOverlay,
+            cancellationToken);
+        TerrainTextureSource[] usedSources = GetTrackedTerrainTextureSources(terrainTexture, terrainTextureOverlay);
+        foreach (TerrainTextureSource usedSource in usedSources)
+        {
+            int useCount = state.DemSourceUseCounts.AddOrUpdate(
+                usedSource.IdentityKey,
+                1,
+                static (_, current) => checked(current + 1));
+            if (useCount == 1)
+            {
+                ReportProgress(
+                    progressReporter,
+                    PlateauLog.Info(
+                        "live",
+                        $"Resolved DEM terrain texture source for package '{terrainTextureOverlay.PackageName}' "
+                        + $"to {DescribeTerrainTextureSource(usedSource)}."));
+            }
+
+            if (IsGsiFallbackSource(usedSource))
+            {
+                await EnsureGsiFallbackLicenseAsync(state, routedClient, cancellationToken);
+            }
+        }
+
+        return new PreparedTextureReference(
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            TextureImport: terrainTexture.TextureImport,
+            TerrainMeshCode: terrainMeshCode,
+            TerrainOverlay: terrainTextureOverlay,
+            GeneratedTerrainTexture: terrainTexture);
+    }
+
+    private static TerrainTextureSource[] GetTrackedTerrainTextureSources(
+        GeneratedTerrainTexture terrainTexture,
+        TerrainTextureOverlay terrainTextureOverlay)
+    {
+        if (terrainTexture.UsedSources is { Count: > 0 })
+        {
+            return terrainTexture.UsedSources
+                .Distinct()
+                .ToArray();
+        }
+
+        return
+        [
+            terrainTexture.UsedSource ?? terrainTextureOverlay.PrimarySource,
+        ];
+    }
+
+    private async Task EnsureGsiFallbackLicenseAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref state.GsiFallbackLicenseEnsured) != 0)
+        {
+            return;
+        }
+
+        await state.GsiFallbackLicenseGate.WaitAsync(cancellationToken);
+        try
+        {
+            if (state.GsiFallbackLicenseEnsured != 0)
+            {
+                return;
+            }
+
+            await datasetLicenseWriter.EnsureGsiFallbackLicenseAsync(
+                routedClient,
+                state.Context.DatasetRootSlot,
+                cancellationToken);
+            Volatile.Write(ref state.GsiFallbackLicenseEnsured, 1);
+        }
+        finally
+        {
+            state.GsiFallbackLicenseGate.Release();
+        }
+    }
+
+    private static bool IsGsiFallbackSource(TerrainTextureSource source)
+    {
+        return DemTerrainTextureDefaults.IsGsiFallbackSource(source);
+    }
+
+    private static string DescribeTerrainTextureSource(TerrainTextureSource source)
+    {
+        return source switch
+        {
+            TerrainTextureGeoReferencedRasterSource rasterSource => string.Create(
+                CultureInfo.InvariantCulture,
+                $"GeoTIFF(path='{Path.GetFileName(rasterSource.SourcePath)}', crs='{rasterSource.Metadata?.CoordinateSystemIdentifier ?? "unknown"}')"),
+            TerrainTextureTileSource tileSource when IsGsiFallbackSource(tileSource) => string.Create(
+                CultureInfo.InvariantCulture,
+                $"GSI seamless photo tile(z={tileSource.ZoomLevel})"),
+            TerrainTextureTileSource tileSource => string.Create(
+                CultureInfo.InvariantCulture,
+                $"PLATEAU-Ortho tile(z={tileSource.ZoomLevel})"),
+            _ => source.GetType().Name,
+        };
+    }
+
+    private static Task<PreparedTextureReference?> PrepareDirectMaterialTextureReferenceAsync(
+        ResoniteMaterialBinding material)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+        ArgumentNullException.ThrowIfNull(material.TexturePayload);
+
+        return Task.FromResult<PreparedTextureReference?>(
+            new PreparedTextureReference(
+                TexturePayload: material.TexturePayload,
+                TextureSourceKind: material.TextureSourceKind,
+                TextureImport: ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
+                TerrainMeshCode: null,
+                TerrainOverlay: null));
+    }
+
+    private static void ReportProgress(Action<string>? progressReporter, string message)
+    {
+        progressReporter?.Invoke(message);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -48,8 +48,9 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     {
         return new ResoniteQueuedCityObjectWorker(
             new ResoniteQueuedCityObjectSender(
-                new TerrainTextureAssetGenerator(),
-                new ResoniteDatasetLicenseWriter(),
+                new ResoniteQueuedTexturePreparer(
+                    new TerrainTextureAssetGenerator(),
+                    new ResoniteDatasetLicenseWriter()),
                 CreatePreparedCityObjectImporter(materialPlanning)));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -51,8 +51,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     {
         return new ResoniteQueuedCityObjectWorker(
             new ResoniteQueuedCityObjectSender(
-                new TerrainTextureAssetGenerator(),
-                new ResoniteDatasetLicenseWriter(),
+                new ResoniteQueuedTexturePreparer(
+                    new TerrainTextureAssetGenerator(),
+                    new ResoniteDatasetLicenseWriter()),
                 CreatePreparedCityObjectImporter(materialPlanning)));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -325,8 +325,9 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
             new ResoniteQueuedCityObjectSender(
-                terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
-                new ResoniteDatasetLicenseWriter(),
+                new ResoniteQueuedTexturePreparer(
+                    terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
+                    new ResoniteDatasetLicenseWriter()),
                 new ResonitePreparedCityObjectImporter(
                     new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
                     new ResoniteSceneMaterialPlanComposer(materialPlanning),


### PR DESCRIPTION
## Summary
- move queued city-object texture preparation into a dedicated service
- keep DEM terrain texture generation, source-use accounting, GSI fallback license creation, and direct payload texture import planning out of the queued sender
- keep queued sender focused on send accounting, geometry preparation, UV canvas application, import delegation, and recoverable failure handling

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false