### PR TITLE
Cache bundled texture imports before decode

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/AsyncInFlightResultCache.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/AsyncInFlightResultCache.cs
@@ -19,12 +19,27 @@ internal sealed class AsyncInFlightResultCache<TKey, TValue>
     {
         ArgumentNullException.ThrowIfNull(factory);
 
+        return await GetOrCreateAsync(
+            key,
+            _ => factory(),
+            factoryCancellationToken: CancellationToken.None,
+            cancellationToken);
+    }
+
+    public async Task<TValue> GetOrCreateAsync(
+        TKey key,
+        Func<CancellationToken, Task<TValue>> factory,
+        CancellationToken factoryCancellationToken,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
         if (completedValues.TryGetValue(key, out TValue? existingValue))
         {
             return existingValue;
         }
 
-        Task<TValue> task = await GetOrCreateTaskAsync(key, factory, cancellationToken);
+        Task<TValue> task = await GetOrCreateTaskAsync(key, factory, factoryCancellationToken, cancellationToken);
         return await task.WaitAsync(cancellationToken);
     }
 
@@ -59,7 +74,8 @@ internal sealed class AsyncInFlightResultCache<TKey, TValue>
 
     private async Task<Task<TValue>> GetOrCreateTaskAsync(
         TKey key,
-        Func<Task<TValue>> factory,
+        Func<CancellationToken, Task<TValue>> factory,
+        CancellationToken factoryCancellationToken,
         CancellationToken cancellationToken)
     {
         SemaphoreSlim gate = gates.GetOrAdd(key, static _ => new SemaphoreSlim(1, 1));
@@ -76,7 +92,7 @@ internal sealed class AsyncInFlightResultCache<TKey, TValue>
                 return existingTask;
             }
 
-            Task<TValue> createdTask = factory();
+            Task<TValue> createdTask = factory(factoryCancellationToken);
             inFlightTasks[key] = createdTask;
             ObserveCompletion(key, createdTask);
             return createdTask;

