### PR TITLE
Extract live send startup orchestration services

### DIFF
--- a/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
@@ -1,6 +1,5 @@
 using System;
 
-using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 using PlateauResoniteLink.Targets.Resonite.Diagnostics;
 using PlateauResoniteLink.Targets.Resonite.Execution;
@@ -37,12 +36,7 @@ internal sealed class DefaultCanonicalDumpLiveSceneImportTargetFactory(
             new Uri("ws://localhost:1/"),
             ConnectionCount: 1,
             EnableSendMetrics: false,
-            options.MemoryProfile switch
-            {
-                PlateauImportMemoryProfile.Small => ResoniteImportMemoryProfile.Small,
-                PlateauImportMemoryProfile.Large => ResoniteImportMemoryProfile.Large,
-                _ => throw new ArgumentOutOfRangeException(nameof(options), options.MemoryProfile, "Unsupported memory profile."),
-            },
+            CliResoniteTargetOptions.MapMemoryProfile(options.MemoryProfile, nameof(options)),
             options.EnableMeshBake,
             TerrainTileCacheRoot: null,
             DisableTerrainTileCache: true,

--- a/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
@@ -55,6 +55,7 @@ internal sealed class DefaultCanonicalDumpLiveSceneImportTargetFactory(
                     connectionInitializer,
                     setupInitializer,
                     runActivatorFactory.Create(workerLauncher)),
+                new ResoniteLiveSendContextFactory(),
                 queue));
     }
 

--- a/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
@@ -1,0 +1,89 @@
+using System;
+
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Targets.Resonite.Diagnostics;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Cli;
+
+internal interface ICanonicalDumpLiveSceneImportTargetFactory
+{
+    ResoniteLiveSceneImportTarget Create(
+        SceneSinkRecordingClient recordingClient,
+        ImportCommandOptions options,
+        Action<string>? progressReporter);
+}
+
+internal sealed class DefaultCanonicalDumpLiveSceneImportTargetFactory(
+    IResoniteDatasetLicenseWriter datasetLicenseWriter,
+    IResonitePreparedCityObjectImporter preparedCityObjectImporter,
+    IResoniteLiveSendStartRequestFactory startRequestFactory,
+    IResoniteLiveSendConnectionInitializer connectionInitializer,
+    IResoniteLiveSendSetupInitializer setupInitializer,
+    ILiveSendRunPlanFactory runPlanFactory,
+    IResoniteLiveSendRunActivatorFactory runActivatorFactory) : ICanonicalDumpLiveSceneImportTargetFactory
+{
+    public ResoniteLiveSceneImportTarget Create(
+        SceneSinkRecordingClient recordingClient,
+        ImportCommandOptions options,
+        Action<string>? progressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(recordingClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        ResoniteLiveSceneImportTargetOptions targetOptions = new(
+            new Uri("ws://localhost:1/"),
+            ConnectionCount: 1,
+            EnableSendMetrics: false,
+            options.MemoryProfile switch
+            {
+                PlateauImportMemoryProfile.Small => ResoniteImportMemoryProfile.Small,
+                PlateauImportMemoryProfile.Large => ResoniteImportMemoryProfile.Large,
+                _ => throw new ArgumentOutOfRangeException(nameof(options), options.MemoryProfile, "Unsupported memory profile."),
+            },
+            options.EnableMeshBake,
+            TerrainTileCacheRoot: null,
+            DisableTerrainTileCache: true,
+            progressReporter);
+
+        ResoniteLiveSendQueue queue = CreateQueue();
+        ResoniteLiveSendWorkerLauncher workerLauncher = CreateWorkerLauncher();
+        return new ResoniteLiveSceneImportTarget(
+            targetOptions,
+            new ResoniteLiveSceneImportDependencies(
+                new SingleRecordingClientSession(recordingClient),
+                ResoniteLinkSendDiagnostics.Disabled,
+                startRequestFactory,
+                new ResoniteLiveSendRunStarter(
+                    connectionInitializer,
+                    setupInitializer,
+                    runPlanFactory,
+                    runActivatorFactory.Create(workerLauncher)),
+                queue));
+    }
+
+    private static ResoniteLiveSendQueue CreateQueue()
+    {
+        IResoniteQueuedCityObjectEnqueuer queuedCityObjectEnqueuer = new ResoniteQueuedCityObjectEnqueuer();
+        return new ResoniteLiveSendQueue(
+            queuedCityObjectEnqueuer,
+            new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
+    }
+
+    private ResoniteLiveSendWorkerLauncher CreateWorkerLauncher()
+    {
+        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
+            new ResoniteQueuedCityObjectLaneProcessor(
+                new ResoniteQueuedCityObjectSender(
+                    new ResoniteQueuedCityObjectPreparer(
+                        new ResoniteQueuedGeometryPreparer(),
+                        new ResoniteQueuedTexturePreparer(
+                            new DeterministicTerrainTextureAssetGenerator(),
+                            datasetLicenseWriter)),
+                    new ResoniteQueuedSendFailurePolicy(),
+                    preparedCityObjectImporter)));
+        return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);
+    }
+}

--- a/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CanonicalDumpLiveSceneImportTargetFactory.cs
@@ -19,9 +19,9 @@ internal sealed class DefaultCanonicalDumpLiveSceneImportTargetFactory(
     IResoniteDatasetLicenseWriter datasetLicenseWriter,
     IResonitePreparedCityObjectImporter preparedCityObjectImporter,
     IResoniteLiveSendStartRequestFactory startRequestFactory,
+    IResoniteLiveSendRunPlanInitializer runPlanInitializer,
     IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendSetupInitializer setupInitializer,
-    ILiveSendRunPlanFactory runPlanFactory,
     IResoniteLiveSendRunActivatorFactory runActivatorFactory) : ICanonicalDumpLiveSceneImportTargetFactory
 {
     public ResoniteLiveSceneImportTarget Create(
@@ -51,9 +51,9 @@ internal sealed class DefaultCanonicalDumpLiveSceneImportTargetFactory(
                 ResoniteLinkSendDiagnostics.Disabled,
                 startRequestFactory,
                 new ResoniteLiveSendRunStarter(
+                    runPlanInitializer,
                     connectionInitializer,
                     setupInitializer,
-                    runPlanFactory,
                     runActivatorFactory.Create(workerLauncher)),
                 queue));
     }

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -254,6 +254,7 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
                 serviceProvider.GetRequiredService<IResoniteLiveSendStartRequestFactory>(),
                 new ResoniteLiveSendRunStarter(
                     serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
+                    serviceProvider.GetRequiredService<IResoniteLiveSendConnectionInitializer>(),
                     serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupPreparer>(),
                     serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupCachePrimer>(),
                     serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -253,14 +253,11 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
                 diagnostics,
                 serviceProvider.GetRequiredService<IResoniteLiveSendStartRequestFactory>(),
                 new ResoniteLiveSendRunStarter(
-                    serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
                     serviceProvider.GetRequiredService<IResoniteLiveSendConnectionInitializer>(),
-                    serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupPreparer>(),
-                    serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupCachePrimer>(),
+                    serviceProvider.GetRequiredService<IResoniteLiveSendSetupInitializer>(),
                     serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
                     serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
-                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),
-                    serviceProvider.GetRequiredService<IResoniteSharedSlotIndexFactory>()),
+                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker)),
                 queue));
     }
 }

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -256,8 +256,9 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
                     serviceProvider.GetRequiredService<IResoniteLiveSendConnectionInitializer>(),
                     serviceProvider.GetRequiredService<IResoniteLiveSendSetupInitializer>(),
                     serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
