### PR TITLE
Route canonical dump through live target factory

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
@@ -19,7 +19,7 @@ internal interface IResoniteCanonicalSceneDumpSinkFactory
 }
 
 internal sealed class ResoniteCanonicalSceneDumpSinkFactory(
-    IResoniteLiveSceneImportDependencyFactory dependencyFactory) : IResoniteCanonicalSceneDumpSinkFactory
+    IResoniteLiveSceneImportFactory targetFactory) : IResoniteCanonicalSceneDumpSinkFactory
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Reliability",
@@ -35,34 +35,18 @@ internal sealed class ResoniteCanonicalSceneDumpSinkFactory(
         SceneSinkRecordingClient recordingClient = new();
         try
         {
-            ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
+            ResoniteLiveSceneImportTarget target = targetFactory.CreateTarget(
                 options,
                 new SingleRecordingClientSession(recordingClient),
                 ResoniteLinkSendDiagnostics.Disabled,
                 new DeterministicTerrainTextureAssetGenerator());
-            return CreateOwnedDumpSink(options, dependencies, recordingClient, outputPath);
+            return new CanonicalSceneDumpSink(target, recordingClient, outputPath);
         }
         catch
         {
             recordingClient.Dispose();
             throw;
         }
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "CanonicalSceneDumpSink owns the created target and disposes it with the recording client.")]
-    private static CanonicalSceneDumpSink CreateOwnedDumpSink(
-        ResoniteLiveSceneImportTargetOptions options,
-        ResoniteLiveSceneImportDependencies dependencies,
-        SceneSinkRecordingClient recordingClient,
-        string outputPath)
-    {
-        return new CanonicalSceneDumpSink(
-            new ResoniteLiveSceneImportTarget(options, dependencies),
-            recordingClient,
-            outputPath);
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSceneImportFactory.cs
@@ -1,5 +1,7 @@
 using System.Net.Http;
 
+using PlateauResoniteLink.Transport.ResoniteLink;
+
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal interface IResoniteLiveSceneImportFactory
@@ -7,6 +9,12 @@ internal interface IResoniteLiveSceneImportFactory
     ResoniteLiveSceneImportTarget CreateTarget(
         ResoniteLiveSceneImportTargetOptions options,
         HttpClient terrainTextureAssetHttpClient);
+
+    ResoniteLiveSceneImportTarget CreateTarget(
+        ResoniteLiveSceneImportTargetOptions options,
+        ILiveSendClientSession clientSession,
+        ResoniteLinkSendDiagnostics diagnostics,
+        ITerrainTextureAssetGenerator terrainTextureAssetGenerator);
 }
 
 internal sealed class ResoniteLiveSceneImportFactory(
@@ -19,6 +27,20 @@ internal sealed class ResoniteLiveSceneImportFactory(
         ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
             options,
             terrainTextureAssetHttpClient);
+        return new ResoniteLiveSceneImportTarget(options, dependencies);
+    }
+
+    public ResoniteLiveSceneImportTarget CreateTarget(
+        ResoniteLiveSceneImportTargetOptions options,
+        ILiveSendClientSession clientSession,
+        ResoniteLinkSendDiagnostics diagnostics,
+        ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
+    {
+        ResoniteLiveSceneImportDependencies dependencies = dependencyFactory.Create(
+            options,
+            clientSession,
+            diagnostics,
+            terrainTextureAssetGenerator);
         return new ResoniteLiveSceneImportTarget(options, dependencies);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -11,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Targets.Resonite.Diagnostics;
 using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
@@ -180,6 +182,38 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
         Assert.NotNull(terrainTextureFactory.LastOptions);
         Assert.Equal("cache-root", terrainTextureFactory.LastOptions!.TerrainTileCacheRoot);
         Assert.True(terrainTextureFactory.LastOptions.DisableTerrainTileCache);
+    }
+
+    [Fact]
+    public async Task AddResoniteLiveSendTargetServicesRoutesCanonicalDumpThroughRegisteredLiveSceneImportFactory()
+    {
+        RecordingLiveSceneImportFactory importFactory = new(new ResoniteMaterialPlanning(CreateBundledDefaultMaterialAssetStore()));
+        ServiceProvider provider = new ServiceCollection()
+            .AddScoped<IResoniteLiveSceneImportFactory>(_ => importFactory)
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+        using TemporaryDirectory outputDirectory = new();
+        string outputPath = Path.Combine(outputDirectory.Path, "scene.json");
+
+        await using ISceneSink _ = scope.ServiceProvider
+            .GetRequiredService<IResoniteCanonicalSceneDumpSinkFactory>()
+            .Create(
+                new ResoniteLiveSceneImportTargetOptions(
+                    new Uri("ws://localhost:12345/"),
+                    1,
+                    EnableSendMetrics: true,
+                    MemoryProfile: ResoniteImportMemoryProfile.Large,
+                    EnableMeshBake: true,
+                    TerrainTileCacheRoot: null,
+                    DisableTerrainTileCache: false,
+                    ProgressReporter: null),
+                outputPath);
+
+        Assert.Equal(1, importFactory.PreconfiguredCreateCallCount);
+        Assert.NotNull(importFactory.LastClientSession);
+        Assert.Same(ResoniteLinkSendDiagnostics.Disabled, importFactory.LastDiagnostics);
+        Assert.NotNull(importFactory.LastTerrainTextureAssetGenerator);
     }
 
     [Fact]
@@ -382,6 +416,50 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
             _ = terrainTextureOverlay;
             cancellationToken.ThrowIfCancellationRequested();
             throw new NotSupportedException("This test only verifies DI override preservation during target creation.");
+        }
+    }
+
+    private sealed class RecordingLiveSceneImportFactory(
+        IResoniteMaterialPlanning materialPlanning) : IResoniteLiveSceneImportFactory
+    {
+        public int PreconfiguredCreateCallCount { get; private set; }
+
+        public ILiveSendClientSession? LastClientSession { get; private set; }
+
+        public ResoniteLinkSendDiagnostics? LastDiagnostics { get; private set; }
+
+        public ITerrainTextureAssetGenerator? LastTerrainTextureAssetGenerator { get; private set; }
+
+        public ResoniteLiveSceneImportTarget CreateTarget(
+            ResoniteLiveSceneImportTargetOptions options,
+            HttpClient terrainTextureAssetHttpClient)
+        {
+            _ = terrainTextureAssetHttpClient;
+            return CreateTarget(
+                options,
+                new DelegatingClientSession(),
+                ResoniteLinkSendDiagnostics.Disabled,
+                new RecordingTerrainTextureAssetGenerator());
+        }
+
+        public ResoniteLiveSceneImportTarget CreateTarget(
+            ResoniteLiveSceneImportTargetOptions options,
+            ILiveSendClientSession clientSession,
+            ResoniteLinkSendDiagnostics diagnostics,
+            ITerrainTextureAssetGenerator terrainTextureAssetGenerator)
+        {
+            PreconfiguredCreateCallCount++;
+            LastClientSession = clientSession;
+            LastDiagnostics = diagnostics;
+            LastTerrainTextureAssetGenerator = terrainTextureAssetGenerator;
+            return new ResoniteLiveSceneImportTarget(
+                options,
+                ResoniteLiveSceneImportTargetTestSupport.CreateDependencies(
+                    clientSession,
+                    diagnostics,
+                    ResoniteLiveSceneImportTargetTestSupport.CreateRunStarter(
+                        materialPlanning,
+                        terrainTextureAssetGenerator: terrainTextureAssetGenerator)));
         }
     }
 


### PR DESCRIPTION
## Summary
- add a preconfigured-session overload to `IResoniteLiveSceneImportFactory`
- route canonical scene dump target creation through the live target factory instead of constructing the target inside diagnostics
- cover the canonical dump factory path with a DI override test

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~ResoniteLiveSceneImportTargetConfigurationTests|FullyQualifiedName~CliHostFactoryTests|FullyQualifiedName~CanonicalSceneDumpSinkTests"` (28 passed)
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (835 passed)