### PR TITLE
Extract surface material resolver

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -48,16 +48,15 @@ internal static class CityGmlSurfaceMaterialResolver
         ArgumentNullException.ThrowIfNull(cityObjectOrigin);
         ArgumentNullException.ThrowIfNull(materialResolver);
 
-        ProjectionSurface[] projectionSurfaces = cityObject.Surfaces
-            .Select(CityGmlProjectionModelAdapter.ToProjectionModel)
-            .ToArray();
-        HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
-            cityObject.PackageName,
-            projectionSurfaces,
-            cityObjectOrigin.ToProjectionModel(),
-            cityObjectCartesian);
+        HashSet<string> culledSurfaceIds = PlateauPackageCatalog.IsBuildingPackage(cityObject.PackageName)
+            ? GetCulledSurfaceIdsBeforeProjection(
+                cityObject.PackageName,
+                cityObject.Surfaces.Select(CityGmlProjectionModelAdapter.ToProjectionModel),
+                cityObjectOrigin.ToProjectionModel(),
+                cityObjectCartesian)
+            : [];
         double cityObjectMinAltitude = CityObjectAltitudeMetricsResolver.GetMinimumAltitude(
-            projectionSurfaces.SelectMany(static surface => surface.Vertices),
+            cityObject.Surfaces.SelectMany(static surface => surface.Vertices),
             static point => point.Altitude);
 
         foreach (ParsedSurface surface in cityObject.Surfaces.Where(surface => !culledSurfaceIds.Contains(surface.PolygonId)))

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -1,0 +1,555 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using GeographicLib;
+
+using PlateauResoniteLink.Domain.Importing;
+
+using ProjectionPoint = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.GeodeticPoint;
+using ProjectionSurface = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedSurface;
+using ProjectionSurfaceSemantic = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedSurfaceSemantic;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityGmlSurfaceMaterialResolver
+{
+    internal static readonly MaterialDepthOffset TerrainAlignedDepthOffset = new(-10.0, -10.0);
+
+    private const double BuildingBottomCullBandMeters = 0.1;
+    private const double UnknownRoofBottomAltitudeToleranceMeters = 0.1;
+    private static readonly ColorRgba DefaultMaterialColor = new(1.0, 1.0, 1.0, 1.0);
+    private static readonly ColorRgba DefaultVegetationMaterialColor = new(0.32, 0.58, 0.24, 1.0);
+
+    internal static ResolvedSurfaceMaterial[] ResolveSurfaces(
+        ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IDefaultMaterialResolver materialResolver)
+    {
+        ArgumentNullException.ThrowIfNull(cityObject);
+        ArgumentNullException.ThrowIfNull(cityObjectOrigin);
+        ArgumentNullException.ThrowIfNull(materialResolver);
+
+        ProjectionSurface[] projectionSurfaces = cityObject.Surfaces
+            .Select(CityGmlProjectionModelAdapter.ToProjectionModel)
+            .ToArray();
+        HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
+            cityObject.PackageName,
+            projectionSurfaces,
+            cityObjectOrigin.ToProjectionModel(),
+            cityObjectCartesian);
+        double cityObjectMinAltitude = CityObjectAltitudeMetricsResolver.GetMinimumAltitude(
+            projectionSurfaces.SelectMany(static surface => surface.Vertices),
+            static point => point.Altitude);
+
+        return
+        [
+            .. cityObject.Surfaces
+                .Where(surface => !culledSurfaceIds.Contains(surface.PolygonId))
+                .Select(surface => ResolveSurfaceMaterial(
+                    cityObject,
+                    cityObjectOrigin,
+                    cityObjectCartesian,
+                    surface,
+                    cityObjectMinAltitude,
+                    demTerrainTextureOverlay,
+                    materialResolver)),
+        ];
+    }
+
+    internal static MaterialBinding[] CreateSharedCommonMaterialBindings(
+        ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IDefaultMaterialResolver materialResolver)
+    {
+        return ResolveSurfaces(
+                cityObject,
+                cityObjectOrigin,
+                cityObjectCartesian,
+                demTerrainTextureOverlay,
+                materialResolver)
+            .GroupBy(
+                resolvedSurface => MaterialGroupingPolicy.CreateKey(
+                    cityObject.ActualMeshCode,
+                    resolvedSurface.Material,
+                    resolvedSurface.DepthOffset,
+                    resolvedSurface.Material.TextureScale,
+                    resolvedSurface.Surface.BaseColor,
+                    resolvedSurface.Material.TextureOffset))
+            .OrderBy(static group => group.Min(static surface => ParsedSurfaceStableSortKey.Create(surface.Surface)), StringComparer.Ordinal)
+            .Select((group, materialIndex) => CreateMaterialBinding(
+                cityObject.ActualMeshCode,
+                group.First(),
+                materialIndex))
+            .Where(static material => material.ReuseScope == MaterialReuseScope.Shared)
+            .ToArray();
+    }
+
+    internal static MaterialBinding[] CreateDemTerrainGridMaterials(
+        ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        string requestedMeshCode,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
+        IDefaultMaterialResolver materialResolver)
+    {
+        return ResolveSurfaces(
+                cityObject,
+                cityObjectOrigin,
+                cityObjectCartesian,
+                demTerrainTextureOverlay,
+                materialResolver)
+            .GroupBy(
+                resolvedSurface => MaterialGroupingPolicy.CreateKey(
+                    TerrainOverlayMeshCodeResolver.ResolveMaterialMeshCodeSource(
+                        cityObject.ActualMeshCode,
+                        requestedMeshCode,
+                        requestedMeshCodeBounds,
+                        resolvedSurface.Material.TerrainOverlay),
+                    resolvedSurface.Material,
+                    resolvedSurface.DepthOffset,
+                    resolvedSurface.Material.TextureScale,
+                    resolvedSurface.Surface.BaseColor,
+                    resolvedSurface.Material.TextureOffset))
+            .OrderBy(static group => group.Min(static surface => ParsedSurfaceStableSortKey.Create(surface.Surface)), StringComparer.Ordinal)
+            .Select((group, materialIndex) =>
+            {
+                ResolvedSurfaceMaterial representativeSurface = group.First();
+                string terrainMaterialMeshCodeSource = TerrainOverlayMeshCodeResolver.ResolveMaterialMeshCodeSource(
+                    cityObject.ActualMeshCode,
+                    requestedMeshCode,
+                    requestedMeshCodeBounds,
+                    representativeSurface.Material.TerrainOverlay);
+                return CreateMaterialBinding(
+                    terrainMaterialMeshCodeSource,
+                    representativeSurface,
+                    materialIndex);
+            })
+            .ToArray();
+    }
+
+    internal static MaterialBinding CreateMaterialBinding(
+        string actualMeshCode,
+        ResolvedSurfaceMaterial representativeSurface,
+        int materialIndex)
+    {
+        string? terrainMeshCode = representativeSurface.Material.TerrainOverlay is null
+            ? null
+            : TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, representativeSurface.Material.TerrainOverlay)
+                ?? throw TerrainOverlayDiagnostics.CreateMeshCodeMismatchException(
+                    "material-binding",
+                    actualMeshCode,
+                    actualMeshCode,
+                    requestedMeshCodeBounds: null,
+                    representativeSurface.Material.TerrainOverlay);
+        ColorRgba baseColor = representativeSurface.Material.TerrainOverlay is null
+            ? ToContractColor(representativeSurface.Surface.BaseColor)
+            : new ColorRgba(1.0, 1.0, 1.0, 1.0);
+        DefaultCommonMaterialMember? commonMaterial = DefaultCommonMaterialAssignment.Resolve(
+            baseColor,
+            representativeSurface.Material.MaterialType,
+            representativeSurface.Material.TexturePayload,
+            representativeSurface.Material.TextureSourceKind,
+            representativeSurface.Material.Projection,
+            representativeSurface.DepthOffset,
+            representativeSurface.Material.TextureScale,
+            representativeSurface.Material.TextureOffset,
+            representativeSurface.Material.TerrainOverlay,
+            representativeSurface.Material.CommonMaterial);
+        return new MaterialBinding(
+            BaseColor: baseColor,
+            MaterialType: representativeSurface.Material.MaterialType,
+            TexturePayload: representativeSurface.Material.TexturePayload,
+            TextureSourceKind: representativeSurface.Material.TextureSourceKind,
+            Projection: representativeSurface.Material.Projection,
+            DepthOffset: representativeSurface.DepthOffset,
+            SubmeshIndices: [materialIndex],
+            TextureScale: representativeSurface.Material.TextureScale,
+            Family: representativeSurface.Material.Family,
+            TextureOffset: representativeSurface.Material.TextureOffset,
+            ReuseScope: representativeSurface.Material.ReuseScope,
+            TerrainOverlay: representativeSurface.Material.TerrainOverlay,
+            BundledVariantIndex: representativeSurface.Material.BundledVariantIndex,
+            TerrainMeshCode: terrainMeshCode,
+            CommonMaterial: commonMaterial);
+    }
+
+    private static ResolvedSurfaceMaterial ResolveSurfaceMaterial(
+        ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        ParsedSurface surface,
+        double cityObjectMinAltitude,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IDefaultMaterialResolver materialResolver)
+    {
+        ProjectionSurface projectionSurface = CityGmlProjectionModelAdapter.ToProjectionModel(surface);
+        if (projectionSurface.UsesGeneratedDemTexture)
+        {
+            return new ResolvedSurfaceMaterial(
+                projectionSurface,
+                new ResolvedMaterial(
+                    MaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind.Dataset,
+                    MaterialProjection.Uv,
+                    Family: null,
+                    TextureScale: null,
+                    ReuseScope: MaterialReuseScope.PerObject,
+                    TerrainOverlay: demTerrainTextureOverlay),
+                DepthOffset: null);
+        }
+
+        ResolvedMaterial? roofTerrainTextureMaterial = TryCreateRoofTerrainTextureMaterial(
+            cityObject.ActualMeshCode,
+            cityObject.PackageName,
+            projectionSurface,
+            cityObjectMinAltitude,
+            demTerrainTextureOverlay,
+            cityObjectOrigin.ToProjectionModel(),
+            cityObjectCartesian);
+        if (roofTerrainTextureMaterial is not null)
+        {
+            return new ResolvedSurfaceMaterial(
+                projectionSurface with { BaseColor = DefaultMaterialColor },
+                roofTerrainTextureMaterial,
+                DepthOffset: null);
+        }
+
+        if (string.Equals(cityObject.PackageName, "veg", StringComparison.OrdinalIgnoreCase)
+            && projectionSurface.TexturePayload is null)
+        {
+            if (HasExplicitMaterialColor(projectionSurface.BaseColor))
+            {
+                return new ResolvedSurfaceMaterial(
+                    projectionSurface,
+                    new ResolvedMaterial(
+                        MaterialType.VertexColor,
+                        TexturePayload: null,
+                        TextureSourceKind.Bundled,
+                        MaterialProjection.Uv,
+                        Family: null,
+                        TextureScale: null,
+                        ReuseScope: MaterialReuseScope.PerObject),
+                    DepthOffset: null);
+            }
+
+            return new ResolvedSurfaceMaterial(
+                projectionSurface with { BaseColor = DefaultVegetationMaterialColor },
+                new ResolvedMaterial(
+                    MaterialType.Standard,
+                    TexturePayload: null,
+                    TextureSourceKind.Bundled,
+                    MaterialProjection.Uv,
+                    Family: null,
+                    TextureScale: null,
+                    ReuseScope: MaterialReuseScope.PerObject),
+                DepthOffset: null);
+        }
+
+        if (IsGeneratedRoadMarkingSurface(projectionSurface))
+        {
+            return new ResolvedSurfaceMaterial(
+                projectionSurface,
+                new ResolvedMaterial(
+                    MaterialType.VertexColor,
+                    TexturePayload: null,
+                    TextureSourceKind.Bundled,
+                    MaterialProjection.Uv,
+                    Family: null,
+                    TextureScale: null,
+                    ReuseScope: MaterialReuseScope.PerObject),
+                TerrainAlignedDepthOffset);
+        }
+
+        bool preferUvProjection = ShouldPreferUvProjection(
+            cityObject.PackageName,
+            projectionSurface,
+            cityObjectOrigin.ToProjectionModel(),
+            cityObjectCartesian);
+        ResolvedMaterial resolvedMaterial = materialResolver.ResolveMaterial(new DefaultMaterialRequest(
+            cityObject.PackageName,
+            projectionSurface.TexturePayload,
+            preferUvProjection,
+            FamilyOverride: null,
+            VariantSelectionKey: $"{cityObject.SlotKey}:{(preferUvProjection ? "uv" : "triplanar")}",
+            BuildingAttributes: cityObject.BuildingAttributes,
+            FloorsAboveGround: cityObject.FloorsAboveGround,
+            MeasuredHeightMeters: cityObject.MeasuredHeightMeters,
+            GeometryHeightMeters: cityObject.GeometryHeightMeters,
+            FootprintAreaSquareMeters: cityObject.BuildingAttributes is null
+                ? null
+                : BuildingAttributeQueries.TryGetKnownPositiveMetric(cityObject.BuildingAttributes.BuildingFootprintArea),
+            SurfaceRole: ToDefaultMaterialSurfaceRole(projectionSurface.Semantic)));
+        MaterialDepthOffset? depthOffset = cityObject.TerrainAligned
+            ? TerrainAlignedDepthOffset
+            : null;
+        return new ResolvedSurfaceMaterial(projectionSurface, resolvedMaterial, depthOffset);
+    }
+
+    private static ResolvedMaterial? TryCreateRoofTerrainTextureMaterial(
+        string actualMeshCode,
+        string packageName,
+        ProjectionSurface surface,
+        double cityObjectMinAltitude,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        ProjectionPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (demTerrainTextureOverlay is null
+            || TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, demTerrainTextureOverlay) is null
+            || surface.TexturePayload is not null
+            || !PlateauPackageCatalog.IsBuildingPackage(packageName)
+            || !IsRoofTerrainTextureSurface(surface, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian))
+        {
+            return null;
+        }
+
+        return new ResolvedMaterial(
+            MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind.Dataset,
+            MaterialProjection.Uv,
+            Family: null,
+            TextureScale: null,
+            ReuseScope: MaterialReuseScope.PerObject,
+            TerrainOverlay: demTerrainTextureOverlay);
+    }
+
+    private static bool ShouldPreferUvProjection(
+        string packageName,
+        ProjectionSurface surface,
+        ProjectionPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (surface.TexturePayload is not null)
+        {
+            return true;
+        }
+
+        if (string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!PlateauPackageCatalog.IsBuildingPackage(packageName))
+        {
+            return PlateauPackageCatalog.IsPathLikePackage(packageName)
+                && IsNearHorizontalSurface(surface, cityObjectOrigin, cityObjectCartesian);
+        }
+
+        if (surface.Semantic is ProjectionSurfaceSemantic.Wall)
+        {
+            return true;
+        }
+
+        if (surface.Semantic is ProjectionSurfaceSemantic.Roof
+            or ProjectionSurfaceSemantic.Ground
+            or ProjectionSurfaceSemantic.OuterCeiling
+            or ProjectionSurfaceSemantic.OuterFloor)
+        {
+            return false;
+        }
+
+        return IsFacadeSurface(surface, cityObjectOrigin, cityObjectCartesian);
+    }
+
+    private static DefaultMaterialSurfaceRole ToDefaultMaterialSurfaceRole(ProjectionSurfaceSemantic semantic)
+    {
+        return semantic switch
+        {
+            ProjectionSurfaceSemantic.Wall => DefaultMaterialSurfaceRole.Wall,
+            ProjectionSurfaceSemantic.Roof => DefaultMaterialSurfaceRole.Roof,
+            ProjectionSurfaceSemantic.Ground => DefaultMaterialSurfaceRole.Ground,
+            ProjectionSurfaceSemantic.Closure => DefaultMaterialSurfaceRole.Closure,
+            ProjectionSurfaceSemantic.OuterCeiling => DefaultMaterialSurfaceRole.OuterCeiling,
+            ProjectionSurfaceSemantic.OuterFloor => DefaultMaterialSurfaceRole.OuterFloor,
+            _ => DefaultMaterialSurfaceRole.Unknown,
+        };
+    }
+
+    private static bool IsRoofTerrainTextureSurface(
+        ProjectionSurface surface,
+        double cityObjectMinAltitude,
+        ProjectionPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (surface.Semantic == ProjectionSurfaceSemantic.Roof)
+        {
+            return true;
+        }
+
+        if (surface.Semantic is not (ProjectionSurfaceSemantic.Unknown
+            or ProjectionSurfaceSemantic.Ground
+            or ProjectionSurfaceSemantic.OuterCeiling
+            or ProjectionSurfaceSemantic.OuterFloor))
+        {
+            return false;
+        }
+
+        Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
+        return normal is not null
+            && Math.Abs(normal.Y) >= 0.98
+            && surface.Vertices.Min(static vertex => vertex.Altitude) > cityObjectMinAltitude + UnknownRoofBottomAltitudeToleranceMeters;
+    }
+
+    private static bool IsGeneratedRoadMarkingSurface(ProjectionSurface surface)
+    {
+        return surface.PolygonId.Contains("_generated_marking", StringComparison.Ordinal);
+    }
+
+    private static bool HasExplicitMaterialColor(ColorRgba color)
+    {
+        return color.A > 0.0
+            && (Math.Abs(color.R - 1.0) > 1e-6
+                || Math.Abs(color.G - 1.0) > 1e-6
+                || Math.Abs(color.B - 1.0) > 1e-6
+                || Math.Abs(color.A - 1.0) > 1e-6);
+    }
+
+    private static HashSet<string> GetCulledSurfaceIdsBeforeProjection(
+        string packageName,
+        IEnumerable<ProjectionSurface> surfaces,
+        ProjectionPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (!PlateauPackageCatalog.IsBuildingPackage(packageName))
+        {
+            return [];
+        }
+
+        SurfaceProjectionInfo[] candidates = surfaces
+            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
+            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
+            .ToArray();
+
+        if (candidates.Length == 0)
+        {
+            return [];
+        }
+
+        double objectMinimumY = candidates.Min(static info => info.MinimumY!.Value);
+        double objectMaximumY = candidates.Max(static info => info.MaximumY!.Value);
+
+        return candidates
+            .Where(static info => info.IsNearHorizontal)
+            .Where(info => info.MaximumY!.Value <= objectMinimumY + BuildingBottomCullBandMeters)
+            .Where(info => objectMaximumY > info.MaximumY!.Value + BuildingBottomCullBandMeters)
+            .Select(static info => info.Surface.PolygonId)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static bool IsFacadeSurface(
+        ProjectionSurface surface,
+        ProjectionPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian) is not Float3 normal)
+        {
+            return false;
+        }
+
+        return Math.Abs(normal.Y) < 0.45;
+    }
+
+    private static bool IsNearHorizontalSurface(
+        ProjectionSurface surface,
+        ProjectionPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
+        return normal is not null && Math.Abs(normal.Y) >= 0.98;
+    }
+
+    private static SurfaceProjectionInfo CreateSurfaceProjectionInfo(
+        ProjectionSurface surface,
+        ProjectionPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        Float3[] positions = surface.Vertices
+            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
+            .ToArray();
+        if (positions.Length == 0)
+        {
+            return new SurfaceProjectionInfo(surface, null, null, false);
+        }
+
+        Float3? normal = ComputePolygonNormal(positions);
+        bool isNearHorizontal = normal is not null && Math.Abs(normal.Y) >= 0.98;
+
+        return new SurfaceProjectionInfo(
+            surface,
+            positions.Min(static position => position.Y),
+            positions.Max(static position => position.Y),
+            isNearHorizontal);
+    }
+
+    private static Float3? ComputeSurfaceNormal(
+        ProjectionSurface surface,
+        ProjectionPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        Float3[] positions = surface.Vertices
+            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
+            .ToArray();
+        return ComputePolygonNormal(positions);
+    }
+
+    private static Float3 CreateScenePosition(
+        ProjectionPoint point,
+        ProjectionPoint origin,
+        LocalCartesian? cartesian)
+    {
+        return SceneAxisMapper.CreatePosition(
+            point.Latitude,
+            point.Longitude,
+            point.Altitude,
+            origin.Latitude,
+            origin.Longitude,
+            origin.Altitude,
+            cartesian);
+    }
+
+    private static Float3? ComputePolygonNormal(IEnumerable<Float3> positions)
+    {
+        Float3[] points = positions.ToArray();
+        if (points.Length < 3)
+        {
+            return null;
+        }
+
+        double normalX = 0.0;
+        double normalY = 0.0;
+        double normalZ = 0.0;
+
+        for (int index = 0; index < points.Length; index++)
+        {
+            Float3 current = points[index];
+            Float3 next = points[(index + 1) % points.Length];
+            normalX += (current.Y - next.Y) * (current.Z + next.Z);
+            normalY += (current.Z - next.Z) * (current.X + next.X);
+            normalZ += (current.X - next.X) * (current.Y + next.Y);
+        }
+
+        double magnitude = Math.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ));
+        if (magnitude < 1e-8)
+        {
+            return null;
+        }
+
+        return new Float3(normalX / magnitude, normalY / magnitude, normalZ / magnitude);
+    }
+
+    private static ColorRgba ToContractColor(ColorRgba value) => new(value.R, value.G, value.B, value.A);
+
+    private readonly record struct SurfaceProjectionInfo(
+        ProjectionSurface Surface,
+        double? MinimumY,
+        double? MaximumY,
+        bool IsNearHorizontal);
+}

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -28,6 +28,22 @@ internal static class CityGmlSurfaceMaterialResolver
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
+        return EnumerateSurfaces(
+                cityObject,
+                cityObjectOrigin,
+                cityObjectCartesian,
+                demTerrainTextureOverlay,
+                materialResolver)
+            .ToArray();
+    }
+
+    internal static IEnumerable<ResolvedSurfaceMaterial> EnumerateSurfaces(
+        ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IDefaultMaterialResolver materialResolver)
+    {
         ArgumentNullException.ThrowIfNull(cityObject);
         ArgumentNullException.ThrowIfNull(cityObjectOrigin);
         ArgumentNullException.ThrowIfNull(materialResolver);
@@ -44,19 +60,17 @@ internal static class CityGmlSurfaceMaterialResolver
             projectionSurfaces.SelectMany(static surface => surface.Vertices),
             static point => point.Altitude);
 
