### PR TITLE
Extract live send run setup preparation

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record LiveSendPreparedRunSetup(
+    LiveSendRunPlan RunPlan,
+    ResoniteSceneSetupState SetupState,
+    LiveSendProgressSink Progress,
+    CommonMaterialAssetCache Materials,
+    ResoniteSharedSlotIndex Placement);
+
+internal interface IResoniteLiveSendRunSetupPreparer
+{
+    Task<LiveSendPreparedRunSetup> PrepareAsync(
+        LiveSendRunPlan runPlan,
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteLiveSendRunSetupPreparer(
+    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
+    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
+    IResoniteSlotCreator slotCreator) : IResoniteLiveSendRunSetupPreparer
+{
+    public async Task<LiveSendPreparedRunSetup> PrepareAsync(
+        LiveSendRunPlan runPlan,
+        LiveSendRunStartRequest request,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(runPlan);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+
+        LiveSendProgressSink progress = new();
+        CommonMaterialAssetCache materials = new();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "Reusing dataset content source provided by caller."));
+        ReportProgress(
+            context,
+            PlateauLog.Info("live", "Setting up mutable helpers (baker)."));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "Starting setup slot setup: dataset root, assets root, common assets root, location slot, and source-file root reference."));
+        Stopwatch setupStopwatch = Stopwatch.StartNew();
+        ResoniteSceneSetupState setupState = await sceneSetupInterpreter.SetupAsync(
+            GetRoutedClient(context),
+            runPlan.SetupInfo,
+            request.CommonMaterials,
+            cancellationToken);
+        setupStopwatch.Stop();
+        ResoniteSharedSlotIndex placement = new(
+            setupState.DatasetRootSlot,
+            setupState.DatasetAssetsRootSlot,
+            runPlan.RequestLocalOrigin,
+            runPlan.SourceFileSlotNamesByRelativePath,
+            setupState.SceneAnchor,
+            slotCreator.CreateAsync);
+        placement.IndexSetupHierarchy(setupState);
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Scene setup complete in {setupStopwatch.Elapsed.TotalSeconds:F2}s "
+                + $"(dataset_root={setupState.DatasetRootSlot.SlotName}, assets_root={setupState.DatasetAssetsRootSlot.SlotName}, "
+                + $"common_root={setupState.CommonAssetsRootSlot.SlotName}, "
+                + $"dataset_root_existed={setupState.DatasetRootExisted}, "
+                + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
+                + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
+                + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
+        CacheSetupCommonMaterials(setupState, materials);
+        ReportSetupCommonMaterials(setupState, context);
+        await commonMaterialSetupPreparer.PrepareAsync(
+            GetRoutedClient(context),
+            setupState,
+            materials,
+            request.CommonMaterials,
+            context.ProgressReporter,
+            cancellationToken);
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "setup fixed dataset license metadata/component before city-object streaming starts."));
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Dataset metadata/license phase complete during setup. "
+                + $"Dataset root existed={setupState.DatasetRootExisted}."));
+        return new LiveSendPreparedRunSetup(
+            runPlan,
+            setupState,
+            progress,
+            materials,
+            placement);
+    }
+
+    private static void CacheSetupCommonMaterials(
+        ResoniteSceneSetupState setupState,
+        CommonMaterialAssetCache materials)
+    {
+        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
+        {
+            materials.CommonMaterialAssets.Set(materialAsset.Item);
+        }
+
+        foreach (string family in setupState.CommonMaterialFamilies)
+        {
+            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
+        }
+    }
+
+    private static void ReportSetupCommonMaterials(
+        ResoniteSceneSetupState setupState,
+        LiveSendRunStartContext context)
+    {
+        if (setupState.CommonMaterialAssets.Count > 0)
+        {
+            ReportProgress(
+                context,
+                PlateauLog.Info(
+                    "live",
+                    $"Setup batch prepared {setupState.CommonMaterialAssets.Count} textureless common materials."));
+            return;
+        }
+
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                "Setup created common material slots; no textureless common material components were needed in setup batch."));
+    }
+
+    private static IResoniteLinkClient GetRoutedClient(LiveSendRunStartContext context)
+    {
+        return context.ClientSession.GetRequiredClient();
+    }
+
+    private static void ReportProgress(
+        LiveSendRunStartContext context,
+        string message)
+    {
+        context.ProgressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Domain.Importing;
-using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -36,12 +35,10 @@ internal interface IResoniteLiveSendRunStarter
 }
 
 internal sealed class ResoniteLiveSendRunStarter(
-    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
-    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
     ILiveSendRunPlanFactory runPlanFactory,
+    IResoniteLiveSendRunSetupPreparer runSetupPreparer,
     ILiveSendRunStateFactory runStateFactory,
-    IResoniteLiveSendWorkerLauncher workerLauncher,
-    IResoniteSlotCreator slotCreator) : IResoniteLiveSendRunStarter
+    IResoniteLiveSendWorkerLauncher workerLauncher) : IResoniteLiveSendRunStarter
 {
     public async Task<LiveSendRunState> StartAsync(
         LiveSendRunStartRequest request,
@@ -90,108 +87,25 @@ internal sealed class ResoniteLiveSendRunStarter(
                 "live",
                 $"ResoniteLink connection pool ready in {connectionStopwatch.Elapsed.TotalSeconds:F2}s "
                 + $"(dataset='{request.SetupInfo.Dataset}', mesh='{request.SetupInfo.MeshCode}')."));
-        LiveSendProgressSink progress = new();
-        CommonMaterialAssetCache materials = new();
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                "Reusing dataset content source provided by caller."));
-        ReportProgress(
-            context,
-            PlateauLog.Info("live", "Setting up mutable helpers (baker)."));
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                "Starting setup slot setup: dataset root, assets root, common assets root, location slot, and source-file root reference."));
-        Stopwatch setupStopwatch = Stopwatch.StartNew();
-        ResoniteSceneSetupState setupState = await sceneSetupInterpreter.SetupAsync(
-            GetRoutedClient(context),
-            runPlan.SetupInfo,
-            request.CommonMaterials,
-            cancellationToken);
-        setupStopwatch.Stop();
-        ResoniteSharedSlotIndex placement = new(
-            setupState.DatasetRootSlot,
-            setupState.DatasetAssetsRootSlot,
-            runPlan.RequestLocalOrigin,
-            runPlan.SourceFileSlotNamesByRelativePath,
-            setupState.SceneAnchor,
-            slotCreator.CreateAsync);
-        placement.IndexSetupHierarchy(setupState);
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Scene setup complete in {setupStopwatch.Elapsed.TotalSeconds:F2}s "
-                + $"(dataset_root={setupState.DatasetRootSlot.SlotName}, assets_root={setupState.DatasetAssetsRootSlot.SlotName}, "
-                + $"common_root={setupState.CommonAssetsRootSlot.SlotName}, "
-                + $"dataset_root_existed={setupState.DatasetRootExisted}, "
-                + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
-                + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
-                + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
-        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
-        {
-            materials.CommonMaterialAssets.Set(materialAsset.Item);
-        }
-
-        foreach (string family in setupState.CommonMaterialFamilies)
-        {
-            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
-        }
-
-        if (setupState.CommonMaterialAssets.Count > 0)
-        {
-            ReportProgress(
-                context,
-                PlateauLog.Info(
-                    "live",
-                    $"Setup batch prepared {setupState.CommonMaterialAssets.Count} textureless common materials."));
-        }
-        else
-        {
-            ReportProgress(context, PlateauLog.Info("live", "Setup created common material slots; no textureless common material components were needed in setup batch."));
-        }
-
-        await commonMaterialSetupPreparer.PrepareAsync(
-            GetRoutedClient(context),
-            setupState,
-            materials,
-            request.CommonMaterials,
-            context.ProgressReporter,
-            cancellationToken);
-
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                "setup fixed dataset license metadata/component before city-object streaming starts."));
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Dataset metadata/license phase complete during setup. "
-                + $"Dataset root existed={setupState.DatasetRootExisted}."));
-        LiveSendRunState state = runStateFactory.Create(
+        LiveSendPreparedRunSetup preparedSetup = await runSetupPreparer.PrepareAsync(
             runPlan,
-            setupState,
-            progress,
-            materials,
-            placement,
+            request,
+            context,
+            cancellationToken);
+        LiveSendRunState state = runStateFactory.Create(
+            preparedSetup.RunPlan,
+            preparedSetup.SetupState,
+            preparedSetup.Progress,
+            preparedSetup.Materials,
+            preparedSetup.Placement,
             cancellationToken);
         workerLauncher.Launch(
             new LiveSendWorkerLaunchRequest(
                 state,
-                runPlan.Queue,
-                runPlan.ResourceBudget),
+                preparedSetup.RunPlan.Queue,
+                preparedSetup.RunPlan.ResourceBudget),
             context);
         return state;
