### PR TITLE
Route canonical dump through live target factory

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliHostFactory.cs
+++ b/src/PlateauResoniteLink.Cli/CliHostFactory.cs
@@ -12,9 +12,7 @@ using Microsoft.Extensions.Logging;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
-using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Targets.Resonite.Diagnostics;
-using PlateauResoniteLink.Transport.ResoniteLink;
 namespace PlateauResoniteLink.Cli;
 
 internal static class CliHostFactory
@@ -135,23 +133,13 @@ internal sealed class DefaultSceneSinkFactory(
         {
             if (!string.IsNullOrWhiteSpace(options.CanonicalSceneDumpPath))
             {
-                SceneSinkRecordingClient recordingClient = new();
-                try
-                {
-                    ResoniteLiveSceneImportTarget dumpTarget = CreateCanonicalDumpTarget(
-                        scope,
-                        recordingClient,
-                        options,
-                        progressReporter);
-                    return new ScopedSceneSink(
-                        scope,
-                        new CanonicalSceneDumpSink(dumpTarget, recordingClient, options.CanonicalSceneDumpPath));
-                }
-                catch
-                {
-                    recordingClient.Dispose();
-                    throw;
-                }
+                IResoniteCanonicalSceneDumpSinkFactory dumpSinkFactory =
+                    scope.ServiceProvider.GetRequiredService<IResoniteCanonicalSceneDumpSinkFactory>();
+                return new ScopedSceneSink(
+                    scope,
+                    dumpSinkFactory.Create(
+                        CreateCanonicalDumpTargetOptions(options, progressReporter),
+                        options.CanonicalSceneDumpPath));
             }
 
             ResoniteLiveSceneImportTargetOptions targetOptions = new(
@@ -182,13 +170,11 @@ internal sealed class DefaultSceneSinkFactory(
         }
     }
 
-    private static ResoniteLiveSceneImportTarget CreateCanonicalDumpTarget(
-        AsyncServiceScope scope,
-        SceneSinkRecordingClient recordingClient,
+    private static ResoniteLiveSceneImportTargetOptions CreateCanonicalDumpTargetOptions(
         ImportCommandOptions options,
         Action<string>? progressReporter)
     {
-        ResoniteLiveSceneImportTargetOptions targetOptions = new(
+        return new ResoniteLiveSceneImportTargetOptions(
             new Uri("ws://localhost:1/"),
             ConnectionCount: 1,
             EnableSendMetrics: false,
@@ -202,38 +188,6 @@ internal sealed class DefaultSceneSinkFactory(
             TerrainTileCacheRoot: null,
             DisableTerrainTileCache: true,
             progressReporter);
-
-        IServiceProvider serviceProvider = scope.ServiceProvider;
-        ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
-        IResoniteLiveSendRunResourceReleaser resourceReleaser =
-            serviceProvider.GetRequiredService<IResoniteLiveSendRunResourceReleaser>();
-        IResoniteQueuedCityObjectEnqueuer queuedCityObjectEnqueuer = new ResoniteQueuedCityObjectEnqueuer();
-        ResoniteLiveSendQueue queue = new(
-            queuedCityObjectEnqueuer,
-            new ResoniteLiveSendFinalizer(queuedCityObjectEnqueuer));
-        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(
-            new ResoniteQueuedCityObjectSender(
-                new ResoniteQueuedTexturePreparer(
-                    new DeterministicTerrainTextureAssetGenerator(),
-                    serviceProvider.GetRequiredService<IResoniteDatasetLicenseWriter>()),
-                serviceProvider.GetRequiredService<IResonitePreparedCityObjectImporter>()));
-        return new ResoniteLiveSceneImportTarget(
-            targetOptions,
-            new ResoniteLiveSceneImportDependencies(
-                new SingleRecordingClientSession(recordingClient),
-                diagnostics,
-                serviceProvider.GetRequiredService<IResoniteLiveSendStartRequestFactory>(),
-                new ResoniteLiveSendRunExecutor(
-                    new ResoniteLiveSendRunStarter(
-                        serviceProvider.GetRequiredService<IResoniteSceneSetupInterpreter>(),
-                        serviceProvider.GetRequiredService<IResoniteCommonMaterialSetupPreparer>(),
-                        serviceProvider.GetRequiredService<ILiveSendRunPlanFactory>(),
-                        serviceProvider.GetRequiredService<ILiveSendRunStateFactory>(),
-                        new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker),
-                        serviceProvider.GetRequiredService<IResoniteSlotCreator>()),
-                    queue,
-                    resourceReleaser),
-                resourceReleaser));
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
@@ -19,7 +19,7 @@ internal interface IResoniteCanonicalSceneDumpSinkFactory
 }
 
 internal sealed class ResoniteCanonicalSceneDumpSinkFactory(
-    IResoniteLiveSceneImportDependencyFactory dependencyFactory) : IResoniteCanonicalSceneDumpSinkFactory
+    IResoniteLiveSceneImportFactory targetFactory) : IResoniteCanonicalSceneDumpSinkFactory
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Reliability",
@@ -35,34 +35,18 @@ internal sealed class ResoniteCanonicalSceneDumpSinkFactory(
         SceneSinkRecordingClient recordingClient = new();
         try
         {
-            ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
+            ResoniteLiveSceneImportTarget target = targetFactory.CreateTarget(
                 options,
                 new SingleRecordingClientSession(recordingClient),
                 ResoniteLinkSendDiagnostics.Disabled,
                 new DeterministicTerrainTextureAssetGenerator());
-            return CreateOwnedDumpSink(options, dependencies, recordingClient, outputPath);
+            return new CanonicalSceneDumpSink(target, recordingClient, outputPath);
         }
         catch
         {
             recordingClient.Dispose();
             throw;
         }
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "CanonicalSceneDumpSink owns the created target and disposes it with the recording client.")]
-    private static CanonicalSceneDumpSink CreateOwnedDumpSink(
-        ResoniteLiveSceneImportTargetOptions options,
-        ResoniteLiveSceneImportDependencies dependencies,
-        SceneSinkRecordingClient recordingClient,
-        string outputPath)
-    {
-        return new CanonicalSceneDumpSink(
-            new ResoniteLiveSceneImportTarget(options, dependencies),
-            recordingClient,
-            outputPath);
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
@@ -38,7 +38,6 @@ internal sealed class ResoniteCanonicalSceneDumpSinkFactory(
             ResoniteLiveSceneImportTarget target = targetFactory.CreateTarget(
                 options,
                 new SingleRecordingClientSession(recordingClient),
-                ResoniteLinkSendDiagnostics.Disabled,
                 new DeterministicTerrainTextureAssetGenerator());
             return new CanonicalSceneDumpSink(target, recordingClient, outputPath);
         }

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -9,6 +10,61 @@ using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite.Diagnostics;
+
+internal interface IResoniteCanonicalSceneDumpSinkFactory
+{
+    ISceneSink Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        string outputPath);
+}
+
+internal sealed class ResoniteCanonicalSceneDumpSinkFactory(
+    IResoniteLiveSceneImportDependencyFactory dependencyFactory) : IResoniteCanonicalSceneDumpSinkFactory
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "CanonicalSceneDumpSink owns the recording client after successful construction; failures dispose it here.")]
+    public ISceneSink Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        string outputPath)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputPath);
+
+        SceneSinkRecordingClient recordingClient = new();
+        try
+        {
+            ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
+                options,
+                new SingleRecordingClientSession(recordingClient),
+                ResoniteLinkSendDiagnostics.Disabled,
+                new DeterministicTerrainTextureAssetGenerator());
+            return CreateOwnedDumpSink(options, dependencies, recordingClient, outputPath);
+        }
+        catch
+        {
+            recordingClient.Dispose();
+            throw;
+        }
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "CanonicalSceneDumpSink owns the created target and disposes it with the recording client.")]
+    private static CanonicalSceneDumpSink CreateOwnedDumpSink(
+        ResoniteLiveSceneImportTargetOptions options,
+        ResoniteLiveSceneImportDependencies dependencies,
+        SceneSinkRecordingClient recordingClient,
+        string outputPath)
+    {
+        return new CanonicalSceneDumpSink(
+            new ResoniteLiveSceneImportTarget(options, dependencies),
+            recordingClient,
+            outputPath);
+    }
+}
 
 internal sealed class CanonicalSceneDumpSink(
     ISceneSink inner,

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunRuntimeComponentsFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunRuntimeComponentsFactory.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record LiveSendRunRuntimeComponents(
+    TerrainTextureAssetCache TerrainTextures,
+    LiveSendExecutionRuntime Runtime,
+    SemaphoreSlim GsiFallbackLicenseGate,
+    ConcurrentDictionary<string, int> DemSourceUseCounts);
+
+internal interface ILiveSendRunRuntimeComponentsFactory
+{
+    LiveSendRunRuntimeComponents Create(
+        LiveSendQueuePlan queuePlan,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class LiveSendRunRuntimeComponentsFactory : ILiveSendRunRuntimeComponentsFactory
+{
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to LiveSendRunState and released by ResoniteLiveSendRunResourceReleaser.")]
+    public LiveSendRunRuntimeComponents Create(
+        LiveSendQueuePlan queuePlan,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(queuePlan);
+
+        return new LiveSendRunRuntimeComponents(
+            new TerrainTextureAssetCache(),
+            new LiveSendExecutionRuntime(queuePlan, cancellationToken),
+            new SemaphoreSlim(1, 1),
+            new ConcurrentDictionary<string, int>(StringComparer.Ordinal));
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunStateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunStateFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Threading;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -16,7 +15,8 @@ internal interface ILiveSendRunStateFactory
 }
 
 internal sealed class LiveSendRunStateFactory(
-    IResoniteBufferedCityObjectBakerFactory cityObjectBakerFactory) : ILiveSendRunStateFactory
+    IResoniteBufferedCityObjectBakerFactory cityObjectBakerFactory,
+    ILiveSendRunRuntimeComponentsFactory runtimeComponentsFactory) : ILiveSendRunStateFactory
 {
     public LiveSendRunState Create(
         LiveSendRunPlan runPlan,
@@ -31,10 +31,12 @@ internal sealed class LiveSendRunStateFactory(
         ArgumentNullException.ThrowIfNull(materials);
         ArgumentNullException.ThrowIfNull(placement);
 
-        LiveSendExecutionRuntime runtime = new(runPlan.Queue, cancellationToken);
         CompositeCityObjectBaker? cityObjectBaker = cityObjectBakerFactory.Create(
             runPlan.MeshBakeEnabled,
             runPlan.ResourceBudget);
+        LiveSendRunRuntimeComponents runtimeComponents = runtimeComponentsFactory.Create(
+            runPlan.Queue,
+            cancellationToken);
         LiveSendRunContext context = new(
             runPlan,
             setupState.DatasetRootSlot,
@@ -46,11 +48,11 @@ internal sealed class LiveSendRunStateFactory(
             Context = context,
             Progress = progress,
             Materials = materials,
-            TerrainTextures = new TerrainTextureAssetCache(),
+            TerrainTextures = runtimeComponents.TerrainTextures,
             Placement = placement,
-            Runtime = runtime,
-            GsiFallbackLicenseGate = new SemaphoreSlim(1, 1),
-            DemSourceUseCounts = new ConcurrentDictionary<string, int>(StringComparer.Ordinal),
+            Runtime = runtimeComponents.Runtime,
+            GsiFallbackLicenseGate = runtimeComponents.GsiFallbackLicenseGate,
+            DemSourceUseCounts = runtimeComponents.DemSourceUseCounts,
         };
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencies.cs
@@ -4,7 +4,6 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed record ResoniteLiveSceneImportDependencies(
     ILiveSendClientSession ClientSession,
-    ResoniteLinkSendDiagnostics Diagnostics,
     IResoniteLiveSendStartRequestFactory StartRequestFactory,
     IResoniteLiveSendRunExecutor RunExecutor,
     IResoniteLiveSendRunResourceReleaser ResourceReleaser);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
@@ -10,6 +10,12 @@ internal interface IResoniteLiveSceneImportDependencyFactory
     ResoniteLiveSceneImportDependencies Create(
         ResoniteLiveSceneImportTargetOptions options,
         HttpClient terrainTextureAssetHttpClient);
+
+    ResoniteLiveSceneImportDependencies Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        ILiveSendClientSession clientSession,
+        ResoniteLinkSendDiagnostics diagnostics,
+        ITerrainTextureAssetGenerator terrainTextureAssetGenerator);
 }
 
 internal sealed class ResoniteLiveSceneImportDependencyFactory(
@@ -32,6 +38,35 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
 
         ILiveSendClientSession clientSession = clientSessionFactory.Create(options, diagnostics);
         IResoniteLiveSendRunStarter runStarter = runStarterFactory.Create(terrainTextureAssetHttpClient, options);
+
+        return Create(options, clientSession, diagnostics, runStarter);
+    }
+
+    public ResoniteLiveSceneImportDependencies Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        ILiveSendClientSession clientSession,
+        ResoniteLinkSendDiagnostics diagnostics,
+        ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(clientSession);
+        ArgumentNullException.ThrowIfNull(diagnostics);
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
+
+        IResoniteLiveSendRunStarter runStarter = runStarterFactory.Create(terrainTextureAssetGenerator, options);
+        return Create(options, clientSession, diagnostics, runStarter);
+    }
+
+    private ResoniteLiveSceneImportDependencies Create(
+        ResoniteLiveSceneImportTargetOptions options,
+        ILiveSendClientSession clientSession,
+        ResoniteLinkSendDiagnostics diagnostics,
+        IResoniteLiveSendRunStarter runStarter)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(clientSession);
+        ArgumentNullException.ThrowIfNull(diagnostics);
+        ArgumentNullException.ThrowIfNull(runStarter);
 
         return new ResoniteLiveSceneImportDependencies(
             clientSession,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
@@ -53,7 +53,7 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
         ArgumentNullException.ThrowIfNull(diagnostics);
         ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
 
-        IResoniteLiveSendRunStarter runStarter = runStarterFactory.Create(terrainTextureAssetGenerator, options);
+        IResoniteLiveSendRunStarter runStarter = runStarterFactory.Create(terrainTextureAssetGenerator);
         return Create(options, clientSession, diagnostics, runStarter);
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
@@ -14,7 +14,6 @@ internal interface IResoniteLiveSceneImportDependencyFactory
     ResoniteLiveSceneImportDependencies Create(
         ResoniteLiveSceneImportTargetOptions options,
         ILiveSendClientSession clientSession,
-        ResoniteLinkSendDiagnostics diagnostics,
         ITerrainTextureAssetGenerator terrainTextureAssetGenerator);
 }
 
@@ -39,38 +38,33 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
         ILiveSendClientSession clientSession = clientSessionFactory.Create(options, diagnostics);
         IResoniteLiveSendRunStarter runStarter = runStarterFactory.Create(terrainTextureAssetHttpClient, options);
 
-        return Create(options, clientSession, diagnostics, runStarter);
+        return Create(options, clientSession, runStarter);
     }
 
     public ResoniteLiveSceneImportDependencies Create(
         ResoniteLiveSceneImportTargetOptions options,
         ILiveSendClientSession clientSession,
-        ResoniteLinkSendDiagnostics diagnostics,
         ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(clientSession);
-        ArgumentNullException.ThrowIfNull(diagnostics);
         ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
 
         IResoniteLiveSendRunStarter runStarter = runStarterFactory.Create(terrainTextureAssetGenerator);
-        return Create(options, clientSession, diagnostics, runStarter);
+        return Create(options, clientSession, runStarter);
     }
 
     private ResoniteLiveSceneImportDependencies Create(
         ResoniteLiveSceneImportTargetOptions options,
         ILiveSendClientSession clientSession,
-        ResoniteLinkSendDiagnostics diagnostics,
         IResoniteLiveSendRunStarter runStarter)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(clientSession);
-        ArgumentNullException.ThrowIfNull(diagnostics);
         ArgumentNullException.ThrowIfNull(runStarter);
 
         return new ResoniteLiveSceneImportDependencies(
             clientSession,
-            diagnostics,
             startRequestFactory,
             runExecutorFactory.Create(runStarter),
             resourceReleaser);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportFactory.cs
@@ -13,7 +13,6 @@ internal interface IResoniteLiveSceneImportFactory
     ResoniteLiveSceneImportTarget CreateTarget(
         ResoniteLiveSceneImportTargetOptions options,
         ILiveSendClientSession clientSession,
-        ResoniteLinkSendDiagnostics diagnostics,
         ITerrainTextureAssetGenerator terrainTextureAssetGenerator);
 }
 
@@ -33,13 +32,11 @@ internal sealed class ResoniteLiveSceneImportFactory(
     public ResoniteLiveSceneImportTarget CreateTarget(
         ResoniteLiveSceneImportTargetOptions options,
         ILiveSendClientSession clientSession,
-        ResoniteLinkSendDiagnostics diagnostics,
         ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
     {
         ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
             options,
             clientSession,
-            diagnostics,
             terrainTextureAssetGenerator);
         return new ResoniteLiveSceneImportTarget(options, dependencies);
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportFactory.cs
@@ -1,5 +1,7 @@
 using System.Net.Http;
 
+using PlateauResoniteLink.Transport.ResoniteLink;
+
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal interface IResoniteLiveSceneImportFactory
@@ -7,6 +9,12 @@ internal interface IResoniteLiveSceneImportFactory
     ResoniteLiveSceneImportTarget CreateTarget(
         ResoniteLiveSceneImportTargetOptions options,
         HttpClient terrainTextureAssetHttpClient);
+
+    ResoniteLiveSceneImportTarget CreateTarget(
+        ResoniteLiveSceneImportTargetOptions options,
+        ILiveSendClientSession clientSession,
+        ResoniteLinkSendDiagnostics diagnostics,
+        ITerrainTextureAssetGenerator terrainTextureAssetGenerator);
 }
 
 internal sealed class ResoniteLiveSceneImportFactory(
@@ -19,6 +27,20 @@ internal sealed class ResoniteLiveSceneImportFactory(
         ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
             options,
             terrainTextureAssetHttpClient);
+        return new ResoniteLiveSceneImportTarget(options, dependencies);
+    }
+
+    public ResoniteLiveSceneImportTarget CreateTarget(
+        ResoniteLiveSceneImportTargetOptions options,
+        ILiveSendClientSession clientSession,
+        ResoniteLinkSendDiagnostics diagnostics,
+        ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
+    {
+        ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
+            options,
+            clientSession,
+            diagnostics,
+            terrainTextureAssetGenerator);
         return new ResoniteLiveSceneImportTarget(options, dependencies);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportTarget.cs
@@ -36,7 +36,7 @@ public sealed class ResoniteLiveSceneImportTarget : ISceneSink
         endpoint = options.Endpoint;
         connectionCount = options.ConnectionCount;
         MemoryProfile = options.MemoryProfile;
-        Diagnostics = dependencies.Diagnostics;
+        Diagnostics = dependencies.ClientSession.Diagnostics;
         MeshBakeEnabled = options.EnableMeshBake;
         progressReporter = options.ProgressReporter;
         startRequestFactory = dependencies.StartRequestFactory;

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendConnectionInitializer
+{
+    Task EnsureConnectedAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunPlan runPlan,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteLiveSendConnectionInitializer : IResoniteLiveSendConnectionInitializer
+{
+    public async Task EnsureConnectedAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunPlan runPlan,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.SetupInfo);
+        ArgumentNullException.ThrowIfNull(request.NormalizedRequest);
+        ArgumentNullException.ThrowIfNull(runPlan);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.Endpoint);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Initializing scene state for dataset '{request.SetupInfo.Dataset}' "
+                + $"mesh '{request.SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
+        Stopwatch connectionStopwatch = Stopwatch.StartNew();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Connecting ResoniteLink connection pool to {context.Endpoint} "
+                + $"with {request.ConnectionCount} available routed connection(s)."));
+        await context.ClientSession.EnsureConnectedAsync(
+            new LiveSendConnectionRequest(
+                request.NormalizedRequest.Dataset,
+                request.NormalizedRequest.MeshCode),
+            cancellationToken);
+        connectionStopwatch.Stop();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"ResoniteLink connection pool ready in {connectionStopwatch.Elapsed.TotalSeconds:F2}s "
+                + $"(dataset='{request.SetupInfo.Dataset}', mesh='{request.SetupInfo.MeshCode}')."));
+    }
+
+    private static void ReportProgress(
+        LiveSendRunStartContext context,
+        string message)
+    {
+        context.ProgressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunResourceReleaser.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunResourceReleaser.cs
@@ -26,7 +26,14 @@ internal sealed class ResoniteLiveSendRunResourceReleaser : IResoniteLiveSendRun
 
         if (state is not null)
         {
-            await state.Runtime.DisposeAsync();
+            try
+            {
+                await state.Runtime.DisposeAsync();
+            }
+            finally
+            {
+                state.GsiFallbackLicenseGate.Dispose();
+            }
         }
 
         if (disposeClients)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record LiveSendPreparedRunSetup(
+    LiveSendRunPlan RunPlan,
+    ResoniteSceneSetupState SetupState,
+    LiveSendProgressSink Progress,
+    CommonMaterialAssetCache Materials,
+    ResoniteSharedSlotIndex Placement);
+
+internal interface IResoniteLiveSendRunSetupPreparer
+{
+    Task<LiveSendPreparedRunSetup> PrepareAsync(
+        LiveSendRunPlan runPlan,
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteLiveSendRunSetupPreparer(
+    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
+    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
+    IResoniteSlotCreator slotCreator) : IResoniteLiveSendRunSetupPreparer
+{
+    public async Task<LiveSendPreparedRunSetup> PrepareAsync(
+        LiveSendRunPlan runPlan,
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(runPlan);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+
+        LiveSendProgressSink progress = new();
+        CommonMaterialAssetCache materials = new();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "Reusing dataset content source provided by caller."));
+        ReportProgress(
+            context,
+            PlateauLog.Info("live", "Setting up mutable helpers (baker)."));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "Starting setup slot setup: dataset root, assets root, common assets root, location slot, and source-file root reference."));
+        Stopwatch setupStopwatch = Stopwatch.StartNew();
+        ResoniteSceneSetupState setupState = await sceneSetupInterpreter.SetupAsync(
+            GetRoutedClient(context),
+            runPlan.SetupInfo,
+            request.CommonMaterials,
+            cancellationToken);
+        setupStopwatch.Stop();
+        ResoniteSharedSlotIndex placement = new(
+            setupState.DatasetRootSlot,
+            setupState.DatasetAssetsRootSlot,
+            runPlan.RequestLocalOrigin,
+            runPlan.SourceFileSlotNamesByRelativePath,
+            setupState.SceneAnchor,
+            slotCreator.CreateAsync);
+        placement.IndexSetupHierarchy(setupState);
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Scene setup complete in {setupStopwatch.Elapsed.TotalSeconds:F2}s "
+                + $"(dataset_root={setupState.DatasetRootSlot.SlotName}, assets_root={setupState.DatasetAssetsRootSlot.SlotName}, "
+                + $"common_root={setupState.CommonAssetsRootSlot.SlotName}, "
+                + $"dataset_root_existed={setupState.DatasetRootExisted}, "
+                + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
+                + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
+                + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
+        CacheSetupCommonMaterials(setupState, materials);
+        ReportSetupCommonMaterials(setupState, context);
+        await commonMaterialSetupPreparer.PrepareAsync(
+            GetRoutedClient(context),
+            setupState,
+            materials,
+            request.CommonMaterials,
+            context.ProgressReporter,
+            cancellationToken);
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "setup fixed dataset license metadata/component before city-object streaming starts."));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Dataset metadata/license phase complete during setup. "
+                + $"Dataset root existed={setupState.DatasetRootExisted}."));
+        return new LiveSendPreparedRunSetup(
+            runPlan,
+            setupState,
+            progress,
+            materials,
+            placement);
+    }
+
+    private static void CacheSetupCommonMaterials(
+        ResoniteSceneSetupState setupState,
+        CommonMaterialAssetCache materials)
+    {
+        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
+        {
+            materials.CommonMaterialAssets.Set(materialAsset.Item);
+        }
+
+        foreach (string family in setupState.CommonMaterialFamilies)
+        {
+            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
+        }
+    }
+
+    private static void ReportSetupCommonMaterials(
+        ResoniteSceneSetupState setupState,
+        LiveSendRunStartContext context)
+    {
+        if (setupState.CommonMaterialAssets.Count > 0)
+        {
+            ReportProgress(
+                context,
+                PlateauLog.Info(
+                    "live",
+                    $"Setup batch prepared {setupState.CommonMaterialAssets.Count} textureless common materials."));
+            return;
+        }
+
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "Setup created common material slots; no textureless common material components were needed in setup batch."));
+    }
+
+    private static IResoniteLinkClient GetRoutedClient(LiveSendRunStartContext context)
+    {
+        return context.ClientSession.GetRequiredClient();
+    }
+
+    private static void ReportProgress(
+        LiveSendRunStartContext context,
+        string message)
+    {
+        context.ProgressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
@@ -29,7 +28,7 @@ internal interface IResoniteLiveSendRunSetupPreparer
 internal sealed class ResoniteLiveSendRunSetupPreparer(
     IResoniteSceneSetupInterpreter sceneSetupInterpreter,
     IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
-    IResoniteSlotCreator slotCreator) : IResoniteLiveSendRunSetupPreparer
+    IResonitePreparedRunSetupComposer preparedRunSetupComposer) : IResoniteLiveSendRunSetupPreparer
 {
     public async Task<LiveSendPreparedRunSetup> PrepareAsync(
         LiveSendRunPlan runPlan,
@@ -43,8 +42,6 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(context.ClientSession);
 
-        LiveSendProgressSink progress = new();
-        CommonMaterialAssetCache materials = new();
         ReportProgress(
             context,
             PlateauLog.Info(
@@ -65,14 +62,6 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
             request.CommonMaterials,
             cancellationToken);
         setupStopwatch.Stop();
-        ResoniteSharedSlotIndex placement = new(
-            setupState.DatasetRootSlot,
-            setupState.DatasetAssetsRootSlot,
-            runPlan.RequestLocalOrigin,
-            runPlan.SourceFileSlotNamesByRelativePath,
-            setupState.SceneAnchor,
-            slotCreator.CreateAsync);
-        placement.IndexSetupHierarchy(setupState);
         ReportProgress(
             context,
             PlateauLog.Info(
@@ -84,12 +73,14 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
                 + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
                 + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
                 + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
-        CacheSetupCommonMaterials(setupState, materials);
+        LiveSendPreparedRunSetup preparedSetup = preparedRunSetupComposer.Compose(
+            runPlan,
+            setupState);
         ReportSetupCommonMaterials(setupState, context);
         await commonMaterialSetupPreparer.PrepareAsync(
             GetRoutedClient(context),
             setupState,
-            materials,
+            preparedSetup.Materials,
             request.CommonMaterials,
             context.ProgressReporter,
             cancellationToken);
@@ -104,27 +95,7 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
                 "live",
                 $"Dataset metadata/license phase complete during setup. "
                 + $"Dataset root existed={setupState.DatasetRootExisted}."));
-        return new LiveSendPreparedRunSetup(
-            runPlan,
-            setupState,
-            progress,
-            materials,
-            placement);
-    }
-
-    private static void CacheSetupCommonMaterials(
-        ResoniteSceneSetupState setupState,
-        CommonMaterialAssetCache materials)
-    {
-        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
-        {
-            materials.CommonMaterialAssets.Set(materialAsset.Item);
-        }
-
-        foreach (string family in setupState.CommonMaterialFamilies)
-        {
-            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
-        }
+        return preparedSetup;
     }
 
     private static void ReportSetupCommonMaterials(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
@@ -36,6 +34,7 @@ internal interface IResoniteLiveSendRunStarter
 
 internal sealed class ResoniteLiveSendRunStarter(
     ILiveSendRunPlanFactory runPlanFactory,
+    IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendRunSetupPreparer runSetupPreparer,
     ILiveSendRunStateFactory runStateFactory,
     IResoniteLiveSendWorkerLauncher workerLauncher) : IResoniteLiveSendRunStarter
@@ -62,31 +61,11 @@ internal sealed class ResoniteLiveSendRunStarter(
             request.MemoryProfile,
             request.ConnectionCount,
             request.MeshBakeEnabled);
-        ReportProgress(
+        await connectionInitializer.EnsureConnectedAsync(
+            request,
+            runPlan,
             context,
-            PlateauLog.Info(
-                "live",
-                $"Initializing scene state for dataset '{request.SetupInfo.Dataset}' "
-                + $"mesh '{request.SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
-        Stopwatch connectionStopwatch = Stopwatch.StartNew();
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Connecting ResoniteLink connection pool to {context.Endpoint} "
-                + $"with {request.ConnectionCount} available routed connection(s)."));
-        await context.ClientSession.EnsureConnectedAsync(
-            new LiveSendConnectionRequest(
-                request.NormalizedRequest.Dataset,
-                request.NormalizedRequest.MeshCode),
             cancellationToken);
-        connectionStopwatch.Stop();
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"ResoniteLink connection pool ready in {connectionStopwatch.Elapsed.TotalSeconds:F2}s "
-                + $"(dataset='{request.SetupInfo.Dataset}', mesh='{request.SetupInfo.MeshCode}')."));
         LiveSendPreparedRunSetup preparedSetup = await runSetupPreparer.PrepareAsync(
             runPlan,
             request,
@@ -106,12 +85,5 @@ internal sealed class ResoniteLiveSendRunStarter(
                 preparedSetup.RunPlan.ResourceBudget),
             context);
         return state;
-    }
-
-    private static void ReportProgress(
-        LiveSendRunStartContext context,
-        string message)
-    {
-        context.ProgressReporter?.Invoke(message);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Domain.Importing;
-using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -36,12 +35,10 @@ internal interface IResoniteLiveSendRunStarter
 }
 
 internal sealed class ResoniteLiveSendRunStarter(
-    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
-    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
     ILiveSendRunPlanFactory runPlanFactory,
+    IResoniteLiveSendRunSetupPreparer runSetupPreparer,
     ILiveSendRunStateFactory runStateFactory,
-    IResoniteLiveSendWorkerLauncher workerLauncher,
-    IResoniteSlotCreator slotCreator) : IResoniteLiveSendRunStarter
+    IResoniteLiveSendWorkerLauncher workerLauncher) : IResoniteLiveSendRunStarter
 {
     public async Task<LiveSendRunState> StartAsync(
         LiveSendRunStartRequest request,
@@ -90,108 +87,25 @@ internal sealed class ResoniteLiveSendRunStarter(
                 "live",
                 $"ResoniteLink connection pool ready in {connectionStopwatch.Elapsed.TotalSeconds:F2}s "
                 + $"(dataset='{request.SetupInfo.Dataset}', mesh='{request.SetupInfo.MeshCode}')."));
-        LiveSendProgressSink progress = new();
-        CommonMaterialAssetCache materials = new();
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                "Reusing dataset content source provided by caller."));
-        ReportProgress(
-            context,
-            PlateauLog.Info("live", "Setting up mutable helpers (baker)."));
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                "Starting setup slot setup: dataset root, assets root, common assets root, location slot, and source-file root reference."));
-        Stopwatch setupStopwatch = Stopwatch.StartNew();
-        ResoniteSceneSetupState setupState = await sceneSetupInterpreter.SetupAsync(
-            GetRoutedClient(context),
-            runPlan.SetupInfo,
-            request.CommonMaterials,
-            cancellationToken);
-        setupStopwatch.Stop();
-        ResoniteSharedSlotIndex placement = new(
-            setupState.DatasetRootSlot,
-            setupState.DatasetAssetsRootSlot,
-            runPlan.RequestLocalOrigin,
-            runPlan.SourceFileSlotNamesByRelativePath,
-            setupState.SceneAnchor,
-            slotCreator.CreateAsync);
-        placement.IndexSetupHierarchy(setupState);
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Scene setup complete in {setupStopwatch.Elapsed.TotalSeconds:F2}s "
-                + $"(dataset_root={setupState.DatasetRootSlot.SlotName}, assets_root={setupState.DatasetAssetsRootSlot.SlotName}, "
-                + $"common_root={setupState.CommonAssetsRootSlot.SlotName}, "
-                + $"dataset_root_existed={setupState.DatasetRootExisted}, "
-                + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
-                + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
-                + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
-        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
-        {
-            materials.CommonMaterialAssets.Set(materialAsset.Item);
-        }
-
-        foreach (string family in setupState.CommonMaterialFamilies)
-        {
-            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
-        }
-
-        if (setupState.CommonMaterialAssets.Count > 0)
-        {
-            ReportProgress(
-                context,
-                PlateauLog.Info(
-                    "live",
-                    $"Setup batch prepared {setupState.CommonMaterialAssets.Count} textureless common materials."));
-        }
-        else
-        {
-            ReportProgress(context, PlateauLog.Info("live", "Setup created common material slots; no textureless common material components were needed in setup batch."));
-        }
-
-        await commonMaterialSetupPreparer.PrepareAsync(
-            GetRoutedClient(context),
-            setupState,
-            materials,
-            request.CommonMaterials,
-            context.ProgressReporter,
-            cancellationToken);
-
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                "setup fixed dataset license metadata/component before city-object streaming starts."));
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Dataset metadata/license phase complete during setup. "
-                + $"Dataset root existed={setupState.DatasetRootExisted}."));
-        LiveSendRunState state = runStateFactory.Create(
+        LiveSendPreparedRunSetup preparedSetup = await runSetupPreparer.PrepareAsync(
             runPlan,
-            setupState,
-            progress,
-            materials,
-            placement,
+            request,
+            context,
+            cancellationToken);
+        LiveSendRunState state = runStateFactory.Create(
+            preparedSetup.RunPlan,
+            preparedSetup.SetupState,
+            preparedSetup.Progress,
+            preparedSetup.Materials,
+            preparedSetup.Placement,
             cancellationToken);
         workerLauncher.Launch(
             new LiveSendWorkerLaunchRequest(
                 state,
-                runPlan.Queue,
-                runPlan.ResourceBudget),
+                preparedSetup.RunPlan.Queue,
+                preparedSetup.RunPlan.ResourceBudget),
             context);
         return state;
