### PR TITLE
Extract queued city object lane processor

### DIFF
--- a/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
@@ -1,6 +1,5 @@
 using System;
 
-using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 using PlateauResoniteLink.Targets.Resonite.Diagnostics;
 using PlateauResoniteLink.Targets.Resonite.Execution;
@@ -37,12 +36,7 @@ internal sealed class DefaultCanonicalDumpLiveSceneImportTargetFactory(
             new Uri("ws://localhost:1/"),
             ConnectionCount: 1,
             EnableSendMetrics: false,
-            options.MemoryProfile switch
-            {
-                PlateauImportMemoryProfile.Small => ResoniteImportMemoryProfile.Small,
-                PlateauImportMemoryProfile.Large => ResoniteImportMemoryProfile.Large,
-                _ => throw new ArgumentOutOfRangeException(nameof(options), options.MemoryProfile, "Unsupported memory profile."),
-            },
+            CliResoniteTargetOptions.MapMemoryProfile(options.MemoryProfile, nameof(options)),
             options.EnableMeshBake,
             TerrainTileCacheRoot: null,
             DisableTerrainTileCache: true,

--- a/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
@@ -22,8 +22,12 @@ internal sealed class DefaultCanonicalDumpLiveSceneImportTargetFactory(
     IResoniteLiveSendRunPlanInitializer runPlanInitializer,
     IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendSetupInitializer setupInitializer,
-    IResoniteLiveSendRunActivatorFactory runActivatorFactory) : ICanonicalDumpLiveSceneImportTargetFactory
+    IResoniteLiveSendRunActivatorFactory runActivatorFactory,
+    IResoniteLiveSendContextFactory contextFactory) : ICanonicalDumpLiveSceneImportTargetFactory
 {
+    private readonly IResoniteLiveSendContextFactory contextFactory =
+        contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+
     public ResoniteLiveSceneImportTarget Create(
         SceneSinkRecordingClient recordingClient,
         ImportCommandOptions options,
@@ -36,7 +40,7 @@ internal sealed class DefaultCanonicalDumpLiveSceneImportTargetFactory(
             new Uri("ws://localhost:1/"),
             ConnectionCount: 1,
             EnableSendMetrics: false,
-            CliResoniteTargetOptions.MapMemoryProfile(options.MemoryProfile, nameof(options)),
+            CliResoniteTargetOptions.MapMemoryProfile(options.MemoryProfile, nameof(options.MemoryProfile)),
             options.EnableMeshBake,
             TerrainTileCacheRoot: null,
             DisableTerrainTileCache: true,
@@ -55,7 +59,7 @@ internal sealed class DefaultCanonicalDumpLiveSceneImportTargetFactory(
                     connectionInitializer,
                     setupInitializer,
                     runActivatorFactory.Create(workerLauncher)),
-                new ResoniteLiveSendContextFactory(),
+                contextFactory,
                 queue));
     }
 

--- a/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
@@ -55,6 +55,7 @@ internal sealed class DefaultCanonicalDumpLiveSceneImportTargetFactory(
                     connectionInitializer,
                     setupInitializer,
                     runActivatorFactory.Create(workerLauncher)),
+                new ResoniteLiveSendContextFactory(),
                 queue));
     }
 

--- a/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
@@ -1,0 +1,89 @@
+using System;
+
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Targets.Resonite.Diagnostics;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Cli;
+
+internal interface ICanonicalDumpLiveSceneImportTargetFactory
+{
+    ResoniteLiveSceneImportTarget Create(
+        SceneSinkRecordingClient recordingClient,
+        ImportCommandOptions options,
+        Action<string>? progressReporter);
+}
+
+internal sealed class DefaultCanonicalDumpLiveSceneImportTargetFactory(
+    IResoniteDatasetLicenseWriter datasetLicenseWriter,
+    IResonitePreparedCityObjectImporter preparedCityObjectImporter,
+    IResoniteLiveSendStartRequestFactory startRequestFactory,
+    IResoniteLiveSendConnectionInitializer connectionInitializer,
+    IResoniteLiveSendSetupInitializer setupInitializer,
+    ILiveSendRunPlanFactory runPlanFactory,
+    IResoniteLiveSendRunActivatorFactory runActivatorFactory) : ICanonicalDumpLiveSceneImportTargetFactory
+{
+    public ResoniteLiveSceneImportTarget Create(
+        SceneSinkRecordingClient recordingClient,
+        ImportCommandOptions options,
+        Action<string>? progressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(recordingClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        ResoniteLiveSceneImportTargetOptions targetOptions = new(
+            new Uri("ws://localhost:1/"),
+            ConnectionCount: 1,
+            EnableSendMetrics: false,
+            options.MemoryProfile switch
+            {
+                PlateauImportMemoryProfile.Small => ResoniteImportMemoryProfile.Small,
+                PlateauImportMemoryProfile.Large => ResoniteImportMemoryProfile.Large,
+                _ => throw new ArgumentOutOfRangeException(nameof(options), options.MemoryProfile, "Unsupported memory profile."),
+            },
+            options.EnableMeshBake,
+            TerrainTileCacheRoot: null,
+            DisableTerrainTileCache: true,
+            progressReporter);
+
+        ResoniteLiveSendQueue queue = CreateQueue();
+        ResoniteLiveSendWorkerLauncher workerLauncher = CreateWorkerLauncher();
+        return new ResoniteLiveSceneImportTarget(
+            targetOptions,
+            new ResoniteLiveSceneImportDependencies(
+                new SingleRecordingClientSession(recordingClient),
+                ResoniteLinkSendDiagnostics.Disabled,
+                startRequestFactory,
+                new ResoniteLiveSendRunStarter(
+                    connectionInitializer,
+                    setupInitializer,
+                    runPlanFactory,
+                    runActivatorFactory.Create(workerLauncher)),
+                queue));
+    }
+
+    private static ResoniteLiveSendQueue CreateQueue()
+    {
+        IResoniteQueuedCityObjectEnqueuer queuedCityObjectEnqueuer = new ResoniteQueuedCityObjectEnqueuer();
+        return new ResoniteLiveSendQueue(
+            queuedCityObjectEnqueuer,
+            new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
+    }
+
+    private ResoniteLiveSendWorkerLauncher CreateWorkerLauncher()
+    {
+        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
+            new ResoniteQueuedCityObjectLaneProcessor(
+                new ResoniteQueuedCityObjectSender(
+                    new ResoniteQueuedCityObjectPreparer(
+                        new ResoniteQueuedGeometryPreparer(),
+                        new ResoniteQueuedTexturePreparer(
+                            new DeterministicTerrainTextureAssetGenerator(),
+                            datasetLicenseWriter)),
+                    new ResoniteQueuedSendFailurePolicy(),
+                    preparedCityObjectImporter)));
+        return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);
+    }
+}

--- a/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
@@ -19,9 +19,9 @@ internal sealed class DefaultCanonicalDumpLiveSceneImportTargetFactory(
     IResoniteDatasetLicenseWriter datasetLicenseWriter,
     IResonitePreparedCityObjectImporter preparedCityObjectImporter,
     IResoniteLiveSendStartRequestFactory startRequestFactory,
+    IResoniteLiveSendRunPlanInitializer runPlanInitializer,
     IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendSetupInitializer setupInitializer,
-    ILiveSendRunPlanFactory runPlanFactory,
     IResoniteLiveSendRunActivatorFactory runActivatorFactory) : ICanonicalDumpLiveSceneImportTargetFactory
 {
     public ResoniteLiveSceneImportTarget Create(
@@ -51,9 +51,9 @@ internal sealed class DefaultCanonicalDumpLiveSceneImportTargetFactory(
                 ResoniteLinkSendDiagnostics.Disabled,
                 startRequestFactory,
                 new ResoniteLiveSendRunStarter(
+                    runPlanInitializer,
                     connectionInitializer,
                     setupInitializer,
-                    runPlanFactory,
                     runActivatorFactory.Create(workerLauncher)),
                 queue));
     }

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -254,6 +254,7 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
                 serviceProvider.GetRequiredService<IResoniteLiveSendStartRequestFactory>(),
                 new ResoniteLiveSendRunStarter(
                     serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
+                    serviceProvider.GetRequiredService<IResoniteLiveSendConnectionInitializer>(),
                     serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupPreparer>(),
                     serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupCachePrimer>(),
                     serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -253,14 +253,11 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
                 diagnostics,
                 serviceProvider.GetRequiredService<IResoniteLiveSendStartRequestFactory>(),
                 new ResoniteLiveSendRunStarter(
-                    serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
                     serviceProvider.GetRequiredService<IResoniteLiveSendConnectionInitializer>(),
-                    serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupPreparer>(),
-                    serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupCachePrimer>(),
+                    serviceProvider.GetRequiredService<IResoniteLiveSendSetupInitializer>(),
                     serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
                     serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
-                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),
-                    serviceProvider.GetRequiredService<IResoniteSharedSlotIndexFactory>()),
+                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker)),
                 queue));
     }
 }

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -255,6 +255,7 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
                 new ResoniteLiveSendRunStarter(
                     serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
                     serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupPreparer>(),
+                    serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupCachePrimer>(),
                     serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
                     serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
                     new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -237,14 +237,15 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
             queuedCityObjectEnqueuer,
             new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
-            new ResoniteQueuedCityObjectSender(
-                new ResoniteQueuedCityObjectPreparer(
-                    new ResoniteQueuedGeometryPreparer(),
-                    new ResoniteQueuedTexturePreparer(
-                        new DeterministicTerrainTextureAssetGenerator(),
-                        serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>())),
-                new ResoniteQueuedSendFailurePolicy(),
-                serviceProvider.GetRequiredService<IResonitePreparedCityObjectImporter>()));
+            new ResoniteQueuedCityObjectLaneProcessor(
+                new ResoniteQueuedCityObjectSender(
+                    new ResoniteQueuedCityObjectPreparer(
+                        new ResoniteQueuedGeometryPreparer(),
+                        new ResoniteQueuedTexturePreparer(
+                            new DeterministicTerrainTextureAssetGenerator(),
+                            serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>())),
+                    new ResoniteQueuedSendFailurePolicy(),
+                    serviceProvider.GetRequiredService<IResonitePreparedCityObjectImporter>())));
         return new ResoniteLiveSceneImportTarget(
             targetOptions,
             new ResoniteLiveSceneImportDependencies(

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -256,8 +256,9 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
                     serviceProvider.GetRequiredService<IResoniteLiveSendConnectionInitializer>(),
                     serviceProvider.GetRequiredService<IResoniteLiveSendSetupInitializer>(),
                     serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
-                    serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
-                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker)),
+                    new ResoniteLiveSendRunActivator(
+                        serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
+                        new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker))),
                 queue));
     }
 }

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -151,7 +151,7 @@ internal sealed class DefaultSceneSinkFactory(
                 options.ResoniteLinkUri!,
                 options.ResoniteLinkConnectionCount,
                 options.EnableSendMetrics,
-                CliResoniteTargetOptions.MapMemoryProfile(options.MemoryProfile, nameof(options)),
+                CliResoniteTargetOptions.MapMemoryProfile(options.MemoryProfile, nameof(options.MemoryProfile)),
                 options.EnableMeshBake,
                 options.TerrainTileCacheRoot,
                 options.DisableTerrainTileCache,

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -12,9 +12,7 @@ using Microsoft.Extensions.Logging;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
-using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Targets.Resonite.Diagnostics;
-using PlateauResoniteLink.Transport.ResoniteLink;
 namespace PlateauResoniteLink.Cli;
 
 internal static class CliHostFactory
@@ -51,7 +49,8 @@ internal static class CliServiceCollectionExtensions
         services.AddSingleton<DatasetInspectionService>();
         services.AddSingleton<IImportServiceFactory, DefaultImportServiceFactory>();
         services.AddSingleton<IPlateauDatasetSourceResolverFactory, DefaultPlateauDatasetSourceResolverFactory>();
-        services.AddSingleton<ICanonicalSceneDumpSinkFactory, DefaultCanonicalSceneDumpSinkFactory>();
+        services.AddScoped<ICanonicalDumpLiveSceneImportTargetFactory, DefaultCanonicalDumpLiveSceneImportTargetFactory>();
+        services.AddScoped<ICanonicalSceneDumpSinkFactory, DefaultCanonicalSceneDumpSinkFactory>();
         services.AddSingleton<ISceneSinkFactory, DefaultSceneSinkFactory>();
         services.AddSingleton<CliApplication>(_ => new CliApplication(
             standardOutput,
@@ -178,7 +177,8 @@ internal sealed class DefaultSceneSinkFactory(
     }
 }
 
-internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDumpSinkFactory
+internal sealed class DefaultCanonicalSceneDumpSinkFactory(
+    ICanonicalDumpLiveSceneImportTargetFactory targetFactory) : ICanonicalSceneDumpSinkFactory
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Reliability",
@@ -194,8 +194,7 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
         SceneSinkRecordingClient recordingClient = new();
         try
         {
-            ResoniteLiveSceneImportTarget dumpTarget = CreateCanonicalDumpTarget(
-                scope.ServiceProvider,
+            ResoniteLiveSceneImportTarget dumpTarget = targetFactory.Create(
                 recordingClient,
                 options,
                 progressReporter);
@@ -208,58 +207,6 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
             recordingClient.Dispose();
             throw;
         }
-    }
-
-    private static ResoniteLiveSceneImportTarget CreateCanonicalDumpTarget(
-        IServiceProvider serviceProvider,
-        SceneSinkRecordingClient recordingClient,
-        ImportCommandOptions options,
-        Action<string>? progressReporter)
-    {
-        ResoniteLiveSceneImportTargetOptions targetOptions = new(
-            new Uri("ws://localhost:1/"),
-            ConnectionCount: 1,
-            EnableSendMetrics: false,
-            options.MemoryProfile switch
-            {
-                PlateauImportMemoryProfile.Small => ResoniteImportMemoryProfile.Small,
-                PlateauImportMemoryProfile.Large => ResoniteImportMemoryProfile.Large,
-                _ => throw new ArgumentOutOfRangeException(nameof(options), options.MemoryProfile, "Unsupported memory profile."),
-            },
-            options.EnableMeshBake,
-            TerrainTileCacheRoot: null,
-            DisableTerrainTileCache: true,
-            progressReporter);
-
-        ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
-        IResoniteQueuedCityObjectEnqueuer queuedCityObjectEnqueuer = new ResoniteQueuedCityObjectEnqueuer();
-        ResoniteLiveSendQueue queue = new(
-            queuedCityObjectEnqueuer,
-            new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
-        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
-            new ResoniteQueuedCityObjectLaneProcessor(
-                new ResoniteQueuedCityObjectSender(
-                    new ResoniteQueuedCityObjectPreparer(
-                        new ResoniteQueuedGeometryPreparer(),
-                        new ResoniteQueuedTexturePreparer(
-                            new DeterministicTerrainTextureAssetGenerator(),
-                            serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>())),
-                    new ResoniteQueuedSendFailurePolicy(),
-                    serviceProvider.GetRequiredService<IResonitePreparedCityObjectImporter>())));
-        return new ResoniteLiveSceneImportTarget(
-            targetOptions,
-            new ResoniteLiveSceneImportDependencies(
-                new SingleRecordingClientSession(recordingClient),
-                diagnostics,
-                serviceProvider.GetRequiredService<IResoniteLiveSendStartRequestFactory>(),
-                new ResoniteLiveSendRunStarter(
-                    serviceProvider.GetRequiredService<IResoniteLiveSendConnectionInitializer>(),
-                    serviceProvider.GetRequiredService<IResoniteLiveSendSetupInitializer>(),
-                    serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
-                    new ResoniteLiveSendRunActivator(
-                        serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
-                        new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker))),
-                queue));
     }
 }
 

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 using PlateauResoniteLink.Targets.Resonite.Diagnostics;
 namespace PlateauResoniteLink.Cli;
