### PR TITLE
Extract terrain overlay projection split policy

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -3216,7 +3216,7 @@ internal static class LocalCityGmlObjectProjection
         List<ImportedCityObject> generatedRoadMarkings = [];
 
         foreach ((global::PlateauResoniteLink.Application.Importing.ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
-                 in SplitParsedCityObjectForTerrainProjection(
+                 in TerrainOverlayProjectionSplitPolicy.SplitParsedCityObject(
                      terrainAlignedParsedCityObject,
                      demTerrainTextureOverlays,
                      requestedMeshCodeBounds,
@@ -3224,7 +3224,7 @@ internal static class LocalCityGmlObjectProjection
                      cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!ShouldProjectTerrainOverlaySplit(
+            if (!TerrainOverlayProjectionSplitPolicy.ShouldProjectSplit(
                     splitCityObject.CityObject.ActualMeshCode,
                     request.MeshCode,
                     requestedMeshCodeBounds,
@@ -3328,12 +3328,12 @@ internal static class LocalCityGmlObjectProjection
             };
 
         foreach ((global::PlateauResoniteLink.Application.Importing.ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
-                 in SplitParsedCityObjectForTerrainProjection(
+                 in TerrainOverlayProjectionSplitPolicy.SplitParsedCityObject(
                      terrainAlignedParsedCityObject,
                      demTerrainTextureOverlays,
                      requestedMeshCodeBounds))
         {
-            if (!ShouldProjectTerrainOverlaySplit(
+            if (!TerrainOverlayProjectionSplitPolicy.ShouldProjectSplit(
                     splitCityObject.CityObject.ActualMeshCode,
                     request.MeshCode,
                     requestedMeshCodeBounds ?? [],
@@ -4386,307 +4386,6 @@ internal static class LocalCityGmlObjectProjection
             requestedMeshCode,
             requestedMeshCodeBounds,
             terrainOverlay);
-    }
-
-    private static IEnumerable<(global::PlateauResoniteLink.Application.Importing.ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> SplitParsedCityObjectForTerrainProjection(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
-        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
-        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
-        Action<string>? progressReporter = null,
-        CancellationToken cancellationToken = default)
-    {
-        foreach ((global::PlateauResoniteLink.Application.Importing.ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
-                 in DemTerrainOverlayAssignment.SplitParsedCityObject(
-                     cityObject,
-                     demTerrainTextureOverlays,
-                     requestedMeshCodeBounds,
-                     progressReporter,
-                     cancellationToken))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (splitCityObject.Overlay is not null
-                || string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
-            {
-                yield return splitCityObject;
-                continue;
-            }
-
-            foreach ((global::PlateauResoniteLink.Application.Importing.ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) nonDemSplit
-                     in SplitNonDemCityObjectByTerrainOverlay(
-                         splitCityObject.CityObject,
-                         demTerrainTextureOverlays,
-                         requestedMeshCodeBounds,
-                         progressReporter,
-                         cancellationToken))
-            {
-                yield return nonDemSplit;
-            }
-        }
-    }
-
-    private static IEnumerable<(global::PlateauResoniteLink.Application.Importing.ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> SplitNonDemCityObjectByTerrainOverlay(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
-        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
-        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
-        Action<string>? progressReporter,
-        CancellationToken cancellationToken)
-    {
-        if (demTerrainTextureOverlays.Count == 0 || !IsBuildingPackage(cityObject.PackageName))
-        {
-            yield return (cityObject, null);
-            yield break;
-        }
-
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
-        LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
-            ? new LocalCartesian(
-                cityObjectOrigin.Latitude,
-                cityObjectOrigin.Longitude,
-                cityObjectOrigin.Altitude,
-                cityObject.ReferenceSystem.Geocentric)
-            : null;
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint[] cityObjectVertices =
-        [
-            .. cityObject.Surfaces.SelectMany(static surface => surface.Vertices)
-        ];
-        if (cityObjectVertices.Length == 0)
-        {
-            yield return (cityObject, null);
-            yield break;
-        }
-
-        double cityObjectMinAltitude = CityObjectAltitudeMetricsResolver.GetMinimumAltitude(cityObjectVertices);
-
-        List<global::PlateauResoniteLink.Application.Importing.ParsedSurface> untexturedSurfaces = [];
-        List<(global::PlateauResoniteLink.Application.Importing.ParsedSurface Surface, TerrainTextureOverlay Overlay)> terrainOverlaySurfaces = [];
-        foreach (global::PlateauResoniteLink.Application.Importing.ParsedSurface surface in cityObject.Surfaces)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (!IsNonDemTerrainTextureSurface(cityObject, surface, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian)
-                || !TryCreateSurfaceGeographicBounds(surface, out GeographicRectangle surfaceBounds))
-            {
-                untexturedSurfaces.Add(surface);
-                continue;
-            }
-
-            global::PlateauResoniteLink.Application.Importing.ParsedSurface terrainProjectionSurface =
-                NormalizeNonDemTerrainTextureSurface(surface);
-
-            TerrainTextureOverlay[] candidateOverlays = demTerrainTextureOverlays
-                .Where(overlay => TerrainOverlayMeshCodeResolver.IsRequestedOverlay(overlay, requestedMeshCodeBounds)
-                    || TerrainOverlayMeshCodeResolver.ResolveMeshCode(cityObject.ActualMeshCode, overlay) is not null)
-                .Where(overlay => TerrainOverlayMeshCodeResolver.BoundsOverlap(surfaceBounds, overlay.GeographicBounds))
-                .OrderBy(static overlay => overlay.GeographicBounds.MinLatitude)
-                .ThenBy(static overlay => overlay.GeographicBounds.MinLongitude)
-                .ToArray();
-            if (candidateOverlays.Length == 0)
-            {
-                TerrainTextureOverlay? overlappingOverlay = demTerrainTextureOverlays
-                    .FirstOrDefault(overlay => TerrainOverlayMeshCodeResolver.BoundsOverlap(surfaceBounds, overlay.GeographicBounds));
-                if (overlappingOverlay is not null)
-                {
-                    throw CreateTerrainOverlayMeshCodeMismatchException(
-                        "non-dem-terrain-candidate",
-                        cityObject.ActualMeshCode,
-                        cityObject.ActualMeshCode,
-                        requestedMeshCodeBounds,
-                        overlappingOverlay);
-                }
-
-                untexturedSurfaces.Add(surface);
-                continue;
-            }
-
-            if (candidateOverlays.Length == 1)
-            {
-                terrainOverlaySurfaces.Add((terrainProjectionSurface, candidateOverlays[0]));
-                continue;
-            }
-
-            TerrainTextureOverlay? containingOverlay = candidateOverlays.FirstOrDefault(overlay =>
-                TerrainOverlayMeshCodeResolver.ContainsBounds(overlay.GeographicBounds, surfaceBounds));
-            if (containingOverlay is not null)
-            {
-                terrainOverlaySurfaces.Add((terrainProjectionSurface, containingOverlay));
-                continue;
-            }
-
-            IReadOnlyList<(global::PlateauResoniteLink.Application.Importing.ParsedSurface Surface, TerrainTextureOverlay Overlay)> clippedSurfaces =
-                DemTerrainOverlaySurfaceClipper.ClipGeneratedSurfaceToOverlays(
-                    terrainProjectionSurface,
-                    candidateOverlays,
-                    progressReporter,
-                    cancellationToken);
-            if (clippedSurfaces.Count == 0)
-            {
-                untexturedSurfaces.Add(surface);
-                continue;
-            }
-
-            terrainOverlaySurfaces.AddRange(clippedSurfaces);
-        }
-
-        IGrouping<TerrainTextureOverlay, (global::PlateauResoniteLink.Application.Importing.ParsedSurface Surface, TerrainTextureOverlay Overlay)>[] terrainGroups =
-            terrainOverlaySurfaces
-                .GroupBy(static entry => entry.Overlay)
-                .OrderBy(static group => group.Key.GeographicBounds.MinLatitude)
-                .ThenBy(static group => group.Key.GeographicBounds.MinLongitude)
-                .ToArray();
-        int splitCount = terrainGroups.Length + (untexturedSurfaces.Count == 0 ? 0 : 1);
-        if (splitCount == 0)
-        {
-            yield break;
-        }
-
-        if (splitCount == 1)
-        {
-            if (terrainGroups.Length == 1)
-            {
-                string terrainMeshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
-                        cityObject.ActualMeshCode,
-                        cityObject.ActualMeshCode,
-                        requestedMeshCodeBounds,
-                        terrainGroups[0].Key)
-                    ?? throw CreateTerrainOverlayMeshCodeMismatchException(
-                        "non-dem-terrain-single-split",
-                        cityObject.ActualMeshCode,
-                        cityObject.ActualMeshCode,
-                        requestedMeshCodeBounds,
-                        terrainGroups[0].Key);
-                yield return (
-                    cityObject with
-                    {
-                        ActualMeshCode = terrainMeshCode,
-                        Surfaces = terrainGroups[0].Select(static entry => MarkUsesGeneratedDemTexture(entry.Surface)).ToArray(),
-                        GeodeticOriginOverride = cityObjectOrigin,
-                    },
-                    terrainGroups[0].Key);
-                yield break;
-            }
-
-            yield return (
-                cityObject with
-                {
-                    Surfaces = untexturedSurfaces.ToArray(),
-                    GeodeticOriginOverride = cityObjectOrigin,
-                },
-                null);
-            yield break;
-        }
-
-        int splitIndex = 0;
-        foreach (IGrouping<TerrainTextureOverlay, (global::PlateauResoniteLink.Application.Importing.ParsedSurface Surface, TerrainTextureOverlay Overlay)> group in terrainGroups)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            string terrainMeshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
-                    cityObject.ActualMeshCode,
-                    cityObject.ActualMeshCode,
-                    requestedMeshCodeBounds,
-                    group.Key)
-                ?? throw CreateTerrainOverlayMeshCodeMismatchException(
-                    "non-dem-terrain-split",
-                    cityObject.ActualMeshCode,
-                    cityObject.ActualMeshCode,
-                    requestedMeshCodeBounds,
-                    group.Key);
-            yield return (
-                cityObject with
-                {
-                    ActualMeshCode = terrainMeshCode,
-                    SlotKey = $"{cityObject.SlotKey}_terrain_{terrainMeshCode}",
-                    DisplayName = $"{cityObject.DisplayName} ({splitIndex + 1})",
-                    Surfaces = group.Select(static entry => MarkUsesGeneratedDemTexture(entry.Surface)).ToArray(),
-                    GeodeticOriginOverride = cityObjectOrigin,
-                },
-                group.Key);
-            splitIndex++;
-        }
-
-        if (untexturedSurfaces.Count != 0)
-        {
-            yield return (
-                cityObject with
-                {
-                    SlotKey = $"{cityObject.SlotKey}_terrain_none",
-                    DisplayName = $"{cityObject.DisplayName} ({splitIndex + 1})",
-                    Surfaces = untexturedSurfaces.ToArray(),
-                    GeodeticOriginOverride = cityObjectOrigin,
-                },
-                null);
-        }
-    }
-
-    private static global::PlateauResoniteLink.Application.Importing.ParsedSurface MarkUsesGeneratedDemTexture(
-        global::PlateauResoniteLink.Application.Importing.ParsedSurface surface)
-    {
-        return surface with { UsesGeneratedDemTexture = true };
-    }
-
-    private static global::PlateauResoniteLink.Application.Importing.ParsedSurface NormalizeNonDemTerrainTextureSurface(
-        global::PlateauResoniteLink.Application.Importing.ParsedSurface surface)
-    {
-        return surface.Semantic == global::PlateauResoniteLink.Application.Importing.ParsedSurfaceSemantic.Roof
-            ? surface
-            : surface with { Semantic = global::PlateauResoniteLink.Application.Importing.ParsedSurfaceSemantic.Roof };
-    }
-
-    private static bool IsNonDemTerrainTextureSurface(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
-        global::PlateauResoniteLink.Application.Importing.ParsedSurface surface,
-        double cityObjectMinAltitude,
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        return surface.TexturePayload is null
-            && !surface.UsesGeneratedDemTexture
-            && IsRoofTerrainTextureSurface(
-                global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface),
-                cityObjectMinAltitude,
-                cityObjectOrigin.ToProjectionModel(),
-                cityObjectCartesian);
-    }
-
-    private static bool ShouldProjectTerrainOverlaySplit(
-        string actualMeshCode,
-        string requestedMeshCode,
-        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
-        TerrainTextureOverlay? terrainOverlay)
-    {
-        if (terrainOverlay is null)
-        {
-            return true;
-        }
-
-        if (requestedMeshCodeBounds.Count > 0)
-        {
-            return TerrainOverlayMeshCodeResolver.IsRequestedOverlay(terrainOverlay, requestedMeshCodeBounds);
-        }
-
-        return TerrainOverlayMeshCodeResolver.ResolveForOverlay(
-                actualMeshCode,
-                requestedMeshCode,
-                requestedMeshCodeBounds,
-                terrainOverlay)
-            is not null;
-    }
-
-    private static bool TryCreateSurfaceGeographicBounds(
-        global::PlateauResoniteLink.Application.Importing.ParsedSurface surface,
-        out GeographicRectangle bounds)
-    {
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint[] vertices = surface.ExteriorRing.Vertices;
-        if (vertices.Length == 0)
-        {
-            bounds = new GeographicRectangle(0.0, 0.0, 0.0, 0.0);
-            return false;
-        }
-
-        bounds = new GeographicRectangle(
-            vertices.Min(static vertex => vertex.Latitude),
-            vertices.Max(static vertex => vertex.Latitude),
-            vertices.Min(static vertex => vertex.Longitude),
-            vertices.Max(static vertex => vertex.Longitude));
-        return true;
     }
 
     private static Float2 ToContractFloat2(Float2 value) => new(value.X, value.Y);

--- a/src/PlateauResoniteLink/Application/Importing/RoofTerrainTextureSurfacePolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/RoofTerrainTextureSurfacePolicy.cs
@@ -42,7 +42,7 @@ internal static class RoofTerrainTextureSurfacePolicy
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
-        Float3[] positions = surface.Vertices
+        Float3[] positions = surface.ExteriorRing.Vertices
             .Select(point => SceneAxisMapper.CreatePosition(
                 point.Latitude,
                 point.Longitude,

--- a/src/PlateauResoniteLink/Application/Importing/RoofTerrainTextureSurfacePolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/RoofTerrainTextureSurfacePolicy.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+
+using GeographicLib;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class RoofTerrainTextureSurfacePolicy
+{
+    private const double UnknownRoofBottomAltitudeToleranceMeters = 0.1;
+
+    internal static bool IsRoofTerrainTextureSurface(
+        ParsedSurface surface,
+        double cityObjectMinAltitude,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (surface.Semantic == ParsedSurfaceSemantic.Roof)
+        {
+            return true;
+        }
+
+        if (surface.Semantic is not (ParsedSurfaceSemantic.Unknown
+            or ParsedSurfaceSemantic.Ground
+            or ParsedSurfaceSemantic.OuterCeiling
+            or ParsedSurfaceSemantic.OuterFloor))
+        {
+            return false;
+        }
+
+        Float3? normal = ComputeSurfaceNormal(
+            surface,
+            cityObjectOrigin,
+            cityObjectCartesian);
+        return normal is not null
+            && Math.Abs(normal.Y) >= 0.98
+            && surface.Vertices.Min(static vertex => vertex.Altitude) > cityObjectMinAltitude + UnknownRoofBottomAltitudeToleranceMeters;
+    }
+
+    private static Float3? ComputeSurfaceNormal(
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        Float3[] positions = surface.Vertices
+            .Select(point => SceneAxisMapper.CreatePosition(
+                point.Latitude,
+                point.Longitude,
+                point.Altitude,
+                cityObjectOrigin.Latitude,
+                cityObjectOrigin.Longitude,
+                cityObjectOrigin.Altitude,
+                cityObjectCartesian))
+            .ToArray();
+        return ComputePolygonNormal(positions);
+    }
+
+    private static Float3? ComputePolygonNormal(Float3[] points)
+    {
+        if (points.Length < 3)
+        {
+            return null;
+        }
+
+        double normalX = 0.0;
+        double normalY = 0.0;
+        double normalZ = 0.0;
+
+        for (int index = 0; index < points.Length; index++)
+        {
+            Float3 current = points[index];
+            Float3 next = points[(index + 1) % points.Length];
+            normalX += (current.Y - next.Y) * (current.Z + next.Z);
+            normalY += (current.Z - next.Z) * (current.X + next.X);
+            normalZ += (current.X - next.X) * (current.Y + next.Y);
+        }
+
+        double magnitude = Math.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ));
+        if (magnitude < 1e-8)
+        {
+            return null;
+        }
+
+        return new Float3(normalX / magnitude, normalY / magnitude, normalZ / magnitude);
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayProjectionSplitPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayProjectionSplitPolicy.cs
@@ -1,0 +1,411 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using GeographicLib;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class TerrainOverlayProjectionSplitPolicy
+{
+    private const double UnknownRoofBottomAltitudeToleranceMeters = 0.1;
+
+    internal static IEnumerable<(ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> SplitParsedCityObject(
+        ParsedCityObject cityObject,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
+        Action<string>? progressReporter = null,
+        CancellationToken cancellationToken = default)
+    {
+        foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
+                 in DemTerrainOverlayAssignment.SplitParsedCityObject(
+                     cityObject,
+                     demTerrainTextureOverlays,
+                     requestedMeshCodeBounds,
+                     progressReporter,
+                     cancellationToken))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (splitCityObject.Overlay is not null
+                || string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
+            {
+                yield return splitCityObject;
+                continue;
+            }
+
+            foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) nonDemSplit
+                     in SplitNonDemCityObjectByTerrainOverlay(
+                         splitCityObject.CityObject,
+                         demTerrainTextureOverlays,
+                         requestedMeshCodeBounds,
+                         progressReporter,
+                         cancellationToken))
+            {
+                yield return nonDemSplit;
+            }
+        }
+    }
+
+    internal static bool ShouldProjectSplit(
+        string actualMeshCode,
+        string requestedMeshCode,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
+        TerrainTextureOverlay? terrainOverlay)
+    {
+        if (terrainOverlay is null)
+        {
+            return true;
+        }
+
+        if (requestedMeshCodeBounds.Count > 0)
+        {
+            return TerrainOverlayMeshCodeResolver.IsRequestedOverlay(terrainOverlay, requestedMeshCodeBounds);
+        }
+
+        return TerrainOverlayMeshCodeResolver.ResolveForOverlay(
+                actualMeshCode,
+                requestedMeshCode,
+                requestedMeshCodeBounds,
+                terrainOverlay)
+            is not null;
+    }
+
+    private static IEnumerable<(ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> SplitNonDemCityObjectByTerrainOverlay(
+        ParsedCityObject cityObject,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
+    {
+        if (demTerrainTextureOverlays.Count == 0 || !PlateauPackageCatalog.IsBuildingPackage(cityObject.PackageName))
+        {
+            yield return (cityObject, null);
+            yield break;
+        }
+
+        GeodeticPoint cityObjectOrigin = GetCityObjectOrigin(cityObject);
+        LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
+            ? new LocalCartesian(
+                cityObjectOrigin.Latitude,
+                cityObjectOrigin.Longitude,
+                cityObjectOrigin.Altitude,
+                cityObject.ReferenceSystem.Geocentric)
+            : null;
+        GeodeticPoint[] cityObjectVertices =
+        [
+            .. cityObject.Surfaces.SelectMany(static surface => surface.Vertices)
+        ];
+        if (cityObjectVertices.Length == 0)
+        {
+            yield return (cityObject, null);
+            yield break;
+        }
+
+        double cityObjectMinAltitude = CityObjectAltitudeMetricsResolver.GetMinimumAltitude(cityObjectVertices);
+
+        List<ParsedSurface> untexturedSurfaces = [];
+        List<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> terrainOverlaySurfaces = [];
+        foreach (ParsedSurface surface in cityObject.Surfaces)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!IsNonDemTerrainTextureSurface(surface, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian)
+                || !TryCreateSurfaceGeographicBounds(surface, out GeographicRectangle surfaceBounds))
+            {
+                untexturedSurfaces.Add(surface);
+                continue;
+            }
+
+            ParsedSurface terrainProjectionSurface = NormalizeNonDemTerrainTextureSurface(surface);
+
+            TerrainTextureOverlay[] candidateOverlays = demTerrainTextureOverlays
+                .Where(overlay => TerrainOverlayMeshCodeResolver.IsRequestedOverlay(overlay, requestedMeshCodeBounds)
+                    || TerrainOverlayMeshCodeResolver.ResolveMeshCode(cityObject.ActualMeshCode, overlay) is not null)
+                .Where(overlay => TerrainOverlayMeshCodeResolver.BoundsOverlap(surfaceBounds, overlay.GeographicBounds))
+                .OrderBy(static overlay => overlay.GeographicBounds.MinLatitude)
+                .ThenBy(static overlay => overlay.GeographicBounds.MinLongitude)
+                .ToArray();
+            if (candidateOverlays.Length == 0)
+            {
+                TerrainTextureOverlay? overlappingOverlay = demTerrainTextureOverlays
+                    .FirstOrDefault(overlay => TerrainOverlayMeshCodeResolver.BoundsOverlap(surfaceBounds, overlay.GeographicBounds));
+                if (overlappingOverlay is not null)
+                {
+                    throw CreateTerrainOverlayMeshCodeMismatchException(
+                        "non-dem-terrain-candidate",
+                        cityObject.ActualMeshCode,
+                        cityObject.ActualMeshCode,
+                        requestedMeshCodeBounds,
+                        overlappingOverlay);
+                }
+
+                untexturedSurfaces.Add(surface);
+                continue;
+            }
+
+            if (candidateOverlays.Length == 1)
+            {
+                terrainOverlaySurfaces.Add((terrainProjectionSurface, candidateOverlays[0]));
+                continue;
+            }
+
+            TerrainTextureOverlay? containingOverlay = candidateOverlays.FirstOrDefault(overlay =>
+                TerrainOverlayMeshCodeResolver.ContainsBounds(overlay.GeographicBounds, surfaceBounds));
+            if (containingOverlay is not null)
+            {
+                terrainOverlaySurfaces.Add((terrainProjectionSurface, containingOverlay));
+                continue;
+            }
+
+            IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> clippedSurfaces =
+                DemTerrainOverlaySurfaceClipper.ClipGeneratedSurfaceToOverlays(
+                    terrainProjectionSurface,
+                    candidateOverlays,
+                    progressReporter,
+                    cancellationToken);
+            if (clippedSurfaces.Count == 0)
+            {
+                untexturedSurfaces.Add(surface);
+                continue;
+            }
+
+            terrainOverlaySurfaces.AddRange(clippedSurfaces);
+        }
+
+        IGrouping<TerrainTextureOverlay, (ParsedSurface Surface, TerrainTextureOverlay Overlay)>[] terrainGroups =
+            terrainOverlaySurfaces
+                .GroupBy(static entry => entry.Overlay)
+                .OrderBy(static group => group.Key.GeographicBounds.MinLatitude)
+                .ThenBy(static group => group.Key.GeographicBounds.MinLongitude)
+                .ToArray();
+        int splitCount = terrainGroups.Length + (untexturedSurfaces.Count == 0 ? 0 : 1);
+        if (splitCount == 0)
+        {
+            yield break;
+        }
+
+        if (splitCount == 1)
+        {
+            if (terrainGroups.Length == 1)
+            {
+                string terrainMeshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
+                        cityObject.ActualMeshCode,
+                        cityObject.ActualMeshCode,
+                        requestedMeshCodeBounds,
+                        terrainGroups[0].Key)
+                    ?? throw CreateTerrainOverlayMeshCodeMismatchException(
+                        "non-dem-terrain-single-split",
+                        cityObject.ActualMeshCode,
+                        cityObject.ActualMeshCode,
+                        requestedMeshCodeBounds,
+                        terrainGroups[0].Key);
+                yield return (
+                    cityObject with
+                    {
+                        ActualMeshCode = terrainMeshCode,
+                        Surfaces = terrainGroups[0].Select(static entry => MarkUsesGeneratedDemTexture(entry.Surface)).ToArray(),
+                        GeodeticOriginOverride = cityObjectOrigin,
+                    },
+                    terrainGroups[0].Key);
+                yield break;
+            }
+
+            yield return (
+                cityObject with
+                {
+                    Surfaces = untexturedSurfaces.ToArray(),
+                    GeodeticOriginOverride = cityObjectOrigin,
+                },
+                null);
+            yield break;
+        }
+
+        int splitIndex = 0;
+        foreach (IGrouping<TerrainTextureOverlay, (ParsedSurface Surface, TerrainTextureOverlay Overlay)> group in terrainGroups)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string terrainMeshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
+                    cityObject.ActualMeshCode,
+                    cityObject.ActualMeshCode,
+                    requestedMeshCodeBounds,
+                    group.Key)
+                ?? throw CreateTerrainOverlayMeshCodeMismatchException(
+                    "non-dem-terrain-split",
+                    cityObject.ActualMeshCode,
+                    cityObject.ActualMeshCode,
+                    requestedMeshCodeBounds,
+                    group.Key);
+            yield return (
+                cityObject with
+                {
+                    ActualMeshCode = terrainMeshCode,
+                    SlotKey = $"{cityObject.SlotKey}_terrain_{terrainMeshCode}",
+                    DisplayName = $"{cityObject.DisplayName} ({splitIndex + 1})",
+                    Surfaces = group.Select(static entry => MarkUsesGeneratedDemTexture(entry.Surface)).ToArray(),
+                    GeodeticOriginOverride = cityObjectOrigin,
+                },
+                group.Key);
+            splitIndex++;
+        }
+
+        if (untexturedSurfaces.Count != 0)
+        {
+            yield return (
+                cityObject with
+                {
+                    SlotKey = $"{cityObject.SlotKey}_terrain_none",
+                    DisplayName = $"{cityObject.DisplayName} ({splitIndex + 1})",
+                    Surfaces = untexturedSurfaces.ToArray(),
+                    GeodeticOriginOverride = cityObjectOrigin,
+                },
+                null);
+        }
+    }
+
+    private static ParsedSurface MarkUsesGeneratedDemTexture(ParsedSurface surface)
+    {
+        return surface with { UsesGeneratedDemTexture = true };
+    }
+
+    private static ParsedSurface NormalizeNonDemTerrainTextureSurface(ParsedSurface surface)
+    {
+        return surface.Semantic == ParsedSurfaceSemantic.Roof
+            ? surface
+            : surface with { Semantic = ParsedSurfaceSemantic.Roof };
+    }
+
+    private static bool IsNonDemTerrainTextureSurface(
+        ParsedSurface surface,
+        double cityObjectMinAltitude,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        return surface.TexturePayload is null
+            && !surface.UsesGeneratedDemTexture
+            && IsRoofTerrainTextureSurface(surface, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian);
+    }
+
+    private static bool IsRoofTerrainTextureSurface(
+        ParsedSurface surface,
+        double cityObjectMinAltitude,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (surface.Semantic == ParsedSurfaceSemantic.Roof)
+        {
+            return true;
+        }
+
+        if (surface.Semantic is not (ParsedSurfaceSemantic.Unknown
+            or ParsedSurfaceSemantic.Ground
+            or ParsedSurfaceSemantic.OuterCeiling
+            or ParsedSurfaceSemantic.OuterFloor))
+        {
+            return false;
+        }
+
+        Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
+        return normal is not null
+            && Math.Abs(normal.Y) >= 0.98
+            && IsAboveCityObjectBottomAltitude(surface, cityObjectMinAltitude);
+    }
+
+    private static bool IsAboveCityObjectBottomAltitude(
+        ParsedSurface surface,
+        double cityObjectMinAltitude)
+    {
+        double surfaceMinAltitude = surface.Vertices.Min(static vertex => vertex.Altitude);
+        return surfaceMinAltitude > cityObjectMinAltitude + UnknownRoofBottomAltitudeToleranceMeters;
+    }
+
+    private static bool TryCreateSurfaceGeographicBounds(
+        ParsedSurface surface,
+        out GeographicRectangle bounds)
+    {
+        GeodeticPoint[] vertices = surface.ExteriorRing.Vertices;
+        if (vertices.Length == 0)
+        {
+            bounds = new GeographicRectangle(0.0, 0.0, 0.0, 0.0);
+            return false;
+        }
+
+        bounds = new GeographicRectangle(
+            vertices.Min(static vertex => vertex.Latitude),
+            vertices.Max(static vertex => vertex.Latitude),
+            vertices.Min(static vertex => vertex.Longitude),
+            vertices.Max(static vertex => vertex.Longitude));
+        return true;
+    }
+
+    private static GeodeticPoint GetCityObjectOrigin(ParsedCityObject cityObject)
+    {
+        return CityObjectOriginResolver.Resolve(
+            cityObject.GeodeticOriginOverride,
+            cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
+    }
+
+    private static Float3? ComputeSurfaceNormal(
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        Float3[] positions = surface.Vertices
+            .Select(point => SceneAxisMapper.CreatePosition(
+                point.Latitude,
+                point.Longitude,
+                point.Altitude,
+                cityObjectOrigin.Latitude,
+                cityObjectOrigin.Longitude,
+                cityObjectOrigin.Altitude,
+                cityObjectCartesian))
+            .ToArray();
+        return ComputePolygonNormal(positions);
+    }
+
+    private static Float3? ComputePolygonNormal(IEnumerable<Float3> positions)
+    {
+        Float3[] points = positions.ToArray();
+        if (points.Length < 3)
+        {
+            return null;
+        }
+
+        double normalX = 0.0;
+        double normalY = 0.0;
+        double normalZ = 0.0;
+
+        for (int index = 0; index < points.Length; index++)
+        {
+            Float3 current = points[index];
+            Float3 next = points[(index + 1) % points.Length];
+            normalX += (current.Y - next.Y) * (current.Z + next.Z);
+            normalY += (current.Z - next.Z) * (current.X + next.X);
+            normalZ += (current.X - next.X) * (current.Y + next.Y);
+        }
+
+        double magnitude = Math.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ));
+        if (magnitude < 1e-8)
+        {
+            return null;
+        }
+
+        return new Float3(normalX / magnitude, normalY / magnitude, normalZ / magnitude);
+    }
+
+    private static InvalidOperationException CreateTerrainOverlayMeshCodeMismatchException(
+        string phase,
+        string actualMeshCode,
+        string requestedMeshCode,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
+        TerrainTextureOverlay? terrainOverlay)
+    {
+        return TerrainOverlayDiagnostics.CreateMeshCodeMismatchException(
+            phase,
+            actualMeshCode,
+            requestedMeshCode,
+            requestedMeshCodeBounds,
+            terrainOverlay);
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayProjectionSplitPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayProjectionSplitPolicy.cs
@@ -11,8 +11,6 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal static class TerrainOverlayProjectionSplitPolicy
 {
-    private const double UnknownRoofBottomAltitudeToleranceMeters = 0.1;
-
     internal static IEnumerable<(ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> SplitParsedCityObject(
         ParsedCityObject cityObject,
         IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
@@ -284,40 +282,11 @@ internal static class TerrainOverlayProjectionSplitPolicy
     {
         return surface.TexturePayload is null
             && !surface.UsesGeneratedDemTexture
-            && IsRoofTerrainTextureSurface(surface, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian);
-    }
-
-    private static bool IsRoofTerrainTextureSurface(
-        ParsedSurface surface,
-        double cityObjectMinAltitude,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        if (surface.Semantic == ParsedSurfaceSemantic.Roof)
-        {
-            return true;
-        }
-
-        if (surface.Semantic is not (ParsedSurfaceSemantic.Unknown
-            or ParsedSurfaceSemantic.Ground
-            or ParsedSurfaceSemantic.OuterCeiling
-            or ParsedSurfaceSemantic.OuterFloor))
-        {
-            return false;
-        }
-
-        Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
-        return normal is not null
-            && Math.Abs(normal.Y) >= 0.98
-            && IsAboveCityObjectBottomAltitude(surface, cityObjectMinAltitude);
-    }
-
-    private static bool IsAboveCityObjectBottomAltitude(
-        ParsedSurface surface,
-        double cityObjectMinAltitude)
-    {
-        double surfaceMinAltitude = surface.Vertices.Min(static vertex => vertex.Altitude);
-        return surfaceMinAltitude > cityObjectMinAltitude + UnknownRoofBottomAltitudeToleranceMeters;
+            && RoofTerrainTextureSurfacePolicy.IsRoofTerrainTextureSurface(
+                surface,
+                cityObjectMinAltitude,
+                cityObjectOrigin,
+                cityObjectCartesian);
     }
 
     private static bool TryCreateSurfaceGeographicBounds(
@@ -344,54 +313,6 @@ internal static class TerrainOverlayProjectionSplitPolicy
         return CityObjectOriginResolver.Resolve(
             cityObject.GeodeticOriginOverride,
             cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
-    }
-
-    private static Float3? ComputeSurfaceNormal(
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        Float3[] positions = surface.Vertices
-            .Select(point => SceneAxisMapper.CreatePosition(
-                point.Latitude,
-                point.Longitude,
-                point.Altitude,
-                cityObjectOrigin.Latitude,
-                cityObjectOrigin.Longitude,
-                cityObjectOrigin.Altitude,
-                cityObjectCartesian))
-            .ToArray();
-        return ComputePolygonNormal(positions);
-    }
-
-    private static Float3? ComputePolygonNormal(IEnumerable<Float3> positions)
-    {
-        Float3[] points = positions.ToArray();
-        if (points.Length < 3)
-        {
-            return null;
-        }
-
-        double normalX = 0.0;
-        double normalY = 0.0;
-        double normalZ = 0.0;
-
-        for (int index = 0; index < points.Length; index++)
-        {
-            Float3 current = points[index];
-            Float3 next = points[(index + 1) % points.Length];
-            normalX += (current.Y - next.Y) * (current.Z + next.Z);
-            normalY += (current.Z - next.Z) * (current.X + next.X);
-            normalZ += (current.X - next.X) * (current.Y + next.Y);
-        }
-
-        double magnitude = Math.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ));
-        if (magnitude < 1e-8)
-        {
-            return null;
-        }
-
-        return new Float3(normalX / magnitude, normalY / magnitude, normalZ / magnitude);
     }
 
     private static InvalidOperationException CreateTerrainOverlayMeshCodeMismatchException(

--- a/tests/PlateauResoniteLink.Tests/Profiles/RoofTerrainTextureSurfacePolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/RoofTerrainTextureSurfacePolicyTests.cs
@@ -1,0 +1,45 @@
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class RoofTerrainTextureSurfacePolicyTests
+{
+    [Fact]
+    public void IsRoofTerrainTextureSurfaceComputesUnknownSurfaceNormalFromExteriorRing()
+    {
+        ParsedSurface surface = new(
+            PolygonId: "surface-with-hole",
+            Semantic: ParsedSurfaceSemantic.Unknown,
+            ExteriorRing: new ParsedRing(
+                "surface-with-hole-exterior",
+                [
+                    new GeodeticPoint(35.0, 139.0, 10.0),
+                    new GeodeticPoint(35.0, 139.1, 10.0),
+                    new GeodeticPoint(35.1, 139.1, 10.0),
+                    new GeodeticPoint(35.1, 139.0, 10.0),
+                ],
+                UVs: null),
+            InteriorRings:
+            [
+                new ParsedRing(
+                    "surface-with-hole-interior",
+                    [
+                        new GeodeticPoint(35.02, 139.02, 10.0),
+                        new GeodeticPoint(35.08, 139.02, 80.0),
+                        new GeodeticPoint(35.08, 139.08, 10.0),
+                        new GeodeticPoint(35.02, 139.08, 80.0),
+                    ],
+                    UVs: null),
+            ],
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null);
+
+        bool result = RoofTerrainTextureSurfacePolicy.IsRoofTerrainTextureSurface(
+            surface,
+            cityObjectMinAltitude: 0.0,
+            cityObjectOrigin: new GeodeticPoint(35.0, 139.0, 0.0),
+            cityObjectCartesian: null);
+
+        Assert.True(result);
+    }
+}


### PR DESCRIPTION
## Summary
- extract non-DEM terrain overlay split selection from LocalCityGmlObjectProjection into TerrainOverlayProjectionSplitPolicy
- keep projection entrypoints focused on projecting already-split city objects and validating requested overlay eligibility
- preserve existing DEM split path through DemTerrainOverlayAssignment

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --no-build --filter "FullyQualifiedName~DemTerrainOverlayAssignmentTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests" --verbosity normal
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

Note: one full-test run first failed because C: had insufficient space while expanding project default-material temp assets under %TEMP%\PlateauResoniteLink; after deleting only that project temp directory, the same full-test command passed (842/842).