### PR TITLE
Extract live send run executor

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -205,6 +205,8 @@ internal sealed class DefaultSceneSinkFactory(
 
         IServiceProvider serviceProvider = scope.ServiceProvider;
         ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
+        IResoniteLiveSendRunResourceReleaser resourceReleaser =
+            serviceProvider.GetRequiredService<IResoniteLiveSendRunResourceReleaser>();
         IResoniteQueuedCityObjectEnqueuer queuedCityObjectEnqueuer = new ResoniteQueuedCityObjectEnqueuer();
         ResoniteLiveSendQueue queue = new(
             queuedCityObjectEnqueuer,
@@ -221,14 +223,17 @@ internal sealed class DefaultSceneSinkFactory(
                 new SingleRecordingClientSession(recordingClient),
                 diagnostics,
                 serviceProvider.GetRequiredService<IResoniteLiveSendStartRequestFactory>(),
-                new ResoniteLiveSendRunStarter(
-                    serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
-                    serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupPreparer>(),
-                    serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
-                    serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
-                    new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),
-                    serviceProvider.GetRequiredService<IResoniteSlotCreator>()),
-                queue));
+                new ResoniteLiveSendRunExecutor(
+                    new ResoniteLiveSendRunStarter(
+                        serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
+                        serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupPreparer>(),
+                        serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
+                        serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
+                        new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),
+                        serviceProvider.GetRequiredService<IResoniteSlotCreator>()),
+                    queue,
+                    resourceReleaser),
+                resourceReleaser));
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
@@ -6,5 +6,5 @@ internal sealed record ResoniteLiveSceneImportDependencies(
     ILiveSendClientSession ClientSession,
     ResoniteLinkSendDiagnostics Diagnostics,
     IResoniteLiveSendStartRequestFactory StartRequestFactory,
-    IResoniteLiveSendRunStarter RunStarter,
-    IResoniteLiveSendQueue Queue);
+    IResoniteLiveSendRunExecutor RunExecutor,
+    IResoniteLiveSendRunResourceReleaser ResourceReleaser);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
@@ -16,7 +16,8 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
     IResoniteClientSessionFactory clientSessionFactory,
     IResoniteLiveSendRunStarterFactory runStarterFactory,
     IResoniteLiveSendStartRequestFactory startRequestFactory,
-    IResoniteLiveSendQueue queue)
+    IResoniteLiveSendRunExecutorFactory runExecutorFactory,
+    IResoniteLiveSendRunResourceReleaser resourceReleaser)
     : IResoniteLiveSceneImportDependencyFactory
 {
     public ResoniteLiveSceneImportDependencies Create(
@@ -29,11 +30,14 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
             ? ResoniteLinkSendDiagnostics.CreateEnabled(options.ProgressReporter)
             : ResoniteLinkSendDiagnostics.Disabled;
 
+        ILiveSendClientSession clientSession = clientSessionFactory.Create(options, diagnostics);
+        IResoniteLiveSendRunStarter runStarter = runStarterFactory.Create(terrainTextureAssetHttpClient, options);
+
         return new ResoniteLiveSceneImportDependencies(
-            clientSessionFactory.Create(options, diagnostics),
+            clientSession,
             diagnostics,
             startRequestFactory,
-            runStarterFactory.Create(terrainTextureAssetHttpClient, options),
-            queue);
+            runExecutorFactory.Create(runStarter),
+            resourceReleaser);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -13,8 +13,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
     private readonly Uri endpoint;
     private readonly int connectionCount;
     private readonly IResoniteLiveSendStartRequestFactory startRequestFactory;
-    private readonly IResoniteLiveSendRunStarter runStarter;
-    private readonly IResoniteLiveSendQueue queue;
+    private readonly IResoniteLiveSendRunExecutor runExecutor;
+    private readonly IResoniteLiveSendRunResourceReleaser resourceReleaser;
 #pragma warning disable CA1859
     private ILiveSendClientSession ClientSessionInternal { get; }
 #pragma warning restore CA1859
@@ -30,8 +30,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         ArgumentNullException.ThrowIfNull(dependencies);
         ArgumentNullException.ThrowIfNull(dependencies.ClientSession);
         ArgumentNullException.ThrowIfNull(dependencies.StartRequestFactory);
-        ArgumentNullException.ThrowIfNull(dependencies.RunStarter);
-        ArgumentNullException.ThrowIfNull(dependencies.Queue);
+        ArgumentNullException.ThrowIfNull(dependencies.RunExecutor);
+        ArgumentNullException.ThrowIfNull(dependencies.ResourceReleaser);
 
         endpoint = options.Endpoint;
         connectionCount = options.ConnectionCount;
@@ -40,8 +40,8 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         MeshBakeEnabled = options.EnableMeshBake;
         progressReporter = options.ProgressReporter;
         startRequestFactory = dependencies.StartRequestFactory;
-        runStarter = dependencies.RunStarter;
-        queue = dependencies.Queue;
+        runExecutor = dependencies.RunExecutor;
+        resourceReleaser = dependencies.ResourceReleaser;
         ClientSessionInternal = dependencies.ClientSession;
     }
 
