### PR TITLE
Extract queued sender composition factories

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -45,9 +45,7 @@ internal interface IResoniteLiveSendWorkerLauncherFactory
 }
 
 internal sealed class ResoniteLiveSendWorkerLauncherFactory(
-    ITerrainTextureAssetGeneratorFactory terrainTextureAssetGeneratorFactory,
-    IResoniteDatasetLicenseWriter datasetLicenseWriter,
-    IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteLiveSendWorkerLauncherFactory
+    IResoniteQueuedCityObjectSenderFactory queuedCityObjectSenderFactory) : IResoniteLiveSendWorkerLauncherFactory
 {
     public IResoniteLiveSendWorkerLauncher Create(
         HttpClient terrainTextureAssetHttpClient,
@@ -56,16 +54,8 @@ internal sealed class ResoniteLiveSendWorkerLauncherFactory(
         ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
         ArgumentNullException.ThrowIfNull(options);
 
-        ResoniteQueuedTexturePreparer texturePreparer = new(
-            terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
-            datasetLicenseWriter);
-        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
-            new ResoniteQueuedCityObjectPreparer(
-                new ResoniteQueuedGeometryPreparer(),
-                texturePreparer),
-            new ResoniteQueuedSendFailurePolicy(),
-            preparedCityObjectImporter);
-        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
+        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
+            queuedCityObjectSenderFactory.Create(terrainTextureAssetHttpClient, options));
         return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -35,6 +35,10 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResonitePreparedTextureUploader, ResonitePreparedTextureUploader>();
         services.TryAddScoped<IResonitePreparedCityObjectAssetPlanner, ResonitePreparedCityObjectAssetPlanner>();
         services.TryAddScoped<IResonitePreparedCityObjectImporter, ResonitePreparedCityObjectImporter>();
+        services.TryAddScoped<IResoniteQueuedGeometryPreparer, ResoniteQueuedGeometryPreparer>();
+        services.TryAddScoped<IResoniteQueuedSendFailurePolicy, ResoniteQueuedSendFailurePolicy>();
+        services.TryAddScoped<IResoniteQueuedCityObjectPreparerFactory, ResoniteQueuedCityObjectPreparerFactory>();
+        services.TryAddScoped<IResoniteQueuedCityObjectSenderFactory, ResoniteQueuedCityObjectSenderFactory>();
         services.TryAddScoped<IResoniteQueuedCityObjectEnqueuer, ResoniteQueuedCityObjectEnqueuer>();
         services.TryAddScoped<IResoniteLiveSendFinalizer, ResoniteLiveSendFinalizer>();
         services.TryAddScoped<IResoniteLiveSendQueue, ResoniteLiveSendQueue>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparerFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparerFactory.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Net.Http;
+
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteQueuedCityObjectPreparerFactory
+{
+    IResoniteQueuedCityObjectPreparer Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options);
+}
+
+internal sealed class ResoniteQueuedCityObjectPreparerFactory(
+    IResoniteQueuedGeometryPreparer geometryPreparer,
+    ITerrainTextureAssetGeneratorFactory terrainTextureAssetGeneratorFactory,
+    IResoniteDatasetLicenseWriter datasetLicenseWriter) : IResoniteQueuedCityObjectPreparerFactory
+{
+    public IResoniteQueuedCityObjectPreparer Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        ResoniteQueuedTexturePreparer texturePreparer = new(
+            terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
+            datasetLicenseWriter);
+        return new ResoniteQueuedCityObjectPreparer(
+            geometryPreparer,
+            texturePreparer);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSenderFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSenderFactory.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Net.Http;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteQueuedCityObjectSenderFactory
+{
+    IResoniteQueuedCityObjectSender Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options);
+}
+
+internal sealed class ResoniteQueuedCityObjectSenderFactory(
+    IResoniteQueuedCityObjectPreparerFactory preparerFactory,
+    IResoniteQueuedSendFailurePolicy sendFailurePolicy,
+    IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteQueuedCityObjectSenderFactory
+{
+    public IResoniteQueuedCityObjectSender Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        return new ResoniteQueuedCityObjectSender(
+            preparerFactory.Create(terrainTextureAssetHttpClient, options),
+            sendFailurePolicy,
+            preparedCityObjectImporter);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -219,6 +219,39 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The created target is disposed via await using in this test.")]
+    public async Task AddResoniteLiveSendTargetServicesPreservesPreRegisteredQueuedSenderFactory()
+    {
+        RecordingQueuedCityObjectSenderFactory queuedSenderFactory = new();
+        ServiceProvider provider = new ServiceCollection()
+            .AddScoped<IResoniteQueuedCityObjectSenderFactory>(_ => queuedSenderFactory)
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+        using HttpClient terrainTextureAssetHttpClient = new();
+        ISceneSink target = scope.ServiceProvider
+            .GetRequiredService<IResoniteLiveSceneImportFactory>()
+            .CreateTarget(
+                new ResoniteLiveSceneImportTargetOptions(
+                    new Uri("ws://localhost:12345/"),
+                    1,
+                    EnableSendMetrics: false,
+                    MemoryProfile: ResoniteImportMemoryProfile.Large,
+                    EnableMeshBake: false,
+                    TerrainTileCacheRoot: "cache-root",
+                    DisableTerrainTileCache: true,
+                    ProgressReporter: null),
+                terrainTextureAssetHttpClient);
+        await using ResoniteLiveSceneImportTarget _ = Assert.IsType<ResoniteLiveSceneImportTarget>(target);
+
+        Assert.Equal(1, queuedSenderFactory.CreateCallCount);
+        Assert.Same(terrainTextureAssetHttpClient, queuedSenderFactory.LastHttpClient);
+        Assert.NotNull(queuedSenderFactory.LastOptions);
+        Assert.False(queuedSenderFactory.LastOptions!.EnableMeshBake);
+        Assert.Equal("cache-root", queuedSenderFactory.LastOptions.TerrainTileCacheRoot);
+    }
+
+    [Fact]
     public void AddResoniteLiveSendTargetServicesPreservesPreRegisteredNonDemSourceFileBakeEmitterFactory()
     {
         RecordingNonDemSourceFileBakeEmitterFactory sourceFileBakeEmitterFactory = new();
@@ -416,6 +449,45 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             _ = onBakedCityObject;
             cancellationToken.ThrowIfCancellationRequested();
             throw new NotSupportedException("This test only verifies DI override preservation during baker creation.");
+        }
+    }
+
+    private sealed class RecordingQueuedCityObjectSenderFactory : IResoniteQueuedCityObjectSenderFactory
+    {
+        public int CreateCallCount { get; private set; }
+
+        public HttpClient? LastHttpClient { get; private set; }
+
+        public ResoniteLiveSceneImportTargetOptions? LastOptions { get; private set; }
+
+        public IResoniteQueuedCityObjectSender Create(
+            HttpClient terrainTextureAssetHttpClient,
+            ResoniteLiveSceneImportTargetOptions options)
+        {
+            CreateCallCount++;
+            LastHttpClient = terrainTextureAssetHttpClient;
+            LastOptions = options;
+            return new RecordingQueuedCityObjectSender();
+        }
+    }
+
+    private sealed class RecordingQueuedCityObjectSender : IResoniteQueuedCityObjectSender
+    {
+        public Task SendAsync(
+            LiveSendRunState state,
+            IResoniteLinkClient routedClient,
+            LiveSendQueuedCityObject queuedCityObject,
+            ResoniteLinkSendDiagnostics diagnostics,
+            Action<string>? progressReporter,
+            CancellationToken cancellationToken)
+        {
+            _ = state;
+            _ = routedClient;
+            _ = queuedCityObject;
+            _ = diagnostics;
+            _ = progressReporter;
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new NotSupportedException("This test only verifies DI override preservation during target creation.");
         }
     }
 


### PR DESCRIPTION
## Summary
- move queued sender and preparer option-bound construction behind dedicated factories
- register queued geometry preparer, send failure policy, and queued sender/preparer factories with DI
- add a DI override test that proves queued sender composition stays replaceable during target creation

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false