### PR TITLE
Extract CityGML surface projection policy

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceProjectionPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceProjectionPolicy.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using GeographicLib;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityGmlSurfaceProjectionPolicy
+{
+    private const double BuildingBottomCullBandMeters = 0.1;
+
+    internal static bool IsFacadeSurface(
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
+        return normal is not null && Math.Abs(normal.Y) < 0.45;
+    }
+
+    internal static bool IsNearHorizontalSurface(
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
+        return normal is not null && Math.Abs(normal.Y) >= 0.98;
+    }
+
+    internal static HashSet<string> GetCulledSurfaceIdsBeforeProjection(
+        string packageName,
+        IEnumerable<ParsedSurface> surfaces,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (!PlateauPackageCatalog.IsBuildingPackage(packageName))
+        {
+            return [];
+        }
+
+        SurfaceProjectionInfo[] candidates = surfaces
+            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
+            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
+            .ToArray();
+
+        if (candidates.Length == 0)
+        {
+            return [];
+        }
+
+        double objectMinimumY = candidates.Min(static info => info.MinimumY!.Value);
+        double objectMaximumY = candidates.Max(static info => info.MaximumY!.Value);
+
+        return candidates
+            .Where(static info => info.IsNearHorizontal)
+            .Where(info => info.MaximumY!.Value <= objectMinimumY + BuildingBottomCullBandMeters)
+            .Where(info => objectMaximumY > info.MaximumY!.Value + BuildingBottomCullBandMeters)
+            .Select(static info => info.Surface.PolygonId)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    internal static FacadeUvProjectionContext? TryCreateFacadeUvProjectionContext(
+        string packageName,
+        IEnumerable<ParsedSurface> surfaces,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (!PlateauPackageCatalog.IsBuildingPackage(packageName))
+        {
+            return null;
+        }
+
+        SurfaceProjectionInfo[] surfaceInfos = surfaces
+            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
+            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
+            .ToArray();
+        if (surfaceInfos.Length == 0)
+        {
+            return null;
+        }
+
+        SurfaceProjectionInfo[] contextSurfaceInfos = surfaceInfos
+            .Where(static info => !IsGeneratedLod1RoofSurface(info.Surface))
+            .ToArray();
+        if (contextSurfaceInfos.Length == 0)
+        {
+            contextSurfaceInfos = surfaceInfos;
+        }
+
+        (double minimumY, double maximumY) = ResolveFacadeUvVerticalRange(contextSurfaceInfos, surfaceInfos);
+        double geometryHeightMeters = Math.Max(maximumY - minimumY, 0.0);
+        int floorCount = Math.Max(
+            1,
+            (int)Math.Ceiling(Math.Max(geometryHeightMeters, FacadeFloorMetrics.DefaultFloorUnitMeters) / FacadeFloorMetrics.DefaultFloorUnitMeters));
+        double floorHeightMeters = Math.Max(
+            geometryHeightMeters / floorCount,
+            1e-6);
+
+        return new FacadeUvProjectionContext(
+            minimumY,
+            maximumY,
+            floorHeightMeters,
+            floorCount);
+    }
+
+    internal static Float3? ComputeSurfaceNormal(
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        Float3[] positions = surface.Vertices
+            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
+            .ToArray();
+        return ComputePolygonNormal(positions);
+    }
+
+    private static SurfaceProjectionInfo CreateSurfaceProjectionInfo(
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        Float3[] positions = surface.Vertices
+            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
+            .ToArray();
+        if (positions.Length == 0)
+        {
+            return new SurfaceProjectionInfo(surface, null, null, false);
+        }
+
+        Float3? normal = ComputePolygonNormal(positions);
+        bool isNearHorizontal = normal is not null && Math.Abs(normal.Y) >= 0.98;
+
+        return new SurfaceProjectionInfo(
+            surface,
+            positions.Min(static position => position.Y),
+            positions.Max(static position => position.Y),
+            isNearHorizontal);
+    }
+
+    private static (double MinimumY, double MaximumY) ResolveFacadeUvVerticalRange(
+        IReadOnlyList<SurfaceProjectionInfo> contextSurfaceInfos,
+        IReadOnlyList<SurfaceProjectionInfo> allSurfaceInfos)
+    {
+        double minimumY = contextSurfaceInfos.Min(static info => info.MinimumY!.Value);
+        double maximumY = contextSurfaceInfos.Max(static info => info.MaximumY!.Value);
+        if (maximumY - minimumY > 1e-6 || contextSurfaceInfos.Count == allSurfaceInfos.Count)
+        {
+            return (minimumY, maximumY);
+        }
+
+        double fallbackMinimumY = allSurfaceInfos.Min(static info => info.MinimumY!.Value);
+        double fallbackMaximumY = allSurfaceInfos.Max(static info => info.MaximumY!.Value);
+        return fallbackMaximumY - fallbackMinimumY > maximumY - minimumY
+            ? (fallbackMinimumY, fallbackMaximumY)
+            : (minimumY, maximumY);
+    }
+
+    private static bool IsGeneratedLod1RoofSurface(ParsedSurface surface)
+    {
+        return surface.PolygonId.Contains("_generated_shed-", StringComparison.Ordinal)
+            || surface.PolygonId.Contains("_generated_gable-", StringComparison.Ordinal)
+            || surface.PolygonId.Contains("_generated_hip-", StringComparison.Ordinal);
+    }
+
+    private static Float3? ComputePolygonNormal(IEnumerable<Float3> positions)
+    {
+        Float3[] points = positions.ToArray();
+        if (points.Length < 3)
+        {
+            return null;
+        }
+
+        double normalX = 0.0;
+        double normalY = 0.0;
+        double normalZ = 0.0;
+
+        for (int index = 0; index < points.Length; index++)
+        {
+            Float3 current = points[index];
+            Float3 next = points[(index + 1) % points.Length];
+            normalX += (current.Y - next.Y) * (current.Z + next.Z);
+            normalY += (current.Z - next.Z) * (current.X + next.X);
+            normalZ += (current.X - next.X) * (current.Y + next.Y);
+        }
+
+        double magnitude = Math.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ));
+        if (magnitude < 1e-8)
+        {
+            return null;
+        }
+
+        return new Float3(normalX / magnitude, normalY / magnitude, normalZ / magnitude);
+    }
+
+    private static Float3 CreateScenePosition(
+        GeodeticPoint point,
+        GeodeticPoint origin,
+        LocalCartesian? cartesian)
+    {
+        return SceneAxisMapper.CreatePosition(
+            point.Latitude,
+            point.Longitude,
+            point.Altitude,
+            origin.Latitude,
+            origin.Longitude,
+            origin.Altitude,
+            cartesian);
+    }
+
+    private sealed record SurfaceProjectionInfo(
+        ParsedSurface Surface,
+        double? MinimumY,
+        double? MaximumY,
+        bool IsNearHorizontal);
+}

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceProjectionPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceProjectionPolicy.cs
@@ -6,6 +6,9 @@ using GeographicLib;
 
 using PlateauResoniteLink.Domain.Importing;
 