@@ -64,110 +64,36 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         {
             throw new InvalidOperationException("A live scene import run is already active on this live scene import target instance.");
         }
-        bool completedSuccessfully = false;
-        LiveSendRunState? state = null;
-
         try
         {
-            state = await runStarter.StartAsync(
+            return await runExecutor.ExecuteAsync(
                 startRequestFactory.Create(
                     plan,
                     MemoryProfile,
                     connectionCount,
                     MeshBakeEnabled),
-                CreateRunStartContext(),
+                objectUnits,
+                new LiveSendRunExecutionContext(
+                    endpoint,
+                    connectionCount,
+                    ClientSessionInternal,
+                    Diagnostics,
+                    progressReporter),
                 cancellationToken);
-
-            LiveSendEnqueueContext enqueueContext = CreateEnqueueContext();
-            await foreach (ImportedObjectUnit objectUnit in objectUnits.WithCancellation(cancellationToken))
-            {
-                await queue.QueueUnitAsync(
-                    state,
-                    objectUnit,
-                    enqueueContext,
-                    cancellationToken);
-            }
-
-            SceneImportExecutionResult result = await queue.CompleteAsync(
-                state,
-                CreateFinalizationContext(),
-                cancellationToken);
-            completedSuccessfully = true;
-            return result;
         }
         finally
         {
-            try
-            {
-                await ReleaseRunResourcesAsync(
-                    state,
-                    disposeClients: false,
-                    resetClients: !completedSuccessfully);
-            }
-            finally
-            {
-                Volatile.Write(ref executionClaimed, 0);
-            }
+            Volatile.Write(ref executionClaimed, 0);
         }
     }
 
     public async ValueTask DisposeAsync()
     {
-        await ReleaseRunResourcesAsync(
+        await resourceReleaser.ReleaseAsync(
             state: null,
+            clientSession: ClientSessionInternal,
             disposeClients: true,
             resetClients: false);
-    }
-
-    private async ValueTask ReleaseRunResourcesAsync(
-        LiveSendRunState? state,
-        bool disposeClients,
-        bool resetClients)
-    {
-        if (state is not null)
-        {
-            await state.Runtime.DisposeAsync();
-        }
-
-        if (disposeClients)
-        {
-            ClientSessionInternal.DisposeClients();
-        }
-        else if (resetClients)
-        {
-            await ClientSessionInternal.ResetClientsAsync();
-        }
-    }
-
-    private IResoniteLinkClient GetRoutedClient()
-    {
-        return ClientSessionInternal.GetRequiredClient();
-    }
-
-    private LiveSendEnqueueContext CreateEnqueueContext()
-    {
-        return new LiveSendEnqueueContext(
-            connectionCount,
-            GetRoutedClient,
-            progressReporter);
-    }
-
-    private LiveSendFinalizationContext CreateFinalizationContext()
-    {
-        return new LiveSendFinalizationContext(
-            endpoint,
-            CreateEnqueueContext(),
-            Diagnostics,
-            progressReporter);
-    }
-
-    private LiveSendRunStartContext CreateRunStartContext()
-    {
-        return new LiveSendRunStartContext(
-            endpoint,
-            ClientSessionInternal,
-            Diagnostics,
-            progressReporter);
     }
 
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunExecutor.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunExecutor.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record LiveSendRunExecutionContext(
+    Uri Endpoint,
+    int ConnectionCount,
+    ILiveSendClientSession ClientSession,
+    ResoniteLinkSendDiagnostics Diagnostics,
+    Action<string>? ProgressReporter);
+
+internal interface IResoniteLiveSendRunExecutor
+{
+    Task<SceneImportExecutionResult> ExecuteAsync(
+        LiveSendRunStartRequest request,
+        IAsyncEnumerable<ImportedObjectUnit> objectUnits,
+        LiveSendRunExecutionContext context,
+        CancellationToken cancellationToken);
+}
+
+internal interface IResoniteLiveSendRunExecutorFactory
+{
+    IResoniteLiveSendRunExecutor Create(IResoniteLiveSendRunStarter runStarter);
+}
+
+internal sealed class ResoniteLiveSendRunExecutorFactory(
+    IResoniteLiveSendQueue queue,
+    IResoniteLiveSendRunResourceReleaser resourceReleaser) : IResoniteLiveSendRunExecutorFactory
+{
+    public IResoniteLiveSendRunExecutor Create(IResoniteLiveSendRunStarter runStarter)
+    {
+        ArgumentNullException.ThrowIfNull(runStarter);
+
+        return new ResoniteLiveSendRunExecutor(
+            runStarter,
+            queue,
+            resourceReleaser);
+    }
+}
+
+internal sealed class ResoniteLiveSendRunExecutor(
+    IResoniteLiveSendRunStarter runStarter,
+    IResoniteLiveSendQueue queue,
+    IResoniteLiveSendRunResourceReleaser resourceReleaser) : IResoniteLiveSendRunExecutor
+{
+    private readonly IResoniteLiveSendRunStarter runStarter =
+        runStarter ?? throw new ArgumentNullException(nameof(runStarter));
+    private readonly IResoniteLiveSendQueue queue =
+        queue ?? throw new ArgumentNullException(nameof(queue));
+    private readonly IResoniteLiveSendRunResourceReleaser resourceReleaser =
+        resourceReleaser ?? throw new ArgumentNullException(nameof(resourceReleaser));
+
+    public async Task<SceneImportExecutionResult> ExecuteAsync(
+        LiveSendRunStartRequest request,
+        IAsyncEnumerable<ImportedObjectUnit> objectUnits,
+        LiveSendRunExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(objectUnits);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.Endpoint);
+        ArgumentOutOfRangeException.ThrowIfLessThan(context.ConnectionCount, 1);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+        ArgumentNullException.ThrowIfNull(context.Diagnostics);
+
+        bool completedSuccessfully = false;
+        LiveSendRunState? state = null;
+
+        try
+        {
+            state = await runStarter.StartAsync(
+                request,
+                CreateRunStartContext(context),
+                cancellationToken);
+
+            LiveSendEnqueueContext enqueueContext = CreateEnqueueContext(context);
+            await foreach (ImportedObjectUnit objectUnit in objectUnits.WithCancellation(cancellationToken))
+            {
+                await queue.QueueUnitAsync(
+                    state,
+                    objectUnit,
+                    enqueueContext,
+                    cancellationToken);
+            }
+
+            SceneImportExecutionResult result = await queue.CompleteAsync(
+                state,
+                CreateFinalizationContext(context, enqueueContext),
+                cancellationToken);
+            completedSuccessfully = true;
+            return result;
+        }
+        finally
+        {
+            await resourceReleaser.ReleaseAsync(
+                state,
+                context.ClientSession,
+                disposeClients: false,
+                resetClients: !completedSuccessfully);
+        }
+    }
+
+    private static LiveSendRunStartContext CreateRunStartContext(LiveSendRunExecutionContext context)
+    {
+        return new LiveSendRunStartContext(
+            context.Endpoint,
+            context.ClientSession,
+            context.Diagnostics,
+            context.ProgressReporter);
+    }
+
+    private static LiveSendEnqueueContext CreateEnqueueContext(LiveSendRunExecutionContext context)
+    {
+        return new LiveSendEnqueueContext(
+            context.ConnectionCount,
+            context.ClientSession.GetRequiredClient,
+            context.ProgressReporter);
+    }
+
+    private static LiveSendFinalizationContext CreateFinalizationContext(
+        LiveSendRunExecutionContext context,
+        LiveSendEnqueueContext enqueueContext)
+    {
+        return new LiveSendFinalizationContext(
+            context.Endpoint,
+            enqueueContext,
+            context.Diagnostics,
+            context.ProgressReporter);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunResourceReleaser.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunResourceReleaser.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendRunResourceReleaser
+{
+    ValueTask ReleaseAsync(
+        LiveSendRunState? state,
+        ILiveSendClientSession clientSession,
+        bool disposeClients,
+        bool resetClients);
+}
+
+internal sealed class ResoniteLiveSendRunResourceReleaser : IResoniteLiveSendRunResourceReleaser
+{
+    public async ValueTask ReleaseAsync(
+        LiveSendRunState? state,
+        ILiveSendClientSession clientSession,
+        bool disposeClients,
+        bool resetClients)
+    {
+        ArgumentNullException.ThrowIfNull(clientSession);
+
+        if (state is not null)
+        {
+            await state.Runtime.DisposeAsync();
+        }
+
+        if (disposeClients)
+        {
+            clientSession.DisposeClients();
+        }
+        else if (resetClients)
+        {
+            await clientSession.ResetClientsAsync();
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -35,6 +35,8 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteQueuedCityObjectEnqueuer, ResoniteQueuedCityObjectEnqueuer>();
         services.TryAddScoped<IResoniteLiveSendFinalizer, ResoniteLiveSendFinalizer>();
         services.TryAddScoped<IResoniteLiveSendQueue, ResoniteLiveSendQueue>();
+        services.TryAddScoped<IResoniteLiveSendRunResourceReleaser, ResoniteLiveSendRunResourceReleaser>();
+        services.TryAddScoped<IResoniteLiveSendRunExecutorFactory, ResoniteLiveSendRunExecutorFactory>();
         services.TryAddScoped<IResoniteSceneBatchEmitter, PlannedBatchEmissionInterpreter>();
         services.TryAddScoped<IResoniteSlotCreator, ResoniteSlotCreator>();
         services.TryAddScoped<IResoniteSceneAnchorResolver, ResoniteSceneAnchorResolver>();

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -59,12 +59,10 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
                 TerrainTileCacheRoot: null,
                 DisableTerrainTileCache: false,
                 ProgressReporter: null),
-            new ResoniteLiveSceneImportDependencies(
+            ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 new DelegatingClientSession(),
                 diagnostics,
-                new ResoniteLiveSendStartRequestFactory(),
-                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning),
-                ResoniteLiveSceneImportTargetTestSupport.CreateQueue()));
+                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning)));
 
         Assert.Same(diagnostics, importTarget.Diagnostics);
     }
