### PR TITLE
Extract generated LOD1 roof city object factory

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainGridChunkBoundaryAlignmentPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainGridChunkBoundaryAlignmentPolicy.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class DemTerrainGridChunkBoundaryAlignmentPolicy
+{
+    internal static ImportedCityObject[] Align(IReadOnlyList<ImportedCityObject> cityObjects)
+    {
+        TerrainGridChunkAlignmentState?[] states = cityObjects
+            .Select(static cityObject => TerrainGridChunkAlignmentState.TryCreate(cityObject))
+            .ToArray();
+        if (states.Any(static state => state is null))
+        {
+            return cityObjects.ToArray();
+        }
+
+        TerrainGridChunkAlignmentState[] chunkStates = states
+            .Select(static state => state!)
+            .ToArray();
+        const double seaLevelWorldHeightTolerance = 1e-6;
+        Dictionary<DemBoundarySampleKey, List<BoundaryHeightSampleReference>> sampleReferencesByKey = [];
+        foreach (TerrainGridChunkAlignmentState state in chunkStates)
+        {
+            foreach (BoundaryHeightSampleReference sampleReference in EnumerateBoundaryHeightSampleReferences(state))
+            {
+                if (!sampleReferencesByKey.TryGetValue(sampleReference.Key, out List<BoundaryHeightSampleReference>? references))
+                {
+                    references = [];
+                    sampleReferencesByKey.Add(sampleReference.Key, references);
+                }
+
+                references.Add(sampleReference);
+            }
+        }
+
+        bool foundSharedBoundary = false;
+        foreach (List<BoundaryHeightSampleReference> references in sampleReferencesByKey.Values)
+        {
+            if (references.Count < 2
+                || references.Select(static reference => reference.State.CityObject).Distinct().Count() < 2)
+            {
+                continue;
+            }
+
+            foundSharedBoundary = true;
+            double worldHeightSum = 0.0;
+            int sampleCount = 0;
+            double nonSeaLevelWorldHeightSum = 0.0;
+            int nonSeaLevelSampleCount = 0;
+            foreach (BoundaryHeightSampleReference reference in references)
+            {
+                double worldHeight = reference.State.BaseHeight + reference.State.HeightSamples[reference.SampleIndex];
+                bool isSeaLevelFallbackCandidate = Math.Abs(worldHeight) <= seaLevelWorldHeightTolerance;
+                worldHeightSum += worldHeight;
+                sampleCount++;
+                if (!isSeaLevelFallbackCandidate)
+                {
+                    nonSeaLevelWorldHeightSum += worldHeight;
+                    nonSeaLevelSampleCount++;
+                }
+            }
+
+            double alignedWorldHeight = nonSeaLevelSampleCount > 0
+                ? nonSeaLevelWorldHeightSum / nonSeaLevelSampleCount
+                : worldHeightSum / sampleCount;
+            foreach (BoundaryHeightSampleReference reference in references)
+            {
+                reference.State.HeightSamples[reference.SampleIndex] = alignedWorldHeight - reference.State.BaseHeight;
+            }
+        }
+
+        if (!foundSharedBoundary)
+        {
+            return cityObjects.ToArray();
+        }
+
+        return chunkStates
+            .Select(static state => state.ToCityObject())
+            .ToArray();
+    }
+
+    private static IEnumerable<BoundaryHeightSampleReference> EnumerateBoundaryHeightSampleReferences(
+        TerrainGridChunkAlignmentState state)
+    {
+        int width = state.Geometry.Width;
+        int height = state.Geometry.Height;
+        if (width < 2 || height < 2)
+        {
+            yield break;
+        }
+
+        for (int row = 0; row < height; row++)
+        {
+            yield return CreateBoundaryHeightSampleReference(state, row, 0);
+            yield return CreateBoundaryHeightSampleReference(state, row, width - 1);
+        }
+
+        for (int column = 1; column < width - 1; column++)
+        {
+            yield return CreateBoundaryHeightSampleReference(state, 0, column);
+            yield return CreateBoundaryHeightSampleReference(state, height - 1, column);
+        }
+    }
+
+    private static BoundaryHeightSampleReference CreateBoundaryHeightSampleReference(
+        TerrainGridChunkAlignmentState state,
+        int row,
+        int column)
+    {
+        double u = state.Geometry.Width == 1 ? 0.0 : (double)column / (state.Geometry.Width - 1);
+        double v = state.Geometry.Height == 1 ? 0.0 : (double)row / (state.Geometry.Height - 1);
+        double x = (state.CityObject.Transform.Position.X - (state.Geometry.Size.X / 2.0)) + (state.Geometry.Size.X * u);
+        double z = (state.CityObject.Transform.Position.Z - (state.Geometry.Size.Y / 2.0)) + (state.Geometry.Size.Y * v);
+        int sampleIndex = (row * state.Geometry.Width) + column;
+        return new BoundaryHeightSampleReference(
+            state,
+            sampleIndex,
+            new DemBoundarySampleKey(
+                QuantizeBoundaryCoordinate(x),
+                QuantizeBoundaryCoordinate(z)));
+    }
+
+    private static long QuantizeBoundaryCoordinate(double coordinate)
+    {
+        const double boundaryTolerance = 1e-3;
+        return (long)Math.Round(coordinate / boundaryTolerance, MidpointRounding.AwayFromZero);
+    }
+
+    private sealed class TerrainGridChunkAlignmentState
+    {
+        public TerrainGridChunkAlignmentState(
+            ImportedCityObject cityObject,
+            TerrainGridGeometry geometry,
+            double[] heightSamples)
+        {
+            CityObject = cityObject;
+            Geometry = geometry;
+            HeightSamples = heightSamples;
+            BaseHeight = cityObject.Transform.Position.Y - geometry.MaxHeight;
+        }
+
+        public ImportedCityObject CityObject { get; }
+
+        public TerrainGridGeometry Geometry { get; }
+
+        public double[] HeightSamples { get; }
+
+        public double BaseHeight { get; }
+
+        public static TerrainGridChunkAlignmentState? TryCreate(ImportedCityObject cityObject)
+        {
+            TerrainGridGeometry? geometry = cityObject.Geometry switch
+            {
+                TerrainGridGeometry terrainGrid => terrainGrid,
+                DynamicTerrainGeometry dynamicTerrain => dynamicTerrain.GridMesh,
+                _ => null,
+            };
+            return geometry is not null
+                ? new TerrainGridChunkAlignmentState(cityObject, geometry, geometry.HeightSamples.ToArray())
+                : null;
+        }
+
+        public ImportedCityObject ToCityObject()
+        {
+            double minHeight = HeightSamples.Min();
+            double maxHeight = HeightSamples.Max();
+            Transform3D alignedTransform = CityObject.Transform with
+            {
+                Position = CityObject.Transform.Position with
+                {
+                    Y = BaseHeight + maxHeight,
+                },
+            };
+
+            return CityObject with
+            {
+                Transform = alignedTransform,
+                Geometry = CityObject.Geometry switch
+                {
+                    DynamicTerrainGeometry dynamicTerrain => dynamicTerrain with
+                    {
+                        StaticMesh = TriangleMeshTransformRebaser.Rebase(
+                            dynamicTerrain.StaticMesh,
+                            CityObject.Transform,
+                            alignedTransform),
+                        GridMesh = dynamicTerrain.GridMesh with
+                        {
+                            MinHeight = minHeight,
+                            MaxHeight = maxHeight,
+                            HeightSamples = HeightSamples,
+                        },
+                    },
+                    _ => Geometry with
+                    {
+                        MinHeight = minHeight,
+                        MaxHeight = maxHeight,
+                        HeightSamples = HeightSamples,
+                    },
+                },
+            };
+        }
+    }
+
+    private sealed record DemBoundarySampleKey(
+        long QuantizedX,
+        long QuantizedZ);
+
+    private sealed record BoundaryHeightSampleReference(
+        TerrainGridChunkAlignmentState State,
+        int SampleIndex,
+        DemBoundarySampleKey Key);
+}

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -19,7 +19,7 @@ internal static class GeneratedLod1RoofCityObjectFactory
         if (!PlateauPackageCatalog.IsBuildingPackage(cityObject.PackageName)
             || cityObject.LodLevel != 1
             || !cityObject.ReferenceSystem.IsGeographic
-            || cityObject.Surfaces.Any(IsGeneratedLod1RoofSurface))
+            || cityObject.Surfaces.Any(GeneratedLod1RoofSurfaceIdentity.IsGenerated))
         {
             return cityObject;
         }
