### PR TITLE
Extract generated road marking factory

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
@@ -73,7 +73,7 @@ internal static class GeneratedRoadMarkingCityObjectFactory
             return [];
         }
 
-        RoadMarkingEdgePair edgePair = SelectEdgePair(vertices, positions);
+        ParsedEdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(vertices, positions);
         if (edgePair.Length < 1.0 || edgePair.Width < 0.3)
         {
             return [];
@@ -166,39 +166,6 @@ internal static class GeneratedRoadMarkingCityObjectFactory
         return new Float3(normalX / magnitude, normalY / magnitude, normalZ / magnitude);
     }
 
-    private static RoadMarkingEdgePair SelectEdgePair(
-        GeodeticPoint[] vertices,
-        Float3[] positions)
-    {
-        double edge01 = Distance(positions[0], positions[1]);
-        double edge12 = Distance(positions[1], positions[2]);
-        double edge23 = Distance(positions[2], positions[3]);
-        double edge30 = Distance(positions[3], positions[0]);
-
-        double pair01Length = (edge01 + edge23) * 0.5;
-        double pair12Length = (edge12 + edge30) * 0.5;
-
-        return pair01Length >= pair12Length
-            ? new RoadMarkingEdgePair(
-                [vertices[0], vertices[1]],
-                [vertices[3], vertices[2]],
-                pair01Length,
-                (Distance(positions[0], positions[3]) + Distance(positions[1], positions[2])) * 0.5)
-            : new RoadMarkingEdgePair(
-                [vertices[1], vertices[2]],
-                [vertices[0], vertices[3]],
-                pair12Length,
-                (Distance(positions[1], positions[0]) + Distance(positions[2], positions[3])) * 0.5);
-    }
-
-    private static double Distance(Float3 left, Float3 right)
-    {
-        double deltaX = left.X - right.X;
-        double deltaY = left.Y - right.Y;
-        double deltaZ = left.Z - right.Z;
-        return Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY) + (deltaZ * deltaZ));
-    }
-
     private static Float3 CreateScenePosition(
         GeodeticPoint point,
         GeodeticPoint origin,
@@ -285,10 +252,4 @@ internal static class GeneratedRoadMarkingCityObjectFactory
 
         return moved;
     }
-
-    private sealed record RoadMarkingEdgePair(
-        GeodeticPoint[] Side0,
-        GeodeticPoint[] Side1,
-        double Length,
-        double Width);
 }

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
@@ -4,10 +4,6 @@ using System.Linq;
 
 using GeographicLib;
 
-using ProjectionGeodeticPoint = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.GeodeticPoint;
-using ProjectionParsedRing = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedRing;
-using ProjectionParsedSurface = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedSurface;
-
 namespace PlateauResoniteLink.Application.Importing;
 
 internal static class GeneratedRoadMarkingCityObjectFactory
@@ -27,7 +23,6 @@ internal static class GeneratedRoadMarkingCityObjectFactory
             return null;
         }
 
-        ProjectionGeodeticPoint projectionOrigin = cityObjectOrigin.ToProjectionModel();
         List<ParsedSurface> markingSurfaces = [];
         foreach (ParsedSurface surface in cityObject.Surfaces)
         {
@@ -36,17 +31,16 @@ internal static class GeneratedRoadMarkingCityObjectFactory
                 continue;
             }
 
-            List<ProjectionParsedSurface> generatedSurfaces =
-                CreateSurfaces(
-                    CityGmlProjectionModelAdapter.ToProjectionModel(surface),
-                    projectionOrigin,
-                    cityObjectCartesian);
+            List<ParsedSurface> generatedSurfaces = CreateSurfaces(
+                surface,
+                cityObjectOrigin,
+                cityObjectCartesian);
             if (generatedSurfaces.Count == 0)
             {
                 continue;
             }
 
-            markingSurfaces.AddRange(generatedSurfaces.Select(CityGmlProjectionModelAdapter.FromProjectionModel));
+            markingSurfaces.AddRange(generatedSurfaces);
         }
 
         return markingSurfaces.Count == 0
@@ -59,12 +53,12 @@ internal static class GeneratedRoadMarkingCityObjectFactory
             };
     }
 
