### PR TITLE
Extract live send phase context factory

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendPhaseContextFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendPhaseContextFactory.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteLiveSendPhaseContextFactory
+{
+    LiveSendRunStartContext CreateRunStartContext(LiveSendRunExecutionContext context);
+
+    LiveSendEnqueueContext CreateEnqueueContext(LiveSendRunExecutionContext context);
+
+    LiveSendFinalizationContext CreateFinalizationContext(
+        LiveSendRunExecutionContext context,
+        LiveSendEnqueueContext enqueueContext);
+}
+
+internal sealed class ResoniteLiveSendPhaseContextFactory : IResoniteLiveSendPhaseContextFactory
+{
+    public LiveSendRunStartContext CreateRunStartContext(LiveSendRunExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.Endpoint);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+        ArgumentNullException.ThrowIfNull(context.Diagnostics);
+
+        return new LiveSendRunStartContext(
+            context.Endpoint,
+            context.ClientSession,
+            context.Diagnostics,
+            context.ProgressReporter);
+    }
+
+    public LiveSendEnqueueContext CreateEnqueueContext(LiveSendRunExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentOutOfRangeException.ThrowIfLessThan(context.ConnectionCount, 1);
+        ArgumentNullException.ThrowIfNull(context.ClientSession);
+
+        return new LiveSendEnqueueContext(
+            context.ConnectionCount,
+            context.ClientSession.GetRequiredClient,
+            context.ProgressReporter);
+    }
+
+    public LiveSendFinalizationContext CreateFinalizationContext(
+        LiveSendRunExecutionContext context,
+        LiveSendEnqueueContext enqueueContext)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.Endpoint);
+        ArgumentNullException.ThrowIfNull(context.Diagnostics);
+        ArgumentNullException.ThrowIfNull(enqueueContext);
+
+        return new LiveSendFinalizationContext(
+            context.Endpoint,
+            enqueueContext,
+            context.Diagnostics,
+            context.ProgressReporter);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunExecutor.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunExecutor.cs
@@ -31,7 +31,8 @@ internal interface IResoniteLiveSendRunExecutorFactory
 
 internal sealed class ResoniteLiveSendRunExecutorFactory(
     IResoniteLiveSendQueue queue,
-    IResoniteLiveSendRunResourceReleaser resourceReleaser) : IResoniteLiveSendRunExecutorFactory
+    IResoniteLiveSendRunResourceReleaser resourceReleaser,
+    IResoniteLiveSendPhaseContextFactory phaseContextFactory) : IResoniteLiveSendRunExecutorFactory
 {
     public IResoniteLiveSendRunExecutor Create(IResoniteLiveSendRunStarter runStarter)
     {
@@ -40,14 +41,16 @@ internal sealed class ResoniteLiveSendRunExecutorFactory(
         return new ResoniteLiveSendRunExecutor(
             runStarter,
             queue,
-            resourceReleaser);
+            resourceReleaser,
+            phaseContextFactory);
     }
 }
 
 internal sealed class ResoniteLiveSendRunExecutor(
     IResoniteLiveSendRunStarter runStarter,
     IResoniteLiveSendQueue queue,
-    IResoniteLiveSendRunResourceReleaser resourceReleaser) : IResoniteLiveSendRunExecutor
+    IResoniteLiveSendRunResourceReleaser resourceReleaser,
+    IResoniteLiveSendPhaseContextFactory phaseContextFactory) : IResoniteLiveSendRunExecutor
 {
     private readonly IResoniteLiveSendRunStarter runStarter =
         runStarter ?? throw new ArgumentNullException(nameof(runStarter));
@@ -55,6 +58,8 @@ internal sealed class ResoniteLiveSendRunExecutor(
         queue ?? throw new ArgumentNullException(nameof(queue));
     private readonly IResoniteLiveSendRunResourceReleaser resourceReleaser =
         resourceReleaser ?? throw new ArgumentNullException(nameof(resourceReleaser));
+    private readonly IResoniteLiveSendPhaseContextFactory phaseContextFactory =
+        phaseContextFactory ?? throw new ArgumentNullException(nameof(phaseContextFactory));
 
     public async Task<SceneImportExecutionResult> ExecuteAsync(
         LiveSendRunStartRequest request,
@@ -77,10 +82,10 @@ internal sealed class ResoniteLiveSendRunExecutor(
         {
             state = await runStarter.StartAsync(
                 request,
-                CreateRunStartContext(context),
+                phaseContextFactory.CreateRunStartContext(context),
                 cancellationToken);
 
-            LiveSendEnqueueContext enqueueContext = CreateEnqueueContext(context);
+            LiveSendEnqueueContext enqueueContext = phaseContextFactory.CreateEnqueueContext(context);
             await foreach (ImportedObjectUnit objectUnit in objectUnits.WithCancellation(cancellationToken))
             {
                 await queue.QueueUnitAsync(
@@ -92,7 +97,7 @@ internal sealed class ResoniteLiveSendRunExecutor(
 
             SceneImportExecutionResult result = await queue.CompleteAsync(
                 state,
-                CreateFinalizationContext(context, enqueueContext),
+                phaseContextFactory.CreateFinalizationContext(context, enqueueContext),
                 cancellationToken);
             completedSuccessfully = true;
             return result;
@@ -105,33 +110,5 @@ internal sealed class ResoniteLiveSendRunExecutor(
                 disposeClients: false,
                 resetClients: !completedSuccessfully);
         }
-    }
-
-    private static LiveSendRunStartContext CreateRunStartContext(LiveSendRunExecutionContext context)
-    {
-        return new LiveSendRunStartContext(
-            context.Endpoint,
-            context.ClientSession,
-            context.Diagnostics,
-            context.ProgressReporter);
-    }
-
-    private static LiveSendEnqueueContext CreateEnqueueContext(LiveSendRunExecutionContext context)
-    {
-        return new LiveSendEnqueueContext(
-            context.ConnectionCount,
-            context.ClientSession.GetRequiredClient,
-            context.ProgressReporter);
-    }
-
-    private static LiveSendFinalizationContext CreateFinalizationContext(
-        LiveSendRunExecutionContext context,
-        LiveSendEnqueueContext enqueueContext)
-    {
-        return new LiveSendFinalizationContext(
-            context.Endpoint,
-            enqueueContext,
-            context.Diagnostics,
-            context.ProgressReporter);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteLiveSendFinalizer, ResoniteLiveSendFinalizer>();
         services.TryAddScoped<IResoniteLiveSendQueue, ResoniteLiveSendQueue>();
         services.TryAddScoped<IResoniteLiveSendRunResourceReleaser, ResoniteLiveSendRunResourceReleaser>();
+        services.TryAddScoped<IResoniteLiveSendPhaseContextFactory, ResoniteLiveSendPhaseContextFactory>();
         services.TryAddScoped<IResoniteLiveSendRunExecutorFactory, ResoniteLiveSendRunExecutorFactory>();
         services.TryAddScoped<IResoniteCanonicalSceneDumpSinkFactory, ResoniteCanonicalSceneDumpSinkFactory>();
         services.TryAddScoped<IResoniteSceneBatchEmitter, PlannedBatchEmissionInterpreter>();

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -145,6 +145,18 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesRegistersPhaseContextFactory()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        Assert.IsType<ResoniteLiveSendPhaseContextFactory>(
+            scope.ServiceProvider.GetRequiredService<IResoniteLiveSendPhaseContextFactory>());
+    }
+
+    [Fact]
     public void AddResoniteLiveSendTargetServicesRegistersWorkerPipelineFactory()
     {
         using ServiceProvider provider = new ServiceCollection()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -352,7 +352,8 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             new ResoniteLiveSendRunExecutor(
                 runStarter,
                 effectiveQueue,
-                effectiveResourceReleaser),
+                effectiveResourceReleaser,
+                new ResoniteLiveSendPhaseContextFactory()),
             effectiveResourceReleaser);
     }
 


### PR DESCRIPTION
## Summary
- Extract live-send phase context creation into `ResoniteLiveSendPhaseContextFactory`.
- Keep `ResoniteLiveSendRunExecutor` focused on the execution flow: start, enqueue, complete, release.
- Register the new factory through DI so phase-context shaping remains overrideable and does not stay hidden inside executor control flow.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`

Notes: the first full test attempt failed because `C:\Users\esnya\AppData\Local\Temp\PlateauResoniteLink` could not expand bundled material assets with only about 25 MB free on C:. I removed only that project temp directory, reran the same full test command, and it passed: 839/839.

## Review
- Local subagent review of the boundary split returned no findings.