-    }
-
-    private static IResoniteLinkClient GetRoutedClient(LiveSendRunStartContext context)
-    {
-        return context.ClientSession.GetRequiredClient();
     }
 
     private static void ReportProgress(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -17,12 +17,10 @@ internal interface IResoniteLiveSendRunStarterFactory
 }
 
 internal sealed class ResoniteLiveSendRunStarterFactory(
-    IResoniteSceneSetupInterpreter sceneSetupInterpreter,
-    IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
     ILiveSendRunPlanFactory runPlanFactory,
+    IResoniteLiveSendRunSetupPreparer runSetupPreparer,
     ILiveSendRunStateFactory runStateFactory,
-    IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory,
-    IResoniteSlotCreator slotCreator) : IResoniteLiveSendRunStarterFactory
+    IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory) : IResoniteLiveSendRunStarterFactory
 {
     public IResoniteLiveSendRunStarter Create(
         HttpClient terrainTextureAssetHttpClient,
@@ -56,12 +54,10 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
         ArgumentNullException.ThrowIfNull(options);
 
         return new ResoniteLiveSendRunStarter(
-            sceneSetupInterpreter,
-            commonMaterialSetupPreparer,
             runPlanFactory,
+            runSetupPreparer,
             runStateFactory,
-            workerLauncher,
-            slotCreator);
+            workerLauncher);
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteSceneMaterialPlanComposer, ResoniteSceneMaterialPlanComposer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
+        services.TryAddScoped<IResoniteLiveSendRunSetupPreparer, ResoniteLiveSendRunSetupPreparer>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
         services.TryAddScoped<IResoniteLiveSendWorkerLauncherFactory, ResoniteLiveSendWorkerLauncherFactory>();

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -95,6 +95,18 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesRegistersRunSetupPreparer()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        Assert.IsType<ResoniteLiveSendRunSetupPreparer>(
+            scope.ServiceProvider.GetRequiredService<IResoniteLiveSendRunSetupPreparer>());
+    }
+
+    [Fact]
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The created target is disposed via await using in this test.")]
     public async Task AddResoniteLiveSendTargetServicesPreservesPreRegisteredSessionFactory()
     {

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -115,6 +115,50 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_DoesNotLaunchWorkersWhenRunSetupFails()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        using TemporaryDirectory workDirectory = new();
+        using SceneSinkRecordingClient routedClient = new();
+        DelegatingClientSession session = new(routedClient);
+        ResoniteLinkSendDiagnostics diagnostics = ResoniteLinkSendDiagnostics.Disabled;
+        RecordingWorkerLauncher workerLauncher = new();
+        await using ResoniteLiveSceneImportTarget importTarget = new(
+            new ResoniteLiveSceneImportTargetOptions(
+                new Uri("ws://localhost:12345/"),
+                1,
+                EnableSendMetrics: false,
+                ResoniteImportMemoryProfile.Large,
+                EnableMeshBake: true,
+                TerrainTileCacheRoot: null,
+                DisableTerrainTileCache: false,
+                ProgressReporter: null),
+            ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
+                session,
+                diagnostics,
+                new ResoniteLiveSendRunStarter(
+                    new LiveSendRunPlanFactory(),
+                    new ThrowingRunSetupPreparer(),
+                    new LiveSendRunStateFactory(
+                        new ResoniteBufferedCityObjectBakerFactory(
+                            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
+                    workerLauncher)));
+
+        PlateauImportRequest request = CreateRequest(datasetDirectory.Path);
+        ImportedSceneMetadata metadata = CreateMetadata(
+            request,
+            ["udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml"]);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => importTarget.ExecuteAsync(
+                ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(metadata, workDirectory.Path),
+                EmptyImportedObjectUnits()));
+        Assert.Equal("setup failed", exception.Message);
+        Assert.Equal(1, session.EnsureConnectedCallCount);
+        Assert.Equal(0, workerLauncher.LaunchCallCount);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_RejectsConcurrentRunsBeforeSetupCompletes()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -1219,6 +1263,36 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 new ResoniteMeshSubmesh(0, [0, 1, 2]),
                 new ResoniteMeshSubmesh(1, [3, 4, 5]),
             ]);