+using ProjectionPoint = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.GeodeticPoint;
+using ProjectionSurface = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedSurface;
+
 namespace PlateauResoniteLink.Application.Importing;
 
 internal static class CityGmlSurfaceProjectionPolicy
@@ -21,9 +24,27 @@ internal static class CityGmlSurfaceProjectionPolicy
         return normal is not null && Math.Abs(normal.Y) < 0.45;
     }
 
+    internal static bool IsFacadeSurface(
+        ProjectionSurface surface,
+        ProjectionPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
+        return normal is not null && Math.Abs(normal.Y) < 0.45;
+    }
+
     internal static bool IsNearHorizontalSurface(
         ParsedSurface surface,
         GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
+        return normal is not null && Math.Abs(normal.Y) >= 0.98;
+    }
+
+    internal static bool IsNearHorizontalSurface(
+        ProjectionSurface surface,
+        ProjectionPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
         Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
@@ -58,7 +79,39 @@ internal static class CityGmlSurfaceProjectionPolicy
             .Where(static info => info.IsNearHorizontal)
             .Where(info => info.MaximumY!.Value <= objectMinimumY + BuildingBottomCullBandMeters)
             .Where(info => objectMaximumY > info.MaximumY!.Value + BuildingBottomCullBandMeters)
-            .Select(static info => info.Surface.PolygonId)
+            .Select(static info => info.PolygonId)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    internal static HashSet<string> GetCulledSurfaceIdsBeforeProjection(
+        string packageName,
+        IEnumerable<ProjectionSurface> surfaces,
+        ProjectionPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (!PlateauPackageCatalog.IsBuildingPackage(packageName))
+        {
+            return [];
+        }
+
+        SurfaceProjectionInfo[] candidates = surfaces
+            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
+            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
+            .ToArray();
+
+        if (candidates.Length == 0)
+        {
+            return [];
+        }
+
+        double objectMinimumY = candidates.Min(static info => info.MinimumY!.Value);
+        double objectMaximumY = candidates.Max(static info => info.MaximumY!.Value);
+
+        return candidates
+            .Where(static info => info.IsNearHorizontal)
+            .Where(info => info.MaximumY!.Value <= objectMinimumY + BuildingBottomCullBandMeters)
+            .Where(info => objectMaximumY > info.MaximumY!.Value + BuildingBottomCullBandMeters)
+            .Select(static info => info.PolygonId)
             .ToHashSet(StringComparer.Ordinal);
     }
 
@@ -83,7 +136,51 @@ internal static class CityGmlSurfaceProjectionPolicy
         }
 
         SurfaceProjectionInfo[] contextSurfaceInfos = surfaceInfos