--- a/src/PlateauResoniteLink/Targets/Resonite/BundledTextureImportKey.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/BundledTextureImportKey.cs
@@ -1,0 +1,7 @@
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal readonly record struct BundledTextureImportKey(
+    BundledDefaultTextureAsset Asset,
+    string ColorProfile);

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -16,7 +16,7 @@ internal interface IResoniteMaterialPlanning
     Task<PlannedDedicatedMaterialAsset> PlanCommonMaterialAssetAsync(
         IResoniteLinkClient importClient,
         ResoniteMaterialBinding material,
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri> bundledTextureImportTasks,
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri> bundledTextureImportTasks,
         CancellationToken cancellationToken);
 
     Task<PlannedDedicatedMaterialAsset> PlanDedicatedMaterialAssetAsync(
@@ -44,7 +44,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
     public async Task<PlannedDedicatedMaterialAsset> PlanCommonMaterialAssetAsync(
         IResoniteLinkClient importClient,
         ResoniteMaterialBinding material,
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri> bundledTextureImportTasks,
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri> bundledTextureImportTasks,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(importClient);
@@ -329,7 +329,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         IResoniteLinkClient importClient,
         ResoniteMaterialBinding material,
         Task<Uri?> albedoTextureTask,
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri>? bundledTextureImportTasks,
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri>? bundledTextureImportTasks,
         CancellationToken cancellationToken)
     {
         Task<Uri?> normalTextureTask = Task.FromResult<Uri?>(null);
@@ -420,7 +420,25 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         IResoniteLinkClient importClient,
         BundledDefaultTextureAsset asset,
         string colorProfile,
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri>? bundledTextureImportTasks,
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri>? bundledTextureImportTasks,
+        CancellationToken cancellationToken)
+    {
+        if (bundledTextureImportTasks is null)
+        {
+            return await ImportBundledTextureCoreAsync(importClient, asset, colorProfile, cancellationToken);
+        }
+
+        BundledTextureImportKey importKey = new(asset, colorProfile);
+        return await bundledTextureImportTasks.GetOrCreateAsync(
+            importKey,
+            () => ImportBundledTextureCoreAsync(importClient, asset, colorProfile, cancellationToken),
+            cancellationToken);
+    }
+
+    private async Task<Uri> ImportBundledTextureCoreAsync(
+        IResoniteLinkClient importClient,
+        BundledDefaultTextureAsset asset,
+        string colorProfile,
         CancellationToken cancellationToken)
     {
         string absolutePath = bundledDefaultMaterialAssetStore.GetAbsolutePath(asset);
@@ -428,30 +446,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             absolutePath,
             colorProfile,
             cancellationToken);
-        return await ImportOptionalTextureAsync(
-            importClient,
-            textureImport,
-            asset,
-            bundledTextureImportTasks,
-            cancellationToken);
-    }
-
-    private static async Task<Uri?> ImportOptionalTextureAsync(
-        IResoniteLinkClient importClient,
-        ResoniteTextureImport textureImport,
-        BundledDefaultTextureAsset? bundledTextureImportAsset,
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri>? bundledTextureImportTasks,
-        CancellationToken cancellationToken)
-    {
-        if (bundledTextureImportTasks is null || bundledTextureImportAsset is null)
-        {
-            return await importClient.ImportTextureAsync(textureImport, cancellationToken);
-        }
-
-        return await bundledTextureImportTasks.GetOrCreateAsync(
-            bundledTextureImportAsset,
-            () => importClient.ImportTextureAsync(textureImport, cancellationToken),
-            cancellationToken);
+        return await importClient.ImportTextureAsync(textureImport, cancellationToken);
     }
 
     private Task<Uri?> ImportBundledAlbedoTextureAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -431,7 +431,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         BundledTextureImportKey importKey = new(asset, colorProfile);
         return await bundledTextureImportTasks.GetOrCreateAsync(
             importKey,
-            () => ImportBundledTextureCoreAsync(importClient, asset, colorProfile, cancellationToken),
+            () => ImportBundledTextureCoreAsync(importClient, asset, colorProfile, CancellationToken.None),
             cancellationToken);
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -431,7 +431,12 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         BundledTextureImportKey importKey = new(asset, colorProfile);
         return await bundledTextureImportTasks.GetOrCreateAsync(
             importKey,
-            () => ImportBundledTextureCoreAsync(importClient, asset, colorProfile, CancellationToken.None),
+            factoryCancellationToken => ImportBundledTextureCoreAsync(
+                importClient,
+                asset,
+                colorProfile,
+                factoryCancellationToken),
+            factoryCancellationToken: cancellationToken,
             cancellationToken);
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
@@ -4,8 +4,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class LiveSendProgressSink
@@ -48,7 +46,7 @@ internal sealed class CommonMaterialAssetCache
 
     public ResoniteCommonMaterialAssetAccumulator CommonMaterialAssets { get; } = new();
 
-    public AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri> BundledTextureImportTasks { get; } = new();
+    public AsyncInFlightResultCache<BundledTextureImportKey, Uri> BundledTextureImportTasks { get; } = new();
 }
 
 internal sealed class TerrainTextureAssetCache

--- a/tests/PlateauResoniteLink.Tests/Targets/AsyncInFlightResultCacheTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/AsyncInFlightResultCacheTests.cs
@@ -68,4 +68,28 @@ public sealed class AsyncInFlightResultCacheTests
         Assert.Equal(1, Volatile.Read(ref invocationCount));
         Assert.Equal(42, result);
     }