@@ -152,12 +151,7 @@ internal sealed class DefaultSceneSinkFactory(
                 options.ResoniteLinkUri!,
                 options.ResoniteLinkConnectionCount,
                 options.EnableSendMetrics,
-                options.MemoryProfile switch
-                {
-                    PlateauImportMemoryProfile.Small => ResoniteImportMemoryProfile.Small,
-                    PlateauImportMemoryProfile.Large => ResoniteImportMemoryProfile.Large,
-                    _ => throw new ArgumentOutOfRangeException(nameof(options), options.MemoryProfile, "Unsupported memory profile."),
-                },
+                CliResoniteTargetOptions.MapMemoryProfile(options.MemoryProfile, nameof(options)),
                 options.EnableMeshBake,
                 options.TerrainTileCacheRoot,
                 options.DisableTerrainTileCache,

--- a/src/PlateauResoniteLink.Cli/CliResoniteTargetOptions.cs
+++ b/src/PlateauResoniteLink.Cli/CliResoniteTargetOptions.cs
@@ -1,0 +1,21 @@
+using System;
+
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Cli;
+
+internal static class CliResoniteTargetOptions
+{
+    public static ResoniteImportMemoryProfile MapMemoryProfile(
+        PlateauImportMemoryProfile memoryProfile,
+        string parameterName)
+    {
+        return memoryProfile switch
+        {
+            PlateauImportMemoryProfile.Small => ResoniteImportMemoryProfile.Small,
+            PlateauImportMemoryProfile.Large => ResoniteImportMemoryProfile.Large,
+            _ => throw new ArgumentOutOfRangeException(parameterName, memoryProfile, "Unsupported memory profile."),
+        };
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunStartContracts.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunStartContracts.cs
@@ -1,0 +1,23 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record LiveSendRunStartRequest(
+    ResoniteSceneSetupInfo SetupInfo,
+    string WorkRoot,
+    CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials,
+    PlateauImportRequest NormalizedRequest,
+    ResoniteLocalOrigin RequestLocalOrigin,
+    ResoniteImportMemoryProfile MemoryProfile,
+    int ConnectionCount,
+    bool MeshBakeEnabled);
+
+internal sealed record LiveSendRunStartContext(
+    Uri Endpoint,
+    ILiveSendClientSession ClientSession,
+    ResoniteLinkSendDiagnostics Diagnostics,
+    Action<string>? ProgressReporter);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupCachePrimer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupCachePrimer.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Application.Logging;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteCommonMaterialSetupCachePrimer
+{
+    void Prime(
+        ResoniteSceneSetupState setupState,
+        CommonMaterialAssetCache materials,
+        LiveSendProgressSink progress,
+        Action<string>? progressReporter);
+}
+
+internal sealed class ResoniteCommonMaterialSetupCachePrimer : IResoniteCommonMaterialSetupCachePrimer
+{
+    public void Prime(
+        ResoniteSceneSetupState setupState,
+        CommonMaterialAssetCache materials,
+        LiveSendProgressSink progress,
+        Action<string>? progressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(materials);
+        ArgumentNullException.ThrowIfNull(progress);
+
+        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
+        {
+            materials.CommonMaterialAssets.Set(materialAsset.Item);
+        }
+
+        foreach (string family in setupState.CommonMaterialFamilies)
+        {
+            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
+        }
+
+        if (setupState.CommonMaterialAssets.Count > 0)
+        {
+            progress.FirstCommonMaterialPrepLogged = setupState.CommonMaterialAssets.Count;
+            ReportProgress(
+                progressReporter,
+                PlateauLog.Info(
+                    "live",
+                    $"Setup batch prepared {setupState.CommonMaterialAssets.Count} textureless common materials."));
+        }
+        else
+        {
+            ReportProgress(
+                progressReporter,
+                PlateauLog.Info(
+                    "live",
+                    "Setup created common material slots; no textureless common material components were needed in setup batch."));
+        }
+    }
+
+    private static void ReportProgress(Action<string>? progressReporter, string message)
+    {
+        progressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
@@ -7,4 +7,5 @@ internal sealed record ResoniteLiveSceneImportDependencies(
     ResoniteLinkSendDiagnostics Diagnostics,
     IResoniteLiveSendStartRequestFactory StartRequestFactory,
     IResoniteLiveSendRunStarter RunStarter,
+    IResoniteLiveSendContextFactory ContextFactory,
     IResoniteLiveSendQueue Queue);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
@@ -16,6 +16,7 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
     IResoniteClientSessionFactory clientSessionFactory,
     IResoniteLiveSendRunStarterFactory runStarterFactory,
     IResoniteLiveSendStartRequestFactory startRequestFactory,
+    IResoniteLiveSendContextFactory contextFactory,
     IResoniteLiveSendQueue queue)
     : IResoniteLiveSceneImportDependencyFactory
 {
@@ -34,6 +35,7 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
             diagnostics,
             startRequestFactory,
             runStarterFactory.Create(terrainTextureAssetHttpClient, options),
+            contextFactory,
             queue);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -14,6 +14,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
     private readonly int connectionCount;
     private readonly IResoniteLiveSendStartRequestFactory startRequestFactory;
     private readonly IResoniteLiveSendRunStarter runStarter;
+    private readonly IResoniteLiveSendContextFactory contextFactory;
     private readonly IResoniteLiveSendQueue queue;
 #pragma warning disable CA1859
     private ILiveSendClientSession ClientSessionInternal { get; }
@@ -31,6 +32,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         ArgumentNullException.ThrowIfNull(dependencies.ClientSession);
         ArgumentNullException.ThrowIfNull(dependencies.StartRequestFactory);
         ArgumentNullException.ThrowIfNull(dependencies.RunStarter);
+        ArgumentNullException.ThrowIfNull(dependencies.ContextFactory);
         ArgumentNullException.ThrowIfNull(dependencies.Queue);
 
         endpoint = options.Endpoint;
@@ -41,6 +43,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         progressReporter = options.ProgressReporter;
         startRequestFactory = dependencies.StartRequestFactory;
         runStarter = dependencies.RunStarter;
+        contextFactory = dependencies.ContextFactory;
         queue = dependencies.Queue;
         ClientSessionInternal = dependencies.ClientSession;
     }
@@ -69,13 +72,14 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 
         try
         {
+            ResoniteLiveSendTargetContext liveSendContext = CreateLiveSendContext();
             state = await runStarter.StartAsync(
                 startRequestFactory.Create(
                     plan,
                     MemoryProfile,
                     connectionCount,
                     MeshBakeEnabled),
-                CreateRunStartContext(),
+                contextFactory.CreateRunStart(liveSendContext),
                 cancellationToken);
 
             await foreach (ImportedObjectUnit objectUnit in objectUnits.WithCancellation(cancellationToken))
@@ -83,13 +87,13 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 await queue.QueueUnitAsync(
                     state,
                     objectUnit,
-                    CreateEnqueueContext(),
+                    contextFactory.CreateEnqueue(liveSendContext),
                     cancellationToken);
             }
 
             SceneImportExecutionResult result = await queue.CompleteAsync(
                 state,
-                CreateFinalizationContext(),
+                contextFactory.CreateFinalization(liveSendContext),
                 cancellationToken);
             completedSuccessfully = true;
             return result;
@@ -138,35 +142,13 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         }
     }
 
-    private IResoniteLinkClient GetRoutedClient()
+    private ResoniteLiveSendTargetContext CreateLiveSendContext()
     {
-        return ClientSessionInternal.GetRequiredClient();
-    }
-
-    private LiveSendEnqueueContext CreateEnqueueContext()
-    {
-        return new LiveSendEnqueueContext(
+        return new ResoniteLiveSendTargetContext(
+            endpoint,
             connectionCount,
-            GetRoutedClient,
-            progressReporter);
-    }
-
-    private LiveSendFinalizationContext CreateFinalizationContext()
-    {
-        return new LiveSendFinalizationContext(
-            endpoint,
-            CreateEnqueueContext(),
-            Diagnostics,
-            progressReporter);
-    }
-
-    private LiveSendRunStartContext CreateRunStartContext()
-    {
-        return new LiveSendRunStartContext(
-            endpoint,
             ClientSessionInternal,
             Diagnostics,
             progressReporter);
     }
-
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendConnectionInitializer
+{
+    Task EnsureConnectedAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteLiveSendConnectionInitializer : IResoniteLiveSendConnectionInitializer
+{
+    public async Task EnsureConnectedAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.NormalizedRequest);
+        ArgumentNullException.ThrowIfNull(request.SetupInfo);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.Endpoint);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+
+        Stopwatch connectionStopwatch = Stopwatch.StartNew();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Connecting ResoniteLink connection pool to {context.Endpoint} "
+                + $"with {request.ConnectionCount} available routed connection(s)."));
+        await context.ClientSession.EnsureConnectedAsync(
+            new LiveSendConnectionRequest(
+                request.NormalizedRequest.Dataset,
+                request.NormalizedRequest.MeshCode),
+            cancellationToken);
+        connectionStopwatch.Stop();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"ResoniteLink connection pool ready in {connectionStopwatch.Elapsed.TotalSeconds:F2}s "
+                + $"(dataset='{request.SetupInfo.Dataset}', mesh='{request.SetupInfo.MeshCode}')."));
+    }
+
+    private static void ReportProgress(
+        LiveSendRunStartContext context,
+        string message)
+    {
+        context.ProgressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendContextFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendContextFactory.cs
@@ -1,0 +1,56 @@
+using System;
+
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendContextFactory
+{
+    LiveSendRunStartContext CreateRunStart(ResoniteLiveSendTargetContext context);
+
+    LiveSendEnqueueContext CreateEnqueue(ResoniteLiveSendTargetContext context);
+
+    LiveSendFinalizationContext CreateFinalization(ResoniteLiveSendTargetContext context);
+}
+
+internal sealed class ResoniteLiveSendContextFactory : IResoniteLiveSendContextFactory
+{
+    public LiveSendRunStartContext CreateRunStart(ResoniteLiveSendTargetContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return new LiveSendRunStartContext(
+            context.Endpoint,
+            context.ClientSession,
+            context.Diagnostics,
+            context.ProgressReporter);
+    }
+
+    public LiveSendEnqueueContext CreateEnqueue(ResoniteLiveSendTargetContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return new LiveSendEnqueueContext(
+            context.ConnectionCount,
+            context.ClientSession.GetRequiredClient,
+            context.ProgressReporter);
+    }
+
+    public LiveSendFinalizationContext CreateFinalization(ResoniteLiveSendTargetContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return new LiveSendFinalizationContext(
+            context.Endpoint,
+            CreateEnqueue(context),
+            context.Diagnostics,
+            context.ProgressReporter);
+    }
+}
+
+internal sealed record ResoniteLiveSendTargetContext(
+    Uri Endpoint,
+    int ConnectionCount,
+    ILiveSendClientSession ClientSession,
+    ResoniteLinkSendDiagnostics Diagnostics,
+    Action<string>? ProgressReporter);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunActivator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunActivator.cs
@@ -13,6 +13,21 @@ internal interface IResoniteLiveSendRunActivator
         CancellationToken cancellationToken);
 }
 