-                    serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
-                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker)),
+                    new ResoniteLiveSendRunActivator(
+                        serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
+                        new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker))),
                 queue));
     }
 }

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -12,9 +12,7 @@ using Microsoft.Extensions.Logging;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
-using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Targets.Resonite.Diagnostics;
-using PlateauResoniteLink.Transport.ResoniteLink;
 namespace PlateauResoniteLink.Cli;
 
 internal static class CliHostFactory
@@ -51,7 +49,8 @@ internal static class CliServiceCollectionExtensions
         services.AddSingleton<DatasetInspectionService>();
         services.AddSingleton<IImportServiceFactory, DefaultImportServiceFactory>();
         services.AddSingleton<IPlateauDatasetSourceResolverFactory, DefaultPlateauDatasetSourceResolverFactory>();
-        services.AddSingleton<ICanonicalSceneDumpSinkFactory, DefaultCanonicalSceneDumpSinkFactory>();
+        services.AddScoped<ICanonicalDumpLiveSceneImportTargetFactory, DefaultCanonicalDumpLiveSceneImportTargetFactory>();
+        services.AddScoped<ICanonicalSceneDumpSinkFactory, DefaultCanonicalSceneDumpSinkFactory>();
         services.AddSingleton<ISceneSinkFactory, DefaultSceneSinkFactory>();
         services.AddSingleton<CliApplication>(_ => new CliApplication(
             standardOutput,
@@ -178,7 +177,8 @@ internal sealed class DefaultSceneSinkFactory(
     }
 }
 
-internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDumpSinkFactory
+internal sealed class DefaultCanonicalSceneDumpSinkFactory(
+    ICanonicalDumpLiveSceneImportTargetFactory targetFactory) : ICanonicalSceneDumpSinkFactory
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Reliability",
@@ -194,8 +194,7 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
         SceneSinkRecordingClient recordingClient = new();
         try
         {
-            ResoniteLiveSceneImportTarget dumpTarget = CreateCanonicalDumpTarget(
-                scope.ServiceProvider,
+            ResoniteLiveSceneImportTarget dumpTarget = targetFactory.Create(
                 recordingClient,
                 options,
                 progressReporter);
@@ -208,58 +207,6 @@ internal sealed class DefaultCanonicalSceneDumpSinkFactory : ICanonicalSceneDump
             recordingClient.Dispose();
             throw;
         }
-    }
-
-    private static ResoniteLiveSceneImportTarget CreateCanonicalDumpTarget(
-        IServiceProvider serviceProvider,
-        SceneSinkRecordingClient recordingClient,
-        ImportCommandOptions options,
-        Action<string>? progressReporter)
-    {
-        ResoniteLiveSceneImportTargetOptions targetOptions = new(
-            new Uri("ws://localhost:1/"),
-            ConnectionCount: 1,
-            EnableSendMetrics: false,
-            options.MemoryProfile switch
-            {
-                PlateauImportMemoryProfile.Small => ResoniteImportMemoryProfile.Small,
-                PlateauImportMemoryProfile.Large => ResoniteImportMemoryProfile.Large,
-                _ => throw new ArgumentOutOfRangeException(nameof(options), options.MemoryProfile, "Unsupported memory profile."),
-            },
-            options.EnableMeshBake,
-            TerrainTileCacheRoot: null,
-            DisableTerrainTileCache: true,
-            progressReporter);
-
-        ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
-        IResoniteQueuedCityObjectEnqueuer queuedCityObjectEnqueuer = new ResoniteQueuedCityObjectEnqueuer();
-        ResoniteLiveSendQueue queue = new(
-            queuedCityObjectEnqueuer,
-            new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
-        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
-            new ResoniteQueuedCityObjectLaneProcessor(
-                new ResoniteQueuedCityObjectSender(
-                    new ResoniteQueuedCityObjectPreparer(
-                        new ResoniteQueuedGeometryPreparer(),
-                        new ResoniteQueuedTexturePreparer(
-                            new DeterministicTerrainTextureAssetGenerator(),
-                            serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>())),
-                    new ResoniteQueuedSendFailurePolicy(),
-                    serviceProvider.GetRequiredService<IResonitePreparedCityObjectImporter>())));
-        return new ResoniteLiveSceneImportTarget(
-            targetOptions,
-            new ResoniteLiveSceneImportDependencies(
-                new SingleRecordingClientSession(recordingClient),
-                diagnostics,
-                serviceProvider.GetRequiredService<IResoniteLiveSendStartRequestFactory>(),
-                new ResoniteLiveSendRunStarter(
-                    serviceProvider.GetRequiredService<IResoniteLiveSendConnectionInitializer>(),
-                    serviceProvider.GetRequiredService<IResoniteLiveSendSetupInitializer>(),
-                    serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
-                    new ResoniteLiveSendRunActivator(
-                        serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
-                        new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker))),
-                queue));
     }
 }
 

--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 using PlateauResoniteLink.Targets.Resonite.Diagnostics;
 namespace PlateauResoniteLink.Cli;