-    }
-
-    private static IResoniteLinkClient GetRoutedClient(LiveSendRunStartContext context)
-    {
-        return context.ClientSession.GetRequiredClient();
     }
 
     private static void ReportProgress(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -10,6 +10,10 @@ internal interface IResoniteLiveSendRunStarterFactory
     IResoniteLiveSendRunStarter Create(
         HttpClient terrainTextureAssetHttpClient,
         ResoniteLiveSceneImportTargetOptions options);
+
+    IResoniteLiveSendRunStarter Create(
+        ITerrainTextureAssetGenerator terrainTextureAssetGenerator,
+        ResoniteLiveSceneImportTargetOptions options);
 }
 
 internal sealed class ResoniteLiveSendRunStarterFactory(
@@ -27,12 +31,36 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
         ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
         ArgumentNullException.ThrowIfNull(options);
 
+        return Create(
+            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options),
+            options);
+    }
+
+    public IResoniteLiveSendRunStarter Create(
+        ITerrainTextureAssetGenerator terrainTextureAssetGenerator,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
+        ArgumentNullException.ThrowIfNull(options);
+
+        return Create(
+            workerLauncherFactory.Create(terrainTextureAssetGenerator),
+            options);
+    }
+
+    private ResoniteLiveSendRunStarter Create(
+        IResoniteLiveSendWorkerLauncher workerLauncher,
+        ResoniteLiveSceneImportTargetOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(workerLauncher);
+        ArgumentNullException.ThrowIfNull(options);
+
         return new ResoniteLiveSendRunStarter(
             sceneSetupInterpreter,
             commonMaterialSetupPreparer,
             runPlanFactory,
             runStateFactory,
-            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options),
+            workerLauncher,
             slotCreator);
     }
 }
