### PR TITLE
Extract queued city object preparation

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerPipelineFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerPipelineFactory.cs
@@ -20,8 +20,9 @@ internal sealed class ResoniteLiveSendWorkerPipelineFactory(
         ResoniteQueuedTexturePreparer texturePreparer = new(
             terrainTextureAssetGenerator,
             datasetLicenseWriter);
+        ResoniteQueuedCityObjectPreparation cityObjectPreparation = new(texturePreparer);
         ResoniteQueuedCityObjectSender queuedCityObjectSender = new(
-            texturePreparer,
+            cityObjectPreparation,
             preparedCityObjectImporter);
         return new ResoniteQueuedCityObjectWorker(queuedCityObjectSender);
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparation.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparation.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal interface IResoniteQueuedCityObjectPreparation
+{
+    Task<PreparedCityObject> PrepareAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        ResoniteConstructionCityObject cityObject,
+        ResoniteLinkSendDiagnostics diagnostics,
+        Action<string>? progressReporter,
+        CancellationToken callerCancellationToken);
+}
+
+internal sealed class ResoniteQueuedCityObjectPreparation(
+    IResoniteQueuedTexturePreparer texturePreparer) : IResoniteQueuedCityObjectPreparation
+{
+    private readonly IResoniteQueuedTexturePreparer texturePreparer =
+        texturePreparer ?? throw new ArgumentNullException(nameof(texturePreparer));
+
+    public async Task<PreparedCityObject> PrepareAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        ResoniteConstructionCityObject cityObject,
+        ResoniteLinkSendDiagnostics diagnostics,
+        Action<string>? progressReporter,
+        CancellationToken callerCancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(routedClient);
+        ArgumentNullException.ThrowIfNull(cityObject);
+        ArgumentNullException.ThrowIfNull(diagnostics);
+
+        if (Interlocked.CompareExchange(ref state.Progress.FirstCityObjectPreparationStartedLogged, 1, 0) == 0)
+        {
+            ReportProgress(
+                progressReporter,
+                PlateauLog.Info(
+                    "live",
+                    $"City object preparation started after {state.Runtime.ElapsedTotalSeconds:F3}s: "
+                    + $"{cityObject.DisplayName} ({cityObject.PackageName}/{cityObject.SlotKey}) "
+                    + $"mesh='{cityObject.ActualMeshCode}'."));
+        }
+
+        using CancellationTokenSource linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            callerCancellationToken,
+            state.Runtime.ProcessingCancellationToken);
+        return await PrepareCityObjectAsync(
+            state,
+            routedClient,
+            cityObject,
+            diagnostics,
+            progressReporter,
+            linkedCancellation.Token);
+    }
+
+    private async Task<PreparedCityObject> PrepareCityObjectAsync(
+        LiveSendRunState state,
+        IResoniteLinkClient routedClient,
+        ResoniteConstructionCityObject cityObject,
+        ResoniteLinkSendDiagnostics diagnostics,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
+    {
+        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
+
+        if (cityObject.Geometry is ResoniteTriangleMeshGeometry triangleGeometry)
+        {
+            ResoniteCityObjectPreparation.ValidateTriangleMeshBindingsForImport(cityObject, triangleGeometry.Mesh);
+        }
+        else if (cityObject.Geometry is ResoniteDynamicTerrainGeometry dynamicTerrain)
+        {
+            ResoniteCityObjectPreparation.ValidateTriangleMeshBindingsForImport(cityObject, dynamicTerrain.StaticMesh.Mesh);
+        }
+
+        Task<PreparedConstructionGeometry> geometryPreparationTask = cityObject.Geometry switch
+        {
+            ResoniteTriangleMeshGeometry triangleMesh => Task.Run<PreparedConstructionGeometry>(
+                () => ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, triangleMesh.Mesh),
+                cancellationToken),
+            ResoniteTerrainGridGeometry heightMap => Task.Run<PreparedConstructionGeometry>(
+                () => new PreparedTerrainGridGeometry(heightMap, ResoniteCityObjectPreparation.PrepareTerrainGridDisplacementTexture(heightMap)),
+                cancellationToken),
+            ResoniteDynamicTerrainGeometry dynamicTerrain => Task.Run<PreparedConstructionGeometry>(
+                () => new PreparedDynamicTerrainGeometry(
+                    ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, dynamicTerrain.StaticMesh.Mesh),
+                    new PreparedTerrainGridGeometry(
+                        dynamicTerrain.GridMesh,
+                        ResoniteCityObjectPreparation.PrepareTerrainGridDisplacementTexture(dynamicTerrain.GridMesh))),
+                cancellationToken),
+            _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
+        };
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        PreparedTextureReference[] preparedTextures = await texturePreparer.PrepareAsync(
+            state,
+            routedClient,
+            cityObject,
+            progressReporter,
+            cancellationToken);
+        PreparedConstructionGeometry preparedGeometry = await geometryPreparationTask;
+        Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay = preparedTextures
+            .Where(static texture => texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
+            .ToDictionary(
+                static texture => texture.TerrainOverlay!,
+                static texture => texture.GeneratedTerrainTexture!);
+        cityObject = ResoniteCityObjectPreparation.ApplyTerrainTextureCanvasUv(
+            cityObject,
+            preparedTerrainTextureDataByOverlay,
+            clampCanvasUv: ResonitePackageSemantics.IsDemPackage(cityObject.PackageName));
+        if (cityObject.Geometry is ResoniteTriangleMeshGeometry resolvedTriangleMesh
+            && preparedGeometry is PreparedTriangleMeshGeometry)
+        {
+            preparedGeometry = ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, resolvedTriangleMesh.Mesh);
+        }
+        else if (cityObject.Geometry is ResoniteDynamicTerrainGeometry resolvedDynamicTerrain
+            && preparedGeometry is PreparedDynamicTerrainGeometry preparedDynamicTerrain)
+        {
+            preparedGeometry = preparedDynamicTerrain with
+            {
+                StaticMesh = ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, resolvedDynamicTerrain.StaticMesh.Mesh),
+            };
+        }
+
+        stopwatch.Stop();
+        diagnostics.RecordPrepare(cityObject.PackageName, stopwatch.Elapsed.TotalSeconds);
+
+        if (Interlocked.CompareExchange(ref state.Progress.FirstPreparedCityObjectLogged, 1, 0) == 0)
+        {
+            ReportProgress(
+                progressReporter,
+                PlateauLog.Info(
+                    "live",
+                    $"First city object prepared in {stopwatch.Elapsed.TotalSeconds:F3}s "
+                    + $"after scene start {state.Runtime.ElapsedTotalSeconds:F3}s: "
+                    + $"{cityObject.DisplayName} "
+                    + $"(textures={preparedTextures.Length}, geometry={PreparedConstructionGeometryFormatter.Describe(preparedGeometry)})."));
+        }
+
+        return new PreparedCityObject(
+            cityObject,
+            preparedGeometry,
+            preparedTextures);
+    }
+
+    private static void ReportProgress(Action<string>? progressReporter, string message)
+    {
+        progressReporter?.Invoke(message);
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparation.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparation.cs
@@ -107,7 +107,7 @@ internal sealed class ResoniteQueuedCityObjectPreparation(
             cityObject,
             progressReporter,
             cancellationToken);
-        PreparedConstructionGeometry preparedGeometry = await geometryPreparationTask;
+        PreparedConstructionGeometry preparedGeometry = await geometryPreparationTask.WaitAsync(cancellationToken);
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay = preparedTextures
             .Where(static texture => texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
             .ToDictionary(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
@@ -1,13 +1,9 @@
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
-using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -24,11 +20,11 @@ internal interface IResoniteQueuedCityObjectSender
 }
 
 internal sealed class ResoniteQueuedCityObjectSender(
-    IResoniteQueuedTexturePreparer texturePreparer,
+    IResoniteQueuedCityObjectPreparation cityObjectPreparation,
     IResonitePreparedCityObjectImporter preparedCityObjectImporter) : IResoniteQueuedCityObjectSender
 {
-    private readonly IResoniteQueuedTexturePreparer texturePreparer =
-        texturePreparer ?? throw new ArgumentNullException(nameof(texturePreparer));
+    private readonly IResoniteQueuedCityObjectPreparation cityObjectPreparation =
+        cityObjectPreparation ?? throw new ArgumentNullException(nameof(cityObjectPreparation));
     private readonly IResonitePreparedCityObjectImporter preparedCityObjectImporter =
         preparedCityObjectImporter ?? throw new ArgumentNullException(nameof(preparedCityObjectImporter));
 
@@ -52,14 +48,12 @@ internal sealed class ResoniteQueuedCityObjectSender(
         Interlocked.Increment(ref state.Progress.AttemptedCityObjectCount);
         try
         {
-            PreparedCityObject preparedCityObject = await AwaitWithCancellationAsync(
-                CreatePreparationTask(
-                    state,
-                    routedClient,
-                    queuedCityObject.CityObject,
-                    diagnostics,
-                    progressReporter,
-                    cancellationToken),
+            PreparedCityObject preparedCityObject = await cityObjectPreparation.PrepareAsync(
+                state,
+                routedClient,
+                queuedCityObject.CityObject,
+                diagnostics,
+                progressReporter,
                 cancellationToken);
             await preparedCityObjectImporter.ImportAsync(
                 state,
@@ -106,155 +100,10 @@ internal sealed class ResoniteQueuedCityObjectSender(
         }
     }
 
-    private Task<PreparedCityObject> CreatePreparationTask(
-        LiveSendRunState state,
-        IResoniteLinkClient routedClient,
-        ResoniteConstructionCityObject cityObject,
-        ResoniteLinkSendDiagnostics diagnostics,
-        Action<string>? progressReporter,
-        CancellationToken callerCancellationToken)
-    {
-        if (Interlocked.CompareExchange(ref state.Progress.FirstCityObjectPreparationStartedLogged, 1, 0) == 0)
-        {
-            ReportProgress(
-                progressReporter,
-                PlateauLog.Info(
-                    "live",
-                    $"City object preparation started after {state.Runtime.ElapsedTotalSeconds:F3}s: "
-                    + $"{cityObject.DisplayName} ({cityObject.PackageName}/{cityObject.SlotKey}) "
-                    + $"mesh='{cityObject.ActualMeshCode}'."));
-        }
-
-        CancellationToken processingCancellationToken = state.Runtime.ProcessingCancellationToken;
-        return PrepareCityObjectWithLinkedCancellationAsync(
-            state,
-            routedClient,
-            cityObject,
-            diagnostics,
-            progressReporter,
-            callerCancellationToken,
-            processingCancellationToken);
-    }
-
-    private async Task<PreparedCityObject> PrepareCityObjectWithLinkedCancellationAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient routedClient,
-        ResoniteConstructionCityObject cityObject,
-        ResoniteLinkSendDiagnostics diagnostics,
-        Action<string>? progressReporter,
-        CancellationToken callerCancellationToken,
-        CancellationToken processingCancellationToken)
-    {
-        using CancellationTokenSource linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
-            callerCancellationToken,
-            processingCancellationToken);
-        return await PrepareCityObjectAsync(
-            state,
-            routedClient,
-            cityObject,
-            diagnostics,
-            progressReporter,
-            linkedCancellation.Token);
-    }
-
-    private async Task<PreparedCityObject> PrepareCityObjectAsync(
-        LiveSendRunState state,
-        IResoniteLinkClient routedClient,
-        ResoniteConstructionCityObject cityObject,
-        ResoniteLinkSendDiagnostics diagnostics,
-        Action<string>? progressReporter,
-        CancellationToken cancellationToken)
-    {
-        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
-
-        if (cityObject.Geometry is ResoniteTriangleMeshGeometry triangleGeometry)
-        {
-            ResoniteCityObjectPreparation.ValidateTriangleMeshBindingsForImport(cityObject, triangleGeometry.Mesh);
-        }
-        else if (cityObject.Geometry is ResoniteDynamicTerrainGeometry dynamicTerrain)
-        {
-            ResoniteCityObjectPreparation.ValidateTriangleMeshBindingsForImport(cityObject, dynamicTerrain.StaticMesh.Mesh);
-        }
-
-        Task<PreparedConstructionGeometry> geometryPreparationTask = cityObject.Geometry switch
-        {
-            ResoniteTriangleMeshGeometry triangleMesh => Task.Run<PreparedConstructionGeometry>(
-                () => ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, triangleMesh.Mesh),
-                cancellationToken),
-            ResoniteTerrainGridGeometry heightMap => Task.Run<PreparedConstructionGeometry>(
-                () => new PreparedTerrainGridGeometry(heightMap, ResoniteCityObjectPreparation.PrepareTerrainGridDisplacementTexture(heightMap)),
-                cancellationToken),
-            ResoniteDynamicTerrainGeometry dynamicTerrain => Task.Run<PreparedConstructionGeometry>(
-                () => new PreparedDynamicTerrainGeometry(
-                    ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, dynamicTerrain.StaticMesh.Mesh),
-                    new PreparedTerrainGridGeometry(
-                        dynamicTerrain.GridMesh,
-                        ResoniteCityObjectPreparation.PrepareTerrainGridDisplacementTexture(dynamicTerrain.GridMesh))),
-                cancellationToken),
-            _ => throw new InvalidOperationException($"Unsupported geometry type '{cityObject.Geometry.GetType().Name}'."),
-        };
-        Stopwatch stopwatch = Stopwatch.StartNew();
-        PreparedTextureReference[] preparedTextures = await texturePreparer.PrepareAsync(
-            state,
-            routedClient,
-            cityObject,
-            progressReporter,
-            cancellationToken);
-        PreparedConstructionGeometry preparedGeometry = await geometryPreparationTask;
-        Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay = preparedTextures
-            .Where(static texture => texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
-            .ToDictionary(
-                static texture => texture.TerrainOverlay!,
-                static texture => texture.GeneratedTerrainTexture!);
-        cityObject = ResoniteCityObjectPreparation.ApplyTerrainTextureCanvasUv(
-            cityObject,
-            preparedTerrainTextureDataByOverlay,
-            clampCanvasUv: ResonitePackageSemantics.IsDemPackage(cityObject.PackageName));
-        if (cityObject.Geometry is ResoniteTriangleMeshGeometry resolvedTriangleMesh
-            && preparedGeometry is PreparedTriangleMeshGeometry)
-        {
-            preparedGeometry = ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, resolvedTriangleMesh.Mesh);
-        }
-        else if (cityObject.Geometry is ResoniteDynamicTerrainGeometry resolvedDynamicTerrain
-            && preparedGeometry is PreparedDynamicTerrainGeometry preparedDynamicTerrain)
-        {
-            preparedGeometry = preparedDynamicTerrain with
-            {
-                StaticMesh = ResoniteCityObjectPreparation.PrepareTriangleMeshGeometry(cityObject, resolvedDynamicTerrain.StaticMesh.Mesh),
-            };
-        }
-        stopwatch.Stop();
-        diagnostics.RecordPrepare(cityObject.PackageName, stopwatch.Elapsed.TotalSeconds);
-
-        if (Interlocked.CompareExchange(ref state.Progress.FirstPreparedCityObjectLogged, 1, 0) == 0)
-        {
-            ReportProgress(
-                progressReporter,
-                PlateauLog.Info(
-                    "live",
-                    $"First city object prepared in {stopwatch.Elapsed.TotalSeconds:F3}s "
-                    + $"after scene start {state.Runtime.ElapsedTotalSeconds:F3}s: "
-                    + $"{cityObject.DisplayName} "
-                    + $"(textures={preparedTextures.Length}, geometry={PreparedConstructionGeometryFormatter.Describe(preparedGeometry)})."));
-        }
-
-        return new PreparedCityObject(
-            cityObject,
-            preparedGeometry,
-            preparedTextures);
-    }
-
     private static bool IsRecoverableCityObjectSendFailure(Exception exception)
     {
         return exception is ContinuableImportException
             || FindResoniteLinkOperationException(exception) is { OperationName: "ImportMesh" or "ImportTexture" or "GetSlot" or "GetComponent" };
-    }
-
-    private static Task<T> AwaitWithCancellationAsync<T>(
-        Task<T> operationTask,
-        CancellationToken cancellationToken)
-    {
-        return operationTask.WaitAsync(cancellationToken);
     }
 
     private static ResoniteLinkOperationException? FindResoniteLinkOperationException(Exception exception)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -389,9 +389,10 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
     {
         return new ResoniteQueuedCityObjectWorker(
             new ResoniteQueuedCityObjectSender(
-                new ResoniteQueuedTexturePreparer(
-                    terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
-                    new ResoniteDatasetLicenseWriter()),
+                new ResoniteQueuedCityObjectPreparation(
+                    new ResoniteQueuedTexturePreparer(
+                        terrainTextureAssetGenerator ?? new TerrainTextureAssetGenerator(),
+                        new ResoniteDatasetLicenseWriter())),
                 CreatePreparedCityObjectImporter(materialPlanning)));
     }
 


### PR DESCRIPTION
## Summary
- move queued city object normalization, validation, texture preparation, geometry preparation, and preparation diagnostics into ResoniteQueuedCityObjectPreparation
- keep ResoniteQueuedCityObjectSender focused on send orchestration, per-object failure policy, progress counters, and memory lease cleanup
- update live worker pipeline and test support wiring to compose the preparation boundary explicitly

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false