-        return
-        [
-            .. cityObject.Surfaces
-                .Where(surface => !culledSurfaceIds.Contains(surface.PolygonId))
-                .Select(surface => ResolveSurfaceMaterial(
-                    cityObject,
-                    cityObjectOrigin,
-                    cityObjectCartesian,
-                    surface,
-                    cityObjectMinAltitude,
-                    demTerrainTextureOverlay,
-                    materialResolver)),
-        ];
+        foreach (ParsedSurface surface in cityObject.Surfaces.Where(surface => !culledSurfaceIds.Contains(surface.PolygonId)))
+        {
+            yield return ResolveSurfaceMaterial(
+                cityObject,
+                cityObjectOrigin,
+                cityObjectCartesian,
+                surface,
+                cityObjectMinAltitude,
+                demTerrainTextureOverlay,
+                materialResolver);
+        }
     }
 
     internal static MaterialBinding[] CreateSharedCommonMaterialBindings(

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -144,7 +144,7 @@ internal static class CityGmlSurfaceMaterialResolver
                 ?? throw TerrainOverlayDiagnostics.CreateMeshCodeMismatchException(
                     "material-binding",
                     actualMeshCode,
-                    actualMeshCode,
+                    requestedMeshCode: null,
                     requestedMeshCodeBounds: null,
                     representativeSurface.Material.TerrainOverlay);
         ColorRgba baseColor = representativeSurface.Material.TerrainOverlay is null

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
@@ -359,7 +359,7 @@ internal static class DemTerrainOverlayAssignment
 
     public static (Float2? TextureScale, Float2? TextureOffset) TryCreateTerrainGridTextureTransform(
         ParsedCityObject cityObject,
-        LocalCityGmlObjectProjection.ResolvedSurfaceMaterial materializedSurface,
+        ResolvedSurfaceMaterial materializedSurface,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         GeographicRectangle? cityObjectGeographicBounds = null)
     {
@@ -377,7 +377,7 @@ internal static class DemTerrainOverlayAssignment
 
     public static TextureUvRect? TryCreateTerrainGridOccupiedUvRect(
         ParsedCityObject cityObject,
-        LocalCityGmlObjectProjection.ResolvedSurfaceMaterial materializedSurface,
+        ResolvedSurfaceMaterial materializedSurface,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         GeographicRectangle? cityObjectGeographicBounds = null)
     {

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -941,16 +941,10 @@ internal static class LocalCityGmlObjectProjection
             cityObjectOrigin.ToProjectionModel(),
             globalOriginPoint.ToProjectionModel(),
             globalCartesian);
-        HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
-            cityObject.PackageName,
-            cityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel),
-            cityObjectOrigin.ToProjectionModel(),
-            cityObjectCartesian);
         List<MeshVertex> vertices = [];
         List<MeshSubmesh> submeshes = [];
         List<MaterialBinding> materials = [];
         DemUvProjection? demUvProjection = TryCreateDemUvProjection(cityObject.ActualMeshCode, demTerrainTextureOverlay);
