### PR TITLE
Extract DEM terrain grid sampler

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridSampler.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridSampler.cs
@@ -1,0 +1,374 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityGmlDemTerrainGridSampler
+{
+    internal static DemTerrainGridHeightSamples Sample(
+        double minX,
+        double maxX,
+        double minZ,
+        double maxZ,
+        double metersPerVertex,
+        int maxResolution,
+        double fallbackHeight,
+        IReadOnlyList<TerrainGridTriangle> triangles,
+        CancellationToken cancellationToken = default)
+    {
+        double extentX = maxX - minX;
+        double extentZ = maxZ - minZ;
+        int width = Math.Clamp(
+            (int)Math.Ceiling(extentX / metersPerVertex) + 1,
+            2,
+            maxResolution);
+        int height = Math.Clamp(
+            (int)Math.Ceiling(extentZ / metersPerVertex) + 1,
+            2,
+            maxResolution);
+        double[] localHeights = new double[width * height];
+        bool[] sampledInsideTriangles = new bool[width * height];
+        TerrainGridSpatialIndex spatialIndex = TerrainGridSpatialIndex.Create(
+            triangles,
+            minX,
+            maxX,
+            minZ,
+            maxZ);
+
+        for (int zIndex = 0; zIndex < height; zIndex++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            double v = height == 1 ? 0.0 : (double)zIndex / (height - 1);
+            double sampleZ = minZ + (extentZ * v);
+            for (int xIndex = 0; xIndex < width; xIndex++)
+            {
+                double u = width == 1 ? 0.0 : (double)xIndex / (width - 1);
+                double sampleX = minX + (extentX * u);
+                int sampleIndex = (zIndex * width) + xIndex;
+                if (TrySampleLocalHeight(sampleX, sampleZ, triangles, spatialIndex, out double localHeight))
+                {
+                    localHeights[sampleIndex] = localHeight;
+                    sampledInsideTriangles[sampleIndex] = true;
+                }
+                else
+                {
+                    localHeights[sampleIndex] = fallbackHeight;
+                }
+            }
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        ExtendBoundaryConnectedMissingHeightSamples(localHeights, sampledInsideTriangles, width, height);
+        return new DemTerrainGridHeightSamples(width, height, localHeights);
+    }
+
+    internal static bool TrySampleLocalHeight(
+        double x,
+        double z,
+        IReadOnlyList<TerrainGridTriangle> triangles,
+        TerrainGridSpatialIndex spatialIndex,
+        out double height)
+    {
+        foreach (int triangleIndex in spatialIndex.GetCandidateTriangleIndices(x, z))
+        {
+            TerrainGridTriangle triangle = triangles[triangleIndex];
+            if (TryInterpolateLocalTriangleHeight(triangle, x, z, out height))
+            {
+                return true;
+            }
+        }
+
+        height = 0.0;
+        return false;
+    }
+
+    internal static void ExtendBoundaryConnectedMissingHeightSamples(
+        double[] localHeights,
+        bool[] sampledInsideTriangles,
+        int width,
+        int height)
+    {
+        bool[] boundaryConnectedMissing = FindBoundaryConnectedMissingSamples(sampledInsideTriangles, width, height);
+        if (!boundaryConnectedMissing.Any(static missing => missing))
+        {
+            return;
+        }
+
+        Queue<(int Row, int Column)> frontier = new();
+
+        for (int row = 0; row < height; row++)
+        {
+            for (int column = 0; column < width; column++)
+            {
+                int sampleIndex = (row * width) + column;
+                if (!sampledInsideTriangles[sampleIndex])
+                {
+                    continue;
+                }
+
+                if (TouchesBoundaryConnectedMissing(row, column))
+                {
+                    frontier.Enqueue((row, column));
+                }
+            }
+        }
+
+        while (frontier.Count > 0)
+        {
+            (int row, int column) = frontier.Dequeue();
+            int sourceIndex = (row * width) + column;
+            TryPropagate(row - 1, column, localHeights[sourceIndex]);
+            TryPropagate(row + 1, column, localHeights[sourceIndex]);
+            TryPropagate(row, column - 1, localHeights[sourceIndex]);
+            TryPropagate(row, column + 1, localHeights[sourceIndex]);
+        }
+
+        bool TouchesBoundaryConnectedMissing(int row, int column)
+        {
+            return IsBoundaryConnectedMissing(row - 1, column)
+                || IsBoundaryConnectedMissing(row + 1, column)
+                || IsBoundaryConnectedMissing(row, column - 1)
+                || IsBoundaryConnectedMissing(row, column + 1);
+        }
+
+        bool IsBoundaryConnectedMissing(int row, int column)
+        {
+            if ((uint)row >= (uint)height || (uint)column >= (uint)width)
+            {
+                return false;
+            }
+
+            return boundaryConnectedMissing[(row * width) + column];
+        }
+
+        void TryPropagate(int row, int column, double heightValue)
+        {
+            if ((uint)row >= (uint)height || (uint)column >= (uint)width)
+            {
+                return;
+            }
+
+            int targetIndex = (row * width) + column;
+            if (!boundaryConnectedMissing[targetIndex] || sampledInsideTriangles[targetIndex])
+            {
+                return;
+            }
+
+            localHeights[targetIndex] = heightValue;
+            sampledInsideTriangles[targetIndex] = true;
+            frontier.Enqueue((row, column));
+        }
+    }
+
+    private static bool TryInterpolateLocalTriangleHeight(
+        TerrainGridTriangle triangle,
+        double x,
+        double z,
+        out double height)
+    {
+        double denominator = ((triangle.B.Z - triangle.C.Z) * (triangle.A.X - triangle.C.X))
+            + ((triangle.C.X - triangle.B.X) * (triangle.A.Z - triangle.C.Z));
+        if (Math.Abs(denominator) < 1e-8)
+        {
+            height = 0.0;
+            return false;
+        }
+
+        double weight0 = (((triangle.B.Z - triangle.C.Z) * (x - triangle.C.X))
+            + ((triangle.C.X - triangle.B.X) * (z - triangle.C.Z))) / denominator;
+        double weight1 = (((triangle.C.Z - triangle.A.Z) * (x - triangle.C.X))
+            + ((triangle.A.X - triangle.C.X) * (z - triangle.C.Z))) / denominator;
+        double weight2 = 1.0 - weight0 - weight1;
+        if (weight0 < -1e-5 || weight1 < -1e-5 || weight2 < -1e-5)
+        {
+            height = 0.0;
+            return false;
+        }
+
+        height = (triangle.A.Y * weight0) + (triangle.B.Y * weight1) + (triangle.C.Y * weight2);
+        return true;
+    }
+
+    private static bool[] FindBoundaryConnectedMissingSamples(
+        bool[] sampledInsideTriangles,
+        int width,
+        int height)
+    {
+        bool[] boundaryConnectedMissing = new bool[width * height];
+        Queue<(int Row, int Column)> frontier = new();
+
+        for (int column = 0; column < width; column++)
+        {
+            EnqueueIfBoundaryMissing(0, column);
+            EnqueueIfBoundaryMissing(height - 1, column);
+        }
+
+        for (int row = 1; row < height - 1; row++)
+        {
+            EnqueueIfBoundaryMissing(row, 0);
+            EnqueueIfBoundaryMissing(row, width - 1);
+        }
+
+        while (frontier.Count > 0)
+        {
+            (int row, int column) = frontier.Dequeue();
+            TryVisit(row - 1, column);
+            TryVisit(row + 1, column);
+            TryVisit(row, column - 1);
+            TryVisit(row, column + 1);
+        }
+
+        return boundaryConnectedMissing;
+
+        void EnqueueIfBoundaryMissing(int row, int column)
+        {
+            if ((uint)row >= (uint)height || (uint)column >= (uint)width)
+            {
+                return;
+            }
+
+            int sampleIndex = (row * width) + column;
+            if (sampledInsideTriangles[sampleIndex] || boundaryConnectedMissing[sampleIndex])
+            {
+                return;
+            }
+
+            boundaryConnectedMissing[sampleIndex] = true;
+            frontier.Enqueue((row, column));
+        }
+
+        void TryVisit(int row, int column)
+        {
+            if ((uint)row >= (uint)height || (uint)column >= (uint)width)
+            {
+                return;
+            }
+
+            int sampleIndex = (row * width) + column;
+            if (sampledInsideTriangles[sampleIndex] || boundaryConnectedMissing[sampleIndex])
+            {
+                return;
+            }
+
+            boundaryConnectedMissing[sampleIndex] = true;
+            frontier.Enqueue((row, column));
+        }
+    }
+}
+
+internal sealed record DemTerrainGridHeightSamples(
+    int Width,
+    int Height,
+    double[] LocalHeights);
+
+internal sealed record TerrainGridTriangle(
+    Float3 A,
+    Float3 B,
+    Float3 C);
+
+internal sealed class TerrainGridSpatialIndex
+{
+    private static readonly IReadOnlyList<int> EmptyTriangleIndices = Array.Empty<int>();
+
+    private readonly IReadOnlyList<int>[] triangleBuckets;
+    private readonly double minX;
+    private readonly double minZ;
+    private readonly double inverseCellSizeX;
+    private readonly double inverseCellSizeZ;
+    private readonly int cellsX;
+    private readonly int cellsZ;
+
+    private TerrainGridSpatialIndex(
+        IReadOnlyList<int>[] triangleBuckets,
+        double minX,
+        double minZ,
+        double inverseCellSizeX,
+        double inverseCellSizeZ,
+        int cellsX,
+        int cellsZ)
+    {
+        this.triangleBuckets = triangleBuckets;
+        this.minX = minX;
+        this.minZ = minZ;
+        this.inverseCellSizeX = inverseCellSizeX;
+        this.inverseCellSizeZ = inverseCellSizeZ;
+        this.cellsX = cellsX;
+        this.cellsZ = cellsZ;
+    }
+
+    public static TerrainGridSpatialIndex Create(
+        IReadOnlyList<TerrainGridTriangle> triangles,
+        double minX,
+        double maxX,
+        double minZ,
+        double maxZ)
+    {
+        if (triangles.Count == 0)
+        {
+            return new TerrainGridSpatialIndex([EmptyTriangleIndices], minX, minZ, 1.0, 1.0, 1, 1);
+        }
+
+        double extentX = Math.Max(maxX - minX, 1e-6);
+        double extentZ = Math.Max(maxZ - minZ, 1e-6);
+        double aspectRatio = extentX / extentZ;
+        double baseCellCount = Math.Ceiling(Math.Sqrt(triangles.Count));
+        int cellsX = Math.Clamp((int)Math.Ceiling(baseCellCount * Math.Sqrt(aspectRatio)), 1, 256);
+        int cellsZ = Math.Clamp((int)Math.Ceiling(baseCellCount / Math.Sqrt(aspectRatio)), 1, 256);
+        double cellSizeX = extentX / cellsX;
+        double cellSizeZ = extentZ / cellsZ;
+        List<int>[] mutableTriangleBuckets = new List<int>[cellsX * cellsZ];
+
+        for (int triangleIndex = 0; triangleIndex < triangles.Count; triangleIndex++)
+        {
+            TerrainGridTriangle triangle = triangles[triangleIndex];
+            double triangleMinX = Math.Min(triangle.A.X, Math.Min(triangle.B.X, triangle.C.X));
+            double triangleMaxX = Math.Max(triangle.A.X, Math.Max(triangle.B.X, triangle.C.X));
+            double triangleMinZ = Math.Min(triangle.A.Z, Math.Min(triangle.B.Z, triangle.C.Z));
+            double triangleMaxZ = Math.Max(triangle.A.Z, Math.Max(triangle.B.Z, triangle.C.Z));
+            int startX = GetCellIndex(triangleMinX, minX, cellSizeX, cellsX);
+            int endX = GetCellIndex(triangleMaxX, minX, cellSizeX, cellsX);
+            int startZ = GetCellIndex(triangleMinZ, minZ, cellSizeZ, cellsZ);
+            int endZ = GetCellIndex(triangleMaxZ, minZ, cellSizeZ, cellsZ);
+
+            for (int cellZ = startZ; cellZ <= endZ; cellZ++)
+            {
+                for (int cellX = startX; cellX <= endX; cellX++)
+                {
+                    int bucketIndex = (cellZ * cellsX) + cellX;
+                    (mutableTriangleBuckets[bucketIndex] ??= []).Add(triangleIndex);
+                }
+            }
+        }
+
+        IReadOnlyList<int>[] triangleBuckets = new IReadOnlyList<int>[mutableTriangleBuckets.Length];
+        for (int bucketIndex = 0; bucketIndex < triangleBuckets.Length; bucketIndex++)
+        {
+            triangleBuckets[bucketIndex] = mutableTriangleBuckets[bucketIndex]?.ToArray()
+                ?? EmptyTriangleIndices;
+        }
+
+        return new TerrainGridSpatialIndex(
+            triangleBuckets,
+            minX,
+            minZ,
+            1.0 / cellSizeX,
+            1.0 / cellSizeZ,
+            cellsX,
+            cellsZ);
+    }
+
+    public IReadOnlyList<int> GetCandidateTriangleIndices(double x, double z)
+    {
+        int cellX = Math.Clamp((int)((x - minX) * inverseCellSizeX), 0, cellsX - 1);
+        int cellZ = Math.Clamp((int)((z - minZ) * inverseCellSizeZ), 0, cellsZ - 1);
+        IReadOnlyList<int> bucket = triangleBuckets[(cellZ * cellsX) + cellX];
+        return bucket is { Count: > 0 } ? bucket : EmptyTriangleIndices;
+    }
+
+    private static int GetCellIndex(double coordinate, double minimum, double cellSize, int cellCount)
+    {
+        return Math.Clamp((int)((coordinate - minimum) / cellSize), 0, cellCount - 1);
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridSampler.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridSampler.cs
@@ -40,11 +40,11 @@ internal static class CityGmlDemTerrainGridSampler
         for (int zIndex = 0; zIndex < height; zIndex++)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            double v = height == 1 ? 0.0 : (double)zIndex / (height - 1);
+            double v = (double)zIndex / (height - 1);
             double sampleZ = minZ + (extentZ * v);
             for (int xIndex = 0; xIndex < width; xIndex++)
             {
-                double u = width == 1 ? 0.0 : (double)xIndex / (width - 1);
+                double u = (double)xIndex / (width - 1);
                 double sampleX = minX + (extentX * u);
                 int sampleIndex = (zIndex * width) + xIndex;
                 if (TrySampleLocalHeight(sampleX, sampleZ, triangles, spatialIndex, out double localHeight))

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -1529,46 +1529,18 @@ internal static class LocalCityGmlObjectProjection
             return false;
         }
 
-        TerrainGridSpatialIndex spatialIndex = TerrainGridSpatialIndex.Create(
-            triangles,
+        DemTerrainGridHeightSamples heightSamples = CityGmlDemTerrainGridSampler.Sample(
             minX,
             maxX,
             minZ,
-            maxZ);
-
-        int width = Math.Clamp(
-            (int)Math.Ceiling(extentX / request.TerrainGridMetersPerVertex) + 1,
-            2,
-            request.TerrainGridMaxResolution);
-        int height = Math.Clamp(
-            (int)Math.Ceiling(extentZ / request.TerrainGridMetersPerVertex) + 1,
-            2,
-            request.TerrainGridMaxResolution);
-        double[] localHeights = new double[width * height];
-        bool[] sampledInsideTriangles = new bool[width * height];
-
-        for (int zIndex = 0; zIndex < height; zIndex++)
-        {
-            double v = height == 1 ? 0.0 : (double)zIndex / (height - 1);
-            double sampleZ = minZ + (extentZ * v);
-            for (int xIndex = 0; xIndex < width; xIndex++)
-            {
-                double u = width == 1 ? 0.0 : (double)xIndex / (width - 1);
-                double sampleX = minX + (extentX * u);
-                int sampleIndex = (zIndex * width) + xIndex;
-                if (TrySampleLocalDemHeight(sampleX, sampleZ, triangles, spatialIndex, out double localHeight))
-                {
-                    localHeights[sampleIndex] = localHeight;
-                    sampledInsideTriangles[sampleIndex] = true;
-                }
-                else
-                {
-                    localHeights[sampleIndex] = seaLevelLocalHeight;
-                }
-            }
-        }
-
-        ExtendBoundaryConnectedMissingHeightSamples(localHeights, sampledInsideTriangles, width, height);
+            maxZ,
+            request.TerrainGridMetersPerVertex,
+            request.TerrainGridMaxResolution,
+            seaLevelLocalHeight,
+            triangles);
+        int width = heightSamples.Width;
+        int height = heightSamples.Height;
+        double[] localHeights = heightSamples.LocalHeights;
         double minHeight = localHeights.Min();
         double maxHeight = localHeights.Max();
 
@@ -1700,13 +1672,6 @@ internal static class LocalCityGmlObjectProjection
             return false;
         }
 
-        TerrainGridSpatialIndex spatialIndex = TerrainGridSpatialIndex.Create(
-            triangles,
-            minX,
-            maxX,
-            minZ,
-            maxZ);
-
         int width = Math.Clamp(
             (int)Math.Ceiling(extentX / request.TerrainGridMetersPerVertex) + 1,
             2,
@@ -1720,33 +1685,19 @@ internal static class LocalCityGmlObjectProjection
                 "import",
                 $"Sampling DEM terrain grid '{cityObject.SlotKey}' "
                 + $"(width={width}, height={height}, triangles={triangles.Length})."));
-        double[] localHeights = new double[width * height];
-        bool[] sampledInsideTriangles = new bool[width * height];
-
-        for (int zIndex = 0; zIndex < height; zIndex++)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            double v = height == 1 ? 0.0 : (double)zIndex / (height - 1);
-            double sampleZ = minZ + (extentZ * v);
-            for (int xIndex = 0; xIndex < width; xIndex++)
-            {
-                double u = width == 1 ? 0.0 : (double)xIndex / (width - 1);
-                double sampleX = minX + (extentX * u);
-                int sampleIndex = (zIndex * width) + xIndex;
-                if (TrySampleLocalDemHeight(sampleX, sampleZ, triangles, spatialIndex, out double localHeight))
-                {
-                    localHeights[sampleIndex] = localHeight;
-                    sampledInsideTriangles[sampleIndex] = true;
-                }
-                else
-                {
-                    localHeights[sampleIndex] = seaLevelLocalHeight;
-                }
-            }
-        }
-
-        cancellationToken.ThrowIfCancellationRequested();
-        ExtendBoundaryConnectedMissingHeightSamples(localHeights, sampledInsideTriangles, width, height);
+        DemTerrainGridHeightSamples heightSamples = CityGmlDemTerrainGridSampler.Sample(
+            minX,
+            maxX,
+            minZ,
+            maxZ,
+            request.TerrainGridMetersPerVertex,
+            request.TerrainGridMaxResolution,
+            seaLevelLocalHeight,
+            triangles,
+            cancellationToken);
+        width = heightSamples.Width;
+        height = heightSamples.Height;
+        double[] localHeights = heightSamples.LocalHeights;
         double minHeight = localHeights.Min();
         double maxHeight = localHeights.Max();
 