@@ -152,12 +151,7 @@ internal sealed class DefaultSceneSinkFactory(
                 options.ResoniteLinkUri!,
                 options.ResoniteLinkConnectionCount,
                 options.EnableSendMetrics,
-                options.MemoryProfile switch
-                {
-                    PlateauImportMemoryProfile.Small => ResoniteImportMemoryProfile.Small,
-                    PlateauImportMemoryProfile.Large => ResoniteImportMemoryProfile.Large,
-                    _ => throw new ArgumentOutOfRangeException(nameof(options), options.MemoryProfile, "Unsupported memory profile."),
-                },
+                CliResoniteTargetOptions.MapMemoryProfile(options.MemoryProfile, nameof(options)),
                 options.EnableMeshBake,
                 options.TerrainTileCacheRoot,
                 options.DisableTerrainTileCache,

--- a/src/PlateauResoniteLink.Cli/CliResoniteTargetOptions.cs
+++ b/src/PlateauResoniteLink.Cli/CliResoniteTargetOptions.cs
@@ -1,0 +1,21 @@
+using System;
+
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Cli;
+
+internal static class CliResoniteTargetOptions
+{
+    public static ResoniteImportMemoryProfile MapMemoryProfile(
+        PlateauImportMemoryProfile memoryProfile,
+        string parameterName)
+    {
+        return memoryProfile switch
+        {
+            PlateauImportMemoryProfile.Small => ResoniteImportMemoryProfile.Small,
+            PlateauImportMemoryProfile.Large => ResoniteImportMemoryProfile.Large,
+            _ => throw new ArgumentOutOfRangeException(parameterName, memoryProfile, "Unsupported memory profile."),
+        };
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunStartContracts.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunStartContracts.cs
@@ -1,0 +1,23 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record LiveSendRunStartRequest(
+    ResoniteSceneSetupInfo SetupInfo,
+    string WorkRoot,
+    CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials,
+    PlateauImportRequest NormalizedRequest,
+    ResoniteLocalOrigin RequestLocalOrigin,
+    ResoniteImportMemoryProfile MemoryProfile,
+    int ConnectionCount,
+    bool MeshBakeEnabled);
+
+internal sealed record LiveSendRunStartContext(
+    Uri Endpoint,
+    ILiveSendClientSession ClientSession,
+    ResoniteLinkSendDiagnostics Diagnostics,
+    Action<string>? ProgressReporter);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
@@ -7,4 +7,5 @@ internal sealed record ResoniteLiveSceneImportDependencies(
     ResoniteLinkSendDiagnostics Diagnostics,
     IResoniteLiveSendStartRequestFactory StartRequestFactory,
     IResoniteLiveSendRunStarter RunStarter,
+    IResoniteLiveSendContextFactory ContextFactory,
     IResoniteLiveSendQueue Queue);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
@@ -16,6 +16,7 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
     IResoniteClientSessionFactory clientSessionFactory,
     IResoniteLiveSendRunStarterFactory runStarterFactory,
     IResoniteLiveSendStartRequestFactory startRequestFactory,
+    IResoniteLiveSendContextFactory contextFactory,
     IResoniteLiveSendQueue queue)
     : IResoniteLiveSceneImportDependencyFactory
 {
@@ -34,6 +35,7 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
             diagnostics,
             startRequestFactory,
             runStarterFactory.Create(terrainTextureAssetHttpClient, options),
+            contextFactory,
             queue);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -14,6 +14,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
     private readonly int connectionCount;
     private readonly IResoniteLiveSendStartRequestFactory startRequestFactory;
     private readonly IResoniteLiveSendRunStarter runStarter;
+    private readonly IResoniteLiveSendContextFactory contextFactory;
     private readonly IResoniteLiveSendQueue queue;
 #pragma warning disable CA1859
     private ILiveSendClientSession ClientSessionInternal { get; }
@@ -31,6 +32,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         ArgumentNullException.ThrowIfNull(dependencies.ClientSession);
         ArgumentNullException.ThrowIfNull(dependencies.StartRequestFactory);
         ArgumentNullException.ThrowIfNull(dependencies.RunStarter);
+        ArgumentNullException.ThrowIfNull(dependencies.ContextFactory);
         ArgumentNullException.ThrowIfNull(dependencies.Queue);
 
         endpoint = options.Endpoint;
@@ -41,6 +43,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         progressReporter = options.ProgressReporter;
         startRequestFactory = dependencies.StartRequestFactory;
         runStarter = dependencies.RunStarter;
+        contextFactory = dependencies.ContextFactory;
         queue = dependencies.Queue;
         ClientSessionInternal = dependencies.ClientSession;
     }
@@ -69,13 +72,14 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
 
         try
         {
+            ResoniteLiveSendTargetContext liveSendContext = CreateLiveSendContext();
             state = await runStarter.StartAsync(
                 startRequestFactory.Create(
                     plan,
                     MemoryProfile,
                     connectionCount,
                     MeshBakeEnabled),
-                CreateRunStartContext(),
+                contextFactory.CreateRunStart(liveSendContext),
                 cancellationToken);
 
             await foreach (ImportedObjectUnit objectUnit in objectUnits.WithCancellation(cancellationToken))
@@ -83,13 +87,13 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
                 await queue.QueueUnitAsync(
                     state,
                     objectUnit,
-                    CreateEnqueueContext(),
+                    contextFactory.CreateEnqueue(liveSendContext),
                     cancellationToken);
             }
 
             SceneImportExecutionResult result = await queue.CompleteAsync(
                 state,
-                CreateFinalizationContext(),
+                contextFactory.CreateFinalization(liveSendContext),
                 cancellationToken);
             completedSuccessfully = true;
             return result;
@@ -138,35 +142,13 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         }
     }
 
-    private IResoniteLinkClient GetRoutedClient()
+    private ResoniteLiveSendTargetContext CreateLiveSendContext()
     {
-        return ClientSessionInternal.GetRequiredClient();
-    }
-
-    private LiveSendEnqueueContext CreateEnqueueContext()
-    {
-        return new LiveSendEnqueueContext(
+        return new ResoniteLiveSendTargetContext(
+            endpoint,
             connectionCount,
-            GetRoutedClient,
-            progressReporter);
-    }
-
-    private LiveSendFinalizationContext CreateFinalizationContext()
-    {
-        return new LiveSendFinalizationContext(
-            endpoint,
-            CreateEnqueueContext(),
-            Diagnostics,
-            progressReporter);
-    }
-
-    private LiveSendRunStartContext CreateRunStartContext()
-    {
-        return new LiveSendRunStartContext(
-            endpoint,
             ClientSessionInternal,
             Diagnostics,
             progressReporter);
     }
-
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendConnectionInitializer
+{
+    Task EnsureConnectedAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteLiveSendConnectionInitializer : IResoniteLiveSendConnectionInitializer
+{
+    public async Task EnsureConnectedAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.NormalizedRequest);
+        ArgumentNullException.ThrowIfNull(request.SetupInfo);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.Endpoint);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+
+        Stopwatch connectionStopwatch = Stopwatch.StartNew();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Connecting ResoniteLink connection pool to {context.Endpoint} "
+                + $"with {request.ConnectionCount} available routed connection(s)."));
+        await context.ClientSession.EnsureConnectedAsync(
+            new LiveSendConnectionRequest(
+                request.NormalizedRequest.Dataset,
+                request.NormalizedRequest.MeshCode),
+            cancellationToken);
+        connectionStopwatch.Stop();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"ResoniteLink connection pool ready in {connectionStopwatch.Elapsed.TotalSeconds:F2}s "
+                + $"(dataset='{request.SetupInfo.Dataset}', mesh='{request.SetupInfo.MeshCode}')."));
+    }
+
+    private static void ReportProgress(
+        LiveSendRunStartContext context,
+        string message)
+    {
+        context.ProgressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendContextFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendContextFactory.cs
@@ -1,0 +1,56 @@
+using System;
+
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendContextFactory
+{
+    LiveSendRunStartContext CreateRunStart(ResoniteLiveSendTargetContext context);
+
+    LiveSendEnqueueContext CreateEnqueue(ResoniteLiveSendTargetContext context);
+
+    LiveSendFinalizationContext CreateFinalization(ResoniteLiveSendTargetContext context);
+}
+
+internal sealed class ResoniteLiveSendContextFactory : IResoniteLiveSendContextFactory
+{
+    public LiveSendRunStartContext CreateRunStart(ResoniteLiveSendTargetContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return new LiveSendRunStartContext(
+            context.Endpoint,
+            context.ClientSession,
+            context.Diagnostics,
+            context.ProgressReporter);
+    }
+
+    public LiveSendEnqueueContext CreateEnqueue(ResoniteLiveSendTargetContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return new LiveSendEnqueueContext(
+            context.ConnectionCount,
+            context.ClientSession.GetRequiredClient,
+            context.ProgressReporter);
+    }
+
+    public LiveSendFinalizationContext CreateFinalization(ResoniteLiveSendTargetContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return new LiveSendFinalizationContext(
+            context.Endpoint,
+            CreateEnqueue(context),
+            context.Diagnostics,
+            context.ProgressReporter);
+    }
+}
+
+internal sealed record ResoniteLiveSendTargetContext(
+    Uri Endpoint,
+    int ConnectionCount,
+    ILiveSendClientSession ClientSession,
+    ResoniteLinkSendDiagnostics Diagnostics,
+    Action<string>? ProgressReporter);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunActivator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunActivator.cs
@@ -13,6 +13,21 @@ internal interface IResoniteLiveSendRunActivator
         CancellationToken cancellationToken);
 }
 
