### PR TITLE
Extract CityGML terrain conformer

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlTerrainConformer.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlTerrainConformer.cs
@@ -1,0 +1,387 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using GeographicLib;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityGmlTerrainConformer
+{
+    internal static TerrainConformanceResult Conform(
+        ParsedCityObject cityObject,
+        ProjectionTerrainHeightSampler terrainHeightSampler,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        ArgumentNullException.ThrowIfNull(cityObject);
+        ArgumentNullException.ThrowIfNull(terrainHeightSampler);
+
+        bool terrainAligned = false;
+        ParsedSurface[] conformedSurfaces = PlateauPackageCatalog.IsRoadPackage(cityObject.PackageName)
+            ? ConformRoadSurfacesToTerrainWithFallback(
+                cityObject.Surfaces,
+                terrainHeightSampler,
+                ref terrainAligned)
+            : ConformSurfacesToTerrain(
+                cityObject.PackageName,
+                cityObject.Surfaces,
+                terrainHeightSampler,
+                cityObjectOrigin,
+                cityObjectCartesian,
+                ref terrainAligned);
+
+        return new TerrainConformanceResult(conformedSurfaces, terrainAligned);
+    }
+
+    internal static bool ShouldTerrainAlign(string packageName, int? lodLevel)
+    {
+        packageName = packageName.ToLowerInvariant();
+        if (PlateauPackageCatalog.IsRoadPackage(packageName))
+        {
+            return !lodLevel.HasValue || lodLevel.Value < 3;
+        }
+
+        return packageName switch
+        {
+            "fld" or "ifld" or "lsld" or "luse" or "rfld" or "tnm" or "urf" or "wtr" or "wwy" => true,
+            _ => false,
+        };
+    }
+
+    private static ParsedSurface[] ConformSurfacesToTerrain(
+        string packageName,
+        ParsedSurface[] surfaces,
+        ProjectionTerrainHeightSampler terrainHeightSampler,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        ref bool terrainAligned)
+    {
+        ParsedSurface[] conformedSurfaces = new ParsedSurface[surfaces.Length];
+        for (int index = 0; index < surfaces.Length; index++)
+        {
+            ParsedSurface surface = surfaces[index];
+            conformedSurfaces[index] = ShouldConformSurfaceToTerrain(
+                    packageName,
+                    surface,
+                    cityObjectOrigin,
+                    cityObjectCartesian)
+                ? ConformSurfaceToTerrain(surface, terrainHeightSampler, ref terrainAligned)
+                : surface;
+        }
+
+        return conformedSurfaces;
+    }
+
+    private static ParsedSurface[] ConformRoadSurfacesToTerrainWithFallback(
+        ParsedSurface[] surfaces,
+        ProjectionTerrainHeightSampler terrainHeightSampler,
+        ref bool terrainAligned)
+    {
+        List<TerrainSampleAnchor> anchors = [];
+        foreach (ParsedSurface surface in surfaces)
+        {
+            foreach (GeodeticPoint point in surface.Vertices)
+            {
+                if (terrainHeightSampler.TrySampleHeight(point.Latitude, point.Longitude, out double altitude, allowNearestPointFallback: false))
+                {
+                    anchors.Add(new TerrainSampleAnchor(point.Latitude, point.Longitude, altitude));
+                }
+            }
+        }
+
+        if (anchors.Count == 0)
+        {
+            return [.. surfaces];
+        }
+
+        ParsedSurface[] conformedSurfaces = new ParsedSurface[surfaces.Length];
+        for (int index = 0; index < surfaces.Length; index++)
+        {
+            conformedSurfaces[index] = ConformRoadSurfaceToTerrainWithFallback(
+                surfaces[index],
+                terrainHeightSampler,
+                anchors,
+                ref terrainAligned);
+        }
+
+        return conformedSurfaces;
+    }
+
+    private static ParsedSurface ConformRoadSurfaceToTerrainWithFallback(
+        ParsedSurface surface,
+        ProjectionTerrainHeightSampler terrainHeightSampler,
+        IReadOnlyList<TerrainSampleAnchor> anchors,
+        ref bool terrainAligned)
+    {
+        ParsedRing exteriorRing = ConformRoadRingToTerrainWithFallback(surface.ExteriorRing, terrainHeightSampler, anchors, ref terrainAligned);
+        ParsedRing[] interiorRings = new ParsedRing[surface.InteriorRings.Length];
+        for (int index = 0; index < surface.InteriorRings.Length; index++)
+        {
+            interiorRings[index] = ConformRoadRingToTerrainWithFallback(surface.InteriorRings[index], terrainHeightSampler, anchors, ref terrainAligned);
+        }
+
+        return surface with
+        {
+            ExteriorRing = exteriorRing,
+            InteriorRings = interiorRings,
+        };
+    }
+
+    private static ParsedRing ConformRoadRingToTerrainWithFallback(
+        ParsedRing ring,
+        ProjectionTerrainHeightSampler terrainHeightSampler,
+        IReadOnlyList<TerrainSampleAnchor> anchors,
+        ref bool terrainAligned)
+    {
+        GeodeticPoint[] vertices = new GeodeticPoint[ring.Vertices.Length];
+        for (int index = 0; index < ring.Vertices.Length; index++)
+        {
+            GeodeticPoint point = ring.Vertices[index];
+            double altitude = terrainHeightSampler.TrySampleHeight(point.Latitude, point.Longitude, out double sampledAltitude, allowNearestPointFallback: false)
+                ? sampledAltitude
+                : FindNearestAnchorAltitude(point, anchors);
+            if (Math.Abs(point.Altitude - altitude) > 1e-6)
+            {
+                terrainAligned = true;
+            }
+
+            vertices[index] = new GeodeticPoint(point.Latitude, point.Longitude, altitude);
+        }
+
+        return ring with { Vertices = vertices };
+    }
+
+    private static double FindNearestAnchorAltitude(GeodeticPoint point, IReadOnlyList<TerrainSampleAnchor> anchors)
+    {
+        double nearestDistanceSquared = double.MaxValue;
+        double altitude = point.Altitude;
+        foreach (TerrainSampleAnchor anchor in anchors)
+        {
+            double deltaLatitude = point.Latitude - anchor.Latitude;
+            double deltaLongitude = point.Longitude - anchor.Longitude;
+            double distanceSquared = (deltaLatitude * deltaLatitude) + (deltaLongitude * deltaLongitude);
+            if (distanceSquared < nearestDistanceSquared)
+            {
+                nearestDistanceSquared = distanceSquared;
+                altitude = anchor.Altitude;
+            }
+        }
+
+        return altitude;
+    }
+
+    private static ParsedSurface ConformSurfaceToTerrain(
+        ParsedSurface surface,
+        ProjectionTerrainHeightSampler terrainHeightSampler,
+        ref bool terrainAligned)
+    {
+        ParsedRing exteriorRing = ConformRingToTerrain(surface.ExteriorRing, terrainHeightSampler, ref terrainAligned);
+        ParsedRing[] interiorRings = new ParsedRing[surface.InteriorRings.Length];
+        for (int index = 0; index < surface.InteriorRings.Length; index++)
+        {
+            interiorRings[index] = ConformRingToTerrain(surface.InteriorRings[index], terrainHeightSampler, ref terrainAligned);
+        }
+
+        return surface with
+        {
+            ExteriorRing = exteriorRing,
+            InteriorRings = interiorRings,
+        };
+    }
+
+    private static ParsedRing ConformRingToTerrain(
+        ParsedRing ring,
+        ProjectionTerrainHeightSampler terrainHeightSampler,
+        ref bool terrainAligned)
+    {
+        GeodeticPoint[] vertices = new GeodeticPoint[ring.Vertices.Length];
+        bool[] sampled = new bool[ring.Vertices.Length];
+        int sampledCount = 0;
+
+        for (int index = 0; index < ring.Vertices.Length; index++)
+        {
+            GeodeticPoint point = ring.Vertices[index];
+            if (!terrainHeightSampler.TrySampleHeight(point.Latitude, point.Longitude, out double altitude, allowNearestPointFallback: false))
+            {
+                vertices[index] = point;
+                continue;
+            }
+
+            sampled[index] = true;
+            sampledCount++;
+            if (Math.Abs(point.Altitude - altitude) > 1e-6)
+            {
+                terrainAligned = true;
+            }
+
+            vertices[index] = new GeodeticPoint(point.Latitude, point.Longitude, altitude);
+        }
+
+        if (sampledCount > 0 && sampledCount < vertices.Length)
+        {
+            InterpolateUnsampledTerrainVertices(vertices, sampled, ref terrainAligned);
+        }
+
+        return ring with
+        {
+            Vertices = vertices,
+        };
+    }
+
+    private static void InterpolateUnsampledTerrainVertices(
+        GeodeticPoint[] vertices,
+        bool[] sampled,
+        ref bool terrainAligned)
+    {
+        for (int index = 0; index < vertices.Length; index++)
+        {
+            if (sampled[index])
+            {
+                continue;
+            }
+
+            int previousSampledIndex = FindPreviousSampledIndex(sampled, index);
+            int nextSampledIndex = FindNextSampledIndex(sampled, index);
+            double altitude = ResolveInterpolatedAltitude(vertices, index, previousSampledIndex, nextSampledIndex);
+            if (Math.Abs(vertices[index].Altitude - altitude) > 1e-6)
+            {
+                terrainAligned = true;
+            }
+
+            vertices[index] = new GeodeticPoint(vertices[index].Latitude, vertices[index].Longitude, altitude);
+            sampled[index] = true;
+        }
+    }
+
+    private static double ResolveInterpolatedAltitude(
+        GeodeticPoint[] vertices,
+        int index,
+        int previousSampledIndex,
+        int nextSampledIndex)
+    {
+        if (previousSampledIndex >= 0 && nextSampledIndex >= 0 && previousSampledIndex != nextSampledIndex)
+        {
+            int previousToIndexSteps = (index - previousSampledIndex + vertices.Length) % vertices.Length;
+            int previousToNextSteps = (nextSampledIndex - previousSampledIndex + vertices.Length) % vertices.Length;
+            if (previousToNextSteps > 0)
+            {
+                double ratio = (double)previousToIndexSteps / previousToNextSteps;
+                return vertices[previousSampledIndex].Altitude
+                    + ((vertices[nextSampledIndex].Altitude - vertices[previousSampledIndex].Altitude) * ratio);
+            }
+        }
+
+        int fallbackIndex = previousSampledIndex >= 0
+            ? previousSampledIndex
+            : nextSampledIndex;
+        return vertices[fallbackIndex].Altitude;
+    }
+
+    private static int FindPreviousSampledIndex(bool[] sampled, int index)
+    {
+        for (int offset = 1; offset < sampled.Length; offset++)
+        {
+            int candidate = (index - offset + sampled.Length) % sampled.Length;
+            if (sampled[candidate])
+            {
+                return candidate;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int FindNextSampledIndex(bool[] sampled, int index)
+    {
+        for (int offset = 1; offset < sampled.Length; offset++)
+        {
+            int candidate = (index + offset) % sampled.Length;
+            if (sampled[candidate])
+            {
+                return candidate;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool ShouldConformSurfaceToTerrain(
+        string packageName,
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (!PlateauPackageCatalog.IsRoadPackage(packageName))
+        {
+            return true;
+        }
+
+        Float3[] positions = surface.ExteriorRing.Vertices
+            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
+            .ToArray();
+        return IsNearHorizontalSurface(positions);
+    }
+
+    private static bool IsNearHorizontalSurface(Float3[] positions)
+    {
+        Float3? normal = ComputePolygonNormal(positions);
+        return normal is not null && Math.Abs(normal.Y) >= 0.7;
+    }
+
+    private static Float3? ComputePolygonNormal(IEnumerable<Float3> positions)
+    {
+        Float3[] points = positions.ToArray();
+        if (points.Length < 3)
+        {
+            return null;
+        }
+
+        double normalX = 0.0;
+        double normalY = 0.0;
+        double normalZ = 0.0;
+
+        for (int index = 0; index < points.Length; index++)
+        {
+            Float3 current = points[index];
+            Float3 next = points[(index + 1) % points.Length];
+            normalX += (current.Y - next.Y) * (current.Z + next.Z);
+            normalY += (current.Z - next.Z) * (current.X + next.X);
+            normalZ += (current.X - next.X) * (current.Y + next.Y);
+        }
+
+        double magnitude = Math.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ));
+        if (magnitude < 1e-8)
+        {
+            return null;
+        }
+
+        return new Float3(normalX / magnitude, normalY / magnitude, normalZ / magnitude);
+    }
+
+    private static Float3 CreateScenePosition(
+        GeodeticPoint point,
+        GeodeticPoint origin,
+        LocalCartesian? cartesian)
+    {
+        return SceneAxisMapper.CreatePosition(
+            point.Latitude,
+            point.Longitude,
+            point.Altitude,
+            origin.Latitude,
+            origin.Longitude,
+            origin.Altitude,
+            cartesian);
+    }
+
+    private readonly record struct TerrainSampleAnchor(
+        double Latitude,
+        double Longitude,
+        double Altitude);
+}
+
+internal sealed record TerrainConformanceResult(
+    ParsedSurface[] Surfaces,
+    bool TerrainAligned);

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -336,263 +336,6 @@ internal static class LocalCityGmlObjectProjection
         return strips.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel).ToList();
     }
 
-    private static ParsedSurface[] ConformSurfacesToTerrain(
-        string packageName,
-        ParsedSurface[] surfaces,
-        ProjectionTerrainHeightSampler terrainHeightSampler,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian,
-        ref bool terrainAligned)
-    {
-        ParsedSurface[] conformedSurfaces = new ParsedSurface[surfaces.Length];
-        for (int index = 0; index < surfaces.Length; index++)
-        {
-            ParsedSurface surface = surfaces[index];
-            conformedSurfaces[index] = ShouldConformSurfaceToTerrain(
-                    packageName,
-                    surface,
-                    cityObjectOrigin,
-                    cityObjectCartesian)
-                ? ConformSurfaceToTerrain(surface, terrainHeightSampler, ref terrainAligned)
-                : surface;
-        }
-
-        return conformedSurfaces;
-    }
-
-    private static ParsedSurface[] ConformRoadSurfacesToTerrainWithFallback(
-        ParsedSurface[] surfaces,
-        ProjectionTerrainHeightSampler terrainHeightSampler,
-        ref bool terrainAligned)
-    {
-        List<TerrainSampleAnchor> anchors = [];
-        foreach (ParsedSurface surface in surfaces)
-        {
-            foreach (GeodeticPoint point in surface.Vertices)
-            {
-                if (terrainHeightSampler.TrySampleHeight(point.Latitude, point.Longitude, out double altitude, allowNearestPointFallback: false))
-                {
-                    anchors.Add(new TerrainSampleAnchor(point.Latitude, point.Longitude, altitude));
-                }
-            }
-        }
-
-        if (anchors.Count == 0)
-        {
-            return [.. surfaces];
-        }
-
-        ParsedSurface[] conformedSurfaces = new ParsedSurface[surfaces.Length];
-        for (int index = 0; index < surfaces.Length; index++)
-        {
-            conformedSurfaces[index] = ConformRoadSurfaceToTerrainWithFallback(
-                surfaces[index],
-                terrainHeightSampler,
-                anchors,
-                ref terrainAligned);
-        }
-
-        return conformedSurfaces;
-    }
-
-    private static ParsedSurface ConformRoadSurfaceToTerrainWithFallback(
-        ParsedSurface surface,
-        ProjectionTerrainHeightSampler terrainHeightSampler,
-        IReadOnlyList<TerrainSampleAnchor> anchors,
-        ref bool terrainAligned)
-    {
-        ParsedRing exteriorRing = ConformRoadRingToTerrainWithFallback(surface.ExteriorRing, terrainHeightSampler, anchors, ref terrainAligned);
-        ParsedRing[] interiorRings = new ParsedRing[surface.InteriorRings.Length];
-        for (int index = 0; index < surface.InteriorRings.Length; index++)
-        {
-            interiorRings[index] = ConformRoadRingToTerrainWithFallback(surface.InteriorRings[index], terrainHeightSampler, anchors, ref terrainAligned);
-        }
-
-        return surface with
-        {
-            ExteriorRing = exteriorRing,
-            InteriorRings = interiorRings,
-        };
-    }
-
-    private static ParsedRing ConformRoadRingToTerrainWithFallback(
-        ParsedRing ring,
-        ProjectionTerrainHeightSampler terrainHeightSampler,
-        IReadOnlyList<TerrainSampleAnchor> anchors,
-        ref bool terrainAligned)
-    {
-        GeodeticPoint[] vertices = new GeodeticPoint[ring.Vertices.Length];
-        for (int index = 0; index < ring.Vertices.Length; index++)
-        {
-            GeodeticPoint point = ring.Vertices[index];
-            double altitude = terrainHeightSampler.TrySampleHeight(point.Latitude, point.Longitude, out double sampledAltitude, allowNearestPointFallback: false)
-                ? sampledAltitude
-                : FindNearestAnchorAltitude(point, anchors);
-            if (Math.Abs(point.Altitude - altitude) > 1e-6)
-            {
-                terrainAligned = true;
-            }
-
-            vertices[index] = new GeodeticPoint(point.Latitude, point.Longitude, altitude);
-        }
-
-        return ring with { Vertices = vertices };
-    }
-
-    private static double FindNearestAnchorAltitude(GeodeticPoint point, IReadOnlyList<TerrainSampleAnchor> anchors)
-    {
-        double nearestDistanceSquared = double.MaxValue;
-        double altitude = point.Altitude;
-        foreach (TerrainSampleAnchor anchor in anchors)
-        {
-            double deltaLatitude = point.Latitude - anchor.Latitude;
-            double deltaLongitude = point.Longitude - anchor.Longitude;
-            double distanceSquared = (deltaLatitude * deltaLatitude) + (deltaLongitude * deltaLongitude);
-            if (distanceSquared < nearestDistanceSquared)
-            {
-                nearestDistanceSquared = distanceSquared;
-                altitude = anchor.Altitude;
-            }
-        }
-
-        return altitude;
-    }
-
-    private static ParsedSurface ConformSurfaceToTerrain(
-        ParsedSurface surface,
-        ProjectionTerrainHeightSampler terrainHeightSampler,
-        ref bool terrainAligned)
-    {
-        ParsedRing exteriorRing = ConformRingToTerrain(surface.ExteriorRing, terrainHeightSampler, ref terrainAligned);
-        ParsedRing[] interiorRings = new ParsedRing[surface.InteriorRings.Length];
-        for (int index = 0; index < surface.InteriorRings.Length; index++)
-        {
-            interiorRings[index] = ConformRingToTerrain(surface.InteriorRings[index], terrainHeightSampler, ref terrainAligned);
-        }
-
-        return surface with
-        {
-            ExteriorRing = exteriorRing,
-            InteriorRings = interiorRings,
-        };
-    }
-
-    private static ParsedRing ConformRingToTerrain(
-        ParsedRing ring,
-        ProjectionTerrainHeightSampler terrainHeightSampler,
-        ref bool terrainAligned)
-    {
-        GeodeticPoint[] vertices = new GeodeticPoint[ring.Vertices.Length];
-        bool[] sampled = new bool[ring.Vertices.Length];
-        int sampledCount = 0;
-
-        for (int index = 0; index < ring.Vertices.Length; index++)
-        {
-            GeodeticPoint point = ring.Vertices[index];
-            if (!terrainHeightSampler.TrySampleHeight(point.Latitude, point.Longitude, out double altitude, allowNearestPointFallback: false))
-            {
-                vertices[index] = point;
-                continue;
-            }
-
-            sampled[index] = true;
-            sampledCount++;
-            if (Math.Abs(point.Altitude - altitude) > 1e-6)
-            {
-                terrainAligned = true;
-            }
-
-            vertices[index] = new GeodeticPoint(point.Latitude, point.Longitude, altitude);
-        }
-
-        if (sampledCount > 0 && sampledCount < vertices.Length)
-        {
-            InterpolateUnsampledTerrainVertices(vertices, sampled, ref terrainAligned);
-        }
-
-        return ring with
-        {
-            Vertices = vertices,
-        };
-    }
-
-    private static void InterpolateUnsampledTerrainVertices(
-        GeodeticPoint[] vertices,
-        bool[] sampled,
-        ref bool terrainAligned)
-    {
-        for (int index = 0; index < vertices.Length; index++)
-        {
-            if (sampled[index])
-            {
-                continue;
-            }
-
-            int previousSampledIndex = FindPreviousSampledIndex(sampled, index);
-            int nextSampledIndex = FindNextSampledIndex(sampled, index);
-            double altitude = ResolveInterpolatedAltitude(vertices, index, previousSampledIndex, nextSampledIndex);
-            if (Math.Abs(vertices[index].Altitude - altitude) > 1e-6)
-            {
-                terrainAligned = true;
-            }
-
-            vertices[index] = new GeodeticPoint(vertices[index].Latitude, vertices[index].Longitude, altitude);
-            sampled[index] = true;
-        }
-    }
-
-    private static double ResolveInterpolatedAltitude(
-        GeodeticPoint[] vertices,
-        int index,
-        int previousSampledIndex,
-        int nextSampledIndex)
-    {
-        if (previousSampledIndex >= 0 && nextSampledIndex >= 0 && previousSampledIndex != nextSampledIndex)
-        {
-            int previousToIndexSteps = (index - previousSampledIndex + vertices.Length) % vertices.Length;
-            int previousToNextSteps = (nextSampledIndex - previousSampledIndex + vertices.Length) % vertices.Length;
-            if (previousToNextSteps > 0)
-            {
-                double ratio = (double)previousToIndexSteps / previousToNextSteps;
-                return vertices[previousSampledIndex].Altitude
-                    + ((vertices[nextSampledIndex].Altitude - vertices[previousSampledIndex].Altitude) * ratio);
-            }
-        }
-
-        int fallbackIndex = previousSampledIndex >= 0
-            ? previousSampledIndex
-            : nextSampledIndex;
-        return vertices[fallbackIndex].Altitude;
-    }
-
-    private static int FindPreviousSampledIndex(bool[] sampled, int index)
-    {
-        for (int offset = 1; offset < sampled.Length; offset++)
-        {
-            int candidate = (index - offset + sampled.Length) % sampled.Length;
-            if (sampled[candidate])
-            {
-                return candidate;
-            }
-        }
-
-        return -1;
-    }
-
-    private static int FindNextSampledIndex(bool[] sampled, int index)
-    {
-        for (int offset = 1; offset < sampled.Length; offset++)
-        {
-            int candidate = (index + offset) % sampled.Length;
-            if (sampled[candidate])
-            {
-                return candidate;
-            }
-        }
-
-        return -1;
-    }
-
     private static bool IsTerrainDependentCityObject(ParsedCityObject cityObject)
     {
         return string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
@@ -601,24 +344,7 @@ internal static class LocalCityGmlObjectProjection
 
     private static bool ShouldTerrainAlignCityObject(ParsedCityObject cityObject)
     {
-        return ShouldTerrainAlignCityObject(cityObject.PackageName, cityObject.LodLevel);
-    }
-
-    private static bool ShouldConformSurfaceToTerrain(
-        string packageName,
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        if (!PlateauPackageCatalog.IsRoadPackage(packageName))
-        {
-            return true;
-        }
-
-        Float3[] positions = surface.ExteriorRing.Vertices
-            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
-            .ToArray();
-        return IsNearHorizontalSurface(positions);
+        return CityGmlTerrainConformer.ShouldTerrainAlign(cityObject.PackageName, cityObject.LodLevel);
     }
 
     private static bool IsNearHorizontalSurface(Float3[] positions)
@@ -1774,7 +1500,6 @@ internal static class LocalCityGmlObjectProjection
 
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject subdividedCityObject =
             SubdivideTerrainAlignedCityObject(parsedCityObject);
-        bool terrainAligned = false;
         global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(subdividedCityObject);
         LocalCartesian? cityObjectCartesian = subdividedCityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(
@@ -1783,28 +1508,17 @@ internal static class LocalCityGmlObjectProjection
                 cityObjectOrigin.Altitude,
                 subdividedCityObject.ReferenceSystem.Geocentric)
             : null;
-        global::PlateauResoniteLink.Application.Importing.ParsedSurface[] conformedSurfaces =
-            PlateauPackageCatalog.IsRoadPackage(subdividedCityObject.PackageName)
-                ? ConformRoadSurfacesToTerrainWithFallback(
-                        subdividedCityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel).ToArray(),
-                        terrainHeightSampler,
-                        ref terrainAligned)
-                    .Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel)
-                    .ToArray()
-                : ConformSurfacesToTerrain(
-                        subdividedCityObject.PackageName,
-                        subdividedCityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel).ToArray(),
-                        terrainHeightSampler,
-                        cityObjectOrigin.ToProjectionModel(),
-                        cityObjectCartesian,
-                        ref terrainAligned)
-                    .Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel)
-                    .ToArray();
 