@@ -42,6 +70,9 @@ internal interface IResoniteLiveSendWorkerLauncherFactory
     IResoniteLiveSendWorkerLauncher Create(
         HttpClient terrainTextureAssetHttpClient,
         ResoniteLiveSceneImportTargetOptions options);
+
+    IResoniteLiveSendWorkerLauncher Create(
+        ITerrainTextureAssetGenerator terrainTextureAssetGenerator);
 }
 
 internal sealed class ResoniteLiveSendWorkerLauncherFactory(
@@ -56,8 +87,16 @@ internal sealed class ResoniteLiveSendWorkerLauncherFactory(
         ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
         ArgumentNullException.ThrowIfNull(options);
 
+        return Create(terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options));
+    }
+
+    public IResoniteLiveSendWorkerLauncher Create(
+        ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
+
         ResoniteQueuedTexturePreparer texturePreparer = new(
-            terrainTextureAssetGeneratorFactory.Create(terrainTextureAssetHttpClient, options),
+            terrainTextureAssetGenerator,
             datasetLicenseWriter);
         ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
             texturePreparer,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -14,6 +14,7 @@ internal interface IResoniteLiveSendRunStarterFactory
 
 internal sealed class ResoniteLiveSendRunStarterFactory(
     ILiveSendRunPlanFactory runPlanFactory,
+    IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendRunSetupPreparer runSetupPreparer,
     ILiveSendRunStateFactory runStateFactory,
     IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory) : IResoniteLiveSendRunStarterFactory
@@ -41,6 +42,7 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
 
         return new ResoniteLiveSendRunStarter(
             runPlanFactory,
+            connectionInitializer,
             runSetupPreparer,
             runStateFactory,
             workerLauncher);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Net.Http;
 
-using PlateauResoniteLink.Targets.Resonite.Execution;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal interface IResoniteLiveSendRunStarterFactory
@@ -11,9 +9,7 @@ internal interface IResoniteLiveSendRunStarterFactory
         HttpClient terrainTextureAssetHttpClient,
         ResoniteLiveSceneImportTargetOptions options);
 
