### PR TITLE
Extract queued geometry preparation

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -211,6 +211,7 @@ internal sealed class DefaultSceneSinkFactory(
             new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
             new ResoniteQueuedCityObjectSender(
+                new ResoniteQueuedGeometryPreparer(),
                 new ResoniteQueuedTexturePreparer(
                     new DeterministicTerrainTextureAssetGenerator(),
                     serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>()),

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -60,6 +60,7 @@ internal sealed class ResoniteLiveSendWorkerLauncherFactory(
             terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
             datasetLicenseWriter);
         ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
+            new ResoniteQueuedGeometryPreparer(),
             texturePreparer,
             preparedCityObjectImporter);
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
@@ -1,13 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
-using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -24,9 +21,12 @@ internal interface IResoniteQueuedCityObjectSender
 }
 
 internal sealed class ResoniteQueuedCityObjectSender(
+    IResoniteQueuedGeometryPreparer geometryPreparer,
     IResoniteQueuedTexturePreparer texturePreparer,
     IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteQueuedCityObjectSender
 {
+    private readonly IResoniteQueuedGeometryPreparer geometryPreparer =
+        geometryPreparer ?? throw new ArgumentNullException(nameof(geometryPreparer));
     private readonly IResoniteQueuedTexturePreparer texturePreparer =
         texturePreparer ?? throw new ArgumentNullException(nameof(texturePreparer));
     private readonly IResonitePreparedCityObjectImporter preparedCityObjectImporter =
@@ -165,64 +165,21 @@ internal sealed class ResoniteQueuedCityObjectSender(
         Action<string>? progressReporter,
         CancellationToken cancellationToken)
     {
-        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
-
-        if (cityObject.Geometry is ResoniteTriangleMeshGeometry triangleGeometry)
-        {
-            ResoniteCityObjectPreparation.ValidateTriangleMeshBindingsForImport(cityObject, triangleGeometry.Mesh);
-        }
-        else if (cityObject.Geometry is ResoniteDynamicTerrainGeometry dynamicTerrain)
-        {
-            ResoniteCityObjectPreparation.ValidateTriangleMeshBindingsForImport(cityObject, dynamicTerrain.StaticMesh.Mesh);
-        }
-
-        Task<PreparedConstructionGeometry> geometryPreparationTask = cityObject.Geometry switch
-        {
-            ResoniteTriangleMeshGeometry triangleMesh => Task.Run<PreparedConstructionGeometry>(
-                () => ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, triangleMesh.Mesh),
-                cancellationToken),
-            ResoniteTerrainGridGeometry heightMap => Task.Run<PreparedConstructionGeometry>(
-                () => new PreparedTerrainGridGeometry(heightMap, ResoniteCityObjectPreparation.PrepareTerrainGridDisplacementTexture(heightMap)),
-                cancellationToken),
-            ResoniteDynamicTerrainGeometry dynamicTerrain => Task.Run<PreparedConstructionGeometry>(
-                () => new PreparedDynamicTerrainGeometry(
-                    ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, dynamicTerrain.StaticMesh.Mesh),
-                    new PreparedTerrainGridGeometry(
-                        dynamicTerrain.GridMesh,
-                        ResoniteCityObjectPreparation.PrepareTerrainGridDisplacementTexture(dynamicTerrain.GridMesh))),
-                cancellationToken),
-            _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
-        };
+        ResoniteQueuedGeometryPreparation geometryPreparation = geometryPreparer.Start(
+            cityObject,
+            cancellationToken);
         Stopwatch stopwatch = Stopwatch.StartNew();
         PreparedTextureReference[] preparedTextures = await texturePreparer.PrepareAsync(
             state,
             routedClient,
-            cityObject,
+            geometryPreparation.CityObject,
             progressReporter,
             cancellationToken);
-        PreparedConstructionGeometry preparedGeometry = await geometryPreparationTask;
-        Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay = preparedTextures
-            .Where(static texture => texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
-            .ToDictionary(
-                static texture => texture.TerrainOverlay!,
-                static texture => texture.GeneratedTerrainTexture!);
-        cityObject = ResoniteCityObjectPreparation.ApplyTerrainTextureCanvasUv(
-            cityObject,
-            preparedTerrainTextureDataByOverlay,
-            clampCanvasUv: ResonitePackageSemantics.IsDemPackage(cityObject.PackageName));
-        if (cityObject.Geometry is ResoniteTriangleMeshGeometry resolvedTriangleMesh
-            && preparedGeometry is PreparedTriangleMeshGeometry)
-        {
-            preparedGeometry = ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, resolvedTriangleMesh.Mesh);
-        }
-        else if (cityObject.Geometry is ResoniteDynamicTerrainGeometry resolvedDynamicTerrain
-            && preparedGeometry is PreparedDynamicTerrainGeometry preparedDynamicTerrain)
-        {
-            preparedGeometry = preparedDynamicTerrain with
-            {
-                StaticMesh = ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, resolvedDynamicTerrain.StaticMesh.Mesh),
-            };
-        }
+        PreparedQueuedGeometry preparedQueuedGeometry = await geometryPreparer.CompleteAsync(
+            geometryPreparation,
+            preparedTextures);
+        cityObject = preparedQueuedGeometry.CityObject;
+        PreparedConstructionGeometry preparedGeometry = preparedQueuedGeometry.Geometry;
         stopwatch.Stop();
         diagnostics.RecordPrepare(cityObject.PackageName, stopwatch.Elapsed.TotalSeconds);
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedGeometryPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedGeometryPreparer.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteQueuedGeometryPreparer
+{
+    ResoniteQueuedGeometryPreparation Start(
+        ResoniteConstructionCityObject cityObject,
+        CancellationToken cancellationToken);
+
+    Task<PreparedQueuedGeometry> CompleteAsync(
+        ResoniteQueuedGeometryPreparation preparation,
+        IReadOnlyList<PreparedTextureReference> preparedTextures);
+}
+
+internal sealed class ResoniteQueuedGeometryPreparer : IResoniteQueuedGeometryPreparer
+{
+    public ResoniteQueuedGeometryPreparation Start(
+        ResoniteConstructionCityObject cityObject,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(cityObject);
+
+        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
+        ValidateGeometry(cityObject);
+        return new ResoniteQueuedGeometryPreparation(
+            cityObject,
+            CreateGeometryPreparationTask(cityObject, cancellationToken));
+    }
+
+    public async Task<PreparedQueuedGeometry> CompleteAsync(
+        ResoniteQueuedGeometryPreparation preparation,
+        IReadOnlyList<PreparedTextureReference> preparedTextures)
+    {
+        ArgumentNullException.ThrowIfNull(preparedTextures);
+
+        PreparedConstructionGeometry preparedGeometry = await preparation.GeometryPreparationTask;
+        ResoniteConstructionCityObject cityObject = ApplyTextureCanvasUv(
+            preparation.CityObject,
+            preparedTextures);
+        preparedGeometry = RefreshPreparedGeometryAfterUvUpdate(
+            cityObject,
+            preparedGeometry);
+        return new PreparedQueuedGeometry(cityObject, preparedGeometry);
+    }
+
+    private static void ValidateGeometry(ResoniteConstructionCityObject cityObject)
+    {
+        if (cityObject.Geometry is ResoniteTriangleMeshGeometry triangleGeometry)
+        {
+            ResoniteCityObjectPreparation.ValidateTriangleMeshBindingsForImport(cityObject, triangleGeometry.Mesh);
+        }
+        else if (cityObject.Geometry is ResoniteDynamicTerrainGeometry dynamicTerrain)
+        {
+            ResoniteCityObjectPreparation.ValidateTriangleMeshBindingsForImport(cityObject, dynamicTerrain.StaticMesh.Mesh);
+        }
+    }
+
+    private static Task<PreparedConstructionGeometry> CreateGeometryPreparationTask(
+        ResoniteConstructionCityObject cityObject,
+        CancellationToken cancellationToken)
+    {
+        return cityObject.Geometry switch
+        {
+            ResoniteTriangleMeshGeometry triangleMesh => Task.Run<PreparedConstructionGeometry>(
+                () => ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, triangleMesh.Mesh),
+                cancellationToken),
+            ResoniteTerrainGridGeometry heightMap => Task.Run<PreparedConstructionGeometry>(
+                () => new PreparedTerrainGridGeometry(heightMap, ResoniteCityObjectPreparation.PrepareTerrainGridDisplacementTexture(heightMap)),
+                cancellationToken),
+            ResoniteDynamicTerrainGeometry dynamicTerrain => Task.Run<PreparedConstructionGeometry>(
+                () => new PreparedDynamicTerrainGeometry(
+                    ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, dynamicTerrain.StaticMesh.Mesh),
+                    new PreparedTerrainGridGeometry(
+                        dynamicTerrain.GridMesh,
+                        ResoniteCityObjectPreparation.PrepareTerrainGridDisplacementTexture(dynamicTerrain.GridMesh))),
+                cancellationToken),
+            _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
+        };
+    }
+
+    private static ResoniteConstructionCityObject ApplyTextureCanvasUv(
+        ResoniteConstructionCityObject cityObject,
+        IReadOnlyList<PreparedTextureReference> preparedTextures)
+    {
+        Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay = preparedTextures
+            .Where(static texture => texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
+            .ToDictionary(
+                static texture => texture.TerrainOverlay!,
+                static texture => texture.GeneratedTerrainTexture!);
+        return ResoniteCityObjectPreparation.ApplyTerrainTextureCanvasUv(
+            cityObject,
+            preparedTerrainTextureDataByOverlay,
+            clampCanvasUv: ResonitePackageSemantics.IsDemPackage(cityObject.PackageName));
+    }
+
+    private static PreparedConstructionGeometry RefreshPreparedGeometryAfterUvUpdate(
+        ResoniteConstructionCityObject cityObject,
+        PreparedConstructionGeometry preparedGeometry)
+    {
+        if (cityObject.Geometry is ResoniteTriangleMeshGeometry resolvedTriangleMesh
+            && preparedGeometry is PreparedTriangleMeshGeometry)
+        {
+            return ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, resolvedTriangleMesh.Mesh);
+        }
+
+        if (cityObject.Geometry is ResoniteDynamicTerrainGeometry resolvedDynamicTerrain
+            && preparedGeometry is PreparedDynamicTerrainGeometry preparedDynamicTerrain)
+        {
+            return preparedDynamicTerrain with
+            {
+                StaticMesh = ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, resolvedDynamicTerrain.StaticMesh.Mesh),
+            };
+        }
+
+        return preparedGeometry;
+    }
+}
+
+internal sealed record ResoniteQueuedGeometryPreparation(
+    ResoniteConstructionCityObject CityObject,
+    Task<PreparedConstructionGeometry> GeometryPreparationTask);
+
+internal sealed record PreparedQueuedGeometry(
+    ResoniteConstructionCityObject CityObject,
+    PreparedConstructionGeometry Geometry);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -48,6 +48,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     {
         return new ResoniteQueuedCityObjectWorker(
             new ResoniteQueuedCityObjectSender(
+                new ResoniteQueuedGeometryPreparer(),
                 new ResoniteQueuedTexturePreparer(
                     new TerrainTextureAssetGenerator(),
                     new ResoniteDatasetLicenseWriter()),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -51,6 +51,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     {
         return new ResoniteQueuedCityObjectWorker(
             new ResoniteQueuedCityObjectSender(
+                new ResoniteQueuedGeometryPreparer(),
                 new ResoniteQueuedTexturePreparer(
                     new TerrainTextureAssetGenerator(),
                     new ResoniteDatasetLicenseWriter()),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -325,6 +325,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
             new ResoniteQueuedCityObjectSender(
+                new ResoniteQueuedGeometryPreparer(),
                 new ResoniteQueuedTexturePreparer(
                     terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
                     new ResoniteDatasetLicenseWriter()),


### PR DESCRIPTION
## Summary
- move queued city-object geometry normalization, validation, preparation, and terrain texture canvas UV application into a dedicated service
- keep queued sender focused on send accounting, linked cancellation, texture preparation orchestration, import delegation, progress, and recoverable failure handling
- preserve texture/geometry preparation concurrency while keeping semantic output unchanged

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false