-        double cityObjectMinAltitude = ResolveParsedMinimumAltitude(cityObject.Surfaces);
 
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -4215,7 +4215,7 @@ internal static class LocalCityGmlObjectProjection
         }
 
         GeographicRectangle? demObjectBounds = TryGetDemObjectGeographicBounds(cityObject, demTerrainTextureOverlay);
-        ResolvedSurfaceMaterial? representativeSurface = CityGmlSurfaceMaterialResolver.ResolveSurfaces(
+        ResolvedSurfaceMaterial? representativeSurface = CityGmlSurfaceMaterialResolver.EnumerateSurfaces(
                 cityObject,
                 cityObjectOrigin,
                 cityObjectCartesian,

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -34,7 +34,7 @@ internal static class LocalCityGmlObjectProjection
     public const double DefaultTerrainAlignedTransportationSegmentLengthMeters = 5.0;
     public const double MinTerrainAlignedTransportationSegmentLengthMeters = 2.0;
     public const double TerrainAlignedTransportationSegmentLengthByWidthRatio = 0.8;
-    public static readonly MaterialDepthOffset DefaultTerrainAlignedMaterialDepthOffset = new(-10.0, -10.0);
+    public static readonly MaterialDepthOffset DefaultTerrainAlignedMaterialDepthOffset = CityGmlSurfaceMaterialResolver.TerrainAlignedDepthOffset;
 
     private static readonly Quaternion GridMeshTerrainRotation = new(
         X: Math.Sqrt(0.5),
@@ -954,16 +954,12 @@ internal static class LocalCityGmlObjectProjection
 
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
-            .. cityObject.Surfaces
-                .Where(surface => !culledSurfaceIds.Contains(surface.PolygonId))
-                .Select(surface => ResolveSurfaceMaterial(
-                    cityObject,
-                    cityObjectOrigin,
-                    cityObjectCartesian,
-                    surface,
-                    cityObjectMinAltitude,
-                    demTerrainTextureOverlay,
-                    materialResolver)),
+            .. CityGmlSurfaceMaterialResolver.ResolveSurfaces(
+                cityObject,
+                cityObjectOrigin,
+                cityObjectCartesian,
+                demTerrainTextureOverlay,
+                materialResolver),
         ];
 
         IGrouping<MaterialGroupingKey, ResolvedSurfaceMaterial>[] materialGroups = resolvedSurfaces
@@ -1013,7 +1009,7 @@ internal static class LocalCityGmlObjectProjection
 
             ResolvedSurfaceMaterial representativeSurface = materialGroup.First();
             submeshes.Add(new MeshSubmesh(materialIndex, indices));
-            materials.Add(CreateMaterialBinding(cityObject.ActualMeshCode, representativeSurface, materialIndex));
+            materials.Add(CityGmlSurfaceMaterialResolver.CreateMaterialBinding(cityObject.ActualMeshCode, representativeSurface, materialIndex));
         }
 
         return new ImportedCityObject(
@@ -1623,119 +1619,6 @@ internal static class LocalCityGmlObjectProjection
             ? DefaultTerrainAlignedMaterialDepthOffset
             : null;
         return new ResolvedSurfaceMaterial(surface, resolvedMaterial, depthOffset);
-    }
-
-    private static ResolvedSurfaceMaterial ResolveSurfaceMaterial(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian,
-        global::PlateauResoniteLink.Application.Importing.ParsedSurface surface,
-        double cityObjectMinAltitude,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        IDefaultMaterialResolver materialResolver)
-    {
-        ParsedSurface projectionSurface = global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface);
-        if (projectionSurface.UsesGeneratedDemTexture)
-        {
-            return new ResolvedSurfaceMaterial(
-                projectionSurface,
-                new ResolvedMaterial(
-                    MaterialType.Standard,
-                    TexturePayload: null,
-                    TextureSourceKind.Dataset,
-                    MaterialProjection.Uv,
-                    Family: null,
-                    TextureScale: null,
-                    ReuseScope: MaterialReuseScope.PerObject,
-                    TerrainOverlay: demTerrainTextureOverlay),
-                DepthOffset: null);
-        }
-
-        ResolvedMaterial? roofTerrainTextureMaterial = TryCreateRoofTerrainTextureMaterial(
-            cityObject.ActualMeshCode,
-            cityObject.PackageName,
-            projectionSurface,
-            cityObjectMinAltitude,
-            demTerrainTextureOverlay,
-            cityObjectOrigin.ToProjectionModel(),
-            cityObjectCartesian);
-        if (roofTerrainTextureMaterial is not null)
-        {
-            return new ResolvedSurfaceMaterial(
-                projectionSurface with { BaseColor = DefaultMaterialColor },
-                roofTerrainTextureMaterial,
-                DepthOffset: null);
-        }
-
-        if (string.Equals(cityObject.PackageName, "veg", StringComparison.OrdinalIgnoreCase)
-            && projectionSurface.TexturePayload is null)
-        {
-            if (HasExplicitMaterialColor(projectionSurface.BaseColor))
-            {
-                return new ResolvedSurfaceMaterial(
-                    projectionSurface,
-                    new ResolvedMaterial(
-                        MaterialType.VertexColor,
-                        TexturePayload: null,
-                        TextureSourceKind.Bundled,
-                        MaterialProjection.Uv,
-                        Family: null,
-                        TextureScale: null,
-                        ReuseScope: MaterialReuseScope.PerObject),
-                    DepthOffset: null);
-            }
-
-            return new ResolvedSurfaceMaterial(
-                projectionSurface with { BaseColor = DefaultVegetationMaterialColor },
-                new ResolvedMaterial(
-                    MaterialType.Standard,
-                    TexturePayload: null,
-                    TextureSourceKind.Bundled,
-                    MaterialProjection.Uv,
-                    Family: null,
-                    TextureScale: null,
-                    ReuseScope: MaterialReuseScope.PerObject),
-                DepthOffset: null);
-        }
-
-        if (IsGeneratedRoadMarkingSurface(projectionSurface))
-        {
-            return new ResolvedSurfaceMaterial(
-                projectionSurface,
-                new ResolvedMaterial(
-                    MaterialType.VertexColor,
-                    TexturePayload: null,
-                    TextureSourceKind.Bundled,
-                    MaterialProjection.Uv,
-                    Family: null,
-                    TextureScale: null,
-                    ReuseScope: MaterialReuseScope.PerObject),
-                DefaultTerrainAlignedMaterialDepthOffset);
-        }
-
-        bool preferUvProjection = ShouldPreferUvProjection(
-            cityObject.PackageName,
-            projectionSurface,
-            cityObjectOrigin.ToProjectionModel(),
-            cityObjectCartesian);
-        ResolvedMaterial resolvedMaterial = materialResolver.ResolveMaterial(new DefaultMaterialRequest(
-            cityObject.PackageName,
-            projectionSurface.TexturePayload,
-            preferUvProjection,
-            FamilyOverride: null,
-            VariantSelectionKey: $"{cityObject.SlotKey}:{(preferUvProjection ? "uv" : "triplanar")}",
-            BuildingAttributes: cityObject.BuildingAttributes,
-            FloorsAboveGround: cityObject.FloorsAboveGround,
-            MeasuredHeightMeters: cityObject.MeasuredHeightMeters,
-            GeometryHeightMeters: cityObject.GeometryHeightMeters,
-            FootprintAreaSquareMeters: cityObject.BuildingAttributes is null
-                ? null
-                : BuildingAttributeQueries.TryGetKnownPositiveMetric(cityObject.BuildingAttributes.BuildingFootprintArea),
-            SurfaceRole: ToDefaultMaterialSurfaceRole(projectionSurface.Semantic)));
-        MaterialDepthOffset? depthOffset = cityObject.TerrainAligned
-            ? DefaultTerrainAlignedMaterialDepthOffset
-            : null;
-        return new ResolvedSurfaceMaterial(projectionSurface, resolvedMaterial, depthOffset);
     }
 
     private static ResolvedMaterial? TryCreateRoofTerrainTextureMaterial(
@@ -3358,7 +3241,7 @@ internal static class LocalCityGmlObjectProjection
 
             foreach (MaterialBinding material in request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
                          && string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
-                            ? CreateDemTerrainGridMaterials(
+                            ? CityGmlSurfaceMaterialResolver.CreateDemTerrainGridMaterials(
                                 splitCityObject.CityObject,
                                 cityObjectOrigin,
                                 cityObjectCartesian,
@@ -3366,7 +3249,7 @@ internal static class LocalCityGmlObjectProjection
                                 request.MeshCode,
                                 requestedMeshCodeBounds,
                                 materialResolver)
-                            : CreateCommonMaterialBindings(
+                            : CityGmlSurfaceMaterialResolver.CreateSharedCommonMaterialBindings(
                                 splitCityObject.CityObject,
                                 cityObjectOrigin,
                                 cityObjectCartesian,
@@ -3564,58 +3447,6 @@ internal static class LocalCityGmlObjectProjection
             cityObjectOrigin,
             cityObjectCartesian);
         double cityObjectMinAltitude = ResolveProjectionMinimumAltitude(cityObject.Surfaces);
-        List<ResolvedSurfaceMaterial> resolvedSurfaces =
-        [
-            .. cityObject.Surfaces
-                .Where(surface => !culledSurfaceIds.Contains(surface.PolygonId))
-                .Select(surface => ResolveSurfaceMaterial(
-                    cityObject,
-                    cityObjectOrigin,
-                    cityObjectCartesian,
-                    surface,
-                    cityObjectMinAltitude,
-                    demTerrainTextureOverlay,
-                    materialResolver)),
-        ];
-
-        return resolvedSurfaces
-            .GroupBy(
-                resolvedSurface => MaterialGroupingPolicy.CreateKey(
-                    cityObject.ActualMeshCode,
-                    resolvedSurface.Material,
-                    resolvedSurface.DepthOffset,
-                    resolvedSurface.Material.TextureScale,
-                    resolvedSurface.Surface.BaseColor,
-                    resolvedSurface.Material.TextureOffset))
-            .OrderBy(static group => group.Min(static surface => ParsedSurfaceStableSortKey.Create(surface.Surface)), StringComparer.Ordinal)
-            .Select((group, materialIndex) =>
-            {
-                ResolvedSurfaceMaterial representativeSurface = group.First();
-                return CreateMaterialBinding(
-                    cityObject.ActualMeshCode,
-                    representativeSurface,
-                    materialIndex);
-            })
-            .Where(static material => material.ReuseScope == MaterialReuseScope.Shared)
-            .ToArray();
-    }
-
-    private static MaterialBinding[] CreateCommonMaterialBindings(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        IDefaultMaterialResolver materialResolver)
-    {
-        ParsedSurface[] projectionSurfaces = cityObject.Surfaces
-            .Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel)
-            .ToArray();
-        HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
-            cityObject.PackageName,
-            projectionSurfaces,
-            cityObjectOrigin.ToProjectionModel(),
-            cityObjectCartesian);
-        double cityObjectMinAltitude = ResolveProjectionMinimumAltitude(projectionSurfaces);
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
             .. cityObject.Surfaces
@@ -4142,7 +3973,7 @@ internal static class LocalCityGmlObjectProjection
         double minHeight = localHeights.Min();
         double maxHeight = localHeights.Max();
 
-        MaterialBinding[] materials = CreateDemTerrainGridMaterials(
+        MaterialBinding[] materials = CityGmlSurfaceMaterialResolver.CreateDemTerrainGridMaterials(
             cityObject,
             cityObjectOrigin,
             cityObjectCartesian,
@@ -4213,68 +4044,6 @@ internal static class LocalCityGmlObjectProjection
             cityObjectOrigin,
             cityObjectCartesian);
         double cityObjectMinAltitude = ResolveProjectionMinimumAltitude(cityObject.Surfaces);
-        List<ResolvedSurfaceMaterial> resolvedSurfaces =
-        [
-            .. cityObject.Surfaces
-                .Where(surface => !culledSurfaceIds.Contains(surface.PolygonId))
-                .Select(surface => ResolveSurfaceMaterial(
-                    cityObject,
-                    cityObjectOrigin,
-                    cityObjectCartesian,
-                    surface,
-                    cityObjectMinAltitude,
-                    demTerrainTextureOverlay,
-                    materialResolver)),
-        ];
-
-        return resolvedSurfaces
-            .GroupBy(
-                resolvedSurface => MaterialGroupingPolicy.CreateKey(
-                    TerrainOverlayMeshCodeResolver.ResolveMaterialMeshCodeSource(
-                        cityObject.ActualMeshCode,
-                        requestedMeshCode,
-                        requestedMeshCodeBounds,
-                        resolvedSurface.Material.TerrainOverlay),
-                    resolvedSurface.Material,
-                    resolvedSurface.DepthOffset,
-                    resolvedSurface.Material.TextureScale,
-                    resolvedSurface.Surface.BaseColor,
-                    resolvedSurface.Material.TextureOffset))
-            .OrderBy(static group => group.Min(static surface => ParsedSurfaceStableSortKey.Create(surface.Surface)), StringComparer.Ordinal)
-            .Select((group, materialIndex) =>
-            {
-                ResolvedSurfaceMaterial representativeSurface = group.First();
-                string terrainMaterialMeshCodeSource = TerrainOverlayMeshCodeResolver.ResolveMaterialMeshCodeSource(
-                    cityObject.ActualMeshCode,
-                    requestedMeshCode,
-                    requestedMeshCodeBounds,
-                    representativeSurface.Material.TerrainOverlay);
-                return CreateMaterialBinding(
-                    terrainMaterialMeshCodeSource,
-                    representativeSurface,
-                    materialIndex);
-            })
-            .ToArray();
-    }
-
-    private static MaterialBinding[] CreateDemTerrainGridMaterials(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        string requestedMeshCode,
-        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
-        IDefaultMaterialResolver materialResolver)
-    {
-        ParsedSurface[] projectionSurfaces = cityObject.Surfaces
-            .Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel)
-            .ToArray();
-        HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
-            cityObject.PackageName,
-            projectionSurfaces,
-            cityObjectOrigin.ToProjectionModel(),
-            cityObjectCartesian);
-        double cityObjectMinAltitude = ResolveProjectionMinimumAltitude(projectionSurfaces);
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
             .. cityObject.Surfaces
@@ -4452,16 +4221,12 @@ internal static class LocalCityGmlObjectProjection
         }
 
         GeographicRectangle? demObjectBounds = TryGetDemObjectGeographicBounds(cityObject, demTerrainTextureOverlay);
