### PR TITLE
Extract prepared texture asset planning services

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -31,6 +31,9 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
         services.TryAddScoped<IResoniteLiveSendWorkerLauncherFactory, ResoniteLiveSendWorkerLauncherFactory>();
         services.TryAddScoped<IResoniteLiveSendStartRequestFactory, ResoniteLiveSendStartRequestFactory>();
+        services.TryAddScoped<IResoniteSharedTerrainTextureAssetWriter, ResoniteSharedTerrainTextureAssetWriter>();
+        services.TryAddScoped<IResonitePreparedTextureUploader, ResonitePreparedTextureUploader>();
+        services.TryAddScoped<IResonitePreparedCityObjectAssetPlanner, ResonitePreparedCityObjectAssetPlanner>();
         services.TryAddScoped<IResonitePreparedCityObjectImporter, ResonitePreparedCityObjectImporter>();
         services.TryAddScoped<IResoniteQueuedCityObjectEnqueuer, ResoniteQueuedCityObjectEnqueuer>();
         services.TryAddScoped<IResoniteLiveSendFinalizer, ResoniteLiveSendFinalizer>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedCityObjectAssetPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedCityObjectAssetPlanner.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record PreparedCityObjectAssetPlan(
+    PlannedGeometryAsset GeometryAsset,
+    PlannedSceneMaterialPlan Materials,
+    double GeometryAssetSeconds,
+    double MaterialSeconds);
+
+internal interface IResonitePreparedCityObjectAssetPlanner
+{
+    Task<PreparedCityObjectAssetPlan> PlanAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        PreparedCityObject preparedCityObject,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResonitePreparedCityObjectAssetPlanner(
+    IResonitePreparedTextureUploader textureUploader,
+    IResoniteGeometryAssetPlanner geometryAssetPlanner,
+    IResoniteSceneMaterialPlanComposer sceneMaterialPlanComposer) : IResonitePreparedCityObjectAssetPlanner
+{
+    private readonly IResonitePreparedTextureUploader textureUploader =
+        textureUploader ?? throw new ArgumentNullException(nameof(textureUploader));
+    private readonly IResoniteGeometryAssetPlanner geometryAssetPlanner =
+        geometryAssetPlanner ?? throw new ArgumentNullException(nameof(geometryAssetPlanner));
+    private readonly IResoniteSceneMaterialPlanComposer sceneMaterialPlanComposer =
+        sceneMaterialPlanComposer ?? throw new ArgumentNullException(nameof(sceneMaterialPlanComposer));
+
+    public async Task<PreparedCityObjectAssetPlan> PlanAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        PreparedCityObject preparedCityObject,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(routedClient);
+        ArgumentNullException.ThrowIfNull(preparedCityObject);
+
+        ResoniteConstructionCityObject cityObject = preparedCityObject.CityObject;
+        using CancellationTokenSource importStepCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay =
+            CreatePreparedTerrainTextureDataByOverlay(preparedCityObject);
+        Task<ResoniteUploadedTextureAssetSet> uploadedTextureAssetsTask = textureUploader.UploadAsync(
+            state,
+            routedClient,
+            preparedCityObject,
+            importStepCancellation.Token);
+        Stopwatch geometryStopwatch = Stopwatch.StartNew();
+        Task<PlannedGeometryAsset> geometryPlanningTask = geometryAssetPlanner.PlanAsync(
+            routedClient,
+            cityObject,
+            preparedCityObject,
+            preparedTerrainTextureDataByOverlay,
+            progressReporter,
+            importStepCancellation.Token);
+        Stopwatch materialStopwatch = new();
+        Task<PlannedSceneMaterialPlan>? materialPlanningTask = null;
+        Action<string> reportProgress = progressReporter ?? (_ => { });
+        try
+        {
+            ResoniteUploadedTextureAssetSet uploadedTextureAssets = await uploadedTextureAssetsTask;
+            materialStopwatch.Start();
+            materialPlanningTask = sceneMaterialPlanComposer.ComposeAsync(
+                state,
+                routedClient,
+                cityObject,
+                uploadedTextureAssets.TextureUrisByPayload,
+                uploadedTextureAssets.TerrainTextureUrisByOverlay,
+                uploadedTextureAssets.TerrainTexturePropertyBlockComponentsByMeshCode,
+                reportProgress,
+                importStepCancellation.Token);
+            PlannedSceneMaterialPlan plannedMaterials = await materialPlanningTask;
+            materialStopwatch.Stop();
+
+            reportProgress($"Preparing geometry assets ({PreparedConstructionGeometryFormatter.Describe(preparedCityObject.Geometry)}).");
+            PlannedGeometryAsset plannedGeometryAsset = await geometryPlanningTask;
+            geometryStopwatch.Stop();
+            return new PreparedCityObjectAssetPlan(
+                plannedGeometryAsset,
+                plannedMaterials,
+                geometryStopwatch.Elapsed.TotalSeconds,
+                materialStopwatch.Elapsed.TotalSeconds);
+        }
+        catch
+        {
+            await importStepCancellation.CancelAsync();
+            IEnumerable<Task> tasksToObserve = materialPlanningTask is null
+                ? [uploadedTextureAssetsTask, geometryPlanningTask]
+                : [uploadedTextureAssetsTask, materialPlanningTask, geometryPlanningTask];
+            await ObserveTaskFailuresAsync(tasksToObserve);
+            throw;
+        }
+    }
+
+    private static Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> CreatePreparedTerrainTextureDataByOverlay(
+        PreparedCityObject preparedCityObject)
+    {
+        Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> generatedTerrainTexturesByOverlay = [];
+        foreach (PreparedTextureReference texture in preparedCityObject.Textures)
+        {
+            if (texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
+            {
+                generatedTerrainTexturesByOverlay.TryAdd(texture.TerrainOverlay, texture.GeneratedTerrainTexture);
+            }
+        }
+
+        return generatedTerrainTexturesByOverlay;
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Best-effort cleanup should observe and suppress orphaned import task failures after the primary send failure.")]
+    private static async Task ObserveTaskFailureAsync(Task task)
+    {
+        try
+        {
+            await task;
+        }
+        catch
+        {
+        }
+    }
+
+    private static Task ObserveTaskFailuresAsync(IEnumerable<Task> tasks)
+    {
+        return Task.WhenAll(tasks.Select(ObserveTaskFailureAsync));
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedCityObjectImporter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedCityObjectImporter.cs
@@ -1,12 +1,9 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Logging;
-using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
@@ -25,11 +22,13 @@ internal interface IResonitePreparedCityObjectImporter
 }
 
 internal sealed class ResonitePreparedCityObjectImporter(
-    IResoniteGeometryAssetPlanner geometryAssetPlanner,
-    IResoniteSceneMaterialPlanComposer sceneMaterialPlanComposer,
+    IResonitePreparedCityObjectAssetPlanner assetPlanner,
     IResoniteBatchEmissionPlanner batchEmissionPlanner,
     IResoniteSceneBatchEmitter batchEmitter) : IResonitePreparedCityObjectImporter
 {
+    private readonly IResonitePreparedCityObjectAssetPlanner assetPlanner =
+        assetPlanner ?? throw new ArgumentNullException(nameof(assetPlanner));
+
     public async Task ImportAsync(
         LiveSendRunState state,
         IResoniteLinkClient routedClient,
@@ -54,64 +53,21 @@ internal sealed class ResonitePreparedCityObjectImporter(
             queuedCityObject.ObjectHierarchyTask,
             cancellationToken);
         slotHierarchyStopwatch.Stop();
-        using CancellationTokenSource importStepCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay =
-            CreatePreparedTerrainTextureDataByOverlay(preparedCityObject);
-        Task<ResoniteUploadedTextureAssetSet> uploadedTextureAssetsTask = ResonitePreparedTextureUploader.UploadAsync(
+        PreparedCityObjectAssetPlan assetPlan = await assetPlanner.PlanAsync(
             state,
             routedClient,
             preparedCityObject,
-            importStepCancellation.Token);
-        Stopwatch geometryStopwatch = Stopwatch.StartNew();
-        Task<PlannedGeometryAsset> geometryPlanningTask = geometryAssetPlanner.PlanAsync(
-            routedClient,
-            cityObject,
-            preparedCityObject,
-            preparedTerrainTextureDataByOverlay,
-            progressReporter,
-            importStepCancellation.Token);
-        Stopwatch materialStopwatch = new();
-        Task<PlannedSceneMaterialPlan>? materialPlanningTask = null;
-        PlannedSceneMaterialPlan plannedMaterials;
-        PlannedGeometryAsset plannedGeometryAsset;
-        try
-        {
-            ResoniteUploadedTextureAssetSet uploadedTextureAssets = await uploadedTextureAssetsTask;
-            materialStopwatch.Start();
-            materialPlanningTask = sceneMaterialPlanComposer.ComposeAsync(
-                state,
-                routedClient,
-                cityObject,
-                uploadedTextureAssets.TextureUrisByPayload,
-                uploadedTextureAssets.TerrainTextureUrisByOverlay,
-                uploadedTextureAssets.TerrainTexturePropertyBlockComponentsByMeshCode,
-                message => ReportImportStep(progressReporter, cityObject, message),
-                importStepCancellation.Token);
-            plannedMaterials = await materialPlanningTask;
-            materialStopwatch.Stop();
-
-            ReportImportStep(progressReporter, cityObject, $"Preparing geometry assets ({PreparedConstructionGeometryFormatter.Describe(preparedCityObject.Geometry)}).");
-            plannedGeometryAsset = await geometryPlanningTask;
-            geometryStopwatch.Stop();
-        }
-        catch
-        {
-            await importStepCancellation.CancelAsync();
-            IEnumerable<Task> tasksToObserve = materialPlanningTask is null
-                ? [uploadedTextureAssetsTask, geometryPlanningTask]
-                : [uploadedTextureAssetsTask, materialPlanningTask, geometryPlanningTask];
-            await ObserveTaskFailuresAsync(tasksToObserve);
-            throw;
-        }
+            message => ReportImportStep(progressReporter, cityObject, message),
+            cancellationToken);
 
         PlannedSceneObjectEmission emissionPlan = new(
-            plannedGeometryAsset,
-            plannedMaterials.MaterialAssets,
+            assetPlan.GeometryAsset,
+            assetPlan.Materials.MaterialAssets,
             new PlannedRenderer(
-                plannedGeometryAsset.Identity,
-                plannedMaterials.RendererMaterialBindings),
+                assetPlan.GeometryAsset.Identity,
+                assetPlan.Materials.RendererMaterialBindings),
             new PlannedCollider(
-                plannedGeometryAsset.Identity,
+                assetPlan.GeometryAsset.Identity,
                 cityObject.CollisionEnabled));
         PlannedBatchEmission batchEmission = batchEmissionPlanner.Create(objectSlots, emissionPlan);
 
@@ -132,8 +88,8 @@ internal sealed class ResonitePreparedCityObjectImporter(
                 "live",
                 $"City object '{cityObject.DisplayName}' phase timings: "
                 + $"slot_hierarchy_s={slotHierarchyStopwatch.Elapsed.TotalSeconds:F3} "
-                + $"geometry_assets_s={geometryStopwatch.Elapsed.TotalSeconds:F3} "
-                + $"materials_s={materialStopwatch.Elapsed.TotalSeconds:F3} "
+                + $"geometry_assets_s={assetPlan.GeometryAssetSeconds:F3} "
+                + $"materials_s={assetPlan.MaterialSeconds:F3} "
                 + $"batch_s={batchStopwatch.Elapsed.TotalSeconds:F3} "
                 + $"total_send_s={cityObjectStopwatch.Elapsed.TotalSeconds:F3}."));
         sendScope.MarkSent();
@@ -145,41 +101,6 @@ internal sealed class ResonitePreparedCityObjectImporter(
                     $"First city object imported after {state.Runtime.ElapsedTotalSeconds:F3}s: "
                     + $"{cityObject.DisplayName} ({cityObject.PackageName}/{cityObject.SlotKey})"));
         }
-    }
-
-    private static Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> CreatePreparedTerrainTextureDataByOverlay(
-        PreparedCityObject preparedCityObject)
-    {
-        Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> generatedTerrainTexturesByOverlay = [];
-        foreach (PreparedTextureReference texture in preparedCityObject.Textures)
-        {
-            if (texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
-            {
-                generatedTerrainTexturesByOverlay.TryAdd(texture.TerrainOverlay, texture.GeneratedTerrainTexture);
-            }
-        }
-
-        return generatedTerrainTexturesByOverlay;
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Design",
-        "CA1031:Do not catch general exception types",
-        Justification = "Best-effort cleanup should observe and suppress orphaned import task failures after the primary send failure.")]
-    private static async Task ObserveTaskFailureAsync(Task task)
-    {
-        try
-        {
-            await task;
-        }
-        catch
-        {
-        }
-    }
-
-    private static Task ObserveTaskFailuresAsync(IEnumerable<Task> tasks)
-    {
-        return Task.WhenAll(tasks.Select(ObserveTaskFailureAsync));
     }
 
     private static Task<T> AwaitWithSlowCityObjectWarningAsync<T>(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedTextureUploader.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedTextureUploader.cs
@@ -5,10 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Domain.Importing;
-using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
-
-using ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
@@ -17,14 +14,31 @@ internal sealed record ResoniteUploadedTextureAssetSet(
     Dictionary<TerrainTextureOverlay, Uri> TerrainTextureUrisByOverlay,
     Dictionary<string, ResoniteComponentLocator> TerrainTexturePropertyBlockComponentsByMeshCode);
 
-internal static class ResonitePreparedTextureUploader
+internal interface IResonitePreparedTextureUploader
 {
-    public static async Task<ResoniteUploadedTextureAssetSet> UploadAsync(
+    Task<ResoniteUploadedTextureAssetSet> UploadAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient importClient,
+        PreparedCityObject preparedCityObject,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResonitePreparedTextureUploader(
+    IResoniteSharedTerrainTextureAssetWriter terrainTextureAssetWriter) : IResonitePreparedTextureUploader
+{
+    private readonly IResoniteSharedTerrainTextureAssetWriter terrainTextureAssetWriter =
+        terrainTextureAssetWriter ?? throw new ArgumentNullException(nameof(terrainTextureAssetWriter));
+
+    public async Task<ResoniteUploadedTextureAssetSet> UploadAsync(
         LiveSendRunState state,
         IResoniteLinkClient importClient,
         PreparedCityObject preparedCityObject,
         CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(importClient);
+        ArgumentNullException.ThrowIfNull(preparedCityObject);
+
         Dictionary<ResoniteTexturePayload, Uri> textureUrisByPayload = new(ResoniteTexturePayloadReferenceComparer.Instance);
         Dictionary<TerrainTextureOverlay, Uri> terrainTextureUrisByOverlay = [];
         Dictionary<string, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode = new(StringComparer.Ordinal);
@@ -44,7 +58,7 @@ internal static class ResonitePreparedTextureUploader
                 string meshCode = ResolveTerrainTextureMeshCode(texture);
                 terrainTextureImportTasks.Add((
                     texture,
-                    EnsureSharedTerrainTextureAssetAsync(
+                    terrainTextureAssetWriter.EnsureAsync(
                         state,
                         importClient,
                         meshCode,
@@ -85,164 +99,6 @@ internal static class ResonitePreparedTextureUploader
             textureUrisByPayload,
             terrainTextureUrisByOverlay,
             terrainTexturePropertyBlockComponentsByMeshCode);
-    }
-
-    private static Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient importClient,
-        string meshCode,
-        ResoniteTextureImport textureImport,
-        CancellationToken cancellationToken)
-    {
-        return state.TerrainTextures.AssetsByMeshCode.GetOrCreateAsync(
-            meshCode,
-            () => EnsureSharedTerrainTextureAssetCoreAsync(state, importClient, meshCode, textureImport, cancellationToken),
-            cancellationToken);
-    }
-
-    private static async Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetCoreAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient importClient,
-        string meshCode,
-        ResoniteTextureImport textureImport,
-        CancellationToken cancellationToken)
-    {
-        CreatedSlot terrainTexturesRoot = await state.Placement.GetOrCreateSharedChildSlotAsync(
-            importClient,
-            state.Context.DatasetAssetsRootSlot.Locator,
-            "Terrain Textures",
-            cancellationToken);
-        CreatedSlot meshSlot = await state.Placement.GetOrCreateSharedChildSlotAsync(
-            importClient,
-            terrainTexturesRoot.Locator,
-            meshCode,
-            cancellationToken);
-        SharedTerrainTextureAsset? existingTexture = await TryFindSharedTerrainTextureAssetAsync(
-            importClient,
-            meshSlot,
-            cancellationToken);
-        if (existingTexture is not null)
-        {
-            Uri refreshedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
-            await importClient.UpdateComponentAsync(
-                new ResoniteComponentUpdate
-                {
-                    Component = new ResoniteTransportComponentLocator(existingTexture.TextureComponent.Locator.Value),
-                    Members = ResoniteSceneMaterialConventions.CreateTextureMembers(
-                        refreshedTextureUri,
-                        ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride),
-                },
-                cancellationToken);
-            return existingTexture with
-            {
-                TextureUri = refreshedTextureUri,
-            };
-        }
-
-        Uri importedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
-        CreatedComponent textureComponent = await ResoniteMaterialPlanning.CreateComponentAsync(
-            importClient,
-            meshSlot.Locator,
-            "[FrooxEngine]FrooxEngine.StaticTexture2D",
-            ResoniteSceneMaterialConventions.CreateTextureMembers(
-                importedTextureUri,
-                ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride),
-            cancellationToken);
-        CreatedComponent propertyBlockComponent = await CreateTerrainMainTexturePropertyBlockAsync(
-            importClient,
-            meshSlot.Locator,
-            textureComponent.Locator,
-            cancellationToken);
-        return new SharedTerrainTextureAsset(
-            importedTextureUri,
-            textureComponent,
-            propertyBlockComponent);
-    }
-
-    private static async Task<SharedTerrainTextureAsset?> TryFindSharedTerrainTextureAssetAsync(
-        IResoniteLinkClient importClient,
-        CreatedSlot meshSlot,
-        CancellationToken cancellationToken)
-    {
-        Slot? slot = await importClient.GetSlotAsync(
-            new ResoniteTransportSlotLocator(meshSlot.Locator.Value),
-            depth: 0,
-            cancellationToken);
-        Component? textureComponent = slot?.Components?
-            .FirstOrDefault(IsSharedTerrainTextureComponent);
-        if (textureComponent?.ID is null
-            || textureComponent.Members["URL"] is not Field_Uri url)
-        {
-            return null;
-        }
-
-        if (url.Value is null)
-        {
-            return null;
-        }
-
-        CreatedComponent createdTextureComponent = new(new ResoniteComponentLocator(textureComponent.ID), textureComponent.ComponentType);
-        Component? propertyBlockComponent = slot?.Components?
-            .Where(component => IsSharedTerrainMainTexturePropertyBlockComponent(component, textureComponent.ID))
-            .OrderBy(static component => component.ID, StringComparer.Ordinal)
-            .FirstOrDefault();
-        CreatedComponent createdPropertyBlockComponent = propertyBlockComponent?.ID is null
-            ? await CreateTerrainMainTexturePropertyBlockAsync(
-                importClient,
-                meshSlot.Locator,
-                createdTextureComponent.Locator,
-                cancellationToken)
-            : new CreatedComponent(new ResoniteComponentLocator(propertyBlockComponent.ID), propertyBlockComponent.ComponentType);
-
-        return new SharedTerrainTextureAsset(
-            url.Value,
-            createdTextureComponent,
-            createdPropertyBlockComponent);
-    }
-
-    private static Task<CreatedComponent> CreateTerrainMainTexturePropertyBlockAsync(
-        IResoniteLinkClient importClient,
-        ResoniteSlotLocator meshSlot,
-        ResoniteComponentLocator textureComponent,
-        CancellationToken cancellationToken)
-    {
-        return ResoniteMaterialPlanning.CreateComponentAsync(
-            importClient,
-            meshSlot,
-            "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
-            new Dictionary<string, Member>(StringComparer.Ordinal)
-            {
-                ["Texture"] = new Reference
-                {
-                    TargetID = textureComponent.Value,
-                },
-            },
-            cancellationToken);
-    }
-
-    private static bool IsSharedTerrainMainTexturePropertyBlockComponent(Component component, string textureComponentId)
-    {
-        return string.Equals(
-                component.ComponentType,
-                "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
-                StringComparison.Ordinal)
-            && component.Members.TryGetValue("Texture", out Member? textureMember)
-            && textureMember is Reference { TargetID: string targetId }
-            && string.Equals(targetId, textureComponentId, StringComparison.Ordinal);
-    }
-
-    private static bool IsSharedTerrainTextureComponent(Component component)
-    {
-        return string.Equals(
-                component.ComponentType,
-                "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                StringComparison.Ordinal)
-            && component.Members.TryGetValue("URL", out Member? urlMember)
-            && urlMember is Field_Uri
-            && component.Members.TryGetValue("WrapModeU", out Member? wrapModeUMember)
-            && wrapModeUMember is Field_Enum { Value: "Clamp" }
-            && component.Members.TryGetValue("WrapModeV", out Member? wrapModeVMember)
-            && wrapModeVMember is Field_Enum { Value: "Clamp" };
     }
 
     private static string ResolveTerrainTextureMeshCode(PreparedTextureReference texture)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedTerrainTextureAssetWriter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedTerrainTextureAssetWriter.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Targets.Resonite.Execution;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteSharedTerrainTextureAssetWriter
+{
+    Task<SharedTerrainTextureAsset> EnsureAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient importClient,
+        string meshCode,
+        ResoniteTextureImport textureImport,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteSharedTerrainTextureAssetWriter : IResoniteSharedTerrainTextureAssetWriter
+{
+    public Task<SharedTerrainTextureAsset> EnsureAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient importClient,
+        string meshCode,
+        ResoniteTextureImport textureImport,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(importClient);
+        ArgumentException.ThrowIfNullOrWhiteSpace(meshCode);
+        ArgumentNullException.ThrowIfNull(textureImport);
+
+        return state.TerrainTextures.AssetsByMeshCode.GetOrCreateAsync(
+            meshCode,
+            () => EnsureCoreAsync(state, importClient, meshCode, textureImport, cancellationToken),
+            cancellationToken);
+    }
+
+    private static async Task<SharedTerrainTextureAsset> EnsureCoreAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient importClient,
+        string meshCode,
+        ResoniteTextureImport textureImport,
+        CancellationToken cancellationToken)
+    {
+        CreatedSlot terrainTexturesRoot = await state.Placement.GetOrCreateSharedChildSlotAsync(
+            importClient,
+            state.Context.DatasetAssetsRootSlot.Locator,
+            "Terrain Textures",
+            cancellationToken);
+        CreatedSlot meshSlot = await state.Placement.GetOrCreateSharedChildSlotAsync(
+            importClient,
+            terrainTexturesRoot.Locator,
+            meshCode,
+            cancellationToken);
+        SharedTerrainTextureAsset? existingTexture = await TryFindSharedTerrainTextureAssetAsync(
+            importClient,
+            meshSlot,
+            cancellationToken);
+        if (existingTexture is not null)
+        {
+            Uri refreshedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
+            await importClient.UpdateComponentAsync(
+                new ResoniteComponentUpdate
+                {
+                    Component = new ResoniteTransportComponentLocator(existingTexture.TextureComponent.Locator.Value),
+                    Members = ResoniteSceneMaterialConventions.CreateTextureMembers(
+                        refreshedTextureUri,
+                        ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride),
+                },
+                cancellationToken);
+            return existingTexture with
+            {
+                TextureUri = refreshedTextureUri,
+            };
+        }
+
+        Uri importedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
+        CreatedComponent textureComponent = await ResoniteMaterialPlanning.CreateComponentAsync(
+            importClient,
+            meshSlot.Locator,
+            "[FrooxEngine]FrooxEngine.StaticTexture2D",
+            ResoniteSceneMaterialConventions.CreateTextureMembers(
+                importedTextureUri,
+                ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride),
+            cancellationToken);
+        CreatedComponent propertyBlockComponent = await CreateTerrainMainTexturePropertyBlockAsync(
+            importClient,
+            meshSlot.Locator,
+            textureComponent.Locator,
+            cancellationToken);
+        return new SharedTerrainTextureAsset(
+            importedTextureUri,
+            textureComponent,
+            propertyBlockComponent);
+    }
+
+    private static async Task<SharedTerrainTextureAsset?> TryFindSharedTerrainTextureAssetAsync(
+        IResoniteLinkClient importClient,
+        CreatedSlot meshSlot,
+        CancellationToken cancellationToken)
+    {
+        Slot? slot = await importClient.GetSlotAsync(
+            new ResoniteTransportSlotLocator(meshSlot.Locator.Value),
+            depth: 0,
+            cancellationToken);
+        Component? textureComponent = slot?.Components?
+            .FirstOrDefault(IsSharedTerrainTextureComponent);
+        if (textureComponent?.ID is null
+            || textureComponent.Members["URL"] is not Field_Uri url)
+        {
+            return null;
+        }
+
+        if (url.Value is null)
+        {
+            return null;
+        }
+
+        CreatedComponent createdTextureComponent = new(new ResoniteComponentLocator(textureComponent.ID), textureComponent.ComponentType);
+        Component? propertyBlockComponent = slot?.Components?
+            .Where(component => IsSharedTerrainMainTexturePropertyBlockComponent(component, textureComponent.ID))
+            .OrderBy(static component => component.ID, StringComparer.Ordinal)
+            .FirstOrDefault();
+        CreatedComponent createdPropertyBlockComponent = propertyBlockComponent?.ID is null
+            ? await CreateTerrainMainTexturePropertyBlockAsync(
+                importClient,
+                meshSlot.Locator,
+                createdTextureComponent.Locator,
+                cancellationToken)
+            : new CreatedComponent(new ResoniteComponentLocator(propertyBlockComponent.ID), propertyBlockComponent.ComponentType);
+
+        return new SharedTerrainTextureAsset(
+            url.Value,
+            createdTextureComponent,
+            createdPropertyBlockComponent);
+    }
+
+    private static Task<CreatedComponent> CreateTerrainMainTexturePropertyBlockAsync(
+        IResoniteLinkClient importClient,
+        ResoniteSlotLocator meshSlot,
+        ResoniteComponentLocator textureComponent,
+        CancellationToken cancellationToken)
+    {
+        return ResoniteMaterialPlanning.CreateComponentAsync(
+            importClient,
+            meshSlot,
+            "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
+            new Dictionary<string, Member>(StringComparer.Ordinal)
+            {
+                ["Texture"] = new Reference
+                {
+                    TargetID = textureComponent.Value,
+                },
+            },
+            cancellationToken);
+    }
+
+    private static bool IsSharedTerrainMainTexturePropertyBlockComponent(Component component, string textureComponentId)
+    {
+        return string.Equals(
+                component.ComponentType,
+                "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
+                StringComparison.Ordinal)
+            && component.Members.TryGetValue("Texture", out Member? textureMember)
+            && textureMember is Reference { TargetID: string targetId }
+            && string.Equals(targetId, textureComponentId, StringComparison.Ordinal);
+    }
+
+    private static bool IsSharedTerrainTextureComponent(Component component)
+    {
+        return string.Equals(
+                component.ComponentType,
+                "[FrooxEngine]FrooxEngine.StaticTexture2D",
+                StringComparison.Ordinal)
+            && component.Members.TryGetValue("URL", out Member? urlMember)
+            && urlMember is Field_Uri
+            && component.Members.TryGetValue("WrapModeU", out Member? wrapModeUMember)
+            && wrapModeUMember is Field_Enum { Value: "Clamp" }
+            && component.Members.TryGetValue("WrapModeV", out Member? wrapModeVMember)
+            && wrapModeVMember is Field_Enum { Value: "Clamp" };
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -37,8 +37,10 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         IResoniteMaterialPlanning materialPlanning)
     {
         return new ResonitePreparedCityObjectImporter(
-            new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
-            new ResoniteSceneMaterialPlanComposer(materialPlanning),
+            new ResonitePreparedCityObjectAssetPlanner(
+                new ResonitePreparedTextureUploader(new ResoniteSharedTerrainTextureAssetWriter()),
+                new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
+                new ResoniteSceneMaterialPlanComposer(materialPlanning)),
             new ResoniteBatchEmissionPlanner(),
             new PlannedBatchEmissionInterpreter());
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -40,8 +40,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         IResoniteMaterialPlanning materialPlanning)
     {
         return new ResonitePreparedCityObjectImporter(
-            new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
-            new ResoniteSceneMaterialPlanComposer(materialPlanning),
+            new ResonitePreparedCityObjectAssetPlanner(
+                new ResonitePreparedTextureUploader(new ResoniteSharedTerrainTextureAssetWriter()),
+                new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
+                new ResoniteSceneMaterialPlanComposer(materialPlanning)),
             new ResoniteBatchEmissionPlanner(),
             new PlannedBatchEmissionInterpreter());
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -330,8 +330,10 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                     terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
                     new ResoniteDatasetLicenseWriter()),
                 new ResonitePreparedCityObjectImporter(
-                    new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
-                    new ResoniteSceneMaterialPlanComposer(materialPlanning),
+                    new ResonitePreparedCityObjectAssetPlanner(
+                        new ResonitePreparedTextureUploader(new ResoniteSharedTerrainTextureAssetWriter()),
+                        new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
+                        new ResoniteSceneMaterialPlanComposer(materialPlanning)),
                     new ResoniteBatchEmissionPlanner(),
                     new PlannedBatchEmissionInterpreter())));
         return new ResoniteLiveSceneImportTarget(


### PR DESCRIPTION
## Summary
- move prepared city-object texture upload, material planning, and geometry asset planning concurrency into a dedicated asset planner service
- replace the static prepared texture uploader with DI-friendly collaborators
- isolate shared terrain texture upsert/readback behavior in its own writer service while preserving output semantics

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false