### PR TITLE
Repair truncated bundled material extractions

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/BundledDefaultMaterialAssetStore.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/BundledDefaultMaterialAssetStore.cs
@@ -50,9 +50,9 @@ internal sealed class BundledDefaultMaterialAssetStore
 
         lock (SyncRoot)
         {
-            if (File.Exists(absolutePath)
-                && ResourceLengths.TryGetValue(resourceName, out long expectedLength)
-                && new FileInfo(absolutePath).Length == expectedLength)
+            if (ResourceLengths.TryGetValue(resourceName, out long expectedLength)
+                && TryGetExistingFileLength(absolutePath, out long existingLength)
+                && existingLength == expectedLength)
             {
                 return absolutePath;
             }
@@ -60,13 +60,10 @@ internal sealed class BundledDefaultMaterialAssetStore
             using Stream resourceStream = Assembly.GetManifestResourceStream(resourceName)
                 ?? throw new InvalidOperationException($"Embedded resource '{resourceName}' was not found.");
             ResourceLengths[resourceName] = resourceStream.Length;
-            if (File.Exists(absolutePath))
+            if (TryGetExistingFileLength(absolutePath, out existingLength)
+                && existingLength == resourceStream.Length)
             {
-                FileInfo existingFile = new(absolutePath);
-                if (existingFile.Length == resourceStream.Length)
-                {
-                    return absolutePath;
-                }
+                return absolutePath;
             }
 
             Directory.CreateDirectory(directory);
@@ -150,6 +147,31 @@ internal sealed class BundledDefaultMaterialAssetStore
         }
 
         return false;
+    }
+
+    internal static bool TryGetExistingFileLength(string path, out long length)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                length = 0;
+                return false;
+            }
+
+            length = new FileInfo(path).Length;
+            return true;
+        }
+        catch (IOException)
+        {
+            length = 0;
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            length = 0;
+            return false;
+        }
     }
 
     private static string CreateNormalizedResourceSuffix(string relativePath)

--- a/src/PlateauResoniteLink/Targets/Resonite/BundledDefaultMaterialAssetStore.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/BundledDefaultMaterialAssetStore.cs
@@ -49,20 +49,19 @@ internal sealed class BundledDefaultMaterialAssetStore
 
         lock (SyncRoot)
         {
+            using Stream resourceStream = Assembly.GetManifestResourceStream(resourceName)
+                ?? throw new InvalidOperationException($"Embedded resource '{resourceName}' was not found.");
             if (File.Exists(absolutePath))
             {
-                return absolutePath;
+                FileInfo existingFile = new(absolutePath);
+                if (existingFile.Length == resourceStream.Length)
+                {
+                    return absolutePath;
+                }
             }
 
             Directory.CreateDirectory(directory);
-            using Stream resourceStream = Assembly.GetManifestResourceStream(resourceName)
-                ?? throw new InvalidOperationException($"Embedded resource '{resourceName}' was not found.");
-            using FileStream fileStream = new(
-                absolutePath,
-                FileMode.Create,
-                FileAccess.Write,
-                FileShare.Read);
-            resourceStream.CopyTo(fileStream);
+            WriteResourceAtomically(absolutePath, resourceStream);
         }
 
         return absolutePath;
@@ -163,6 +162,31 @@ internal sealed class BundledDefaultMaterialAssetStore
     private static string GetExtractionRoot()
     {
         return ExtractionRootOverride.Value ?? DefaultExtractionRoot;
+    }
+
+    private static void WriteResourceAtomically(string absolutePath, Stream resourceStream)
+    {
+        string temporaryPath = $"{absolutePath}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            using (FileStream fileStream = new(
+                temporaryPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None))
+            {
+                resourceStream.CopyTo(fileStream);
+            }
+
+            File.Move(temporaryPath, absolutePath, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(temporaryPath))
+            {
+                File.Delete(temporaryPath);
+            }
+        }
     }
 
     private sealed class ExtractionRootOverrideScope(string? previousRoot) : IDisposable

--- a/src/PlateauResoniteLink/Targets/Resonite/BundledDefaultMaterialAssetStore.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/BundledDefaultMaterialAssetStore.cs
@@ -21,6 +21,7 @@ internal sealed class BundledDefaultMaterialAssetStore
     private static readonly HashSet<string> ResourceNames = Assembly
         .GetManifestResourceNames()
         .ToHashSet(StringComparer.Ordinal);