+internal interface IResoniteLiveSendRunActivatorFactory
+{
+    IResoniteLiveSendRunActivator Create(IResoniteLiveSendWorkerLauncher workerLauncher);
+}
+
+internal sealed class ResoniteLiveSendRunActivatorFactory(
+    ILiveSendRunStateFactory runStateFactory) : IResoniteLiveSendRunActivatorFactory
+{
+    public IResoniteLiveSendRunActivator Create(IResoniteLiveSendWorkerLauncher workerLauncher)
+    {
+        ArgumentNullException.ThrowIfNull(workerLauncher);
+        return new ResoniteLiveSendRunActivator(runStateFactory, workerLauncher);
+    }
+}
+
 internal sealed class ResoniteLiveSendRunActivator(
     ILiveSendRunStateFactory runStateFactory,
     IResoniteLiveSendWorkerLauncher workerLauncher) : IResoniteLiveSendRunActivator

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunActivator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunActivator.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendRunActivator
+{
+    LiveSendRunState Activate(
+        LiveSendRunPlan runPlan,
+        LiveSendSetupInitialization setup,
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteLiveSendRunActivator(
+    ILiveSendRunStateFactory runStateFactory,
+    IResoniteLiveSendWorkerLauncher workerLauncher) : IResoniteLiveSendRunActivator
+{
+    public LiveSendRunState Activate(
+        LiveSendRunPlan runPlan,
+        LiveSendSetupInitialization setup,
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(runPlan);
+        ArgumentNullException.ThrowIfNull(setup);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+
+        LiveSendRunState state = runStateFactory.Create(
+            runPlan,
+            setup.SetupState,
+            setup.Progress,
+            setup.Materials,
+            setup.Placement,
+            cancellationToken);
+        workerLauncher.Launch(
+            new LiveSendWorkerLaunchRequest(
+                state,
+                runPlan.Queue,
+                runPlan.ResourceBudget,
+                request.ConnectionCount),
+            context);
+        return state;
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunPlanInitializer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunPlanInitializer.cs
@@ -1,0 +1,53 @@
+using System;
+
+using PlateauResoniteLink.Application.Logging;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendRunPlanInitializer
+{
+    LiveSendRunPlan Initialize(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context);
+}
+
+internal sealed class ResoniteLiveSendRunPlanInitializer(
+    ILiveSendRunPlanFactory runPlanFactory) : IResoniteLiveSendRunPlanInitializer
+{
+    public LiveSendRunPlan Initialize(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(request.SetupInfo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkRoot);
+        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
+        ArgumentNullException.ThrowIfNull(request.NormalizedRequest);
+        ArgumentNullException.ThrowIfNull(context.Endpoint);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+        ArgumentNullException.ThrowIfNull(context.Diagnostics);
+
+        LiveSendRunPlan runPlan = runPlanFactory.Create(
+            request.SetupInfo,
+            request.WorkRoot,
+            request.RequestLocalOrigin,
+            request.MemoryProfile,
+            request.ConnectionCount,
+            request.MeshBakeEnabled);
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Initializing scene state for dataset '{request.SetupInfo.Dataset}' "
+                + $"mesh '{request.SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
+        return runPlan;
+    }
+
+    private static void ReportProgress(
+        LiveSendRunStartContext context,
+        string message)
+    {
+        context.ProgressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -2,28 +2,9 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
-using PlateauResoniteLink.Domain.Importing;
-using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
-
-internal sealed record LiveSendRunStartRequest(
-    ResoniteSceneSetupInfo SetupInfo,
-    string WorkRoot,
-    CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials,
-    PlateauImportRequest NormalizedRequest,
-    ResoniteLocalOrigin RequestLocalOrigin,
-    ResoniteImportMemoryProfile MemoryProfile,
-    int ConnectionCount,
-    bool MeshBakeEnabled);
-
-internal sealed record LiveSendRunStartContext(
-    Uri Endpoint,
-    ILiveSendClientSession ClientSession,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
 
 internal interface IResoniteLiveSendRunStarter
 {
@@ -37,8 +18,7 @@ internal sealed class ResoniteLiveSendRunStarter(
     IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendSetupInitializer setupInitializer,
     ILiveSendRunPlanFactory runPlanFactory,
-    ILiveSendRunStateFactory runStateFactory,
-    IResoniteLiveSendWorkerLauncher workerLauncher) : IResoniteLiveSendRunStarter
+    IResoniteLiveSendRunActivator runActivator) : IResoniteLiveSendRunStarter
 {
     public async Task<LiveSendRunState> StartAsync(
         LiveSendRunStartRequest request,
@@ -74,21 +54,12 @@ internal sealed class ResoniteLiveSendRunStarter(
             context,
             runPlan,
             cancellationToken);
-        LiveSendRunState state = runStateFactory.Create(
+        return runActivator.Activate(
             runPlan,
-            setup.SetupState,
-            setup.Progress,
-            setup.Materials,
-            setup.Placement,
+            setup,
+            request,
+            context,
             cancellationToken);
-        workerLauncher.Launch(
-            new LiveSendWorkerLaunchRequest(
-                state,
-                runPlan.Queue,
-                runPlan.ResourceBudget,
-                request.ConnectionCount),
-            context);
-        return state;
     }
 
     private static void ReportProgress(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
-
-using PlateauResoniteLink.Application.Logging;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
@@ -15,9 +12,9 @@ internal interface IResoniteLiveSendRunStarter
 }
 
 internal sealed class ResoniteLiveSendRunStarter(
+    IResoniteLiveSendRunPlanInitializer runPlanInitializer,
     IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendSetupInitializer setupInitializer,
-    ILiveSendRunPlanFactory runPlanFactory,
     IResoniteLiveSendRunActivator runActivator) : IResoniteLiveSendRunStarter
 {
     public async Task<LiveSendRunState> StartAsync(
@@ -25,29 +22,7 @@ internal sealed class ResoniteLiveSendRunStarter(
         LiveSendRunStartContext context,
         CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(request.SetupInfo);
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkRoot);
-        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
-        ArgumentNullException.ThrowIfNull(request.NormalizedRequest);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
-
-        LiveSendRunPlan runPlan = runPlanFactory.Create(
-            request.SetupInfo,
-            request.WorkRoot,
-            request.RequestLocalOrigin,
-            request.MemoryProfile,
-            request.ConnectionCount,
-            request.MeshBakeEnabled);
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Initializing scene state for dataset '{request.SetupInfo.Dataset}' "
-                + $"mesh '{request.SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
+        LiveSendRunPlan runPlan = runPlanInitializer.Initialize(request, context);
         await connectionInitializer.EnsureConnectedAsync(request, context, cancellationToken);
         LiveSendSetupInitialization setup = await setupInitializer.InitializeAsync(
             request,
@@ -60,12 +35,5 @@ internal sealed class ResoniteLiveSendRunStarter(
             request,
             context,
             cancellationToken);
-    }
-
-    private static void ReportProgress(
-        LiveSendRunStartContext context,
-        string message)
-    {
-        context.ProgressReporter?.Invoke(message);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -1,12 +1,10 @@
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Domain.Importing;
-using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -36,14 +34,11 @@ internal interface IResoniteLiveSendRunStarter
 }
 
 internal sealed class ResoniteLiveSendRunStarter(
-    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
     IResoniteLiveSendConnectionInitializer connectionInitializer,
-    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
-    IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
+    IResoniteLiveSendSetupInitializer setupInitializer,
     ILiveSendRunPlanFactory runPlanFactory,
     ILiveSendRunStateFactory runStateFactory,
-    IResoniteLiveSendWorkerLauncher workerLauncher,
-    IResoniteSharedSlotIndexFactory sharedSlotIndexFactory) : IResoniteLiveSendRunStarter
+    IResoniteLiveSendWorkerLauncher workerLauncher) : IResoniteLiveSendRunStarter
 {
     public async Task<LiveSendRunState> StartAsync(
         LiveSendRunStartRequest request,
@@ -74,71 +69,17 @@ internal sealed class ResoniteLiveSendRunStarter(
                 $"Initializing scene state for dataset '{request.SetupInfo.Dataset}' "
                 + $"mesh '{request.SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
         await connectionInitializer.EnsureConnectedAsync(request, context, cancellationToken);
-        LiveSendProgressSink progress = new();
-        CommonMaterialAssetCache materials = new();
-        ReportProgress(
+        LiveSendSetupInitialization setup = await setupInitializer.InitializeAsync(
+            request,
             context,
-            PlateauLog.Info(
-                "live",
-                "Reusing dataset content source provided by caller."));
-        ReportProgress(
-            context,
-            PlateauLog.Info("live", "Setting up mutable helpers (baker)."));
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                "Starting setup slot setup: dataset root, assets root, common assets root, location slot, and source-file root reference."));
-        Stopwatch setupStopwatch = Stopwatch.StartNew();
-        ResoniteSceneSetupState setupState = await sceneSetupInterpreter.SetupAsync(
-            GetRoutedClient(context),
-            runPlan.SetupInfo,
-            request.CommonMaterials,
+            runPlan,
             cancellationToken);
-        setupStopwatch.Stop();
-        ResoniteSharedSlotIndex placement = sharedSlotIndexFactory.Create(setupState, runPlan);
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Scene setup complete in {setupStopwatch.Elapsed.TotalSeconds:F2}s "
-                + $"(dataset_root={setupState.DatasetRootSlot.SlotName}, assets_root={setupState.DatasetAssetsRootSlot.SlotName}, "
-                + $"common_root={setupState.CommonAssetsRootSlot.SlotName}, "
-                + $"dataset_root_existed={setupState.DatasetRootExisted}, "
-                + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
-                + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
-                + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
-        commonMaterialSetupCachePrimer.Prime(
-            setupState,
-            materials,
-            progress,
-            context.ProgressReporter);
-
-        await commonMaterialSetupPreparer.PrepareAsync(
-            GetRoutedClient(context),
-            setupState,
-            materials,
-            request.CommonMaterials,
-            context.ProgressReporter,
-            cancellationToken);
-
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                "setup fixed dataset license metadata/component before city-object streaming starts."));
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Dataset metadata/license phase complete during setup. "
-                + $"Dataset root existed={setupState.DatasetRootExisted}."));
         LiveSendRunState state = runStateFactory.Create(
             runPlan,
-            setupState,
-            progress,
-            materials,
-            placement,
+            setup.SetupState,
+            setup.Progress,
+            setup.Materials,
+            setup.Placement,
             cancellationToken);
         workerLauncher.Launch(
             new LiveSendWorkerLaunchRequest(
@@ -148,11 +89,6 @@ internal sealed class ResoniteLiveSendRunStarter(
                 request.ConnectionCount),
             context);
         return state;
-    }
-
-    private static IResoniteLinkClient GetRoutedClient(LiveSendRunStartContext context)
-    {
-        return context.ClientSession.GetRequiredClient();
     }
 
     private static void ReportProgress(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -37,6 +37,7 @@ internal interface IResoniteLiveSendRunStarter
 
 internal sealed class ResoniteLiveSendRunStarter(
     IResoniteSceneSetupInterpreter sceneSetupInterpreter,
+    IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
     IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
     ILiveSendRunPlanFactory runPlanFactory,
@@ -72,25 +73,7 @@ internal sealed class ResoniteLiveSendRunStarter(
                 "live",
                 $"Initializing scene state for dataset '{request.SetupInfo.Dataset}' "
                 + $"mesh '{request.SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
-        Stopwatch connectionStopwatch = Stopwatch.StartNew();
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Connecting ResoniteLink connection pool to {context.Endpoint} "
-                + $"with {request.ConnectionCount} available routed connection(s)."));
-        await context.ClientSession.EnsureConnectedAsync(
-            new LiveSendConnectionRequest(
-                request.NormalizedRequest.Dataset,
-                request.NormalizedRequest.MeshCode),
-            cancellationToken);
-        connectionStopwatch.Stop();
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"ResoniteLink connection pool ready in {connectionStopwatch.Elapsed.TotalSeconds:F2}s "
-                + $"(dataset='{request.SetupInfo.Dataset}', mesh='{request.SetupInfo.MeshCode}')."));
+        await connectionInitializer.EnsureConnectedAsync(request, context, cancellationToken);
         LiveSendProgressSink progress = new();
         CommonMaterialAssetCache materials = new();
         ReportProgress(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -14,7 +14,7 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
     IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendSetupInitializer setupInitializer,
     ILiveSendRunPlanFactory runPlanFactory,
-    ILiveSendRunStateFactory runStateFactory,
+    IResoniteLiveSendRunActivatorFactory runActivatorFactory,
     IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory) : IResoniteLiveSendRunStarterFactory
 {
     public IResoniteLiveSendRunStarter Create(
@@ -24,38 +24,12 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
         ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
         ArgumentNullException.ThrowIfNull(options);
 
+        IResoniteLiveSendWorkerLauncher workerLauncher =
+            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options);
         return new ResoniteLiveSendRunStarter(
             connectionInitializer,
             setupInitializer,
             runPlanFactory,
-            new ResoniteLiveSendRunActivator(
-                runStateFactory,
-                workerLauncherFactory.Create(terrainTextureAssetHttpClient, options)));
-    }
-}
-
-internal interface IResoniteLiveSendWorkerLauncherFactory
-{
-    IResoniteLiveSendWorkerLauncher Create(
-        HttpClient terrainTextureAssetHttpClient,
-        ResoniteLiveSceneImportTargetOptions options);
-}
-
-internal sealed class ResoniteLiveSendWorkerLauncherFactory(
-    IResoniteQueuedCityObjectSenderFactory queuedCityObjectSenderFactory,
-    IResoniteQueuedCityObjectLaneProcessorFactory laneProcessorFactory) : IResoniteLiveSendWorkerLauncherFactory
-{
-    public IResoniteLiveSendWorkerLauncher Create(
-        HttpClient terrainTextureAssetHttpClient,
-        ResoniteLiveSceneImportTargetOptions options)
-    {
-        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
-        ArgumentNullException.ThrowIfNull(options);
-
-        IResoniteQueuedCityObjectSender queuedCityObjectSender =
-            queuedCityObjectSenderFactory.Create(terrainTextureAssetHttpClient, options);
-        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
-            laneProcessorFactory.Create(queuedCityObjectSender));
-        return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);
+            runActivatorFactory.Create(workerLauncher));
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -14,6 +14,7 @@ internal interface IResoniteLiveSendRunStarterFactory
 
 internal sealed class ResoniteLiveSendRunStarterFactory(
     IResoniteSceneSetupInterpreter sceneSetupInterpreter,
+    IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
     IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
     ILiveSendRunPlanFactory runPlanFactory,
@@ -30,6 +31,7 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
 
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter,
+            connectionInitializer,
             commonMaterialSetupPreparer,
             commonMaterialSetupCachePrimer,
             runPlanFactory,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -13,7 +13,7 @@ internal interface IResoniteLiveSendRunStarterFactory
 internal sealed class ResoniteLiveSendRunStarterFactory(
     IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendSetupInitializer setupInitializer,
-    ILiveSendRunPlanFactory runPlanFactory,
+    IResoniteLiveSendRunPlanInitializer runPlanInitializer,
     IResoniteLiveSendRunActivatorFactory runActivatorFactory,
     IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory) : IResoniteLiveSendRunStarterFactory
 {
@@ -27,9 +27,9 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
         IResoniteLiveSendWorkerLauncher workerLauncher =
             workerLauncherFactory.Create(terrainTextureAssetHttpClient, options);
         return new ResoniteLiveSendRunStarter(
+            runPlanInitializer,
             connectionInitializer,
             setupInitializer,
-            runPlanFactory,
             runActivatorFactory.Create(workerLauncher));
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Net.Http;
 
-using PlateauResoniteLink.Targets.Resonite.Execution;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal interface IResoniteLiveSendRunStarterFactory
@@ -13,14 +11,11 @@ internal interface IResoniteLiveSendRunStarterFactory
 }
 
 internal sealed class ResoniteLiveSendRunStarterFactory(
-    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
     IResoniteLiveSendConnectionInitializer connectionInitializer,
-    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
-    IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
+    IResoniteLiveSendSetupInitializer setupInitializer,
     ILiveSendRunPlanFactory runPlanFactory,
     ILiveSendRunStateFactory runStateFactory,
-    IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory,
-    IResoniteSharedSlotIndexFactory sharedSlotIndexFactory) : IResoniteLiveSendRunStarterFactory
+    IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory) : IResoniteLiveSendRunStarterFactory
 {
     public IResoniteLiveSendRunStarter Create(
         HttpClient terrainTextureAssetHttpClient,
@@ -30,14 +25,11 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
         ArgumentNullException.ThrowIfNull(options);
 
         return new ResoniteLiveSendRunStarter(
-            sceneSetupInterpreter,
             connectionInitializer,
-            commonMaterialSetupPreparer,
-            commonMaterialSetupCachePrimer,
+            setupInitializer,
             runPlanFactory,
             runStateFactory,
-            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options),
-            sharedSlotIndexFactory);
+            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options));
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -28,8 +28,9 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
             connectionInitializer,
             setupInitializer,
             runPlanFactory,
-            runStateFactory,
-            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options));
+            new ResoniteLiveSendRunActivator(
+                runStateFactory,
+                workerLauncherFactory.Create(terrainTextureAssetHttpClient, options)));
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendSetupInitializer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendSetupInitializer.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record LiveSendSetupInitialization(
+    ResoniteSceneSetupState SetupState,
+    LiveSendProgressSink Progress,
+    CommonMaterialAssetCache Materials,
+    ResoniteSharedSlotIndex Placement);
+
+internal interface IResoniteLiveSendSetupInitializer
+{
+    Task<LiveSendSetupInitialization> InitializeAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        LiveSendRunPlan runPlan,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteLiveSendSetupInitializer(
+    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
+    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
+    IResoniteCommonMaterialSetupCachePrimer commonMaterialSetupCachePrimer,
+    IResoniteSharedSlotIndexFactory sharedSlotIndexFactory) : IResoniteLiveSendSetupInitializer
+{
+    public async Task<LiveSendSetupInitialization> InitializeAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        LiveSendRunPlan runPlan,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+        ArgumentNullException.ThrowIfNull(runPlan);
+
+        LiveSendProgressSink progress = new();
+        CommonMaterialAssetCache materials = new();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "Reusing dataset content source provided by caller."));
+        ReportProgress(
+            context,
+            PlateauLog.Info("live", "Setting up mutable helpers (baker)."));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "Starting setup slot setup: dataset root, assets root, common assets root, location slot, and source-file root reference."));
+        Stopwatch setupStopwatch = Stopwatch.StartNew();
+        ResoniteSceneSetupState setupState = await sceneSetupInterpreter.SetupAsync(
+            GetRoutedClient(context),
+            runPlan.SetupInfo,
+            request.CommonMaterials,
+            cancellationToken);
+        setupStopwatch.Stop();
+        ResoniteSharedSlotIndex placement = sharedSlotIndexFactory.Create(setupState, runPlan);
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Scene setup complete in {setupStopwatch.Elapsed.TotalSeconds:F2}s "
+                + $"(dataset_root={setupState.DatasetRootSlot.SlotName}, assets_root={setupState.DatasetAssetsRootSlot.SlotName}, "
+                + $"common_root={setupState.CommonAssetsRootSlot.SlotName}, "
+                + $"dataset_root_existed={setupState.DatasetRootExisted}, "
+                + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
+                + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
+                + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
+        commonMaterialSetupCachePrimer.Prime(
+            setupState,
+            materials,
+            progress,
+            context.ProgressReporter);
+
+        await commonMaterialSetupPreparer.PrepareAsync(
+            GetRoutedClient(context),
+            setupState,
+            materials,
+            request.CommonMaterials,
+            context.ProgressReporter,
+            cancellationToken);
+
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "setup fixed dataset license metadata/component before city-object streaming starts."));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Dataset metadata/license phase complete during setup. "
+                + $"Dataset root existed={setupState.DatasetRootExisted}."));
+
+        return new LiveSendSetupInitialization(
+            setupState,
+            progress,
+            materials,
+            placement);
+    }
+
+    private static IResoniteLinkClient GetRoutedClient(LiveSendRunStartContext context)
+    {
+        return context.ClientSession.GetRequiredClient();
+    }
+
+    private static void ReportProgress(
+        LiveSendRunStartContext context,
+        string message)
+    {
+        context.ProgressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupCachePrimer, ResoniteCommonMaterialSetupCachePrimer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
+        services.TryAddScoped<IResoniteLiveSendRunPlanInitializer, ResoniteLiveSendRunPlanInitializer>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunActivatorFactory, ResoniteLiveSendRunActivatorFactory>();
         services.TryAddScoped<IResoniteSharedSlotIndexFactory, ResoniteSharedSlotIndexFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteMaterialPlanning, ResoniteMaterialPlanning>();
         services.TryAddScoped<IResoniteSceneMaterialPlanComposer, ResoniteSceneMaterialPlanComposer>();
         services.TryAddScoped<IResoniteLiveSendConnectionInitializer, ResoniteLiveSendConnectionInitializer>();
+        services.TryAddScoped<IResoniteLiveSendSetupInitializer, ResoniteLiveSendSetupInitializer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupCachePrimer, ResoniteCommonMaterialSetupCachePrimer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteCommonMaterialSetupCachePrimer, ResoniteCommonMaterialSetupCachePrimer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
+        services.TryAddScoped<IResoniteLiveSendRunActivatorFactory, ResoniteLiveSendRunActivatorFactory>();
         services.TryAddScoped<IResoniteSharedSlotIndexFactory, ResoniteSharedSlotIndexFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
         services.TryAddScoped<IResoniteLiveSendWorkerLauncherFactory, ResoniteLiveSendWorkerLauncherFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteGeometryAssetPlanner, ResoniteGeometryAssetPlanner>();
         services.TryAddScoped<IResoniteMaterialPlanning, ResoniteMaterialPlanning>();
         services.TryAddScoped<IResoniteSceneMaterialPlanComposer, ResoniteSceneMaterialPlanComposer>();
+        services.TryAddScoped<IResoniteLiveSendConnectionInitializer, ResoniteLiveSendConnectionInitializer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupCachePrimer, ResoniteCommonMaterialSetupCachePrimer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteLiveSendRunPlanInitializer, ResoniteLiveSendRunPlanInitializer>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunActivatorFactory, ResoniteLiveSendRunActivatorFactory>();
+        services.TryAddScoped<IResoniteLiveSendContextFactory, ResoniteLiveSendContextFactory>();
         services.TryAddScoped<IResoniteSharedSlotIndexFactory, ResoniteSharedSlotIndexFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
         services.TryAddScoped<IResoniteLiveSendWorkerLauncherFactory, ResoniteLiveSendWorkerLauncherFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncherFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncherFactory.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Net.Http;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendWorkerLauncherFactory
+{
+    IResoniteLiveSendWorkerLauncher Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options);
+}
+
+internal sealed class ResoniteLiveSendWorkerLauncherFactory(
+    IResoniteQueuedCityObjectSenderFactory queuedCityObjectSenderFactory,
+    IResoniteQueuedCityObjectLaneProcessorFactory laneProcessorFactory) : IResoniteLiveSendWorkerLauncherFactory
+{
+    public IResoniteLiveSendWorkerLauncher Create(
+        HttpClient terrainTextureAssetHttpClient,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        IResoniteQueuedCityObjectSender queuedCityObjectSender =
+            queuedCityObjectSenderFactory.Create(terrainTextureAssetHttpClient, options);
+        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
+            laneProcessorFactory.Create(queuedCityObjectSender));
+        return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -67,6 +67,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     {
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
+            new ResoniteLiveSendConnectionInitializer(),
             CreateCommonMaterialSetupPreparer(materialPlanning),
             new ResoniteCommonMaterialSetupCachePrimer(),
             new LiveSendRunPlanFactory(),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -66,13 +66,13 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null)
     {
         return new ResoniteLiveSendRunStarter(
+            new ResoniteLiveSendRunPlanInitializer(new LiveSendRunPlanFactory()),
             new ResoniteLiveSendConnectionInitializer(),
             new ResoniteLiveSendSetupInitializer(
                 sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
                 CreateCommonMaterialSetupPreparer(materialPlanning),
                 new ResoniteCommonMaterialSetupCachePrimer(),
                 new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
-            new LiveSendRunPlanFactory(),
             new ResoniteLiveSendRunActivator(
                 CreateRunStateFactory(),
                 new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning))));

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -66,14 +66,15 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null)
     {
         return new ResoniteLiveSendRunStarter(
-            sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
             new ResoniteLiveSendConnectionInitializer(),
-            CreateCommonMaterialSetupPreparer(materialPlanning),
-            new ResoniteCommonMaterialSetupCachePrimer(),
+            new ResoniteLiveSendSetupInitializer(
+                sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
+                CreateCommonMaterialSetupPreparer(materialPlanning),
+                new ResoniteCommonMaterialSetupCachePrimer(),
+                new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
-            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),
-            new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator()));
+            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)));
     }
 
     private static ResoniteLiveSendQueue CreateQueue()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -128,6 +128,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
 
         Assert.Same(diagnostics, importTarget.Diagnostics);