+internal interface IResoniteLiveSendRunActivatorFactory
+{
+    IResoniteLiveSendRunActivator Create(IResoniteLiveSendWorkerLauncher workerLauncher);
+}
+
+internal sealed class ResoniteLiveSendRunActivatorFactory(
+    ILiveSendRunStateFactory runStateFactory) : IResoniteLiveSendRunActivatorFactory
+{
+    public IResoniteLiveSendRunActivator Create(IResoniteLiveSendWorkerLauncher workerLauncher)
+    {
+        ArgumentNullException.ThrowIfNull(workerLauncher);
+        return new ResoniteLiveSendRunActivator(runStateFactory, workerLauncher);
+    }
+}
+
 internal sealed class ResoniteLiveSendRunActivator(
     ILiveSendRunStateFactory runStateFactory,
     IResoniteLiveSendWorkerLauncher workerLauncher) : IResoniteLiveSendRunActivator

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunActivator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunActivator.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendRunActivator
+{
+    LiveSendRunState Activate(
+        LiveSendRunPlan runPlan,
+        LiveSendSetupInitialization setup,
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteLiveSendRunActivator(
+    ILiveSendRunStateFactory runStateFactory,
+    IResoniteLiveSendWorkerLauncher workerLauncher) : IResoniteLiveSendRunActivator
+{
+    public LiveSendRunState Activate(
+        LiveSendRunPlan runPlan,
+        LiveSendSetupInitialization setup,
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(runPlan);
+        ArgumentNullException.ThrowIfNull(setup);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+
+        LiveSendRunState state = runStateFactory.Create(
+            runPlan,
+            setup.SetupState,
+            setup.Progress,
+            setup.Materials,
+            setup.Placement,
+            cancellationToken);
+        workerLauncher.Launch(
+            new LiveSendWorkerLaunchRequest(
+                state,
+                runPlan.Queue,
+                runPlan.ResourceBudget,
+                request.ConnectionCount),
+            context);
+        return state;
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunPlanInitializer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunPlanInitializer.cs
@@ -1,0 +1,53 @@
+using System;
+
+using PlateauResoniteLink.Application.Logging;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendRunPlanInitializer
+{
+    LiveSendRunPlan Initialize(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context);
+}
+
+internal sealed class ResoniteLiveSendRunPlanInitializer(
+    ILiveSendRunPlanFactory runPlanFactory) : IResoniteLiveSendRunPlanInitializer
+{
+    public LiveSendRunPlan Initialize(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(request.SetupInfo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkRoot);
+        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
+        ArgumentNullException.ThrowIfNull(request.NormalizedRequest);
+        ArgumentNullException.ThrowIfNull(context.Endpoint);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+        ArgumentNullException.ThrowIfNull(context.Diagnostics);
+
+        LiveSendRunPlan runPlan = runPlanFactory.Create(
+            request.SetupInfo,
+            request.WorkRoot,
+            request.RequestLocalOrigin,
+            request.MemoryProfile,
+            request.ConnectionCount,
+            request.MeshBakeEnabled);
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Initializing scene state for dataset '{request.SetupInfo.Dataset}' "
+                + $"mesh '{request.SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
+        return runPlan;
+    }
+
+    private static void ReportProgress(
+        LiveSendRunStartContext context,
+        string message)
+    {
+        context.ProgressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -2,28 +2,9 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
-using PlateauResoniteLink.Domain.Importing;
-using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
-
-internal sealed record LiveSendRunStartRequest(
-    ResoniteSceneSetupInfo SetupInfo,
-    string WorkRoot,
-    CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials,
-    PlateauImportRequest NormalizedRequest,
-    ResoniteLocalOrigin RequestLocalOrigin,
-    ResoniteImportMemoryProfile MemoryProfile,
-    int ConnectionCount,
-    bool MeshBakeEnabled);
-
-internal sealed record LiveSendRunStartContext(
-    Uri Endpoint,
-    ILiveSendClientSession ClientSession,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
 
 internal interface IResoniteLiveSendRunStarter
 {
@@ -37,8 +18,7 @@ internal sealed class ResoniteLiveSendRunStarter(
     IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendSetupInitializer setupInitializer,
     ILiveSendRunPlanFactory runPlanFactory,
-    ILiveSendRunStateFactory runStateFactory,
-    IResoniteLiveSendWorkerLauncher workerLauncher) : IResoniteLiveSendRunStarter
+    IResoniteLiveSendRunActivator runActivator) : IResoniteLiveSendRunStarter
 {
     public async Task<LiveSendRunState> StartAsync(
         LiveSendRunStartRequest request,
@@ -74,21 +54,12 @@ internal sealed class ResoniteLiveSendRunStarter(
             context,
             runPlan,
             cancellationToken);
-        LiveSendRunState state = runStateFactory.Create(
+        return runActivator.Activate(
             runPlan,
-            setup.SetupState,
-            setup.Progress,
-            setup.Materials,
-            setup.Placement,
+            setup,
+            request,
+            context,
             cancellationToken);
-        workerLauncher.Launch(
-            new LiveSendWorkerLaunchRequest(
-                state,
-                runPlan.Queue,
-                runPlan.ResourceBudget,
-                request.ConnectionCount),
-            context);
-        return state;
     }
 
     private static void ReportProgress(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
-
-using PlateauResoniteLink.Application.Logging;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
@@ -15,9 +12,9 @@ internal interface IResoniteLiveSendRunStarter
 }
 
 internal sealed class ResoniteLiveSendRunStarter(
+    IResoniteLiveSendRunPlanInitializer runPlanInitializer,
     IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendSetupInitializer setupInitializer,
-    ILiveSendRunPlanFactory runPlanFactory,
     IResoniteLiveSendRunActivator runActivator) : IResoniteLiveSendRunStarter
 {
     public async Task<LiveSendRunState> StartAsync(
@@ -25,29 +22,7 @@ internal sealed class ResoniteLiveSendRunStarter(
         LiveSendRunStartContext context,
         CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(request.SetupInfo);
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkRoot);
-        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
-        ArgumentNullException.ThrowIfNull(request.NormalizedRequest);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
-
-        LiveSendRunPlan runPlan = runPlanFactory.Create(
-            request.SetupInfo,
-            request.WorkRoot,
-            request.RequestLocalOrigin,
-            request.MemoryProfile,
-            request.ConnectionCount,
-            request.MeshBakeEnabled);
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Initializing scene state for dataset '{request.SetupInfo.Dataset}' "
-                + $"mesh '{request.SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
+        LiveSendRunPlan runPlan = runPlanInitializer.Initialize(request, context);
         await connectionInitializer.EnsureConnectedAsync(request, context, cancellationToken);
         LiveSendSetupInitialization setup = await setupInitializer.InitializeAsync(
             request,
@@ -60,12 +35,5 @@ internal sealed class ResoniteLiveSendRunStarter(
             request,
             context,
             cancellationToken);
-    }
-
-    private static void ReportProgress(
-        LiveSendRunStartContext context,
-        string message)
-    {
-        context.ProgressReporter?.Invoke(message);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -38,6 +38,7 @@ internal interface IResoniteLiveSendRunStarter
 internal sealed class ResoniteLiveSendRunStarter(
     IResoniteSceneSetupInterpreter sceneSetupInterpreter,
     IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
+    IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
     ILiveSendRunPlanFactory runPlanFactory,
     ILiveSendRunStateFactory runStateFactory,
     IResoniteLiveSendWorkerLauncher workerLauncher,
@@ -124,29 +125,11 @@ internal sealed class ResoniteLiveSendRunStarter(
                 + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
                 + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
                 + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
-        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
-        {
-            materials.CommonMaterialAssets.Set(materialAsset.Item);
-        }
-
-        foreach (string family in setupState.CommonMaterialFamilies)
-        {
-            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
-        }
-
-        if (setupState.CommonMaterialAssets.Count > 0)
-        {
-            progress.FirstCommonMaterialPrepLogged = setupState.CommonMaterialAssets.Count;
-            ReportProgress(
-                context,
-                PlateauLog.Info(
-                    "live",
-                    $"Setup batch prepared {setupState.CommonMaterialAssets.Count} textureless common materials."));
-        }
-        else
-        {
-            ReportProgress(context, PlateauLog.Info("live", "Setup created common material slots; no textureless common material components were needed in setup batch."));
-        }
+        commonMaterialSetupCachePrimer.Prime(
+            setupState,
+            materials,
+            progress,
+            context.ProgressReporter);
 
         await commonMaterialSetupPreparer.PrepareAsync(
             GetRoutedClient(context),

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -1,12 +1,10 @@
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Domain.Importing;
-using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -36,14 +34,11 @@ internal interface IResoniteLiveSendRunStarter
 }
 
 internal sealed class ResoniteLiveSendRunStarter(
-    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
     IResoniteLiveSendConnectionInitializer connectionInitializer,
-    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
-    IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
+    IResoniteLiveSendSetupInitializer setupInitializer,
     ILiveSendRunPlanFactory runPlanFactory,
     ILiveSendRunStateFactory runStateFactory,
-    IResoniteLiveSendWorkerLauncher workerLauncher,
-    IResoniteSharedSlotIndexFactory sharedSlotIndexFactory) : IResoniteLiveSendRunStarter
+    IResoniteLiveSendWorkerLauncher workerLauncher) : IResoniteLiveSendRunStarter
 {
     public async Task<LiveSendRunState> StartAsync(
         LiveSendRunStartRequest request,
@@ -74,71 +69,17 @@ internal sealed class ResoniteLiveSendRunStarter(
                 $"Initializing scene state for dataset '{request.SetupInfo.Dataset}' "
                 + $"mesh '{request.SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
         await connectionInitializer.EnsureConnectedAsync(request, context, cancellationToken);
-        LiveSendProgressSink progress = new();
-        CommonMaterialAssetCache materials = new();
-        ReportProgress(
+        LiveSendSetupInitialization setup = await setupInitializer.InitializeAsync(
+            request,
             context,
-            PlateauLog.Info(
-                "live",
-                "Reusing dataset content source provided by caller."));
-        ReportProgress(
-            context,
-            PlateauLog.Info("live", "Setting up mutable helpers (baker)."));
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                "Starting setup slot setup: dataset root, assets root, common assets root, location slot, and source-file root reference."));
-        Stopwatch setupStopwatch = Stopwatch.StartNew();
-        ResoniteSceneSetupState setupState = await sceneSetupInterpreter.SetupAsync(
-            GetRoutedClient(context),
-            runPlan.SetupInfo,
-            request.CommonMaterials,
+            runPlan,
             cancellationToken);
-        setupStopwatch.Stop();
-        ResoniteSharedSlotIndex placement = sharedSlotIndexFactory.Create(setupState, runPlan);
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Scene setup complete in {setupStopwatch.Elapsed.TotalSeconds:F2}s "
-                + $"(dataset_root={setupState.DatasetRootSlot.SlotName}, assets_root={setupState.DatasetAssetsRootSlot.SlotName}, "
-                + $"common_root={setupState.CommonAssetsRootSlot.SlotName}, "
-                + $"dataset_root_existed={setupState.DatasetRootExisted}, "
-                + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
-                + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
-                + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
-        commonMaterialSetupCachePrimer.Prime(
-            setupState,
-            materials,
-            progress,
-            context.ProgressReporter);
-
-        await commonMaterialSetupPreparer.PrepareAsync(
-            GetRoutedClient(context),
-            setupState,
-            materials,
-            request.CommonMaterials,
-            context.ProgressReporter,
-            cancellationToken);
-
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                "setup fixed dataset license metadata/component before city-object streaming starts."));
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Dataset metadata/license phase complete during setup. "
-                + $"Dataset root existed={setupState.DatasetRootExisted}."));
         LiveSendRunState state = runStateFactory.Create(
             runPlan,
-            setupState,
-            progress,
-            materials,
-            placement,
+            setup.SetupState,
+            setup.Progress,
+            setup.Materials,
+            setup.Placement,
             cancellationToken);
         workerLauncher.Launch(
             new LiveSendWorkerLaunchRequest(
@@ -148,11 +89,6 @@ internal sealed class ResoniteLiveSendRunStarter(
                 request.ConnectionCount),
             context);
         return state;
-    }
-
-    private static IResoniteLinkClient GetRoutedClient(LiveSendRunStartContext context)
-    {
-        return context.ClientSession.GetRequiredClient();
     }
 
     private static void ReportProgress(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -37,6 +37,7 @@ internal interface IResoniteLiveSendRunStarter
 
 internal sealed class ResoniteLiveSendRunStarter(
     IResoniteSceneSetupInterpreter sceneSetupInterpreter,
+    IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
     IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
     ILiveSendRunPlanFactory runPlanFactory,
@@ -72,25 +73,7 @@ internal sealed class ResoniteLiveSendRunStarter(
                 "live",
                 $"Initializing scene state for dataset '{request.SetupInfo.Dataset}' "
                 + $"mesh '{request.SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
-        Stopwatch connectionStopwatch = Stopwatch.StartNew();
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Connecting ResoniteLink connection pool to {context.Endpoint} "
-                + $"with {request.ConnectionCount} available routed connection(s)."));
-        await context.ClientSession.EnsureConnectedAsync(
-            new LiveSendConnectionRequest(
-                request.NormalizedRequest.Dataset,
-                request.NormalizedRequest.MeshCode),
-            cancellationToken);
-        connectionStopwatch.Stop();
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"ResoniteLink connection pool ready in {connectionStopwatch.Elapsed.TotalSeconds:F2}s "
-                + $"(dataset='{request.SetupInfo.Dataset}', mesh='{request.SetupInfo.MeshCode}')."));
+        await connectionInitializer.EnsureConnectedAsync(request, context, cancellationToken);
         LiveSendProgressSink progress = new();
         CommonMaterialAssetCache materials = new();
         ReportProgress(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -45,7 +45,8 @@ internal interface IResoniteLiveSendWorkerLauncherFactory
 }
 
 internal sealed class ResoniteLiveSendWorkerLauncherFactory(
-    IResoniteQueuedCityObjectSenderFactory queuedCityObjectSenderFactory) : IResoniteLiveSendWorkerLauncherFactory
+    IResoniteQueuedCityObjectSenderFactory queuedCityObjectSenderFactory,
+    IResoniteQueuedCityObjectLaneProcessorFactory laneProcessorFactory) : IResoniteLiveSendWorkerLauncherFactory
 {
     public IResoniteLiveSendWorkerLauncher Create(
         HttpClient terrainTextureAssetHttpClient,
@@ -54,8 +55,10 @@ internal sealed class ResoniteLiveSendWorkerLauncherFactory(
         ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
         ArgumentNullException.ThrowIfNull(options);
 
+        IResoniteQueuedCityObjectSender queuedCityObjectSender =
+            queuedCityObjectSenderFactory.Create(terrainTextureAssetHttpClient, options);
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
-            queuedCityObjectSenderFactory.Create(terrainTextureAssetHttpClient, options));
+            laneProcessorFactory.Create(queuedCityObjectSender));
         return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -15,6 +15,7 @@ internal interface IResoniteLiveSendRunStarterFactory
 internal sealed class ResoniteLiveSendRunStarterFactory(
     IResoniteSceneSetupInterpreter sceneSetupInterpreter,
     IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
+    IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
     ILiveSendRunPlanFactory runPlanFactory,
     ILiveSendRunStateFactory runStateFactory,
     IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory,
@@ -30,6 +31,7 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter,
             commonMaterialSetupPreparer,
+            commonMaterialSetupCachePrimer,
             runPlanFactory,
             runStateFactory,
             workerLauncherFactory.Create(terrainTextureAssetHttpClient, options),

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -14,7 +14,7 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
     IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendSetupInitializer setupInitializer,
     ILiveSendRunPlanFactory runPlanFactory,
-    ILiveSendRunStateFactory runStateFactory,
+    IResoniteLiveSendRunActivatorFactory runActivatorFactory,
     IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory) : IResoniteLiveSendRunStarterFactory
 {
     public IResoniteLiveSendRunStarter Create(
@@ -24,38 +24,12 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
         ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
         ArgumentNullException.ThrowIfNull(options);
 
+        IResoniteLiveSendWorkerLauncher workerLauncher =
+            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options);
         return new ResoniteLiveSendRunStarter(
             connectionInitializer,
             setupInitializer,
             runPlanFactory,
-            new ResoniteLiveSendRunActivator(
-                runStateFactory,
-                workerLauncherFactory.Create(terrainTextureAssetHttpClient, options)));
-    }
-}
-
-internal interface IResoniteLiveSendWorkerLauncherFactory
-{
-    IResoniteLiveSendWorkerLauncher Create(
-        HttpClient terrainTextureAssetHttpClient,
-        ResoniteLiveSceneImportTargetOptions options);
-}
-
-internal sealed class ResoniteLiveSendWorkerLauncherFactory(
-    IResoniteQueuedCityObjectSenderFactory queuedCityObjectSenderFactory,
-    IResoniteQueuedCityObjectLaneProcessorFactory laneProcessorFactory) : IResoniteLiveSendWorkerLauncherFactory
-{
-    public IResoniteLiveSendWorkerLauncher Create(
-        HttpClient terrainTextureAssetHttpClient,
-        ResoniteLiveSceneImportTargetOptions options)
-    {
-        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
-        ArgumentNullException.ThrowIfNull(options);
-
-        IResoniteQueuedCityObjectSender queuedCityObjectSender =
-            queuedCityObjectSenderFactory.Create(terrainTextureAssetHttpClient, options);
-        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
-            laneProcessorFactory.Create(queuedCityObjectSender));
-        return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);
+            runActivatorFactory.Create(workerLauncher));
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -14,6 +14,7 @@ internal interface IResoniteLiveSendRunStarterFactory
 
 internal sealed class ResoniteLiveSendRunStarterFactory(
     IResoniteSceneSetupInterpreter sceneSetupInterpreter,
+    IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
     IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
     ILiveSendRunPlanFactory runPlanFactory,
@@ -30,6 +31,7 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
 
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter,
+            connectionInitializer,
             commonMaterialSetupPreparer,
             commonMaterialSetupCachePrimer,
             runPlanFactory,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -13,7 +13,7 @@ internal interface IResoniteLiveSendRunStarterFactory
 internal sealed class ResoniteLiveSendRunStarterFactory(
     IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendSetupInitializer setupInitializer,
-    ILiveSendRunPlanFactory runPlanFactory,
+    IResoniteLiveSendRunPlanInitializer runPlanInitializer,
     IResoniteLiveSendRunActivatorFactory runActivatorFactory,
     IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory) : IResoniteLiveSendRunStarterFactory
 {
@@ -27,9 +27,9 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
         IResoniteLiveSendWorkerLauncher workerLauncher =
             workerLauncherFactory.Create(terrainTextureAssetHttpClient, options);
         return new ResoniteLiveSendRunStarter(
+            runPlanInitializer,
             connectionInitializer,
             setupInitializer,
-            runPlanFactory,
             runActivatorFactory.Create(workerLauncher));
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Net.Http;
 
-using PlateauResoniteLink.Targets.Resonite.Execution;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal interface IResoniteLiveSendRunStarterFactory
@@ -13,14 +11,11 @@ internal interface IResoniteLiveSendRunStarterFactory
 }
 
 internal sealed class ResoniteLiveSendRunStarterFactory(
-    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
     IResoniteLiveSendConnectionInitializer connectionInitializer,
-    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
-    IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
+    IResoniteLiveSendSetupInitializer setupInitializer,
     ILiveSendRunPlanFactory runPlanFactory,
     ILiveSendRunStateFactory runStateFactory,
-    IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory,
-    IResoniteSharedSlotIndexFactory sharedSlotIndexFactory) : IResoniteLiveSendRunStarterFactory
+    IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory) : IResoniteLiveSendRunStarterFactory
 {
     public IResoniteLiveSendRunStarter Create(
         HttpClient terrainTextureAssetHttpClient,
@@ -30,14 +25,11 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
         ArgumentNullException.ThrowIfNull(options);
 
         return new ResoniteLiveSendRunStarter(
-            sceneSetupInterpreter,
             connectionInitializer,
-            commonMaterialSetupPreparer,
-            commonMaterialSetupCachePrimer,
+            setupInitializer,
             runPlanFactory,
             runStateFactory,
-            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options),
-            sharedSlotIndexFactory);
+            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options));
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -28,8 +28,9 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
             connectionInitializer,
             setupInitializer,
             runPlanFactory,
-            runStateFactory,
-            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options));
+            new ResoniteLiveSendRunActivator(
+                runStateFactory,
+                workerLauncherFactory.Create(terrainTextureAssetHttpClient, options)));
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendSetupInitializer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendSetupInitializer.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record LiveSendSetupInitialization(
+    ResoniteSceneSetupState SetupState,
+    LiveSendProgressSink Progress,
+    CommonMaterialAssetCache Materials,
+    ResoniteSharedSlotIndex Placement);
+
+internal interface IResoniteLiveSendSetupInitializer
+{
+    Task<LiveSendSetupInitialization> InitializeAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        LiveSendRunPlan runPlan,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteLiveSendSetupInitializer(
+    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
+    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
+    IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
+    IResoniteSharedSlotIndexFactory sharedSlotIndexFactory) : IResoniteLiveSendSetupInitializer
+{
+    public async Task<LiveSendSetupInitialization> InitializeAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        LiveSendRunPlan runPlan,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+        ArgumentNullException.ThrowIfNull(runPlan);
+
+        LiveSendProgressSink progress = new();
+        CommonMaterialAssetCache materials = new();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "Reusing dataset content source provided by caller."));
+        ReportProgress(
+            context,
+            PlateauLog.Info("live", "Setting up mutable helpers (baker)."));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "Starting setup slot setup: dataset root, assets root, common assets root, location slot, and source-file root reference."));
+        Stopwatch setupStopwatch = Stopwatch.StartNew();
+        ResoniteSceneSetupState setupState = await sceneSetupInterpreter.SetupAsync(
+            GetRoutedClient(context),
+            runPlan.SetupInfo,
+            request.CommonMaterials,
+            cancellationToken);
+        setupStopwatch.Stop();
+        ResoniteSharedSlotIndex placement = sharedSlotIndexFactory.Create(setupState, runPlan);
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Scene setup complete in {setupStopwatch.Elapsed.TotalSeconds:F2}s "
+                + $"(dataset_root={setupState.DatasetRootSlot.SlotName}, assets_root={setupState.DatasetAssetsRootSlot.SlotName}, "
+                + $"common_root={setupState.CommonAssetsRootSlot.SlotName}, "
+                + $"dataset_root_existed={setupState.DatasetRootExisted}, "
+                + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
+                + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
+                + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
+        commonMaterialSetupCachePrimer.Prime(
+            setupState,
+            materials,
+            progress,
+            context.ProgressReporter);
+
+        await commonMaterialSetupPreparer.PrepareAsync(
+            GetRoutedClient(context),
+            setupState,
+            materials,
+            request.CommonMaterials,
+            context.ProgressReporter,
+            cancellationToken);
+
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "setup fixed dataset license metadata/component before city-object streaming starts."));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Dataset metadata/license phase complete during setup. "
+                + $"Dataset root existed={setupState.DatasetRootExisted}."));
+
+        return new LiveSendSetupInitialization(
+            setupState,
+            progress,
+            materials,
+            placement);
+    }
+
+    private static IResoniteLinkClient GetRoutedClient(LiveSendRunStartContext context)
+    {
+        return context.ClientSession.GetRequiredClient();
+    }
+
+    private static void ReportProgress(
+        LiveSendRunStartContext context,
+        string message)
+    {
+        context.ProgressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteMaterialPlanning, ResoniteMaterialPlanning>();
         services.TryAddScoped<IResoniteSceneMaterialPlanComposer, ResoniteSceneMaterialPlanComposer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
+        services.TryAddScoped<IResoniteCommonMaterialSetupCachePrimer, ResoniteCommonMaterialSetupCachePrimer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteSharedSlotIndexFactory, ResoniteSharedSlotIndexFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupCachePrimer, ResoniteCommonMaterialSetupCachePrimer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
+        services.TryAddScoped<IResoniteLiveSendRunPlanInitializer, ResoniteLiveSendRunPlanInitializer>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunActivatorFactory, ResoniteLiveSendRunActivatorFactory>();
         services.TryAddScoped<IResoniteSharedSlotIndexFactory, ResoniteSharedSlotIndexFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteMaterialPlanning, ResoniteMaterialPlanning>();
         services.TryAddScoped<IResoniteSceneMaterialPlanComposer, ResoniteSceneMaterialPlanComposer>();
         services.TryAddScoped<IResoniteLiveSendConnectionInitializer, ResoniteLiveSendConnectionInitializer>();
+        services.TryAddScoped<IResoniteLiveSendSetupInitializer, ResoniteLiveSendSetupInitializer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupCachePrimer, ResoniteCommonMaterialSetupCachePrimer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteCommonMaterialSetupCachePrimer, ResoniteCommonMaterialSetupCachePrimer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
+        services.TryAddScoped<IResoniteLiveSendRunActivatorFactory, ResoniteLiveSendRunActivatorFactory>();
         services.TryAddScoped<IResoniteSharedSlotIndexFactory, ResoniteSharedSlotIndexFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
         services.TryAddScoped<IResoniteLiveSendWorkerLauncherFactory, ResoniteLiveSendWorkerLauncherFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteGeometryAssetPlanner, ResoniteGeometryAssetPlanner>();
         services.TryAddScoped<IResoniteMaterialPlanning, ResoniteMaterialPlanning>();
         services.TryAddScoped<IResoniteSceneMaterialPlanComposer, ResoniteSceneMaterialPlanComposer>();
+        services.TryAddScoped<IResoniteLiveSendConnectionInitializer, ResoniteLiveSendConnectionInitializer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupCachePrimer, ResoniteCommonMaterialSetupCachePrimer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteLiveSendRunPlanInitializer, ResoniteLiveSendRunPlanInitializer>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunActivatorFactory, ResoniteLiveSendRunActivatorFactory>();
+        services.TryAddScoped<IResoniteLiveSendContextFactory, ResoniteLiveSendContextFactory>();
         services.TryAddScoped<IResoniteSharedSlotIndexFactory, ResoniteSharedSlotIndexFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
         services.TryAddScoped<IResoniteLiveSendWorkerLauncherFactory, ResoniteLiveSendWorkerLauncherFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteQueuedSendFailurePolicy, ResoniteQueuedSendFailurePolicy>();
         services.TryAddScoped<IResoniteQueuedCityObjectPreparerFactory, ResoniteQueuedCityObjectPreparerFactory>();
         services.TryAddScoped<IResoniteQueuedCityObjectSenderFactory, ResoniteQueuedCityObjectSenderFactory>();
+        services.TryAddScoped<IResoniteQueuedCityObjectLaneProcessorFactory, ResoniteQueuedCityObjectLaneProcessorFactory>();
         services.TryAddScoped<IResoniteQueuedCityObjectEnqueuer, ResoniteQueuedCityObjectEnqueuer>();
         services.TryAddScoped<IResoniteLiveSendFinalizer, ResoniteLiveSendFinalizer>();
         services.TryAddScoped<IResoniteLiveSendQueue, ResoniteLiveSendQueue>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncherFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncherFactory.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Net.Http;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendWorkerLauncherFactory
+{
+    IResoniteLiveSendWorkerLauncher Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options);
+}
+
+internal sealed class ResoniteLiveSendWorkerLauncherFactory(
+    IResoniteQueuedCityObjectSenderFactory queuedCityObjectSenderFactory,
+    IResoniteQueuedCityObjectLaneProcessorFactory laneProcessorFactory) : IResoniteLiveSendWorkerLauncherFactory
+{
+    public IResoniteLiveSendWorkerLauncher Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        IResoniteQueuedCityObjectSender queuedCityObjectSender =
+            queuedCityObjectSenderFactory.Create(terrainTextureAssetHttpClient, options);
+        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
+            laneProcessorFactory.Create(queuedCityObjectSender));
+        return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectLaneProcessor.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectLaneProcessor.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Logging;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteQueuedCityObjectLaneProcessor
+{
+    Task ProcessAsync(
+        LiveSendRunState state,
+        LiveSendWorkerContext context,
+        ChannelReader<LiveSendQueuedCityObject> reader,
+        int laneIndex,
+        CancellationToken cancellationToken);
+}
+
+internal interface IResoniteQueuedCityObjectLaneProcessorFactory
+{
+    IResoniteQueuedCityObjectLaneProcessor Create(
+        IResoniteQueuedCityObjectSender queuedCityObjectSender);
+}
+
+internal sealed class ResoniteQueuedCityObjectLaneProcessorFactory : IResoniteQueuedCityObjectLaneProcessorFactory
+{
+    public IResoniteQueuedCityObjectLaneProcessor Create(
+        IResoniteQueuedCityObjectSender queuedCityObjectSender)
+    {
+        ArgumentNullException.ThrowIfNull(queuedCityObjectSender);
+
+        return new ResoniteQueuedCityObjectLaneProcessor(queuedCityObjectSender);
+    }
+}
+
+internal sealed class ResoniteQueuedCityObjectLaneProcessor(
+    IResoniteQueuedCityObjectSender queuedCityObjectSender) : IResoniteQueuedCityObjectLaneProcessor
+{
+    private readonly IResoniteQueuedCityObjectSender queuedCityObjectSender =
+        queuedCityObjectSender ?? throw new ArgumentNullException(nameof(queuedCityObjectSender));
+
+    public async Task ProcessAsync(
+        LiveSendRunState state,
+        LiveSendWorkerContext context,
+        ChannelReader<LiveSendQueuedCityObject> reader,
+        int laneIndex,
+        CancellationToken cancellationToken)
+    {
+        Stopwatch laneClientStopwatch = Stopwatch.StartNew();
+        ResoniteSceneSetupInfo setupInfo = state.Context.Plan.SetupInfo;
+        if (laneIndex == 0)
+        {
+            ReportProgress(
+                context,
+                PlateauLog.Info(
+                    "live",
+                    $"Send worker {laneIndex + 1}/{context.ConnectionCount} is ready to consume from the routed connection pool."));
+        }
+        else
+        {
+            ReportProgress(
+                context,
+                PlateauLog.Info(
+                    "live",
+                    $"Preparing send worker {laneIndex + 1}/{context.ConnectionCount} "
+                    + $"against routed connections to {context.Endpoint} for dataset '{setupInfo.Dataset}' mesh '{setupInfo.MeshCode}'."));
+        }
+
+        laneClientStopwatch.Stop();
+        try
+        {
+            ReportProgress(
+                context,
+                PlateauLog.Info(
+                    "live",
+                    $"Send worker {laneIndex + 1}/{context.ConnectionCount} ready against routed connections "
+                    + $"in {laneClientStopwatch.Elapsed.TotalSeconds:F2}s."));
+            await ProcessQueuedCityObjectsAsync(state, context, reader, laneIndex, cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            TryMarkProcessingFailure(state, exception);
+            CancelProcessing(state);
+            throw;
+        }
+    }
+
+    private async Task ProcessQueuedCityObjectsAsync(
+        LiveSendRunState state,
+        LiveSendWorkerContext context,
+        ChannelReader<LiveSendQueuedCityObject> reader,
+        int laneIndex,
+        CancellationToken cancellationToken)
+    {
+        LiveSendQueuedCityObject? currentCityObject = null;
+        try
+        {
+            if (Interlocked.CompareExchange(ref state.Progress.FirstCityObjectStreamingStartedLogged, 1, 0) == 0)
+            {
+                ReportProgress(
+                    context,
+                    PlateauLog.Info(
+                        "live",
+                        $"City-object send pipeline is active and waiting for queue on lane {laneIndex + 1}/{context.ConnectionCount}."));
+            }
+
+            await foreach (LiveSendQueuedCityObject queuedCityObject in reader.ReadAllAsync(cancellationToken))
+            {
+                currentCityObject = queuedCityObject;
+                if (Interlocked.CompareExchange(ref state.Progress.FirstCityObjectDequeuedLogged, 1, 0) == 0)
+                {
+                    ReportProgress(
+                        context,
+                        PlateauLog.Info(
+                            "live",
+                            $"First city object dequeued on lane {laneIndex + 1}/{context.ConnectionCount} "
+                            + $"after scene-start {state.Runtime.ElapsedTotalSeconds:F3}s: "
+                            + $"{queuedCityObject.CityObject.DisplayName} "
+                            + $"({queuedCityObject.CityObject.PackageName}/{queuedCityObject.CityObject.SlotKey})."));
+                }
+
+                await queuedCityObjectSender.SendAsync(
+                    state,
+                    context.GetRoutedClient(),
+                    queuedCityObject,
+                    context.Diagnostics,
+                    context.ProgressReporter,
+                    cancellationToken);
+                currentCityObject = null;
+            }
+
+            ReportProgress(
+                context,
+                PlateauLog.Info(
+                    "live",
+                    $"Send lane {laneIndex + 1}/{context.ConnectionCount} drained."));
+        }
+        catch (OperationCanceledException)
+        {
+            ReportProgress(
+                context,
+                PlateauLog.Warning("live", $"Send lane {laneIndex + 1}/{context.ConnectionCount} canceled."));
+            throw;
+        }
+        catch (Exception exception)
+        {
+            TryMarkProcessingFailure(state, exception);
+            CancelProcessing(state);
+            string cityObjectContext = currentCityObject is null
+                ? string.Empty
+                : string.Create(
+                    CultureInfo.InvariantCulture,
+                    $" while processing '{currentCityObject.CityObject.DisplayName}' "
+                    + $"({currentCityObject.CityObject.PackageName}/{currentCityObject.CityObject.SlotKey}) "
+                    + $"mesh='{currentCityObject.CityObject.ActualMeshCode}' "
+                    + $"sourceFile='{currentCityObject.CityObject.SourceFileRelativePath ?? "<null>"}'");
+            ReportProgress(
+                context,
+                PlateauLog.Error(
+                    "live",
+                    $"Send lane {laneIndex + 1}/{context.ConnectionCount} failed{cityObjectContext}: {exception.Message}"));
+            throw;
+        }
+    }
+
+    private static void ReportProgress(LiveSendWorkerContext context, string message)
+    {
+        context.ProgressReporter?.Invoke(message);
+    }
+
+    private static void TryMarkProcessingFailure(LiveSendRunState state, Exception exception)
+    {
+        state.Runtime.TryMarkFailure(exception);
+    }
+
+    private static void CancelProcessing(LiveSendRunState state)
+    {
+        state.Runtime.Cancel();
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectWorker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectWorker.cs
@@ -1,11 +1,6 @@
 using System;
-using System.Diagnostics;
-using System.Globalization;
-using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -18,10 +13,10 @@ internal interface IResoniteQueuedCityObjectWorker
 }
 
 internal sealed class ResoniteQueuedCityObjectWorker(
-    IResoniteQueuedCityObjectSender queuedCityObjectSender) : IResoniteQueuedCityObjectWorker
+    IResoniteQueuedCityObjectLaneProcessor laneProcessor) : IResoniteQueuedCityObjectWorker
 {
-    private readonly IResoniteQueuedCityObjectSender queuedCityObjectSender =
-        queuedCityObjectSender ?? throw new ArgumentNullException(nameof(queuedCityObjectSender));
+    private readonly IResoniteQueuedCityObjectLaneProcessor laneProcessor =
+        laneProcessor ?? throw new ArgumentNullException(nameof(laneProcessor));
 
     public Task[] CreateProcessingTasks(
         LiveSendRunState state,
@@ -34,7 +29,7 @@ internal sealed class ResoniteQueuedCityObjectWorker(
         for (int laneIndex = 0; laneIndex < context.ConnectionCount; laneIndex++)
         {
             int capturedLaneIndex = laneIndex;
-            tasks[capturedLaneIndex] = ProcessQueuedCityObjectsOnLaneAsync(
+            tasks[capturedLaneIndex] = laneProcessor.ProcessAsync(
                 state,
                 context,
                 state.Runtime.Reader,
@@ -43,145 +38,6 @@ internal sealed class ResoniteQueuedCityObjectWorker(
         }
 
         return tasks;
-    }
-
-    private async Task ProcessQueuedCityObjectsAsync(
-        LiveSendRunState state,
-        LiveSendWorkerContext context,
-        ChannelReader<LiveSendQueuedCityObject> reader,
-        int laneIndex,
-        CancellationToken cancellationToken)
-    {
-        LiveSendQueuedCityObject? currentCityObject = null;
-        try
-        {
-            if (Interlocked.CompareExchange(ref state.Progress.FirstCityObjectStreamingStartedLogged, 1, 0) == 0)
-            {
-                ReportProgress(
-                    context,
-                    PlateauLog.Info(
-                        "live",
-                        $"City-object send pipeline is active and waiting for queue on lane {laneIndex + 1}/{context.ConnectionCount}."));
-            }
-
-            await foreach (LiveSendQueuedCityObject queuedCityObject in reader.ReadAllAsync(cancellationToken))
-            {
-                currentCityObject = queuedCityObject;
-                if (Interlocked.CompareExchange(ref state.Progress.FirstCityObjectDequeuedLogged, 1, 0) == 0)
-                {
-                    ReportProgress(
-                        context,
-                        PlateauLog.Info(
-                            "live",
-                            $"First city object dequeued on lane {laneIndex + 1}/{context.ConnectionCount} "
-                            + $"after scene-start {state.Runtime.ElapsedTotalSeconds:F3}s: "
-                            + $"{queuedCityObject.CityObject.DisplayName} "
-                            + $"({queuedCityObject.CityObject.PackageName}/{queuedCityObject.CityObject.SlotKey})."));
-                }
-
-                await queuedCityObjectSender.SendAsync(
-                    state,
-                    context.GetRoutedClient(),
-                    queuedCityObject,
-                    context.Diagnostics,
-                    context.ProgressReporter,
-                    cancellationToken);
-                currentCityObject = null;
-            }
-
-            ReportProgress(
-                context,
-                PlateauLog.Info(
-                    "live",
-                    $"Send lane {laneIndex + 1}/{context.ConnectionCount} drained."));
-        }
-        catch (OperationCanceledException)
-        {
-            ReportProgress(
-                context,
-                PlateauLog.Warning("live", $"Send lane {laneIndex + 1}/{context.ConnectionCount} canceled."));
-            throw;
-        }
-        catch (Exception exception)
-        {
-            TryMarkProcessingFailure(state, exception);
-            CancelProcessing(state);
-            string cityObjectContext = currentCityObject is null
-                ? string.Empty
-                : string.Create(
-                    CultureInfo.InvariantCulture,
-                    $" while processing '{currentCityObject.CityObject.DisplayName}' "
-                    + $"({currentCityObject.CityObject.PackageName}/{currentCityObject.CityObject.SlotKey}) "
-                    + $"mesh='{currentCityObject.CityObject.ActualMeshCode}' "
-                    + $"sourceFile='{currentCityObject.CityObject.SourceFileRelativePath ?? "<null>"}'");
-            ReportProgress(
-                context,
-                PlateauLog.Error(
-                    "live",
-                    $"Send lane {laneIndex + 1}/{context.ConnectionCount} failed{cityObjectContext}: {exception.Message}"));
-            throw;
-        }
-    }
-
-    private async Task ProcessQueuedCityObjectsOnLaneAsync(
-        LiveSendRunState state,
-        LiveSendWorkerContext context,
-        ChannelReader<LiveSendQueuedCityObject> reader,
-        int laneIndex,
-        CancellationToken cancellationToken)
-    {
-        Stopwatch laneClientStopwatch = Stopwatch.StartNew();
-        ResoniteSceneSetupInfo setupInfo = state.Context.Plan.SetupInfo;
-        if (laneIndex == 0)
-        {
-            ReportProgress(
-                context,
-                PlateauLog.Info(
-                    "live",
-                    $"Send worker {laneIndex + 1}/{context.ConnectionCount} is ready to consume from the routed connection pool."));
-        }
-        else
-        {
-            ReportProgress(
-                context,
-                PlateauLog.Info(
-                    "live",
-                    $"Preparing send worker {laneIndex + 1}/{context.ConnectionCount} "
-                    + $"against routed connections to {context.Endpoint} for dataset '{setupInfo.Dataset}' mesh '{setupInfo.MeshCode}'."));
-        }
-
-        laneClientStopwatch.Stop();
-        try
-        {
-            ReportProgress(
-                context,
-                PlateauLog.Info(
-                    "live",
-                    $"Send worker {laneIndex + 1}/{context.ConnectionCount} ready against routed connections "
-                    + $"in {laneClientStopwatch.Elapsed.TotalSeconds:F2}s."));
-            await ProcessQueuedCityObjectsAsync(state, context, reader, laneIndex, cancellationToken);
-        }
-        catch (Exception exception)
-        {
-            TryMarkProcessingFailure(state, exception);
-            CancelProcessing(state);
-            throw;
-        }
-    }
-
-    private static void ReportProgress(LiveSendWorkerContext context, string message)
-    {
-        context.ProgressReporter?.Invoke(message);
-    }
-
-    private static void TryMarkProcessingFailure(LiveSendRunState state, Exception exception)
-    {
-        state.Runtime.TryMarkFailure(exception);
-    }
-
-    private static void CancelProcessing(LiveSendRunState state)
-    {
-        state.Runtime.Cancel();
     }
 }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteCommonMaterialSetupCachePrimerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteCommonMaterialSetupCachePrimerTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class ResoniteCommonMaterialSetupCachePrimerTests
+{
+    [Fact]
+    public void PrimeSeedsSetupBatchAssetsFamiliesAndProgress()
+    {
+        CommonMaterialCatalog<DefaultCommonMaterialMember> catalog = CommonMaterialCatalog.Create();
+        CreatedMaterialAsset expectedAsset = new(
+            new ResoniteComponentLocator("generic-uv-material"),
+            MaterialPropertyBlockComponent: null);
+        ResoniteSceneSetupState setupState = CreateSetupState(
+            catalog.FilterToDefinitions([catalog.Generic.Uv.Definition])
+                .Map(member => new ResoniteCommonMaterialAsset(
+                    member,
+                    SceneImportContractMapper.ToInternal(member.CreateBinding([0])),
+                    expectedAsset)),
+            ["generic"]);
+        CommonMaterialAssetCache materials = new();
+        LiveSendProgressSink progress = new();
+        List<string> progressMessages = [];
+
+        new ResoniteCommonMaterialSetupCachePrimer().Prime(
+            setupState,
+            materials,
+            progress,
+            progressMessages.Add);
+
+        Assert.True(materials.CommonMaterialAssets.TryGetAsset(catalog.Generic.Uv, out CreatedMaterialAsset actualAsset));
+        Assert.Equal(expectedAsset, actualAsset);
+        Assert.True(materials.CommonMaterialFamilyWarmupTasks.TryGetValue("generic", out Task? warmupTask));
+        Assert.Same(Task.CompletedTask, warmupTask);
+        Assert.Equal(1, progress.FirstCommonMaterialPrepLogged);
+        Assert.Contains(
+            progressMessages,
+            static message => message.Contains("Setup batch prepared 1 textureless common materials.", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void PrimeReportsEmptySetupBatchWithoutMarkingFirstCommonMaterialPreparation()
+    {
+        CommonMaterialCatalog<DefaultCommonMaterialMember> catalog = CommonMaterialCatalog.Create();
+        ResoniteSceneSetupState setupState = CreateSetupState(
+            catalog.FilterToDefinitions([])
+                .Map(member => new ResoniteCommonMaterialAsset(
+                    member,
+                    SceneImportContractMapper.ToInternal(member.CreateBinding([0])),
+                    default)),
+            []);
+        CommonMaterialAssetCache materials = new();
+        LiveSendProgressSink progress = new();
+        List<string> progressMessages = [];
+
+        new ResoniteCommonMaterialSetupCachePrimer().Prime(
+            setupState,
+            materials,
+            progress,
+            progressMessages.Add);
+
+        Assert.Equal(0, materials.CommonMaterialAssets.Count);
+        Assert.Empty(materials.CommonMaterialFamilyWarmupTasks);
+        Assert.Equal(0, progress.FirstCommonMaterialPrepLogged);
+        Assert.Contains(
+            progressMessages,
+            static message => message.Contains(
+                "Setup created common material slots; no textureless common material components were needed in setup batch.",
+                StringComparison.Ordinal));
+    }
+
+    private static ResoniteSceneSetupState CreateSetupState(
+        CommonMaterialCatalog<ResoniteCommonMaterialAsset> commonMaterialAssets,
+        IReadOnlyCollection<string> commonMaterialFamilies)
+    {
+        CreatedSlot datasetRoot = new(new ResoniteSlotLocator("dataset-root"), "PLATEAU tokyo23ku");
+        return new ResoniteSceneSetupState(
+            datasetRoot,
+            new CreatedSlot(new ResoniteSlotLocator("assets-root"), "Assets"),
+            new CreatedSlot(new ResoniteSlotLocator("common-root"), "Common Materials"),
+            DatasetRootExisted: false,
+            new SceneAnchor(
+                datasetRoot.Locator,
+                "53394525",
+                new ResoniteFloat3(0.0, 0.0, 0.0),
+                ReferenceSourceFileRoot: null),
+            DatasetRootSnapshot: null,
+            commonMaterialAssets,
+            commonMaterialFamilies);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -67,6 +67,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     {
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
+            new ResoniteLiveSendConnectionInitializer(),
             CreateCommonMaterialSetupPreparer(materialPlanning),
             new ResoniteCommonMaterialSetupCachePrimer(),
             new LiveSendRunPlanFactory(),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -66,13 +66,13 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null)
     {
         return new ResoniteLiveSendRunStarter(
+            new ResoniteLiveSendRunPlanInitializer(new LiveSendRunPlanFactory()),
             new ResoniteLiveSendConnectionInitializer(),
             new ResoniteLiveSendSetupInitializer(
                 sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
                 CreateCommonMaterialSetupPreparer(materialPlanning),
                 new ResoniteCommonMaterialSetupCachePrimer(),
                 new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
-            new LiveSendRunPlanFactory(),
             new ResoniteLiveSendRunActivator(
                 CreateRunStateFactory(),
                 new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning))));

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -49,14 +50,15 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         IResoniteMaterialPlanning materialPlanning)
     {
         return new ResoniteQueuedCityObjectWorker(
-            new ResoniteQueuedCityObjectSender(
+            new ResoniteQueuedCityObjectLaneProcessor(
+                new ResoniteQueuedCityObjectSender(
                 new ResoniteQueuedCityObjectPreparer(
                     new ResoniteQueuedGeometryPreparer(),
                     new ResoniteQueuedTexturePreparer(
                         new TerrainTextureAssetGenerator(),
                         new ResoniteDatasetLicenseWriter())),
                 new ResoniteQueuedSendFailurePolicy(),
-                CreatePreparedCityObjectImporter(materialPlanning)));
+                    CreatePreparedCityObjectImporter(materialPlanning))));
     }
 
     private static ResoniteLiveSendRunStarter CreateRunStarter(
@@ -249,6 +251,36 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         Assert.NotNull(queuedSenderFactory.LastOptions);
         Assert.False(queuedSenderFactory.LastOptions!.EnableMeshBake);
         Assert.Equal("cache-root", queuedSenderFactory.LastOptions.TerrainTileCacheRoot);
+    }
+
+    [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The created target is disposed via await using in this test.")]
+    public async Task AddResoniteLiveSendTargetServicesPreservesPreRegisteredQueuedLaneProcessorFactory()
+    {
+        RecordingQueuedCityObjectLaneProcessorFactory laneProcessorFactory = new();
+        ServiceProvider provider = new ServiceCollection()
+            .AddScoped<IResoniteQueuedCityObjectLaneProcessorFactory>(_ => laneProcessorFactory)
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+        using HttpClient terrainTextureAssetHttpClient = new();
+        ISceneSink target = scope.ServiceProvider
+            .GetRequiredService<IResoniteLiveSceneImportFactory>()
+            .CreateTarget(
+                new ResoniteLiveSceneImportTargetOptions(
+                    new Uri("ws://localhost:12345/"),
+                    1,
+                    EnableSendMetrics: false,
+                    MemoryProfile: ResoniteImportMemoryProfile.Large,
+                    EnableMeshBake: true,
+                    TerrainTileCacheRoot: null,
+                    DisableTerrainTileCache: false,
+                    ProgressReporter: null),
+                terrainTextureAssetHttpClient);
+        await using ResoniteLiveSceneImportTarget _ = Assert.IsType<ResoniteLiveSceneImportTarget>(target);
+
+        Assert.Equal(1, laneProcessorFactory.CreateCallCount);
+        Assert.IsAssignableFrom<IResoniteQueuedCityObjectSender>(laneProcessorFactory.LastSender);
     }
 
     [Fact]
@@ -502,6 +534,39 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             _ = queuedCityObject;
             _ = diagnostics;
             _ = progressReporter;
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new NotSupportedException("This test only verifies DI override preservation during target creation.");
+        }
+    }
+
+    private sealed class RecordingQueuedCityObjectLaneProcessorFactory : IResoniteQueuedCityObjectLaneProcessorFactory
+    {
+        public int CreateCallCount { get; private set; }
+
+        public IResoniteQueuedCityObjectSender? LastSender { get; private set; }
+
+        public IResoniteQueuedCityObjectLaneProcessor Create(
+            IResoniteQueuedCityObjectSender queuedCityObjectSender)
+        {
+            CreateCallCount++;
+            LastSender = queuedCityObjectSender;
+            return new RecordingQueuedCityObjectLaneProcessor();
+        }
+    }
+
+    private sealed class RecordingQueuedCityObjectLaneProcessor : IResoniteQueuedCityObjectLaneProcessor
+    {
+        public Task ProcessAsync(
+            LiveSendRunState state,
+            LiveSendWorkerContext context,
+            ChannelReader<LiveSendQueuedCityObject> reader,
+            int laneIndex,
+            CancellationToken cancellationToken)
+        {
+            _ = state;
+            _ = context;
+            _ = reader;
+            _ = laneIndex;
             cancellationToken.ThrowIfCancellationRequested();
             throw new NotSupportedException("This test only verifies DI override preservation during target creation.");
         }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -68,6 +68,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
             CreateCommonMaterialSetupPreparer(materialPlanning),
+            new ResoniteCommonMaterialSetupCachePrimer(),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
             new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),
@@ -320,6 +321,22 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             .GetRequiredService<IResoniteSharedSlotIndexFactory>();
 
         Assert.Same(sharedSlotIndexFactory, resolvedFactory);
+    }
+
+    [Fact]
+    public void AddResoniteLiveSendTargetServicesPreservesPreRegisteredCommonMaterialSetupCachePrimer()
+    {
+        RecordingCommonMaterialSetupCachePrimer cachePrimer = new();
+        ServiceProvider provider = new ServiceCollection()
+            .AddScoped<IResoniteCommonMaterialSetupCachePrimer>(_ => cachePrimer)
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        IResoniteCommonMaterialSetupCachePrimer resolvedPrimer = scope.ServiceProvider
+            .GetRequiredService<IResoniteCommonMaterialSetupCachePrimer>();
+
+        Assert.Same(cachePrimer, resolvedPrimer);
     }
 
     [Fact]
@@ -580,6 +597,22 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         {
             _ = setupState;
             _ = runPlan;
+            throw new NotSupportedException("This test only verifies DI override preservation.");
+        }
+    }
+
+    private sealed class RecordingCommonMaterialSetupCachePrimer : IResoniteCommonMaterialSetupCachePrimer
+    {
+        public void Prime(
+            ResoniteSceneSetupState setupState,
+            CommonMaterialAssetCache materials,
+            LiveSendProgressSink progress,
+            Action<string>? progressReporter)
+        {
+            _ = setupState;
+            _ = materials;
+            _ = progress;
+            _ = progressReporter;
             throw new NotSupportedException("This test only verifies DI override preservation.");
         }
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -66,14 +66,15 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null)
     {
         return new ResoniteLiveSendRunStarter(
-            sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
             new ResoniteLiveSendConnectionInitializer(),
-            CreateCommonMaterialSetupPreparer(materialPlanning),
-            new ResoniteCommonMaterialSetupCachePrimer(),
+            new ResoniteLiveSendSetupInitializer(
+                sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
+                CreateCommonMaterialSetupPreparer(materialPlanning),
+                new ResoniteCommonMaterialSetupCachePrimer(),
+                new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
-            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),
-            new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator()));
+            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)));
     }
 
     private static ResoniteLiveSendQueue CreateQueue()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -128,6 +128,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
 
         Assert.Same(diagnostics, importTarget.Diagnostics);
@@ -454,6 +455,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -73,8 +73,9 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
                 new ResoniteCommonMaterialSetupCachePrimer(),
                 new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
             new LiveSendRunPlanFactory(),
-            CreateRunStateFactory(),
-            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)));
+            new ResoniteLiveSendRunActivator(
+                CreateRunStateFactory(),
+                new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning))));
     }
 
     private static ResoniteLiveSendQueue CreateQueue()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -52,14 +52,15 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         IResoniteMaterialPlanning materialPlanning)
     {
         return new ResoniteQueuedCityObjectWorker(
-            new ResoniteQueuedCityObjectSender(
+            new ResoniteQueuedCityObjectLaneProcessor(
+                new ResoniteQueuedCityObjectSender(
                 new ResoniteQueuedCityObjectPreparer(
                     new ResoniteQueuedGeometryPreparer(),
                     new ResoniteQueuedTexturePreparer(
                         new TerrainTextureAssetGenerator(),
                         new ResoniteDatasetLicenseWriter())),
                 new ResoniteQueuedSendFailurePolicy(),
-                CreatePreparedCityObjectImporter(materialPlanning)));
+                    CreatePreparedCityObjectImporter(materialPlanning))));
     }
 
     private static ResoniteLiveSendRunStarter CreateRunStarter(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -69,6 +69,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     {
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
+            new ResoniteLiveSendConnectionInitializer(),
             CreateCommonMaterialSetupPreparer(materialPlanning),
             new ResoniteCommonMaterialSetupCachePrimer(),
             new LiveSendRunPlanFactory(),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -68,14 +68,15 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null)
     {
         return new ResoniteLiveSendRunStarter(
-            sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
             new ResoniteLiveSendConnectionInitializer(),
-            CreateCommonMaterialSetupPreparer(materialPlanning),
-            new ResoniteCommonMaterialSetupCachePrimer(),
+            new ResoniteLiveSendSetupInitializer(
+                sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
+                CreateCommonMaterialSetupPreparer(materialPlanning),
+                new ResoniteCommonMaterialSetupCachePrimer(),
+                new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
-            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),
-            new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator()));
+            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)));
     }
 
     private static ResoniteLiveSendQueue CreateQueue()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -70,6 +70,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
             CreateCommonMaterialSetupPreparer(materialPlanning),