@@ -144,21 +144,6 @@ internal static class GeneratedLod1RoofCityObjectFactory
             positions.Min(static position => position.Y),
             positions.Max(static position => position.Y),
             isNearHorizontal);
-    }
-
-    private static bool IsGeneratedLod1RoofSurface(ParsedSurface surface)
-    {
-        const string generatedToken = "_generated_";
-        int generatedTokenIndex = surface.PolygonId.LastIndexOf(generatedToken, StringComparison.Ordinal);
-        if (generatedTokenIndex < 0)
-        {
-            return false;
-        }
-
-        ReadOnlySpan<char> suffix = surface.PolygonId.AsSpan(generatedTokenIndex + generatedToken.Length);
-        return suffix.StartsWith("shed-", StringComparison.Ordinal)
-            || suffix.StartsWith("gable-", StringComparison.Ordinal)
-            || suffix.StartsWith("hip-", StringComparison.Ordinal);
     }
 
     private static GeodeticPoint[] RemoveClosingPoint(GeodeticPoint[] vertices)

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -149,7 +149,7 @@ internal static class GeneratedLod1RoofCityObjectFactory
     private static bool IsGeneratedLod1RoofSurface(ParsedSurface surface)
     {
         const string generatedToken = "_generated_";
-        int generatedTokenIndex = surface.PolygonId.IndexOf(generatedToken, StringComparison.Ordinal);
+        int generatedTokenIndex = surface.PolygonId.LastIndexOf(generatedToken, StringComparison.Ordinal);
         if (generatedTokenIndex < 0)
         {
             return false;

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -148,7 +148,17 @@ internal static class GeneratedLod1RoofCityObjectFactory
 
     private static bool IsGeneratedLod1RoofSurface(ParsedSurface surface)
     {
-        return surface.PolygonId.Contains("_generated_", StringComparison.Ordinal);
+        const string generatedToken = "_generated_";
+        int generatedTokenIndex = surface.PolygonId.IndexOf(generatedToken, StringComparison.Ordinal);
+        if (generatedTokenIndex < 0)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> suffix = surface.PolygonId.AsSpan(generatedTokenIndex + generatedToken.Length);
+        return suffix.StartsWith("shed-", StringComparison.Ordinal)
+            || suffix.StartsWith("gable-", StringComparison.Ordinal)
+            || suffix.StartsWith("hip-", StringComparison.Ordinal);
     }
 
     private static GeodeticPoint[] RemoveClosingPoint(GeodeticPoint[] vertices)

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using GeographicLib;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class GeneratedLod1RoofCityObjectFactory
+{
+    private const double BuildingBottomCullBandMeters = 0.1;
+
+    internal static ParsedCityObject Create(ParsedCityObject cityObject)
+    {
+        ArgumentNullException.ThrowIfNull(cityObject);
+
+        if (!PlateauPackageCatalog.IsBuildingPackage(cityObject.PackageName)
+            || cityObject.LodLevel != 1
+            || !cityObject.ReferenceSystem.IsGeographic
+            || cityObject.Surfaces.Any(IsGeneratedLod1RoofSurface))
+        {
+            return cityObject;
+        }
+
+        GeodeticPoint cityObjectOrigin = CityObjectOriginResolver.Resolve(
+            cityObject.GeodeticOriginOverride,
+            cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
+        LocalCartesian cityObjectCartesian = new(
+            cityObjectOrigin.Latitude,
+            cityObjectOrigin.Longitude,
+            cityObjectOrigin.Altitude,
+            cityObject.ReferenceSystem.Geocentric);
+        if (!TryCreateFootprint(cityObject, cityObjectOrigin, cityObjectCartesian, out Lod1RoofFootprint? footprint))
+        {
+            return cityObject;
+        }
+
+        Lod1RoofFootprint resolvedFootprint = footprint!;
+        GeneratedLod1RoofShape roofShape = Lod1RoofShapePolicy.Select(
+            cityObject.SlotKey,
+            resolvedFootprint.Attributes,
+            resolvedFootprint.GeometryHeightMeters,
+            resolvedFootprint.LengthMeters,
+            resolvedFootprint.WidthMeters);
+        if (roofShape == GeneratedLod1RoofShape.Flat)
+        {
+            return cityObject;
+        }
+
+        ParsedSurface[] generatedSurfaces = GeneratedLod1RoofSurfaceFactory.Create(resolvedFootprint, roofShape);
+        if (generatedSurfaces.Length == 0)
+        {
+            return cityObject;
+        }
+
+        ParsedSurface[] surfaces =
+        [
+            .. cityObject.Surfaces.Where(surface => !string.Equals(surface.PolygonId, resolvedFootprint.TopSurface.PolygonId, StringComparison.Ordinal)),
+            .. generatedSurfaces,
+        ];
+        return cityObject with { Surfaces = surfaces };
+    }
+
+    private static bool TryCreateFootprint(
+        ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian cityObjectCartesian,
+        out Lod1RoofFootprint? footprint)
+    {
+        footprint = null;
+        SurfaceProjectionInfo[] surfaceInfos = cityObject.Surfaces
+            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
+            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
+            .ToArray();
+        if (surfaceInfos.Length == 0)
+        {
+            return false;
+        }
+
+        double objectMinimumY = surfaceInfos.Min(static info => info.MinimumY!.Value);
+        double objectMaximumY = surfaceInfos.Max(static info => info.MaximumY!.Value);
+        double geometryHeight = objectMaximumY - objectMinimumY;
+        SurfaceProjectionInfo[] topCandidates = surfaceInfos
+            .Where(static info => info.IsNearHorizontal)
+            .Where(info => info.MaximumY!.Value >= objectMaximumY - 0.1)
+            .Where(info => info.MinimumY!.Value > objectMinimumY + BuildingBottomCullBandMeters)
+            .ToArray();
+        if (topCandidates.Length != 1)
+        {
+            return false;
+        }
+
+        ParsedSurface topSurface = topCandidates[0].Surface;
+        if (topSurface.TexturePayload is not null || topSurface.InteriorRings.Length != 0)
+        {
+            return false;
+        }
+
+        GeodeticPoint[] ring = RemoveClosingPoint(topSurface.ExteriorRing.Vertices);
+        if (ring.Length != 4)
+        {
+            return false;
+        }
+
+        Float3[] positions = ring
+            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
+            .ToArray();
+        if (!TryClassifyRectangle(positions, out bool firstEdgeIsLongAxis, out double length, out double width))
+        {
+            return false;
+        }
+
+        footprint = new Lod1RoofFootprint(
+            topSurface,
+            ring,
+            length,
+            width,
+            geometryHeight,
+            cityObject.BuildingAttributes ?? BuildingAttributeContext.Empty,
+            firstEdgeIsLongAxis);
+        return true;
+    }
+
+    private static SurfaceProjectionInfo CreateSurfaceProjectionInfo(
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian cityObjectCartesian)
+    {
+        Float3[] positions = surface.Vertices
+            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
+            .ToArray();
+        if (positions.Length == 0)
+        {
+            return new SurfaceProjectionInfo(surface, null, null, false);
+        }
+
+        Float3? normal = ComputePolygonNormal(positions);
+        bool isNearHorizontal = normal is not null && Math.Abs(normal.Y) >= 0.98;
+
+        return new SurfaceProjectionInfo(
+            surface,
+            positions.Min(static position => position.Y),
+            positions.Max(static position => position.Y),
+            isNearHorizontal);
+    }
+
+    private static bool IsGeneratedLod1RoofSurface(ParsedSurface surface)
+    {
+        return surface.PolygonId.Contains("_generated_", StringComparison.Ordinal);
+    }
+
+    private static GeodeticPoint[] RemoveClosingPoint(GeodeticPoint[] vertices)
+    {
+        if (vertices.Length > 1 && AreSamePoint(vertices[0], vertices[^1]))
+        {
+            return vertices.Take(vertices.Length - 1).ToArray();
+        }
+
+        return vertices.ToArray();
+    }
+
+    private static bool TryClassifyRectangle(
+        Float3[] positions,
+        out bool firstEdgeIsLongAxis,
+        out double length,
+        out double width)
+    {
+        firstEdgeIsLongAxis = false;
+        length = 0.0;
+        width = 0.0;
+        if (positions.Length != 4)
+        {
+            return false;
+        }
+
+        double[] edges =
+        [
+            HorizontalDistance(positions[0], positions[1]),
+            HorizontalDistance(positions[1], positions[2]),
+            HorizontalDistance(positions[2], positions[3]),
+            HorizontalDistance(positions[3], positions[0]),
+        ];
+        if (edges.Any(static edge => edge < 1.0))
+        {
+            return false;
+        }
+
+        if (!ApproximatelyEqual(edges[0], edges[2], 0.15)
+            || !ApproximatelyEqual(edges[1], edges[3], 0.15))
+        {
+            return false;
+        }
+
+        Float3 edge0 = NormalizeHorizontal(Subtract(positions[1], positions[0]));
+        Float3 edge1 = NormalizeHorizontal(Subtract(positions[2], positions[1]));
+        if (Math.Abs(Dot(edge0, edge1)) > 0.15)
+        {
+            return false;
+        }
+
+        firstEdgeIsLongAxis = edges[0] >= edges[1];
+        length = Math.Max(edges[0], edges[1]);
+        width = Math.Min(edges[0], edges[1]);
+        return true;
+    }
+
+    private static Float3? ComputePolygonNormal(IEnumerable<Float3> positions)
+    {
+        Float3[] points = positions.ToArray();
+        if (points.Length < 3)
+        {
+            return null;
+        }
+
+        double normalX = 0.0;
+        double normalY = 0.0;
+        double normalZ = 0.0;
+
+        for (int index = 0; index < points.Length; index++)
+        {
+            Float3 current = points[index];
+            Float3 next = points[(index + 1) % points.Length];
+            normalX += (current.Y - next.Y) * (current.Z + next.Z);
+            normalY += (current.Z - next.Z) * (current.X + next.X);
+            normalZ += (current.X - next.X) * (current.Y + next.Y);
+        }
+
+        double magnitude = Math.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ));
+        if (magnitude < 1e-8)
+        {
+            return null;
+        }
+
+        return new Float3(normalX / magnitude, normalY / magnitude, normalZ / magnitude);
+    }
+
+    private static Float3 CreateScenePosition(
+        GeodeticPoint point,
+        GeodeticPoint origin,
+        LocalCartesian cartesian)
+    {
+        return SceneAxisMapper.CreatePosition(
+            point.Latitude,
+            point.Longitude,
+            point.Altitude,
+            origin.Latitude,
+            origin.Longitude,
+            origin.Altitude,
+            cartesian);
+    }
+
+    private static bool AreSamePoint(GeodeticPoint left, GeodeticPoint right)
+    {
+        const double tolerance = 1e-8;
+        return Math.Abs(left.Latitude - right.Latitude) < tolerance
+            && Math.Abs(left.Longitude - right.Longitude) < tolerance
+            && Math.Abs(left.Altitude - right.Altitude) < tolerance;
+    }
+
+    private static Float3 NormalizeHorizontal(Float3 value)
+    {
+        Float3 horizontal = new(value.X, 0.0, value.Z);
+        double lengthSquared = (horizontal.X * horizontal.X) + (horizontal.Z * horizontal.Z);
+        if (lengthSquared < 1e-12)
+        {
+            return horizontal;
+        }
+
+        double length = Math.Sqrt(lengthSquared);
+        return new Float3(horizontal.X / length, 0.0, horizontal.Z / length);
+    }
+
+    private static double HorizontalDistance(Float3 left, Float3 right)
+    {
+        double deltaX = left.X - right.X;
+        double deltaZ = left.Z - right.Z;
+        return Math.Sqrt((deltaX * deltaX) + (deltaZ * deltaZ));
+    }
+
+    private static bool ApproximatelyEqual(double left, double right, double relativeTolerance)
+    {
+        double scale = Math.Max(Math.Max(Math.Abs(left), Math.Abs(right)), 1.0);
+        return Math.Abs(left - right) <= scale * relativeTolerance;
+    }
+
+    private static Float3 Subtract(Float3 left, Float3 right)
+    {
+        return new Float3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
+    }
+
+    private static double Dot(Float3 left, Float3 right)
+    {
+        return (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z);
+    }
+
+    private readonly record struct SurfaceProjectionInfo(
+        ParsedSurface Surface,
+        double? MinimumY,
+        double? MaximumY,
+        bool IsNearHorizontal);
+}

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofSurfaceIdentity.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofSurfaceIdentity.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class GeneratedLod1RoofSurfaceIdentity
+{
+    internal static bool IsGenerated(ParsedSurface surface)
+    {
+        return surface.PolygonId.Contains("_generated_shed-", StringComparison.Ordinal)
+            || surface.PolygonId.Contains("_generated_gable-", StringComparison.Ordinal)
+            || surface.PolygonId.Contains("_generated_hip-", StringComparison.Ordinal);
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -2419,7 +2419,7 @@ internal static class LocalCityGmlObjectProjection
         ImportedCityObject[] alignedCityObjects =
             request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
             && string.Equals(terrainAlignedParsedCityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
-                ? AlignAdjacentDemTerrainGridChunkBoundaries(projectedCityObjects)
+                ? DemTerrainGridChunkBoundaryAlignmentPolicy.Align(projectedCityObjects)
                 : [.. projectedCityObjects];
 
         foreach (ImportedCityObject cityObject in alignedCityObjects)
@@ -2555,7 +2555,7 @@ internal static class LocalCityGmlObjectProjection
             demTerrainTextureOverlay,
             materialResolver);
         TriangleMeshGeometry staticMesh = AssertTriangleMeshGeometry(staticCityObject);
-        TriangleMeshGeometry rebasedStaticMesh = RebaseTriangleMeshToTransform(
+        TriangleMeshGeometry rebasedStaticMesh = TriangleMeshTransformRebaser.Rebase(
             staticMesh,
             staticCityObject.Transform,
             heightMapCityObject!.Transform);
@@ -2729,213 +2729,6 @@ internal static class LocalCityGmlObjectProjection
             .Where(static material => material.ReuseScope == MaterialReuseScope.Shared)
             .ToArray();
     }
-
-    private static ImportedCityObject[] AlignAdjacentDemTerrainGridChunkBoundaries(
-        IReadOnlyList<ImportedCityObject> cityObjects)
-    {
-        TerrainGridChunkAlignmentState?[] states = cityObjects
-            .Select(static cityObject => TerrainGridChunkAlignmentState.TryCreate(cityObject))
-            .ToArray();
-        if (states.Any(static state => state is null))
-        {
-            return cityObjects.ToArray();
-        }
-
-        TerrainGridChunkAlignmentState[] chunkStates = states
-            .Select(static state => state!)
-            .ToArray();
-        const double seaLevelWorldHeightTolerance = 1e-6;
-        Dictionary<DemBoundarySampleKey, List<BoundaryHeightSampleReference>> sampleReferencesByKey = [];
-        foreach (TerrainGridChunkAlignmentState state in chunkStates)
-        {
-            foreach (BoundaryHeightSampleReference sampleReference in EnumerateBoundaryHeightSampleReferences(state))
-            {
-                if (!sampleReferencesByKey.TryGetValue(sampleReference.Key, out List<BoundaryHeightSampleReference>? references))
-                {
-                    references = [];
-                    sampleReferencesByKey.Add(sampleReference.Key, references);
-                }
-
-                references.Add(sampleReference);
-            }
-        }
-
-        bool foundSharedBoundary = false;
-        foreach (List<BoundaryHeightSampleReference> references in sampleReferencesByKey.Values)
-        {
-            if (references.Count < 2
-                || references.Select(static reference => reference.State.CityObject).Distinct().Count() < 2)
-            {
-                continue;
-            }
-
-            foundSharedBoundary = true;
-            double worldHeightSum = 0.0;
-            int sampleCount = 0;
-            double nonSeaLevelWorldHeightSum = 0.0;
-            int nonSeaLevelSampleCount = 0;
-            foreach (BoundaryHeightSampleReference reference in references)
-            {
-                double worldHeight = reference.State.BaseHeight + reference.State.HeightSamples[reference.SampleIndex];
-                bool isSeaLevelFallbackCandidate = Math.Abs(worldHeight) <= seaLevelWorldHeightTolerance;
-                worldHeightSum += worldHeight;
-                sampleCount++;
-                if (!isSeaLevelFallbackCandidate)
-                {
-                    nonSeaLevelWorldHeightSum += worldHeight;
-                    nonSeaLevelSampleCount++;
-                }
-            }
-
-            double alignedWorldHeight = nonSeaLevelSampleCount > 0
-                ? nonSeaLevelWorldHeightSum / nonSeaLevelSampleCount
-                : worldHeightSum / sampleCount;
-            foreach (BoundaryHeightSampleReference reference in references)
-            {
-                reference.State.HeightSamples[reference.SampleIndex] = alignedWorldHeight - reference.State.BaseHeight;
-            }
-        }
-
-        if (!foundSharedBoundary)
-        {
-            return cityObjects.ToArray();
-        }
-
-        return chunkStates
-            .Select(static state => state.ToCityObject())
-            .ToArray();
-    }
-
-    private static IEnumerable<BoundaryHeightSampleReference> EnumerateBoundaryHeightSampleReferences(
-        TerrainGridChunkAlignmentState state)
-    {
-        int width = state.Geometry.Width;
-        int height = state.Geometry.Height;
-        if (width < 2 || height < 2)
-        {
-            yield break;
-        }
-
-        for (int row = 0; row < height; row++)
-        {
-            yield return CreateBoundaryHeightSampleReference(state, row, 0);
-            yield return CreateBoundaryHeightSampleReference(state, row, width - 1);
-        }
-
-        for (int column = 1; column < width - 1; column++)
-        {
-            yield return CreateBoundaryHeightSampleReference(state, 0, column);
-            yield return CreateBoundaryHeightSampleReference(state, height - 1, column);
-        }
-    }
-
-    private static BoundaryHeightSampleReference CreateBoundaryHeightSampleReference(
-        TerrainGridChunkAlignmentState state,
-        int row,
-        int column)
-    {
-        double u = state.Geometry.Width == 1 ? 0.0 : (double)column / (state.Geometry.Width - 1);
-        double v = state.Geometry.Height == 1 ? 0.0 : (double)row / (state.Geometry.Height - 1);
-        double x = (state.CityObject.Transform.Position.X - (state.Geometry.Size.X / 2.0)) + (state.Geometry.Size.X * u);
-        double z = (state.CityObject.Transform.Position.Z - (state.Geometry.Size.Y / 2.0)) + (state.Geometry.Size.Y * v);
-        int sampleIndex = (row * state.Geometry.Width) + column;
-        return new BoundaryHeightSampleReference(
-            state,
-            sampleIndex,
-            new DemBoundarySampleKey(
-                QuantizeBoundaryCoordinate(x),
-                QuantizeBoundaryCoordinate(z)));
-    }
-
-    private static long QuantizeBoundaryCoordinate(double coordinate)
-    {
-        const double boundaryTolerance = 1e-3;
-        return (long)Math.Round(coordinate / boundaryTolerance, MidpointRounding.AwayFromZero);
-    }
-
-    private sealed class TerrainGridChunkAlignmentState
-    {
-        public TerrainGridChunkAlignmentState(
-            ImportedCityObject cityObject,
-            TerrainGridGeometry geometry,
-            double[] heightSamples)
-        {
-            CityObject = cityObject;
-            Geometry = geometry;
-            HeightSamples = heightSamples;
-            BaseHeight = cityObject.Transform.Position.Y - geometry.MaxHeight;
-        }
-
-        public ImportedCityObject CityObject { get; }
-
-        public TerrainGridGeometry Geometry { get; }
-
-        public double[] HeightSamples { get; }
-
-        public double BaseHeight { get; }
-
-        public static TerrainGridChunkAlignmentState? TryCreate(ImportedCityObject cityObject)
-        {
-            TerrainGridGeometry? geometry = cityObject.Geometry switch
-            {
-                TerrainGridGeometry terrainGrid => terrainGrid,
-                DynamicTerrainGeometry dynamicTerrain => dynamicTerrain.GridMesh,
-                _ => null,
-            };
-            return geometry is not null
-                ? new TerrainGridChunkAlignmentState(cityObject, geometry, geometry.HeightSamples.ToArray())
-                : null;
-        }
-
-        public ImportedCityObject ToCityObject()
-        {
-            double minHeight = HeightSamples.Min();
-            double maxHeight = HeightSamples.Max();
-            Transform3D alignedTransform = CityObject.Transform with
-            {
-                Position = CityObject.Transform.Position with
-                {
-                    Y = BaseHeight + maxHeight,
-                },
-            };
-
-            return CityObject with
-            {
-                Transform = alignedTransform,
-                Geometry = CityObject.Geometry switch
-                {
-                    DynamicTerrainGeometry dynamicTerrain => dynamicTerrain with
-                    {
-                        StaticMesh = RebaseTriangleMeshToTransform(
-                            dynamicTerrain.StaticMesh,
-                            CityObject.Transform,
-                            alignedTransform),
-                        GridMesh = dynamicTerrain.GridMesh with
-                        {
-                            MinHeight = minHeight,
-                            MaxHeight = maxHeight,
-                            HeightSamples = HeightSamples,
-                        },
-                    },
-                    _ => Geometry with
-                    {
-                        MinHeight = minHeight,
-                        MaxHeight = maxHeight,
-                        HeightSamples = HeightSamples,
-                    },
-                },
-            };
-        }
-    }
-
-    private sealed record DemBoundarySampleKey(
-        long QuantizedX,
-        long QuantizedZ);
-
-    private sealed record BoundaryHeightSampleReference(
-        TerrainGridChunkAlignmentState State,
-        int SampleIndex,
-        DemBoundarySampleKey Key);
 
     private static bool TryProjectDemTerrainGridCityObject(
         ParsedCityObject cityObject,
@@ -3656,14 +3449,6 @@ internal static class LocalCityGmlObjectProjection
             MaxLongitude: Math.Min(left.MaxLongitude, right.MaxLongitude));
     }
 
-    private static Float3 TransformPointToWorld(Transform3D transform, Float3 localPosition)
-    {
-        Float3 rotated = transform.Rotation is null
-            ? localPosition
-            : Rotate(localPosition, transform.Rotation);
-        return Add(transform.Position, rotated);
-    }
-
     private static TriangleMeshGeometry AssertTriangleMeshGeometry(ImportedCityObject cityObject)
     {
         return cityObject.Geometry as TriangleMeshGeometry
@@ -3674,66 +3459,6 @@ internal static class LocalCityGmlObjectProjection
     {
         return cityObject.Geometry as TerrainGridGeometry
             ?? throw new InvalidOperationException("Dynamic terrain grid variant must be projected as a terrain grid.");
-    }
-
-    private static TriangleMeshGeometry RebaseTriangleMeshToTransform(
-        TriangleMeshGeometry source,
-        Transform3D sourceTransform,
-        Transform3D targetTransform)
-    {
-        ImportedMesh mesh = source.Mesh;
-        MeshVertex[] vertices = mesh.Vertices
-            .Select(vertex =>
-            {
-                Float3 worldPosition = TransformPointToWorld(sourceTransform, vertex.Position);
-                Float3 localPosition = TransformVectorFromWorld(targetTransform, Subtract(worldPosition, targetTransform.Position));
-                Float3 worldNormal = sourceTransform.Rotation is null ? vertex.Normal : Rotate(vertex.Normal, sourceTransform.Rotation);
-                Float3 localNormal = TransformVectorFromWorld(targetTransform, worldNormal);
-                return vertex with
-                {
-                    Position = localPosition,
-                    Normal = localNormal,
-                };
-            })
-            .ToArray();
-        return new TriangleMeshGeometry(new ImportedMesh(vertices, mesh.Submeshes));
-    }
-
-    private static Float3 TransformVectorFromWorld(Transform3D transform, Float3 worldVector)
-    {
-        return transform.Rotation is null
-            ? worldVector
-            : Rotate(worldVector, Conjugate(transform.Rotation));
-    }
-
-    private static Float3 Rotate(Float3 value, Quaternion rotation)
-    {
-        Float3 qv = new(rotation.X, rotation.Y, rotation.Z);
-        Float3 uv = Cross3(qv, value);
-        Float3 uuv = Cross3(qv, uv);
-        return Add(
-            value,
-            Add(
-                Scale3(uv, 2.0 * rotation.W),
-                Scale3(uuv, 2.0)));
-    }
-
-    private static Quaternion Conjugate(Quaternion value)
-    {
-        return new Quaternion(-value.X, -value.Y, -value.Z, value.W);
-    }
-
-    private static Float3 Cross3(Float3 left, Float3 right)
-    {
-        return new Float3(
-            (left.Y * right.Z) - (left.Z * right.Y),
-            (left.Z * right.X) - (left.X * right.Z),
-            (left.X * right.Y) - (left.Y * right.X));
-    }
-
-    private static Float3 Scale3(Float3 value, double scalar)
-    {
-        return new Float3(value.X * scalar, value.Y * scalar, value.Z * scalar);
     }
 
     private static bool HasRenderableGeometry(ImportedCityObject cityObject)

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -338,27 +338,6 @@ internal static class LocalCityGmlObjectProjection
         return strips.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel).ToList();
     }
 
-    private static Float3 NormalizeHorizontal(Float3 value)
-    {
-        double length = Math.Sqrt((value.X * value.X) + (value.Z * value.Z));
-        if (length <= 1e-8)
-        {
-            return new Float3(0.0, 0.0, 0.0);
-        }
-
-        return new Float3(value.X / length, 0.0, value.Z / length);
-    }
-
-    private static double DotHorizontal(Float3 left, Float3 right)
-    {
-        return (left.X * right.X) + (left.Z * right.Z);
-    }
-
-    private static double LengthSquared(Float3 value)
-    {
-        return (value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z);
-    }
-
     private static ParsedSurface[] ConformSurfacesToTerrain(
         string packageName,
         ParsedSurface[] surfaces,
@@ -706,7 +685,7 @@ internal static class LocalCityGmlObjectProjection
     {
         double? geometryHeightMeters = cityObject.GeometryHeightMeters
             ?? ResolveParsedGeometryHeightMeters(cityObject.Surfaces);
-        cityObject = ApplyGeneratedLod1Roof(cityObject) with
+        cityObject = GeneratedLod1RoofCityObjectFactory.Create(cityObject) with
         {
             GeometryHeightMeters = geometryHeightMeters,
         };
@@ -798,192 +777,6 @@ internal static class LocalCityGmlObjectProjection
             Mesh: new ImportedMesh(vertices.ToArray(), submeshes.ToArray()),
             Materials: materials,
             SourceFileRelativePath: cityObject.SourceFileRelativePath);
-    }
-
-    private static global::PlateauResoniteLink.Application.Importing.ParsedCityObject ApplyGeneratedLod1Roof(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject)
-    {
-        if (!IsBuildingPackage(cityObject.PackageName)
-            || cityObject.LodLevel != 1
-            || !cityObject.ReferenceSystem.IsGeographic
-            || cityObject.Surfaces.Any(static surface => IsGeneratedLod1RoofSurface(
-                global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface))))
-        {
-            return cityObject;
-        }
-
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
-        LocalCartesian cityObjectCartesian = new(
-            cityObjectOrigin.Latitude,
-            cityObjectOrigin.Longitude,
-            cityObjectOrigin.Altitude,
-            cityObject.ReferenceSystem.Geocentric);
-        if (!TryCreateLod1RoofFootprint(cityObject, cityObjectOrigin, cityObjectCartesian, out Lod1RoofFootprint? footprint))
-        {
-            return cityObject;
-        }
-
-        Lod1RoofFootprint resolvedFootprint = footprint!;
-        GeneratedLod1RoofShape roofShape = Lod1RoofShapePolicy.Select(
-            cityObject.SlotKey,
-            resolvedFootprint.Attributes,
-            resolvedFootprint.GeometryHeightMeters,
-            resolvedFootprint.LengthMeters,
-            resolvedFootprint.WidthMeters);
-        if (roofShape == GeneratedLod1RoofShape.Flat)
-        {
-            return cityObject;
-        }
-
-        global::PlateauResoniteLink.Application.Importing.ParsedSurface[] generatedSurfaces =
-            GeneratedLod1RoofSurfaceFactory.Create(resolvedFootprint, roofShape);
-        if (generatedSurfaces.Length == 0)
-        {
-            return cityObject;
-        }
-
-        global::PlateauResoniteLink.Application.Importing.ParsedSurface[] surfaces =
-        [
-            .. cityObject.Surfaces.Where(surface => !string.Equals(surface.PolygonId, resolvedFootprint.TopSurface.PolygonId, StringComparison.Ordinal)),
-            .. generatedSurfaces,
-        ];
-        return cityObject with { Surfaces = surfaces };
-    }
-
-    private static bool TryCreateLod1RoofFootprint(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
-        LocalCartesian cityObjectCartesian,
-        out Lod1RoofFootprint? footprint)
-    {
-        footprint = null;
-        SurfaceProjectionInfo[] surfaceInfos = cityObject.Surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(
-                global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel(surface),
-                cityObjectOrigin.ToProjectionModel(),
-                cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
-        if (surfaceInfos.Length == 0)
-        {
-            return false;
-        }
-
-        double objectMinimumY = surfaceInfos.Min(static info => info.MinimumY!.Value);
-        double objectMaximumY = surfaceInfos.Max(static info => info.MaximumY!.Value);
-        double geometryHeight = objectMaximumY - objectMinimumY;
-        SurfaceProjectionInfo[] topCandidates = surfaceInfos
-            .Where(static info => info.IsNearHorizontal)
-            .Where(info => info.MaximumY!.Value >= objectMaximumY - 0.1)
-            .Where(info => info.MinimumY!.Value > objectMinimumY + BuildingBottomCullBandMeters)
-            .ToArray();
-        if (topCandidates.Length != 1)
-        {
-            return false;
-        }
-
-        ParsedSurface topProjectionSurface = topCandidates[0].Surface;
-        global::PlateauResoniteLink.Application.Importing.ParsedSurface? topSurface = cityObject.Surfaces
-            .FirstOrDefault(surface => string.Equals(surface.PolygonId, topProjectionSurface.PolygonId, StringComparison.Ordinal));
-        if (topSurface is null
-            || topSurface.TexturePayload is not null
-            || topSurface.InteriorRings.Length != 0)
-        {
-            return false;
-        }
-
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint[] ring = RemoveClosingPoint(topSurface.ExteriorRing.Vertices);
-        if (ring.Length != 4)
-        {
-            return false;
-        }
-
-        Float3[] positions = ring
-            .Select(point => CreateScenePosition(point.ToProjectionModel(), cityObjectOrigin.ToProjectionModel(), cityObjectCartesian))
-            .ToArray();
-        if (!TryClassifyRectangle(positions, out bool firstEdgeIsLongAxis, out double length, out double width))
-        {
-            return false;
-        }
-
-        footprint = new Lod1RoofFootprint(
-            topSurface,
-            ring,
-            length,
-            width,
-            geometryHeight,
-            cityObject.BuildingAttributes ?? BuildingAttributeContext.Empty,
-            firstEdgeIsLongAxis);
-        return true;
-    }
-
-    private static global::PlateauResoniteLink.Application.Importing.GeodeticPoint[] RemoveClosingPoint(
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint[] vertices)
-    {
-        if (vertices.Length > 1 && AreSamePoint(vertices[0].ToProjectionModel(), vertices[^1].ToProjectionModel()))
-        {
-            return vertices.Take(vertices.Length - 1).ToArray();
-        }
-
-        return vertices.ToArray();
-    }
-
-    private static bool TryClassifyRectangle(
-        Float3[] positions,
-        out bool firstEdgeIsLongAxis,
-        out double length,
-        out double width)
-    {
-        firstEdgeIsLongAxis = false;
-        length = 0.0;
-        width = 0.0;
-        if (positions.Length != 4)
-        {
-            return false;
-        }
-
-        double[] edges =
-        [
-            HorizontalDistance(positions[0], positions[1]),
-            HorizontalDistance(positions[1], positions[2]),
-            HorizontalDistance(positions[2], positions[3]),
-            HorizontalDistance(positions[3], positions[0]),
-        ];
-        if (edges.Any(static edge => edge < 1.0))
-        {
-            return false;
-        }
-
-        if (!ApproximatelyEqual(edges[0], edges[2], 0.15)
-            || !ApproximatelyEqual(edges[1], edges[3], 0.15))
-        {
-            return false;
-        }
-
-        Float3 edge0 = NormalizeHorizontal(Subtract(positions[1], positions[0]));
-        Float3 edge1 = NormalizeHorizontal(Subtract(positions[2], positions[1]));
-        if (Math.Abs(Dot(edge0, edge1)) > 0.15)
-        {
-            return false;
-        }
-
-        firstEdgeIsLongAxis = edges[0] >= edges[1];
-        length = Math.Max(edges[0], edges[1]);
-        width = Math.Min(edges[0], edges[1]);
-        return true;
-    }
-
-    private static double HorizontalDistance(Float3 left, Float3 right)
-    {
-        double deltaX = left.X - right.X;
-        double deltaZ = left.Z - right.Z;
-        return Math.Sqrt((deltaX * deltaX) + (deltaZ * deltaZ));
-    }
-
-    private static bool ApproximatelyEqual(double left, double right, double relativeTolerance)
-    {
-        double scale = Math.Max(Math.Max(Math.Abs(left), Math.Abs(right)), 1.0);
-        return Math.Abs(left - right) <= scale * relativeTolerance;
     }
 
     private static GeodeticPoint ResolveProjectionCityObjectOrigin(ParsedCityObject cityObject)
@@ -2338,7 +2131,7 @@ internal static class LocalCityGmlObjectProjection
 
         double? geometryHeightMeters = ResolveParsedGeometryHeightMeters(parsedCityObject.Surfaces);
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject terrainAlignedParsedCityObject =
-            ApplyGeneratedLod1Roof(ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler)) with
+            GeneratedLod1RoofCityObjectFactory.Create(ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler)) with
             {
                 GeometryHeightMeters = geometryHeightMeters,
             };