-        return terrainAligned
+        TerrainConformanceResult conformance = CityGmlTerrainConformer.Conform(
+            subdividedCityObject,
+            terrainHeightSampler,
+            cityObjectOrigin,
+            cityObjectCartesian);
+
+        return conformance.TerrainAligned
             ? subdividedCityObject with
             {
-                Surfaces = conformedSurfaces,
+                Surfaces = conformance.Surfaces,
                 TerrainAligned = true,
             }
             : subdividedCityObject;
@@ -1838,7 +1552,7 @@ internal static class LocalCityGmlObjectProjection
     private static bool ShouldTerrainAlignCityObject(
         global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject)
     {
-        return ShouldTerrainAlignCityObject(cityObject.PackageName, cityObject.LodLevel);
+        return CityGmlTerrainConformer.ShouldTerrainAlign(cityObject.PackageName, cityObject.LodLevel);
     }
 
     private static bool ShouldSubdivideTerrainAlignedCityObject(string packageName, int? lodLevel)
@@ -1849,17 +1563,7 @@ internal static class LocalCityGmlObjectProjection
 
     private static bool ShouldTerrainAlignCityObject(string packageName, int? lodLevel)
     {
-        packageName = packageName.ToLowerInvariant();
-        if (PlateauPackageCatalog.IsRoadPackage(packageName))
-        {
-            return !lodLevel.HasValue || lodLevel.Value < 3;
-        }
-
-        return packageName switch
-        {
-            "fld" or "ifld" or "lsld" or "luse" or "rfld" or "tnm" or "urf" or "wtr" or "wwy" => true,
-            _ => false,
-        };
+        return CityGmlTerrainConformer.ShouldTerrainAlign(packageName, lodLevel);
     }
 
     private static MaterialBinding[] CreateCommonMaterialBindings(
@@ -3110,11 +2814,6 @@ internal static class LocalCityGmlObjectProjection
             return Math.Clamp((int)((coordinate - minimum) / cellSize), 0, cellCount - 1);
         }
     }