-            .Where(static info => !IsGeneratedLod1RoofSurface(info.Surface))
+            .Where(static info => !info.IsGeneratedLod1RoofSurface)
+            .ToArray();
+        if (contextSurfaceInfos.Length == 0)
+        {
+            contextSurfaceInfos = surfaceInfos;
+        }
+
+        (double minimumY, double maximumY) = ResolveFacadeUvVerticalRange(contextSurfaceInfos, surfaceInfos);
+        double geometryHeightMeters = Math.Max(maximumY - minimumY, 0.0);
+        int floorCount = Math.Max(
+            1,
+            (int)Math.Ceiling(Math.Max(geometryHeightMeters, FacadeFloorMetrics.DefaultFloorUnitMeters) / FacadeFloorMetrics.DefaultFloorUnitMeters));
+        double floorHeightMeters = Math.Max(
+            geometryHeightMeters / floorCount,
+            1e-6);
+
+        return new FacadeUvProjectionContext(
+            minimumY,
+            maximumY,
+            floorHeightMeters,
+            floorCount);
+    }
+
+    internal static FacadeUvProjectionContext? TryCreateFacadeUvProjectionContext(
+        string packageName,
+        IEnumerable<ProjectionSurface> surfaces,
+        ProjectionPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        if (!PlateauPackageCatalog.IsBuildingPackage(packageName))
+        {
+            return null;
+        }
+
+        SurfaceProjectionInfo[] surfaceInfos = surfaces
+            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
+            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
+            .ToArray();
+        if (surfaceInfos.Length == 0)
+        {
+            return null;
+        }
+
+        SurfaceProjectionInfo[] contextSurfaceInfos = surfaceInfos
+            .Where(static info => !info.IsGeneratedLod1RoofSurface)
             .ToArray();
         if (contextSurfaceInfos.Length == 0)
         {
@@ -117,6 +214,17 @@ internal static class CityGmlSurfaceProjectionPolicy
         return ComputePolygonNormal(positions);
     }
 
+    internal static Float3? ComputeSurfaceNormal(
+        ProjectionSurface surface,
+        ProjectionPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        Float3[] positions = surface.Vertices
+            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
+            .ToArray();
+        return ComputePolygonNormal(positions);
+    }
+
     private static SurfaceProjectionInfo CreateSurfaceProjectionInfo(
         ParsedSurface surface,
         GeodeticPoint cityObjectOrigin,
@@ -127,17 +235,42 @@ internal static class CityGmlSurfaceProjectionPolicy
             .ToArray();
         if (positions.Length == 0)
         {
-            return new SurfaceProjectionInfo(surface, null, null, false);
+            return new SurfaceProjectionInfo(surface.PolygonId, null, null, false, IsGeneratedLod1RoofSurface(surface.PolygonId));
         }
 
         Float3? normal = ComputePolygonNormal(positions);
         bool isNearHorizontal = normal is not null && Math.Abs(normal.Y) >= 0.98;
 
         return new SurfaceProjectionInfo(
-            surface,
+            surface.PolygonId,
             positions.Min(static position => position.Y),
             positions.Max(static position => position.Y),
-            isNearHorizontal);
+            isNearHorizontal,
+            IsGeneratedLod1RoofSurface(surface.PolygonId));
+    }
+
+    private static SurfaceProjectionInfo CreateSurfaceProjectionInfo(
+        ProjectionSurface surface,
+        ProjectionPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian)
+    {
+        Float3[] positions = surface.Vertices
+            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
+            .ToArray();
+        if (positions.Length == 0)
+        {
+            return new SurfaceProjectionInfo(surface.PolygonId, null, null, false, IsGeneratedLod1RoofSurface(surface.PolygonId));
+        }
+
+        Float3? normal = ComputePolygonNormal(positions);
+        bool isNearHorizontal = normal is not null && Math.Abs(normal.Y) >= 0.98;
+
+        return new SurfaceProjectionInfo(
+            surface.PolygonId,
+            positions.Min(static position => position.Y),
+            positions.Max(static position => position.Y),
+            isNearHorizontal,
+            IsGeneratedLod1RoofSurface(surface.PolygonId));
     }
 
     private static (double MinimumY, double MaximumY) ResolveFacadeUvVerticalRange(
@@ -158,11 +291,11 @@ internal static class CityGmlSurfaceProjectionPolicy
             : (minimumY, maximumY);
     }
 
