### PR TITLE
Extract queued send preparation services

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -211,10 +211,12 @@ internal sealed class DefaultSceneSinkFactory(
             new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
             new ResoniteQueuedCityObjectSender(
-                new ResoniteQueuedGeometryPreparer(),
-                new ResoniteQueuedTexturePreparer(
-                    new DeterministicTerrainTextureAssetGenerator(),
-                    serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>()),
+                new ResoniteQueuedCityObjectPreparer(
+                    new ResoniteQueuedGeometryPreparer(),
+                    new ResoniteQueuedTexturePreparer(
+                        new DeterministicTerrainTextureAssetGenerator(),
+                        serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>())),
+                new ResoniteQueuedSendFailurePolicy(),
                 serviceProvider.GetRequiredService<IResonitePreparedCityObjectImporter>()));
         return new ResoniteLiveSceneImportTarget(
             targetOptions,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -45,9 +45,7 @@ internal interface IResoniteLiveSendWorkerLauncherFactory
 }
 
 internal sealed class ResoniteLiveSendWorkerLauncherFactory(
-    ITerrainTextureAssetGeneratorFactory terrainTextureAssetGeneratorFactory,
-    IResoniteDatasetLicenseWriter datasetLicenseWriter,
-    IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteLiveSendWorkerLauncherFactory
+    IResoniteQueuedCityObjectSenderFactory queuedCityObjectSenderFactory) : IResoniteLiveSendWorkerLauncherFactory
 {
     public IResoniteLiveSendWorkerLauncher Create(
         HttpClient terrainTextureAssetHttpClient,
@@ -56,16 +54,8 @@ internal sealed class ResoniteLiveSendWorkerLauncherFactory(
         ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
         ArgumentNullException.ThrowIfNull(options);
 
-        ResoniteQueuedTexturePreparer texturePreparer = new(
-            terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
-            datasetLicenseWriter);
-        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
-            new ResoniteQueuedCityObjectPreparer(
-                new ResoniteQueuedGeometryPreparer(),
-                texturePreparer),
-            new ResoniteQueuedSendFailurePolicy(),
-            preparedCityObjectImporter);
-        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
+        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
+            queuedCityObjectSenderFactory.Create(terrainTextureAssetHttpClient, options));
         return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -60,8 +60,10 @@ internal sealed class ResoniteLiveSendWorkerLauncherFactory(
             terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
             datasetLicenseWriter);
         ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
-            new ResoniteQueuedGeometryPreparer(),
-            texturePreparer,
+            new ResoniteQueuedCityObjectPreparer(
+                new ResoniteQueuedGeometryPreparer(),
+                texturePreparer),
+            new ResoniteQueuedSendFailurePolicy(),
             preparedCityObjectImporter);
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
         return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -35,6 +35,10 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResonitePreparedTextureUploader, ResonitePreparedTextureUploader>();
         services.TryAddScoped<IResonitePreparedCityObjectAssetPlanner, ResonitePreparedCityObjectAssetPlanner>();
         services.TryAddScoped<IResonitePreparedCityObjectImporter, ResonitePreparedCityObjectImporter>();
+        services.TryAddScoped<IResoniteQueuedGeometryPreparer, ResoniteQueuedGeometryPreparer>();
+        services.TryAddScoped<IResoniteQueuedSendFailurePolicy, ResoniteQueuedSendFailurePolicy>();
+        services.TryAddScoped<IResoniteQueuedCityObjectPreparerFactory, ResoniteQueuedCityObjectPreparerFactory>();
+        services.TryAddScoped<IResoniteQueuedCityObjectSenderFactory, ResoniteQueuedCityObjectSenderFactory>();
         services.TryAddScoped<IResoniteQueuedCityObjectEnqueuer, ResoniteQueuedCityObjectEnqueuer>();
         services.TryAddScoped<IResoniteLiveSendFinalizer, ResoniteLiveSendFinalizer>();
         services.TryAddScoped<IResoniteLiveSendQueue, ResoniteLiveSendQueue>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparer.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteQueuedCityObjectPreparer
+{
+    Task<PreparedCityObject> PrepareAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        ResoniteConstructionCityObject cityObject,
+        ResoniteLinkSendDiagnostics diagnostics,
+        Action<string>? progressReporter,
+        CancellationToken callerCancellationToken);
+}
+
+internal sealed class ResoniteQueuedCityObjectPreparer(
+    IResoniteQueuedGeometryPreparer geometryPreparer,
+    IResoniteQueuedTexturePreparer texturePreparer) : IResoniteQueuedCityObjectPreparer
+{
+    private readonly IResoniteQueuedGeometryPreparer geometryPreparer =
+        geometryPreparer ?? throw new ArgumentNullException(nameof(geometryPreparer));
+    private readonly IResoniteQueuedTexturePreparer texturePreparer =
+        texturePreparer ?? throw new ArgumentNullException(nameof(texturePreparer));
+
+    public Task<PreparedCityObject> PrepareAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        ResoniteConstructionCityObject cityObject,
+        ResoniteLinkSendDiagnostics diagnostics,
+        Action<string>? progressReporter,
+        CancellationToken callerCancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(routedClient);
+        ArgumentNullException.ThrowIfNull(cityObject);
+        ArgumentNullException.ThrowIfNull(diagnostics);
+
+        if (Interlocked.CompareExchange(ref state.Progress.FirstCityObjectPreparationStartedLogged, 1, 0) == 0)
+        {
+            ReportProgress(
+                progressReporter,
+                PlateauLog.Info(
+                    "live",
+                    $"City object preparation started after {state.Runtime.ElapsedTotalSeconds:F3}s: "
+                    + $"{cityObject.DisplayName} ({cityObject.PackageName}/{cityObject.SlotKey}) "
+                    + $"mesh='{cityObject.ActualMeshCode}'."));
+        }
+
+        CancellationToken processingCancellationToken = state.Runtime.ProcessingCancellationToken;
+        return PrepareWithLinkedCancellationAsync(
+            state,
+            routedClient,
+            cityObject,
+            diagnostics,
+            progressReporter,
+            callerCancellationToken,
+            processingCancellationToken);
+    }
+
+    private async Task<PreparedCityObject> PrepareWithLinkedCancellationAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        ResoniteConstructionCityObject cityObject,
+        ResoniteLinkSendDiagnostics diagnostics,
+        Action<string>? progressReporter,
+        CancellationToken callerCancellationToken,
+        CancellationToken processingCancellationToken)
+    {
+        using CancellationTokenSource linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            callerCancellationToken,
+            processingCancellationToken);
+        return await PrepareCoreAsync(
+            state,
+            routedClient,
+            cityObject,
+            diagnostics,
+            progressReporter,
+            linkedCancellation.Token);
+    }
+
+    private async Task<PreparedCityObject> PrepareCoreAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        ResoniteConstructionCityObject cityObject,
+        ResoniteLinkSendDiagnostics diagnostics,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
+    {
+        ResoniteQueuedGeometryPreparation geometryPreparation = geometryPreparer.Start(
+            cityObject,
+            cancellationToken);
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        PreparedTextureReference[] preparedTextures = await texturePreparer.PrepareAsync(
+            state,
+            routedClient,
+            geometryPreparation.CityObject,
+            progressReporter,
+            cancellationToken);
+        PreparedQueuedGeometry preparedQueuedGeometry = await geometryPreparer.CompleteAsync(
+            geometryPreparation,
+            preparedTextures);
+        cityObject = preparedQueuedGeometry.CityObject;
+        PreparedConstructionGeometry preparedGeometry = preparedQueuedGeometry.Geometry;
+        stopwatch.Stop();
+        diagnostics.RecordPrepare(cityObject.PackageName, stopwatch.Elapsed.TotalSeconds);
+
+        if (Interlocked.CompareExchange(ref state.Progress.FirstPreparedCityObjectLogged, 1, 0) == 0)
+        {
+            ReportProgress(
+                progressReporter,
+                PlateauLog.Info(
+                    "live",
+                    $"First city object prepared in {stopwatch.Elapsed.TotalSeconds:F3}s "
+                    + $"after scene start {state.Runtime.ElapsedTotalSeconds:F3}s: "
+                    + $"{cityObject.DisplayName} "
+                    + $"(textures={preparedTextures.Length}, geometry={PreparedConstructionGeometryFormatter.Describe(preparedGeometry)})."));
+        }
+
+        return new PreparedCityObject(
+            cityObject,
+            preparedGeometry,
+            preparedTextures);
+    }
+
+    private static void ReportProgress(Action<string>? progressReporter, string message)
+    {
+        progressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparerFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparerFactory.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Net.Http;
+
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteQueuedCityObjectPreparerFactory
+{
+    IResoniteQueuedCityObjectPreparer Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options);
+}
+
+internal sealed class ResoniteQueuedCityObjectPreparerFactory(
+    IResoniteQueuedGeometryPreparer geometryPreparer,
+    ITerrainTextureAssetGeneratorFactory terrainTextureAssetGeneratorFactory,
+    IResoniteDatasetLicenseWriter datasetLicenseWriter) : IResoniteQueuedCityObjectPreparerFactory
+{
+    public IResoniteQueuedCityObjectPreparer Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        ResoniteQueuedTexturePreparer texturePreparer = new(
+            terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
+            datasetLicenseWriter);
+        return new ResoniteQueuedCityObjectPreparer(
+            geometryPreparer,
+            texturePreparer);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
@@ -21,14 +19,14 @@ internal interface IResoniteQueuedCityObjectSender
 }
 
 internal sealed class ResoniteQueuedCityObjectSender(
-    IResoniteQueuedGeometryPreparer geometryPreparer,
-    IResoniteQueuedTexturePreparer texturePreparer,
+    IResoniteQueuedCityObjectPreparer cityObjectPreparer,
+    IResoniteQueuedSendFailurePolicy sendFailurePolicy,
     IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteQueuedCityObjectSender
 {
-    private readonly IResoniteQueuedGeometryPreparer geometryPreparer =
-        geometryPreparer ?? throw new ArgumentNullException(nameof(geometryPreparer));
-    private readonly IResoniteQueuedTexturePreparer texturePreparer =
-        texturePreparer ?? throw new ArgumentNullException(nameof(texturePreparer));
+    private readonly IResoniteQueuedCityObjectPreparer cityObjectPreparer =
+        cityObjectPreparer ?? throw new ArgumentNullException(nameof(cityObjectPreparer));
+    private readonly IResoniteQueuedSendFailurePolicy sendFailurePolicy =
+        sendFailurePolicy ?? throw new ArgumentNullException(nameof(sendFailurePolicy));
     private readonly IResonitePreparedCityObjectImporter preparedCityObjectImporter =
         preparedCityObjectImporter ?? throw new ArgumentNullException(nameof(preparedCityObjectImporter));
 
@@ -53,7 +51,7 @@ internal sealed class ResoniteQueuedCityObjectSender(
         try
         {
             PreparedCityObject preparedCityObject = await AwaitWithSlowCityObjectWarningAsync(
-                CreatePreparationTask(
+                cityObjectPreparer.PrepareAsync(
                     state,
                     routedClient,
                     queuedCityObject.CityObject,
@@ -85,7 +83,7 @@ internal sealed class ResoniteQueuedCityObjectSender(
         }
         catch (Exception exception)
         {
-            if (!IsRecoverableCityObjectSendFailure(exception))
+            if (!sendFailurePolicy.IsRecoverable(exception))
             {
                 throw;
             }
@@ -106,125 +104,11 @@ internal sealed class ResoniteQueuedCityObjectSender(
         }
     }
 
-    private Task<PreparedCityObject> CreatePreparationTask(
-        LiveSendRunState state,
-        IResoniteLinkClient routedClient,
-        ResoniteConstructionCityObject cityObject,
-        ResoniteLinkSendDiagnostics diagnostics,
-        Action<string>? progressReporter,
-        CancellationToken callerCancellationToken)
-    {
-        if (Interlocked.CompareExchange(ref state.Progress.FirstCityObjectPreparationStartedLogged, 1, 0) == 0)
-        {
-            ReportProgress(
-                progressReporter,
-                PlateauLog.Info(
-                    "live",
-                    $"City object preparation started after {state.Runtime.ElapsedTotalSeconds:F3}s: "
-                    + $"{cityObject.DisplayName} ({cityObject.PackageName}/{cityObject.SlotKey}) "
-                    + $"mesh='{cityObject.ActualMeshCode}'."));
-        }
-
-        CancellationToken processingCancellationToken = state.Runtime.ProcessingCancellationToken;
-        return PrepareCityObjectWithLinkedCancellationAsync(
-            state,
-            routedClient,
-            cityObject,
-            diagnostics,
-            progressReporter,
-            callerCancellationToken,
-            processingCancellationToken);
-    }
-
-    private async Task<PreparedCityObject> PrepareCityObjectWithLinkedCancellationAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient routedClient,
-        ResoniteConstructionCityObject cityObject,
-        ResoniteLinkSendDiagnostics diagnostics,
-        Action<string>? progressReporter,
-        CancellationToken callerCancellationToken,
-        CancellationToken processingCancellationToken)
-    {
-        using CancellationTokenSource linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
-            callerCancellationToken,
-            processingCancellationToken);
-        return await PrepareCityObjectAsync(
-            state,
-            routedClient,
-            cityObject,
-            diagnostics,
-            progressReporter,
-            linkedCancellation.Token);
-    }
-
-    private async Task<PreparedCityObject> PrepareCityObjectAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient routedClient,
-        ResoniteConstructionCityObject cityObject,
-        ResoniteLinkSendDiagnostics diagnostics,
-        Action<string>? progressReporter,
-        CancellationToken cancellationToken)
-    {
-        ResoniteQueuedGeometryPreparation geometryPreparation = geometryPreparer.Start(
-            cityObject,
-            cancellationToken);
-        Stopwatch stopwatch = Stopwatch.StartNew();
-        PreparedTextureReference[] preparedTextures = await texturePreparer.PrepareAsync(
-            state,
-            routedClient,
-            geometryPreparation.CityObject,
-            progressReporter,
-            cancellationToken);
-        PreparedQueuedGeometry preparedQueuedGeometry = await geometryPreparer.CompleteAsync(
-            geometryPreparation,
-            preparedTextures);
-        cityObject = preparedQueuedGeometry.CityObject;
-        PreparedConstructionGeometry preparedGeometry = preparedQueuedGeometry.Geometry;
-        stopwatch.Stop();
-        diagnostics.RecordPrepare(cityObject.PackageName, stopwatch.Elapsed.TotalSeconds);
-
-        if (Interlocked.CompareExchange(ref state.Progress.FirstPreparedCityObjectLogged, 1, 0) == 0)
-        {
-            ReportProgress(
-                progressReporter,
-                PlateauLog.Info(
-                    "live",
-                    $"First city object prepared in {stopwatch.Elapsed.TotalSeconds:F3}s "
-                    + $"after scene start {state.Runtime.ElapsedTotalSeconds:F3}s: "
-                    + $"{cityObject.DisplayName} "
-                    + $"(textures={preparedTextures.Length}, geometry={PreparedConstructionGeometryFormatter.Describe(preparedGeometry)})."));
-        }
-
-        return new PreparedCityObject(
-            cityObject,
-            preparedGeometry,
-            preparedTextures);
-    }
-
-    private static bool IsRecoverableCityObjectSendFailure(Exception exception)
-    {
-        return exception is ContinuableImportException
-            || FindResoniteLinkOperationException(exception) is { OperationName: "ImportMesh" or "ImportTexture" or "GetSlot" or "GetComponent" };
-    }
-
     private static Task<T> AwaitWithSlowCityObjectWarningAsync<T>(
         Task<T> operationTask,
         CancellationToken cancellationToken)
     {
         return operationTask.WaitAsync(cancellationToken);
-    }
-
-    private static ResoniteLinkOperationException? FindResoniteLinkOperationException(Exception exception)
-    {
-        for (Exception? current = exception; current is not null; current = current.InnerException)
-        {
-            if (current is ResoniteLinkOperationException operationException)
-            {
-                return operationException;
-            }
-        }
-
-        return null;
     }
 
     private static void ReportProgress(Action<string>? progressReporter, string message)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSenderFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSenderFactory.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Net.Http;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteQueuedCityObjectSenderFactory
+{
+    IResoniteQueuedCityObjectSender Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options);
+}
+
+internal sealed class ResoniteQueuedCityObjectSenderFactory(
+    IResoniteQueuedCityObjectPreparerFactory preparerFactory,
+    IResoniteQueuedSendFailurePolicy sendFailurePolicy,
+    IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteQueuedCityObjectSenderFactory
+{
+    public IResoniteQueuedCityObjectSender Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        return new ResoniteQueuedCityObjectSender(
+            preparerFactory.Create(terrainTextureAssetHttpClient, options),
+            sendFailurePolicy,
+            preparedCityObjectImporter);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedSendFailurePolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedSendFailurePolicy.cs
@@ -1,0 +1,35 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteQueuedSendFailurePolicy
+{
+    bool IsRecoverable(Exception exception);
+}
+
+internal sealed class ResoniteQueuedSendFailurePolicy : IResoniteQueuedSendFailurePolicy
+{
+    public bool IsRecoverable(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        return exception is ContinuableImportException
+            || FindResoniteLinkOperationException(exception) is { OperationName: "ImportMesh" or "ImportTexture" or "GetSlot" or "GetComponent" };
+    }
+
+    private static ResoniteLinkOperationException? FindResoniteLinkOperationException(Exception exception)
+    {
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is ResoniteLinkOperationException operationException)
+            {
+                return operationException;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -50,10 +50,12 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     {
         return new ResoniteQueuedCityObjectWorker(
             new ResoniteQueuedCityObjectSender(
-                new ResoniteQueuedGeometryPreparer(),
-                new ResoniteQueuedTexturePreparer(
-                    new TerrainTextureAssetGenerator(),
-                    new ResoniteDatasetLicenseWriter()),
+                new ResoniteQueuedCityObjectPreparer(
+                    new ResoniteQueuedGeometryPreparer(),
+                    new ResoniteQueuedTexturePreparer(
+                        new TerrainTextureAssetGenerator(),
+                        new ResoniteDatasetLicenseWriter())),
+                new ResoniteQueuedSendFailurePolicy(),
                 CreatePreparedCityObjectImporter(materialPlanning)));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -219,6 +219,39 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The created target is disposed via await using in this test.")]
+    public async Task AddResoniteLiveSendTargetServicesPreservesPreRegisteredQueuedSenderFactory()
+    {
+        RecordingQueuedCityObjectSenderFactory queuedSenderFactory = new();
+        ServiceProvider provider = new ServiceCollection()
+            .AddScoped<IResoniteQueuedCityObjectSenderFactory>(_ => queuedSenderFactory)
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+        using HttpClient terrainTextureAssetHttpClient = new();
+        ISceneSink target = scope.ServiceProvider
+            .GetRequiredService<IResoniteLiveSceneImportFactory>()
+            .CreateTarget(
+                new ResoniteLiveSceneImportTargetOptions(
+                    new Uri("ws://localhost:12345/"),
+                    1,
+                    EnableSendMetrics: false,
+                    MemoryProfile: ResoniteImportMemoryProfile.Large,
+                    EnableMeshBake: false,
+                    TerrainTileCacheRoot: "cache-root",
+                    DisableTerrainTileCache: true,
+                    ProgressReporter: null),
+                terrainTextureAssetHttpClient);
+        await using ResoniteLiveSceneImportTarget _ = Assert.IsType<ResoniteLiveSceneImportTarget>(target);
+
+        Assert.Equal(1, queuedSenderFactory.CreateCallCount);
+        Assert.Same(terrainTextureAssetHttpClient, queuedSenderFactory.LastHttpClient);
+        Assert.NotNull(queuedSenderFactory.LastOptions);
+        Assert.False(queuedSenderFactory.LastOptions!.EnableMeshBake);
+        Assert.Equal("cache-root", queuedSenderFactory.LastOptions.TerrainTileCacheRoot);
+    }
+
+    [Fact]
     public void AddResoniteLiveSendTargetServicesPreservesPreRegisteredNonDemSourceFileBakeEmitterFactory()
     {
         RecordingNonDemSourceFileBakeEmitterFactory sourceFileBakeEmitterFactory = new();
@@ -416,6 +449,45 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             _ = onBakedCityObject;
             cancellationToken.ThrowIfCancellationRequested();
             throw new NotSupportedException("This test only verifies DI override preservation during baker creation.");
+        }
+    }
+
+    private sealed class RecordingQueuedCityObjectSenderFactory : IResoniteQueuedCityObjectSenderFactory
+    {
+        public int CreateCallCount { get; private set; }
+
+        public HttpClient? LastHttpClient { get; private set; }
+
+        public ResoniteLiveSceneImportTargetOptions? LastOptions { get; private set; }
+
+        public IResoniteQueuedCityObjectSender Create(
+            HttpClient terrainTextureAssetHttpClient,
+            ResoniteLiveSceneImportTargetOptions options)
+        {
+            CreateCallCount++;
+            LastHttpClient = terrainTextureAssetHttpClient;
+            LastOptions = options;
+            return new RecordingQueuedCityObjectSender();
+        }
+    }
+
+    private sealed class RecordingQueuedCityObjectSender : IResoniteQueuedCityObjectSender
+    {
+        public Task SendAsync(
+            LiveSendRunState state,
+            IResoniteLinkClient routedClient,
+            LiveSendQueuedCityObject queuedCityObject,
+            ResoniteLinkSendDiagnostics diagnostics,
+            Action<string>? progressReporter,
+            CancellationToken cancellationToken)
+        {
+            _ = state;
+            _ = routedClient;
+            _ = queuedCityObject;
+            _ = diagnostics;
+            _ = progressReporter;
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new NotSupportedException("This test only verifies DI override preservation during target creation.");
         }
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -53,10 +53,12 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     {
         return new ResoniteQueuedCityObjectWorker(
             new ResoniteQueuedCityObjectSender(
-                new ResoniteQueuedGeometryPreparer(),
-                new ResoniteQueuedTexturePreparer(
-                    new TerrainTextureAssetGenerator(),
-                    new ResoniteDatasetLicenseWriter()),
+                new ResoniteQueuedCityObjectPreparer(
+                    new ResoniteQueuedGeometryPreparer(),
+                    new ResoniteQueuedTexturePreparer(
+                        new TerrainTextureAssetGenerator(),
+                        new ResoniteDatasetLicenseWriter())),
+                new ResoniteQueuedSendFailurePolicy(),
                 CreatePreparedCityObjectImporter(materialPlanning)));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -325,10 +325,12 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
             new ResoniteQueuedCityObjectSender(
-                new ResoniteQueuedGeometryPreparer(),
-                new ResoniteQueuedTexturePreparer(
-                    terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
-                    new ResoniteDatasetLicenseWriter()),
+                new ResoniteQueuedCityObjectPreparer(
+                    new ResoniteQueuedGeometryPreparer(),
+                    new ResoniteQueuedTexturePreparer(
+                        terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
+                        new ResoniteDatasetLicenseWriter())),
+                new ResoniteQueuedSendFailurePolicy(),
                 new ResonitePreparedCityObjectImporter(
                     new ResonitePreparedCityObjectAssetPlanner(
                         new ResonitePreparedTextureUploader(new ResoniteSharedTerrainTextureAssetWriter()),


### PR DESCRIPTION
## Summary
- move queued city-object preparation orchestration into a dedicated service
- isolate recoverable send failure classification from the sender
- keep the sender focused on attempt/success/failure accounting, importer delegation, progress logging, and lease cleanup

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false