### PR TITLE
Extract prepared run setup composer

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunRuntimeComponentsFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunRuntimeComponentsFactory.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record LiveSendRunRuntimeComponents(
+    TerrainTextureAssetCache TerrainTextures,
+    LiveSendExecutionRuntime Runtime,
+    SemaphoreSlim GsiFallbackLicenseGate,
+    ConcurrentDictionary<string, int> DemSourceUseCounts);
+
+internal interface ILiveSendRunRuntimeComponentsFactory
+{
+    LiveSendRunRuntimeComponents Create(
+        LiveSendQueuePlan queuePlan,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class LiveSendRunRuntimeComponentsFactory : ILiveSendRunRuntimeComponentsFactory
+{
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to LiveSendRunState and released by ResoniteLiveSendRunResourceReleaser.")]
+    public LiveSendRunRuntimeComponents Create(
+        LiveSendQueuePlan queuePlan,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(queuePlan);
+
+        return new LiveSendRunRuntimeComponents(
+            new TerrainTextureAssetCache(),
+            new LiveSendExecutionRuntime(queuePlan, cancellationToken),
+            new SemaphoreSlim(1, 1),
+            new ConcurrentDictionary<string, int>(StringComparer.Ordinal));
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunStateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunStateFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Threading;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -16,7 +15,8 @@ internal interface ILiveSendRunStateFactory
 }
 
 internal sealed class LiveSendRunStateFactory(
-    IResoniteBufferedCityObjectBakerFactory cityObjectBakerFactory) : ILiveSendRunStateFactory
+    IResoniteBufferedCityObjectBakerFactory cityObjectBakerFactory,
+    ILiveSendRunRuntimeComponentsFactory runtimeComponentsFactory) : ILiveSendRunStateFactory
 {
     public LiveSendRunState Create(
         LiveSendRunPlan runPlan,
@@ -31,10 +31,12 @@ internal sealed class LiveSendRunStateFactory(
         ArgumentNullException.ThrowIfNull(materials);
         ArgumentNullException.ThrowIfNull(placement);
 
-        LiveSendExecutionRuntime runtime = new(runPlan.Queue, cancellationToken);
         CompositeCityObjectBaker? cityObjectBaker = cityObjectBakerFactory.Create(
             runPlan.MeshBakeEnabled,
             runPlan.ResourceBudget);
+        LiveSendRunRuntimeComponents runtimeComponents = runtimeComponentsFactory.Create(
+            runPlan.Queue,
+            cancellationToken);
         LiveSendRunContext context = new(
             runPlan,
             setupState.DatasetRootSlot,
@@ -46,11 +48,11 @@ internal sealed class LiveSendRunStateFactory(
             Context = context,
             Progress = progress,
             Materials = materials,
-            TerrainTextures = new TerrainTextureAssetCache(),
+            TerrainTextures = runtimeComponents.TerrainTextures,
             Placement = placement,
-            Runtime = runtime,
-            GsiFallbackLicenseGate = new SemaphoreSlim(1, 1),
-            DemSourceUseCounts = new ConcurrentDictionary<string, int>(StringComparer.Ordinal),
+            Runtime = runtimeComponents.Runtime,
+            GsiFallbackLicenseGate = runtimeComponents.GsiFallbackLicenseGate,
+            DemSourceUseCounts = runtimeComponents.DemSourceUseCounts,
         };
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunResourceReleaser.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunResourceReleaser.cs
@@ -26,7 +26,14 @@ internal sealed class ResoniteLiveSendRunResourceReleaser : IResoniteLiveSendRun
 
         if (state is not null)
         {
-            await state.Runtime.DisposeAsync();
+            try
+            {
+                await state.Runtime.DisposeAsync();
+            }
+            finally
+            {
+                state.GsiFallbackLicenseGate.Dispose();
+            }
         }
 
         if (disposeClients)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
@@ -29,7 +28,7 @@ internal interface IResoniteLiveSendRunSetupPreparer
 internal sealed class ResoniteLiveSendRunSetupPreparer(
     IResoniteSceneSetupInterpreter sceneSetupInterpreter,
     IResoniteCommonMaterialSetupPreparer commonMaterialSetupPreparer,
-    IResoniteSlotCreator slotCreator) : IResoniteLiveSendRunSetupPreparer
+    IResonitePreparedRunSetupComposer preparedRunSetupComposer) : IResoniteLiveSendRunSetupPreparer
 {
     public async Task<LiveSendPreparedRunSetup> PrepareAsync(
         LiveSendRunPlan runPlan,
@@ -43,8 +42,6 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(context.ClientSession);
 
-        LiveSendProgressSink progress = new();
-        CommonMaterialAssetCache materials = new();
         ReportProgress(
             context,
             PlateauLog.Info(
@@ -65,14 +62,6 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
             request.CommonMaterials,
             cancellationToken);
         setupStopwatch.Stop();
-        ResoniteSharedSlotIndex placement = new(
-            setupState.DatasetRootSlot,
-            setupState.DatasetAssetsRootSlot,
-            runPlan.RequestLocalOrigin,
-            runPlan.SourceFileSlotNamesByRelativePath,
-            setupState.SceneAnchor,
-            slotCreator.CreateAsync);
-        placement.IndexSetupHierarchy(setupState);
         ReportProgress(
             context,
             PlateauLog.Info(
@@ -84,12 +73,14 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
                 + $"location_slot='{setupState.SceneAnchor.LocationSlot.Value}', "
                 + $"anchor_mesh='{setupState.SceneAnchor.MeshCode}', "
                 + $"anchor_source_file_root='{setupState.SceneAnchor.ReferenceSourceFileRoot?.Value ?? "<pending>"}')."));
-        CacheSetupCommonMaterials(setupState, materials);
+        LiveSendPreparedRunSetup preparedSetup = preparedRunSetupComposer.Compose(
+            runPlan,
+            setupState);
         ReportSetupCommonMaterials(setupState, context);
         await commonMaterialSetupPreparer.PrepareAsync(
             GetRoutedClient(context),
             setupState,
-            materials,
+            preparedSetup.Materials,
             request.CommonMaterials,
             context.ProgressReporter,
             cancellationToken);
@@ -104,27 +95,7 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
                 "live",
                 $"Dataset metadata/license phase complete during setup. "
                 + $"Dataset root existed={setupState.DatasetRootExisted}."));
-        return new LiveSendPreparedRunSetup(
-            runPlan,
-            setupState,
-            progress,
-            materials,
-            placement);
-    }
-
-    private static void CacheSetupCommonMaterials(
-        ResoniteSceneSetupState setupState,
-        CommonMaterialAssetCache materials)
-    {
-        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
-        {
-            materials.CommonMaterialAssets.Set(materialAsset.Item);
-        }
-
-        foreach (string family in setupState.CommonMaterialFamilies)
-        {
-            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
-        }
+        return preparedSetup;
     }
 
     private static void ReportSetupCommonMaterials(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteCommonMaterialSetupPreparer, ResoniteCommonMaterialSetupPreparer>();
         services.TryAddScoped<ILiveSendRunPlanFactory, LiveSendRunPlanFactory>();
         services.TryAddScoped<IResoniteLiveSendConnectionInitializer, ResoniteLiveSendConnectionInitializer>();
+        services.TryAddScoped<IResonitePreparedRunSetupComposer, ResonitePreparedRunSetupComposer>();
         services.TryAddScoped<IResoniteLiveSendRunSetupPreparer, ResoniteLiveSendRunSetupPreparer>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteLiveSendConnectionInitializer, ResoniteLiveSendConnectionInitializer>();
         services.TryAddScoped<IResonitePreparedRunSetupComposer, ResonitePreparedRunSetupComposer>();
         services.TryAddScoped<IResoniteLiveSendRunSetupPreparer, ResoniteLiveSendRunSetupPreparer>();
+        services.TryAddScoped<ILiveSendRunRuntimeComponentsFactory, LiveSendRunRuntimeComponentsFactory>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
         services.TryAddScoped<IResoniteLiveSendWorkerPipelineFactory, ResoniteLiveSendWorkerPipelineFactory>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedRunSetupComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedRunSetupComposer.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResonitePreparedRunSetupComposer
+{
+    LiveSendPreparedRunSetup Compose(
+        LiveSendRunPlan runPlan,
+        ResoniteSceneSetupState setupState);
+}
+
+internal sealed class ResonitePreparedRunSetupComposer(
+    IResoniteSlotCreator slotCreator) : IResonitePreparedRunSetupComposer
+{
+    public LiveSendPreparedRunSetup Compose(
+        LiveSendRunPlan runPlan,
+        ResoniteSceneSetupState setupState)
+    {
+        ArgumentNullException.ThrowIfNull(runPlan);
+
+        LiveSendProgressSink progress = new();
+        CommonMaterialAssetCache materials = CreateMaterialCache(setupState);
+        ResoniteSharedSlotIndex placement = new(
+            setupState.DatasetRootSlot,
+            setupState.DatasetAssetsRootSlot,
+            runPlan.RequestLocalOrigin,
+            runPlan.SourceFileSlotNamesByRelativePath,
+            setupState.SceneAnchor,
+            slotCreator.CreateAsync);
+        placement.IndexSetupHierarchy(setupState);
+
+        return new LiveSendPreparedRunSetup(
+            runPlan,
+            setupState,
+            progress,
+            materials,
+            placement);
+    }
+
+    private static CommonMaterialAssetCache CreateMaterialCache(
+        ResoniteSceneSetupState setupState)
+    {
+        CommonMaterialAssetCache materials = new();
+        foreach (CommonMaterialCatalogMember<ResoniteCommonMaterialAsset> materialAsset in setupState.CommonMaterialAssets.EnumerateMembers())
+        {
+            materials.CommonMaterialAssets.Set(materialAsset.Item);
+        }
+
+        foreach (string family in setupState.CommonMaterialFamilies)
+        {
+            materials.CommonMaterialFamilyWarmupTasks[family] = Task.CompletedTask;
+        }
+
+        return materials;
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedRunSetupComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedRunSetupComposer.cs
@@ -21,6 +21,7 @@ internal sealed class ResonitePreparedRunSetupComposer(
         ResoniteSceneSetupState setupState)
     {
         ArgumentNullException.ThrowIfNull(runPlan);
+        ValidateSetupState(setupState);
 
         LiveSendProgressSink progress = new();
         CommonMaterialAssetCache materials = CreateMaterialCache(setupState);
@@ -56,5 +57,20 @@ internal sealed class ResonitePreparedRunSetupComposer(
         }
 
         return materials;
+    }
+
+    private static void ValidateSetupState(ResoniteSceneSetupState setupState)
+    {
+        if (string.IsNullOrWhiteSpace(setupState.DatasetRootSlot.Locator.Value)
+            || string.IsNullOrWhiteSpace(setupState.DatasetAssetsRootSlot.Locator.Value)
+            || string.IsNullOrWhiteSpace(setupState.CommonAssetsRootSlot.Locator.Value)
+            || string.IsNullOrWhiteSpace(setupState.SceneAnchor.LocationSlot.Value)
+            || setupState.CommonMaterialAssets is null
+            || setupState.CommonMaterialFamilies is null)
+        {
+            throw new ArgumentException(
+                "Setup state must be created by the scene setup interpreter before composing a prepared run setup.",
+                nameof(setupState));
+        }
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -133,6 +133,22 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void PreparedRunSetupComposerRejectsDefaultSetupState()
+    {
+        ResonitePreparedRunSetupComposer composer = new(new ResoniteSlotCreator());
+        LiveSendRunPlan runPlan = new(
+            SetupInfo: null!,
+            ResolvedWorkRoot: "work",
+            RequestLocalOrigin: new ResoniteLocalOrigin(0.0, 0.0, 0.0),
+            SourceFileSlotNamesByRelativePath: new Dictionary<string, string>(),
+            ResourceBudget: ResoniteImportBudgetProfiles.ForProfile(ResoniteImportMemoryProfile.Large),
+            Queue: new LiveSendQueuePlan(ConnectionCount: 1, QueueCapacity: 4, MemoryBudgetBytes: 1),
+            MeshBakeEnabled: true);
+
+        Assert.Throws<ArgumentException>(() => composer.Compose(runPlan, setupState: default));
+    }
+
+    [Fact]
     public void AddResoniteLiveSendTargetServicesRegistersRunRuntimeComponentsFactory()
     {
         using ServiceProvider provider = new ServiceCollection()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -121,6 +121,18 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesRegistersPreparedRunSetupComposer()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        Assert.IsType<ResonitePreparedRunSetupComposer>(
+            scope.ServiceProvider.GetRequiredService<IResonitePreparedRunSetupComposer>());
+    }
+
+    [Fact]
     public void AddResoniteLiveSendTargetServicesRegistersWorkerPipelineFactory()
     {
         using ServiceProvider provider = new ServiceCollection()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -133,6 +133,18 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesRegistersRunRuntimeComponentsFactory()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        Assert.IsType<LiveSendRunRuntimeComponentsFactory>(
+            scope.ServiceProvider.GetRequiredService<ILiveSendRunRuntimeComponentsFactory>());
+    }
+
+    [Fact]
     public void AddResoniteLiveSendTargetServicesRegistersWorkerPipelineFactory()
     {
         using ServiceProvider provider = new ServiceCollection()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -142,7 +142,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     new ThrowingRunSetupPreparer(),
                     new LiveSendRunStateFactory(
                         new ResoniteBufferedCityObjectBakerFactory(
-                            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
+                            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader())),
+                        new LiveSendRunRuntimeComponentsFactory()),
                     workerLauncher)));
 
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -368,7 +368,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             new ResoniteLiveSendRunSetupPreparer(
                 sceneSetupInterpreter ?? new ResoniteSceneSetupInterpreter(new ResoniteSceneSlotLocator(), new ResoniteSceneAnchorResolver()),
                 new ResoniteCommonMaterialSetupPreparer(materialPlanning),
-                new ResoniteSlotCreator()),
+                new ResonitePreparedRunSetupComposer(new ResoniteSlotCreator())),
             new LiveSendRunStateFactory(
                 new ResoniteBufferedCityObjectBakerFactory(
                     new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -371,7 +371,8 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 new ResonitePreparedRunSetupComposer(new ResoniteSlotCreator())),
             new LiveSendRunStateFactory(
                 new ResoniteBufferedCityObjectBakerFactory(
-                    new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
+                    new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader())),
+                new LiveSendRunRuntimeComponentsFactory()),
             new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning, terrainTextureAssetGenerator)));
     }
 


### PR DESCRIPTION
## Summary
- extract prepared run setup composition from ResoniteLiveSendRunSetupPreparer
- move common-material cache seeding and placement index construction behind IResonitePreparedRunSetupComposer
- register and test the new DI seam so run setup remains overrideable

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

## Review
- local review subagent: no findings