-    private static bool IsGeneratedLod1RoofSurface(ParsedSurface surface)
+    private static bool IsGeneratedLod1RoofSurface(string polygonId)
     {
-        return surface.PolygonId.Contains("_generated_shed-", StringComparison.Ordinal)
-            || surface.PolygonId.Contains("_generated_gable-", StringComparison.Ordinal)
-            || surface.PolygonId.Contains("_generated_hip-", StringComparison.Ordinal);
+        return polygonId.Contains("_generated_shed-", StringComparison.Ordinal)
+            || polygonId.Contains("_generated_gable-", StringComparison.Ordinal)
+            || polygonId.Contains("_generated_hip-", StringComparison.Ordinal);
     }
 
     private static Float3? ComputePolygonNormal(IEnumerable<Float3> positions)
@@ -210,9 +343,25 @@ internal static class CityGmlSurfaceProjectionPolicy
             cartesian);
     }
 
-    private sealed record SurfaceProjectionInfo(
-        ParsedSurface Surface,
+    private static Float3 CreateScenePosition(
+        ProjectionPoint point,
+        ProjectionPoint origin,
+        LocalCartesian? cartesian)
+    {
+        return SceneAxisMapper.CreatePosition(
+            point.Latitude,
+            point.Longitude,
+            point.Altitude,
+            origin.Latitude,
+            origin.Longitude,
+            origin.Altitude,
+            cartesian);
+    }
+
+    private readonly record struct SurfaceProjectionInfo(
+        string PolygonId,
         double? MinimumY,
         double? MaximumY,
-        bool IsNearHorizontal);
+        bool IsNearHorizontal,
+        bool IsGeneratedLod1RoofSurface);
 }

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -19,7 +19,6 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal static class LocalCityGmlObjectProjection
 {
-    private const double BuildingBottomCullBandMeters = 0.1;
     private const double UnknownRoofBottomAltitudeToleranceMeters = 0.1;
     public const string DefaultDemTerrainTexturePath = DemTerrainTextureDefaults.PlateauOrthoPath;
     public const string DefaultDemTerrainTextureUrlTemplate = DemTerrainTextureDefaults.PlateauOrthoUrlTemplate;
@@ -452,10 +451,10 @@ internal static class LocalCityGmlObjectProjection
                     resolvedSurface.Material.TextureOffset))
             .OrderBy(static group => group.Min(static surface => ParsedSurfaceStableSortKey.Create(surface.Surface)), StringComparer.Ordinal)
             .ToArray();