-    IResoniteLiveSendRunStarter Create(
-        ITerrainTextureAssetGenerator terrainTextureAssetGenerator,
-        ResoniteLiveSceneImportTargetOptions options);
+    IResoniteLiveSendRunStarter Create(ITerrainTextureAssetGenerator terrainTextureAssetGenerator);
 }
 
 internal sealed class ResoniteLiveSendRunStarterFactory(
@@ -29,29 +25,19 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
         ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
         ArgumentNullException.ThrowIfNull(options);
 
-        return Create(
-            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options),
-            options);
+        return Create(workerLauncherFactory.Create(terrainTextureAssetHttpClient, options));
     }
 
-    public IResoniteLiveSendRunStarter Create(
-        ITerrainTextureAssetGenerator terrainTextureAssetGenerator,
-        ResoniteLiveSceneImportTargetOptions options)
+    public IResoniteLiveSendRunStarter Create(ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
     {
         ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
-        ArgumentNullException.ThrowIfNull(options);
 
-        return Create(
-            workerLauncherFactory.Create(terrainTextureAssetGenerator),
-            options);
+        return Create(workerLauncherFactory.Create(terrainTextureAssetGenerator));
     }
 
-    private ResoniteLiveSendRunStarter Create(
-        IResoniteLiveSendWorkerLauncher workerLauncher,
-        ResoniteLiveSceneImportTargetOptions options)
+    private ResoniteLiveSendRunStarter Create(IResoniteLiveSendWorkerLauncher workerLauncher)
     {
         ArgumentNullException.ThrowIfNull(workerLauncher);
-        ArgumentNullException.ThrowIfNull(options);
 
         return new ResoniteLiveSendRunStarter(
             runPlanFactory,
@@ -73,8 +59,7 @@ internal interface IResoniteLiveSendWorkerLauncherFactory
 
 internal sealed class ResoniteLiveSendWorkerLauncherFactory(
     ITerrainTextureAssetGeneratorFactory terrainTextureAssetGeneratorFactory,
-    IResoniteDatasetLicenseWriter datasetLicenseWriter,
-    IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteLiveSendWorkerLauncherFactory
+    IResoniteLiveSendWorkerPipelineFactory workerPipelineFactory) : IResoniteLiveSendWorkerLauncherFactory
 {
     public IResoniteLiveSendWorkerLauncher Create(
         HttpClient terrainTextureAssetHttpClient,
@@ -91,13 +76,6 @@ internal sealed class ResoniteLiveSendWorkerLauncherFactory(
     {
         ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
 
-        ResoniteQueuedTexturePreparer texturePreparer = new(
-            terrainTextureAssetGenerator,
-            datasetLicenseWriter);
-        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
-            texturePreparer,
-            preparedCityObjectImporter);
-        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
-        return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);
+        return new ResoniteLiveSendWorkerLauncher(workerPipelineFactory.Create(terrainTextureAssetGenerator));
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -17,12 +17,10 @@ internal interface IResoniteLiveSendRunStarterFactory
 }
 
 internal sealed class ResoniteLiveSendRunStarterFactory(
-    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
-    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
     ILiveSendRunPlanFactory runPlanFactory,
+    IResoniteLiveSendRunSetupPreparer runSetupPreparer,
     ILiveSendRunStateFactory runStateFactory,
-    IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory,
-    IResoniteSlotCreator slotCreator) : IResoniteLiveSendRunStarterFactory
+    IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory) : IResoniteLiveSendRunStarterFactory
 {
     public IResoniteLiveSendRunStarter Create(
         HttpClient terrainTextureAssetHttpClient,
@@ -56,12 +54,10 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
         ArgumentNullException.ThrowIfNull(options);
 
         return new ResoniteLiveSendRunStarter(
-            sceneSetupInterpreter,
-            commonMaterialSetupPreparer,
             runPlanFactory,
+            runSetupPreparer,
             runStateFactory,
-            workerLauncher,
-            slotCreator);
+            workerLauncher);
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
         services.TryAddScoped<IResoniteLiveSendConnectionInitializer, ResoniteLiveSendConnectionInitializer>();
+        services.TryAddScoped<IResonitePreparedRunSetupComposer, ResonitePreparedRunSetupComposer>();
         services.TryAddScoped<IResoniteLiveSendRunSetupPreparer, ResoniteLiveSendRunSetupPreparer>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteSceneMaterialPlanComposer, ResoniteSceneMaterialPlanComposer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
+        services.TryAddScoped<IResoniteLiveSendConnectionInitializer, ResoniteLiveSendConnectionInitializer>();
         services.TryAddScoped<IResoniteLiveSendRunSetupPreparer, ResoniteLiveSendRunSetupPreparer>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteLiveSendRunSetupPreparer, ResoniteLiveSendRunSetupPreparer>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
+        services.TryAddScoped<IResoniteLiveSendWorkerPipelineFactory, ResoniteLiveSendWorkerPipelineFactory>();
         services.TryAddScoped<IResoniteLiveSendWorkerLauncherFactory, ResoniteLiveSendWorkerLauncherFactory>();
         services.TryAddScoped<IResoniteLiveSendStartRequestFactory, ResoniteLiveSendStartRequestFactory>();
         services.TryAddScoped<IResonitePreparedCityObjectImporter, ResonitePreparedCityObjectImporter>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteSceneMaterialPlanComposer, ResoniteSceneMaterialPlanComposer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
+        services.TryAddScoped<IResoniteLiveSendRunSetupPreparer, ResoniteLiveSendRunSetupPreparer>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
         services.TryAddScoped<IResoniteLiveSendWorkerLauncherFactory, ResoniteLiveSendWorkerLauncherFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 using PlateauResoniteLink.Targets.Resonite.Execution;
+using PlateauResoniteLink.Targets.Resonite.Diagnostics;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -37,6 +38,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteLiveSendQueue, ResoniteLiveSendQueue>();
         services.TryAddScoped<IResoniteLiveSendRunResourceReleaser, ResoniteLiveSendRunResourceReleaser>();
         services.TryAddScoped<IResoniteLiveSendRunExecutorFactory, ResoniteLiveSendRunExecutorFactory>();
+        services.TryAddScoped<IResoniteCanonicalSceneDumpSinkFactory, ResoniteCanonicalSceneDumpSinkFactory>();
         services.TryAddScoped<IResoniteSceneBatchEmitter, PlannedBatchEmissionInterpreter>();
         services.TryAddScoped<IResoniteSlotCreator, ResoniteSlotCreator>();
         services.TryAddScoped<IResoniteSceneAnchorResolver, ResoniteSceneAnchorResolver>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteLiveSendConnectionInitializer, ResoniteLiveSendConnectionInitializer>();
         services.TryAddScoped<IResonitePreparedRunSetupComposer, ResonitePreparedRunSetupComposer>();
         services.TryAddScoped<IResoniteLiveSendRunSetupPreparer, ResoniteLiveSendRunSetupPreparer>();
+        services.TryAddScoped<ILiveSendRunRuntimeComponentsFactory, LiveSendRunRuntimeComponentsFactory>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
         services.TryAddScoped<IResoniteLiveSendWorkerPipelineFactory, ResoniteLiveSendWorkerPipelineFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerPipelineFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerPipelineFactory.cs
@@ -1,0 +1,28 @@
+using System;
+
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendWorkerPipelineFactory
+{
+    IResoniteQueuedCityObjectWorker Create(ITerrainTextureAssetGenerator terrainTextureAssetGenerator);
+}
+
+internal sealed class ResoniteLiveSendWorkerPipelineFactory(
+    IResoniteDatasetLicenseWriter datasetLicenseWriter,
+    IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteLiveSendWorkerPipelineFactory
+{
+    public IResoniteQueuedCityObjectWorker Create(ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
+
+        ResoniteQueuedTexturePreparer texturePreparer = new(
+            terrainTextureAssetGenerator,
+            datasetLicenseWriter);
+        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
+            texturePreparer,
+            preparedCityObjectImporter);
+        return new ResoniteQueuedCityObjectWorker(queuedCityObjectSender);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedRunSetupComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedRunSetupComposer.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResonitePreparedRunSetupComposer
+{
+    LiveSendPreparedRunSetup Compose(
+        LiveSendRunPlan runPlan,
+        ResoniteSceneSetupState setupState);
+}
+
+internal sealed class ResonitePreparedRunSetupComposer(
+    IResoniteSlotCreator slotCreator) : IResonitePreparedRunSetupComposer
+{
+    public LiveSendPreparedRunSetup Compose(
+        LiveSendRunPlan runPlan,
+        ResoniteSceneSetupState setupState)
+    {
+        ArgumentNullException.ThrowIfNull(runPlan);
+
+        LiveSendProgressSink progress = new();
+        CommonMaterialAssetCache materials = CreateMaterialCache(setupState);
+        ResoniteSharedSlotIndex placement = new(
+            setupState.DatasetRootSlot,
+            setupState.DatasetAssetsRootSlot,
+            runPlan.RequestLocalOrigin,
+            runPlan.SourceFileSlotNamesByRelativePath,
+            setupState.SceneAnchor,
+            slotCreator.CreateAsync);
+        placement.IndexSetupHierarchy(setupState);
+
+        return new LiveSendPreparedRunSetup(
+            runPlan,
+            setupState,
+            progress,
+            materials,
+            placement);
+    }
+
+    private static CommonMaterialAssetCache CreateMaterialCache(
+        ResoniteSceneSetupState setupState)
+    {
+        CommonMaterialAssetCache materials = new();
+        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
+        {
+            materials.CommonMaterialAssets.Set(materialAsset.Item);
+        }
+
+        foreach (string family in setupState.CommonMaterialFamilies)
+        {
+            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
+        }
+
+        return materials;
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedRunSetupComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedRunSetupComposer.cs
@@ -21,6 +21,7 @@ internal sealed class ResonitePreparedRunSetupComposer(
         ResoniteSceneSetupState setupState)
     {
         ArgumentNullException.ThrowIfNull(runPlan);
+        ValidateSetupState(setupState);
 
         LiveSendProgressSink progress = new();
         CommonMaterialAssetCache materials = CreateMaterialCache(setupState);
@@ -56,5 +57,20 @@ internal sealed class ResonitePreparedRunSetupComposer(
         }
 
         return materials;
+    }
+
+    private static void ValidateSetupState(ResoniteSceneSetupState setupState)
+    {
+        if (string.IsNullOrWhiteSpace(setupState.DatasetRootSlot.Locator.Value)
+            || string.IsNullOrWhiteSpace(setupState.DatasetAssetsRootSlot.Locator.Value)
+            || string.IsNullOrWhiteSpace(setupState.CommonAssetsRootSlot.Locator.Value)
+            || string.IsNullOrWhiteSpace(setupState.SceneAnchor.LocationSlot.Value)
+            || setupState.CommonMaterialAssets is null
+            || setupState.CommonMaterialFamilies is null)
+        {
+            throw new ArgumentException(
+                "Setup state must be created by the scene setup interpreter before composing a prepared run setup.",
+                nameof(setupState));
+        }
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Cli/CliHostFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliHostFactoryTests.cs
@@ -1,11 +1,14 @@
 using System;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Cli;
+using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Cli;
@@ -41,5 +44,31 @@ public sealed class CliHostFactoryTests
 
         Assert.Same(importTarget.Diagnostics, importTarget.ClientSession.Diagnostics);
     }
-}
 
+    [Fact]
+    public async Task CreateSceneSinkFactoryBuildsCanonicalDumpSinkThroughRegisteredFactory()
+    {
+        using IHost host = CliHostFactory.Create([]);
+        ISceneSinkFactory sceneSinkFactory = host.Services.GetRequiredService<ISceneSinkFactory>();
+
+        await using ISceneSink sink = sceneSinkFactory.Create(
+            new ImportCommandOptions(
+                new PlateauImportRequest(
+                    Dataset: "tokyo23ku",
+                    MeshCode: "53394525",
+                    CityGmlSource: DatasetLocation.Local(Path.GetTempPath())),
+                WorkRoot: Path.GetTempPath(),
+                ResoniteLinkUri: null,
+                ResoniteLinkConnectionCount: 4,
+                MemoryProfile: PlateauImportMemoryProfile.Large,
+                EnableMeshBake: true,
+                TerrainTileCacheRoot: null,
+                DisableTerrainTileCache: false,
+                CanonicalSceneDumpPath: Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.json"),
+                EnableSendMetrics: true,
+                VerboseLogging: false),
+            progressReporter: null);
+
+        Assert.NotNull(sink);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -62,8 +62,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
                 DisableTerrainTileCache: false,
                 ProgressReporter: null),
             ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
-                new DelegatingClientSession(),
-                diagnostics,
+                new DelegatingClientSession(diagnostics: diagnostics),
                 ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning)));
 
         Assert.Same(diagnostics, importTarget.Diagnostics);
@@ -392,8 +391,7 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
                 DisableTerrainTileCache: false,
                 ProgressReporter: null),
             ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
-                new DelegatingClientSession(),
-                diagnostics,
+                new DelegatingClientSession(diagnostics: diagnostics),
                 ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning)));
     }
 