+
+    [Fact]
+    public async Task GetOrCreateAsyncPassesFactoryCancellationTokenToCreatedTask()
+    {
+        PlateauResoniteLink.Targets.Resonite.AsyncInFlightResultCache<string, int> cache = new();
+        using CancellationTokenSource factoryCancellation = new();
+        TaskCompletionSource factoryStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<int> request = cache.GetOrCreateAsync(
+            "shared",
+            async cancellationToken =>
+            {
+                factoryStarted.SetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return 42;
+            },
+            factoryCancellation.Token,
+            CancellationToken.None);
+
+        await factoryStarted.Task;
+        await factoryCancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await request);
+    }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -42,7 +42,7 @@ public sealed class ResoniteMaterialPlanningTests
         PlannedDedicatedMaterialAsset plannedAsset = await planning.PlanCommonMaterialAssetAsync(
             client,
             material,
-            new AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri>(),
+            new AsyncInFlightResultCache<BundledTextureImportKey, Uri>(),
             CancellationToken.None);
 
         PlannedTextureAsset metallicAsset = Assert.Single(
@@ -63,7 +63,7 @@ public sealed class ResoniteMaterialPlanningTests
     {
         using SceneSinkRecordingClient client = new();
         ResoniteMaterialPlanning planning = new(new BundledDefaultMaterialAssetStore());
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri> bundledTextureImportTasks = new();
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri> bundledTextureImportTasks = new();
         ResoniteMaterialBinding uvMaterial = CreateRoadMaterial(ResoniteMaterialProjection.Uv);
         ResoniteMaterialBinding triplanarMaterial = CreateRoadMaterial(ResoniteMaterialProjection.Triplanar);
 
@@ -88,7 +88,7 @@ public sealed class ResoniteMaterialPlanningTests
     {
         using SceneSinkRecordingClient client = new();
         ResoniteMaterialPlanning planning = new(new BundledDefaultMaterialAssetStore());
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri> bundledTextureImportTasks = new();
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri> bundledTextureImportTasks = new();
         ResoniteMaterialBinding baseMaterial = CreateBundledMaterial(BundledDefaultMaterialFamilies.WallResidentialPlasterLow, 0);
         ResoniteMaterialBinding colorVariantMaterial = CreateBundledMaterial(BundledDefaultMaterialFamilies.WallResidentialPlasterLow, 1);
 
@@ -128,7 +128,7 @@ public sealed class ResoniteMaterialPlanningTests
     {
         using SceneSinkRecordingClient client = new();
         ResoniteMaterialPlanning planning = new(new BundledDefaultMaterialAssetStore());
-        AsyncInFlightResultCache<BundledDefaultTextureAsset, Uri> bundledTextureImportTasks = new();
+        AsyncInFlightResultCache<BundledTextureImportKey, Uri> bundledTextureImportTasks = new();
         ResoniteMaterialBinding baseMaterial = CreateBundledMaterial(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0);
         ResoniteMaterialBinding colorVariantMaterial = CreateBundledMaterial(BundledDefaultMaterialFamilies.FacadeHighriseNightLow, 0);
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -18,6 +18,19 @@ namespace PlateauResoniteLink.Tests.Targets;
 public sealed class ResoniteMaterialPlanningTests
 {
     [Fact]
+    public void BundledTextureImportKeySeparatesSameTextureAssetByColorProfile()
+    {
+        BundledTextureImportKey srgbKey = new(
+            BundledDefaultTextureAssets.Facade.Facade001.Albedo,
+            ResoniteTextureColorProfiles.Srgb);
+        BundledTextureImportKey linearKey = new(
+            BundledDefaultTextureAssets.Facade.Facade001.Albedo,
+            ResoniteTextureColorProfiles.Linear);
+
+        Assert.NotEqual(srgbKey, linearKey);
+    }
+
+    [Fact]
     public async Task PlanCommonMaterialAssetAsyncImportsMetallicCompanionTextureWithLinearProfile()
     {
         using SceneSinkRecordingClient client = new();


### PR DESCRIPTION
## Summary
- key bundled common-material texture imports by texture asset plus color profile
- move bundled material extraction and ImageSharp decode inside the in-flight cache factory
- keep existing semantic texture output while avoiding repeated decode/import work for shared bundled assets

## Verification
- TEMP/TMP=D:\Temp\PlateauResoniteLinkCodex dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- TEMP/TMP=D:\Temp\PlateauResoniteLinkCodex dotnet format whitespace . --folder --verify-no-changes
- TEMP/TMP=D:\Temp\PlateauResoniteLinkCodex dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- TEMP/TMP=D:\Temp\PlateauResoniteLinkCodex dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

Note: the first full-test attempt hit local C: disk exhaustion and left temp/default-material state corrupt. I removed only this worktree's generated artifacts and reran the official sequence with TEMP/TMP on D:, after which all 842 tests passed.