@@ -2275,199 +2226,6 @@ internal static class LocalCityGmlObjectProjection
             globalPosition.Z - slotPosition.Z);
     }
 
-    private static bool TrySampleLocalDemHeight(
-        double x,
-        double z,
-        IReadOnlyList<TerrainGridTriangle> triangles,
-        TerrainGridSpatialIndex spatialIndex,
-        out double height)
-    {
-        foreach (int triangleIndex in spatialIndex.GetCandidateTriangleIndices(x, z))
-        {
-            TerrainGridTriangle triangle = triangles[triangleIndex];
-            if (TryInterpolateLocalTriangleHeight(triangle, x, z, out height))
-            {
-                return true;
-            }
-        }
-
-        height = 0.0;
-        return false;
-    }
-
-    private static bool TryInterpolateLocalTriangleHeight(
-        TerrainGridTriangle triangle,
-        double x,
-        double z,
-        out double height)
-    {
-        double denominator = ((triangle.B.Z - triangle.C.Z) * (triangle.A.X - triangle.C.X))
-            + ((triangle.C.X - triangle.B.X) * (triangle.A.Z - triangle.C.Z));
-        if (Math.Abs(denominator) < 1e-8)
-        {
-            height = 0.0;
-            return false;
-        }
-
-        double weight0 = (((triangle.B.Z - triangle.C.Z) * (x - triangle.C.X))
-            + ((triangle.C.X - triangle.B.X) * (z - triangle.C.Z))) / denominator;
-        double weight1 = (((triangle.C.Z - triangle.A.Z) * (x - triangle.C.X))
-            + ((triangle.A.X - triangle.C.X) * (z - triangle.C.Z))) / denominator;
-        double weight2 = 1.0 - weight0 - weight1;
-        if (weight0 < -1e-5 || weight1 < -1e-5 || weight2 < -1e-5)
-        {
-            height = 0.0;
-            return false;
-        }
-
-        height = (triangle.A.Y * weight0) + (triangle.B.Y * weight1) + (triangle.C.Y * weight2);
-        return true;
-    }
-
-    private static void ExtendBoundaryConnectedMissingHeightSamples(
-        double[] localHeights,
-        bool[] sampledInsideTriangles,
-        int width,
-        int height)
-    {
-        bool[] boundaryConnectedMissing = FindBoundaryConnectedMissingSamples(sampledInsideTriangles, width, height);
-        if (!boundaryConnectedMissing.Any(static missing => missing))
-        {
-            return;
-        }
-
-        Queue<(int Row, int Column)> frontier = new();
-
-        for (int row = 0; row < height; row++)
-        {
-            for (int column = 0; column < width; column++)
-            {
-                int sampleIndex = (row * width) + column;
-                if (!sampledInsideTriangles[sampleIndex])
-                {
-                    continue;
-                }
-
-                if (TouchesBoundaryConnectedMissing(row, column))
-                {
-                    frontier.Enqueue((row, column));
-                }
-            }
-        }
-
-        while (frontier.Count > 0)
-        {
-            (int row, int column) = frontier.Dequeue();
-            int sourceIndex = (row * width) + column;
-            TryPropagate(row - 1, column, localHeights[sourceIndex]);
-            TryPropagate(row + 1, column, localHeights[sourceIndex]);
-            TryPropagate(row, column - 1, localHeights[sourceIndex]);
-            TryPropagate(row, column + 1, localHeights[sourceIndex]);
-        }
-
-        bool TouchesBoundaryConnectedMissing(int row, int column)
-        {
-            return IsBoundaryConnectedMissing(row - 1, column)
-                || IsBoundaryConnectedMissing(row + 1, column)
-                || IsBoundaryConnectedMissing(row, column - 1)
-                || IsBoundaryConnectedMissing(row, column + 1);
-        }
-
-        bool IsBoundaryConnectedMissing(int row, int column)
-        {
-            if ((uint)row >= (uint)height || (uint)column >= (uint)width)
-            {
-                return false;
-            }
-
-            return boundaryConnectedMissing[(row * width) + column];
-        }
-
-        void TryPropagate(int row, int column, double heightValue)
-        {
-            if ((uint)row >= (uint)height || (uint)column >= (uint)width)
-            {
-                return;
-            }
-
-            int targetIndex = (row * width) + column;
-            if (!boundaryConnectedMissing[targetIndex] || sampledInsideTriangles[targetIndex])
-            {
-                return;
-            }
-
-            localHeights[targetIndex] = heightValue;
-            sampledInsideTriangles[targetIndex] = true;
-            frontier.Enqueue((row, column));
-        }
-    }
-
-    private static bool[] FindBoundaryConnectedMissingSamples(
-        bool[] sampledInsideTriangles,
-        int width,
-        int height)
-    {
-        bool[] boundaryConnectedMissing = new bool[width * height];
-        Queue<(int Row, int Column)> frontier = new();
-
-        for (int column = 0; column < width; column++)
-        {
-            EnqueueIfBoundaryMissing(0, column);
-            EnqueueIfBoundaryMissing(height - 1, column);
-        }
-
-        for (int row = 1; row < height - 1; row++)
-        {
-            EnqueueIfBoundaryMissing(row, 0);
-            EnqueueIfBoundaryMissing(row, width - 1);
-        }
-
-        while (frontier.Count > 0)
-        {
-            (int row, int column) = frontier.Dequeue();
-            TryVisit(row - 1, column);
-            TryVisit(row + 1, column);
-            TryVisit(row, column - 1);
-            TryVisit(row, column + 1);
-        }
-
-        return boundaryConnectedMissing;
-
-        void EnqueueIfBoundaryMissing(int row, int column)
-        {
-            if ((uint)row >= (uint)height || (uint)column >= (uint)width)
-            {
-                return;
-            }
-
-            int sampleIndex = (row * width) + column;
-            if (sampledInsideTriangles[sampleIndex] || boundaryConnectedMissing[sampleIndex])
-            {
-                return;
-            }
-
-            boundaryConnectedMissing[sampleIndex] = true;
-            frontier.Enqueue((row, column));
-        }
-
-        void TryVisit(int row, int column)
-        {
-            if ((uint)row >= (uint)height || (uint)column >= (uint)width)
-            {
-                return;
-            }
-
-            int sampleIndex = (row * width) + column;
-            if (sampledInsideTriangles[sampleIndex] || boundaryConnectedMissing[sampleIndex])
-            {
-                return;
-            }
-
-            boundaryConnectedMissing[sampleIndex] = true;
-            frontier.Enqueue((row, column));
-        }
-    }
-
     internal static void ValidateCompatibleReferenceSystem(
         CoordinateReferenceSystem expectedReferenceSystem,
         CoordinateReferenceSystem? actualReferenceSystem)
