### PR TITLE
Extract DEM grid boundary alignment policy

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainGridChunkBoundaryAlignmentPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainGridChunkBoundaryAlignmentPolicy.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class DemTerrainGridChunkBoundaryAlignmentPolicy
+{
+    internal static ImportedCityObject[] Align(IReadOnlyList<ImportedCityObject> cityObjects)
+    {
+        TerrainGridChunkAlignmentState?[] states = cityObjects
+            .Select(static cityObject => TerrainGridChunkAlignmentState.TryCreate(cityObject))
+            .ToArray();
+        if (states.Any(static state => state is null))
+        {
+            return cityObjects.ToArray();
+        }
+
+        TerrainGridChunkAlignmentState[] chunkStates = states
+            .Select(static state => state!)
+            .ToArray();
+        const double seaLevelWorldHeightTolerance = 1e-6;
+        Dictionary<DemBoundarySampleKey, List<BoundaryHeightSampleReference>> sampleReferencesByKey = [];
+        foreach (TerrainGridChunkAlignmentState state in chunkStates)
+        {
+            foreach (BoundaryHeightSampleReference sampleReference in EnumerateBoundaryHeightSampleReferences(state))
+            {
+                if (!sampleReferencesByKey.TryGetValue(sampleReference.Key, out List<BoundaryHeightSampleReference>? references))
+                {
+                    references = [];
+                    sampleReferencesByKey.Add(sampleReference.Key, references);
+                }
+
+                references.Add(sampleReference);
+            }
+        }
+
+        bool foundSharedBoundary = false;
+        foreach (List<BoundaryHeightSampleReference> references in sampleReferencesByKey.Values)
+        {
+            if (references.Count < 2
+                || references.Select(static reference => reference.State.CityObject).Distinct().Count() < 2)
+            {
+                continue;
+            }
+
+            foundSharedBoundary = true;
+            double worldHeightSum = 0.0;
+            int sampleCount = 0;
+            double nonSeaLevelWorldHeightSum = 0.0;
+            int nonSeaLevelSampleCount = 0;
+            foreach (BoundaryHeightSampleReference reference in references)
+            {
+                double worldHeight = reference.State.BaseHeight + reference.State.HeightSamples[reference.SampleIndex];
+                bool isSeaLevelFallbackCandidate = Math.Abs(worldHeight) <= seaLevelWorldHeightTolerance;
+                worldHeightSum += worldHeight;
+                sampleCount++;
+                if (!isSeaLevelFallbackCandidate)
+                {
+                    nonSeaLevelWorldHeightSum += worldHeight;
+                    nonSeaLevelSampleCount++;
+                }
+            }
+
+            double alignedWorldHeight = nonSeaLevelSampleCount > 0
+                ? nonSeaLevelWorldHeightSum / nonSeaLevelSampleCount
+                : worldHeightSum / sampleCount;
+            foreach (BoundaryHeightSampleReference reference in references)
+            {
+                reference.State.HeightSamples[reference.SampleIndex] = alignedWorldHeight - reference.State.BaseHeight;
+            }
+        }
+
+        if (!foundSharedBoundary)
+        {
+            return cityObjects.ToArray();
+        }
+
+        return chunkStates
+            .Select(static state => state.ToCityObject())
+            .ToArray();
+    }
+
+    private static IEnumerable<BoundaryHeightSampleReference> EnumerateBoundaryHeightSampleReferences(
+        TerrainGridChunkAlignmentState state)
+    {
+        int width = state.Geometry.Width;
+        int height = state.Geometry.Height;
+        if (width < 2 || height < 2)
+        {
+            yield break;
+        }
+
+        for (int row = 0; row < height; row++)
+        {
+            yield return CreateBoundaryHeightSampleReference(state, row, 0);
+            yield return CreateBoundaryHeightSampleReference(state, row, width - 1);
+        }
+
+        for (int column = 1; column < width - 1; column++)
+        {
+            yield return CreateBoundaryHeightSampleReference(state, 0, column);
+            yield return CreateBoundaryHeightSampleReference(state, height - 1, column);
+        }
+    }
+
+    private static BoundaryHeightSampleReference CreateBoundaryHeightSampleReference(
+        TerrainGridChunkAlignmentState state,
+        int row,
+        int column)
+    {
+        double u = state.Geometry.Width == 1 ? 0.0 : (double)column / (state.Geometry.Width - 1);
+        double v = state.Geometry.Height == 1 ? 0.0 : (double)row / (state.Geometry.Height - 1);
+        double x = (state.CityObject.Transform.Position.X - (state.Geometry.Size.X / 2.0)) + (state.Geometry.Size.X * u);
+        double z = (state.CityObject.Transform.Position.Z - (state.Geometry.Size.Y / 2.0)) + (state.Geometry.Size.Y * v);
+        int sampleIndex = (row * state.Geometry.Width) + column;
+        return new BoundaryHeightSampleReference(
+            state,
+            sampleIndex,
+            new DemBoundarySampleKey(
+                QuantizeBoundaryCoordinate(x),
+                QuantizeBoundaryCoordinate(z)));
+    }
+
+    private static long QuantizeBoundaryCoordinate(double coordinate)
+    {
+        const double boundaryTolerance = 1e-3;
+        return (long)Math.Round(coordinate / boundaryTolerance, MidpointRounding.AwayFromZero);
+    }
+
+    private sealed class TerrainGridChunkAlignmentState
+    {
+        public TerrainGridChunkAlignmentState(
+            ImportedCityObject cityObject,
+            TerrainGridGeometry geometry,
+            double[] heightSamples)
+        {
+            CityObject = cityObject;
+            Geometry = geometry;
+            HeightSamples = heightSamples;
+            BaseHeight = cityObject.Transform.Position.Y - geometry.MaxHeight;
+        }
+
+        public ImportedCityObject CityObject { get; }
+
+        public TerrainGridGeometry Geometry { get; }
+
+        public double[] HeightSamples { get; }
+
+        public double BaseHeight { get; }
+
+        public static TerrainGridChunkAlignmentState? TryCreate(ImportedCityObject cityObject)
+        {
+            TerrainGridGeometry? geometry = cityObject.Geometry switch
+            {
+                TerrainGridGeometry terrainGrid => terrainGrid,
+                DynamicTerrainGeometry dynamicTerrain => dynamicTerrain.GridMesh,
+                _ => null,
+            };
+            return geometry is not null
+                ? new TerrainGridChunkAlignmentState(cityObject, geometry, geometry.HeightSamples.ToArray())
+                : null;
+        }
+
+        public ImportedCityObject ToCityObject()
+        {
+            double minHeight = HeightSamples.Min();
+            double maxHeight = HeightSamples.Max();
+            Transform3D alignedTransform = CityObject.Transform with
+            {
+                Position = CityObject.Transform.Position with
+                {
+                    Y = BaseHeight + maxHeight,
+                },
+            };
+
+            return CityObject with
+            {
+                Transform = alignedTransform,
+                Geometry = CityObject.Geometry switch
+                {
+                    DynamicTerrainGeometry dynamicTerrain => dynamicTerrain with
+                    {
+                        StaticMesh = TriangleMeshTransformRebaser.Rebase(
+                            dynamicTerrain.StaticMesh,
+                            CityObject.Transform,
+                            alignedTransform),
+                        GridMesh = dynamicTerrain.GridMesh with
+                        {
+                            MinHeight = minHeight,
+                            MaxHeight = maxHeight,
+                            HeightSamples = HeightSamples,
+                        },
+                    },
+                    _ => Geometry with
+                    {
+                        MinHeight = minHeight,
+                        MaxHeight = maxHeight,
+                        HeightSamples = HeightSamples,
+                    },
+                },
+            };
+        }
+    }
+
+    private sealed record DemBoundarySampleKey(
+        long QuantizedX,
+        long QuantizedZ);
+
+    private sealed record BoundaryHeightSampleReference(
+        TerrainGridChunkAlignmentState State,
+        int SampleIndex,
+        DemBoundarySampleKey Key);
+}

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -2419,7 +2419,7 @@ internal static class LocalCityGmlObjectProjection
         ImportedCityObject[] alignedCityObjects =
             request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
             && string.Equals(terrainAlignedParsedCityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
-                ? AlignAdjacentDemTerrainGridChunkBoundaries(projectedCityObjects)
+                ? DemTerrainGridChunkBoundaryAlignmentPolicy.Align(projectedCityObjects)
                 : [.. projectedCityObjects];
 
         foreach (ImportedCityObject cityObject in alignedCityObjects)
@@ -2555,7 +2555,7 @@ internal static class LocalCityGmlObjectProjection
             demTerrainTextureOverlay,
             materialResolver);
         TriangleMeshGeometry staticMesh = AssertTriangleMeshGeometry(staticCityObject);