-        FacadeUvProjectionContext? facadeUvProjectionContext = TryCreateFacadeUvProjectionContext(
+        FacadeUvProjectionContext? facadeUvProjectionContext = CityGmlSurfaceProjectionPolicy.TryCreateFacadeUvProjectionContext(
             cityObject.PackageName,
-            cityObject.Surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.ToProjectionModel),
-            cityObjectOrigin.ToProjectionModel(),
+            cityObject.Surfaces,
+            cityObjectOrigin,
             cityObjectCartesian);
 
         for (int materialIndex = 0; materialIndex < materialGroups.Length; materialIndex++)
@@ -935,16 +934,10 @@ internal static class LocalCityGmlObjectProjection
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
-        Float3[] positions = surface.Vertices
-            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
-            .ToArray();
-        Float3? normal = ComputePolygonNormal(positions);
-        if (normal is null)
-        {
-            return false;
-        }
-
-        return Math.Abs(normal.Y) < 0.45;
+        return CityGmlSurfaceProjectionPolicy.IsFacadeSurface(
+            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(surface),
+            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            cityObjectCartesian);
     }
 
     private static bool IsNearHorizontalSurface(
@@ -952,25 +945,10 @@ internal static class LocalCityGmlObjectProjection
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
-        Float3[] positions = surface.Vertices
-            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
-            .ToArray();
-        Float3? normal = ComputePolygonNormal(positions);
-        return normal is not null && Math.Abs(normal.Y) >= 0.98;
-    }
-
-    private static bool ShouldCullSurfaceBeforeProjection(
-        string packageName,
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        if (!IsBuildingPackage(packageName))
-        {
-            return false;
-        }
-
-        return IsDownwardNearHorizontalSurface(surface, cityObjectOrigin, cityObjectCartesian);
+        return CityGmlSurfaceProjectionPolicy.IsNearHorizontalSurface(
+            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(surface),
+            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            cityObjectCartesian);
     }
 
     private static HashSet<string> GetCulledSurfaceIdsBeforeProjection(
@@ -979,49 +957,11 @@ internal static class LocalCityGmlObjectProjection
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
-        if (!IsBuildingPackage(packageName))
-        {
-            return [];
-        }
-
-        SurfaceProjectionInfo[] candidates = surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
-
-        if (candidates.Length == 0)
-        {
-            return [];
-        }
-
-        double objectMinimumY = candidates.Min(static info => info.MinimumY!.Value);
-        double objectMaximumY = candidates.Max(static info => info.MaximumY!.Value);
-
-        return candidates
-            .Where(static info => IsBottomBandCullCandidate(info))
-            .Where(info => info.MaximumY!.Value <= objectMinimumY + BuildingBottomCullBandMeters)
-            .Where(info => objectMaximumY > info.MaximumY!.Value + BuildingBottomCullBandMeters)
-            .Select(static info => info.Surface.PolygonId)
-            .ToHashSet(StringComparer.Ordinal);
-    }
-
-    private static bool IsBottomBandCullCandidate(SurfaceProjectionInfo info)
-    {
-        return info.IsNearHorizontal;
-    }
-
-    private static bool IsDownwardNearHorizontalSurface(
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        if (ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian) is not Float3 normal)
-        {
-            return false;
-        }
-
-        return Math.Abs(normal.Y) >= 0.98
-            && normal.Y <= -0.98;
+        return CityGmlSurfaceProjectionPolicy.GetCulledSurfaceIdsBeforeProjection(
+            packageName,
+            surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel),
+            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            cityObjectCartesian);
     }
 
     private static Float3? ComputeSurfaceNormal(
@@ -1029,35 +969,10 @@ internal static class LocalCityGmlObjectProjection
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
-        Float3[] positions = surface.Vertices
-            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
-            .ToArray();
-        return ComputePolygonNormal(positions);
-    }
-
-    private static SurfaceProjectionInfo CreateSurfaceProjectionInfo(
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        Float3[] positions = surface.Vertices
-            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
-            .ToArray();
-        if (positions.Length == 0)
-        {
-            return new SurfaceProjectionInfo(surface, null, null, false, false);
-        }
-
-        Float3? normal = ComputePolygonNormal(positions);
-        bool isNearHorizontal = normal is not null && Math.Abs(normal.Y) >= 0.98;
-        bool isDownwardNearHorizontal = isNearHorizontal && normal is not null && normal.Y <= -0.98;
-
-        return new SurfaceProjectionInfo(
-            surface,
-            positions.Min(static position => position.Y),
-            positions.Max(static position => position.Y),
-            isNearHorizontal,
-            isDownwardNearHorizontal);
+        return CityGmlSurfaceProjectionPolicy.ComputeSurfaceNormal(
+            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(surface),
+            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            cityObjectCartesian);
     }
 
     private static FacadeUvProjectionContext? TryCreateFacadeUvProjectionContext(
@@ -1066,75 +981,12 @@ internal static class LocalCityGmlObjectProjection
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
-        if (!IsBuildingPackage(packageName))
-        {
-            return null;
-        }
-
-        SurfaceProjectionInfo[] surfaceInfos = surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
-        if (surfaceInfos.Length == 0)
-        {
-            return null;
-        }
-
-        SurfaceProjectionInfo[] contextSurfaceInfos = surfaceInfos
-            .Where(static info => !IsGeneratedLod1RoofSurface(info.Surface))
-            .ToArray();
-        if (contextSurfaceInfos.Length == 0)
-        {
-            contextSurfaceInfos = surfaceInfos;
-        }
-
-        (double minimumY, double maximumY) = ResolveFacadeUvVerticalRange(contextSurfaceInfos, surfaceInfos);
-        double geometryHeightMeters = Math.Max(maximumY - minimumY, 0.0);
-        int floorCount = Math.Max(
-            1,
-            (int)Math.Ceiling(Math.Max(geometryHeightMeters, FacadeFloorMetrics.DefaultFloorUnitMeters) / FacadeFloorMetrics.DefaultFloorUnitMeters));
-        double floorHeightMeters = Math.Max(
-            geometryHeightMeters / floorCount,
-            1e-6);
-
-        return new FacadeUvProjectionContext(
-            minimumY,
-            maximumY,
-            floorHeightMeters,
-            floorCount);
+        return CityGmlSurfaceProjectionPolicy.TryCreateFacadeUvProjectionContext(
+            packageName,
+            surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel),
+            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            cityObjectCartesian);
     }
