### PR TITLE
Extract live send worker pipeline factory

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportDependencyFactory.cs
@@ -53,7 +53,7 @@ internal sealed class ResoniteLiveSceneImportDependencyFactory(
         ArgumentNullException.ThrowIfNull(diagnostics);
         ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
 
-        IResoniteLiveSendRunStarter runStarter = runStarterFactory.Create(terrainTextureAssetGenerator, options);
+        IResoniteLiveSendRunStarter runStarter = runStarterFactory.Create(terrainTextureAssetGenerator);
         return Create(options, clientSession, diagnostics, runStarter);
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Net.Http;
 
-using PlateauResoniteLink.Targets.Resonite.Execution;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal interface IResoniteLiveSendRunStarterFactory
@@ -11,9 +9,7 @@ internal interface IResoniteLiveSendRunStarterFactory
         HttpClient terrainTextureAssetHttpClient,
         ResoniteLiveSceneImportTargetOptions options);
 
-    IResoniteLiveSendRunStarter Create(
-        ITerrainTextureAssetGenerator terrainTextureAssetGenerator,
-        ResoniteLiveSceneImportTargetOptions options);
+    IResoniteLiveSendRunStarter Create(ITerrainTextureAssetGenerator terrainTextureAssetGenerator);
 }
 
 internal sealed class ResoniteLiveSendRunStarterFactory(
@@ -29,29 +25,19 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
         ArgumentNullException.ThrowIfNull(terrainTextureAssetHttpClient);
         ArgumentNullException.ThrowIfNull(options);
 
-        return Create(
-            workerLauncherFactory.Create(terrainTextureAssetHttpClient, options),
-            options);
+        return Create(workerLauncherFactory.Create(terrainTextureAssetHttpClient, options));
     }
 
