### PR TITLE
Extract import step task cleanup

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteImportStepTaskCleanup.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteImportStepTaskCleanup.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteImportStepTaskCleanup
+{
+    Task CancelAndObserveFailuresAsync(
+        CancellationTokenSource cancellation,
+        IEnumerable<Task> tasksToObserve);
+}
+
+internal sealed class ResoniteImportStepTaskCleanup : IResoniteImportStepTaskCleanup
+{
+    public async Task CancelAndObserveFailuresAsync(
+        CancellationTokenSource cancellation,
+        IEnumerable<Task> tasksToObserve)
+    {
+        ArgumentNullException.ThrowIfNull(cancellation);
+        ArgumentNullException.ThrowIfNull(tasksToObserve);
+
+        try
+        {
+            await cancellation.CancelAsync();
+        }
+        catch (AggregateException)
+        {
+            // Cancellation callbacks may throw; preserve the primary import failure and continue cleanup.
+        }
+
+        await ObserveTaskFailuresAsync(tasksToObserve);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Best-effort cleanup should observe and suppress orphaned import task failures after the primary send failure.")]
+    private static async Task ObserveTaskFailureAsync(Task task)
+    {
+        try
+        {
+            await task;
+        }
+        catch
+        {
+        }
+    }
+
+    private static Task ObserveTaskFailuresAsync(IEnumerable<Task> tasks)
+    {
+        return Task.WhenAll(tasks.Select(ObserveTaskFailureAsync));
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendTargetServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ public static class ResoniteLiveSendTargetServiceCollectionExtensions
         services.TryAddScoped<IResoniteLiveSendWorkerPipelineFactory, ResoniteLiveSendWorkerPipelineFactory>();
         services.TryAddScoped<IResoniteLiveSendWorkerLauncherFactory, ResoniteLiveSendWorkerLauncherFactory>();
         services.TryAddScoped<IResoniteLiveSendStartRequestFactory, ResoniteLiveSendStartRequestFactory>();
+        services.TryAddScoped<IResoniteImportStepTaskCleanup, ResoniteImportStepTaskCleanup>();
         services.TryAddScoped<IResonitePreparedCityObjectImporter, ResonitePreparedCityObjectImporter>();
         services.TryAddScoped<IResoniteQueuedCityObjectEnqueuer, ResoniteQueuedCityObjectEnqueuer>();
         services.TryAddScoped<IResoniteLiveSendFinalizer, ResoniteLiveSendFinalizer>();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedCityObjectImporter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedCityObjectImporter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -28,7 +27,8 @@ internal sealed class ResonitePreparedCityObjectImporter(
     IResoniteGeometryAssetPlanner geometryAssetPlanner,
     IResoniteSceneMaterialPlanComposer sceneMaterialPlanComposer,
     IResoniteBatchEmissionPlanner batchEmissionPlanner,
-    IResoniteSceneBatchEmitter batchEmitter) : IResonitePreparedCityObjectImporter
+    IResoniteSceneBatchEmitter batchEmitter,
+    IResoniteImportStepTaskCleanup importStepTaskCleanup) : IResonitePreparedCityObjectImporter
 {
     public async Task ImportAsync(
         LiveSendRunState state,
@@ -96,19 +96,12 @@ internal sealed class ResonitePreparedCityObjectImporter(
         }
         catch
         {
-            try
-            {
-                await importStepCancellation.CancelAsync();
-            }
-            catch (AggregateException)
-            {
-                // Cancellation callbacks may throw; preserve the primary import failure and continue cleanup.
-            }
-
             IEnumerable<Task> tasksToObserve = materialPlanningTask is null
                 ? [uploadedTextureAssetsTask, geometryPlanningTask]
                 : [uploadedTextureAssetsTask, materialPlanningTask, geometryPlanningTask];
-            await ObserveTaskFailuresAsync(tasksToObserve);
+            await importStepTaskCleanup.CancelAndObserveFailuresAsync(
+                importStepCancellation,
+                tasksToObserve);
             throw;
         }
 
@@ -168,26 +161,6 @@ internal sealed class ResonitePreparedCityObjectImporter(
         }
 
         return generatedTerrainTexturesByOverlay;
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Design",
-        "CA1031:Do not catch general exception types",
-        Justification = "Best-effort cleanup should observe and suppress orphaned import task failures after the primary send failure.")]
-    private static async Task ObserveTaskFailureAsync(Task task)
-    {
-        try
-        {
-            await task;
-        }
-        catch
-        {
-        }
-    }
-
-    private static Task ObserveTaskFailuresAsync(IEnumerable<Task> tasks)
-    {
-        return Task.WhenAll(tasks.Select(ObserveTaskFailureAsync));
     }
 
     private static Task<T> AwaitWithCancellationAsync<T>(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteImportStepTaskCleanupTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteImportStepTaskCleanupTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class ResoniteImportStepTaskCleanupTests
+{
+    [Fact]
+    public async Task CancelAndObserveFailuresAsyncSuppressesCancellationCallbackFailures()
+    {
+        using CancellationTokenSource cancellation = new();
+        using CancellationTokenRegistration _ = cancellation.Token.Register(
+            static () => throw new InvalidOperationException("callback failed"));
+
+        await new ResoniteImportStepTaskCleanup().CancelAndObserveFailuresAsync(
+            cancellation,
+            [Task.CompletedTask]);
+
+        Assert.True(cancellation.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task CancelAndObserveFailuresAsyncObservesAndSuppressesTaskFailures()
+    {
+        using CancellationTokenSource cancellation = new();
+        Task failedTask = Task.FromException(new InvalidOperationException("secondary failure"));
+
+        await new ResoniteImportStepTaskCleanup().CancelAndObserveFailuresAsync(
+            cancellation,
+            [failedTask]);
+
+        Assert.True(cancellation.IsCancellationRequested);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -157,6 +157,18 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
     }
 
     [Fact]
+    public void AddResoniteLiveSendTargetServicesRegistersImportStepTaskCleanup()
+    {
+        using ServiceProvider provider = new ServiceCollection()
+            .AddResoniteLiveSendTargetServices()
+            .BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        Assert.IsType<ResoniteImportStepTaskCleanup>(
+            scope.ServiceProvider.GetRequiredService<IResoniteImportStepTaskCleanup>());
+    }
+
+    [Fact]
     public void AddResoniteLiveSendTargetServicesRegistersWorkerPipelineFactory()
     {
         using ServiceProvider provider = new ServiceCollection()

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -402,7 +402,8 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             new ResoniteGeometryAssetPlanner(new ResoniteGeometryAssetAssembler()),
             new ResoniteSceneMaterialPlanComposer(materialPlanning),
             new ResoniteBatchEmissionPlanner(),
-            new PlannedBatchEmissionInterpreter());
+            new PlannedBatchEmissionInterpreter(),
+            new ResoniteImportStepTaskCleanup());
     }
 
     private static async IAsyncEnumerable<ImportedObjectUnit> CreateImportedObjectUnitsAsync(


### PR DESCRIPTION
## Summary
- extract best-effort import-step cancellation and orphaned-task observation into ResoniteImportStepTaskCleanup
- inject cleanup through live send DI and test support
- cover cancellation AggregateException preservation and orphaned task observation behavior

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false