### PR TITLE
Extract common material setup cache primer

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -255,6 +255,7 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
                 new ResoniteLiveSendRunStarter(
                     serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
                     serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupPreparer>(),
+                    serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupCachePrimer>(),
                     serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
                     serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
                     new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupCachePrimer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupCachePrimer.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Application.Logging;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteCommonMaterialSetupCachePrimer
+{
+    void Prime(
+        ResoniteSceneSetupState setupState,
+        CommonMaterialAssetCache materials,
+        LiveSendProgressSink progress,
+        Action<string>? progressReporter);
+}
+
+internal sealed class ResoniteCommonMaterialSetupCachePrimer : IResoniteCommonMaterialSetupCachePrimer
+{
+    public void Prime(
+        ResoniteSceneSetupState setupState,
+        CommonMaterialAssetCache materials,
+        LiveSendProgressSink progress,
+        Action<string>? progressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(materials);
+        ArgumentNullException.ThrowIfNull(progress);
+
+        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
+        {
+            materials.CommonMaterialAssets.Set(materialAsset.Item);
+        }
+
+        foreach (string family in setupState.CommonMaterialFamilies)
+        {
+            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
+        }
+
+        if (setupState.CommonMaterialAssets.Count > 0)
+        {
+            progress.FirstCommonMaterialPrepLogged = setupState.CommonMaterialAssets.Count;
+            ReportProgress(
+                progressReporter,
+                PlateauLog.Info(
+                    "live",
+                    $"Setup batch prepared {setupState.CommonMaterialAssets.Count} textureless common materials."));
+        }
+        else
+        {
+            ReportProgress(
+                progressReporter,
+                PlateauLog.Info(
+                    "live",
+                    "Setup created common material slots; no textureless common material components were needed in setup batch."));
+        }
+    }
+
+    private static void ReportProgress(Action<string>? progressReporter, string message)
+    {
+        progressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -38,6 +38,7 @@ internal interface IResoniteLiveSendRunStarter
 internal sealed class ResoniteLiveSendRunStarter(
     IResoniteSceneSetupInterpreter sceneSetupInterpreter,
     IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
+    IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
     ILiveSendRunPlanFactory runPlanFactory,
     ILiveSendRunStateFactory runStateFactory,
     IResoniteLiveSendWorkerLauncher workerLauncher,
@@ -124,29 +125,11 @@ internal sealed class ResoniteLiveSendRunStarter(
                 + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
                 + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
                 + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
-        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
-        {
-            materials.CommonMaterialAssets.Set(materialAsset.Item);
-        }
-
-        foreach (string family in setupState.CommonMaterialFamilies)
-        {
-            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
-        }
-
-        if (setupState.CommonMaterialAssets.Count > 0)
-        {
-            progress.FirstCommonMaterialPrepLogged = setupState.CommonMaterialAssets.Count;
-            ReportProgress(
-                context,
-                PlateauLog.Info(
-                    "live",
-                    $"Setup batch prepared {setupState.CommonMaterialAssets.Count} textureless common materials."));
-        }
-        else
-        {
-            ReportProgress(context, PlateauLog.Info("live", "Setup created common material slots; no textureless common material components were needed in setup batch."));
-        }
+        commonMaterialSetupCachePrimer.Prime(
+            setupState,
+            materials,
+            progress,
+            context.ProgressReporter);
 
         await commonMaterialSetupPreparer.PrepareAsync(
             GetRoutedClient(context),

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -15,6 +15,7 @@ internal interface IResoniteLiveSendRunStarterFactory
 internal sealed class ResoniteLiveSendRunStarterFactory(
     IResoniteSceneSetupInterpreter sceneSetupInterpreter,
     IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
+    IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
     ILiveSendRunPlanFactory runPlanFactory,
     ILiveSendRunStateFactory runStateFactory,
     IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory,
@@ -30,6 +31,7 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter,
             commonMaterialSetupPreparer,
+            commonMaterialSetupCachePrimer,
             runPlanFactory,
             runStateFactory,
             workerLauncherFactory.Create(terrainTextureAssetHttpClient, options),

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteMaterialPlanning, ResoniteMaterialPlanning>();
         services.TryAddScoped<IResoniteSceneMaterialPlanComposer, ResoniteSceneMaterialPlanComposer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
+        services.TryAddScoped<IResoniteCommonMaterialSetupCachePrimer, ResoniteCommonMaterialSetupCachePrimer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteSharedSlotIndexFactory, ResoniteSharedSlotIndexFactory>();

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteCommonMaterialSetupCachePrimerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteCommonMaterialSetupCachePrimerTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class ResoniteCommonMaterialSetupCachePrimerTests
+{
+    [Fact]
+    public void PrimeSeedsSetupBatchAssetsFamiliesAndProgress()
+    {
+        CommonMaterialCatalog<DefaultCommonMaterialMember> catalog = CommonMaterialCatalog.Create();
+        CreatedMaterialAsset expectedAsset = new(
+            new ResoniteComponentLocator("generic-uv-material"),
+            MaterialPropertyBlockComponent: null);
+        ResoniteSceneSetupState setupState = CreateSetupState(
+            catalog.FilterToDefinitions([catalog.Generic.Uv.Definition])
+                .Map(member => new ResoniteCommonMaterialAsset(
+                    member,
+                    SceneImportContractMapper.ToInternal(member.CreateBinding([0])),
+                    expectedAsset)),
+            ["generic"]);
+        CommonMaterialAssetCache materials = new();
+        LiveSendProgressSink progress = new();
+        List<string> progressMessages = [];
+
+        new ResoniteCommonMaterialSetupCachePrimer().Prime(
+            setupState,
+            materials,
+            progress,
+            progressMessages.Add);
+
+        Assert.True(materials.CommonMaterialAssets.TryGetAsset(catalog.Generic.Uv, out CreatedMaterialAsset actualAsset));
+        Assert.Equal(expectedAsset, actualAsset);
+        Assert.True(materials.CommonMaterialFamilyWarmupTasks.TryGetValue("generic", out Task? warmupTask));
+        Assert.Same(Task.CompletedTask, warmupTask);
+        Assert.Equal(1, progress.FirstCommonMaterialPrepLogged);
+        Assert.Contains(
+            progressMessages,
+            static message => message.Contains("Setup batch prepared 1 textureless common materials.", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void PrimeReportsEmptySetupBatchWithoutMarkingFirstCommonMaterialPreparation()
+    {
+        CommonMaterialCatalog<DefaultCommonMaterialMember> catalog = CommonMaterialCatalog.Create();
+        ResoniteSceneSetupState setupState = CreateSetupState(
+            catalog.FilterToDefinitions([])
+                .Map(member => new ResoniteCommonMaterialAsset(
+                    member,
+                    SceneImportContractMapper.ToInternal(member.CreateBinding([0])),
+                    default)),
+            []);
+        CommonMaterialAssetCache materials = new();
+        LiveSendProgressSink progress = new();
+        List<string> progressMessages = [];
+
+        new ResoniteCommonMaterialSetupCachePrimer().Prime(
+            setupState,
+            materials,
+            progress,
+            progressMessages.Add);
+
+        Assert.Equal(0, materials.CommonMaterialAssets.Count);
+        Assert.Empty(materials.CommonMaterialFamilyWarmupTasks);
+        Assert.Equal(0, progress.FirstCommonMaterialPrepLogged);
+        Assert.Contains(
+            progressMessages,
+            static message => message.Contains(
+                "Setup created common material slots; no textureless common material components were needed in setup batch.",
+                StringComparison.Ordinal));
+    }
+
+    private static ResoniteSceneSetupState CreateSetupState(
+        CommonMaterialCatalog<ResoniteCommonMaterialAsset> commonMaterialAssets,
+        IReadOnlyCollection<string> commonMaterialFamilies)
+    {
+        CreatedSlot datasetRoot = new(new ResoniteSlotLocator("dataset-root"), "PLATEAU tokyo23ku");
+        return new ResoniteSceneSetupState(
+            datasetRoot,
+            new CreatedSlot(new ResoniteSlotLocator("assets-root"), "Assets"),
+            new CreatedSlot(new ResoniteSlotLocator("common-root"), "Common Materials"),
+            DatasetRootExisted: false,
+            new SceneAnchor(
+                datasetRoot.Locator,
+                "53394525",
+                new ResoniteFloat3(0.0, 0.0, 0.0),
+                ReferenceSourceFileRoot: null),
+            DatasetRootSnapshot: null,
+            commonMaterialAssets,
+            commonMaterialFamilies);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -68,6 +68,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
             CreateCommonMaterialSetupPreparer(materialPlanning),
+            new ResoniteCommonMaterialSetupCachePrimer(),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
             new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),
@@ -320,6 +321,22 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             .GetRequiredService<IResoniteSharedSlotIndexFactory>();
 
         Assert.Same(sharedSlotIndexFactory, resolvedFactory);
+    }
+
+    [Fact]
+    public void AddResoniteLiveSendTargetServicesPreservesPreRegisteredCommonMaterialSetupCachePrimer()
+    {
+        RecordingCommonMaterialSetupCachePrimer cachePrimer = new();
+        ServiceProvider provider = new ServiceCollection()
+            .AddScoped<IResoniteCommonMaterialSetupCachePrimer>(_ => cachePrimer)
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        IResoniteCommonMaterialSetupCachePrimer resolvedPrimer = scope.ServiceProvider
+            .GetRequiredService<IResoniteCommonMaterialSetupCachePrimer>();
+
+        Assert.Same(cachePrimer, resolvedPrimer);
     }
 
     [Fact]
@@ -580,6 +597,22 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         {
             _ = setupState;
             _ = runPlan;
+            throw new NotSupportedException("This test only verifies DI override preservation.");
+        }
+    }
+
+    private sealed class RecordingCommonMaterialSetupCachePrimer : IResoniteCommonMaterialSetupCachePrimer
+    {
+        public void Prime(
+            ResoniteSceneSetupState setupState,
+            CommonMaterialAssetCache materials,
+            LiveSendProgressSink progress,
+            Action<string>? progressReporter)
+        {
+            _ = setupState;
+            _ = materials;
+            _ = progress;
+            _ = progressReporter;
             throw new NotSupportedException("This test only verifies DI override preservation.");
         }
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -70,6 +70,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
             CreateCommonMaterialSetupPreparer(materialPlanning),
+            new ResoniteCommonMaterialSetupCachePrimer(),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
             new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -358,6 +358,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                         new ResoniteSceneSlotLocator(),
                         new ResoniteSceneAnchorResolver()),
                     new ResoniteCommonMaterialSetupPreparer(materialPlanning),
+                    new ResoniteCommonMaterialSetupCachePrimer(),
                     new LiveSendRunPlanFactory(),
                     new LiveSendRunStateFactory(
                         new ResoniteBufferedCityObjectBakerFactory(


### PR DESCRIPTION
## Summary
- move setup-batch common material cache/progress seeding out of `ResoniteLiveSendRunStarter`
- register `IResoniteCommonMaterialSetupCachePrimer` as a replaceable live-send boundary
- add focused tests for setup asset/family seeding and empty setup-batch progress

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false