### PR TITLE
Extract live send connection initializer

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendConnectionInitializer
+{
+    Task EnsureConnectedAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunPlan runPlan,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class ResoniteLiveSendConnectionInitializer : IResoniteLiveSendConnectionInitializer
+{
+    public async Task EnsureConnectedAsync(
+        LiveSendRunStartRequest request,
+        LiveSendRunPlan runPlan,
+        LiveSendRunStartContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.SetupInfo);
+        ArgumentNullException.ThrowIfNull(request.NormalizedRequest);
+        ArgumentNullException.ThrowIfNull(runPlan);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.Endpoint);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Initializing scene state for dataset '{request.SetupInfo.Dataset}' "
+                + $"mesh '{request.SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
+        Stopwatch connectionStopwatch = Stopwatch.StartNew();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"Connecting ResoniteLink connection pool to {context.Endpoint} "
+                + $"with {request.ConnectionCount} available routed connection(s)."));
+        await context.ClientSession.EnsureConnectedAsync(
+            new LiveSendConnectionRequest(
+                request.NormalizedRequest.Dataset,
+                request.NormalizedRequest.MeshCode),
+            cancellationToken);
+        connectionStopwatch.Stop();
+        ReportProgress(
+            context,
+            PlateauLog.Info(
+                "live",
+                $"ResoniteLink connection pool ready in {connectionStopwatch.Elapsed.TotalSeconds:F2}s "
+                + $"(dataset='{request.SetupInfo.Dataset}', mesh='{request.SetupInfo.MeshCode}')."));
+    }
+
+    private static void ReportProgress(
+        LiveSendRunStartContext context,
+        string message)
+    {
+        context.ProgressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
@@ -36,6 +34,7 @@ internal interface IResoniteLiveSendRunStarter
 
 internal sealed class ResoniteLiveSendRunStarter(
     ILiveSendRunPlanFactory runPlanFactory,
+    IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendRunSetupPreparer runSetupPreparer,
     ILiveSendRunStateFactory runStateFactory,
     IResoniteLiveSendWorkerLauncher workerLauncher) : IResoniteLiveSendRunStarter
@@ -62,31 +61,11 @@ internal sealed class ResoniteLiveSendRunStarter(
             request.MemoryProfile,
             request.ConnectionCount,
             request.MeshBakeEnabled);
-        ReportProgress(
+        await connectionInitializer.EnsureConnectedAsync(
+            request,
+            runPlan,
             context,
-            PlateauLog.Info(
-                "live",
-                $"Initializing scene state for dataset '{request.SetupInfo.Dataset}' "
-                + $"mesh '{request.SetupInfo.MeshCode}' at '{runPlan.ResolvedWorkRoot}'."));
-        Stopwatch connectionStopwatch = Stopwatch.StartNew();
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"Connecting ResoniteLink connection pool to {context.Endpoint} "
-                + $"with {request.ConnectionCount} available routed connection(s)."));
-        await context.ClientSession.EnsureConnectedAsync(
-            new LiveSendConnectionRequest(
-                request.NormalizedRequest.Dataset,
-                request.NormalizedRequest.MeshCode),
             cancellationToken);
-        connectionStopwatch.Stop();
-        ReportProgress(
-            context,
-            PlateauLog.Info(
-                "live",
-                $"ResoniteLink connection pool ready in {connectionStopwatch.Elapsed.TotalSeconds:F2}s "
-                + $"(dataset='{request.SetupInfo.Dataset}', mesh='{request.SetupInfo.MeshCode}')."));
         LiveSendPreparedRunSetup preparedSetup = await runSetupPreparer.PrepareAsync(
             runPlan,
             request,
@@ -106,12 +85,5 @@ internal sealed class ResoniteLiveSendRunStarter(
                 preparedSetup.RunPlan.ResourceBudget),
             context);
         return state;
-    }
-
-    private static void ReportProgress(
-        LiveSendRunStartContext context,
-        string message)
-    {
-        context.ProgressReporter?.Invoke(message);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarterFactory.cs
@@ -14,6 +14,7 @@ internal interface IResoniteLiveSendRunStarterFactory
 
 internal sealed class ResoniteLiveSendRunStarterFactory(
     ILiveSendRunPlanFactory runPlanFactory,
+    IResoniteLiveSendConnectionInitializer connectionInitializer,
     IResoniteLiveSendRunSetupPreparer runSetupPreparer,
     ILiveSendRunStateFactory runStateFactory,
     IResoniteLiveSendWorkerLauncherFactory workerLauncherFactory) : IResoniteLiveSendRunStarterFactory
@@ -41,6 +42,7 @@ internal sealed class ResoniteLiveSendRunStarterFactory(
 
         return new ResoniteLiveSendRunStarter(
             runPlanFactory,
+            connectionInitializer,
             runSetupPreparer,
             runStateFactory,
             workerLauncher);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteSceneMaterialPlanComposer, ResoniteSceneMaterialPlanComposer>();
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
+        services.TryAddScoped<IResoniteLiveSendConnectionInitializer, ResoniteLiveSendConnectionInitializer>();
         services.TryAddScoped<IResoniteLiveSendRunSetupPreparer, ResoniteLiveSendRunSetupPreparer>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -109,6 +109,18 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesRegistersConnectionInitializer()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        Assert.IsType<ResoniteLiveSendConnectionInitializer>(
+            scope.ServiceProvider.GetRequiredService<IResoniteLiveSendConnectionInitializer>());
+    }
+
+    [Fact]
     public void AddResoniteLiveSendTargetServicesRegistersWorkerPipelineFactory()
     {
         using ServiceProvider provider = new ServiceCollection()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -138,6 +138,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 diagnostics,
                 new ResoniteLiveSendRunStarter(
                     new LiveSendRunPlanFactory(),
+                    new ResoniteLiveSendConnectionInitializer(),
                     new ThrowingRunSetupPreparer(),
                     new LiveSendRunStateFactory(
                         new ResoniteBufferedCityObjectBakerFactory(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -364,6 +364,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
     {
         return new ResoniteLiveSendRunStarter(
             new LiveSendRunPlanFactory(),
+            new ResoniteLiveSendConnectionInitializer(),
             new ResoniteLiveSendRunSetupPreparer(
                 sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
                 new ResoniteCommonMaterialSetupPreparer(materialPlanning),


### PR DESCRIPTION
## Summary
- extract ResoniteLink connection setup and connection logging into `IResoniteLiveSendConnectionInitializer`
- keep `ResoniteLiveSendRunStarter` focused on run plan, setup preparation, state creation, and worker launch
- register the new connection initializer and update live-send test construction

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~ResoniteLiveSceneImportTargetLifecycleTests|FullyQualifiedName~ResoniteLiveSceneImportTargetConfigurationTests|FullyQualifiedName~CliHostFactoryTests|FullyQualifiedName~CanonicalSceneDumpSinkTests"` (49 passed)
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (836 passed)

Note: the first full-test attempt failed because `C:\Users\esnya\AppData\Local\Temp\PlateauResoniteLink` filled the disk during generated default-material extraction. I deleted only that temp cache and this worktree's generated build output, then reran the verification sequence from restore; the rerun passed.