@@ -454,6 +455,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -73,8 +73,9 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
                 new ResoniteCommonMaterialSetupCachePrimer(),
                 new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
             new LiveSendRunPlanFactory(),
-            CreateRunStateFactory(),
-            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)));
+            new ResoniteLiveSendRunActivator(
+                CreateRunStateFactory(),
+                new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning))));
     }
 
     private static ResoniteLiveSendQueue CreateQueue()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -69,6 +69,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     {
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
+            new ResoniteLiveSendConnectionInitializer(),
             CreateCommonMaterialSetupPreparer(materialPlanning),
             new ResoniteCommonMaterialSetupCachePrimer(),
             new LiveSendRunPlanFactory(),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -68,14 +68,15 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null)
     {
         return new ResoniteLiveSendRunStarter(
-            sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
             new ResoniteLiveSendConnectionInitializer(),
-            CreateCommonMaterialSetupPreparer(materialPlanning),
-            new ResoniteCommonMaterialSetupCachePrimer(),
+            new ResoniteLiveSendSetupInitializer(
+                sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
+                CreateCommonMaterialSetupPreparer(materialPlanning),
+                new ResoniteCommonMaterialSetupCachePrimer(),
+                new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
             new LiveSendRunPlanFactory(),
             CreateRunStateFactory(),
-            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)),
-            new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator()));
+            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)));
     }
 
     private static ResoniteLiveSendQueue CreateQueue()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -111,6 +111,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
 
         PlateauImportRequest normalizedRequest = new(
@@ -167,6 +168,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
 
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
@@ -214,6 +216,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
@@ -298,6 +301,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 ResoniteLinkSendDiagnostics.Disabled,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter()),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
@@ -342,6 +346,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 ResoniteLinkSendDiagnostics.Disabled,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter()),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
@@ -409,6 +414,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 ResoniteLinkSendDiagnostics.Disabled,
                 new ResoniteLiveSendStartRequestFactory(),
                 CreateRunStarter(materialPlanning),