-    private static List<ProjectionParsedSurface> CreateSurfaces(
-        ProjectionParsedSurface surface,
-        ProjectionGeodeticPoint cityObjectOrigin,
+    private static List<ParsedSurface> CreateSurfaces(
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
-        ProjectionGeodeticPoint[] vertices = surface.ExteriorRing.Vertices;
+        GeodeticPoint[] vertices = surface.ExteriorRing.Vertices;
         if (vertices.Length != 4 || surface.InteriorRings.Length != 0)
         {
             return [];
@@ -79,7 +73,7 @@ internal static class GeneratedRoadMarkingCityObjectFactory
             return [];
         }
 
-        EdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(vertices, positions);
+        RoadMarkingEdgePair edgePair = SelectEdgePair(vertices, positions);
         if (edgePair.Length < 1.0 || edgePair.Width < 0.3)
         {
             return [];
@@ -95,19 +89,19 @@ internal static class GeneratedRoadMarkingCityObjectFactory
         int segmentCount = Math.Max(
             1,
             (int)Math.Ceiling(edgePair.Length / DefaultSegmentLengthMeters));
-        List<ProjectionParsedSurface> segments = new(segmentCount);
+        List<ParsedSurface> segments = new(segmentCount);
 
         for (int segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
         {
             double startT = (double)segmentIndex / segmentCount;
             double endT = (double)(segmentIndex + 1) / segmentCount;
-            ProjectionGeodeticPoint side0Start = InterpolateAlongEdge(edgePair.Side0[0], edgePair.Side0[1], startT);
-            ProjectionGeodeticPoint side0End = InterpolateAlongEdge(edgePair.Side0[0], edgePair.Side0[1], endT);
-            ProjectionGeodeticPoint side1Start = InterpolateAlongEdge(edgePair.Side1[0], edgePair.Side1[1], startT);
-            ProjectionGeodeticPoint side1End = InterpolateAlongEdge(edgePair.Side1[0], edgePair.Side1[1], endT);
+            GeodeticPoint side0Start = InterpolateAlongEdge(edgePair.Side0[0], edgePair.Side0[1], startT);
+            GeodeticPoint side0End = InterpolateAlongEdge(edgePair.Side0[0], edgePair.Side0[1], endT);
+            GeodeticPoint side1Start = InterpolateAlongEdge(edgePair.Side1[0], edgePair.Side1[1], startT);
+            GeodeticPoint side1End = InterpolateAlongEdge(edgePair.Side1[0], edgePair.Side1[1], endT);
 
-            ProjectionGeodeticPoint[] side0Source = [side0Start, side0End];
-            ProjectionGeodeticPoint[] side1Source = [side1Start, side1End];
+            GeodeticPoint[] side0Source = [side0Start, side0End];
+            GeodeticPoint[] side1Source = [side1Start, side1End];
             Float3[] side0Positions = side0Source
                 .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
                 .ToArray();
@@ -115,22 +109,22 @@ internal static class GeneratedRoadMarkingCityObjectFactory
                 .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
                 .ToArray();
 
-            ProjectionGeodeticPoint[] side0 = MoveTowardCrossSection(
+            GeodeticPoint[] side0 = MoveTowardCrossSection(
                 side0Source,
                 side1Source,
                 side0Positions,
                 side1Positions,
                 insetDistance);
-            ProjectionGeodeticPoint[] side1 = MoveTowardCrossSection(
+            GeodeticPoint[] side1 = MoveTowardCrossSection(
                 side1Source,
                 side0Source,
                 side1Positions,
                 side0Positions,
                 insetDistance);
-            segments.Add(new ProjectionParsedSurface(
+            segments.Add(new ParsedSurface(
                 $"{surface.PolygonId}_generated_marking_{segmentIndex:D2}",
                 surface.Semantic,
-                new ProjectionParsedRing(
+                new ParsedRing(
                     $"{surface.ExteriorRing.RingId}_generated_marking_{segmentIndex:D2}",
                     [side0[0], side0[1], side1[1], side1[0]],
                     UVs: null),
@@ -172,9 +166,42 @@ internal static class GeneratedRoadMarkingCityObjectFactory
         return new Float3(normalX / magnitude, normalY / magnitude, normalZ / magnitude);
     }
 
+    private static RoadMarkingEdgePair SelectEdgePair(
+        GeodeticPoint[] vertices,
+        Float3[] positions)
+    {
+        double edge01 = Distance(positions[0], positions[1]);
+        double edge12 = Distance(positions[1], positions[2]);
+        double edge23 = Distance(positions[2], positions[3]);
+        double edge30 = Distance(positions[3], positions[0]);
+
+        double pair01Length = (edge01 + edge23) * 0.5;
+        double pair12Length = (edge12 + edge30) * 0.5;
+
+        return pair01Length >= pair12Length
+            ? new RoadMarkingEdgePair(
+                [vertices[0], vertices[1]],
+                [vertices[3], vertices[2]],
+                pair01Length,
+                (Distance(positions[0], positions[3]) + Distance(positions[1], positions[2])) * 0.5)
+            : new RoadMarkingEdgePair(
+                [vertices[1], vertices[2]],
+                [vertices[0], vertices[3]],
+                pair12Length,
+                (Distance(positions[1], positions[0]) + Distance(positions[2], positions[3])) * 0.5);
+    }
+
+    private static double Distance(Float3 left, Float3 right)
+    {
+        double deltaX = left.X - right.X;
+        double deltaY = left.Y - right.Y;
+        double deltaZ = left.Z - right.Z;
+        return Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY) + (deltaZ * deltaZ));
+    }
+
     private static Float3 CreateScenePosition(
-        ProjectionGeodeticPoint point,
-        ProjectionGeodeticPoint origin,
+        GeodeticPoint point,
+        GeodeticPoint origin,
         LocalCartesian? cartesian)
     {
         return SceneAxisMapper.CreatePosition(
@@ -187,20 +214,20 @@ internal static class GeneratedRoadMarkingCityObjectFactory
             cartesian);
     }
 
-    private static ProjectionGeodeticPoint InterpolateAlongEdge(
-        ProjectionGeodeticPoint start,
-        ProjectionGeodeticPoint end,
+    private static GeodeticPoint InterpolateAlongEdge(
+        GeodeticPoint start,
+        GeodeticPoint end,
         double ratio)
     {
         return Lerp(start, end, ratio);
     }
 
-    private static ProjectionGeodeticPoint Lerp(
-        ProjectionGeodeticPoint source,
-        ProjectionGeodeticPoint target,
+    private static GeodeticPoint Lerp(
+        GeodeticPoint source,
+        GeodeticPoint target,
         double ratio)
     {
-        return new ProjectionGeodeticPoint(
+        return new GeodeticPoint(
             source.Latitude + ((target.Latitude - source.Latitude) * ratio),
             source.Longitude + ((target.Longitude - source.Longitude) * ratio),
             source.Altitude + ((target.Altitude - source.Altitude) * ratio));
@@ -209,9 +236,9 @@ internal static class GeneratedRoadMarkingCityObjectFactory
     // Adapted from PLATEAU-SDK-for-Unity Runtime/RoadAdjust/RnmModelAdjuster.cs.
     // Each source point moves toward the nearest target point, matching upstream behavior.
     // Upstream MIT license text is stored in THIRD_PARTY_LICENSES/PLATEAU-SDK-for-Unity-LICENSE.txt.
-    private static ProjectionGeodeticPoint[] MoveTowardCrossSection(
-        ProjectionGeodeticPoint[] sourceWay,
-        ProjectionGeodeticPoint[] targetWay,
+    private static GeodeticPoint[] MoveTowardCrossSection(
+        GeodeticPoint[] sourceWay,
+        GeodeticPoint[] targetWay,
         Float3[] sourcePositions,
         Float3[] targetPositions,
         double distance)
@@ -225,10 +252,10 @@ internal static class GeneratedRoadMarkingCityObjectFactory
             return sourceWay.ToArray();
         }
 
-        ProjectionGeodeticPoint[] moved = new ProjectionGeodeticPoint[2];
+        GeodeticPoint[] moved = new GeodeticPoint[2];
         for (int index = 0; index < 2; index++)
         {
-            ProjectionGeodeticPoint source = sourceWay[index];
+            GeodeticPoint source = sourceWay[index];
             int nearestTargetIndex = 0;
             double nearestDistanceSquared = double.MaxValue;
             for (int targetIndex = 0; targetIndex < targetPositions.Length; targetIndex++)
@@ -244,7 +271,7 @@ internal static class GeneratedRoadMarkingCityObjectFactory
                 }
             }
 
-            ProjectionGeodeticPoint target = targetWay[nearestTargetIndex];
+            GeodeticPoint target = targetWay[nearestTargetIndex];
             double actualDistance = Math.Sqrt(nearestDistanceSquared);
             if (actualDistance <= 1e-8)
             {
@@ -258,4 +285,10 @@ internal static class GeneratedRoadMarkingCityObjectFactory
 
         return moved;
     }
+
+    private sealed record RoadMarkingEdgePair(
+        GeodeticPoint[] Side0,
+        GeodeticPoint[] Side1,
+        double Length,
+        double Width);
 }

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
@@ -23,6 +23,11 @@ internal static class GeneratedRoadMarkingCityObjectFactory
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
+        if (!string.Equals(cityObject.PackageName, "tran", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
         ProjectionParsedCityObject? markingCityObject = Create(
             CityGmlProjectionModelAdapter.ToProjectionModel(cityObject),
             cityObjectOrigin.ToProjectionModel(),

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using GeographicLib;
+
+using ProjectionGeodeticPoint = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.GeodeticPoint;
+using ProjectionParsedCityObject = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedCityObject;
+using ProjectionParsedRing = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedRing;
+using ProjectionParsedSurface = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedSurface;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class GeneratedRoadMarkingCityObjectFactory
+{
+    internal const double DefaultMarkingWidthMeters = 0.15;
+    internal const double DefaultSegmentLengthMeters = 5.0;
+
+    private static readonly ColorRgba DefaultMarkingColor = new(1.0, 1.0, 1.0, 1.0);
+
+    internal static ParsedCityObject? Create(
+        ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        ProjectionParsedCityObject? markingCityObject = Create(
+            CityGmlProjectionModelAdapter.ToProjectionModel(cityObject),
+            cityObjectOrigin.ToProjectionModel(),
+            cityObjectCartesian);
+
+        return markingCityObject is null
+            ? null
+            : CityGmlProjectionModelAdapter.FromProjectionModel(markingCityObject);
+    }
+
+    private static ProjectionParsedCityObject? Create(
+        ProjectionParsedCityObject cityObject,
+        ProjectionGeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (!string.Equals(cityObject.PackageName, "tran", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        List<ProjectionParsedSurface> markingSurfaces = [];
+        foreach (ProjectionParsedSurface surface in cityObject.Surfaces)
+        {
+            if (surface.TexturePayload is not null)
+            {
+                continue;
+            }
+
+            List<ProjectionParsedSurface> generatedSurfaces =
+                CreateSurfaces(surface, cityObjectOrigin, cityObjectCartesian);
+            if (generatedSurfaces.Count == 0)
+            {
+                continue;
+            }
+
+            markingSurfaces.AddRange(generatedSurfaces);
+        }
+
+        return markingSurfaces.Count == 0
+            ? null
+            : cityObject with
+            {
+                SlotKey = $"{cityObject.SlotKey}_road_marking",
+                DisplayName = $"{cityObject.DisplayName} Marking",
+                Surfaces = markingSurfaces.ToArray(),
+            };
+    }
+
+    private static List<ProjectionParsedSurface> CreateSurfaces(
+        ProjectionParsedSurface surface,
+        ProjectionGeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        ProjectionGeodeticPoint[] vertices = surface.ExteriorRing.Vertices;
+        if (vertices.Length != 4 || surface.InteriorRings.Length != 0)
+        {
+            return [];
+        }
+
+        Float3[] positions = vertices
+            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
+            .ToArray();
+        Float3? normal = ComputePolygonNormal(positions);
+        if (normal is null || Math.Abs(normal.Y) < 0.7)
+        {
+            return [];
+        }
+
+        EdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(vertices, positions);
+        if (edgePair.Length < 1.0 || edgePair.Width < 0.3)
+        {
+            return [];
+        }
+
+        double markingWidth = Math.Min(DefaultMarkingWidthMeters, edgePair.Width * 0.5);
+        double insetDistance = Math.Max((edgePair.Width - markingWidth) * 0.5, 0.0);
+        if (insetDistance <= 1e-6)
+        {
+            return [];
+        }
+
+        int segmentCount = Math.Max(
+            1,
+            (int)Math.Ceiling(edgePair.Length / DefaultSegmentLengthMeters));
+        List<ProjectionParsedSurface> segments = new(segmentCount);
+
+        for (int segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
+        {
+            double startT = (double)segmentIndex / segmentCount;
+            double endT = (double)(segmentIndex + 1) / segmentCount;
+            ProjectionGeodeticPoint side0Start = InterpolateAlongEdge(edgePair.Side0[0], edgePair.Side0[1], startT);
+            ProjectionGeodeticPoint side0End = InterpolateAlongEdge(edgePair.Side0[0], edgePair.Side0[1], endT);
+            ProjectionGeodeticPoint side1Start = InterpolateAlongEdge(edgePair.Side1[0], edgePair.Side1[1], startT);
+            ProjectionGeodeticPoint side1End = InterpolateAlongEdge(edgePair.Side1[0], edgePair.Side1[1], endT);
+
+            ProjectionGeodeticPoint[] side0Source = [side0Start, side0End];
+            ProjectionGeodeticPoint[] side1Source = [side1Start, side1End];
+            Float3[] side0Positions = side0Source
+                .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
+                .ToArray();
+            Float3[] side1Positions = side1Source
+                .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
+                .ToArray();
+
+            ProjectionGeodeticPoint[] side0 = MoveTowardCrossSection(
+                side0Source,
+                side1Source,
+                side0Positions,
+                side1Positions,
+                insetDistance);
+            ProjectionGeodeticPoint[] side1 = MoveTowardCrossSection(
+                side1Source,
+                side0Source,
+                side1Positions,
+                side0Positions,
+                insetDistance);
+            segments.Add(new ProjectionParsedSurface(
+                $"{surface.PolygonId}_generated_marking_{segmentIndex:D2}",
+                surface.Semantic,
+                new ProjectionParsedRing(
+                    $"{surface.ExteriorRing.RingId}_generated_marking_{segmentIndex:D2}",
+                    [side0[0], side0[1], side1[1], side1[0]],
+                    UVs: null),
+                [],
+                DefaultMarkingColor,
+                TexturePayload: null));
+        }
+
+        return segments;
+    }
+
+    private static Float3? ComputePolygonNormal(IEnumerable<Float3> positions)
+    {
+        Float3[] points = positions.ToArray();
+        if (points.Length < 3)
+        {
+            return null;
+        }
+
+        double normalX = 0.0;
+        double normalY = 0.0;
+        double normalZ = 0.0;
+
+        for (int index = 0; index < points.Length; index++)
+        {
+            Float3 current = points[index];
+            Float3 next = points[(index + 1) % points.Length];
+            normalX += (current.Y - next.Y) * (current.Z + next.Z);
+            normalY += (current.Z - next.Z) * (current.X + next.X);
+            normalZ += (current.X - next.X) * (current.Y + next.Y);
+        }
+
+        double magnitude = Math.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ));
+        if (magnitude < 1e-8)
+        {
+            return null;
+        }
+
+        return new Float3(normalX / magnitude, normalY / magnitude, normalZ / magnitude);
+    }
+
+    private static Float3 CreateScenePosition(
+        ProjectionGeodeticPoint point,
+        ProjectionGeodeticPoint origin,
+        LocalCartesian? cartesian)
+    {
+        return SceneAxisMapper.CreatePosition(
+            point.Latitude,
+            point.Longitude,
+            point.Altitude,
+            origin.Latitude,
+            origin.Longitude,
+            origin.Altitude,
+            cartesian);
+    }
+
+    private static ProjectionGeodeticPoint InterpolateAlongEdge(
+        ProjectionGeodeticPoint start,
+        ProjectionGeodeticPoint end,
+        double ratio)
+    {
+        return Lerp(start, end, ratio);
+    }
+
+    private static ProjectionGeodeticPoint Lerp(
+        ProjectionGeodeticPoint source,
+        ProjectionGeodeticPoint target,
+        double ratio)
+    {
+        return new ProjectionGeodeticPoint(
+            source.Latitude + ((target.Latitude - source.Latitude) * ratio),
+            source.Longitude + ((target.Longitude - source.Longitude) * ratio),
+            source.Altitude + ((target.Altitude - source.Altitude) * ratio));
+    }
+
+    // Adapted from PLATEAU-SDK-for-Unity Runtime/RoadAdjust/RnmModelAdjuster.cs.
+    // Each source point moves toward the nearest target point, matching upstream behavior.
+    // Upstream MIT license text is stored in THIRD_PARTY_LICENSES/PLATEAU-SDK-for-Unity-LICENSE.txt.
+    private static ProjectionGeodeticPoint[] MoveTowardCrossSection(
+        ProjectionGeodeticPoint[] sourceWay,
+        ProjectionGeodeticPoint[] targetWay,
+        Float3[] sourcePositions,
+        Float3[] targetPositions,
+        double distance)
+    {
+        if (sourceWay.Length != 2
+            || targetWay.Length != 2
+            || sourcePositions.Length != 2
+            || targetPositions.Length != 2
+            || distance <= 0.0)
+        {
+            return sourceWay.ToArray();
+        }
+
+        ProjectionGeodeticPoint[] moved = new ProjectionGeodeticPoint[2];
+        for (int index = 0; index < 2; index++)
+        {
+            ProjectionGeodeticPoint source = sourceWay[index];
+            int nearestTargetIndex = 0;
+            double nearestDistanceSquared = double.MaxValue;
+            for (int targetIndex = 0; targetIndex < targetPositions.Length; targetIndex++)
+            {
+                double deltaX = sourcePositions[index].X - targetPositions[targetIndex].X;
+                double deltaY = sourcePositions[index].Y - targetPositions[targetIndex].Y;
+                double deltaZ = sourcePositions[index].Z - targetPositions[targetIndex].Z;
+                double distanceSquared = (deltaX * deltaX) + (deltaY * deltaY) + (deltaZ * deltaZ);
+                if (distanceSquared < nearestDistanceSquared)
+                {
+                    nearestDistanceSquared = distanceSquared;
+                    nearestTargetIndex = targetIndex;
+                }
+            }
+
+            ProjectionGeodeticPoint target = targetWay[nearestTargetIndex];
+            double actualDistance = Math.Sqrt(nearestDistanceSquared);
+            if (actualDistance <= 1e-8)
+            {
+                moved[index] = source;
+                continue;
+            }
+
+            double moveRatio = Math.Min(distance, actualDistance) / actualDistance;
+            moved[index] = Lerp(source, target, moveRatio);
+        }
+
+        return moved;
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
@@ -18,6 +18,9 @@ internal static class GeneratedRoadMarkingCityObjectFactory
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
+        ArgumentNullException.ThrowIfNull(cityObject);
+        ArgumentNullException.ThrowIfNull(cityObjectOrigin);
+
         if (!string.Equals(cityObject.PackageName, "tran", StringComparison.OrdinalIgnoreCase))
         {
             return null;
@@ -67,7 +70,7 @@ internal static class GeneratedRoadMarkingCityObjectFactory
         Float3[] positions = vertices
             .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
             .ToArray();
-        Float3? normal = ComputePolygonNormal(positions);
+        Float3? normal = PolygonNormal.Compute(positions);
         if (normal is null || Math.Abs(normal.Y) < 0.7)
         {
             return [];
@@ -134,36 +137,6 @@ internal static class GeneratedRoadMarkingCityObjectFactory
         }
 
         return segments;
-    }
-
-    private static Float3? ComputePolygonNormal(IEnumerable<Float3> positions)
-    {
-        Float3[] points = positions.ToArray();
-        if (points.Length < 3)
-        {
-            return null;
-        }
-
-        double normalX = 0.0;
-        double normalY = 0.0;
-        double normalZ = 0.0;
-
-        for (int index = 0; index < points.Length; index++)
-        {
-            Float3 current = points[index];
-            Float3 next = points[(index + 1) % points.Length];
-            normalX += (current.Y - next.Y) * (current.Z + next.Z);
-            normalY += (current.Z - next.Z) * (current.X + next.X);
-            normalZ += (current.X - next.X) * (current.Y + next.Y);
-        }
-
-        double magnitude = Math.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ));
-        if (magnitude < 1e-8)
-        {
-            return null;
-        }
-
-        return new Float3(normalX / magnitude, normalY / magnitude, normalZ / magnitude);
     }
 
     private static Float3 CreateScenePosition(

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using GeographicLib;
 
 using ProjectionGeodeticPoint = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.GeodeticPoint;
-using ProjectionParsedCityObject = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedCityObject;
 using ProjectionParsedRing = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedRing;
 using ProjectionParsedSurface = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedSurface;
 
@@ -28,28 +27,9 @@ internal static class GeneratedRoadMarkingCityObjectFactory
             return null;
         }
 
-        ProjectionParsedCityObject? markingCityObject = Create(
-            CityGmlProjectionModelAdapter.ToProjectionModel(cityObject),
-            cityObjectOrigin.ToProjectionModel(),
-            cityObjectCartesian);
-
-        return markingCityObject is null
-            ? null
-            : CityGmlProjectionModelAdapter.FromProjectionModel(markingCityObject);
-    }
-
-    private static ProjectionParsedCityObject? Create(
-        ProjectionParsedCityObject cityObject,
-        ProjectionGeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        if (!string.Equals(cityObject.PackageName, "tran", StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
-
-        List<ProjectionParsedSurface> markingSurfaces = [];
-        foreach (ProjectionParsedSurface surface in cityObject.Surfaces)
+        ProjectionGeodeticPoint projectionOrigin = cityObjectOrigin.ToProjectionModel();
+        List<ParsedSurface> markingSurfaces = [];
+        foreach (ParsedSurface surface in cityObject.Surfaces)
         {
             if (surface.TexturePayload is not null)
             {
@@ -57,13 +37,16 @@ internal static class GeneratedRoadMarkingCityObjectFactory
             }
 
             List<ProjectionParsedSurface> generatedSurfaces =
-                CreateSurfaces(surface, cityObjectOrigin, cityObjectCartesian);
+                CreateSurfaces(
+                    CityGmlProjectionModelAdapter.ToProjectionModel(surface),
+                    projectionOrigin,
+                    cityObjectCartesian);
             if (generatedSurfaces.Count == 0)
             {
                 continue;
             }
 
-            markingSurfaces.AddRange(generatedSurfaces);
+            markingSurfaces.AddRange(generatedSurfaces.Select(CityGmlProjectionModelAdapter.FromProjectionModel));
         }
 
         return markingSurfaces.Count == 0

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -29,8 +29,8 @@ internal static class LocalCityGmlObjectProjection
     public const int DefaultDemTerrainTextureZoomLevel = DemTerrainTextureDefaults.PlateauOrthoZoomLevel;
     public const int DefaultDemTerrainTextureFallbackZoomLevel = DemTerrainTextureDefaults.FallbackZoomLevel;
     public const int DefaultDemTerrainTextureMaxSize = DemTerrainTextureDefaults.MaxTextureSize;
-    public const double DefaultGeneratedRoadMarkingWidthMeters = 0.15;
-    public const double DefaultGeneratedRoadMarkingSegmentLengthMeters = 5.0;
+    public const double DefaultGeneratedRoadMarkingWidthMeters = GeneratedRoadMarkingCityObjectFactory.DefaultMarkingWidthMeters;
+    public const double DefaultGeneratedRoadMarkingSegmentLengthMeters = GeneratedRoadMarkingCityObjectFactory.DefaultSegmentLengthMeters;
     public const double DefaultTerrainAlignedTransportationSegmentLengthMeters = TerrainAlignedTransportationSurfaceSplitter.DefaultSegmentLengthMeters;
     public const double MinTerrainAlignedTransportationSegmentLengthMeters = TerrainAlignedTransportationSurfaceSplitter.MinSegmentLengthMeters;
     public const double TerrainAlignedTransportationSegmentLengthByWidthRatio = TerrainAlignedTransportationSurfaceSplitter.SegmentLengthByWidthRatio;
@@ -43,7 +43,6 @@ internal static class LocalCityGmlObjectProjection
         W: Math.Sqrt(0.5));
     private static readonly ColorRgba DefaultMaterialColor = new(1.0, 1.0, 1.0, 1.0);
     private static readonly ColorRgba DefaultVegetationMaterialColor = new(0.32, 0.58, 0.24, 1.0);
-    private static readonly ColorRgba DefaultRoadMarkingColor = new(1.0, 1.0, 1.0, 1.0);
     private static readonly XNamespace App = "http://www.opengis.net/citygml/appearance/2.0";
     private static readonly XNamespace Core = "http://www.opengis.net/citygml/2.0";
     private static readonly XNamespace Gml = "http://www.opengis.net/gml";
@@ -293,7 +292,7 @@ internal static class LocalCityGmlObjectProjection
             return [surface];
         }
 
-        EdgePairSelection edgePair = SelectPrimaryRoadEdgePair(surface.ExteriorRing, positions);
+        EdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(surface.ExteriorRing, positions);
         return TerrainAlignedTransportationSurfaceSplitter.Split(surface, positions, edgePair);
     }
 
@@ -323,7 +322,7 @@ internal static class LocalCityGmlObjectProjection
             return [surface];
         }
 
-        EdgePairSelection edgePair = SelectPrimaryRoadEdgePair(
+        EdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(
             global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface.ExteriorRing),
             positions);
         ParsedSurface projectionSurface = global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface);
@@ -1199,256 +1198,6 @@ internal static class LocalCityGmlObjectProjection
     {
         double surfaceMinAltitude = surface.Vertices.Min(static vertex => vertex.Altitude);
         return surfaceMinAltitude > cityObjectMinAltitude + UnknownRoofBottomAltitudeToleranceMeters;
-    }
-
-    private static global::PlateauResoniteLink.Application.Importing.ParsedCityObject? CreateGeneratedRoadMarkingCityObject(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        if (!string.Equals(cityObject.PackageName, "tran", StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
-
-        List<global::PlateauResoniteLink.Application.Importing.ParsedSurface> markingSurfaces = [];
-        foreach (global::PlateauResoniteLink.Application.Importing.ParsedSurface surface in cityObject.Surfaces)
-        {
-            if (surface.TexturePayload is not null)
-            {
-                continue;
-            }
-
-            List<global::PlateauResoniteLink.Application.Importing.ParsedSurface> generatedSurfaces =
-                CreateGeneratedRoadMarkingSurfaces(surface, cityObjectOrigin, cityObjectCartesian);
-            if (generatedSurfaces.Count == 0)
-            {
-                continue;
-            }
-
-            markingSurfaces.AddRange(generatedSurfaces);
-        }
-
-        return markingSurfaces.Count == 0
-            ? null
-            : cityObject with
-            {
-                SlotKey = $"{cityObject.SlotKey}_road_marking",
-                DisplayName = $"{cityObject.DisplayName} Marking",
-                Surfaces = markingSurfaces.ToArray(),
-            };
-    }
-
-    private static List<ParsedSurface> CreateGeneratedRoadMarkingSurfaces(
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        GeodeticPoint[] vertices = surface.ExteriorRing.Vertices;
-        if (vertices.Length != 4 || surface.InteriorRings.Length != 0)
-        {
-            return [];
-        }
-
-        Float3[] positions = vertices
-            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
-            .ToArray();
-        Float3? normal = ComputePolygonNormal(positions);
-        if (normal is null || Math.Abs(normal.Y) < 0.7)
-        {
-            return [];
-        }
-
-        EdgePairSelection edgePair = SelectPrimaryRoadEdgePair(vertices, positions);
-        if (edgePair.Length < 1.0 || edgePair.Width < 0.3)
-        {
-            return [];
-        }
-
-        double markingWidth = Math.Min(DefaultGeneratedRoadMarkingWidthMeters, edgePair.Width * 0.5);
-        double insetDistance = Math.Max((edgePair.Width - markingWidth) * 0.5, 0.0);
-        if (insetDistance <= 1e-6)
-        {
-            return [];
-        }
-
-        int segmentCount = Math.Max(
-            1,
-            (int)Math.Ceiling(edgePair.Length / DefaultGeneratedRoadMarkingSegmentLengthMeters));
-        List<ParsedSurface> segments = new(segmentCount);
-
-        for (int segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
-        {
-            double startT = (double)segmentIndex / segmentCount;
-            double endT = (double)(segmentIndex + 1) / segmentCount;
-            GeodeticPoint side0Start = InterpolateAlongEdge(edgePair.Side0[0], edgePair.Side0[1], startT);
-            GeodeticPoint side0End = InterpolateAlongEdge(edgePair.Side0[0], edgePair.Side0[1], endT);
-            GeodeticPoint side1Start = InterpolateAlongEdge(edgePair.Side1[0], edgePair.Side1[1], startT);
-            GeodeticPoint side1End = InterpolateAlongEdge(edgePair.Side1[0], edgePair.Side1[1], endT);
-
-            GeodeticPoint[] side0Source = [side0Start, side0End];
-            GeodeticPoint[] side1Source = [side1Start, side1End];
-            Float3[] side0Positions = side0Source
-                .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
-                .ToArray();
-            Float3[] side1Positions = side1Source
-                .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
-                .ToArray();
-
-            GeodeticPoint[] side0 = MoveTowardCrossSection(
-                side0Source,
-                side1Source,
-                side0Positions,
-                side1Positions,
-                insetDistance);
-            GeodeticPoint[] side1 = MoveTowardCrossSection(
-                side1Source,
-                side0Source,
-                side1Positions,
-                side0Positions,
-                insetDistance);
-            segments.Add(new ParsedSurface(
-                $"{surface.PolygonId}_generated_marking_{segmentIndex:D2}",
-                surface.Semantic,
-                new ParsedRing(
-                    $"{surface.ExteriorRing.RingId}_generated_marking_{segmentIndex:D2}",
-                    [side0[0], side0[1], side1[1], side1[0]],
-                    UVs: null),
-                [],
-                DefaultRoadMarkingColor,
-                TexturePayload: null));
-        }
-
-        return segments;
-    }
-
-    private static List<global::PlateauResoniteLink.Application.Importing.ParsedSurface> CreateGeneratedRoadMarkingSurfaces(
-        global::PlateauResoniteLink.Application.Importing.ParsedSurface surface,
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        return CreateGeneratedRoadMarkingSurfaces(
-                global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface),
-                cityObjectOrigin.ToProjectionModel(),
-                cityObjectCartesian)
-            .Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel)
-            .ToList();
-    }
-
-    private static EdgePairSelection SelectPrimaryRoadEdgePair(
-        GeodeticPoint[] vertices,
-        Float3[] positions)
-    {
-        double edge01 = Distance(positions[0], positions[1]);
-        double edge12 = Distance(positions[1], positions[2]);
-        double edge23 = Distance(positions[2], positions[3]);
-        double edge30 = Distance(positions[3], positions[0]);
-
-        double pair01Length = (edge01 + edge23) * 0.5;
-        double pair12Length = (edge12 + edge30) * 0.5;
-
-        return pair01Length >= pair12Length
-            ? new EdgePairSelection(
-                [vertices[0], vertices[1]],
-                [vertices[3], vertices[2]],
-                [positions[0], positions[1]],
-                [positions[3], positions[2]],
-                Side0Uvs: null,
-                Side1Uvs: null,
-                pair01Length,
-                (Distance(positions[0], positions[3]) + Distance(positions[1], positions[2])) * 0.5,
-                edge01,
-                edge23)
-            : new EdgePairSelection(
-                [vertices[1], vertices[2]],
-                [vertices[0], vertices[3]],
-                [positions[1], positions[2]],
-                [positions[0], positions[3]],
-                Side0Uvs: null,
-                Side1Uvs: null,
-                pair12Length,
-                (Distance(positions[1], positions[0]) + Distance(positions[2], positions[3])) * 0.5,
-                edge12,
-                edge30);
-    }
-
-    private static EdgePairSelection SelectPrimaryRoadEdgePair(
-        ParsedRing ring,
-        Float3[] positions)
-    {
-        EdgePairSelection pair = SelectPrimaryRoadEdgePair(ring.Vertices, positions);
-        if (ring.UVs is null || ring.UVs.Count != ring.Vertices.Length || ring.Vertices.Length != 4)
-        {
-            return pair;
-        }
-
-        bool usesFirstEdge = AreSamePoint(pair.Side0[0], ring.Vertices[0])
-            && AreSamePoint(pair.Side0[1], ring.Vertices[1]);
-
-        return usesFirstEdge
-            ? pair with
-            {
-                Side0Uvs = [ring.UVs[0], ring.UVs[1]],
-                Side1Uvs = [ring.UVs[3], ring.UVs[2]],
-            }
-            : pair with
-            {
-                Side0Uvs = [ring.UVs[1], ring.UVs[2]],
-                Side1Uvs = [ring.UVs[0], ring.UVs[3]],
-            };
-    }
-
-    // Adapted from PLATEAU-SDK-for-Unity Runtime/RoadAdjust/RnmModelAdjuster.cs.
-    // Each source point moves toward the nearest target point, matching upstream behavior.
-    // Upstream MIT license text is stored in THIRD_PARTY_LICENSES/PLATEAU-SDK-for-Unity-LICENSE.txt.
-    private static GeodeticPoint[] MoveTowardCrossSection(
-        GeodeticPoint[] sourceWay,
-        GeodeticPoint[] targetWay,
-        Float3[] sourcePositions,
-        Float3[] targetPositions,
-        double distance)
-    {
-        if (sourceWay.Length != 2
-            || targetWay.Length != 2
-            || sourcePositions.Length != 2
-            || targetPositions.Length != 2
-            || distance <= 0.0)
-        {
-            return sourceWay.ToArray();
-        }
-
-        GeodeticPoint[] moved = new GeodeticPoint[2];
-        for (int index = 0; index < 2; index++)
-        {
-            GeodeticPoint source = sourceWay[index];
-            int nearestTargetIndex = 0;
-            double nearestDistanceSquared = double.MaxValue;
-            for (int targetIndex = 0; targetIndex < targetPositions.Length; targetIndex++)
-            {
-                double deltaX = sourcePositions[index].X - targetPositions[targetIndex].X;
-                double deltaY = sourcePositions[index].Y - targetPositions[targetIndex].Y;
-                double deltaZ = sourcePositions[index].Z - targetPositions[targetIndex].Z;
-                double distanceSquared = (deltaX * deltaX) + (deltaY * deltaY) + (deltaZ * deltaZ);
-                if (distanceSquared < nearestDistanceSquared)
-                {
-                    nearestDistanceSquared = distanceSquared;
-                    nearestTargetIndex = targetIndex;
-                }
-            }
-
-            GeodeticPoint target = targetWay[nearestTargetIndex];
-            double actualDistance = Math.Sqrt(nearestDistanceSquared);
-            if (actualDistance <= 1e-8)
-            {
-                moved[index] = source;
-                continue;
-            }
-
-            double moveRatio = Math.Min(distance, actualDistance) / actualDistance;
-            moved[index] = Lerp(source, target, moveRatio);
-        }
-
-        return moved;
     }
 
     private static void TriangulateSurface(
@@ -2502,34 +2251,6 @@ internal static class LocalCityGmlObjectProjection
             && Math.Abs(left.Altitude - right.Altitude) < 1e-8;
     }
 
-    private static GeodeticPoint Lerp(GeodeticPoint source, GeodeticPoint target, double ratio)
-    {
-        return new GeodeticPoint(
-            source.Latitude + ((target.Latitude - source.Latitude) * ratio),
-            source.Longitude + ((target.Longitude - source.Longitude) * ratio),
-            source.Altitude + ((target.Altitude - source.Altitude) * ratio));
-    }
-
-    private static GeodeticPoint InterpolateAlongEdge(GeodeticPoint start, GeodeticPoint end, double ratio)
-    {
-        return Lerp(start, end, ratio);
-    }
-
-    private static Float3 Lerp(Float3 source, Float3 target, double ratio)
-    {
-        return new Float3(
-            source.X + ((target.X - source.X) * ratio),
-            source.Y + ((target.Y - source.Y) * ratio),
-            source.Z + ((target.Z - source.Z) * ratio));
-    }
-
-    private static Float2 Lerp(Float2 source, Float2 target, double ratio)
-    {
-        return new Float2(
-            source.X + ((target.X - source.X) * ratio),
-            source.Y + ((target.Y - source.Y) * ratio));
-    }
-
     private static bool HasExplicitMaterialColor(ColorRgba color)
     {
         return Math.Abs(color.R - DefaultMaterialColor.R) >= 1e-8
@@ -2671,7 +2392,7 @@ internal static class LocalCityGmlObjectProjection
                     markingOrigin.Altitude,
                     splitCityObject.CityObject.ReferenceSystem.Geocentric)
                 : null;
-            global::PlateauResoniteLink.Application.Importing.ParsedCityObject? roadMarkingCityObject = CreateGeneratedRoadMarkingCityObject(
+            global::PlateauResoniteLink.Application.Importing.ParsedCityObject? roadMarkingCityObject = GeneratedRoadMarkingCityObjectFactory.Create(
                 splitCityObject.CityObject,
                 markingOrigin,
                 markingCartesian);

--- a/src/PlateauResoniteLink/Application/Importing/RoadSurfaceEdgePairSelector.cs
+++ b/src/PlateauResoniteLink/Application/Importing/RoadSurfaceEdgePairSelector.cs
@@ -11,6 +11,8 @@ internal static class RoadSurfaceEdgePairSelector
         ProjectionGeodeticPoint[] vertices,
         Float3[] positions)
     {
+        ValidateQuadInputs(vertices, positions);
+
         double edge01 = Distance(positions[0], positions[1]);
         double edge12 = Distance(positions[1], positions[2]);
         double edge23 = Distance(positions[2], positions[3]);
@@ -42,6 +44,33 @@ internal static class RoadSurfaceEdgePairSelector
                 (Distance(positions[1], positions[0]) + Distance(positions[2], positions[3])) * 0.5,
                 edge12,
                 edge30);
+    }
+
+    internal static ParsedEdgePairSelection Select(
+        GeodeticPoint[] vertices,
+        Float3[] positions)
+    {
+        ValidateQuadInputs(vertices, positions);
+
+        double edge01 = Distance(positions[0], positions[1]);
+        double edge12 = Distance(positions[1], positions[2]);
+        double edge23 = Distance(positions[2], positions[3]);
+        double edge30 = Distance(positions[3], positions[0]);
+
+        double pair01Length = (edge01 + edge23) * 0.5;
+        double pair12Length = (edge12 + edge30) * 0.5;
+
+        return pair01Length >= pair12Length
+            ? new ParsedEdgePairSelection(
+                [vertices[0], vertices[1]],
+                [vertices[3], vertices[2]],
+                pair01Length,
+                (Distance(positions[0], positions[3]) + Distance(positions[1], positions[2])) * 0.5)
+            : new ParsedEdgePairSelection(
+                [vertices[1], vertices[2]],
+                [vertices[0], vertices[3]],
+                pair12Length,
+                (Distance(positions[1], positions[0]) + Distance(positions[2], positions[3])) * 0.5);
     }
 
     internal static EdgePairSelection Select(
@@ -78,6 +107,21 @@ internal static class RoadSurfaceEdgePairSelector
         return Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY) + (deltaZ * deltaZ));
     }
 
+    private static void ValidateQuadInputs<TPoint>(TPoint[] vertices, Float3[] positions)
+    {
+        ArgumentNullException.ThrowIfNull(vertices);
+        ArgumentNullException.ThrowIfNull(positions);
+        if (vertices.Length != 4)
+        {
+            throw new ArgumentException("Road surface edge-pair selection requires exactly four vertices.", nameof(vertices));
+        }
+
+        if (positions.Length != 4)
+        {
+            throw new ArgumentException("Road surface edge-pair selection requires exactly four positions.", nameof(positions));
+        }
+    }
+
     private static bool AreSamePoint(ProjectionGeodeticPoint left, ProjectionGeodeticPoint right)
     {
         return Math.Abs(left.Latitude - right.Latitude) < 1e-8
@@ -97,3 +141,9 @@ internal sealed record EdgePairSelection(
     double Width,
     double Side0EdgeLength,
     double Side1EdgeLength);
+
+internal sealed record ParsedEdgePairSelection(
+    GeodeticPoint[] Side0,
+    GeodeticPoint[] Side1,
+    double Length,
+    double Width);

--- a/src/PlateauResoniteLink/Application/Importing/RoadSurfaceEdgePairSelector.cs
+++ b/src/PlateauResoniteLink/Application/Importing/RoadSurfaceEdgePairSelector.cs
@@ -1,0 +1,99 @@
+using System;
+
+using ProjectionGeodeticPoint = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.GeodeticPoint;
+using ProjectionParsedRing = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedRing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class RoadSurfaceEdgePairSelector
+{
+    internal static EdgePairSelection Select(
+        ProjectionGeodeticPoint[] vertices,
+        Float3[] positions)
+    {
+        double edge01 = Distance(positions[0], positions[1]);
+        double edge12 = Distance(positions[1], positions[2]);
+        double edge23 = Distance(positions[2], positions[3]);
+        double edge30 = Distance(positions[3], positions[0]);
+
+        double pair01Length = (edge01 + edge23) * 0.5;
+        double pair12Length = (edge12 + edge30) * 0.5;
+
+        return pair01Length >= pair12Length
+            ? new EdgePairSelection(
+                [vertices[0], vertices[1]],
+                [vertices[3], vertices[2]],
+                [positions[0], positions[1]],
+                [positions[3], positions[2]],
+                Side0Uvs: null,
+                Side1Uvs: null,
+                pair01Length,
+                (Distance(positions[0], positions[3]) + Distance(positions[1], positions[2])) * 0.5,
+                edge01,
+                edge23)
+            : new EdgePairSelection(
+                [vertices[1], vertices[2]],
+                [vertices[0], vertices[3]],
+                [positions[1], positions[2]],
+                [positions[0], positions[3]],
+                Side0Uvs: null,
+                Side1Uvs: null,
+                pair12Length,
+                (Distance(positions[1], positions[0]) + Distance(positions[2], positions[3])) * 0.5,
+                edge12,
+                edge30);
+    }
+
+    internal static EdgePairSelection Select(
+        ProjectionParsedRing ring,
+        Float3[] positions)
+    {
+        EdgePairSelection pair = Select(ring.Vertices, positions);
+        if (ring.UVs is null || ring.UVs.Count != ring.Vertices.Length || ring.Vertices.Length != 4)
+        {
+            return pair;
+        }
+
+        bool usesFirstEdge = AreSamePoint(pair.Side0[0], ring.Vertices[0])
+            && AreSamePoint(pair.Side0[1], ring.Vertices[1]);
+
+        return usesFirstEdge
+            ? pair with
+            {
+                Side0Uvs = [ring.UVs[0], ring.UVs[1]],
+                Side1Uvs = [ring.UVs[3], ring.UVs[2]],
+            }
+            : pair with
+            {
+                Side0Uvs = [ring.UVs[1], ring.UVs[2]],
+                Side1Uvs = [ring.UVs[0], ring.UVs[3]],
+            };
+    }
+
+    private static double Distance(Float3 left, Float3 right)
+    {
+        double deltaX = left.X - right.X;
+        double deltaY = left.Y - right.Y;
+        double deltaZ = left.Z - right.Z;
+        return Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY) + (deltaZ * deltaZ));
+    }
+
+    private static bool AreSamePoint(ProjectionGeodeticPoint left, ProjectionGeodeticPoint right)
+    {
+        return Math.Abs(left.Latitude - right.Latitude) < 1e-8
+            && Math.Abs(left.Longitude - right.Longitude) < 1e-8
+            && Math.Abs(left.Altitude - right.Altitude) < 1e-8;
+    }
+}
+
+internal sealed record EdgePairSelection(
+    ProjectionGeodeticPoint[] Side0,
+    ProjectionGeodeticPoint[] Side1,
+    Float3[] Side0Positions,
+    Float3[] Side1Positions,
+    Float2[]? Side0Uvs,
+    Float2[]? Side1Uvs,
+    double Length,
+    double Width,
+    double Side0EdgeLength,
+    double Side1EdgeLength);

--- a/src/PlateauResoniteLink/Application/Importing/RoadSurfaceEdgePairSelector.cs
+++ b/src/PlateauResoniteLink/Application/Importing/RoadSurfaceEdgePairSelector.cs
@@ -77,8 +77,10 @@ internal static class RoadSurfaceEdgePairSelector
         ProjectionParsedRing ring,
         Float3[] positions)
     {
+        ArgumentNullException.ThrowIfNull(ring);
+
         EdgePairSelection pair = Select(ring.Vertices, positions);
-        if (ring.UVs is null || ring.UVs.Count != ring.Vertices.Length || ring.Vertices.Length != 4)
+        if (ring.UVs is null || ring.UVs.Count != ring.Vertices.Length)
         {
             return pair;
         }

--- a/src/PlateauResoniteLink/Application/Importing/TerrainAlignedTransportationSurfaceSplitter.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainAlignedTransportationSurfaceSplitter.cs
@@ -304,15 +304,3 @@ internal static class TerrainAlignedTransportationSurfaceSplitter
         Float2? UV,
         double LateralPosition);
 }
-
-internal sealed record EdgePairSelection(
-    ProjectionGeodeticPoint[] Side0,
-    ProjectionGeodeticPoint[] Side1,
-    Float3[] Side0Positions,
-    Float3[] Side1Positions,
-    Float2[]? Side0Uvs,
-    Float2[]? Side1Uvs,
-    double Length,
-    double Width,
-    double Side0EdgeLength,
-    double Side1EdgeLength);

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
@@ -1,0 +1,112 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class GeneratedRoadMarkingCityObjectFactoryTests
+{
+    [Fact]
+    public void CreateGeneratesCenteredSegmentsForUntexturedTransportationQuad()
+    {
+        ParsedCityObject road = CreateRoadObject(
+            packageName: "tran",
+            surface: CreateRoadSurface(
+                "road",
+                width: 4.0,
+                length: 12.0,
+                texturePayload: null));
+
+        ParsedCityObject? marking = GeneratedRoadMarkingCityObjectFactory.Create(road, new GeodeticPoint(0.0, 0.0, 0.0), cityObjectCartesian: null);
+
+        Assert.NotNull(marking);
+        Assert.Equal("road-slot_road_marking", marking.SlotKey);
+        Assert.Equal("Road Marking", marking.DisplayName);
+        Assert.Equal(3, marking.Surfaces.Length);
+        Assert.All(marking.Surfaces, surface =>
+        {
+            Assert.StartsWith("road_generated_marking_", surface.PolygonId, StringComparison.Ordinal);
+            Assert.Equal(new ColorRgba(1.0, 1.0, 1.0, 1.0), surface.BaseColor);
+            Assert.Null(surface.TexturePayload);
+            Assert.Empty(surface.InteriorRings);
+        });
+
+        GeodeticPoint[] firstVertices = marking.Surfaces[0].ExteriorRing.Vertices;
+        Assert.Equal(0.0, firstVertices[0].Latitude, precision: 6);
+        Assert.Equal(4.0, firstVertices[1].Latitude, precision: 6);
+        Assert.Equal(1.925, firstVertices[0].Longitude, precision: 6);
+        Assert.Equal(1.925, firstVertices[1].Longitude, precision: 6);
+        Assert.Equal(2.075, firstVertices[2].Longitude, precision: 6);
+        Assert.Equal(2.075, firstVertices[3].Longitude, precision: 6);
+    }
+
+    [Fact]
+    public void CreateSkipsNarrowRoadSurface()
+    {
+        ParsedCityObject road = CreateRoadObject(
+            packageName: "tran",
+            surface: CreateRoadSurface(
+                "narrow-road",
+                width: 0.2,
+                length: 12.0,
+                texturePayload: null));
+
+        ParsedCityObject? marking = GeneratedRoadMarkingCityObjectFactory.Create(road, new GeodeticPoint(0.0, 0.0, 0.0), cityObjectCartesian: null);
+
+        Assert.Null(marking);
+    }
+
+    [Fact]
+    public void CreateSkipsTexturedRoadSurface()
+    {
+        ParsedCityObject road = CreateRoadObject(
+            packageName: "tran",
+            surface: CreateRoadSurface(
+                "textured-road",
+                width: 4.0,
+                length: 12.0,
+                texturePayload: new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")));
+
+        ParsedCityObject? marking = GeneratedRoadMarkingCityObjectFactory.Create(road, new GeodeticPoint(0.0, 0.0, 0.0), cityObjectCartesian: null);
+
+        Assert.Null(marking);
+    }
+
+    private static ParsedCityObject CreateRoadObject(string packageName, ParsedSurface surface)
+    {
+        return new ParsedCityObject(
+            "road-slot",
+            "Road",
+            packageName,
+            "53394525",
+            LodLevel: 2,
+            [surface],
+            new CoordinateReferenceSystem("local", Geocentric: null, CompatibilityKey: "local"),
+            "udx/tran/road.gml",
+            SharedAcrossMeshCodes: false,
+            TerrainAligned: true);
+    }
+
+    private static ParsedSurface CreateRoadSurface(
+        string polygonId,
+        double width,
+        double length,
+        TexturePayload? texturePayload)
+    {
+        GeodeticPoint[] vertices =
+        [
+            new(0.0, 0.0, 0.0),
+            new(length, 0.0, 0.0),
+            new(length, width, 0.0),
+            new(0.0, width, 0.0),
+        ];
+
+        return new ParsedSurface(
+            polygonId,
+            ParsedSurfaceSemantic.Ground,
+            new ParsedRing($"{polygonId}-ring", vertices, UVs: null),
+            InteriorRings: [],
+            new ColorRgba(0.2, 0.2, 0.2, 1.0),
+            texturePayload);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
@@ -72,6 +72,22 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
         Assert.Null(marking);
     }
 
+    [Fact]
+    public void CreateSkipsNonTransportationObject()
+    {
+        ParsedCityObject building = CreateRoadObject(
+            packageName: "bldg",
+            surface: CreateRoadSurface(
+                "building-ground",
+                width: 4.0,
+                length: 12.0,
+                texturePayload: null));
+
+        ParsedCityObject? marking = GeneratedRoadMarkingCityObjectFactory.Create(building, new GeodeticPoint(0.0, 0.0, 0.0), cityObjectCartesian: null);
+
+        Assert.Null(marking);
+    }
+
     private static ParsedCityObject CreateRoadObject(string packageName, ParsedSurface surface)
     {
         return new ParsedCityObject(

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
@@ -73,6 +73,31 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
     }
 
     [Fact]
+    public void CreateGeneratesMarkingsOnlyForEligibleTransportationSurfaces()
+    {
+        ParsedCityObject road = CreateRoadObject(
+            packageName: "tran",
+            surfaces:
+            [
+                CreateRoadSurface(
+                    "textured-road",
+                    width: 4.0,
+                    length: 12.0,
+                    texturePayload: new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")),
+                CreateRoadSurface(
+                    "plain-road",
+                    width: 4.0,
+                    length: 12.0,
+                    texturePayload: null),
+            ]);
+
+        ParsedCityObject? marking = GeneratedRoadMarkingCityObjectFactory.Create(road, new GeodeticPoint(0.0, 0.0, 0.0), cityObjectCartesian: null);
+
+        Assert.NotNull(marking);
+        Assert.All(marking.Surfaces, surface => Assert.StartsWith("plain-road_generated_marking_", surface.PolygonId, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void CreateSkipsNonTransportationObject()
     {
         ParsedCityObject building = CreateRoadObject(
@@ -90,13 +115,18 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
 
     private static ParsedCityObject CreateRoadObject(string packageName, ParsedSurface surface)
     {
+        return CreateRoadObject(packageName, [surface]);
+    }
+
+    private static ParsedCityObject CreateRoadObject(string packageName, ParsedSurface[] surfaces)
+    {
         return new ParsedCityObject(
             "road-slot",
             "Road",
             packageName,
             "53394525",
             LodLevel: 2,
-            [surface],
+            surfaces,
             new CoordinateReferenceSystem("local", Geocentric: null, CompatibilityKey: "local"),
             "udx/tran/road.gml",
             SharedAcrossMeshCodes: false,

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
@@ -113,6 +113,29 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
         Assert.Null(marking);
     }
 
+    [Fact]
+    public void RoadSurfaceEdgePairSelectorRejectsNonQuadInputsWithClearPrecondition()
+    {
+        GeodeticPoint[] vertices =
+        [
+            new(0.0, 0.0, 0.0),
+            new(1.0, 0.0, 0.0),
+            new(1.0, 1.0, 0.0),
+        ];
+        Float3[] positions =
+        [
+            new(0.0, 0.0, 0.0),
+            new(1.0, 0.0, 0.0),
+            new(1.0, 0.0, 1.0),
+        ];
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(
+            () => RoadSurfaceEdgePairSelector.Select(vertices, positions));
+
+        Assert.Equal("vertices", exception.ParamName);
+        Assert.Contains("exactly four vertices", exception.Message, StringComparison.Ordinal);
+    }
+
     private static ParsedCityObject CreateRoadObject(string packageName, ParsedSurface surface)
     {
         return CreateRoadObject(packageName, [surface]);


### PR DESCRIPTION
## Summary
- Extract generated road marking city-object construction from `LocalCityGmlObjectProjection` into `GeneratedRoadMarkingCityObjectFactory`.
- Move shared road surface edge-pair selection into `RoadSurfaceEdgePairSelector` so transportation splitting and marking generation use the same explicit contract.
- Add lightweight behavior tests for centered marking generation, narrow-road skip, and textured-surface skip without adding slow end-to-end coverage.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`