+            new ResoniteCommonMaterialSetupCachePrimer(),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
             new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -111,6 +111,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
 
         PlateauImportRequest normalizedRequest = new(
@@ -167,6 +168,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
 
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
@@ -214,6 +216,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
@@ -298,6 +301,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 ResoniteLinkSendDiagnostics.Disabled,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter()),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
@@ -342,6 +346,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 ResoniteLinkSendDiagnostics.Disabled,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter()),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
@@ -409,6 +414,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 ResoniteLinkSendDiagnostics.Disabled,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -68,13 +68,13 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null)
     {
         return new ResoniteLiveSendRunStarter(
+            new ResoniteLiveSendRunPlanInitializer(new LiveSendRunPlanFactory()),
             new ResoniteLiveSendConnectionInitializer(),
             new ResoniteLiveSendSetupInitializer(
                 sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
                 CreateCommonMaterialSetupPreparer(materialPlanning),
                 new ResoniteCommonMaterialSetupCachePrimer(),
                 new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
-            new LiveSendRunPlanFactory(),
             new ResoniteLiveSendRunActivator(
                 CreateRunStateFactory(),
                 new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning))));

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -75,8 +75,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 new ResoniteCommonMaterialSetupCachePrimer(),
                 new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
             new LiveSendRunPlanFactory(),