@@ -450,25 +448,22 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             return CreateTarget(
                 options,
                 new DelegatingClientSession(),
-                ResoniteLinkSendDiagnostics.Disabled,
                 new RecordingTerrainTextureAssetGenerator());
         }
 
         public ResoniteLiveSceneImportTarget CreateTarget(
             ResoniteLiveSceneImportTargetOptions options,
             ILiveSendClientSession clientSession,
-            ResoniteLinkSendDiagnostics diagnostics,
             ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
         {
             PreconfiguredCreateCallCount++;
             LastClientSession = clientSession;
-            LastDiagnostics = diagnostics;
+            LastDiagnostics = clientSession.Diagnostics;
             LastTerrainTextureAssetGenerator = terrainTextureAssetGenerator;
             return new ResoniteLiveSceneImportTarget(
                 options,
                 ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                     clientSession,
-                    diagnostics,
                     ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(
                         materialPlanning,
                         terrainTextureAssetGenerator: terrainTextureAssetGenerator)));

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -95,6 +95,18 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesRegistersRunSetupPreparer()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        Assert.IsType<ResoniteLiveSendRunSetupPreparer>(
+            scope.ServiceProvider.GetRequiredService<IResoniteLiveSendRunSetupPreparer>());
+    }
+
+    [Fact]
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The created target is disposed via await using in this test.")]
     public async Task AddResoniteLiveSendTargetServicesPreservesPreRegisteredSessionFactory()
     {

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -107,6 +107,18 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesRegistersWorkerPipelineFactory()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        Assert.IsType<ResoniteLiveSendWorkerPipelineFactory>(
+            scope.ServiceProvider.GetRequiredService<IResoniteLiveSendWorkerPipelineFactory>());
+    }
+
+    [Fact]
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The created target is disposed via await using in this test.")]
     public async Task AddResoniteLiveSendTargetServicesPreservesPreRegisteredSessionFactory()
     {
@@ -168,6 +180,39 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         Assert.NotNull(terrainTextureFactory.LastOptions);
         Assert.Equal("cache-root", terrainTextureFactory.LastOptions!.TerrainTileCacheRoot);
         Assert.True(terrainTextureFactory.LastOptions.DisableTerrainTileCache);
+    }
+
+    [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The created target is disposed via await using in this test.")]
+    public async Task AddResoniteLiveSendTargetServicesPreservesPreRegisteredWorkerPipelineFactory()
+    {
+        RecordingTerrainTextureAssetGeneratorFactory terrainTextureFactory = new();
+        RecordingWorkerPipelineFactory workerPipelineFactory = new();
+        ServiceProvider provider = new ServiceCollection()
+            .AddScoped<ITerrainTextureAssetGeneratorFactory>(_ => terrainTextureFactory)
+            .AddScoped<IResoniteLiveSendWorkerPipelineFactory>(_ => workerPipelineFactory)
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+        using HttpClient terrainTextureAssetHttpClient = new();
+        ISceneSink target = scope.ServiceProvider
+            .GetRequiredService<IResoniteLiveSceneImportFactory>()
+            .CreateTarget(
+                new ResoniteLiveSceneImportTargetOptions(
+                    new Uri("ws://localhost:12345/"),
+                    1,
+                    EnableSendMetrics: false,
+                    MemoryProfile: ResoniteImportMemoryProfile.Large,
+                    EnableMeshBake: true,
+                    TerrainTileCacheRoot: null,
+                    DisableTerrainTileCache: false,
+                    ProgressReporter: null),
+                terrainTextureAssetHttpClient);
+        await using ResoniteLiveSceneImportTarget _ = Assert.IsType<ResoniteLiveSceneImportTarget>(target);
+
+        Assert.Equal(1, workerPipelineFactory.CreateCallCount);
+        Assert.NotNull(terrainTextureFactory.LastGenerator);
+        Assert.Same(terrainTextureFactory.LastGenerator, workerPipelineFactory.LastTerrainTextureAssetGenerator);
     }
 
     [Fact]
@@ -314,6 +359,8 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
 
         public ResoniteLiveSceneImportTargetOptions? LastOptions { get; private set; }
 
+        public ITerrainTextureAssetGenerator? LastGenerator { get; private set; }
+
         public ITerrainTextureAssetGenerator Create(
             HttpClient terrainTextureAssetHttpClient,
             ResoniteLiveSceneImportTargetOptions options)
@@ -321,7 +368,8 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             CreateCallCount++;
             LastHttpClient = terrainTextureAssetHttpClient;
             LastOptions = options;
-            return new RecordingTerrainTextureAssetGenerator();
+            LastGenerator = new RecordingTerrainTextureAssetGenerator();
+            return LastGenerator;
         }
     }
 
