### PR TITLE
Extract live run runtime components

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunRuntimeComponentsFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunRuntimeComponentsFactory.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record LiveSendRunRuntimeComponents(
+    TerrainTextureAssetCache TerrainTextures,
+    LiveSendExecutionRuntime Runtime,
+    SemaphoreSlim GsiFallbackLicenseGate,
+    ConcurrentDictionary<string, int> DemSourceUseCounts);
+
+internal interface ILiveSendRunRuntimeComponentsFactory
+{
+    LiveSendRunRuntimeComponents Create(
+        LiveSendQueuePlan queuePlan,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class LiveSendRunRuntimeComponentsFactory : ILiveSendRunRuntimeComponentsFactory
+{
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to LiveSendRunState and released by ResoniteLiveSendRunResourceReleaser.")]
+    public LiveSendRunRuntimeComponents Create(
+        LiveSendQueuePlan queuePlan,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(queuePlan);
+
+        return new LiveSendRunRuntimeComponents(
+            new TerrainTextureAssetCache(),
+            new LiveSendExecutionRuntime(queuePlan, cancellationToken),
+            new SemaphoreSlim(1, 1),
+            new ConcurrentDictionary<string, int>(StringComparer.Ordinal));
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunStateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendRunStateFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Threading;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -16,7 +15,8 @@ internal interface ILiveSendRunStateFactory
 }
 
 internal sealed class LiveSendRunStateFactory(
-    IResoniteBufferedCityObjectBakerFactory cityObjectBakerFactory) : ILiveSendRunStateFactory
+    IResoniteBufferedCityObjectBakerFactory cityObjectBakerFactory,
+    ILiveSendRunRuntimeComponentsFactory runtimeComponentsFactory) : ILiveSendRunStateFactory
 {
     public LiveSendRunState Create(
         LiveSendRunPlan runPlan,
@@ -31,10 +31,12 @@ internal sealed class LiveSendRunStateFactory(
         ArgumentNullException.ThrowIfNull(materials);
         ArgumentNullException.ThrowIfNull(placement);
 
-        LiveSendExecutionRuntime runtime = new(runPlan.Queue, cancellationToken);
         CompositeCityObjectBaker? cityObjectBaker = cityObjectBakerFactory.Create(
             runPlan.MeshBakeEnabled,
             runPlan.ResourceBudget);
+        LiveSendRunRuntimeComponents runtimeComponents = runtimeComponentsFactory.Create(
+            runPlan.Queue,
+            cancellationToken);
         LiveSendRunContext context = new(
             runPlan,
             setupState.DatasetRootSlot,
@@ -46,11 +48,11 @@ internal sealed class LiveSendRunStateFactory(
             Context = context,
             Progress = progress,
             Materials = materials,
-            TerrainTextures = new TerrainTextureAssetCache(),
+            TerrainTextures = runtimeComponents.TerrainTextures,
             Placement = placement,
-            Runtime = runtime,
-            GsiFallbackLicenseGate = new SemaphoreSlim(1, 1),
-            DemSourceUseCounts = new ConcurrentDictionary<string, int>(StringComparer.Ordinal),
+            Runtime = runtimeComponents.Runtime,
+            GsiFallbackLicenseGate = runtimeComponents.GsiFallbackLicenseGate,
+            DemSourceUseCounts = runtimeComponents.DemSourceUseCounts,
         };
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunResourceReleaser.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunResourceReleaser.cs
@@ -26,7 +26,14 @@ internal sealed class ResoniteLiveSendRunResourceReleaser : IResoniteLiveSendRun
 
         if (state is not null)
         {
-            await state.Runtime.DisposeAsync();
+            try
+            {
+                await state.Runtime.DisposeAsync();
+            }
+            finally
+            {
+                state.GsiFallbackLicenseGate.Dispose();
+            }
         }
 
         if (disposeClients)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteLiveSendConnectionInitializer, ResoniteLiveSendConnectionInitializer>();
         services.TryAddScoped<IResonitePreparedRunSetupComposer, ResonitePreparedRunSetupComposer>();
         services.TryAddScoped<IResoniteLiveSendRunSetupPreparer, ResoniteLiveSendRunSetupPreparer>();
+        services.TryAddScoped<ILiveSendRunRuntimeComponentsFactory, LiveSendRunRuntimeComponentsFactory>();
         services.TryAddScoped<ILiveSendRunStateFactory, LiveSendRunStateFactory>();
         services.TryAddScoped<IResoniteLiveSendRunStarterFactory, ResoniteLiveSendRunStarterFactory>();
         services.TryAddScoped<IResoniteLiveSendWorkerPipelineFactory, ResoniteLiveSendWorkerPipelineFactory>();

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -133,6 +133,18 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesRegistersRunRuntimeComponentsFactory()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        Assert.IsType<LiveSendRunRuntimeComponentsFactory>(
+            scope.ServiceProvider.GetRequiredService<ILiveSendRunRuntimeComponentsFactory>());
+    }
+
+    [Fact]
     public void AddResoniteLiveSendTargetServicesRegistersWorkerPipelineFactory()
     {
         using ServiceProvider provider = new ServiceCollection()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -142,7 +142,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     new ThrowingRunSetupPreparer(),
                     new LiveSendRunStateFactory(
                         new ResoniteBufferedCityObjectBakerFactory(
-                            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
+                            new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader())),
+                        new LiveSendRunRuntimeComponentsFactory()),
                     workerLauncher)));
 
         PlateauImportRequest request = CreateRequest(datasetDirectory.Path);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -371,7 +371,8 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 new ResonitePreparedRunSetupComposer(new ResoniteSlotCreator())),
             new LiveSendRunStateFactory(
                 new ResoniteBufferedCityObjectBakerFactory(
-                    new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader()))),
+                    new NonDemSourceFileBakeEmitterFactory(new ResoniteTextureImageLoader())),
+                new LiveSendRunRuntimeComponentsFactory()),
             new ResoniteLiveSendWorkerLauncher(CreateQueuedCityObjectWorker(materialPlanning, terrainTextureAssetGenerator)));
     }
 


### PR DESCRIPTION
## Summary
- move live-send runtime mutable component creation behind ILiveSendRunRuntimeComponentsFactory
- keep LiveSendRunStateFactory focused on composing run context and final state
- dispose the GSI fallback license gate with the run runtime resources

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

## Review
- local review subagent: fixed ownership/dispose ordering finding, re-review no findings