@@ -2551,121 +2309,11 @@ internal static class LocalCityGmlObjectProjection
         GeodeticPoint[] Vertices,
         IReadOnlyList<Float2>? UVs);
 
-    private sealed record TerrainGridTriangle(
-        Float3 A,
-        Float3 B,
-        Float3 C);
-
     private sealed record DemTerrainGridBounds(
         double MinX,
         double MaxX,
         double MinZ,
         double MaxZ);
-
-    private sealed class TerrainGridSpatialIndex
-    {
-        private static readonly IReadOnlyList<int> EmptyTriangleIndices = Array.Empty<int>();
-
-        private readonly IReadOnlyList<int>[] triangleBuckets;
-        private readonly double minX;
-        private readonly double minZ;
-        private readonly double inverseCellSizeX;
-        private readonly double inverseCellSizeZ;
-        private readonly int cellsX;
-        private readonly int cellsZ;
-
-        private TerrainGridSpatialIndex(
-            IReadOnlyList<int>[] triangleBuckets,
-            double minX,
-            double minZ,
-            double inverseCellSizeX,
-            double inverseCellSizeZ,
-            int cellsX,
-            int cellsZ)
-        {
-            this.triangleBuckets = triangleBuckets;
-            this.minX = minX;
-            this.minZ = minZ;
-            this.inverseCellSizeX = inverseCellSizeX;
-            this.inverseCellSizeZ = inverseCellSizeZ;
-            this.cellsX = cellsX;
-            this.cellsZ = cellsZ;
-        }
-
-        public static TerrainGridSpatialIndex Create(
-            IReadOnlyList<TerrainGridTriangle> triangles,
-            double minX,
-            double maxX,
-            double minZ,
-            double maxZ)
-        {
-            if (triangles.Count == 0)
-            {
-                return new TerrainGridSpatialIndex([EmptyTriangleIndices], minX, minZ, 1.0, 1.0, 1, 1);
-            }
-
-            double extentX = Math.Max(maxX - minX, 1e-6);
-            double extentZ = Math.Max(maxZ - minZ, 1e-6);
-            double aspectRatio = extentX / extentZ;
-            double baseCellCount = Math.Ceiling(Math.Sqrt(triangles.Count));
-            int cellsX = Math.Clamp((int)Math.Ceiling(baseCellCount * Math.Sqrt(aspectRatio)), 1, 256);
-            int cellsZ = Math.Clamp((int)Math.Ceiling(baseCellCount / Math.Sqrt(aspectRatio)), 1, 256);
-            double cellSizeX = extentX / cellsX;
-            double cellSizeZ = extentZ / cellsZ;
-            List<int>[] mutableTriangleBuckets = new List<int>[cellsX * cellsZ];
-
-            for (int triangleIndex = 0; triangleIndex < triangles.Count; triangleIndex++)
-            {
-                TerrainGridTriangle triangle = triangles[triangleIndex];
-                double triangleMinX = Math.Min(triangle.A.X, Math.Min(triangle.B.X, triangle.C.X));
-                double triangleMaxX = Math.Max(triangle.A.X, Math.Max(triangle.B.X, triangle.C.X));
-                double triangleMinZ = Math.Min(triangle.A.Z, Math.Min(triangle.B.Z, triangle.C.Z));
-                double triangleMaxZ = Math.Max(triangle.A.Z, Math.Max(triangle.B.Z, triangle.C.Z));
-                int startX = GetCellIndex(triangleMinX, minX, cellSizeX, cellsX);
-                int endX = GetCellIndex(triangleMaxX, minX, cellSizeX, cellsX);
-                int startZ = GetCellIndex(triangleMinZ, minZ, cellSizeZ, cellsZ);
-                int endZ = GetCellIndex(triangleMaxZ, minZ, cellSizeZ, cellsZ);
-
-                for (int cellZ = startZ; cellZ <= endZ; cellZ++)
-                {
-                    for (int cellX = startX; cellX <= endX; cellX++)
-                    {
-                        int bucketIndex = (cellZ * cellsX) + cellX;
-                        (mutableTriangleBuckets[bucketIndex] ??= []).Add(triangleIndex);
-                    }
-                }
-            }
-
-            IReadOnlyList<int>[] triangleBuckets = new IReadOnlyList<int>[mutableTriangleBuckets.Length];
-            for (int bucketIndex = 0; bucketIndex < triangleBuckets.Length; bucketIndex++)
-            {
-                triangleBuckets[bucketIndex] = mutableTriangleBuckets[bucketIndex]?.ToArray()
-                    ?? EmptyTriangleIndices;
-            }
-
-            return new TerrainGridSpatialIndex(
-                triangleBuckets,
-                minX,
-                minZ,
-                1.0 / cellSizeX,
-                1.0 / cellSizeZ,
-                cellsX,
-                cellsZ);
-        }
-
-        public IReadOnlyList<int> GetCandidateTriangleIndices(double x, double z)
-        {
-            int cellX = Math.Clamp((int)((x - minX) * inverseCellSizeX), 0, cellsX - 1);
-            int cellZ = Math.Clamp((int)((z - minZ) * inverseCellSizeZ), 0, cellsZ - 1);
-            IReadOnlyList<int> bucket = triangleBuckets[(cellZ * cellsX) + cellX];
-            return bucket is { Count: > 0 } ? bucket : EmptyTriangleIndices;
-        }
-
-        private static int GetCellIndex(double coordinate, double minimum, double cellSize, int cellCount)
-        {
-            return Math.Clamp((int)((coordinate - minimum) / cellSize), 0, cellCount - 1);
-        }
-    }
 
     internal sealed record ParsedSurface(
         string PolygonId,

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlDemTerrainGridSamplerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlDemTerrainGridSamplerTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class CityGmlDemTerrainGridSamplerTests
+{
+    [Fact]
+    public void SampleInterpolatesHeightsInsideTriangles()
+    {
+        TerrainGridTriangle[] triangles =
+        [
+            new(
+                new Float3(0.0, 10.0, 0.0),
+                new Float3(1.0, 20.0, 0.0),
+                new Float3(0.0, 30.0, 1.0)),
+        ];
+
+        DemTerrainGridHeightSamples samples = CityGmlDemTerrainGridSampler.Sample(
+            minX: 0.0,
+            maxX: 1.0,
+            minZ: 0.0,
+            maxZ: 1.0,
+            metersPerVertex: 0.5,
+            maxResolution: 3,
+            fallbackHeight: -100.0,
+            triangles);
+
+        Assert.Equal(3, samples.Width);
+        Assert.Equal(3, samples.Height);
+        Assert.Equal(10.0, samples.LocalHeights[0], precision: 6);
+        Assert.Equal(15.0, samples.LocalHeights[1], precision: 6);
+        Assert.Equal(20.0, samples.LocalHeights[2], precision: 6);
+        Assert.Equal(20.0, samples.LocalHeights[3], precision: 6);
+        Assert.Equal(30.0, samples.LocalHeights[6], precision: 6);
+    }
+
+    [Fact]
+    public void ExtendBoundaryConnectedMissingHeightSamplesKeepsInteriorFallback()
+    {
+        double[] heights =
+        [
+            -10.0, 1.0, -10.0, 1.0, -10.0,
+            -10.0, 1.0, 1.0, 1.0, -10.0,
+            -10.0, 1.0, -99.0, 1.0, -10.0,
+            -10.0, 2.0, 2.0, 2.0, -10.0,
+            -10.0, 2.0, -10.0, 2.0, -10.0,
+        ];
+        bool[] sampled =
+        [
+            false, true, false, true, false,
+            false, true, true, true, false,
+            false, true, false, true, false,
+            false, true, true, true, false,
+            false, true, false, true, false,
+        ];
+
+        CityGmlDemTerrainGridSampler.ExtendBoundaryConnectedMissingHeightSamples(
+            heights,
+            sampled,
+            width: 5,
+            height: 5);
+
+        Assert.Equal(1.0, heights[0], precision: 6);
+        Assert.Equal(1.0, heights[2], precision: 6);
+        Assert.Equal(2.0, heights[20], precision: 6);
+        Assert.Equal(2.0, heights[24], precision: 6);
+        Assert.Equal(-99.0, heights[12], precision: 6);
+    }
+
+    [Fact]
+    public void SampleHonorsCancellationAfterSamplingBeforeBoundaryFill()
+    {
+        using CancellationTokenSource cancellation = new();
+        CancelingTriangleList triangles = new(
+            new TerrainGridTriangle(
+                new Float3(-1.0, 10.0, -1.0),
+                new Float3(3.0, 10.0, -1.0),
+                new Float3(-1.0, 10.0, 3.0)),
+            cancellation,
+            cancelAfterReadCount: 10);
+
+        Assert.Throws<OperationCanceledException>(() =>
+            CityGmlDemTerrainGridSampler.Sample(
+                minX: 0.0,
+                maxX: 1.0,
+                minZ: 0.0,
+                maxZ: 1.0,
+                metersPerVertex: 0.5,
+                maxResolution: 3,
+                fallbackHeight: -100.0,
+                triangles,
+                cancellation.Token));
+    }
+
+    private sealed class CancelingTriangleList(
+        TerrainGridTriangle triangle,
+        CancellationTokenSource cancellation,
+        int cancelAfterReadCount) : IReadOnlyList<TerrainGridTriangle>
+    {
+        private int readCount;
+
+        public int Count => 1;
+
+        public TerrainGridTriangle this[int index]
+        {
+            get
+            {
+                Assert.Equal(0, index);
+                if (++readCount == cancelAfterReadCount)
+                {
+                    cancellation.Cancel();
+                }
+
+                return triangle;
+            }
+        }
+
+        public IEnumerator<TerrainGridTriangle> GetEnumerator()
+        {
+            yield return triangle;
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -2389,26 +2389,26 @@ public sealed class LocalCityGmlObjectProjectionTests
     [Fact]
     public void DemTerrainGridSpatialIndexDoesNotScanEveryTriangleForEmptyCells()
     {
-        object spatialIndex = CreateTerrainGridSpatialIndexForTest(
+        TerrainGridSpatialIndex spatialIndex = TerrainGridSpatialIndex.Create(
             [
-                (new Float3(0.0, 0.0, 0.0), new Float3(1.0, 0.0, 0.0), new Float3(0.0, 0.0, 1.0)),
-                (new Float3(100.0, 0.0, 100.0), new Float3(101.0, 0.0, 100.0), new Float3(100.0, 0.0, 101.0)),
+                new TerrainGridTriangle(new Float3(0.0, 0.0, 0.0), new Float3(1.0, 0.0, 0.0), new Float3(0.0, 0.0, 1.0)),
+                new TerrainGridTriangle(new Float3(100.0, 0.0, 100.0), new Float3(101.0, 0.0, 100.0), new Float3(100.0, 0.0, 101.0)),
             ],
             minX: 0.0,
             maxX: 101.0,
             minZ: 0.0,
             maxZ: 101.0);
 
-        object emptySpatialIndex = CreateTerrainGridSpatialIndexForTest(
+        TerrainGridSpatialIndex emptySpatialIndex = TerrainGridSpatialIndex.Create(
             [],
             minX: 0.0,
             maxX: 1.0,
             minZ: 0.0,
             maxZ: 1.0);
-        IReadOnlyList<int> populatedCellCandidates = GetTerrainGridSpatialIndexCandidateTriangleIndicesForTest(spatialIndex, 0.25, 0.25);
+        IReadOnlyList<int> populatedCellCandidates = spatialIndex.GetCandidateTriangleIndices(0.25, 0.25);
 
-        Assert.Empty(GetTerrainGridSpatialIndexCandidateTriangleIndicesForTest(emptySpatialIndex, 0.5, 0.5));
-        Assert.Empty(GetTerrainGridSpatialIndexCandidateTriangleIndicesForTest(spatialIndex, 25.0, 75.0));
+        Assert.Empty(emptySpatialIndex.GetCandidateTriangleIndices(0.5, 0.5));
+        Assert.Empty(spatialIndex.GetCandidateTriangleIndices(25.0, 75.0));
         Assert.NotEmpty(populatedCellCandidates);
         Assert.IsType<int[]>(populatedCellCandidates);
     }
@@ -3655,55 +3655,6 @@ public sealed class LocalCityGmlObjectProjectionTests
                 null,
                 CancellationToken.None,
             ])!;
-    }
-
-    private static object CreateTerrainGridSpatialIndexForTest(
-        IReadOnlyList<(Float3 A, Float3 B, Float3 C)> triangles,
-        double minX,
-        double maxX,
-        double minZ,
-        double maxZ)
-    {
-        Type triangleType = typeof(LocalCityGmlObjectProjection).GetNestedType(
-                "TerrainGridTriangle",
-                BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException("Failed to resolve TerrainGridTriangle.");
-        Type indexType = typeof(LocalCityGmlObjectProjection).GetNestedType(
-                "TerrainGridSpatialIndex",
-                BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException("Failed to resolve TerrainGridSpatialIndex.");
-        ConstructorInfo triangleConstructor = triangleType.GetConstructor(
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                binder: null,
-                [typeof(Float3), typeof(Float3), typeof(Float3)],
-                modifiers: null)
-            ?? throw new InvalidOperationException("Failed to resolve TerrainGridTriangle constructor.");
-
-        Array triangleArray = Array.CreateInstance(triangleType, triangles.Count);
-        for (int index = 0; index < triangles.Count; index++)
-        {
-            (Float3 a, Float3 b, Float3 c) = triangles[index];
-            triangleArray.SetValue(triangleConstructor.Invoke([a, b, c]), index);
-        }
-
-        MethodInfo createMethod = indexType.GetMethod(
-                "Create",
-                BindingFlags.Public | BindingFlags.Static)
-            ?? throw new InvalidOperationException("Failed to resolve TerrainGridSpatialIndex.Create.");
-        return createMethod.Invoke(null, [triangleArray, minX, maxX, minZ, maxZ])!;
-    }
-
-    private static IReadOnlyList<int> GetTerrainGridSpatialIndexCandidateTriangleIndicesForTest(
-        object spatialIndex,
-        double x,
-        double z)
-    {
-        MethodInfo method = spatialIndex.GetType().GetMethod(
-                "GetCandidateTriangleIndices",
-                BindingFlags.Public | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("Failed to resolve GetCandidateTriangleIndices.");
-
-        return (IReadOnlyList<int>)method.Invoke(spatialIndex, [x, z])!;
     }
 
     private static void AssertGeneratedUpperFacadeTrianglesFaceOutward(


### PR DESCRIPTION
## Summary
- Extract DEM terrain grid sampling, local triangle interpolation, spatial indexing, and boundary-connected missing-sample fill into `CityGmlDemTerrainGridSampler`.
- Keep `LocalCityGmlObjectProjection` focused on DEM grid orchestration, material/bounds lookup, and final `ImportedCityObject` assembly.
- Replace private nested spatial-index reflection coverage with direct tests against the extracted contract.
- Add fast sampler tests for interpolation and boundary fill behavior.

## Verification
- `dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~CityGmlDemTerrainGridSamplerTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests.DemTerrainGrid|FullyQualifiedName~LocalCityGmlObjectProjectionTests.DemTerrainDynamicMode|FullyQualifiedName~LocalCityGmlObjectProjectionTests.ProjectTerrainMeshMode|FullyQualifiedName~LocalCityGmlObjectProjectionTests.DemMeshMode" --verbosity normal`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`