@@ -290,12 +288,10 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
                 TerrainTileCacheRoot: null,
                 DisableTerrainTileCache: false,
                 ProgressReporter: null),
-            new ResoniteLiveSceneImportDependencies(
+            ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 new DelegatingClientSession(),
                 diagnostics,
-                new ResoniteLiveSendStartRequestFactory(),
-                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning),
-                ResoniteLiveSceneImportTargetTestSupport.CreateQueue()));
+                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning)));
     }
 
     private sealed class RecordingTerrainTextureAssetGeneratorFactory : ITerrainTextureAssetGeneratorFactory

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -43,12 +43,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 TerrainTileCacheRoot: null,
                 DisableTerrainTileCache: false,
                 ProgressReporter: null),
-            new ResoniteLiveSceneImportDependencies(
+            ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 session,
                 diagnostics,
-                new ResoniteLiveSendStartRequestFactory(),
-                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning),
-                ResoniteLiveSceneImportTargetTestSupport.CreateQueue()));
+                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning)));
 
         PlateauImportRequest normalizedRequest = new(
             Dataset: "tokyo23ku",
@@ -99,12 +97,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 TerrainTileCacheRoot: null,
                 DisableTerrainTileCache: false,
                 ProgressReporter: null),
-            new ResoniteLiveSceneImportDependencies(
+            ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 session,
                 diagnostics,
-                new ResoniteLiveSendStartRequestFactory(),
-                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning),
-                ResoniteLiveSceneImportTargetTestSupport.CreateQueue()));
+                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning)));
 
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
@@ -146,12 +142,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 TerrainTileCacheRoot: null,
                 DisableTerrainTileCache: false,
                 ProgressReporter: null),