-
-    private static (double MinimumY, double MaximumY) ResolveFacadeUvVerticalRange(
-        IReadOnlyList<SurfaceProjectionInfo> contextSurfaceInfos,
-        IReadOnlyList<SurfaceProjectionInfo> allSurfaceInfos)
-    {
-        double minimumY = contextSurfaceInfos.Min(static info => info.MinimumY!.Value);
-        double maximumY = contextSurfaceInfos.Max(static info => info.MaximumY!.Value);
-        if (maximumY - minimumY > 1e-6 || contextSurfaceInfos.Count == allSurfaceInfos.Count)
-        {
-            return (minimumY, maximumY);
-        }
-
-        double fallbackMinimumY = allSurfaceInfos.Min(static info => info.MinimumY!.Value);
-        double fallbackMaximumY = allSurfaceInfos.Max(static info => info.MaximumY!.Value);
-        return fallbackMaximumY - fallbackMinimumY > maximumY - minimumY
-            ? (fallbackMinimumY, fallbackMaximumY)
-            : (minimumY, maximumY);
-    }
-
-    private static bool IsGeneratedLod1RoofSurface(ParsedSurface surface)
-    {
-        return surface.PolygonId.Contains("_generated_shed-", StringComparison.Ordinal)
-            || surface.PolygonId.Contains("_generated_gable-", StringComparison.Ordinal)
-            || surface.PolygonId.Contains("_generated_hip-", StringComparison.Ordinal);
-    }
-
-    private readonly record struct SurfaceProjectionInfo(
-        ParsedSurface Surface,
-        double? MinimumY,
-        double? MaximumY,
-        bool IsNearHorizontal,
-        bool IsDownwardNearHorizontal);
 
     private static bool IsGeneratedRoadMarkingSurface(ParsedSurface surface)
     {

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -935,8 +935,8 @@ internal static class LocalCityGmlObjectProjection
         LocalCartesian? cityObjectCartesian)
     {
         return CityGmlSurfaceProjectionPolicy.IsFacadeSurface(
-            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(surface),
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            surface,
+            cityObjectOrigin,
             cityObjectCartesian);
     }
 