-    public IResoniteLiveSendRunStarter Create(
-        ITerrainTextureAssetGenerator terrainTextureAssetGenerator,
-        ResoniteLiveSceneImportTargetOptions options)
+    public IResoniteLiveSendRunStarter Create(ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
     {
         ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
-        ArgumentNullException.ThrowIfNull(options);
 
-        return Create(
-            workerLauncherFactory.Create(terrainTextureAssetGenerator),
-            options);
+        return Create(workerLauncherFactory.Create(terrainTextureAssetGenerator));
     }
 
-    private ResoniteLiveSendRunStarter Create(
-        IResoniteLiveSendWorkerLauncher workerLauncher,
-        ResoniteLiveSceneImportTargetOptions options)
+    private ResoniteLiveSendRunStarter Create(IResoniteLiveSendWorkerLauncher workerLauncher)
     {
         ArgumentNullException.ThrowIfNull(workerLauncher);
-        ArgumentNullException.ThrowIfNull(options);
 
         return new ResoniteLiveSendRunStarter(
             runPlanFactory,
@@ -73,8 +59,7 @@ internal interface IResoniteLiveSendWorkerLauncherFactory
 
 internal sealed class ResoniteLiveSendWorkerLauncherFactory(
     ITerrainTextureAssetGeneratorFactory terrainTextureAssetGeneratorFactory,
-    IResoniteDatasetLicenseWriter datasetLicenseWriter,
-    IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteLiveSendWorkerLauncherFactory
+    IResoniteLiveSendWorkerPipelineFactory workerPipelineFactory) : IResoniteLiveSendWorkerLauncherFactory
 {
     public IResoniteLiveSendWorkerLauncher Create(
         HttpClient terrainTextureAssetHttpClient,
@@ -91,13 +76,6 @@ internal sealed class ResoniteLiveSendWorkerLauncherFactory(
     {
         ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
 
-        ResoniteQueuedTexturePreparer texturePreparer = new(
-            terrainTextureAssetGenerator,
-            datasetLicenseWriter);
-        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
-            texturePreparer,
-            preparedCityObjectImporter);
-        ResoniteQueuedCityObjectWorker queuedCityObjectWorker = new(queuedCityObjectSender);
-        return new ResoniteLiveSendWorkerLauncher(queuedCityObjectWorker);
+        return new ResoniteLiveSendWorkerLauncher(workerPipelineFactory.Create(terrainTextureAssetGenerator));
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteLiveSendRunSetupPreparer, ResoniteLiveSendRunSetupPreparer>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
+        services.TryAddScoped<IResoniteLiveSendWorkerPipelineFactory, ResoniteLiveSendWorkerPipelineFactory>();
         services.TryAddScoped<IResoniteLiveSendWorkerLauncherFactory, ResoniteLiveSendWorkerLauncherFactory>();
         services.TryAddScoped<IResoniteLiveSendStartRequestFactory, ResoniteLiveSendStartRequestFactory>();
         services.TryAddScoped<IResonitePreparedCityObjectImporter, ResonitePreparedCityObjectImporter>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerPipelineFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerPipelineFactory.cs
@@ -1,0 +1,28 @@
+using System;
+
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendWorkerPipelineFactory
+{
+    IResoniteQueuedCityObjectWorker Create(ITerrainTextureAssetGenerator terrainTextureAssetGenerator);
+}
+
+internal sealed class ResoniteLiveSendWorkerPipelineFactory(
+    IResoniteDatasetLicenseWriter datasetLicenseWriter,
+    IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteLiveSendWorkerPipelineFactory
+{
+    public IResoniteQueuedCityObjectWorker Create(ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
+    {
+        ArgumentNullException.ThrowIfNull(terrainTextureAssetGenerator);
+
+        ResoniteQueuedTexturePreparer texturePreparer = new(
+            terrainTextureAssetGenerator,
+            datasetLicenseWriter);
+        ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
+            texturePreparer,
+            preparedCityObjectImporter);
+        return new ResoniteQueuedCityObjectWorker(queuedCityObjectSender);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -107,6 +107,18 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesRegistersWorkerPipelineFactory()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        Assert.IsType<ResoniteLiveSendWorkerPipelineFactory>(
+            scope.ServiceProvider.GetRequiredService<IResoniteLiveSendWorkerPipelineFactory>());
+    }
+
+    [Fact]
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The created target is disposed via await using in this test.")]
     public async Task AddResoniteLiveSendTargetServicesPreservesPreRegisteredSessionFactory()
     {
@@ -168,6 +180,39 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         Assert.NotNull(terrainTextureFactory.LastOptions);
         Assert.Equal("cache-root", terrainTextureFactory.LastOptions!.TerrainTileCacheRoot);
         Assert.True(terrainTextureFactory.LastOptions.DisableTerrainTileCache);
+    }
+
+    [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The created target is disposed via await using in this test.")]
+    public async Task AddResoniteLiveSendTargetServicesPreservesPreRegisteredWorkerPipelineFactory()
+    {
+        RecordingTerrainTextureAssetGeneratorFactory terrainTextureFactory = new();
+        RecordingWorkerPipelineFactory workerPipelineFactory = new();
+        ServiceProvider provider = new ServiceCollection()
+            .AddScoped<ITerrainTextureAssetGeneratorFactory>(_ => terrainTextureFactory)
+            .AddScoped<IResoniteLiveSendWorkerPipelineFactory>(_ => workerPipelineFactory)
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+        using HttpClient terrainTextureAssetHttpClient = new();
+        ISceneSink target = scope.ServiceProvider
+            .GetRequiredService<IResoniteLiveSceneImportFactory>()
+            .CreateTarget(
+                new ResoniteLiveSceneImportTargetOptions(
+                    new Uri("ws://localhost:12345/"),
+                    1,
+                    EnableSendMetrics: false,
+                    MemoryProfile: ResoniteImportMemoryProfile.Large,
+                    EnableMeshBake: true,
+                    TerrainTileCacheRoot: null,
+                    DisableTerrainTileCache: false,
+                    ProgressReporter: null),
+                terrainTextureAssetHttpClient);
+        await using ResoniteLiveSceneImportTarget _ = Assert.IsType<ResoniteLiveSceneImportTarget>(target);
+
+        Assert.Equal(1, workerPipelineFactory.CreateCallCount);
+        Assert.NotNull(terrainTextureFactory.LastGenerator);
+        Assert.Same(terrainTextureFactory.LastGenerator, workerPipelineFactory.LastTerrainTextureAssetGenerator);
     }
 
     [Fact]
@@ -314,6 +359,8 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
 
         public ResoniteLiveSceneImportTargetOptions? LastOptions { get; private set; }
 
+        public ITerrainTextureAssetGenerator? LastGenerator { get; private set; }
+
         public ITerrainTextureAssetGenerator Create(
             HttpClient terrainTextureAssetHttpClient,
             ResoniteLiveSceneImportTargetOptions options)
@@ -321,7 +368,8 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             CreateCallCount++;
             LastHttpClient = terrainTextureAssetHttpClient;
             LastOptions = options;
-            return new RecordingTerrainTextureAssetGenerator();
+            LastGenerator = new RecordingTerrainTextureAssetGenerator();
+            return LastGenerator;
         }
     }
 
@@ -366,6 +414,32 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             _ = onBakedCityObject;
             cancellationToken.ThrowIfCancellationRequested();
             throw new NotSupportedException("This test only verifies DI override preservation during baker creation.");
+        }
+    }
+
+    private sealed class RecordingWorkerPipelineFactory : IResoniteLiveSendWorkerPipelineFactory
+    {
+        public int CreateCallCount { get; private set; }
+
+        public ITerrainTextureAssetGenerator? LastTerrainTextureAssetGenerator { get; private set; }
+
+        public IResoniteQueuedCityObjectWorker Create(ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
+        {
+            CreateCallCount++;
+            LastTerrainTextureAssetGenerator = terrainTextureAssetGenerator;
+            return new RecordingQueuedCityObjectWorker();
+        }
+    }
+
+    private sealed class RecordingQueuedCityObjectWorker : IResoniteQueuedCityObjectWorker
+    {
+        public Task[] CreateProcessingTasks(
+            LiveSendRunState state,
+            LiveSendWorkerContext context)
+        {
+            _ = state;
+            _ = context;
+            return [];
         }
     }
 


### PR DESCRIPTION
## Summary
- extract live-send worker pipeline composition behind `IResoniteLiveSendWorkerPipelineFactory`
- keep `ResoniteLiveSendWorkerLauncherFactory` focused on terrain-generator selection and launcher creation
- shrink the terrain-generator injection overload by removing the unused target-options argument
- add DI coverage for the new pipeline factory and pre-registration override path

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~ResoniteLiveSceneImportTargetConfigurationTests|FullyQualifiedName~CliHostFactoryTests|FullyQualifiedName~CanonicalSceneDumpSinkTests"` (27 passed)
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (834 passed)