+                new ResoniteLiveSendContextFactory(),
                 CreateQueue()));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -68,13 +68,13 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         IResoniteSceneSetupInterpreter? sceneSetupInterpreter = null)
     {
         return new ResoniteLiveSendRunStarter(
+            new ResoniteLiveSendRunPlanInitializer(new LiveSendRunPlanFactory()),
             new ResoniteLiveSendConnectionInitializer(),
             new ResoniteLiveSendSetupInitializer(
                 sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
                 CreateCommonMaterialSetupPreparer(materialPlanning),
                 new ResoniteCommonMaterialSetupCachePrimer(),
                 new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
-            new LiveSendRunPlanFactory(),
             new ResoniteLiveSendRunActivator(
                 CreateRunStateFactory(),
                 new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning))));

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -75,8 +75,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 new ResoniteCommonMaterialSetupCachePrimer(),
                 new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
             new LiveSendRunPlanFactory(),
-            CreateRunStateFactory(),
-            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning)));
+            new ResoniteLiveSendRunActivator(
+                CreateRunStateFactory(),
+                new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning))));
     }
 
     private static ResoniteLiveSendQueue CreateQueue()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -354,18 +354,19 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 new ResoniteLiveSendRunStarter(
-                    new ResoniteSceneSetupInterpreter(
-                        new ResoniteSceneSlotLocator(),
-                        new ResoniteSceneAnchorResolver()),
                     new ResoniteLiveSendConnectionInitializer(),
-                    new ResoniteCommonMaterialSetupPreparer(materialPlanning),
-                    new ResoniteCommonMaterialSetupCachePrimer(),
+                    new ResoniteLiveSendSetupInitializer(
+                        new ResoniteSceneSetupInterpreter(
+                            new ResoniteSceneSlotLocator(),
+                            new ResoniteSceneAnchorResolver()),
+                        new ResoniteCommonMaterialSetupPreparer(materialPlanning),
+                        new ResoniteCommonMaterialSetupCachePrimer(),
+                        new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
                     new LiveSendRunPlanFactory(),
                     new LiveSendRunStateFactory(
                         new ResoniteBufferedCityObjectBakerFactory(
                             new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
-                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),
-                    new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
+                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker)),
                 queue));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -354,6 +354,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 diagnostics,
                 new ResoniteLiveSendStartRequestFactory(),
                 new ResoniteLiveSendRunStarter(
+                    new ResoniteLiveSendRunPlanInitializer(new LiveSendRunPlanFactory()),
                     new ResoniteLiveSendConnectionInitializer(),
                     new ResoniteLiveSendSetupInitializer(
                         new ResoniteSceneSetupInterpreter(
@@ -362,7 +363,6 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                         new ResoniteCommonMaterialSetupPreparer(materialPlanning),
                         new ResoniteCommonMaterialSetupCachePrimer(),
                         new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
-                    new LiveSendRunPlanFactory(),
                     new ResoniteLiveSendRunActivator(
                         new LiveSendRunStateFactory(
                             new ResoniteBufferedCityObjectBakerFactory(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -357,6 +357,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                     new ResoniteSceneSetupInterpreter(
                         new ResoniteSceneSlotLocator(),
                         new ResoniteSceneAnchorResolver()),
+                    new ResoniteLiveSendConnectionInitializer(),
                     new ResoniteCommonMaterialSetupPreparer(materialPlanning),
                     new ResoniteCommonMaterialSetupCachePrimer(),
                     new LiveSendRunPlanFactory(),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -363,10 +363,11 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                         new ResoniteCommonMaterialSetupCachePrimer(),
                         new ResoniteSharedSlotIndexFactory(new ResoniteSlotCreator())),
                     new LiveSendRunPlanFactory(),
-                    new LiveSendRunStateFactory(
-                        new ResoniteBufferedCityObjectBakerFactory(
-                            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
-                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker)),
+                    new ResoniteLiveSendRunActivator(
+                        new LiveSendRunStateFactory(
+                            new ResoniteBufferedCityObjectBakerFactory(
+                                new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
+                        new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker))),
                 queue));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -368,6 +368,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                             new ResoniteBufferedCityObjectBakerFactory(
                                 new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
                         new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker))),
+                new ResoniteLiveSendContextFactory(),
                 queue));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSendConnectionInitializerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSendConnectionInitializerTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class ResoniteLiveSendConnectionInitializerTests