@@ -946,8 +946,8 @@ internal static class LocalCityGmlObjectProjection
         LocalCartesian? cityObjectCartesian)
     {
         return CityGmlSurfaceProjectionPolicy.IsNearHorizontalSurface(
-            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(surface),
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            surface,
+            cityObjectOrigin,
             cityObjectCartesian);
     }
 
@@ -959,8 +959,8 @@ internal static class LocalCityGmlObjectProjection
     {
         return CityGmlSurfaceProjectionPolicy.GetCulledSurfaceIdsBeforeProjection(
             packageName,
-            surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel),
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            surfaces,
+            cityObjectOrigin,
             cityObjectCartesian);
     }
 
@@ -970,8 +970,8 @@ internal static class LocalCityGmlObjectProjection
         LocalCartesian? cityObjectCartesian)
     {
         return CityGmlSurfaceProjectionPolicy.ComputeSurfaceNormal(
-            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(surface),
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            surface,
+            cityObjectOrigin,
             cityObjectCartesian);
     }
 
@@ -983,8 +983,8 @@ internal static class LocalCityGmlObjectProjection
     {
         return CityGmlSurfaceProjectionPolicy.TryCreateFacadeUvProjectionContext(
             packageName,
-            surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel),
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            surfaces,
+            cityObjectOrigin,
             cityObjectCartesian);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceProjectionPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceProjectionPolicyTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using GeographicLib;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class CityGmlSurfaceProjectionPolicyTests