@@ -366,6 +414,32 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             _ = onBakedCityObject;
             cancellationToken.ThrowIfCancellationRequested();
             throw new NotSupportedException("This test only verifies DI override preservation during baker creation.");
+        }
+    }
+
+    private sealed class RecordingWorkerPipelineFactory : IResoniteLiveSendWorkerPipelineFactory
+    {
+        public int CreateCallCount { get; private set; }
+
+        public ITerrainTextureAssetGenerator? LastTerrainTextureAssetGenerator { get; private set; }
+
+        public IResoniteQueuedCityObjectWorker Create(ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
+        {
+            CreateCallCount++;
+            LastTerrainTextureAssetGenerator = terrainTextureAssetGenerator;
+            return new RecordingQueuedCityObjectWorker();
+        }
+    }
+
+    private sealed class RecordingQueuedCityObjectWorker : IResoniteQueuedCityObjectWorker
+    {
+        public Task[] CreateProcessingTasks(
+            LiveSendRunState state,
+            LiveSendWorkerContext context)
+        {
+            _ = state;
+            _ = context;
+            return [];
         }
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -109,6 +109,18 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesRegistersConnectionInitializer()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        Assert.IsType<ResoniteLiveSendConnectionInitializer>(
+            scope.ServiceProvider.GetRequiredService<IResoniteLiveSendConnectionInitializer>());
+    }
+
+    [Fact]
     public void AddResoniteLiveSendTargetServicesRegistersWorkerPipelineFactory()
     {
         using ServiceProvider provider = new ServiceCollection()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -133,6 +133,22 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void PreparedRunSetupComposerRejectsDefaultSetupState()
+    {
+        ResonitePreparedRunSetupComposer composer = new(new ResoniteSlotCreator());
+        LiveSendRunPlan runPlan = new(
+            SetupInfo: null!,
+            ResolvedWorkRoot: "work",
+            RequestLocalOrigin: new ResoniteLocalOrigin(0.0, 0.0, 0.0),
+            SourceFileSlotNamesByRelativePath: new Dictionary<string, string>(),
+            ResourceBudget: ResoniteImportBudgetProfiles.ForProfile(ResoniteImportMemoryProfile.Large),
+            Queue: new LiveSendQueuePlan(ConnectionCount: 1, QueueCapacity: 4, MemoryBudgetBytes: 1),
+            MeshBakeEnabled: true);
+
+        Assert.Throws<ArgumentException>(() => composer.Compose(runPlan, setupState: default));
+    }
+
+    [Fact]
     public void AddResoniteLiveSendTargetServicesRegistersRunRuntimeComponentsFactory()
     {
         using ServiceProvider provider = new ServiceCollection()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -121,6 +121,18 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesRegistersPreparedRunSetupComposer()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        Assert.IsType<ResonitePreparedRunSetupComposer>(
+            scope.ServiceProvider.GetRequiredService<IResonitePreparedRunSetupComposer>());
+    }
+
+    [Fact]
     public void AddResoniteLiveSendTargetServicesRegistersWorkerPipelineFactory()
     {
         using ServiceProvider provider = new ServiceCollection()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -133,6 +133,18 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesRegistersRunRuntimeComponentsFactory()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        Assert.IsType<LiveSendRunRuntimeComponentsFactory>(
+            scope.ServiceProvider.GetRequiredService<ILiveSendRunRuntimeComponentsFactory>());
+    }
+
+    [Fact]
     public void AddResoniteLiveSendTargetServicesRegistersWorkerPipelineFactory()
     {
         using ServiceProvider provider = new ServiceCollection()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -11,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Targets.Resonite.Diagnostics;
 using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
@@ -180,6 +182,38 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         Assert.NotNull(terrainTextureFactory.LastOptions);
         Assert.Equal("cache-root", terrainTextureFactory.LastOptions!.TerrainTileCacheRoot);
         Assert.True(terrainTextureFactory.LastOptions.DisableTerrainTileCache);
+    }
+
+    [Fact]
+    public async Task AddResoniteLiveSendTargetServicesRoutesCanonicalDumpThroughRegisteredLiveSceneImportFactory()
+    {
+        RecordingLiveSceneImportFactory importFactory = new(new ResoniteMaterialPlanning(CreateBundledDefaultMaterialAssetStore()));
+        ServiceProvider provider = new ServiceCollection()
+            .AddScoped<IResoniteLiveSceneImportFactory>(_ => importFactory)
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+        using TemporaryDirectory outputDirectory = new();
+        string outputPath = Path.Combine(outputDirectory.Path, "scene.json");
+
+        await using ISceneSink _ = scope.ServiceProvider
+            .GetRequiredService<IResoniteCanonicalSceneDumpSinkFactory>()
+            .Create(
+                new ResoniteLiveSceneImportTargetOptions(
+                    new Uri("ws://localhost:12345/"),
+                    1,
+                    EnableSendMetrics: true,
+                    MemoryProfile: ResoniteImportMemoryProfile.Large,
+                    EnableMeshBake: true,
+                    TerrainTileCacheRoot: null,
+                    DisableTerrainTileCache: false,
+                    ProgressReporter: null),
+                outputPath);
+
+        Assert.Equal(1, importFactory.PreconfiguredCreateCallCount);
+        Assert.NotNull(importFactory.LastClientSession);
+        Assert.Same(ResoniteLinkSendDiagnostics.Disabled, importFactory.LastDiagnostics);
+        Assert.NotNull(importFactory.LastTerrainTextureAssetGenerator);
     }
 
     [Fact]
@@ -382,6 +416,50 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             _ = terrainTextureOverlay;
             cancellationToken.ThrowIfCancellationRequested();
             throw new NotSupportedException("This test only verifies DI override preservation during target creation.");
+        }
+    }
+
+    private sealed class RecordingLiveSceneImportFactory(
+        IResoniteMaterialPlanning materialPlanning) : IResoniteLiveSceneImportFactory
+    {
+        public int PreconfiguredCreateCallCount { get; private set; }
+
+        public ILiveSendClientSession? LastClientSession { get; private set; }
+
+        public ResoniteLinkSendDiagnostics? LastDiagnostics { get; private set; }
+
+        public ITerrainTextureAssetGenerator? LastTerrainTextureAssetGenerator { get; private set; }
+
+        public ResoniteLiveSceneImportTarget CreateTarget(
+            ResoniteLiveSceneImportTargetOptions options,
+            HttpClient terrainTextureAssetHttpClient)
+        {
+            _ = terrainTextureAssetHttpClient;
+            return CreateTarget(
+                options,
+                new DelegatingClientSession(),
+                ResoniteLinkSendDiagnostics.Disabled,
+                new RecordingTerrainTextureAssetGenerator());
+        }
+
+        public ResoniteLiveSceneImportTarget CreateTarget(
+            ResoniteLiveSceneImportTargetOptions options,
+            ILiveSendClientSession clientSession,
+            ResoniteLinkSendDiagnostics diagnostics,
+            ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
+        {
+            PreconfiguredCreateCallCount++;
+            LastClientSession = clientSession;
+            LastDiagnostics = diagnostics;
+            LastTerrainTextureAssetGenerator = terrainTextureAssetGenerator;
+            return new ResoniteLiveSceneImportTarget(
+                options,
+                ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
+                    clientSession,
+                    diagnostics,
+                    ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(
+                        materialPlanning,
+                        terrainTextureAssetGenerator: terrainTextureAssetGenerator)));
         }
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -138,6 +138,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 diagnostics,
                 new ResoniteLiveSendRunStarter(
                     new LiveSendRunPlanFactory(),
+                    new ResoniteLiveSendConnectionInitializer(),
                     new ThrowingRunSetupPreparer(),
                     new LiveSendRunStateFactory(
                         new ResoniteBufferedCityObjectBakerFactory(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -31,7 +31,6 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         using TemporaryDirectory secondWorkDirectory = new();
         using SceneSinkRecordingClient routedClient = new();
         DelegatingClientSession session = new(routedClient);
-        ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
         ResoniteMaterialPlanning materialPlanning = new(CreateBundledDefaultMaterialAssetStore());
         await using ResoniteLiveSceneImportTarget importTarget = new(
             new ResoniteLiveSceneImportTargetOptions(
@@ -84,7 +83,6 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         using TemporaryDirectory workDirectory = new();
         DelegatingClientSession session = new(
             ensureConnectedAsync: static (_, _) => Task.FromException(new InvalidOperationException("connect failed")));
-        ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
         ResoniteMaterialPlanning materialPlanning = new(CreateBundledDefaultMaterialAssetStore());
         await using ResoniteLiveSceneImportTarget importTarget = new(
             new ResoniteLiveSceneImportTargetOptions(
@@ -119,7 +117,6 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         using TemporaryDirectory workDirectory = new();
         using SceneSinkRecordingClient routedClient = new();
         DelegatingClientSession session = new(routedClient);
-        ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
         RecordingWorkerLauncher workerLauncher = new();
         await using ResoniteLiveSceneImportTarget importTarget = new(
             new ResoniteLiveSceneImportTargetOptions(
@@ -172,7 +169,6 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 enteredEnsureConnected.TrySetResult();
                 await releaseEnsureConnected.Task.WaitAsync(cancellationToken);
             });
-        ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
         ResoniteMaterialPlanning materialPlanning = new(CreateBundledDefaultMaterialAssetStore());
         await using ResoniteLiveSceneImportTarget importTarget = new(
             new ResoniteLiveSceneImportTargetOptions(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -115,6 +115,50 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_DoesNotLaunchWorkersWhenRunSetupFails()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using TemporaryDirectory workDirectory = new();
+        using SceneSinkRecordingClient routedClient = new();
+        DelegatingClientSession session = new(routedClient);
+        ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
+        RecordingWorkerLauncher workerLauncher = new();
+        await using ResoniteLiveSceneImportTarget importTarget = new(
+            new ResoniteLiveSceneImportTargetOptions(
+                new Uri("ws://localhost:12345/"),
+                1,
+                EnableSendMetrics: false,
+                ResoniteImportMemoryProfile.Large,
+                EnableMeshBake: true,
+                TerrainTileCacheRoot: null,
+                DisableTerrainTileCache: false,
+                ProgressReporter: null),
+            ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
+                session,
+                diagnostics,
+                new ResoniteLiveSendRunStarter(
+                    new LiveSendRunPlanFactory(),
+                    new ThrowingRunSetupPreparer(),
+                    new LiveSendRunStateFactory(
+                        new ResoniteBufferedCityObjectBakerFactory(
+                            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
+                    workerLauncher)));
+
+        PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
+        ImportedSceneMetadata metadata = CreateMetadata(
+            request,
+            ["udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml"]);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => importTarget.ExecuteAsync(
+                ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(metadata, workDirectory.Path),
+                EmptyImportedObjectUnits()));
+        Assert.Equal("setup failed", exception.Message);
+        Assert.Equal(1, session.EnsureConnectedCallCount);
+        Assert.Equal(0, workerLauncher.LaunchCallCount);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_RejectsConcurrentRunsBeforeSetupCompletes()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -1219,6 +1263,36 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 new ResoniteMeshSubmesh(0, [0, 1, 2]),
                 new ResoniteMeshSubmesh(1, [3, 4, 5]),
             ]);
+    }
+
+    private sealed class ThrowingRunSetupPreparer : IResoniteLiveSendRunSetupPreparer
+    {
+        public Task<LiveSendPreparedRunSetup> PrepareAsync(
+            LiveSendRunPlan runPlan,
+            LiveSendRunStartRequest request,
+            LiveSendRunStartContext context,
+            CancellationToken cancellationToken)
+        {
+            _ = runPlan;
+            _ = request;
+            _ = context;
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromException<LiveSendPreparedRunSetup>(new InvalidOperationException("setup failed"));
+        }
+    }
+
+    private sealed class RecordingWorkerLauncher : IResoniteLiveSendWorkerLauncher
+    {
+        public int LaunchCallCount { get; private set; }
+
+        public void Launch(
+            LiveSendWorkerLaunchRequest request,
+            LiveSendRunStartContext context)
+        {
+            _ = request;
+            _ = context;
+            LaunchCallCount++;
+        }
     }
 
     private sealed class MissingCommonMaterialSetupInterpreter : IResoniteSceneSetupInterpreter

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -142,7 +142,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     new ThrowingRunSetupPreparer(),
                     new LiveSendRunStateFactory(
                         new ResoniteBufferedCityObjectBakerFactory(
-                            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
+                            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader())),
+                        new LiveSendRunRuntimeComponentsFactory()),
                     workerLauncher)));
 
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -45,7 +45,6 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 ProgressReporter: null),
             ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 session,
-                diagnostics,
                 ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning)));
 
         PlateauImportRequest normalizedRequest = new(
@@ -99,7 +98,6 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 ProgressReporter: null),
             ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 session,