+{
+    [Fact]
+    public async Task EnsureConnectedAsyncConnectsWithNormalizedRequestAndReportsProgress()
+    {
+        DelegatingClientSession session = new();
+        List<string> progressMessages = [];
+        ResoniteLiveSendConnectionInitializer initializer = new();
+
+        await initializer.EnsureConnectedAsync(
+            CreateStartRequest(),
+            new LiveSendRunStartContext(
+                new Uri("ws://localhost:12345/"),
+                session,
+                ResoniteLinkSendDiagnostics.Disabled,
+                progressMessages.Add),
+            CancellationToken.None);
+
+        Assert.Equal(
+            [new LiveSendConnectionRequest("normalized-dataset", "normalized-mesh")],
+            session.EnsureConnectedRequests);
+        Assert.Contains(
+            progressMessages,
+            static message => message.Contains(
+                "Connecting ResoniteLink connection pool to ws://localhost:12345/",
+                StringComparison.Ordinal)
+                && message.Contains("with 3 available routed connection(s)", StringComparison.Ordinal));
+        Assert.Contains(
+            progressMessages,
+            static message => message.Contains("ResoniteLink connection pool ready in ", StringComparison.Ordinal)
+                && message.Contains("dataset='setup-dataset'", StringComparison.Ordinal)
+                && message.Contains("mesh='setup-mesh'", StringComparison.Ordinal));
+    }
+
+    private static LiveSendRunStartRequest CreateStartRequest()
+    {
+        return new LiveSendRunStartRequest(
+            new ResoniteSceneSetupInfo(
+                "setup-dataset",
+                "setup-mesh",
+                SourceFiles: [],
+                SelectedMeshCodes: [],
+                new ResoniteLicenseAttributionMetadata(
+                    RequireCredit: false,
+                    CreditText: null,
+                    LicenseName: null,
+                    LicenseUrl: null)),
+            WorkRoot: "work",
+            CommonMaterialCatalog.Create(),
+            new PlateauImportRequest(
+                Dataset: "normalized-dataset",
+                MeshCode: "normalized-mesh",
+                CityGmlSource: DatasetLocation.Local("dataset"),
+                PackageNames: ["bldg"]),
+            new ResoniteLocalOrigin(35.0, 139.0, 0.0),
+            ResoniteImportMemoryProfile.Large,
+            ConnectionCount: 3,
+            MeshBakeEnabled: true);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract ResoniteLink connection-pool startup from ResoniteLiveSendRunStarter into IResoniteLiveSendConnectionInitializer.
- Extract run-plan validation, plan creation, and initial startup progress into IResoniteLiveSendRunPlanInitializer.
- Extract scene setup, shared slot indexing, common material cache priming, and setup-phase progress into IResoniteLiveSendSetupInitializer.
- Extract run-state creation plus worker launch into IResoniteLiveSendRunActivator and add a small activator factory for option-specific worker launcher composition.
- Extract Live Send context creation from ResoniteLiveSceneImportTarget into IResoniteLiveSendContextFactory, with target runtime state passed as a value record.
- Extract run runtime/client cleanup from ResoniteLiveSceneImportTarget into IResoniteLiveSendResourceReleaser, replacing bool cleanup flags with an explicit client-release enum.
- Move shared live-send start request/context records out of ResoniteLiveSendRunStarter so the startup services share explicit contracts instead of depending on a hidden owner file.
- Split worker launcher factory composition into its own file so run-starter factory only composes startup services.
- Extract canonical dump Fake Link target construction into DefaultCanonicalDumpLiveSceneImportTargetFactory, keeping dump sink creation separate from deterministic target wiring.
- Centralize CLI-to-Resonite memory profile mapping so normal live send and canonical dump use one option conversion rule.
- Keep ResoniteLiveSendRunStarter focused on start-order orchestration: plan initialization, connection, setup, and activation.
- Wire the startup services through DI/factory composition, CLI construction, and test construction paths.
- Add a focused behavior test that preserves normalized connection request values and existing progress messages.

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

## Baseline
- Full test run includes ResoniteSemanticGateTests.ExecuteLocalFixture_ToFakeLink_CanonicalDumpMatchesBaseline.