-        double cityObjectMinAltitude = ResolveParsedMinimumAltitude(cityObject.Surfaces);
-        ResolvedSurfaceMaterial? representativeSurface = cityObject.Surfaces
-            .Select(surface => ResolveSurfaceMaterial(
+        ResolvedSurfaceMaterial? representativeSurface = CityGmlSurfaceMaterialResolver.ResolveSurfaces(
                 cityObject,
                 cityObjectOrigin,
                 cityObjectCartesian,
-                surface,
-                cityObjectMinAltitude,
                 demTerrainTextureOverlay,
-                materialResolver))
+                materialResolver)
             .FirstOrDefault(static resolvedSurface => resolvedSurface.Surface.UsesGeneratedDemTexture);
         if (representativeSurface is null)
         {
@@ -5232,11 +4997,6 @@ internal static class LocalCityGmlObjectProjection
         public IEnumerable<GeodeticPoint> Vertices =>
             ExteriorRing.Vertices.Concat(InteriorRings.SelectMany(static ring => ring.Vertices));
     }
-
-    internal sealed record ResolvedSurfaceMaterial(
-        ParsedSurface Surface,
-        ResolvedMaterial Material,
-        MaterialDepthOffset? DepthOffset);
 
     private sealed record Lod1RoofFootprint(
         global::PlateauResoniteLink.Application.Importing.ParsedSurface TopSurface,

--- a/src/PlateauResoniteLink/Application/Importing/ResolvedSurfaceMaterial.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ResolvedSurfaceMaterial.cs
@@ -1,0 +1,6 @@
+namespace PlateauResoniteLink.Application.Importing;
+
+internal sealed record ResolvedSurfaceMaterial(
+    LocalCityGmlObjectProjection.ParsedSurface Surface,
+    ResolvedMaterial Material,
+    MaterialDepthOffset? DepthOffset);

--- a/src/PlateauResoniteLink/Targets/Resonite/AsyncInFlightResultCache.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/AsyncInFlightResultCache.cs
@@ -19,12 +19,27 @@ internal sealed class AsyncInFlightResultCache<TKey, TValue>
     {
         ArgumentNullException.ThrowIfNull(factory);
 
+        return await GetOrCreateAsync(
+            key,
+            _ => factory(),
+            factoryCancellationToken: CancellationToken.None,
+            cancellationToken);
+    }
+
+    public async Task<TValue> GetOrCreateAsync(
+        TKey key,
+        Func<CancellationToken, Task<TValue>> factory,
+        CancellationToken factoryCancellationToken,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
         if (completedValues.TryGetValue(key, out TValue? existingValue))
         {
             return existingValue;
         }
 
-        Task<TValue> task = await GetOrCreateTaskAsync(key, factory, cancellationToken);
+        Task<TValue> task = await GetOrCreateTaskAsync(key, factory, factoryCancellationToken, cancellationToken);
         return await task.WaitAsync(cancellationToken);
     }
 
@@ -59,7 +74,8 @@ internal sealed class AsyncInFlightResultCache<TKey, TValue>
 
     private async Task<Task<TValue>> GetOrCreateTaskAsync(
         TKey key,
-        Func<Task<TValue>> factory,
+        Func<CancellationToken, Task<TValue>> factory,
+        CancellationToken factoryCancellationToken,
         CancellationToken cancellationToken)
     {
         SemaphoreSlim gate = gates.GetOrAdd(key, static _ => new SemaphoreSlim(1, 1));
@@ -76,7 +92,7 @@ internal sealed class AsyncInFlightResultCache<TKey, TValue>
                 return existingTask;
             }
 
-            Task<TValue> createdTask = factory();
+            Task<TValue> createdTask = factory(factoryCancellationToken);
             inFlightTasks[key] = createdTask;
             ObserveCompletion(key, createdTask);
             return createdTask;

--- a/src/PlateauResoniteLink/Targets/Resonite/BundledTextureImportKey.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/BundledTextureImportKey.cs
@@ -1,0 +1,7 @@
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal readonly record struct BundledTextureImportKey(
+    BundledDefaultTextureAsset Asset,
+    string ColorProfile);

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -16,7 +16,7 @@ internal interface IResoniteMaterialPlanning
     Task<PlannedDedicatedMaterialAsset> PlanCommonMaterialAssetAsync(
         IResoniteLinkClient importClient,
         ResoniteMaterialBinding material,
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri> bundledTextureImportTasks,
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri> bundledTextureImportTasks,
         CancellationToken cancellationToken);
 
     Task<PlannedDedicatedMaterialAsset> PlanDedicatedMaterialAssetAsync(
@@ -44,7 +44,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
     public async Task<PlannedDedicatedMaterialAsset> PlanCommonMaterialAssetAsync(
         IResoniteLinkClient importClient,
         ResoniteMaterialBinding material,
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri> bundledTextureImportTasks,
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri> bundledTextureImportTasks,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(importClient);
@@ -329,7 +329,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         IResoniteLinkClient importClient,
         ResoniteMaterialBinding material,
         Task<Uri?> albedoTextureTask,
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri>? bundledTextureImportTasks,
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri>? bundledTextureImportTasks,
         CancellationToken cancellationToken)
     {
         Task<Uri?> normalTextureTask = Task.FromResult<Uri?>(null);
@@ -420,7 +420,25 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         IResoniteLinkClient importClient,
         BundledDefaultTextureAsset asset,
         string colorProfile,
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri>? bundledTextureImportTasks,
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri>? bundledTextureImportTasks,
+        CancellationToken cancellationToken)
+    {
+        if (bundledTextureImportTasks is null)
+        {
+            return await ImportBundledTextureCoreAsync(importClient, asset, colorProfile, cancellationToken);
+        }
+
+        BundledTextureImportKey importKey = new(asset, colorProfile);
+        return await bundledTextureImportTasks.GetOrCreateAsync(
+            importKey,
+            () => ImportBundledTextureCoreAsync(importClient, asset, colorProfile, cancellationToken),
+            cancellationToken);
+    }
+
+    private async Task<Uri> ImportBundledTextureCoreAsync(
+        IResoniteLinkClient importClient,
+        BundledDefaultTextureAsset asset,
+        string colorProfile,
         CancellationToken cancellationToken)
     {
         string absolutePath = bundledDefaultMaterialAssetStore.GetAbsolutePath(asset);
@@ -428,30 +446,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             absolutePath,
             colorProfile,
             cancellationToken);
-        return await ImportOptionalTextureAsync(
-            importClient,
-            textureImport,
-            asset,
-            bundledTextureImportTasks,
-            cancellationToken);
-    }
-
-    private static async Task<Uri?> ImportOptionalTextureAsync(
-        IResoniteLinkClient importClient,
-        ResoniteTextureImport textureImport,
-        BundledDefaultTextureAsset? bundledTextureImportAsset,
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri>? bundledTextureImportTasks,
-        CancellationToken cancellationToken)
-    {
-        if (bundledTextureImportTasks is null || bundledTextureImportAsset is null)
-        {
-            return await importClient.ImportTextureAsync(textureImport, cancellationToken);
-        }
-
-        return await bundledTextureImportTasks.GetOrCreateAsync(
-            bundledTextureImportAsset,
-            () => importClient.ImportTextureAsync(textureImport, cancellationToken),
-            cancellationToken);
+        return await importClient.ImportTextureAsync(textureImport, cancellationToken);
     }
 
     private Task<Uri?> ImportBundledAlbedoTextureAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -431,7 +431,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         BundledTextureImportKey importKey = new(asset, colorProfile);
         return await bundledTextureImportTasks.GetOrCreateAsync(
             importKey,
-            () => ImportBundledTextureCoreAsync(importClient, asset, colorProfile, cancellationToken),
+            () => ImportBundledTextureCoreAsync(importClient, asset, colorProfile, CancellationToken.None),
             cancellationToken);
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -431,7 +431,12 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         BundledTextureImportKey importKey = new(asset, colorProfile);
         return await bundledTextureImportTasks.GetOrCreateAsync(
             importKey,
-            () => ImportBundledTextureCoreAsync(importClient, asset, colorProfile, CancellationToken.None),
+            factoryCancellationToken => ImportBundledTextureCoreAsync(
+                importClient,
+                asset,
+                colorProfile,
+                factoryCancellationToken),
+            factoryCancellationToken: cancellationToken,
             cancellationToken);
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
@@ -4,8 +4,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class LiveSendProgressSink
@@ -48,7 +46,7 @@ internal sealed class CommonMaterialAssetCache
 
     public ResoniteCommonMaterialAssetAccumulator CommonMaterialAssets { get; } = new();
 
-    public AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri> BundledTextureImportTasks { get; } = new();
+    public AsyncInFlightResultCache<BundledTextureImportKey, Uri> BundledTextureImportTasks { get; } = new();
 }
 
 internal sealed class TerrainTextureAssetCache

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceMaterialResolverTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
@@ -7,6 +8,37 @@ namespace PlateauResoniteLink.Tests.Profiles;
 
 public sealed class CityGmlSurfaceMaterialResolverTests
 {
+    [Fact]
+    public void EnumerateSurfacesPreservesLazyScanAfterFirstGeneratedDemSurface()
+    {
+        CountingDefaultMaterialResolver materialResolver = new();
+        ParsedCityObject cityObject = new(
+            SlotKey: "dem-object",
+            DisplayName: "dem-object",
+            PackageName: "dem",
+            ActualMeshCode: "53394525",
+            LodLevel: null,
+            Surfaces:
+            [
+                CreateParsedSurface("generated-dem", usesGeneratedDemTexture: true),
+                CreateParsedSurface("ordinary-dem", usesGeneratedDemTexture: false),
+            ],
+            ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
+            SourceFileRelativePath: "udx/dem/53394525/sample.gml",
+            SharedAcrossMeshCodes: false);
+
+        ResolvedSurfaceMaterial? representativeSurface = CityGmlSurfaceMaterialResolver.EnumerateSurfaces(
+                cityObject,
+                cityObjectOrigin: new GeodeticPoint(35.0, 139.0, 0.0),
+                cityObjectCartesian: null,
+                demTerrainTextureOverlay: CreateOverlay("53394525"),
+                materialResolver)
+            .FirstOrDefault(static resolvedSurface => resolvedSurface.Surface.UsesGeneratedDemTexture);
+
+        Assert.NotNull(representativeSurface);
+        Assert.Equal(0, materialResolver.InvocationCount);
+    }
+
     [Fact]
     public void CreateMaterialBindingReportsMissingRequestedMeshCodeWhenOverlayDoesNotMatchActualMeshCode()
     {
@@ -32,6 +64,25 @@ public sealed class CityGmlSurfaceMaterialResolverTests
         Assert.Contains("phase='material-binding'", exception.Message, StringComparison.Ordinal);
         Assert.Contains("actual_mesh_code='53394600'", exception.Message, StringComparison.Ordinal);
         Assert.DoesNotContain("requested_mesh_code=", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static ParsedSurface CreateParsedSurface(string polygonId, bool usesGeneratedDemTexture)
+    {
+        return new ParsedSurface(
+            PolygonId: polygonId,
+            Semantic: ParsedSurfaceSemantic.Ground,
+            ExteriorRing: new ParsedRing(
+                $"{polygonId}-ring",
+                [
+                    new GeodeticPoint(35.0, 139.0, 10.0),
+                    new GeodeticPoint(35.0, 139.1, 10.0),
+                    new GeodeticPoint(35.1, 139.1, 10.0),
+                ],
+                UVs: null),
+            InteriorRings: [],
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null,
+            UsesGeneratedDemTexture: usesGeneratedDemTexture);
     }
 
     private static LocalCityGmlObjectProjection.ParsedSurface CreateSurface()
@@ -68,5 +119,23 @@ public sealed class CityGmlSurfaceMaterialResolverTests
                 bounds.WestLongitude,
                 bounds.EastLongitude),
             MaxTextureSize: 2048);
+    }
+
+    private sealed class CountingDefaultMaterialResolver : IDefaultMaterialResolver
+    {
+        public int InvocationCount { get; private set; }
+
+        public ResolvedMaterial ResolveMaterial(DefaultMaterialRequest request)
+        {
+            InvocationCount++;
+            return new ResolvedMaterial(
+                MaterialType.Standard,
+                TexturePayload: null,
+                TextureSourceKind.Bundled,
+                MaterialProjection.Uv,
+                Family: null,
+                TextureScale: null,
+                MaterialReuseScope.PerObject);
+        }
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceMaterialResolverTests.cs
@@ -1,0 +1,72 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class CityGmlSurfaceMaterialResolverTests
+{
+    [Fact]
+    public void CreateMaterialBindingReportsMissingRequestedMeshCodeWhenOverlayDoesNotMatchActualMeshCode()
+    {
+        ResolvedSurfaceMaterial representativeSurface = new(
+            CreateSurface(),
+            new ResolvedMaterial(
+                MaterialType.Standard,
+                TexturePayload: null,
+                TextureSourceKind.Bundled,
+                MaterialProjection.Uv,
+                Family: "terrain",
+                TextureScale: null,
+                MaterialReuseScope.Shared,
+                TerrainOverlay: CreateOverlay("53394525")),
+            DepthOffset: null);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CityGmlSurfaceMaterialResolver.CreateMaterialBinding(
+                "53394600",
+                representativeSurface,
+                materialIndex: 0));
+
+        Assert.Contains("phase='material-binding'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("actual_mesh_code='53394600'", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("requested_mesh_code=", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static LocalCityGmlObjectProjection.ParsedSurface CreateSurface()
+    {
+        return new LocalCityGmlObjectProjection.ParsedSurface(
+            PolygonId: "surface",
+            Semantic: LocalCityGmlObjectProjection.ParsedSurfaceSemantic.Roof,
+            ExteriorRing: new LocalCityGmlObjectProjection.ParsedRing(
+                "surface-ring",
+                [
+                    new LocalCityGmlObjectProjection.GeodeticPoint(35.0, 139.0, 10.0),
+                    new LocalCityGmlObjectProjection.GeodeticPoint(35.0, 139.1, 10.0),
+                    new LocalCityGmlObjectProjection.GeodeticPoint(35.1, 139.1, 10.0),
+                ],
+                UVs: null),
+            InteriorRings: [],
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null);
+    }
+
+    private static TerrainTextureOverlay CreateOverlay(string meshCode)
+    {
+        Assert.True(PlateauMeshCode.TryGetBounds(
+            meshCode,
+            out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds));
+
+        return new TerrainTextureOverlay(
+            PackageName: "dem",
+            UrlTemplate: $"https://terrain.example/{meshCode}/{{z}}/{{x}}/{{y}}.png",
+            ZoomLevel: 18,
+            GeographicBounds: new GeographicRectangle(
+                bounds.SouthLatitude,
+                bounds.NorthLatitude,
+                bounds.WestLongitude,
+                bounds.EastLongitude),
+            MaxTextureSize: 2048);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
@@ -370,7 +370,7 @@ public sealed class DemTerrainOverlayAssignmentTests
             MaxTextureSize: DemTerrainTextureDefaults.MaxTextureSize,
             Sources: [new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", 18)]);
         GeographicRectangle objectBounds = GetSurfaceBounds(surface);
-        LocalCityGmlObjectProjection.ResolvedSurfaceMaterial material = new(
+        ResolvedSurfaceMaterial material = new(
             CityGmlProjectionModelAdapter.ToProjectionModel(surface),
             new ResolvedMaterial(
                 MaterialType.Standard,

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -3646,29 +3646,12 @@ public sealed class LocalCityGmlObjectProjectionTests
         LocalCityGmlObjectProjection.GeodeticPoint cityObjectOrigin,
         GeographicLib.LocalCartesian cartesian)
     {
-        MethodInfo method = typeof(LocalCityGmlObjectProjection)
-            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
-            .Single(candidate =>
-            {
-                if (!string.Equals(candidate.Name, "CreateCommonMaterialBindings", StringComparison.Ordinal))
-                {
-                    return false;
-                }
-
-                ParameterInfo[] parameters = candidate.GetParameters();
-                return parameters.Length == 5
-                    && parameters[0].ParameterType == typeof(ParsedCityObject);
-            });
-
-        return (MaterialBinding[])method.Invoke(
-            null,
-            [
-                cityObject,
-                GeodeticPoint.FromProjectionModel(cityObjectOrigin),
-                cartesian,
-                null,
-                new DefaultMaterialResolver(CommonMaterialCatalog.Create()),
-            ])!;
+        return CityGmlSurfaceMaterialResolver.CreateSharedCommonMaterialBindings(
+            cityObject,
+            GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            cartesian,
+            demTerrainTextureOverlay: null,
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
     }
 
     private static bool IsBuildingFacadeMaterial(MaterialBinding material)

--- a/tests/PlateauResoniteLink.Tests/Targets/AsyncInFlightResultCacheTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/AsyncInFlightResultCacheTests.cs
@@ -68,4 +68,28 @@ public sealed class AsyncInFlightResultCacheTests
         Assert.Equal(1, Volatile.Read(ref invocationCount));
         Assert.Equal(42, result);
     }
+
+    [Fact]
+    public async Task GetOrCreateAsyncPassesFactoryCancellationTokenToCreatedTask()
+    {
+        PlateauResoniteLink.Targets.Resonite.AsyncInFlightResultCache<string, int> cache = new();
+        using CancellationTokenSource factoryCancellation = new();
+        TaskCompletionSource factoryStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<int> request = cache.GetOrCreateAsync(
+            "shared",
+            async cancellationToken =>
+            {
+                factoryStarted.SetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return 42;
+            },
+            factoryCancellation.Token,
+            CancellationToken.None);
+
+        await factoryStarted.Task;
+        await factoryCancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await request);
+    }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -42,7 +42,7 @@ public sealed class ResoniteMaterialPlanningTests
         PlannedDedicatedMaterialAsset plannedAsset = await planning.PlanCommonMaterialAssetAsync(
             client,
             material,
-            new AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri>(),
+            new AsyncInFlightResultCache<BundledTextureImportKey, Uri>(),
             CancellationToken.None);
 
         PlannedTextureAsset metallicAsset = Assert.Single(
@@ -63,7 +63,7 @@ public sealed class ResoniteMaterialPlanningTests
     {
         using SceneSinkRecordingClient client = new();
         ResoniteMaterialPlanning planning = new(new BundledDefaultMaterialAssetStore());
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri> bundledTextureImportTasks = new();
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri> bundledTextureImportTasks = new();
         ResoniteMaterialBinding uvMaterial = CreateRoadMaterial(ResoniteMaterialProjection.Uv);
         ResoniteMaterialBinding triplanarMaterial = CreateRoadMaterial(ResoniteMaterialProjection.Triplanar);
 
@@ -88,7 +88,7 @@ public sealed class ResoniteMaterialPlanningTests
     {
         using SceneSinkRecordingClient client = new();
         ResoniteMaterialPlanning planning = new(new BundledDefaultMaterialAssetStore());
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri> bundledTextureImportTasks = new();
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri> bundledTextureImportTasks = new();
         ResoniteMaterialBinding baseMaterial = CreateBundledMaterial(BundledDefaultMaterialFamilies.WallResidentialPlasterLow, 0);
         ResoniteMaterialBinding colorVariantMaterial = CreateBundledMaterial(BundledDefaultMaterialFamilies.WallResidentialPlasterLow, 1);
 
@@ -128,7 +128,7 @@ public sealed class ResoniteMaterialPlanningTests
     {
         using SceneSinkRecordingClient client = new();
         ResoniteMaterialPlanning planning = new(new BundledDefaultMaterialAssetStore());
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri> bundledTextureImportTasks = new();
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri> bundledTextureImportTasks = new();
         ResoniteMaterialBinding baseMaterial = CreateBundledMaterial(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0);
         ResoniteMaterialBinding colorVariantMaterial = CreateBundledMaterial(BundledDefaultMaterialFamilies.FacadeHighriseNightLow, 0);
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -18,6 +18,19 @@ namespace PlateauResoniteLink.Tests.Targets;
 public sealed class ResoniteMaterialPlanningTests
 {
     [Fact]
+    public void BundledTextureImportKeySeparatesSameTextureAssetByColorProfile()
+    {
+        BundledTextureImportKey srgbKey = new(
+            BundledDefaultTextureAssets.Facade.Facade001.Albedo,
+            ResoniteTextureColorProfiles.Srgb);
+        BundledTextureImportKey linearKey = new(
+            BundledDefaultTextureAssets.Facade.Facade001.Albedo,
+            ResoniteTextureColorProfiles.Linear);
+
+        Assert.NotEqual(srgbKey, linearKey);
+    }
+
+    [Fact]
     public async Task PlanCommonMaterialAssetAsyncImportsMetallicCompanionTextureWithLinearProfile()
     {
         using SceneSinkRecordingClient client = new();


### PR DESCRIPTION
## Summary
- extract external ParsedCityObject surface material resolution into CityGmlSurfaceMaterialResolver
- move ResolvedSurfaceMaterial out of LocalCityGmlObjectProjection's nested state
- remove private-reflection test coupling for common material binding behavior

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --no-build --filter "FullyQualifiedName~DemTerrainOverlayAssignmentTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests|FullyQualifiedName~MaterialGroupingPolicyTests" --verbosity normal
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

Note: the first full-test attempt hit local C: temp-space exhaustion while expanding bundled default materials under %TEMP%\PlateauResoniteLink. After removing that project temp directory, the same full command passed: 842/842.