### PR TITLE
Extract canonical dump sink composition

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -191,6 +191,7 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
     {
         ArgumentNullException.ThrowIfNull(options);
 
+        string canonicalSceneDumpPath = GetRequiredCanonicalSceneDumpPath(options.CanonicalSceneDumpPath);
         SceneSinkRecordingClient recordingClient = new();
         try
         {
@@ -201,13 +202,23 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
                 progressReporter);
             return new ScopedSceneSink(
                 scope,
-                new CanonicalSceneDumpSink(dumpTarget, recordingClient, options.CanonicalSceneDumpPath!));
+                new CanonicalSceneDumpSink(dumpTarget, recordingClient, canonicalSceneDumpPath));
         }
         catch
         {
             recordingClient.Dispose();
             throw;
         }
+    }
+
+    private static string GetRequiredCanonicalSceneDumpPath(string? canonicalSceneDumpPath)
+    {
+        if (string.IsNullOrWhiteSpace(canonicalSceneDumpPath))
+        {
+            throw new ArgumentException("Canonical scene dump path must be provided.", nameof(canonicalSceneDumpPath));
+        }
+
+        return canonicalSceneDumpPath;
     }
 
     private static ResoniteLiveSceneImportTarget CreateCanonicalDumpTarget(

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -81,7 +81,7 @@ internal interface ISceneSinkFactory
 internal interface ICanonicalSceneDumpSinkFactory
 {
     ISceneSink Create(
-        AsyncServiceScope scope,
+        IServiceProvider serviceProvider,
         ImportCommandOptions options,
         Action<string>? progressReporter);
 }
@@ -128,7 +128,8 @@ internal sealed class DefaultPlateauDatasetSourceResolverFactory(
 
 internal sealed class DefaultSceneSinkFactory(
     IHttpClientFactory httpClientFactory,
-    IServiceScopeFactory serviceScopeFactory)
+    IServiceScopeFactory serviceScopeFactory,
+    ICanonicalSceneDumpSinkFactory canonicalSceneDumpSinkFactory)
     : ISceneSinkFactory
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
@@ -144,9 +145,11 @@ internal sealed class DefaultSceneSinkFactory(
         {
             if (!string.IsNullOrWhiteSpace(options.CanonicalSceneDumpPath))
             {
-                return scope.ServiceProvider
-                    .GetRequiredService<ICanonicalSceneDumpSinkFactory>()
-                    .Create(scope, options, progressReporter);
+                ISceneSink canonicalSceneDumpSink = canonicalSceneDumpSinkFactory.Create(
+                    scope.ServiceProvider,
+                    options,
+                    progressReporter);
+                return new ScopedSceneSink(scope, canonicalSceneDumpSink);
             }
 
             ResoniteLiveSceneImportTargetOptions targetOptions = new(
@@ -183,12 +186,13 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Reliability",
         "CA2000:Dispose objects before losing scope",
-        Justification = "The returned ScopedSceneSink owns the canonical dump sink, target, recording client, and associated service scope.")]
+        Justification = "The returned CanonicalSceneDumpSink owns the target and recording client for the import run.")]
     public ISceneSink Create(
-        AsyncServiceScope scope,
+        IServiceProvider serviceProvider,
         ImportCommandOptions options,
         Action<string>? progressReporter)
     {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
         ArgumentNullException.ThrowIfNull(options);
 
         string canonicalSceneDumpPath = GetRequiredCanonicalSceneDumpPath(options.CanonicalSceneDumpPath);
@@ -196,13 +200,11 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
         try
         {
             ResoniteLiveSceneImportTarget dumpTarget = CreateCanonicalDumpTarget(
-                scope.ServiceProvider,
+                serviceProvider,
                 recordingClient,
                 options,
                 progressReporter);
-            return new ScopedSceneSink(
-                scope,
-                new CanonicalSceneDumpSink(dumpTarget, recordingClient, canonicalSceneDumpPath));
+            return new CanonicalSceneDumpSink(dumpTarget, recordingClient, canonicalSceneDumpPath);
         }
         catch
         {

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -51,6 +51,7 @@ internal static class CliServiceCollectionExtensions
         services.AddSingleton<DatasetInspectionService>();
         services.AddSingleton<IImportServiceFactory, DefaultImportServiceFactory>();
         services.AddSingleton<IPlateauDatasetSourceResolverFactory, DefaultPlateauDatasetSourceResolverFactory>();
+        services.AddSingleton<ICanonicalSceneDumpSinkFactory, DefaultCanonicalSceneDumpSinkFactory>();
         services.AddSingleton<ISceneSinkFactory, DefaultSceneSinkFactory>();
         services.AddSingleton<CliApplication>(_ => new CliApplication(
             standardOutput,
@@ -75,6 +76,14 @@ internal interface IPlateauDatasetSourceResolverFactory
 internal interface ISceneSinkFactory
 {
     ISceneSink Create(ImportCommandOptions options, Action<string>? progressReporter);
+}
+
+internal interface ICanonicalSceneDumpSinkFactory
+{
+    ISceneSink Create(
+        AsyncServiceScope scope,
+        ImportCommandOptions options,
+        Action<string>? progressReporter);
 }
 
 internal sealed class DefaultImportServiceFactory(
@@ -135,23 +144,9 @@ internal sealed class DefaultSceneSinkFactory(
         {
             if (!string.IsNullOrWhiteSpace(options.CanonicalSceneDumpPath))
             {
-                SceneSinkRecordingClient recordingClient = new();
-                try
-                {
-                    ResoniteLiveSceneImportTarget dumpTarget = CreateCanonicalDumpTarget(
-                        scope,
-                        recordingClient,
-                        options,
-                        progressReporter);
-                    return new ScopedSceneSink(
-                        scope,
-                        new CanonicalSceneDumpSink(dumpTarget, recordingClient, options.CanonicalSceneDumpPath));
-                }
-                catch
-                {
-                    recordingClient.Dispose();
-                    throw;
-                }
+                return scope.ServiceProvider
+                    .GetRequiredService<ICanonicalSceneDumpSinkFactory>()
+                    .Create(scope, options, progressReporter);
             }
 
             ResoniteLiveSceneImportTargetOptions targetOptions = new(
@@ -181,9 +176,42 @@ internal sealed class DefaultSceneSinkFactory(
             throw;
         }
     }
+}
+
+internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDumpSinkFactory
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "The returned ScopedSceneSink owns the canonical dump sink, target, recording client, and associated service scope.")]
+    public ISceneSink Create(
+        AsyncServiceScope scope,
+        ImportCommandOptions options,
+        Action<string>? progressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        SceneSinkRecordingClient recordingClient = new();
+        try
+        {
+            ResoniteLiveSceneImportTarget dumpTarget = CreateCanonicalDumpTarget(
+                scope.ServiceProvider,
+                recordingClient,
+                options,
+                progressReporter);
+            return new ScopedSceneSink(
+                scope,
+                new CanonicalSceneDumpSink(dumpTarget, recordingClient, options.CanonicalSceneDumpPath!));
+        }
+        catch
+        {
+            recordingClient.Dispose();
+            throw;
+        }
+    }
 
     private static ResoniteLiveSceneImportTarget CreateCanonicalDumpTarget(
-        AsyncServiceScope scope,
+        IServiceProvider serviceProvider,
         SceneSinkRecordingClient recordingClient,
         ImportCommandOptions options,
         Action<string>? progressReporter)
@@ -203,7 +231,6 @@ internal sealed class DefaultSceneSinkFactory(
             DisableTerrainTileCache: true,
             progressReporter);
 
-        IServiceProvider serviceProvider = scope.ServiceProvider;
         ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
         IResoniteQueuedCityObjectEnqueuer queuedCityObjectEnqueuer = new ResoniteQueuedCityObjectEnqueuer();
         ResoniteLiveSendQueue queue = new(


### PR DESCRIPTION
## Summary
- move canonical scene dump sink composition out of `DefaultSceneSinkFactory`
- keep the fake-link recording client, deterministic terrain texture generator, and scoped ownership contract intact
- leave normal live-send target creation on the existing factory path

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false