-            CreateRunStateFactory(),
-            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)));
+            new ResoniteLiveSendRunActivator(
+                CreateRunStateFactory(),
+                new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning))));
     }
 
     private static ResoniteLiveSendQueue CreateQueue()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -354,18 +354,19 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 new ResoniteLiveSendRunStarter(
-                    new ResoniteSceneSetupInterpreter(
-                        new ResoniteSceneSlotLocator(),
-                        new ResoniteSceneAnchorResolver()),
                     new ResoniteLiveSendConnectionInitializer(),
-                    new ResoniteCommonMaterialSetupPreparer(materialPlanning),
-                    new ResoniteCommonMaterialSetupCachePrimer(),
+                    new ResoniteLiveSendSetupInitializer(
+                        new ResoniteSceneSetupInterpreter(
+                            new ResoniteSceneSlotLocator(),
+                            new ResoniteSceneAnchorResolver()),
+                        new ResoniteCommonMaterialSetupPreparer(materialPlanning),
+                        new ResoniteCommonMaterialSetupCachePrimer(),
+                        new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
                     new LiveSendRunPlanFactory(),
                     new LiveSendRunStateFactory(
                         new ResoniteBufferedCityObjectBakerFactory(
                             new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
-                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),
-                    new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
+                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker)),
                 queue));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -324,20 +324,21 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             queuedCityObjectEnqueuer,
             new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
         ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