@@ -2452,7 +2245,7 @@ internal static class LocalCityGmlObjectProjection
 
         double? geometryHeightMeters = ResolveParsedGeometryHeightMeters(parsedCityObject.Surfaces);
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject terrainAlignedParsedCityObject =
-            ApplyGeneratedLod1Roof(ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler)) with
+            GeneratedLod1RoofCityObjectFactory.Create(ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler)) with
             {
                 GeometryHeightMeters = geometryHeightMeters,
             };

--- a/src/PlateauResoniteLink/Application/Importing/TriangleMeshTransformRebaser.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TriangleMeshTransformRebaser.cs
@@ -1,0 +1,84 @@
+using System.Linq;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class TriangleMeshTransformRebaser
+{
+    internal static TriangleMeshGeometry Rebase(
+        TriangleMeshGeometry source,
+        Transform3D sourceTransform,
+        Transform3D targetTransform)
+    {
+        ImportedMesh mesh = source.Mesh;
+        MeshVertex[] vertices = mesh.Vertices
+            .Select(vertex =>
+            {
+                Float3 worldPosition = TransformPointToWorld(sourceTransform, vertex.Position);
+                Float3 localPosition = TransformVectorFromWorld(targetTransform, Subtract(worldPosition, targetTransform.Position));
+                Float3 worldNormal = sourceTransform.Rotation is null ? vertex.Normal : Rotate(vertex.Normal, sourceTransform.Rotation);
+                Float3 localNormal = TransformVectorFromWorld(targetTransform, worldNormal);
+                return vertex with
+                {
+                    Position = localPosition,
+                    Normal = localNormal,
+                };
+            })
+            .ToArray();
+        return new TriangleMeshGeometry(new ImportedMesh(vertices, mesh.Submeshes));
+    }
+
+    private static Float3 TransformPointToWorld(Transform3D transform, Float3 localPosition)
+    {
+        Float3 rotated = transform.Rotation is null
+            ? localPosition
+            : Rotate(localPosition, transform.Rotation);
+        return Add(transform.Position, rotated);
+    }
+
+    private static Float3 TransformVectorFromWorld(Transform3D transform, Float3 worldVector)
+    {
+        return transform.Rotation is null
+            ? worldVector
+            : Rotate(worldVector, Conjugate(transform.Rotation));
+    }
+
+    private static Float3 Rotate(Float3 value, Quaternion rotation)
+    {
+        Float3 qv = new(rotation.X, rotation.Y, rotation.Z);
+        Float3 uv = Cross(qv, value);
+        Float3 uuv = Cross(qv, uv);
+        return Add(
+            value,
+            Add(
+                Scale(uv, 2.0 * rotation.W),
+                Scale(uuv, 2.0)));
+    }
+
+    private static Quaternion Conjugate(Quaternion value)
+    {
+        return new Quaternion(-value.X, -value.Y, -value.Z, value.W);
+    }
+
+    private static Float3 Add(Float3 left, Float3 right)
+    {
+        return new Float3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
+    }
+
+    private static Float3 Subtract(Float3 left, Float3 right)
+    {
+        return new Float3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
+    }
+
+    private static Float3 Cross(Float3 left, Float3 right)
+    {
+        return new Float3(
+            (left.Y * right.Z) - (left.Z * right.Y),
+            (left.Z * right.X) - (left.X * right.Z),
+            (left.X * right.Y) - (left.Y * right.X));
+    }
+
+    private static Float3 Scale(Float3 value, double scalar)
+    {
+        return new Float3(value.X * scalar, value.Y * scalar, value.Z * scalar);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGridChunkBoundaryAlignmentPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGridChunkBoundaryAlignmentPolicyTests.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class DemTerrainGridChunkBoundaryAlignmentPolicyTests
+{
+    [Fact]
+    public void AlignAveragesSharedSamplesForPartialOverlapWithDifferentResolution()
+    {
+        ImportedCityObject left = CreateTerrainGridCityObject(
+            "left-dem",
+            new Float3(0.0, 14.0, 0.0),
+            width: 2,
+            height: 5,
+            sizeX: 2.0,
+            sizeZ: 4.0,
+            [
+                1.0, 10.0,
+                1.0, 11.0,
+                1.0, 12.0,
+                1.0, 13.0,
+                1.0, 14.0,
+            ]);
+        ImportedCityObject right = CreateTerrainGridCityObject(
+            "right-dem",
+            new Float3(2.0, 22.0, 0.0),
+            width: 2,
+            height: 3,
+            sizeX: 2.0,
+            sizeZ: 2.0,
+            [
+                20.0, 2.0,
+                21.0, 2.0,
+                22.0, 2.0,
+            ]);
+
+        ImportedCityObject[] aligned = DemTerrainGridChunkBoundaryAlignmentPolicy.Align([left, right]);
+
+        TerrainGridGeometry alignedLeft = Assert.IsType<TerrainGridGeometry>(aligned[0].Geometry);
+        TerrainGridGeometry alignedRight = Assert.IsType<TerrainGridGeometry>(aligned[1].Geometry);
+
+        Assert.Equal(10.0, alignedLeft.HeightSamples[1], 6);
+        Assert.Equal(15.5, alignedLeft.HeightSamples[3], 6);
+        Assert.Equal(16.5, alignedLeft.HeightSamples[5], 6);
+        Assert.Equal(17.5, alignedLeft.HeightSamples[7], 6);
+        Assert.Equal(14.0, alignedLeft.HeightSamples[9], 6);
+
+        Assert.Equal(15.5, alignedRight.HeightSamples[0], 6);
+        Assert.Equal(16.5, alignedRight.HeightSamples[2], 6);
+        Assert.Equal(17.5, alignedRight.HeightSamples[4], 6);
+    }
+
+    [Fact]
+    public void AlignRebasesDynamicTerrainStaticMeshWhenGridTransformChanges()
+    {
+        ImportedCityObject left = CreateDynamicTerrainCityObject(
+            "left-dem",
+            new Float3(0.0, 14.0, 0.0),
+            width: 2,
+            height: 2,
+            sizeX: 2.0,
+            sizeZ: 2.0,
+            [
+                1.0, 10.0,
+                1.0, 14.0,
+            ]);
+        ImportedCityObject right = CreateTerrainGridCityObject(
+            "right-dem",
+            new Float3(2.0, 22.0, 0.0),
+            width: 2,
+            height: 2,
+            sizeX: 2.0,
+            sizeZ: 2.0,
+            [
+                20.0, 2.0,
+                22.0, 2.0,
+            ]);
+        double originalWorldY = left.Transform.Position.Y
+            + Assert.IsType<DynamicTerrainGeometry>(left.Geometry).StaticMesh.Mesh.Vertices[0].Position.Y;
+
+        ImportedCityObject[] aligned = DemTerrainGridChunkBoundaryAlignmentPolicy.Align([left, right]);
+
+        DynamicTerrainGeometry alignedGeometry = Assert.IsType<DynamicTerrainGeometry>(aligned[0].Geometry);
+        double alignedWorldY = aligned[0].Transform.Position.Y
+            + alignedGeometry.StaticMesh.Mesh.Vertices[0].Position.Y;
+        Assert.Equal(originalWorldY, alignedWorldY, precision: 6);
+        Assert.NotEqual(left.Transform.Position.Y, aligned[0].Transform.Position.Y);
+    }
+
+    private static ImportedCityObject CreateDynamicTerrainCityObject(
+        string slotKey,
+        Float3 position,
+        int width,
+        int height,
+        double sizeX,
+        double sizeZ,
+        IReadOnlyList<double> heightSamples)
+    {
+        ImportedCityObject grid = CreateTerrainGridCityObject(
+            slotKey,
+            position,
+            width,
+            height,
+            sizeX,
+            sizeZ,
+            heightSamples);
+        TriangleMeshGeometry staticMesh = new(new ImportedMesh(
+            [
+                new MeshVertex(
+                    new Float3(0.0, 1.0, 0.0),
+                    new Float3(0.0, 1.0, 0.0),
+                    new Float2(0.0, 0.0)),
+            ],
+            [new MeshSubmesh(0, [])]));
+        return grid with
+        {
+            Geometry = new DynamicTerrainGeometry(staticMesh, Assert.IsType<TerrainGridGeometry>(grid.Geometry)),
+        };
+    }
+
+    private static ImportedCityObject CreateTerrainGridCityObject(
+        string slotKey,
+        Float3 position,
+        int width,
+        int height,
+        double sizeX,
+        double sizeZ,
+        IReadOnlyList<double> heightSamples)
+    {
+        MaterialBinding material = new(
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            MaterialType: MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: TextureSourceKind.Bundled,
+            Projection: MaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0]);
+        return new ImportedCityObject(
+            ObjectKey: slotKey,
+            DisplayName: slotKey,
+            PackageName: "dem",
+            ActualMeshCode: "53394525",
+            LodLevel: 1,
+            Transform: new Transform3D(position),
+            Geometry: new TerrainGridGeometry(
+                Width: width,
+                Height: height,
+                Size: new Float2(sizeX, sizeZ),
+                MinHeight: heightSamples.Min(),
+                MaxHeight: heightSamples.Max(),
+                HeightSamples: heightSamples),
+            Materials: [material],
+            SourceFileRelativePath: $"udx/dem/53394525/{slotKey}.gml");
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -55,6 +55,25 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
     }
 
     [Fact]
+    public void CreateSkipsObjectWhoseGeneratedRoofSurfaceIdContainsEarlierGeneratedToken()
+    {
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                CreateSurface("source_generated_part_generated_shed-roof", ParsedSurfaceSemantic.Roof, altitude: 10.0),
+                CreateSurface("lod1-bottom", ParsedSurfaceSemantic.Ground, altitude: 0.0),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with
+            {
+                RoofShape = new BuildingCodeValue<CityGmlRoofShape>(CityGmlRoofShape.Shed, "shed"),
+            });
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Same(cityObject, generated);
+    }
+
+    [Fact]
     public void CreateDoesNotTreatOtherGeneratedSurfaceIdsAsGeneratedRoof()
     {
         ParsedCityObject cityObject = CreateCityObject(

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -1,0 +1,115 @@
+using System.Linq;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class GeneratedLod1RoofCityObjectFactoryTests
+{
+    [Fact]
+    public void CreateReplacesSingleTexturelessTopSurfaceWithGeneratedRoofSurfaces()
+    {
+        ParsedSurface top = CreateSurface(
+            "lod1-top",
+            ParsedSurfaceSemantic.Roof,
+            altitude: 10.0);
+        ParsedSurface bottom = CreateSurface(
+            "lod1-bottom",
+            ParsedSurfaceSemantic.Ground,
+            altitude: 0.0);
+        ParsedCityObject cityObject = CreateCityObject(
+            [top, bottom],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with
+            {
+                RoofShape = new BuildingCodeValue<CityGmlRoofShape>(CityGmlRoofShape.Shed, "shed"),
+            });
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.DoesNotContain(generated.Surfaces, static surface => surface.PolygonId == "lod1-top");
+        Assert.Contains(generated.Surfaces, static surface => surface.PolygonId == "lod1-bottom");
+        Assert.Equal(4, generated.Surfaces.Count(static surface => surface.PolygonId.Contains("_generated_", System.StringComparison.Ordinal)));
+        Assert.All(
+            generated.Surfaces.Where(static surface => surface.PolygonId.Contains("_generated_", System.StringComparison.Ordinal)),
+            static surface => Assert.Null(surface.TexturePayload));
+    }
+
+    [Fact]
+    public void CreateSkipsObjectThatAlreadyHasGeneratedRoofSurface()
+    {
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                CreateSurface("lod1-top_generated_shed-roof", ParsedSurfaceSemantic.Roof, altitude: 10.0),
+                CreateSurface("lod1-bottom", ParsedSurfaceSemantic.Ground, altitude: 0.0),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with
+            {
+                RoofShape = new BuildingCodeValue<CityGmlRoofShape>(CityGmlRoofShape.Shed, "shed"),
+            });
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Same(cityObject, generated);
+    }
+
+    [Fact]
+    public void CreateSkipsNonGeographicObject()
+    {
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                CreateSurface("lod1-top", ParsedSurfaceSemantic.Roof, altitude: 10.0),
+                CreateSurface("lod1-bottom", ParsedSurfaceSemantic.Ground, altitude: 0.0),
+            ],
+            CoordinateReferenceSystem.Parse((string?)null),
+            BuildingAttributeContext.Empty with
+            {
+                RoofShape = new BuildingCodeValue<CityGmlRoofShape>(CityGmlRoofShape.Shed, "shed"),
+            });
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Same(cityObject, generated);
+    }
+
+    private static ParsedCityObject CreateCityObject(
+        ParsedSurface[] surfaces,
+        CoordinateReferenceSystem referenceSystem,
+        BuildingAttributeContext attributes)
+    {
+        return new ParsedCityObject(
+            SlotKey: "bldg-lod1",
+            DisplayName: "bldg-lod1",
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 1,
+            Surfaces: surfaces,
+            ReferenceSystem: referenceSystem,
+            SourceFileRelativePath: "udx/bldg/53394525/bldg.gml",
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: attributes);
+    }
+
+    private static ParsedSurface CreateSurface(
+        string polygonId,
+        ParsedSurfaceSemantic semantic,
+        double altitude)
+    {
+        GeodeticPoint[] vertices =
+        [
+            new(35.0, 139.0, altitude),
+            new(35.0, 139.00020, altitude),
+            new(35.00010, 139.00020, altitude),
+            new(35.00010, 139.0, altitude),
+            new(35.0, 139.0, altitude),
+        ];
+        return new ParsedSurface(
+            polygonId,
+            semantic,
+            new ParsedRing($"{polygonId}-ring", vertices, UVs: null),
+            InteriorRings: [],
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -55,6 +55,28 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
     }
 
     [Fact]
+    public void CreateDoesNotTreatOtherGeneratedSurfaceIdsAsGeneratedRoof()
+    {
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                CreateSurface("lod1-top", ParsedSurfaceSemantic.Roof, altitude: 10.0),
+                CreateSurface("lod1-bottom", ParsedSurfaceSemantic.Ground, altitude: 0.0),
+                CreateSurface("tran_generated_marking", ParsedSurfaceSemantic.Wall, altitude: 1.0),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with
+            {
+                RoofShape = new BuildingCodeValue<CityGmlRoofShape>(CityGmlRoofShape.Shed, "shed"),
+            });
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.NotSame(cityObject, generated);
+        Assert.Contains(generated.Surfaces, static surface => surface.PolygonId == "tran_generated_marking");
+        Assert.Contains(generated.Surfaces, static surface => surface.PolygonId.Contains("_generated_shed-", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void CreateSkipsNonGeographicObject()
     {
         ParsedCityObject cityObject = CreateCityObject(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -2610,52 +2610,6 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public void AlignAdjacentDemTerrainGridChunkBoundariesAveragesSharedSamplesForPartialOverlapWithDifferentResolution()
-    {
-        ImportedCityObject left = CreateTerrainGridCityObject(
-            "left-dem",
-            new Float3(0.0, 14.0, 0.0),
-            width: 2,
-            height: 5,
-            sizeX: 2.0,
-            sizeZ: 4.0,
-            [
-                1.0, 10.0,
-                1.0, 11.0,
-                1.0, 12.0,
-                1.0, 13.0,
-                1.0, 14.0,
-            ]);
-        ImportedCityObject right = CreateTerrainGridCityObject(
-            "right-dem",
-            new Float3(2.0, 22.0, 0.0),
-            width: 2,
-            height: 3,
-            sizeX: 2.0,
-            sizeZ: 2.0,
-            [
-                20.0, 2.0,
-                21.0, 2.0,
-                22.0, 2.0,
-            ]);
-
-        ImportedCityObject[] aligned = AlignAdjacentDemTerrainGridChunkBoundariesForTest([left, right]);
-
-        TerrainGridGeometry alignedLeft = Assert.IsType<TerrainGridGeometry>(aligned[0].Geometry);
-        TerrainGridGeometry alignedRight = Assert.IsType<TerrainGridGeometry>(aligned[1].Geometry);
-
-        Assert.Equal(10.0, alignedLeft.HeightSamples[1], 6);
-        Assert.Equal(15.5, alignedLeft.HeightSamples[3], 6);
-        Assert.Equal(16.5, alignedLeft.HeightSamples[5], 6);
-        Assert.Equal(17.5, alignedLeft.HeightSamples[7], 6);
-        Assert.Equal(14.0, alignedLeft.HeightSamples[9], 6);
-
-        Assert.Equal(15.5, alignedRight.HeightSamples[0], 6);
-        Assert.Equal(16.5, alignedRight.HeightSamples[2], 6);
-        Assert.Equal(17.5, alignedRight.HeightSamples[4], 6);
-    }
-
-    [Fact]
     public async Task TerrainAlignedObjectDoesNotUseNearestTerrainPointOutsideDemTriangles()
     {
         using TemporaryDirectory datasetRoot = new();
@@ -3295,18 +3249,6 @@ public sealed class LocalCityGmlObjectProjectionTests
         return min + ((max - min) * ratio);
     }
 
-    private static ImportedCityObject[] AlignAdjacentDemTerrainGridChunkBoundariesForTest(
-        IReadOnlyList<ImportedCityObject> cityObjects)
-    {
-        MethodInfo method = typeof(LocalCityGmlObjectProjection)
-            .GetMethod(
-                "AlignAdjacentDemTerrainGridChunkBoundaries",
-                BindingFlags.NonPublic | BindingFlags.Static)
-            ?? throw new InvalidOperationException("Failed to resolve AlignAdjacentDemTerrainGridChunkBoundaries.");
-
-        return (ImportedCityObject[])method.Invoke(null, [cityObjects])!;
-    }
-
     private static object CreateGeneratedSurfaceUvProjectionForTest(
         LocalCityGmlObjectProjection.ParsedSurface surface,
         string packageName,
@@ -3736,41 +3678,6 @@ public sealed class LocalCityGmlObjectProjectionTests
             ?? throw new InvalidOperationException("Failed to resolve GetCandidateTriangleIndices.");
 
         return (IReadOnlyList<int>)method.Invoke(spatialIndex, [x, z])!;
-    }
-
-    private static ImportedCityObject CreateTerrainGridCityObject(
-        string slotKey,
-        Float3 position,
-        int width,
-        int height,
-        double sizeX,
-        double sizeZ,
-        IReadOnlyList<double> heightSamples)
-    {
-        MaterialBinding material = new(
-            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
-            MaterialType: MaterialType.Standard,
-            TexturePayload: null,
-            TextureSourceKind: TextureSourceKind.Bundled,
-            Projection: MaterialProjection.Uv,
-            DepthOffset: null,
-            SubmeshIndices: [0]);
-        return new ImportedCityObject(
-            ObjectKey: slotKey,
-            DisplayName: slotKey,
-            PackageName: "dem",
-            ActualMeshCode: "53394525",
-            LodLevel: 1,
-            Transform: new Transform3D(position),
-            Geometry: new TerrainGridGeometry(
-                Width: width,
-                Height: height,
-                Size: new Float2(sizeX, sizeZ),
-                MinHeight: heightSamples.Min(),
-                MaxHeight: heightSamples.Max(),
-                HeightSamples: heightSamples),
-            Materials: [material],
-            SourceFileRelativePath: $"udx/dem/53394525/{slotKey}.gml");
     }
 
     private static void AssertGeneratedUpperFacadeTrianglesFaceOutward(


### PR DESCRIPTION
## Summary
- Extract generated LOD1 roof application from `LocalCityGmlObjectProjection` into `GeneratedLod1RoofCityObjectFactory`.
- Keep shape selection and surface construction behind the existing `Lod1RoofShapePolicy` and `GeneratedLod1RoofSurfaceFactory` boundaries.
- Add direct factory tests for generating roof surfaces and skip conditions so the behavior is specified without pinning projection internals.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`