-                diagnostics,
                 ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning)));
 
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
@@ -135,7 +133,6 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 ProgressReporter: null),
             ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 session,
-                diagnostics,
                 new ResoniteLiveSendRunStarter(
                     new LiveSendRunPlanFactory(),
                     new ResoniteLiveSendConnectionInitializer(),
@@ -189,7 +186,6 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 ProgressReporter: null),
             ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 session,
-                diagnostics,
                 ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning)));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
@@ -271,7 +267,6 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 ProgressReporter: null),
             ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 session,
-                ResoniteLinkSendDiagnostics.Disabled,
                 ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter())));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
@@ -313,7 +308,6 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 ProgressReporter: null),
             ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 session,
-                ResoniteLinkSendDiagnostics.Disabled,
                 ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning, new MissingCommonMaterialSetupInterpreter())));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(
@@ -378,7 +372,6 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 }),
             ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
                 session,
-                ResoniteLinkSendDiagnostics.Disabled,
                 ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(materialPlanning, progressReporter: progressMessages.Add)));
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
         ImportedSceneMetadata metadata = CreateMetadata(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -363,14 +363,15 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         Action<string>? progressReporter = null)
     {
         return new ResoniteLiveSendRunStarter(
-            sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
-            new ResoniteCommonMaterialSetupPreparer(materialPlanning),
             new LiveSendRunPlanFactory(),
+            new ResoniteLiveSendRunSetupPreparer(
+                sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
+                new ResoniteCommonMaterialSetupPreparer(materialPlanning),
+                new ResoniteSlotCreator()),
             new LiveSendRunStateFactory(
                 new ResoniteBufferedCityObjectBakerFactory(
                     new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
-            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning, terrainTextureAssetGenerator)),
-            new ResoniteSlotCreator());
+            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning, terrainTextureAssetGenerator)));
     }
 
     public static ResoniteLiveSendQueue CreateQueue()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -330,14 +330,12 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 DisableTerrainTileCache: false,
                 ProgressReporter: progressReporter),
             CreateDependencies(
-                session ?? new DelegatingClientSession(routedClient),
-                diagnostics,
+                session ?? new DelegatingClientSession(routedClient, diagnostics: diagnostics),
                 CreateRunStarter(materialPlanning, terrainTextureAssetGenerator: terrainTextureAssetGenerator, progressReporter: progressReporter)));
     }
 
     public static ResoniteLiveSceneImportDependencies CreateDependencies(
         ILiveSendClientSession session,
-        ResoniteLinkSendDiagnostics diagnostics,
         IResoniteLiveSendRunStarter runStarter,
         IResoniteLiveSendQueue? queue = null,
         IResoniteLiveSendRunResourceReleaser? resourceReleaser = null)