-            new ResoniteQueuedCityObjectSender(
-                new ResoniteQueuedCityObjectPreparer(
-                    new ResoniteQueuedGeometryPreparer(),
-                    new ResoniteQueuedTexturePreparer(
-                        terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
-                        new ResoniteDatasetLicenseWriter())),
-                new ResoniteQueuedSendFailurePolicy(),
-                new ResonitePreparedCityObjectImporter(
-                    new ResonitePreparedCityObjectAssetPlanner(
-                        new ResonitePreparedTextureUploader(new ResoniteSharedTerrainTextureAssetWriter()),
-                        new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
-                        new ResoniteSceneMaterialPlanComposer(materialPlanning)),
-                    new ResoniteBatchEmissionPlanner(),
-                    new PlannedBatchEmissionInterpreter())));
+            new ResoniteQueuedCityObjectLaneProcessor(
+                new ResoniteQueuedCityObjectSender(
+                    new ResoniteQueuedCityObjectPreparer(
+                        new ResoniteQueuedGeometryPreparer(),
+                        new ResoniteQueuedTexturePreparer(
+                            terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
+                            new ResoniteDatasetLicenseWriter())),
+                    new ResoniteQueuedSendFailurePolicy(),
+                    new ResonitePreparedCityObjectImporter(
+                        new ResonitePreparedCityObjectAssetPlanner(
+                            new ResonitePreparedTextureUploader(new ResoniteSharedTerrainTextureAssetWriter()),
+                            new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
+                            new ResoniteSceneMaterialPlanComposer(materialPlanning)),
+                        new ResoniteBatchEmissionPlanner(),
+                        new PlannedBatchEmissionInterpreter()))));
         return new ResoniteLiveSceneImportTarget(
             new ResoniteLiveSceneImportTargetOptions(
                 new Uri("ws://localhost:12345/"),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -354,6 +354,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 new ResoniteLiveSendRunStarter(
+                    new ResoniteLiveSendRunPlanInitializer(new LiveSendRunPlanFactory()),
                     new ResoniteLiveSendConnectionInitializer(),
                     new ResoniteLiveSendSetupInitializer(
                         new ResoniteSceneSetupInterpreter(
@@ -362,7 +363,6 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                         new ResoniteCommonMaterialSetupPreparer(materialPlanning),
                         new ResoniteCommonMaterialSetupCachePrimer(),
                         new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
-                    new LiveSendRunPlanFactory(),
                     new ResoniteLiveSendRunActivator(
                         new LiveSendRunStateFactory(
                             new ResoniteBufferedCityObjectBakerFactory(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -358,6 +358,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                         new ResoniteSceneSlotLocator(),
                         new ResoniteSceneAnchorResolver()),
                     new ResoniteCommonMaterialSetupPreparer(materialPlanning),
+                    new ResoniteCommonMaterialSetupCachePrimer(),
                     new LiveSendRunPlanFactory(),
                     new LiveSendRunStateFactory(
                         new ResoniteBufferedCityObjectBakerFactory(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -357,6 +357,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                     new ResoniteSceneSetupInterpreter(
                         new ResoniteSceneSlotLocator(),
                         new ResoniteSceneAnchorResolver()),
+                    new ResoniteLiveSendConnectionInitializer(),
                     new ResoniteCommonMaterialSetupPreparer(materialPlanning),
                     new ResoniteCommonMaterialSetupCachePrimer(),
                     new LiveSendRunPlanFactory(),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -363,10 +363,11 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                         new ResoniteCommonMaterialSetupCachePrimer(),
                         new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
                     new LiveSendRunPlanFactory(),
-                    new LiveSendRunStateFactory(
-                        new ResoniteBufferedCityObjectBakerFactory(
-                            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
-                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker)),
+                    new ResoniteLiveSendRunActivator(
+                        new LiveSendRunStateFactory(
+                            new ResoniteBufferedCityObjectBakerFactory(
+                                new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
+                        new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker))),
                 queue));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -368,6 +368,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                             new ResoniteBufferedCityObjectBakerFactory(
                                 new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
                         new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker))),
+                new ResoniteLiveSendContextFactory(),
                 queue));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSendConnectionInitializerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSendConnectionInitializerTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class ResoniteLiveSendConnectionInitializerTests
+{
+    [Fact]
+    public async Task EnsureConnectedAsyncConnectsWithNormalizedRequestAndReportsProgress()
+    {
+        DelegatingClientSession session = new();
+        List<string> progressMessages = [];
+        ResoniteLiveSendConnectionInitializer initializer = new();
+
+        await initializer.EnsureConnectedAsync(
+            CreateStartRequest(),
+            new LiveSendRunStartContext(
+                new Uri("ws://localhost:12345/"),
+                session,
+                ResoniteLinkSendDiagnostics.Disabled,
+                progressMessages.Add),
+            CancellationToken.None);
+
+        Assert.Equal(
+            [new LiveSendConnectionRequest("normalized-dataset", "normalized-mesh")],
+            session.EnsureConnectedRequests);
+        Assert.Contains(
+            progressMessages,
+            static message => message.Contains(
+                "Connecting ResoniteLink connection pool to ws://localhost:12345/",
+                StringComparison.Ordinal)
+                && message.Contains("with 3 available routed connection(s)", StringComparison.Ordinal));
+        Assert.Contains(
+            progressMessages,
+            static message => message.Contains("ResoniteLink connection pool ready in ", StringComparison.Ordinal)
+                && message.Contains("dataset='setup-dataset'", StringComparison.Ordinal)
+                && message.Contains("mesh='setup-mesh'", StringComparison.Ordinal));
+    }
+
+    private static LiveSendRunStartRequest CreateStartRequest()
+    {
+        return new LiveSendRunStartRequest(
+            new ResoniteSceneSetupInfo(
+                "setup-dataset",
+                "setup-mesh",
+                SourceFiles: [],
+                SelectedMeshCodes: [],
+                new ResoniteLicenseAttributionMetadata(
+                    RequireCredit: false,
+                    CreditText: null,
+                    LicenseName: null,
+                    LicenseUrl: null)),
+            WorkRoot: "work",
+            CommonMaterialCatalog.Create(),
+            new PlateauImportRequest(
+                Dataset: "normalized-dataset",
+                MeshCode: "normalized-mesh",
+                CityGmlSource: DatasetLocation.Local("dataset"),
+                PackageNames: ["bldg"]),
+            new ResoniteLocalOrigin(35.0, 139.0, 0.0),
+            ResoniteImportMemoryProfile.Large,
+            ConnectionCount: 3,
+            MeshBakeEnabled: true);
+    }
+}


### PR DESCRIPTION
## Summary
- move queued city-object lane startup, drain, cancellation, and failure handling into `ResoniteQueuedCityObjectLaneProcessor`
- keep `ResoniteQueuedCityObjectWorker` focused on creating one processing task per connection lane over the shared queue reader
- add a lane processor factory boundary and DI override coverage

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false