-            new ResoniteLiveSceneImportDependencies(
+            ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 session,
                 diagnostics,
-                new ResoniteLiveSendStartRequestFactory(),
-                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning),
-                ResoniteLiveSceneImportTargetTestSupport.CreateQueue()));
+                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning)));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
             request,
@@ -230,12 +224,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 TerrainTileCacheRoot: null,
                 DisableTerrainTileCache: false,
                 ProgressReporter: null),
-            new ResoniteLiveSceneImportDependencies(
+            ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 session,
                 ResoniteLinkSendDiagnostics.Disabled,
-                new ResoniteLiveSendStartRequestFactory(),
-                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter()),
-                ResoniteLiveSceneImportTargetTestSupport.CreateQueue()));
+                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter())));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
             request,
@@ -274,12 +266,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 TerrainTileCacheRoot: null,
                 DisableTerrainTileCache: false,
                 ProgressReporter: null),
-            new ResoniteLiveSceneImportDependencies(
+            ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 session,
                 ResoniteLinkSendDiagnostics.Disabled,
-                new ResoniteLiveSendStartRequestFactory(),
-                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter()),
-                ResoniteLiveSceneImportTargetTestSupport.CreateQueue()));
+                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter())));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
             request,
@@ -341,12 +331,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
 
                     progressMessages.Add(message);
                 }),