-
-    private readonly record struct TerrainSampleAnchor(
-        double Latitude,
-        double Longitude,
-        double Altitude);
 
     internal sealed record ParsedSurface(
         string PolygonId,

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlTerrainConformerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlTerrainConformerTests.cs
@@ -1,0 +1,79 @@
+using GeographicLib;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class CityGmlTerrainConformerTests
+{
+    [Fact]
+    public void ShouldTerrainAlignIncludesRoadLodBelowThreeAndTerrainLikePackages()
+    {
+        Assert.True(CityGmlTerrainConformer.ShouldTerrainAlign("tran", lodLevel: 2));
+        Assert.False(CityGmlTerrainConformer.ShouldTerrainAlign("tran", lodLevel: 3));
+        Assert.True(CityGmlTerrainConformer.ShouldTerrainAlign("luse", lodLevel: 1));
+        Assert.False(CityGmlTerrainConformer.ShouldTerrainAlign("bldg", lodLevel: 1));
+    }
+
+    [Fact]
+    public void ConformInterpolatesUnsampledNonRoadRingVerticesBetweenSampledNeighbors()
+    {
+        GeodeticPoint point0 = new(35.0, 139.0, 0.0);
+        GeodeticPoint point1 = new(35.0001, 139.0, 0.0);
+        GeodeticPoint point2 = new(35.0001, 139.0001, 0.0);
+        GeodeticPoint point3 = new(35.0, 139.0001, 0.0);
+        ParsedCityObject cityObject = CreateCityObject(
+            "luse",
+            [
+                CreateSurface("ground", [point0, point1, point2, point3]),
+            ]);
+        ProjectionTerrainHeightSampler sampler = ProjectionTerrainHeightSampler.Create(
+            [
+                new ProjectionTerrainHeightTriangle(
+                    new GeodeticPoint(point0.Latitude, point0.Longitude, 10.0),
+                    new GeodeticPoint(point1.Latitude, point1.Longitude, 20.0),
+                    new GeodeticPoint(point2.Latitude, point2.Longitude, 30.0)),
+            ],
+            new GeodeticPoint(point0.Latitude, point0.Longitude, point0.Altitude),
+            Geocentric.WGS84);
+
+        TerrainConformanceResult result = CityGmlTerrainConformer.Conform(
+            cityObject,
+            sampler,
+            point0,
+            new LocalCartesian(point0.Latitude, point0.Longitude, point0.Altitude, Geocentric.WGS84));
+
+        GeodeticPoint[] vertices = result.Surfaces[0].ExteriorRing.Vertices;
+        Assert.True(result.TerrainAligned);
+        Assert.Equal(10.0, vertices[0].Altitude, precision: 6);
+        Assert.Equal(20.0, vertices[1].Altitude, precision: 6);
+        Assert.Equal(30.0, vertices[2].Altitude, precision: 6);
+        Assert.Equal(20.0, vertices[3].Altitude, precision: 6);
+    }
+
+    private static ParsedCityObject CreateCityObject(string packageName, ParsedSurface[] surfaces)
+    {
+        return new ParsedCityObject(
+            SlotKey: $"{packageName}-slot",
+            DisplayName: packageName,
+            PackageName: packageName,
+            ActualMeshCode: "53394525",
+            LodLevel: 1,
+            Surfaces: surfaces,
+            ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4979"),
+            SourceFileRelativePath: $"udx/{packageName}/53394525/{packageName}.gml",
+            SharedAcrossMeshCodes: false,
+            TerrainAligned: false);
+    }
+
+    private static ParsedSurface CreateSurface(string polygonId, GeodeticPoint[] vertices)
+    {
+        return new ParsedSurface(
+            polygonId,
+            ParsedSurfaceSemantic.Ground,
+            new ParsedRing($"{polygonId}-ring", vertices, UVs: null),
+            InteriorRings: [],
+            BaseColor: new ColorRgba(0.5, 0.5, 0.5, 1.0),
+            TexturePayload: null);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract terrain conformance and terrain-align eligibility from `LocalCityGmlObjectProjection` into `CityGmlTerrainConformer`.
- Keep the conformer on the top-level parsed CityGML model contract instead of depending on `LocalCityGmlObjectProjection` nested types.
- Replace `ref bool` terrain-alignment mutation at the projection boundary with a value result carrying conformed surfaces and alignment state.
- Add direct fast tests for terrain-align eligibility and unsampled vertex interpolation.

## Verification
- `dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~CityGmlTerrainConformerTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests|FullyQualifiedName~TerrainAlignedTransportationSurfaceSplitterTests" --verbosity normal`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`