-        TriangleMeshGeometry rebasedStaticMesh = RebaseTriangleMeshToTransform(
+        TriangleMeshGeometry rebasedStaticMesh = TriangleMeshTransformRebaser.Rebase(
             staticMesh,
             staticCityObject.Transform,
             heightMapCityObject!.Transform);
@@ -2729,213 +2729,6 @@ internal static class LocalCityGmlObjectProjection
             .Where(static material => material.ReuseScope == MaterialReuseScope.Shared)
             .ToArray();
     }
-
-    private static ImportedCityObject[] AlignAdjacentDemTerrainGridChunkBoundaries(
-        IReadOnlyList<ImportedCityObject> cityObjects)
-    {
-        TerrainGridChunkAlignmentState?[] states = cityObjects
-            .Select(static cityObject => TerrainGridChunkAlignmentState.TryCreate(cityObject))
-            .ToArray();
-        if (states.Any(static state => state is null))
-        {
-            return cityObjects.ToArray();
-        }
-
-        TerrainGridChunkAlignmentState[] chunkStates = states
-            .Select(static state => state!)
-            .ToArray();
-        const double seaLevelWorldHeightTolerance = 1e-6;
-        Dictionary<DemBoundarySampleKey, List<BoundaryHeightSampleReference>> sampleReferencesByKey = [];
-        foreach (TerrainGridChunkAlignmentState state in chunkStates)
-        {
-            foreach (BoundaryHeightSampleReference sampleReference in EnumerateBoundaryHeightSampleReferences(state))
-            {
-                if (!sampleReferencesByKey.TryGetValue(sampleReference.Key, out List<BoundaryHeightSampleReference>? references))
-                {
-                    references = [];
-                    sampleReferencesByKey.Add(sampleReference.Key, references);
-                }
-
-                references.Add(sampleReference);
-            }
-        }
-
-        bool foundSharedBoundary = false;
-        foreach (List<BoundaryHeightSampleReference> references in sampleReferencesByKey.Values)
-        {
-            if (references.Count < 2
-                || references.Select(static reference => reference.State.CityObject).Distinct().Count() < 2)
-            {
-                continue;
-            }
-
-            foundSharedBoundary = true;
-            double worldHeightSum = 0.0;
-            int sampleCount = 0;
-            double nonSeaLevelWorldHeightSum = 0.0;
-            int nonSeaLevelSampleCount = 0;
-            foreach (BoundaryHeightSampleReference reference in references)
-            {
-                double worldHeight = reference.State.BaseHeight + reference.State.HeightSamples[reference.SampleIndex];
-                bool isSeaLevelFallbackCandidate = Math.Abs(worldHeight) <= seaLevelWorldHeightTolerance;
-                worldHeightSum += worldHeight;
-                sampleCount++;
-                if (!isSeaLevelFallbackCandidate)
-                {
-                    nonSeaLevelWorldHeightSum += worldHeight;
-                    nonSeaLevelSampleCount++;
-                }
-            }
-
-            double alignedWorldHeight = nonSeaLevelSampleCount > 0
-                ? nonSeaLevelWorldHeightSum / nonSeaLevelSampleCount
-                : worldHeightSum / sampleCount;
-            foreach (BoundaryHeightSampleReference reference in references)
-            {
-                reference.State.HeightSamples[reference.SampleIndex] = alignedWorldHeight - reference.State.BaseHeight;
-            }
-        }
-
-        if (!foundSharedBoundary)
-        {
-            return cityObjects.ToArray();
-        }
-
-        return chunkStates
-            .Select(static state => state.ToCityObject())
-            .ToArray();
-    }
-
-    private static IEnumerable<BoundaryHeightSampleReference> EnumerateBoundaryHeightSampleReferences(
-        TerrainGridChunkAlignmentState state)
-    {
-        int width = state.Geometry.Width;
-        int height = state.Geometry.Height;
-        if (width < 2 || height < 2)
-        {
-            yield break;
-        }
-
-        for (int row = 0; row < height; row++)
-        {
-            yield return CreateBoundaryHeightSampleReference(state, row, 0);
-            yield return CreateBoundaryHeightSampleReference(state, row, width - 1);
-        }
-
-        for (int column = 1; column < width - 1; column++)
-        {
-            yield return CreateBoundaryHeightSampleReference(state, 0, column);
-            yield return CreateBoundaryHeightSampleReference(state, height - 1, column);
-        }
-    }
-
-    private static BoundaryHeightSampleReference CreateBoundaryHeightSampleReference(
-        TerrainGridChunkAlignmentState state,
-        int row,
-        int column)
-    {
-        double u = state.Geometry.Width == 1 ? 0.0 : (double)column / (state.Geometry.Width - 1);
-        double v = state.Geometry.Height == 1 ? 0.0 : (double)row / (state.Geometry.Height - 1);
-        double x = (state.CityObject.Transform.Position.X - (state.Geometry.Size.X / 2.0)) + (state.Geometry.Size.X * u);
-        double z = (state.CityObject.Transform.Position.Z - (state.Geometry.Size.Y / 2.0)) + (state.Geometry.Size.Y * v);
-        int sampleIndex = (row * state.Geometry.Width) + column;
-        return new BoundaryHeightSampleReference(
-            state,
-            sampleIndex,
-            new DemBoundarySampleKey(
-                QuantizeBoundaryCoordinate(x),
-                QuantizeBoundaryCoordinate(z)));
-    }
-
-    private static long QuantizeBoundaryCoordinate(double coordinate)
-    {
-        const double boundaryTolerance = 1e-3;
-        return (long)Math.Round(coordinate / boundaryTolerance, MidpointRounding.AwayFromZero);
-    }
-
-    private sealed class TerrainGridChunkAlignmentState
-    {
-        public TerrainGridChunkAlignmentState(
-            ImportedCityObject cityObject,
-            TerrainGridGeometry geometry,
-            double[] heightSamples)
-        {
-            CityObject = cityObject;
-            Geometry = geometry;
-            HeightSamples = heightSamples;
-            BaseHeight = cityObject.Transform.Position.Y - geometry.MaxHeight;
-        }
-
-        public ImportedCityObject CityObject { get; }
-
-        public TerrainGridGeometry Geometry { get; }
-
-        public double[] HeightSamples { get; }
-
-        public double BaseHeight { get; }
-
-        public static TerrainGridChunkAlignmentState? TryCreate(ImportedCityObject cityObject)
-        {
-            TerrainGridGeometry? geometry = cityObject.Geometry switch
-            {
-                TerrainGridGeometry terrainGrid => terrainGrid,
-                DynamicTerrainGeometry dynamicTerrain => dynamicTerrain.GridMesh,
-                _ => null,
-            };
-            return geometry is not null
-                ? new TerrainGridChunkAlignmentState(cityObject, geometry, geometry.HeightSamples.ToArray())
-                : null;
-        }
-
-        public ImportedCityObject ToCityObject()
-        {
-            double minHeight = HeightSamples.Min();
-            double maxHeight = HeightSamples.Max();
-            Transform3D alignedTransform = CityObject.Transform with
-            {
-                Position = CityObject.Transform.Position with
-                {
-                    Y = BaseHeight + maxHeight,
-                },
-            };
-
-            return CityObject with
-            {
-                Transform = alignedTransform,
-                Geometry = CityObject.Geometry switch
-                {
-                    DynamicTerrainGeometry dynamicTerrain => dynamicTerrain with
-                    {
-                        StaticMesh = RebaseTriangleMeshToTransform(
-                            dynamicTerrain.StaticMesh,
-                            CityObject.Transform,
-                            alignedTransform),
-                        GridMesh = dynamicTerrain.GridMesh with
-                        {
-                            MinHeight = minHeight,
-                            MaxHeight = maxHeight,
-                            HeightSamples = HeightSamples,
-                        },
-                    },
-                    _ => Geometry with
-                    {
-                        MinHeight = minHeight,
-                        MaxHeight = maxHeight,
-                        HeightSamples = HeightSamples,
-                    },
-                },
-            };
-        }
-    }
-
-    private sealed record DemBoundarySampleKey(
-        long QuantizedX,
-        long QuantizedZ);
-
-    private sealed record BoundaryHeightSampleReference(
-        TerrainGridChunkAlignmentState State,
-        int SampleIndex,
-        DemBoundarySampleKey Key);
 
     private static bool TryProjectDemTerrainGridCityObject(
         ParsedCityObject cityObject,
@@ -3656,14 +3449,6 @@ internal static class LocalCityGmlObjectProjection
             MaxLongitude: Math.Min(left.MaxLongitude, right.MaxLongitude));
     }
 