-            new ResoniteLiveSceneImportDependencies(
+            ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 session,
                 ResoniteLinkSendDiagnostics.Disabled,
-                new ResoniteLiveSendStartRequestFactory(),
-                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning, progressReporter: progressMessages.Add),
-                ResoniteLiveSceneImportTargetTestSupport.CreateQueue()));
+                ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning, progressReporter: progressMessages.Add)));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
             request,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -329,12 +329,31 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 TerrainTileCacheRoot: null,
                 DisableTerrainTileCache: false,
                 ProgressReporter: progressReporter),
-            new ResoniteLiveSceneImportDependencies(
+            CreateDependencies(
                 session ?? new DelegatingClientSession(routedClient),
                 diagnostics,
-                new ResoniteLiveSendStartRequestFactory(),
-                CreateRunStarter(materialPlanning, terrainTextureAssetGenerator: terrainTextureAssetGenerator, progressReporter: progressReporter),
-                CreateQueue()));
+                CreateRunStarter(materialPlanning, terrainTextureAssetGenerator: terrainTextureAssetGenerator, progressReporter: progressReporter)));
+    }
+
+    public static ResoniteLiveSceneImportDependencies CreateDependencies(
+        ILiveSendClientSession session,
+        ResoniteLinkSendDiagnostics diagnostics,
+        IResoniteLiveSendRunStarter runStarter,
+        IResoniteLiveSendQueue? queue = null,
+        IResoniteLiveSendRunResourceReleaser? resourceReleaser = null)
+    {
+        IResoniteLiveSendQueue effectiveQueue = queue ?? CreateQueue();
+        IResoniteLiveSendRunResourceReleaser effectiveResourceReleaser =
+            resourceReleaser ?? new ResoniteLiveSendRunResourceReleaser();
+        return new ResoniteLiveSceneImportDependencies(
+            session,
+            diagnostics,
+            new ResoniteLiveSendStartRequestFactory(),
+            new ResoniteLiveSendRunExecutor(
+                runStarter,
+                effectiveQueue,
+                effectiveResourceReleaser),
+            effectiveResourceReleaser);
     }
 
     public static ResoniteLiveSendRunStarter CreateRunStarter(


### PR DESCRIPTION
## Summary
- Move live-send run queueing, finalization, and failure cleanup out of `ResoniteLiveSceneImportTarget` into `ResoniteLiveSendRunExecutor`.
- Add a dedicated run resource releaser so target disposal and failed-run client reset share an explicit boundary.
- Keep production, canonical dump, and test dependency wiring explicit instead of hiding defaults behind the target.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`