+{
+    [Fact]
+    public void GetCulledSurfaceIdsBeforeProjectionCullsBuildingBottomBandOnlyWhenHigherGeometryExists()
+    {
+        GeodeticPoint origin = new(35.0, 139.0, 0.0);
+        LocalCartesian cartesian = CreateCartesian(origin);
+        ParsedSurface wall = CreateSurface(
+            "wall",
+            ParsedSurfaceSemantic.Wall,
+            CreateVerticalQuadVertices(origin, widthMeters: 8.0, heightMeters: 6.0));
+        ParsedSurface bottom = CreateSurface(
+            "bottom",
+            ParsedSurfaceSemantic.Unknown,
+            CreateHorizontalQuadVertices(origin, altitudeMeters: 0.0, sizeMeters: 8.0));
+        ParsedSurface roof = CreateSurface(
+            "roof",
+            ParsedSurfaceSemantic.Unknown,
+            CreateHorizontalQuadVertices(origin, altitudeMeters: 6.0, sizeMeters: 8.0, reverseWinding: true));
+
+        HashSet<string> buildingCull = CityGmlSurfaceProjectionPolicy.GetCulledSurfaceIdsBeforeProjection(
+            "bldg",
+            [wall, bottom, roof],
+            origin,
+            cartesian);
+        HashSet<string> roadCull = CityGmlSurfaceProjectionPolicy.GetCulledSurfaceIdsBeforeProjection(
+            "tran",
+            [bottom],
+            origin,
+            cartesian);
+
+        Assert.Contains("bottom", buildingCull);
+        Assert.DoesNotContain("roof", buildingCull);
+        Assert.Empty(roadCull);
+    }
+
+    [Fact]
+    public void TryCreateFacadeUvProjectionContextIgnoresGeneratedLod1RoofSurfacesWhenWallRangeExists()
+    {
+        GeodeticPoint origin = new(35.0, 139.0, 0.0);
+        LocalCartesian cartesian = CreateCartesian(origin);
+        ParsedSurface wall = CreateSurface(
+            "wall",
+            ParsedSurfaceSemantic.Wall,
+            CreateVerticalQuadVertices(origin, widthMeters: 8.0, heightMeters: 6.0));
+        ParsedSurface generatedRoof = CreateSurface(
+            "bldg_generated_gable-top",
+            ParsedSurfaceSemantic.Roof,
+            CreateHorizontalQuadVertices(origin, altitudeMeters: 9.0, sizeMeters: 8.0, reverseWinding: true));
+
+        FacadeUvProjectionContext? context = CityGmlSurfaceProjectionPolicy.TryCreateFacadeUvProjectionContext(
+            "bldg",
+            [wall, generatedRoof],
+            origin,
+            cartesian);
+
+        Assert.NotNull(context);
+        Assert.InRange(context.Value.MinimumY, -1e-5, 1e-5);
+        Assert.InRange(context.Value.MaximumY, 6.0 - 1e-5, 6.0 + 1e-5);
+    }
+
+    private static LocalCartesian CreateCartesian(GeodeticPoint origin)
+    {
+        return new LocalCartesian(origin.Latitude, origin.Longitude, origin.Altitude, Geocentric.WGS84);
+    }
+
+    private static ParsedSurface CreateSurface(
+        string polygonId,
+        ParsedSurfaceSemantic semantic,
+        IReadOnlyList<GeodeticPoint> vertices)
+    {
+        return new ParsedSurface(
+            polygonId,
+            semantic,
+            new ParsedRing($"{polygonId}-ring", vertices.ToArray(), UVs: null),
+            InteriorRings: [],
+            BaseColor: new ColorRgba(0.5, 0.5, 0.5, 1.0),
+            TexturePayload: null);
+    }
+
+    private static IReadOnlyList<GeodeticPoint> CreateHorizontalQuadVertices(
+        GeodeticPoint origin,
+        double altitudeMeters,
+        double sizeMeters,
+        bool reverseWinding = false)
+    {
+        double latitudeDelta = sizeMeters / 111320.0;
+        double longitudeDelta = sizeMeters / (111320.0 * Math.Cos(origin.Latitude * (Math.PI / 180.0)));
+        GeodeticPoint[] vertices =
+        [
+            new(origin.Latitude, origin.Longitude, altitudeMeters),
+            new(origin.Latitude + latitudeDelta, origin.Longitude, altitudeMeters),
+            new(origin.Latitude + latitudeDelta, origin.Longitude + longitudeDelta, altitudeMeters),
+            new(origin.Latitude, origin.Longitude + longitudeDelta, altitudeMeters),
+        ];
+        if (reverseWinding)
+        {
+            Array.Reverse(vertices);
+        }
+
+        return [.. vertices, vertices[0]];
+    }
+
+    private static IReadOnlyList<GeodeticPoint> CreateVerticalQuadVertices(
+        GeodeticPoint origin,
+        double widthMeters,
+        double heightMeters)
+    {
+        double longitudeDelta = widthMeters / (111320.0 * Math.Cos(origin.Latitude * (Math.PI / 180.0)));
+        return
+        [
+            origin,
+            new(origin.Latitude, origin.Longitude + longitudeDelta, origin.Altitude),
+            new(origin.Latitude, origin.Longitude + longitudeDelta, origin.Altitude + heightMeters),
+            new(origin.Latitude, origin.Longitude, origin.Altitude + heightMeters),
+            origin,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Extract building-related surface projection policy from `LocalCityGmlObjectProjection` into `CityGmlSurfaceProjectionPolicy`.
- Move bottom-band culling and facade UV context range calculation behind a top-level parsed-surface contract.
- Keep top-level `ProjectCityObject` on the new policy directly, avoiding adapter round-trips for this concern.
- Add fast direct tests for bottom-band culling and generated LOD1 roof exclusion in facade UV context selection.

## Verification
- `dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~CityGmlSurfaceProjectionPolicyTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests.ProjectCityObjectCulls|FullyQualifiedName~LocalCityGmlObjectProjectionTests.ProjectCityObjectKeeps|FullyQualifiedName~LocalCityGmlObjectProjectionTests.GeneratedFacadeUvProjection" --verbosity normal`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`