@@ -347,7 +345,6 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             resourceReleaser ?? new ResoniteLiveSendRunResourceReleaser();
         return new ResoniteLiveSceneImportDependencies(
             session,
-            diagnostics,
             new ResoniteLiveSendStartRequestFactory(),
             new ResoniteLiveSendRunExecutor(
                 runStarter,
@@ -564,13 +561,14 @@ internal sealed class SceneSinkRecordingClient : PlateauResoniteLink.Targets.Res
 
 internal sealed class DelegatingClientSession(
     IResoniteLinkClient? routedClient = null,
-    Func<LiveSendConnectionRequest, CancellationToken, Task>? ensureConnectedAsync = null) : ILiveSendClientSession
+    Func<LiveSendConnectionRequest, CancellationToken, Task>? ensureConnectedAsync = null,
+    ResoniteLinkSendDiagnostics? diagnostics = null) : ILiveSendClientSession
 {
     private readonly IResoniteLinkClient? defaultRoutedClient = routedClient;
 
     public IResoniteLinkClient? ConnectedClient { get; set; } = routedClient;
 
-    public ResoniteLinkSendDiagnostics Diagnostics { get; } = ResoniteLinkSendDiagnostics.Disabled;
+    public ResoniteLinkSendDiagnostics Diagnostics { get; } = diagnostics ?? ResoniteLinkSendDiagnostics.Disabled;
 
     public IResoniteLinkClient GetRequiredClient()
     {

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -364,6 +364,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
     {
         return new ResoniteLiveSendRunStarter(
             new LiveSendRunPlanFactory(),
+            new ResoniteLiveSendConnectionInitializer(),
             new ResoniteLiveSendRunSetupPreparer(
                 sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
                 new ResoniteCommonMaterialSetupPreparer(materialPlanning),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -368,7 +368,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             new ResoniteLiveSendRunSetupPreparer(
                 sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
                 new ResoniteCommonMaterialSetupPreparer(materialPlanning),
-                new ResoniteSlotCreator()),
+                new ResonitePreparedRunSetupComposer(new ResoniteSlotCreator())),
             new LiveSendRunStateFactory(
                 new ResoniteBufferedCityObjectBakerFactory(
                     new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -371,7 +371,8 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 new ResonitePreparedRunSetupComposer(new ResoniteSlotCreator())),
             new LiveSendRunStateFactory(
                 new ResoniteBufferedCityObjectBakerFactory(
-                    new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
+                    new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader())),
+                new LiveSendRunRuntimeComponentsFactory()),
             new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning, terrainTextureAssetGenerator)));
     }
 


### PR DESCRIPTION
## Summary
- move canonical scene dump target construction behind a target-side factory
- keep CLI responsible only for command options, scope ownership, and dump sink selection
- reuse the live target dependency factory for executor, queue, finalizer, starter, and worker wiring while injecting the dump-specific recording session and deterministic terrain texture generator

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

Full test result: 830 passed.