+    private static readonly Dictionary<string, long> ResourceLengths = new(StringComparer.Ordinal);
     private static readonly AsyncLocal<string?> ExtractionRootOverride = new();
     private static readonly string DefaultExtractionRoot = Path.Combine(
         Path.GetTempPath(),
@@ -49,8 +50,16 @@ internal sealed class BundledDefaultMaterialAssetStore
 
         lock (SyncRoot)
         {
+            if (File.Exists(absolutePath)
+                && ResourceLengths.TryGetValue(resourceName, out long expectedLength)
+                && new FileInfo(absolutePath).Length == expectedLength)
+            {
+                return absolutePath;
+            }
+
             using Stream resourceStream = Assembly.GetManifestResourceStream(resourceName)
                 ?? throw new InvalidOperationException($"Embedded resource '{resourceName}' was not found.");
+            ResourceLengths[resourceName] = resourceStream.Length;
             if (File.Exists(absolutePath))
             {
                 FileInfo existingFile = new(absolutePath);

--- a/tests/PlateauResoniteLink.Tests/Domain/BundledDefaultMaterialVariantTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Domain/BundledDefaultMaterialVariantTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 using PlateauResoniteLink.Domain.Importing;
@@ -193,6 +194,28 @@ public sealed class BundledDefaultMaterialVariantTests
             .ToArray();
 
         Assert.All(constructorParameterTypes, static type => Assert.NotEqual(typeof(string), Nullable.GetUnderlyingType(type) ?? type));
+    }
+
+    [Fact]
+    public void BundledDefaultMaterialAssetStoreRepairsTruncatedExtractedFile()
+    {
+        string logicalPath = BundledDefaultMaterialFamilies.GetVariant(BundledDefaultMaterialFamilies.CityFurniture, 0);
+        using TemporaryDirectory extractionRoot = new();
+        BundledDefaultMaterialAssetStore assetStore = new();
+        using IDisposable _ = assetStore.PushExtractionRootOverride(extractionRoot.Path);
+        string extractedPath = Path.Combine(
+            extractionRoot.Path,
+            logicalPath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(extractedPath)!);
+        File.WriteAllBytes(extractedPath, [1, 2, 3]);
+
+        string repairedPath = assetStore.GetAbsolutePath(logicalPath);
+
+        Assert.Equal(extractedPath, repairedPath);
+        Assert.True(new FileInfo(repairedPath).Length > 3);
+        using Image image = Image.Load(repairedPath);
+        Assert.True(image.Width > 0);
+        Assert.True(image.Height > 0);
     }
 
     [Theory]

--- a/tests/PlateauResoniteLink.Tests/Domain/BundledDefaultMaterialVariantTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Domain/BundledDefaultMaterialVariantTests.cs
@@ -218,6 +218,17 @@ public sealed class BundledDefaultMaterialVariantTests
         Assert.True(image.Height > 0);
     }
 
+    [Fact]
+    public void BundledDefaultMaterialAssetStoreTreatsMissingCachedFileLengthAsCacheMiss()
+    {
+        string missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "missing.png");
+
+        bool resolved = BundledDefaultMaterialAssetStore.TryGetExistingFileLength(missingPath, out long length);
+
+        Assert.False(resolved);
+        Assert.Equal(0, length);
+    }
+
     [Theory]
     [InlineData("default-materials/ambientcg/facade/Facade018A_2K-JPG_Emission.jpg")]
     [InlineData("default-materials/ambientcg/facade/Facade019A_2K-JPG_Emission.jpg")]


### PR DESCRIPTION
## Summary
- verify extracted bundled material files against embedded resource length instead of trusting File.Exists
- rewrite truncated extracted files through a temporary file before replacing the cached asset
- add a behavior test proving a truncated bundled material extraction is repaired into a decodable image

## Verification
- TEMP/TMP=D:\Temp\PlateauResoniteLinkCodex dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~BundledDefaultMaterialVariantTests|FullyQualifiedName~ResoniteMaterialComponentPolicyTests" --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- TEMP/TMP=D:\Temp\PlateauResoniteLinkCodex dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- TEMP/TMP=D:\Temp\PlateauResoniteLinkCodex dotnet format whitespace . --folder --verify-no-changes
- TEMP/TMP=D:\Temp\PlateauResoniteLinkCodex dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- TEMP/TMP=D:\Temp\PlateauResoniteLinkCodex dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

Note: C: had low free space from generated artifacts, so I removed only this worktree's generated artifacts before the official verification sequence and used D: for TEMP/TMP.