-    private static Float3 TransformPointToWorld(Transform3D transform, Float3 localPosition)
-    {
-        Float3 rotated = transform.Rotation is null
-            ? localPosition
-            : Rotate(localPosition, transform.Rotation);
-        return Add(transform.Position, rotated);
-    }
-
     private static TriangleMeshGeometry AssertTriangleMeshGeometry(ImportedCityObject cityObject)
     {
         return cityObject.Geometry as TriangleMeshGeometry
@@ -3674,66 +3459,6 @@ internal static class LocalCityGmlObjectProjection
     {
         return cityObject.Geometry as TerrainGridGeometry
             ?? throw new InvalidOperationException("Dynamic terrain grid variant must be projected as a terrain grid.");
-    }
-
-    private static TriangleMeshGeometry RebaseTriangleMeshToTransform(
-        TriangleMeshGeometry source,
-        Transform3D sourceTransform,
-        Transform3D targetTransform)
-    {
-        ImportedMesh mesh = source.Mesh;
-        MeshVertex[] vertices = mesh.Vertices
-            .Select(vertex =>
-            {
-                Float3 worldPosition = TransformPointToWorld(sourceTransform, vertex.Position);
-                Float3 localPosition = TransformVectorFromWorld(targetTransform, Subtract(worldPosition, targetTransform.Position));
-                Float3 worldNormal = sourceTransform.Rotation is null ? vertex.Normal : Rotate(vertex.Normal, sourceTransform.Rotation);
-                Float3 localNormal = TransformVectorFromWorld(targetTransform, worldNormal);
-                return vertex with
-                {
-                    Position = localPosition,
-                    Normal = localNormal,
-                };
-            })
-            .ToArray();
-        return new TriangleMeshGeometry(new ImportedMesh(vertices, mesh.Submeshes));
-    }
-
-    private static Float3 TransformVectorFromWorld(Transform3D transform, Float3 worldVector)
-    {
-        return transform.Rotation is null
-            ? worldVector
-            : Rotate(worldVector, Conjugate(transform.Rotation));
-    }
-
-    private static Float3 Rotate(Float3 value, Quaternion rotation)
-    {
-        Float3 qv = new(rotation.X, rotation.Y, rotation.Z);
-        Float3 uv = Cross3(qv, value);
-        Float3 uuv = Cross3(qv, uv);
-        return Add(
-            value,
-            Add(
-                Scale3(uv, 2.0 * rotation.W),
-                Scale3(uuv, 2.0)));
-    }
-
-    private static Quaternion Conjugate(Quaternion value)
-    {
-        return new Quaternion(-value.X, -value.Y, -value.Z, value.W);
-    }
-
-    private static Float3 Cross3(Float3 left, Float3 right)
-    {
-        return new Float3(
-            (left.Y * right.Z) - (left.Z * right.Y),
-            (left.Z * right.X) - (left.X * right.Z),
-            (left.X * right.Y) - (left.Y * right.X));
-    }
-
-    private static Float3 Scale3(Float3 value, double scalar)
-    {
-        return new Float3(value.X * scalar, value.Y * scalar, value.Z * scalar);
     }
 
     private static bool HasRenderableGeometry(ImportedCityObject cityObject)

--- a/src/PlateauResoniteLink/Application/Importing/TriangleMeshTransformRebaser.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TriangleMeshTransformRebaser.cs
@@ -1,0 +1,84 @@
+using System.Linq;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class TriangleMeshTransformRebaser
+{
+    internal static TriangleMeshGeometry Rebase(
+        TriangleMeshGeometry source,
+        Transform3D sourceTransform,
+        Transform3D targetTransform)
+    {
+        ImportedMesh mesh = source.Mesh;
+        MeshVertex[] vertices = mesh.Vertices
+            .Select(vertex =>
+            {
+                Float3 worldPosition = TransformPointToWorld(sourceTransform, vertex.Position);
+                Float3 localPosition = TransformVectorFromWorld(targetTransform, Subtract(worldPosition, targetTransform.Position));
+                Float3 worldNormal = sourceTransform.Rotation is null ? vertex.Normal : Rotate(vertex.Normal, sourceTransform.Rotation);
+                Float3 localNormal = TransformVectorFromWorld(targetTransform, worldNormal);
+                return vertex with
+                {
+                    Position = localPosition,
+                    Normal = localNormal,
+                };
+            })
+            .ToArray();
+        return new TriangleMeshGeometry(new ImportedMesh(vertices, mesh.Submeshes));
+    }
+
+    private static Float3 TransformPointToWorld(Transform3D transform, Float3 localPosition)
+    {
+        Float3 rotated = transform.Rotation is null
+            ? localPosition
+            : Rotate(localPosition, transform.Rotation);
+        return Add(transform.Position, rotated);
+    }
+
+    private static Float3 TransformVectorFromWorld(Transform3D transform, Float3 worldVector)
+    {
+        return transform.Rotation is null
+            ? worldVector
+            : Rotate(worldVector, Conjugate(transform.Rotation));
+    }
+
+    private static Float3 Rotate(Float3 value, Quaternion rotation)
+    {
+        Float3 qv = new(rotation.X, rotation.Y, rotation.Z);
+        Float3 uv = Cross(qv, value);
+        Float3 uuv = Cross(qv, uv);
+        return Add(
+            value,
+            Add(
+                Scale(uv, 2.0 * rotation.W),
+                Scale(uuv, 2.0)));
+    }
+
+    private static Quaternion Conjugate(Quaternion value)
+    {
+        return new Quaternion(-value.X, -value.Y, -value.Z, value.W);
+    }
+
+    private static Float3 Add(Float3 left, Float3 right)
+    {
+        return new Float3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
+    }
+
+    private static Float3 Subtract(Float3 left, Float3 right)
+    {
+        return new Float3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
+    }
+
+    private static Float3 Cross(Float3 left, Float3 right)
+    {
+        return new Float3(
+            (left.Y * right.Z) - (left.Z * right.Y),
+            (left.Z * right.X) - (left.X * right.Z),
+            (left.X * right.Y) - (left.Y * right.X));
+    }
+
+    private static Float3 Scale(Float3 value, double scalar)
+    {
+        return new Float3(value.X * scalar, value.Y * scalar, value.Z * scalar);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGridChunkBoundaryAlignmentPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGridChunkBoundaryAlignmentPolicyTests.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class DemTerrainGridChunkBoundaryAlignmentPolicyTests
+{
+    [Fact]
+    public void AlignAveragesSharedSamplesForPartialOverlapWithDifferentResolution()
+    {
+        ImportedCityObject left = CreateTerrainGridCityObject(
+            "left-dem",
+            new Float3(0.0, 14.0, 0.0),
+            width: 2,
+            height: 5,
+            sizeX: 2.0,
+            sizeZ: 4.0,
+            [
+                1.0, 10.0,
+                1.0, 11.0,
+                1.0, 12.0,
+                1.0, 13.0,
+                1.0, 14.0,
+            ]);
+        ImportedCityObject right = CreateTerrainGridCityObject(
+            "right-dem",
+            new Float3(2.0, 22.0, 0.0),
+            width: 2,
+            height: 3,
+            sizeX: 2.0,
+            sizeZ: 2.0,
+            [
+                20.0, 2.0,
+                21.0, 2.0,
+                22.0, 2.0,
+            ]);
+
+        ImportedCityObject[] aligned = DemTerrainGridChunkBoundaryAlignmentPolicy.Align([left, right]);
+
+        TerrainGridGeometry alignedLeft = Assert.IsType<TerrainGridGeometry>(aligned[0].Geometry);
+        TerrainGridGeometry alignedRight = Assert.IsType<TerrainGridGeometry>(aligned[1].Geometry);
+
+        Assert.Equal(10.0, alignedLeft.HeightSamples[1], 6);
+        Assert.Equal(15.5, alignedLeft.HeightSamples[3], 6);
+        Assert.Equal(16.5, alignedLeft.HeightSamples[5], 6);
+        Assert.Equal(17.5, alignedLeft.HeightSamples[7], 6);
+        Assert.Equal(14.0, alignedLeft.HeightSamples[9], 6);
+
+        Assert.Equal(15.5, alignedRight.HeightSamples[0], 6);
+        Assert.Equal(16.5, alignedRight.HeightSamples[2], 6);
+        Assert.Equal(17.5, alignedRight.HeightSamples[4], 6);
+    }
+
+    [Fact]
+    public void AlignRebasesDynamicTerrainStaticMeshWhenGridTransformChanges()
+    {
+        ImportedCityObject left = CreateDynamicTerrainCityObject(
+            "left-dem",
+            new Float3(0.0, 14.0, 0.0),
+            width: 2,
+            height: 2,
+            sizeX: 2.0,
+            sizeZ: 2.0,
+            [
+                1.0, 10.0,
+                1.0, 14.0,
+            ]);
+        ImportedCityObject right = CreateTerrainGridCityObject(
+            "right-dem",
+            new Float3(2.0, 22.0, 0.0),
+            width: 2,
+            height: 2,
+            sizeX: 2.0,
+            sizeZ: 2.0,
+            [
+                20.0, 2.0,
+                22.0, 2.0,
+            ]);
+        double originalWorldY = left.Transform.Position.Y
+            + Assert.IsType<DynamicTerrainGeometry>(left.Geometry).StaticMesh.Mesh.Vertices[0].Position.Y;
+
+        ImportedCityObject[] aligned = DemTerrainGridChunkBoundaryAlignmentPolicy.Align([left, right]);
+
+        DynamicTerrainGeometry alignedGeometry = Assert.IsType<DynamicTerrainGeometry>(aligned[0].Geometry);
+        double alignedWorldY = aligned[0].Transform.Position.Y
+            + alignedGeometry.StaticMesh.Mesh.Vertices[0].Position.Y;
+        Assert.Equal(originalWorldY, alignedWorldY, precision: 6);
+        Assert.NotEqual(left.Transform.Position.Y, aligned[0].Transform.Position.Y);
+    }
+
+    private static ImportedCityObject CreateDynamicTerrainCityObject(
+        string slotKey,
+        Float3 position,
+        int width,
+        int height,
+        double sizeX,
+        double sizeZ,
+        IReadOnlyList<double> heightSamples)
+    {
+        ImportedCityObject grid = CreateTerrainGridCityObject(
+            slotKey,
+            position,
+            width,
+            height,
+            sizeX,
+            sizeZ,
+            heightSamples);
+        TriangleMeshGeometry staticMesh = new(new ImportedMesh(
+            [
+                new MeshVertex(
+                    new Float3(0.0, 1.0, 0.0),
+                    new Float3(0.0, 1.0, 0.0),
+                    new Float2(0.0, 0.0)),
+            ],
+            [new MeshSubmesh(0, [])]));
+        return grid with
+        {
+            Geometry = new DynamicTerrainGeometry(staticMesh, Assert.IsType<TerrainGridGeometry>(grid.Geometry)),
+        };
+    }
+
+    private static ImportedCityObject CreateTerrainGridCityObject(
+        string slotKey,
+        Float3 position,
+        int width,
+        int height,
+        double sizeX,
+        double sizeZ,
+        IReadOnlyList<double> heightSamples)
+    {
+        MaterialBinding material = new(
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            MaterialType: MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: TextureSourceKind.Bundled,
+            Projection: MaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0]);
+        return new ImportedCityObject(
+            ObjectKey: slotKey,
+            DisplayName: slotKey,
+            PackageName: "dem",
+            ActualMeshCode: "53394525",
+            LodLevel: 1,
+            Transform: new Transform3D(position),
+            Geometry: new TerrainGridGeometry(
+                Width: width,
+                Height: height,
+                Size: new Float2(sizeX, sizeZ),
+                MinHeight: heightSamples.Min(),
+                MaxHeight: heightSamples.Max(),
+                HeightSamples: heightSamples),
+            Materials: [material],
+            SourceFileRelativePath: $"udx/dem/53394525/{slotKey}.gml");
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -2610,52 +2610,6 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public void AlignAdjacentDemTerrainGridChunkBoundariesAveragesSharedSamplesForPartialOverlapWithDifferentResolution()
-    {
-        ImportedCityObject left = CreateTerrainGridCityObject(
-            "left-dem",
-            new Float3(0.0, 14.0, 0.0),
-            width: 2,
-            height: 5,
-            sizeX: 2.0,
-            sizeZ: 4.0,
-            [
-                1.0, 10.0,
-                1.0, 11.0,
-                1.0, 12.0,
-                1.0, 13.0,
-                1.0, 14.0,
-            ]);
-        ImportedCityObject right = CreateTerrainGridCityObject(
-            "right-dem",
-            new Float3(2.0, 22.0, 0.0),
-            width: 2,
-            height: 3,
-            sizeX: 2.0,
-            sizeZ: 2.0,
-            [
-                20.0, 2.0,
-                21.0, 2.0,
-                22.0, 2.0,
-            ]);
-
-        ImportedCityObject[] aligned = AlignAdjacentDemTerrainGridChunkBoundariesForTest([left, right]);
-
-        TerrainGridGeometry alignedLeft = Assert.IsType<TerrainGridGeometry>(aligned[0].Geometry);
-        TerrainGridGeometry alignedRight = Assert.IsType<TerrainGridGeometry>(aligned[1].Geometry);
-
-        Assert.Equal(10.0, alignedLeft.HeightSamples[1], 6);
-        Assert.Equal(15.5, alignedLeft.HeightSamples[3], 6);
-        Assert.Equal(16.5, alignedLeft.HeightSamples[5], 6);
-        Assert.Equal(17.5, alignedLeft.HeightSamples[7], 6);
-        Assert.Equal(14.0, alignedLeft.HeightSamples[9], 6);
-
-        Assert.Equal(15.5, alignedRight.HeightSamples[0], 6);
-        Assert.Equal(16.5, alignedRight.HeightSamples[2], 6);
-        Assert.Equal(17.5, alignedRight.HeightSamples[4], 6);
-    }
-
-    [Fact]
     public async Task TerrainAlignedObjectDoesNotUseNearestTerrainPointOutsideDemTriangles()
     {
         using TemporaryDirectory datasetRoot = new();
@@ -3295,18 +3249,6 @@ public sealed class LocalCityGmlObjectProjectionTests
         return min + ((max - min) * ratio);
     }
 
-    private static ImportedCityObject[] AlignAdjacentDemTerrainGridChunkBoundariesForTest(
-        IReadOnlyList<ImportedCityObject> cityObjects)
-    {
-        MethodInfo method = typeof(LocalCityGmlObjectProjection)
-            .GetMethod(
-                "AlignAdjacentDemTerrainGridChunkBoundaries",
-                BindingFlags.NonPublic | BindingFlags.Static)
-            ?? throw new InvalidOperationException("Failed to resolve AlignAdjacentDemTerrainGridChunkBoundaries.");
-
-        return (ImportedCityObject[])method.Invoke(null, [cityObjects])!;
-    }
-
     private static object CreateGeneratedSurfaceUvProjectionForTest(
         LocalCityGmlObjectProjection.ParsedSurface surface,
         string packageName,
@@ -3736,41 +3678,6 @@ public sealed class LocalCityGmlObjectProjectionTests
             ?? throw new InvalidOperationException("Failed to resolve GetCandidateTriangleIndices.");
 
         return (IReadOnlyList<int>)method.Invoke(spatialIndex, [x, z])!;
-    }
-
-    private static ImportedCityObject CreateTerrainGridCityObject(
-        string slotKey,
-        Float3 position,
-        int width,
-        int height,
-        double sizeX,
-        double sizeZ,
-        IReadOnlyList<double> heightSamples)
-    {
-        MaterialBinding material = new(
-            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
-            MaterialType: MaterialType.Standard,
-            TexturePayload: null,
-            TextureSourceKind: TextureSourceKind.Bundled,
-            Projection: MaterialProjection.Uv,
-            DepthOffset: null,
-            SubmeshIndices: [0]);
-        return new ImportedCityObject(
-            ObjectKey: slotKey,
-            DisplayName: slotKey,
-            PackageName: "dem",
-            ActualMeshCode: "53394525",
-            LodLevel: 1,
-            Transform: new Transform3D(position),
-            Geometry: new TerrainGridGeometry(
-                Width: width,
-                Height: height,
-                Size: new Float2(sizeX, sizeZ),
-                MinHeight: heightSamples.Min(),
-                MaxHeight: heightSamples.Max(),
-                HeightSamples: heightSamples),
-            Materials: [material],
-            SourceFileRelativePath: $"udx/dem/53394525/{slotKey}.gml");
     }
 
     private static void AssertGeneratedUpperFacadeTrianglesFaceOutward(


### PR DESCRIPTION
## Summary
- Extract DEM terrain grid boundary alignment from `LocalCityGmlObjectProjection` into `DemTerrainGridChunkBoundaryAlignmentPolicy`.
- Move dynamic terrain static-mesh rebasing into `TriangleMeshTransformRebaser` so dynamic projection and boundary alignment share the same geometry transform contract.
- Replace the private-reflection boundary alignment test with direct policy tests, including dynamic terrain static mesh world-position preservation.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`