+    }
+
+    private sealed class ThrowingRunSetupPreparer : IResoniteLiveSendRunSetupPreparer
+    {
+        public Task<LiveSendPreparedRunSetup> PrepareAsync(
+            LiveSendRunPlan runPlan,
+            LiveSendRunStartRequest request,
+            LiveSendRunStartContext context,
+            CancellationToken cancellationToken)
+        {
+            _ = runPlan;
+            _ = request;
+            _ = context;
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromException<LiveSendPreparedRunSetup>(new InvalidOperationException("setup failed"));
+        }
+    }
+
+    private sealed class RecordingWorkerLauncher : IResoniteLiveSendWorkerLauncher
+    {
+        public int LaunchCallCount { get; private set; }
+
+        public void Launch(
+            LiveSendWorkerLaunchRequest request,
+            LiveSendRunStartContext context)
+        {
+            _ = request;
+            _ = context;
+            LaunchCallCount++;
+        }
     }
 
     private sealed class MissingCommonMaterialSetupInterpreter : IResoniteSceneSetupInterpreter

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -363,14 +363,15 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         Action<string>? progressReporter = null)
     {
         return new ResoniteLiveSendRunStarter(
-            sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
-            new ResoniteCommonMaterialSetupPreparer(materialPlanning),
             new LiveSendRunPlanFactory(),
+            new ResoniteLiveSendRunSetupPreparer(
+                sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
+                new ResoniteCommonMaterialSetupPreparer(materialPlanning),
+                new ResoniteSlotCreator()),
             new LiveSendRunStateFactory(
                 new ResoniteBufferedCityObjectBakerFactory(
                     new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
-            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning, terrainTextureAssetGenerator)),
-            new ResoniteSlotCreator());
+            new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning, terrainTextureAssetGenerator)));
     }
 
     public static ResoniteLiveSendQueue CreateQueue()


### PR DESCRIPTION
## Summary
- extract scene setup, setup material cache transfer, common material preparation, and placement indexing into `IResoniteLiveSendRunSetupPreparer`
- keep `ResoniteLiveSendRunStarter` focused on run plan creation, connection setup, state creation, and worker launch
- add direct behavior guards for setup-preparer DI resolution and preventing worker launch when setup preparation fails

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

Full test result: 832 passed.