### PR TITLE
Extract parsed city object projection

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -1,0 +1,371 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using PlateauResoniteLink.Application.Logging;
+using PlateauResoniteLink.Domain.Importing;
+
+using LocalCartesian = GeographicLib.LocalCartesian;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityGmlDemTerrainGridCityObjectProjection
+{
+    private static readonly Quaternion GridMeshTerrainRotation = new(
+        X: Math.Sqrt(0.5),
+        Y: 0.0,
+        Z: 0.0,
+        W: Math.Sqrt(0.5));
+
+    internal static bool TryProject(
+        ParsedCityObject cityObject,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        PlateauImportRequest request,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
+        IDefaultMaterialResolver materialResolver,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken,
+        out ImportedCityObject? heightMapCityObject)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        heightMapCityObject = null;
+
+        if (cityObject.Surfaces.SelectMany(static surface => surface.Vertices).Take(3).Count() < 3)
+        {
+            return false;
+        }
+
+        GeodeticPoint cityObjectOrigin = ResolveCityObjectOrigin(cityObject);
+        LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
+            ? new LocalCartesian(
+                cityObjectOrigin.Latitude,
+                cityObjectOrigin.Longitude,
+                cityObjectOrigin.Altitude,
+                cityObject.ReferenceSystem.Geocentric)
+            : null;
+        if (cityObjectCartesian is null)
+        {
+            return false;
+        }
+
+        Float3 slotPosition = CreateScenePosition(cityObjectOrigin, globalOriginPoint, globalCartesian);
+        Float3[] positions = cityObject.Surfaces
+            .SelectMany(static surface => surface.Vertices)
+            .Select(point => CreateGlobalTerrainGridLocalPosition(point, slotPosition, globalOriginPoint, globalCartesian))
+            .ToArray();
+        TerrainGridTriangle[] triangles = CreateDemTerrainGridTriangles(cityObject, slotPosition, globalOriginPoint, globalCartesian);
+        double seaLevelLocalHeight = CreateGlobalTerrainGridLocalPosition(
+            new GeodeticPoint(cityObjectOrigin.Latitude, cityObjectOrigin.Longitude, 0.0),
+            slotPosition,
+            globalOriginPoint,
+            globalCartesian).Y;
+        if (positions.Length < 3)
+        {
+            return false;
+        }
+
+        DemTerrainGridBounds heightMapBounds = CreateDemTerrainGridBounds(
+            cityObject,
+            cityObjectOrigin,
+            slotPosition,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlay,
+            positions);
+        double minX = heightMapBounds.MinX;
+        double maxX = heightMapBounds.MaxX;
+        double minZ = heightMapBounds.MinZ;
+        double maxZ = heightMapBounds.MaxZ;
+        double centerX = (minX + maxX) / 2.0;
+        double centerZ = (minZ + maxZ) / 2.0;
+        double extentX = maxX - minX;
+        double extentZ = maxZ - minZ;
+        if (extentX <= 1e-6 || extentZ <= 1e-6)
+        {
+            return false;
+        }
+
+        int width = Math.Clamp(
+            (int)Math.Ceiling(extentX / request.TerrainGridMetersPerVertex) + 1,
+            2,
+            request.TerrainGridMaxResolution);
+        int height = Math.Clamp(
+            (int)Math.Ceiling(extentZ / request.TerrainGridMetersPerVertex) + 1,
+            2,
+            request.TerrainGridMaxResolution);
+        progressReporter?.Invoke(
+            PlateauLog.Debug(
+                "import",
+                $"Sampling DEM terrain grid '{cityObject.SlotKey}' "
+                + $"(width={width}, height={height}, triangles={triangles.Length})."));
+
+        DemTerrainGridHeightSamples heightSamples = CityGmlDemTerrainGridSampler.Sample(
+            minX,
+            maxX,
+            minZ,
+            maxZ,
+            request.TerrainGridMetersPerVertex,
+            request.TerrainGridMaxResolution,
+            seaLevelLocalHeight,
+            triangles,
+            cancellationToken);
+        width = heightSamples.Width;
+        height = heightSamples.Height;
+        double[] localHeights = heightSamples.LocalHeights;
+        double minHeight = localHeights.Min();
+        double maxHeight = localHeights.Max();
+
+        MaterialBinding[] materials = CityGmlSurfaceMaterialResolver.CreateDemTerrainGridMaterials(
+            cityObject,
+            cityObjectOrigin,
+            cityObjectCartesian,
+            demTerrainTextureOverlay,
+            request.MeshCode,
+            requestedMeshCodeBounds,
+            materialResolver);
+        if (materials.Length == 0)
+        {
+            return false;
+        }
+
+        TextureUvRect? heightMapOccupiedUvRect = TryCreateDemTerrainGridOccupiedUvRect(
+            cityObject,
+            cityObjectOrigin,
+            cityObjectCartesian,
+            demTerrainTextureOverlay,
+            materialResolver);
+        Float2? heightMapUvScale = heightMapOccupiedUvRect.HasValue
+            ? ToContractFloat2(heightMapOccupiedUvRect.Value.ScaleValue)
+            : null;
+        Float2? heightMapUvOffset = heightMapOccupiedUvRect.HasValue
+            ? ToContractFloat2(heightMapOccupiedUvRect.Value.OffsetValue)
+            : null;
+
+        Float3 adjustedSlotPosition = slotPosition with
+        {
+            X = slotPosition.X + centerX,
+            Y = slotPosition.Y + maxHeight,
+            Z = slotPosition.Z + centerZ,
+        };
+
+        heightMapCityObject = new ImportedCityObject(
+            ObjectKey: cityObject.SlotKey,
+            DisplayName: cityObject.DisplayName,
+            PackageName: cityObject.PackageName,
+            ActualMeshCode: cityObject.ActualMeshCode,
+            LodLevel: cityObject.LodLevel,
+            Transform: new Transform3D(
+                ToContractFloat3(adjustedSlotPosition),
+                ToContractQuaternion(GridMeshTerrainRotation)),
+            Geometry: new TerrainGridGeometry(
+                Width: width,
+                Height: height,
+                Size: new Float2(extentX, extentZ),
+                MinHeight: minHeight,
+                MaxHeight: maxHeight,
+                HeightSamples: localHeights,
+                UvScale: heightMapUvScale,
+                UvOffset: heightMapUvOffset),
+            Materials: materials,
+            SourceFileRelativePath: cityObject.SourceFileRelativePath);
+        return true;
+    }
+
+    private static TextureUvRect? TryCreateDemTerrainGridOccupiedUvRect(
+        ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IDefaultMaterialResolver materialResolver)
+    {
+        if (demTerrainTextureOverlay is null)
+        {
+            return null;
+        }
+
+        GeographicRectangle? demObjectBounds = TryGetDemObjectGeographicBounds(cityObject, demTerrainTextureOverlay);
+        ResolvedSurfaceMaterial? representativeSurface = CityGmlSurfaceMaterialResolver.ResolveSurfaces(
+                cityObject,
+                cityObjectOrigin,
+                cityObjectCartesian,
+                demTerrainTextureOverlay,
+                materialResolver)
+            .FirstOrDefault(static resolvedSurface => resolvedSurface.Surface.UsesGeneratedDemTexture);
+        if (representativeSurface is null)
+        {
+            return null;
+        }
+
+        TextureUvRect? occupiedUvRect = DemTerrainOverlayAssignment.TryCreateTerrainGridOccupiedUvRect(
+            cityObject,
+            representativeSurface,
+            demTerrainTextureOverlay,
+            demObjectBounds);
+        return occupiedUvRect is { IsIdentity: true } ? null : occupiedUvRect;
+    }
+
+    private static GeographicRectangle? TryGetDemObjectGeographicBounds(
+        ParsedCityObject cityObject,
+        TerrainTextureOverlay? demTerrainTextureOverlay)
+    {
+        if (demTerrainTextureOverlay is null
+            || !string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return ResolveCityObjectGeographicBounds(cityObject);
+    }
+
+    private static DemTerrainGridBounds CreateDemTerrainGridBounds(
+        ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        Float3 slotPosition,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IReadOnlyList<Float3> positions)
+    {
+        double rawMinX = positions.Min(static position => position.X);
+        double rawMaxX = positions.Max(static position => position.X);
+        double rawMinZ = positions.Min(static position => position.Z);
+        double rawMaxZ = positions.Max(static position => position.Z);
+
+        if (demTerrainTextureOverlay is null)
+        {
+            return new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
+        }
+
+        GeographicRectangle clippedBounds = IntersectGeographicBounds(
+            ResolveCityObjectGeographicBounds(cityObject),
+            demTerrainTextureOverlay.GeographicBounds);
+        double referenceLatitude = cityObjectOrigin.Latitude;
+        double referenceLongitude = cityObjectOrigin.Longitude;
+        Float3 westPosition = CreateGlobalTerrainGridLocalPosition(
+            new GeodeticPoint(referenceLatitude, clippedBounds.MinLongitude, cityObjectOrigin.Altitude),
+            slotPosition,
+            globalOriginPoint,
+            globalCartesian);
+        Float3 eastPosition = CreateGlobalTerrainGridLocalPosition(
+            new GeodeticPoint(referenceLatitude, clippedBounds.MaxLongitude, cityObjectOrigin.Altitude),
+            slotPosition,
+            globalOriginPoint,
+            globalCartesian);
+        Float3 southPosition = CreateGlobalTerrainGridLocalPosition(
+            new GeodeticPoint(clippedBounds.MinLatitude, referenceLongitude, cityObjectOrigin.Altitude),
+            slotPosition,
+            globalOriginPoint,
+            globalCartesian);
+        Float3 northPosition = CreateGlobalTerrainGridLocalPosition(
+            new GeodeticPoint(clippedBounds.MaxLatitude, referenceLongitude, cityObjectOrigin.Altitude),
+            slotPosition,
+            globalOriginPoint,
+            globalCartesian);
+
+        double clippedMinX = Math.Min(westPosition.X, eastPosition.X);
+        double clippedMaxX = Math.Max(westPosition.X, eastPosition.X);
+        double clippedMinZ = Math.Min(southPosition.Z, northPosition.Z);
+        double clippedMaxZ = Math.Max(southPosition.Z, northPosition.Z);
+
+        if ((clippedMaxX - clippedMinX) <= 1e-6 || (clippedMaxZ - clippedMinZ) <= 1e-6)
+        {
+            return new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
+        }
+
+        return new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ);
+    }
+
+    private static GeographicRectangle ResolveCityObjectGeographicBounds(ParsedCityObject cityObject)
+    {
+        return CityObjectGeographicBoundsResolver.Resolve(
+            cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
+    }
+
+    private static GeographicRectangle IntersectGeographicBounds(
+        GeographicRectangle left,
+        GeographicRectangle right)
+    {
+        return new GeographicRectangle(
+            MinLatitude: Math.Max(left.MinLatitude, right.MinLatitude),
+            MaxLatitude: Math.Min(left.MaxLatitude, right.MaxLatitude),
+            MinLongitude: Math.Max(left.MinLongitude, right.MinLongitude),
+            MaxLongitude: Math.Min(left.MaxLongitude, right.MaxLongitude));
+    }
+
+    private static TerrainGridTriangle[] CreateDemTerrainGridTriangles(
+        ParsedCityObject cityObject,
+        Float3 slotPosition,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian)
+    {
+        List<TerrainGridTriangle> triangles = [];
+        foreach (ParsedSurface surface in cityObject.Surfaces)
+        {
+            Float3[] positions = surface.ExteriorRing.Vertices
+                .Select(point => CreateGlobalTerrainGridLocalPosition(point, slotPosition, globalOriginPoint, globalCartesian))
+                .ToArray();
+            if (positions.Length < 3)
+            {
+                continue;
+            }
+
+            Float3 origin = positions[0];
+            for (int index = 1; index + 1 < positions.Length; index++)
+            {
+                triangles.Add(new TerrainGridTriangle(origin, positions[index], positions[index + 1]));
+            }
+        }
+
+        return triangles.ToArray();
+    }
+
+    private static GeodeticPoint ResolveCityObjectOrigin(ParsedCityObject cityObject)
+    {
+        return CityObjectOriginResolver.Resolve(
+            cityObject.GeodeticOriginOverride,
+            cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
+    }
+
+    private static Float3 CreateGlobalTerrainGridLocalPosition(
+        GeodeticPoint point,
+        Float3 slotPosition,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian)
+    {
+        Float3 globalPosition = CreateScenePosition(point, globalOriginPoint, globalCartesian);
+        return new Float3(
+            globalPosition.X - slotPosition.X,
+            globalPosition.Y - slotPosition.Y,
+            globalPosition.Z - slotPosition.Z);
+    }
+
+    private static Float3 CreateScenePosition(
+        GeodeticPoint point,
+        GeodeticPoint origin,
+        LocalCartesian? cartesian)
+    {
+        return SceneAxisMapper.CreatePosition(
+            point.Latitude,
+            point.Longitude,
+            point.Altitude,
+            origin.Latitude,
+            origin.Longitude,
+            origin.Altitude,
+            cartesian);
+    }
+
+    private static Float2 ToContractFloat2(ScalarPair value) => new(value.X, value.Y);
+
+    private static Float3 ToContractFloat3(Float3 value) => new(value.X, value.Y, value.Z);
+
+    private static Quaternion ToContractQuaternion(Quaternion value) => new(value.X, value.Y, value.Z, value.W);
+
+    private sealed record DemTerrainGridBounds(
+        double MinX,
+        double MaxX,
+        double MinZ,
+        double MaxZ);
+}

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -1,0 +1,531 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using PlateauResoniteLink.Domain.Importing;
+
+using LocalCartesian = GeographicLib.LocalCartesian;
+using ProjectionSurface = PlateauResoniteLink.Application.Importing.LocalCityGmlObjectProjection.ParsedSurface;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityGmlParsedCityObjectProjection
+{
+    internal static IEnumerable<ImportedCityObject> ProjectSourceFile(
+        CachedSourceFileDescriptor sourceFile,
+        CoordinateReferenceSystem referenceSystem,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
+        PlateauImportRequest request,
+        IDefaultMaterialResolver materialResolver,
+        Func<ParsedCityObject, bool>? predicate = null,
+        Action<string>? progressReporter = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sourceFile);
+        ArgumentNullException.ThrowIfNull(referenceSystem);
+        ArgumentNullException.ThrowIfNull(globalOriginPoint);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(materialResolver);
+
+        LocalCityGmlObjectProjection.ValidateCompatibleReferenceSystem(
+            referenceSystem.ToProjectionModel(),
+            sourceFile.CityObjects.FirstOrDefault()?.ReferenceSystem.ToProjectionModel() ?? referenceSystem.ToProjectionModel());
+
+        ParsedCityObject[] projectedInputCityObjects =
+            DemCityObjectAggregation.AggregateBySourceFileAndThirdMesh(
+                sourceFile.SourceFile,
+                sourceFile.CityObjects);
+
+        foreach (ParsedCityObject parsedCityObject in projectedInputCityObjects)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (predicate is not null && !predicate(parsedCityObject))
+            {
+                continue;
+            }
+
+            foreach (ImportedCityObject cityObject in Project(
+                         parsedCityObject,
+                         globalOriginPoint,
+                         globalCartesian,
+                         demTerrainTextureOverlays,
+                         requestedMeshCodeBounds,
+                         terrainHeightSampler: null,
+                         request,
+                         materialResolver,
+                         progressReporter,
+                         cancellationToken))
+            {
+                yield return cityObject;
+            }
+        }
+    }
+
+    internal static IEnumerable<ImportedCityObject> Project(
+        ParsedCityObject parsedCityObject,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
+        ProjectionTerrainHeightSampler? terrainHeightSampler,
+        PlateauImportRequest request,
+        IDefaultMaterialResolver materialResolver,
+        Action<string>? progressReporter = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(parsedCityObject);
+        ArgumentNullException.ThrowIfNull(globalOriginPoint);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(materialResolver);
+
+        double? geometryHeightMeters = ResolveGeometryHeightMeters(parsedCityObject.Surfaces);
+        ParsedCityObject terrainAlignedParsedCityObject =
+            GeneratedLod1RoofCityObjectFactory.Create(ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler)) with
+            {
+                GeometryHeightMeters = geometryHeightMeters,
+            };
+        List<ImportedCityObject> projectedCityObjects = [];
+        List<ImportedCityObject> generatedRoadMarkings = [];
+
+        foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
+                 in TerrainOverlayProjectionSplitPolicy.SplitParsedCityObject(
+                     terrainAlignedParsedCityObject,
+                     demTerrainTextureOverlays,
+                     requestedMeshCodeBounds,
+                     progressReporter,
+                     cancellationToken))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TerrainOverlayProjectionSplitPolicy.ShouldProjectSplit(
+                    splitCityObject.CityObject.ActualMeshCode,
+                    request.MeshCode,
+                    requestedMeshCodeBounds,
+                    splitCityObject.Overlay))
+            {
+                throw CreateTerrainOverlayMeshCodeMismatchException(
+                    "project",
+                    splitCityObject.CityObject.ActualMeshCode,
+                    request.MeshCode,
+                    requestedMeshCodeBounds,
+                    splitCityObject.Overlay);
+            }
+
+            ImportedCityObject cityObject = ProjectTerrainMeshModeCityObject(
+                splitCityObject.CityObject,
+                globalOriginPoint,
+                globalCartesian,
+                splitCityObject.Overlay,
+                request,
+                requestedMeshCodeBounds,
+                materialResolver,
+                progressReporter,
+                cancellationToken);
+
+            if (HasRenderableGeometry(cityObject))
+            {
+                projectedCityObjects.Add(cityObject);
+            }
+
+            GeodeticPoint markingOrigin = ResolveCityObjectOrigin(splitCityObject.CityObject);
+            LocalCartesian? markingCartesian = splitCityObject.CityObject.ReferenceSystem.IsGeographic
+                ? new LocalCartesian(
+                    markingOrigin.Latitude,
+                    markingOrigin.Longitude,
+                    markingOrigin.Altitude,
+                    splitCityObject.CityObject.ReferenceSystem.Geocentric)
+                : null;
+            ParsedCityObject? roadMarkingCityObject = GeneratedRoadMarkingCityObjectFactory.Create(
+                splitCityObject.CityObject,
+                markingOrigin,
+                markingCartesian);
+            if (roadMarkingCityObject is null)
+            {
+                continue;
+            }
+
+            ImportedCityObject markingObject = CityGmlTriangleMeshCityObjectProjection.Project(
+                roadMarkingCityObject,
+                globalOriginPoint,
+                globalCartesian,
+                splitCityObject.Overlay,
+                materialResolver) with
+            {
+                CollisionEnabled = false,
+            };
+            if (HasRenderableGeometry(markingObject))
+            {
+                generatedRoadMarkings.Add(markingObject);
+            }
+        }
+
+        ImportedCityObject[] alignedCityObjects =
+            request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
+            && string.Equals(terrainAlignedParsedCityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
+                ? DemTerrainGridChunkBoundaryAlignmentPolicy.Align(projectedCityObjects)
+                : [.. projectedCityObjects];
+
+        foreach (ImportedCityObject cityObject in alignedCityObjects)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return cityObject;
+        }
+
+        foreach (ImportedCityObject markingObject in generatedRoadMarkings)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return markingObject;
+        }
+    }
+
+    internal static IEnumerable<MaterialBinding> EnumerateCommonMaterials(
+        ParsedCityObject parsedCityObject,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
+        ProjectionTerrainHeightSampler? terrainHeightSampler,
+        PlateauImportRequest request,
+        IDefaultMaterialResolver materialResolver)
+    {
+        ArgumentNullException.ThrowIfNull(parsedCityObject);
+        ArgumentNullException.ThrowIfNull(globalOriginPoint);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(materialResolver);
+
+        double? geometryHeightMeters = ResolveGeometryHeightMeters(parsedCityObject.Surfaces);
+        ParsedCityObject terrainAlignedParsedCityObject =
+            GeneratedLod1RoofCityObjectFactory.Create(ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler)) with
+            {
+                GeometryHeightMeters = geometryHeightMeters,
+            };
+
+        foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
+                 in TerrainOverlayProjectionSplitPolicy.SplitParsedCityObject(
+                     terrainAlignedParsedCityObject,
+                     demTerrainTextureOverlays,
+                     requestedMeshCodeBounds))
+        {
+            if (!TerrainOverlayProjectionSplitPolicy.ShouldProjectSplit(
+                    splitCityObject.CityObject.ActualMeshCode,
+                    request.MeshCode,
+                    requestedMeshCodeBounds ?? [],
+                    splitCityObject.Overlay))
+            {
+                throw CreateTerrainOverlayMeshCodeMismatchException(
+                    "common-material-enumeration",
+                    splitCityObject.CityObject.ActualMeshCode,
+                    request.MeshCode,
+                    requestedMeshCodeBounds,
+                    splitCityObject.Overlay);
+            }
+
+            GeodeticPoint cityObjectOrigin = ResolveCityObjectOrigin(splitCityObject.CityObject);
+            LocalCartesian? cityObjectCartesian = splitCityObject.CityObject.ReferenceSystem.IsGeographic
+                ? new LocalCartesian(
+                    cityObjectOrigin.Latitude,
+                    cityObjectOrigin.Longitude,
+                    cityObjectOrigin.Altitude,
+                    splitCityObject.CityObject.ReferenceSystem.Geocentric)
+                : null;
+
+            foreach (MaterialBinding material in request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
+                         && string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
+                            ? CityGmlSurfaceMaterialResolver.CreateDemTerrainGridMaterials(
+                                splitCityObject.CityObject,
+                                cityObjectOrigin,
+                                cityObjectCartesian,
+                                splitCityObject.Overlay,
+                                request.MeshCode,
+                                requestedMeshCodeBounds,
+                                materialResolver)
+                            : CityGmlSurfaceMaterialResolver.CreateSharedCommonMaterialBindings(
+                                splitCityObject.CityObject,
+                                cityObjectOrigin,
+                                cityObjectCartesian,
+                                splitCityObject.Overlay,
+                                materialResolver))
+            {
+                yield return material;
+            }
+        }
+    }
+
+    internal static ImportedCityObject ProjectTerrainMeshModeCityObject(
+        ParsedCityObject cityObject,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        PlateauImportRequest request,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
+        IDefaultMaterialResolver materialResolver,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
+    {
+        bool isDem = string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase);
+        if (!isDem || request.TerrainMeshMode == TerrainMeshMode.Static)
+        {
+            return CityGmlTriangleMeshCityObjectProjection.Project(cityObject, globalOriginPoint, globalCartesian, demTerrainTextureOverlay, materialResolver);
+        }
+
+        bool hasGrid = CityGmlDemTerrainGridCityObjectProjection.TryProject(
+            cityObject,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlay,
+            request,
+            requestedMeshCodeBounds,
+            materialResolver,
+            progressReporter,
+            cancellationToken,
+            out ImportedCityObject? heightMapCityObject);
+        if (!hasGrid)
+        {
+            return request.TerrainMeshMode == TerrainMeshMode.Dynamic
+                ? CreateNonRenderableCityObject(cityObject)
+                : CityGmlTriangleMeshCityObjectProjection.Project(cityObject, globalOriginPoint, globalCartesian, demTerrainTextureOverlay, materialResolver);
+        }
+
+        if (request.TerrainMeshMode == TerrainMeshMode.Grid)
+        {
+            return heightMapCityObject!;
+        }
+
+        ImportedCityObject staticCityObject = CityGmlTriangleMeshCityObjectProjection.Project(
+            cityObject,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlay,
+            materialResolver);
+        TriangleMeshGeometry staticMesh = AssertTriangleMeshGeometry(staticCityObject);
+        TriangleMeshGeometry rebasedStaticMesh = TriangleMeshTransformRebaser.Rebase(
+            staticMesh,
+            staticCityObject.Transform,
+            heightMapCityObject!.Transform);
+        return heightMapCityObject with
+        {
+            Geometry = new DynamicTerrainGeometry(rebasedStaticMesh, AssertTerrainGridGeometry(heightMapCityObject)),
+            Materials = staticCityObject.Materials,
+        };
+    }
+
+    private static ImportedCityObject CreateNonRenderableCityObject(ParsedCityObject cityObject)
+    {
+        return new ImportedCityObject(
+            cityObject.SlotKey,
+            cityObject.DisplayName,
+            cityObject.PackageName,
+            cityObject.ActualMeshCode,
+            cityObject.LodLevel,
+            new Transform3D(new Float3(0.0, 0.0, 0.0)),
+            new TriangleMeshGeometry(new ImportedMesh([], [])),
+            [],
+            SourceFileRelativePath: cityObject.SourceFileRelativePath);
+    }
+
+    private static ParsedCityObject ConformCityObjectToTerrain(
+        ParsedCityObject parsedCityObject,
+        ProjectionTerrainHeightSampler? terrainHeightSampler)
+    {
+        if (terrainHeightSampler is null
+            || !CityGmlTerrainConformer.ShouldTerrainAlign(parsedCityObject.PackageName, parsedCityObject.LodLevel))
+        {
+            return parsedCityObject;
+        }
+
+        ParsedCityObject subdividedCityObject = SubdivideTerrainAlignedCityObject(parsedCityObject);
+        GeodeticPoint cityObjectOrigin = ResolveCityObjectOrigin(subdividedCityObject);
+        LocalCartesian? cityObjectCartesian = subdividedCityObject.ReferenceSystem.IsGeographic
+            ? new LocalCartesian(
+                cityObjectOrigin.Latitude,
+                cityObjectOrigin.Longitude,
+                cityObjectOrigin.Altitude,
+                subdividedCityObject.ReferenceSystem.Geocentric)
+            : null;
+
+        TerrainConformanceResult conformance = CityGmlTerrainConformer.Conform(
+            subdividedCityObject,
+            terrainHeightSampler,
+            cityObjectOrigin,
+            cityObjectCartesian);
+
+        return conformance.TerrainAligned
+            ? subdividedCityObject with
+            {
+                Surfaces = conformance.Surfaces,
+                TerrainAligned = true,
+            }
+            : subdividedCityObject;
+    }
+
+    private static ParsedCityObject SubdivideTerrainAlignedCityObject(ParsedCityObject cityObject)
+    {
+        if (!ShouldSubdivideTerrainAlignedCityObject(cityObject.PackageName, cityObject.LodLevel))
+        {
+            return cityObject;
+        }
+
+        List<ParsedSurface> subdividedSurfaces = [];
+        foreach (ParsedSurface surface in cityObject.Surfaces)
+        {
+            subdividedSurfaces.AddRange(SubdivideTransportationSurfaceForTerrainAlignment(surface, cityObject));
+        }
+
+        return subdividedSurfaces.Count == cityObject.Surfaces.Length
+            ? cityObject
+            : cityObject with { Surfaces = subdividedSurfaces.ToArray() };
+    }
+
+    private static List<ParsedSurface> SubdivideTransportationSurfaceForTerrainAlignment(
+        ParsedSurface surface,
+        ParsedCityObject cityObject)
+    {
+        if (surface.InteriorRings.Length != 0
+            || surface.ExteriorRing.Vertices.Length != 4)
+        {
+            return [surface];
+        }
+
+        if (!ShouldSubdivideTerrainAlignedCityObject(cityObject.PackageName, cityObject.LodLevel))
+        {
+            return [surface];
+        }
+
+        GeodeticPoint cityObjectOrigin = ResolveCityObjectOrigin(cityObject);
+        LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
+            ? new LocalCartesian(
+                cityObjectOrigin.Latitude,
+                cityObjectOrigin.Longitude,
+                cityObjectOrigin.Altitude,
+                cityObject.ReferenceSystem.Geocentric)
+            : null;
+        Float3[] positions = surface.ExteriorRing.Vertices
+            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
+            .ToArray();
+        if (!IsNearHorizontalSurface(positions))
+        {
+            return [surface];
+        }
+
+        EdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(
+            CityGmlProjectionModelAdapter.ToProjectionModel(surface.ExteriorRing),
+            positions);
+        List<ProjectionSurface> strips = TerrainAlignedTransportationSurfaceSplitter.Split(
+            CityGmlProjectionModelAdapter.ToProjectionModel(surface),
+            positions,
+            edgePair);
+        return strips.Select(CityGmlProjectionModelAdapter.FromProjectionModel).ToList();
+    }
+
+    private static bool ShouldSubdivideTerrainAlignedCityObject(string packageName, int? lodLevel)
+    {
+        return PlateauPackageCatalog.IsRoadPackage(packageName)
+            && (!lodLevel.HasValue || lodLevel.Value < 3);
+    }
+
+    private static GeodeticPoint ResolveCityObjectOrigin(ParsedCityObject cityObject)
+    {
+        return CityObjectOriginResolver.Resolve(
+            cityObject.GeodeticOriginOverride,
+            cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
+    }
+
+    private static double? ResolveGeometryHeightMeters(IEnumerable<ParsedSurface> surfaces)
+    {
+        return CityObjectAltitudeMetricsResolver.TryGetGeometryHeightMeters(
+            surfaces.SelectMany(static surface => surface.Vertices));
+    }
+
+    private static bool IsNearHorizontalSurface(Float3[] positions)
+    {
+        Float3? normal = ComputePolygonNormal(positions);
+        return normal is not null && Math.Abs(normal.Y) >= 0.7;
+    }
+
+    private static Float3? ComputePolygonNormal(Float3[] positions)
+    {
+        if (positions.Length < 3)
+        {
+            return null;
+        }
+
+        double normalX = 0.0;
+        double normalY = 0.0;
+        double normalZ = 0.0;
+        for (int index = 0; index < positions.Length; index++)
+        {
+            Float3 current = positions[index];
+            Float3 next = positions[(index + 1) % positions.Length];
+            normalX += (current.Y - next.Y) * (current.Z + next.Z);
+            normalY += (current.Z - next.Z) * (current.X + next.X);
+            normalZ += (current.X - next.X) * (current.Y + next.Y);
+        }
+
+        double length = Math.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ));
+        if (length <= 1e-8)
+        {
+            return null;
+        }
+
+        return new Float3(normalX / length, normalY / length, normalZ / length);
+    }
+
+    private static Float3 CreateScenePosition(
+        GeodeticPoint point,
+        GeodeticPoint origin,
+        LocalCartesian? cartesian)
+    {
+        return SceneAxisMapper.CreatePosition(
+            point.Latitude,
+            point.Longitude,
+            point.Altitude,
+            origin.Latitude,
+            origin.Longitude,
+            origin.Altitude,
+            cartesian);
+    }
+
+    private static InvalidOperationException CreateTerrainOverlayMeshCodeMismatchException(
+        string phase,
+        string actualMeshCode,
+        string requestedMeshCode,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
+        TerrainTextureOverlay? terrainOverlay)
+    {
+        return TerrainOverlayDiagnostics.CreateMeshCodeMismatchException(
+            phase,
+            actualMeshCode,
+            requestedMeshCode,
+            requestedMeshCodeBounds,
+            terrainOverlay);
+    }
+
+    private static TriangleMeshGeometry AssertTriangleMeshGeometry(ImportedCityObject cityObject)
+    {
+        return cityObject.Geometry as TriangleMeshGeometry
+            ?? throw new InvalidOperationException("Dynamic terrain static variant must be projected as a triangle mesh.");
+    }
+
+    private static TerrainGridGeometry AssertTerrainGridGeometry(ImportedCityObject cityObject)
+    {
+        return cityObject.Geometry as TerrainGridGeometry
+            ?? throw new InvalidOperationException("Dynamic terrain grid variant must be projected as a terrain grid.");
+    }
+
+    private static bool HasRenderableGeometry(ImportedCityObject cityObject)
+    {
+        return cityObject.Geometry switch
+        {
+            TriangleMeshGeometry triangleMesh => triangleMesh.Mesh.Submeshes.Count > 0,
+            TerrainGridGeometry heightMap => heightMap.Width > 1 && heightMap.Height > 1,
+            DynamicTerrainGeometry dynamicTerrain =>
+                dynamicTerrain.StaticMesh.Mesh.Submeshes.Count > 0
+                && dynamicTerrain.GridMesh.Width > 1
+                && dynamicTerrain.GridMesh.Height > 1,
+            _ => false,
+        };
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using PlateauResoniteLink.Domain.Importing;
+
+using LocalCartesian = GeographicLib.LocalCartesian;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class CityGmlTriangleMeshCityObjectProjection
+{
+    internal static ImportedCityObject Project(
+        ParsedCityObject cityObject,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IDefaultMaterialResolver materialResolver)
+    {
+        double? geometryHeightMeters = cityObject.GeometryHeightMeters
+            ?? ResolveGeometryHeightMeters(cityObject.Surfaces);
+        cityObject = GeneratedLod1RoofCityObjectFactory.Create(cityObject) with
+        {
+            GeometryHeightMeters = geometryHeightMeters,
+        };
+        GeodeticPoint cityObjectOrigin = ResolveCityObjectOrigin(cityObject);
+
+        LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
+            ? new LocalCartesian(
+                cityObjectOrigin.Latitude,
+                cityObjectOrigin.Longitude,
+                cityObjectOrigin.Altitude,
+                cityObject.ReferenceSystem.Geocentric)
+            : null;
+        Float3 slotPosition = CreateScenePosition(
+            cityObjectOrigin,
+            globalOriginPoint,
+            globalCartesian);
+        List<MeshVertex> vertices = [];
+        List<MeshSubmesh> submeshes = [];
+        List<MaterialBinding> materials = [];
+        DemUvProjection? demUvProjection = TryCreateDemUvProjection(cityObject.ActualMeshCode, demTerrainTextureOverlay);
+
+        List<ResolvedSurfaceMaterial> resolvedSurfaces =
+        [
+            .. CityGmlSurfaceMaterialResolver.ResolveSurfaces(
+                cityObject,
+                cityObjectOrigin,
+                cityObjectCartesian,
+                demTerrainTextureOverlay,
+                materialResolver),
+        ];
+
+        IGrouping<MaterialGroupingKey, ResolvedSurfaceMaterial>[] materialGroups = resolvedSurfaces
+            .GroupBy(
+                resolvedSurface => MaterialGroupingPolicy.CreateKey(
+                    cityObject.ActualMeshCode,
+                    resolvedSurface.Material,
+                    resolvedSurface.DepthOffset,
+                    resolvedSurface.Material.TextureScale,
+                    resolvedSurface.Surface.BaseColor,
+                    resolvedSurface.Material.TextureOffset))
+            .OrderBy(static group => group.Min(static surface => ParsedSurfaceStableSortKey.Create(surface.Surface)), StringComparer.Ordinal)
+            .ToArray();
+
+        for (int materialIndex = 0; materialIndex < materialGroups.Length; materialIndex++)
+        {
+            IGrouping<MaterialGroupingKey, ResolvedSurfaceMaterial> materialGroup = materialGroups[materialIndex];
+            List<int> indices = [];
+            FacadeUvProjectionContext? facadeUvProjectionContext = CityGmlSurfaceProjectionPolicy.TryCreateFacadeUvProjectionContext(
+                cityObject.PackageName,
+                cityObject.Surfaces,
+                cityObjectOrigin,
+                cityObjectCartesian);
+
+            foreach (ResolvedSurfaceMaterial resolvedSurface in materialGroup
+                         .OrderBy(static surface => ParsedSurfaceStableSortKey.Create(surface.Surface), StringComparer.Ordinal))
+            {
+                SurfaceMeshTessellation tessellation = CityGmlSurfaceMeshTessellator.Tessellate(
+                    new SurfaceMeshTessellationRequest(
+                        cityObject.PackageName,
+                        resolvedSurface.Surface,
+                        resolvedSurface.Material,
+                        cityObjectOrigin.ToProjectionModel(),
+                        cityObjectCartesian,
+                        globalOriginPoint.ToProjectionModel(),
+                        globalCartesian,
+                        facadeUvProjectionContext,
+                        demUvProjection));
+                int baseIndex = vertices.Count;
+                vertices.AddRange(tessellation.Vertices);
+                indices.AddRange(tessellation.Indices.Select(index => baseIndex + index));
+            }
+
+            if (indices.Count == 0)
+            {
+                continue;
+            }
+
+            ResolvedSurfaceMaterial representativeSurface = materialGroup.First();
+            submeshes.Add(new MeshSubmesh(materialIndex, indices));
+            materials.Add(CityGmlSurfaceMaterialResolver.CreateMaterialBinding(cityObject.ActualMeshCode, representativeSurface, materialIndex));
+        }
+
+        return new ImportedCityObject(
+            ObjectKey: cityObject.SlotKey,
+            DisplayName: cityObject.DisplayName,
+            PackageName: cityObject.PackageName,
+            ActualMeshCode: cityObject.ActualMeshCode,
+            LodLevel: cityObject.LodLevel,
+            Transform: new Transform3D(ToContractFloat3(slotPosition)),
+            Mesh: new ImportedMesh(vertices.ToArray(), submeshes.ToArray()),
+            Materials: materials,
+            SourceFileRelativePath: cityObject.SourceFileRelativePath);
+    }
+
+    private static GeodeticPoint ResolveCityObjectOrigin(ParsedCityObject cityObject)
+    {
+        return CityObjectOriginResolver.Resolve(
+            cityObject.GeodeticOriginOverride,
+            cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
+    }
+
+    private static double? ResolveGeometryHeightMeters(IEnumerable<ParsedSurface> surfaces)
+    {
+        return CityObjectAltitudeMetricsResolver.TryGetGeometryHeightMeters(
+            surfaces.SelectMany(static surface => surface.Vertices));
+    }
+
+    private static DemUvProjection? TryCreateDemUvProjection(
+        string actualMeshCode,
+        TerrainTextureOverlay? demTerrainTextureOverlay)
+    {
+        if (demTerrainTextureOverlay is null
+            || TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, demTerrainTextureOverlay) is not { } terrainMeshCode
+            || MeshCodeBounds.TryParse(terrainMeshCode) is not { } meshCodeBounds)
+        {
+            return null;
+        }
+
+        return CreateDemUvProjection(
+            meshCodeBounds.WestLongitude,
+            meshCodeBounds.EastLongitude,
+            meshCodeBounds.NorthLatitude,
+            meshCodeBounds.SouthLatitude);
+    }
+
+    private static DemUvProjection CreateDemUvProjection(
+        double westLongitude,
+        double eastLongitude,
+        double northLatitude,
+        double southLatitude)
+    {
+        double west = WebMercatorTileMath.LongitudeToNormalizedX(westLongitude);
+        double east = WebMercatorTileMath.LongitudeToNormalizedX(eastLongitude);
+        double north = WebMercatorTileMath.LatitudeToNormalizedY(northLatitude);
+        double south = WebMercatorTileMath.LatitudeToNormalizedY(southLatitude);
+        double width = Math.Max(east - west, 1e-12);
+        double height = Math.Max(south - north, 1e-12);
+
+        return new DemUvProjection(west, south, width, height);
+    }
+
+    private static Float3 CreateScenePosition(
+        GeodeticPoint point,
+        GeodeticPoint origin,
+        LocalCartesian? cartesian)
+    {
+        return SceneAxisMapper.CreatePosition(
+            point.Latitude,
+            point.Longitude,
+            point.Altitude,
+            origin.Latitude,
+            origin.Longitude,
+            origin.Altitude,
+            cartesian);
+    }
+
+    private static Float3 ToContractFloat3(Float3 value) => new(value.X, value.Y, value.Z);
+}

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -9,7 +9,6 @@ using System.Xml.Linq;
 
 using GeographicLib;
 
-using PlateauResoniteLink.Application.Logging;
 using PlateauResoniteLink.Domain.Importing;
 
 using Geocentric = GeographicLib.Geocentric;
@@ -1613,147 +1612,17 @@ internal static class LocalCityGmlObjectProjection
         CancellationToken cancellationToken,
         out ImportedCityObject? heightMapCityObject)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-        heightMapCityObject = null;
-
-        if (cityObject.Surfaces.SelectMany(static surface => surface.Vertices).Take(3).Count() < 3)
-        {
-            return false;
-        }
-
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
-        LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
-            ? new LocalCartesian(
-                cityObjectOrigin.Latitude,
-                cityObjectOrigin.Longitude,
-                cityObjectOrigin.Altitude,
-                cityObject.ReferenceSystem.Geocentric)
-            : null;
-        if (cityObjectCartesian is null)
-        {
-            return false;
-        }
-
-        Float3 slotPosition = CreateScenePosition(cityObjectOrigin.ToProjectionModel(), globalOriginPoint.ToProjectionModel(), globalCartesian);
-        Float3[] positions = cityObject.Surfaces
-            .SelectMany(static surface => surface.Vertices)
-            .Select(point => CreateGlobalTerrainGridLocalPosition(point.ToProjectionModel(), slotPosition, globalOriginPoint.ToProjectionModel(), globalCartesian))
-            .ToArray();
-        TerrainGridTriangle[] triangles = CreateDemTerrainGridTriangles(cityObject, slotPosition, globalOriginPoint, globalCartesian);
-        double seaLevelLocalHeight = CreateGlobalTerrainGridLocalPosition(
-            new GeodeticPoint(cityObjectOrigin.Latitude, cityObjectOrigin.Longitude, 0.0),
-            slotPosition,
-            globalOriginPoint.ToProjectionModel(),
-            globalCartesian).Y;
-        if (positions.Length < 3)
-        {
-            return false;
-        }
-
-        DemTerrainGridBounds heightMapBounds = CreateDemTerrainGridBounds(
+        return CityGmlDemTerrainGridCityObjectProjection.TryProject(
             cityObject,
-            cityObjectOrigin,
-            slotPosition,
             globalOriginPoint,
             globalCartesian,
             demTerrainTextureOverlay,
-            positions);
-        double minX = heightMapBounds.MinX;
-        double maxX = heightMapBounds.MaxX;
-        double minZ = heightMapBounds.MinZ;
-        double maxZ = heightMapBounds.MaxZ;
-        double centerX = (minX + maxX) / 2.0;
-        double centerZ = (minZ + maxZ) / 2.0;
-        double extentX = maxX - minX;
-        double extentZ = maxZ - minZ;
-        if (extentX <= 1e-6 || extentZ <= 1e-6)
-        {
-            return false;
-        }
-
-        int width = Math.Clamp(
-            (int)Math.Ceiling(extentX / request.TerrainGridMetersPerVertex) + 1,
-            2,
-            request.TerrainGridMaxResolution);
-        int height = Math.Clamp(
-            (int)Math.Ceiling(extentZ / request.TerrainGridMetersPerVertex) + 1,
-            2,
-            request.TerrainGridMaxResolution);
-        progressReporter?.Invoke(
-            PlateauLog.Debug(
-                "import",
-                $"Sampling DEM terrain grid '{cityObject.SlotKey}' "
-                + $"(width={width}, height={height}, triangles={triangles.Length})."));
-        DemTerrainGridHeightSamples heightSamples = CityGmlDemTerrainGridSampler.Sample(
-            minX,
-            maxX,
-            minZ,
-            maxZ,
-            request.TerrainGridMetersPerVertex,
-            request.TerrainGridMaxResolution,
-            seaLevelLocalHeight,
-            triangles,
-            cancellationToken);
-        width = heightSamples.Width;
-        height = heightSamples.Height;
-        double[] localHeights = heightSamples.LocalHeights;
-        double minHeight = localHeights.Min();
-        double maxHeight = localHeights.Max();
-
-        MaterialBinding[] materials = CityGmlSurfaceMaterialResolver.CreateDemTerrainGridMaterials(
-            cityObject,
-            cityObjectOrigin,
-            cityObjectCartesian,
-            demTerrainTextureOverlay,
-            request.MeshCode,
+            request,
             requestedMeshCodeBounds,
-            materialResolver);
-        if (materials.Length == 0)
-        {
-            return false;
-        }
-
-        TextureUvRect? heightMapOccupiedUvRect = TryCreateDemTerrainGridOccupiedUvRect(
-            cityObject,
-            cityObjectOrigin,
-            cityObjectCartesian,
-            demTerrainTextureOverlay,
-            materialResolver);
-        Float2? heightMapUvScale = heightMapOccupiedUvRect.HasValue
-            ? ToContractFloat2(heightMapOccupiedUvRect.Value.ScaleValue)
-            : null;
-        Float2? heightMapUvOffset = heightMapOccupiedUvRect.HasValue
-            ? ToContractFloat2(heightMapOccupiedUvRect.Value.OffsetValue)
-            : null;
-
-        Float3 adjustedSlotPosition = slotPosition with
-        {
-            X = slotPosition.X + centerX,
-            Y = slotPosition.Y + maxHeight,
-            Z = slotPosition.Z + centerZ,
-        };
-
-        heightMapCityObject = new ImportedCityObject(
-            ObjectKey: cityObject.SlotKey,
-            DisplayName: cityObject.DisplayName,
-            PackageName: cityObject.PackageName,
-            ActualMeshCode: cityObject.ActualMeshCode,
-            LodLevel: cityObject.LodLevel,
-            Transform: new Transform3D(
-                ToContractFloat3(adjustedSlotPosition),
-                ToContractQuaternion(GridMeshTerrainRotation)),
-            Geometry: new TerrainGridGeometry(
-                Width: width,
-                Height: height,
-                Size: new Float2(extentX, extentZ),
-                MinHeight: minHeight,
-                MaxHeight: maxHeight,
-                HeightSamples: localHeights,
-                UvScale: heightMapUvScale,
-                UvOffset: heightMapUvOffset),
-            Materials: materials,
-            SourceFileRelativePath: cityObject.SourceFileRelativePath);
-        return true;
+            materialResolver,
+            progressReporter,
+            cancellationToken,
+            out heightMapCityObject);
     }
 
     private static MaterialBinding[] CreateDemTerrainGridMaterials(
@@ -1931,39 +1800,6 @@ internal static class LocalCityGmlObjectProjection
         return occupiedUvRect is { IsIdentity: true } ? null : occupiedUvRect;
     }
 
-    private static TextureUvRect? TryCreateDemTerrainGridOccupiedUvRect(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        IDefaultMaterialResolver materialResolver)
-    {
-        if (demTerrainTextureOverlay is null)
-        {
-            return null;
-        }
-
-        GeographicRectangle? demObjectBounds = TryGetDemObjectGeographicBounds(cityObject, demTerrainTextureOverlay);
-        ResolvedSurfaceMaterial? representativeSurface = CityGmlSurfaceMaterialResolver.ResolveSurfaces(
-                cityObject,
-                cityObjectOrigin,
-                cityObjectCartesian,
-                demTerrainTextureOverlay,
-                materialResolver)
-            .FirstOrDefault(static resolvedSurface => resolvedSurface.Surface.UsesGeneratedDemTexture);
-        if (representativeSurface is null)
-        {
-            return null;
-        }
-
-        TextureUvRect? occupiedUvRect = DemTerrainOverlayAssignment.TryCreateTerrainGridOccupiedUvRect(
-            cityObject,
-            representativeSurface,
-            demTerrainTextureOverlay,
-            demObjectBounds);
-        return occupiedUvRect is { IsIdentity: true } ? null : occupiedUvRect;
-    }
-
     private static GeographicRectangle? TryGetDemObjectGeographicBounds(
         ParsedCityObject cityObject,
         TerrainTextureOverlay? demTerrainTextureOverlay)
@@ -1975,19 +1811,6 @@ internal static class LocalCityGmlObjectProjection
         }
 
         return ResolveProjectionCityObjectGeographicBounds(cityObject);
-    }
-
-    private static GeographicRectangle? TryGetDemObjectGeographicBounds(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
-        TerrainTextureOverlay? demTerrainTextureOverlay)
-    {
-        if (demTerrainTextureOverlay is null
-            || !string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
-
-        return ResolveParsedCityObjectGeographicBounds(cityObject);
     }
 
     private static DemTerrainGridBounds CreateDemTerrainGridBounds(
@@ -2048,77 +1871,12 @@ internal static class LocalCityGmlObjectProjection
         return new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ);
     }
 
-    private static DemTerrainGridBounds CreateDemTerrainGridBounds(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin,
-        Float3 slotPosition,
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint globalOriginPoint,
-        LocalCartesian? globalCartesian,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        IReadOnlyList<Float3> positions)
-    {
-        double rawMinX = positions.Min(static position => position.X);
-        double rawMaxX = positions.Max(static position => position.X);
-        double rawMinZ = positions.Min(static position => position.Z);
-        double rawMaxZ = positions.Max(static position => position.Z);
-
-        if (demTerrainTextureOverlay is null)
-        {
-            return new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
-        }
-
-        GeographicRectangle clippedBounds = IntersectGeographicBounds(
-            ResolveParsedCityObjectGeographicBounds(cityObject),
-            demTerrainTextureOverlay.GeographicBounds);
-        double referenceLatitude = cityObjectOrigin.Latitude;
-        double referenceLongitude = cityObjectOrigin.Longitude;
-        Float3 westPosition = CreateGlobalTerrainGridLocalPosition(
-            new GeodeticPoint(referenceLatitude, clippedBounds.MinLongitude, cityObjectOrigin.Altitude),
-            slotPosition,
-            globalOriginPoint.ToProjectionModel(),
-            globalCartesian);
-        Float3 eastPosition = CreateGlobalTerrainGridLocalPosition(
-            new GeodeticPoint(referenceLatitude, clippedBounds.MaxLongitude, cityObjectOrigin.Altitude),
-            slotPosition,
-            globalOriginPoint.ToProjectionModel(),
-            globalCartesian);
-        Float3 southPosition = CreateGlobalTerrainGridLocalPosition(
-            new GeodeticPoint(clippedBounds.MinLatitude, referenceLongitude, cityObjectOrigin.Altitude),
-            slotPosition,
-            globalOriginPoint.ToProjectionModel(),
-            globalCartesian);
-        Float3 northPosition = CreateGlobalTerrainGridLocalPosition(
-            new GeodeticPoint(clippedBounds.MaxLatitude, referenceLongitude, cityObjectOrigin.Altitude),
-            slotPosition,
-            globalOriginPoint.ToProjectionModel(),
-            globalCartesian);
-
-        double clippedMinX = Math.Min(westPosition.X, eastPosition.X);
-        double clippedMaxX = Math.Max(westPosition.X, eastPosition.X);
-        double clippedMinZ = Math.Min(southPosition.Z, northPosition.Z);
-        double clippedMaxZ = Math.Max(southPosition.Z, northPosition.Z);
-
-        if ((clippedMaxX - clippedMinX) <= 1e-6 || (clippedMaxZ - clippedMinZ) <= 1e-6)
-        {
-            return new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
-        }
-
-        return new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ);
-    }
-
     private static GeographicRectangle ResolveProjectionCityObjectGeographicBounds(ParsedCityObject cityObject)
     {
         return CityObjectGeographicBoundsResolver.Resolve(
             cityObject.Surfaces.SelectMany(static surface => surface.Vertices),
             static point => point.Latitude,
             static point => point.Longitude);
-    }
-
-    private static GeographicRectangle ResolveParsedCityObjectGeographicBounds(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject)
-    {
-        return CityObjectGeographicBoundsResolver.Resolve(
-            cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
     }
 
     private static GeographicRectangle IntersectGeographicBounds(
@@ -2169,33 +1927,6 @@ internal static class LocalCityGmlObjectProjection
         {
             Float3[] positions = surface.ExteriorRing.Vertices
                 .Select(point => CreateGlobalTerrainGridLocalPosition(point, slotPosition, globalOriginPoint, globalCartesian))
-                .ToArray();
-            if (positions.Length < 3)
-            {
-                continue;
-            }
-
-            Float3 origin = positions[0];
-            for (int index = 1; index + 1 < positions.Length; index++)
-            {
-                triangles.Add(new TerrainGridTriangle(origin, positions[index], positions[index + 1]));
-            }
-        }
-
-        return triangles.ToArray();
-    }
-
-    private static TerrainGridTriangle[] CreateDemTerrainGridTriangles(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
-        Float3 slotPosition,
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint globalOriginPoint,
-        LocalCartesian? globalCartesian)
-    {
-        List<TerrainGridTriangle> triangles = [];
-        foreach (global::PlateauResoniteLink.Application.Importing.ParsedSurface surface in cityObject.Surfaces)
-        {
-            Float3[] positions = surface.ExteriorRing.Vertices
-                .Select(point => CreateGlobalTerrainGridLocalPosition(point.ToProjectionModel(), slotPosition, globalOriginPoint.ToProjectionModel(), globalCartesian))
                 .ToArray();
             if (positions.Length < 3)
             {

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -405,101 +405,12 @@ internal static class LocalCityGmlObjectProjection
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
-        double? geometryHeightMeters = cityObject.GeometryHeightMeters
-            ?? ResolveParsedGeometryHeightMeters(cityObject.Surfaces);
-        cityObject = GeneratedLod1RoofCityObjectFactory.Create(cityObject) with
-        {
-            GeometryHeightMeters = geometryHeightMeters,
-        };
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(cityObject);
-
-        LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
-            ? new LocalCartesian(
-                cityObjectOrigin.Latitude,
-                cityObjectOrigin.Longitude,
-                cityObjectOrigin.Altitude,
-                cityObject.ReferenceSystem.Geocentric)
-            : null;
-        Float3 slotPosition = CreateScenePosition(
-            cityObjectOrigin.ToProjectionModel(),
-            globalOriginPoint.ToProjectionModel(),
-            globalCartesian);
-        List<MeshVertex> vertices = [];
-        List<MeshSubmesh> submeshes = [];
-        List<MaterialBinding> materials = [];
-        DemUvProjection? demUvProjection = TryCreateDemUvProjection(cityObject.ActualMeshCode, demTerrainTextureOverlay);
-
-        List<ResolvedSurfaceMaterial> resolvedSurfaces =
-        [
-            .. CityGmlSurfaceMaterialResolver.ResolveSurfaces(
-                cityObject,
-                cityObjectOrigin,
-                cityObjectCartesian,
-                demTerrainTextureOverlay,
-                materialResolver),
-        ];
-
-        IGrouping<MaterialGroupingKey, ResolvedSurfaceMaterial>[] materialGroups = resolvedSurfaces
-            .GroupBy(
-                resolvedSurface => MaterialGroupingPolicy.CreateKey(
-                    cityObject.ActualMeshCode,
-                    resolvedSurface.Material,
-                    resolvedSurface.DepthOffset,
-                    resolvedSurface.Material.TextureScale,
-                    resolvedSurface.Surface.BaseColor,
-                    resolvedSurface.Material.TextureOffset))
-            .OrderBy(static group => group.Min(static surface => ParsedSurfaceStableSortKey.Create(surface.Surface)), StringComparer.Ordinal)
-            .ToArray();
-
-        for (int materialIndex = 0; materialIndex < materialGroups.Length; materialIndex++)
-        {
-            IGrouping<MaterialGroupingKey, ResolvedSurfaceMaterial> materialGroup = materialGroups[materialIndex];
-            List<int> indices = [];
-            FacadeUvProjectionContext? facadeUvProjectionContext = CityGmlSurfaceProjectionPolicy.TryCreateFacadeUvProjectionContext(
-                cityObject.PackageName,
-                cityObject.Surfaces,
-                cityObjectOrigin,
-                cityObjectCartesian);
-
-            foreach (ResolvedSurfaceMaterial resolvedSurface in materialGroup
-                         .OrderBy(static surface => ParsedSurfaceStableSortKey.Create(surface.Surface), StringComparer.Ordinal))
-            {
-                SurfaceMeshTessellation tessellation = CityGmlSurfaceMeshTessellator.Tessellate(
-                    new SurfaceMeshTessellationRequest(
-                        cityObject.PackageName,
-                        resolvedSurface.Surface,
-                        resolvedSurface.Material,
-                        cityObjectOrigin.ToProjectionModel(),
-                        cityObjectCartesian,
-                        globalOriginPoint.ToProjectionModel(),
-                        globalCartesian,
-                        facadeUvProjectionContext,
-                        demUvProjection));
-                int baseIndex = vertices.Count;
-                vertices.AddRange(tessellation.Vertices);
-                indices.AddRange(tessellation.Indices.Select(index => baseIndex + index));
-            }
-
-            if (indices.Count == 0)
-            {
-                continue;
-            }
-
-            ResolvedSurfaceMaterial representativeSurface = materialGroup.First();
-            submeshes.Add(new MeshSubmesh(materialIndex, indices));
-            materials.Add(CityGmlSurfaceMaterialResolver.CreateMaterialBinding(cityObject.ActualMeshCode, representativeSurface, materialIndex));
-        }
-
-        return new ImportedCityObject(
-            ObjectKey: cityObject.SlotKey,
-            DisplayName: cityObject.DisplayName,
-            PackageName: cityObject.PackageName,
-            ActualMeshCode: cityObject.ActualMeshCode,
-            LodLevel: cityObject.LodLevel,
-            Transform: new Transform3D(ToContractFloat3(slotPosition)),
-            Mesh: new ImportedMesh(vertices.ToArray(), submeshes.ToArray()),
-            Materials: materials,
-            SourceFileRelativePath: cityObject.SourceFileRelativePath);
+        return CityGmlTriangleMeshCityObjectProjection.Project(
+            cityObject,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlay,
+            materialResolver);
     }
 
     private static GeodeticPoint ResolveProjectionCityObjectOrigin(ParsedCityObject cityObject)
@@ -1035,45 +946,18 @@ internal static class LocalCityGmlObjectProjection
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(sourceFile);
-        ArgumentNullException.ThrowIfNull(referenceSystem);
-        ArgumentNullException.ThrowIfNull(globalOriginPoint);
-        ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(materialResolver);
-
-        CoordinateReferenceSystem projectionReferenceSystem = referenceSystem.ToProjectionModel();
-        ValidateCompatibleReferenceSystem(
-            projectionReferenceSystem,
-            sourceFile.CityObjects.FirstOrDefault()?.ReferenceSystem.ToProjectionModel() ?? projectionReferenceSystem);
-
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject[] projectedInputCityObjects =
-            global::PlateauResoniteLink.Application.Importing.DemCityObjectAggregation.AggregateBySourceFileAndThirdMesh(
-                sourceFile.SourceFile,
-                sourceFile.CityObjects);
-
-        foreach (global::PlateauResoniteLink.Application.Importing.ParsedCityObject parsedCityObject in projectedInputCityObjects)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (predicate is not null && !predicate(parsedCityObject))
-            {
-                continue;
-            }
-
-            foreach (ImportedCityObject cityObject in ProjectParsedCityObject(
-                         parsedCityObject,
-                         globalOriginPoint,
-                         globalCartesian,
-                         demTerrainTextureOverlays,
-                         requestedMeshCodeBounds,
-                         terrainHeightSampler: null,
-                         request,
-                         materialResolver,
-                         progressReporter,
-                         cancellationToken))
-            {
-                yield return cityObject;
-            }
-        }
+        return CityGmlParsedCityObjectProjection.ProjectSourceFile(
+            sourceFile,
+            referenceSystem,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlays,
+            requestedMeshCodeBounds,
+            request,
+            materialResolver,
+            predicate,
+            progressReporter,
+            cancellationToken);
     }
 
     internal static IEnumerable<ImportedCityObject> ProjectParsedCityObject(
@@ -1088,108 +972,17 @@ internal static class LocalCityGmlObjectProjection
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(parsedCityObject);
-        ArgumentNullException.ThrowIfNull(globalOriginPoint);
-        ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(materialResolver);
-
-        double? geometryHeightMeters = ResolveParsedGeometryHeightMeters(parsedCityObject.Surfaces);
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject terrainAlignedParsedCityObject =
-            GeneratedLod1RoofCityObjectFactory.Create(ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler)) with
-            {
-                GeometryHeightMeters = geometryHeightMeters,
-            };
-        List<ImportedCityObject> projectedCityObjects = [];
-        List<ImportedCityObject> generatedRoadMarkings = [];
-
-        foreach ((global::PlateauResoniteLink.Application.Importing.ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
-                 in TerrainOverlayProjectionSplitPolicy.SplitParsedCityObject(
-                     terrainAlignedParsedCityObject,
-                     demTerrainTextureOverlays,
-                     requestedMeshCodeBounds,
-                     progressReporter,
-                     cancellationToken))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (!TerrainOverlayProjectionSplitPolicy.ShouldProjectSplit(
-                    splitCityObject.CityObject.ActualMeshCode,
-                    request.MeshCode,
-                    requestedMeshCodeBounds,
-                    splitCityObject.Overlay))
-            {
-                throw CreateTerrainOverlayMeshCodeMismatchException(
-                    "project",
-                    splitCityObject.CityObject.ActualMeshCode,
-                    request.MeshCode,
-                    requestedMeshCodeBounds,
-                    splitCityObject.Overlay);
-            }
-
-            ImportedCityObject cityObject = ProjectTerrainMeshModeCityObject(
-                splitCityObject.CityObject,
-                globalOriginPoint,
-                globalCartesian,
-                splitCityObject.Overlay,
-                request,
-                requestedMeshCodeBounds,
-                materialResolver,
-                progressReporter,
-                cancellationToken);
-
-            if (HasRenderableGeometry(cityObject))
-            {
-                projectedCityObjects.Add(cityObject);
-            }
-
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint markingOrigin = ResolveParsedCityObjectOrigin(splitCityObject.CityObject);
-            LocalCartesian? markingCartesian = splitCityObject.CityObject.ReferenceSystem.IsGeographic
-                ? new LocalCartesian(
-                    markingOrigin.Latitude,
-                    markingOrigin.Longitude,
-                    markingOrigin.Altitude,
-                    splitCityObject.CityObject.ReferenceSystem.Geocentric)
-                : null;
-            global::PlateauResoniteLink.Application.Importing.ParsedCityObject? roadMarkingCityObject = GeneratedRoadMarkingCityObjectFactory.Create(
-                splitCityObject.CityObject,
-                markingOrigin,
-                markingCartesian);
-            if (roadMarkingCityObject is null)
-            {
-                continue;
-            }
-
-            ImportedCityObject markingObject = ProjectCityObject(
-                roadMarkingCityObject,
-                globalOriginPoint,
-                globalCartesian,
-                splitCityObject.Overlay,
-                materialResolver) with
-            {
-                CollisionEnabled = false,
-            };
-            if (HasRenderableGeometry(markingObject))
-            {
-                generatedRoadMarkings.Add(markingObject);
-            }
-        }
-
-        ImportedCityObject[] alignedCityObjects =
-            request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
-            && string.Equals(terrainAlignedParsedCityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
-                ? DemTerrainGridChunkBoundaryAlignmentPolicy.Align(projectedCityObjects)
-                : [.. projectedCityObjects];
-
-        foreach (ImportedCityObject cityObject in alignedCityObjects)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            yield return cityObject;
-        }
-
-        foreach (ImportedCityObject markingObject in generatedRoadMarkings)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            yield return markingObject;
-        }
+        return CityGmlParsedCityObjectProjection.Project(
+            parsedCityObject,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlays,
+            requestedMeshCodeBounds,
+            terrainHeightSampler,
+            request,
+            materialResolver,
+            progressReporter,
+            cancellationToken);
     }
 
     internal static IEnumerable<MaterialBinding> EnumerateCommonMaterialsForParsedCityObject(
@@ -1202,218 +995,15 @@ internal static class LocalCityGmlObjectProjection
         PlateauImportRequest request,
         IDefaultMaterialResolver materialResolver)
     {
-        ArgumentNullException.ThrowIfNull(parsedCityObject);
-        ArgumentNullException.ThrowIfNull(globalOriginPoint);
-        ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(materialResolver);
-
-        double? geometryHeightMeters = ResolveParsedGeometryHeightMeters(parsedCityObject.Surfaces);
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject terrainAlignedParsedCityObject =
-            GeneratedLod1RoofCityObjectFactory.Create(ConformCityObjectToTerrain(parsedCityObject, terrainHeightSampler)) with
-            {
-                GeometryHeightMeters = geometryHeightMeters,
-            };
-
-        foreach ((global::PlateauResoniteLink.Application.Importing.ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
-                 in TerrainOverlayProjectionSplitPolicy.SplitParsedCityObject(
-                     terrainAlignedParsedCityObject,
-                     demTerrainTextureOverlays,
-                     requestedMeshCodeBounds))
-        {
-            if (!TerrainOverlayProjectionSplitPolicy.ShouldProjectSplit(
-                    splitCityObject.CityObject.ActualMeshCode,
-                    request.MeshCode,
-                    requestedMeshCodeBounds ?? [],
-                    splitCityObject.Overlay))
-            {
-                throw CreateTerrainOverlayMeshCodeMismatchException(
-                    "common-material-enumeration",
-                    splitCityObject.CityObject.ActualMeshCode,
-                    request.MeshCode,
-                    requestedMeshCodeBounds,
-                    splitCityObject.Overlay);
-            }
-
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(splitCityObject.CityObject);
-            LocalCartesian? cityObjectCartesian = splitCityObject.CityObject.ReferenceSystem.IsGeographic
-                ? new LocalCartesian(
-                    cityObjectOrigin.Latitude,
-                    cityObjectOrigin.Longitude,
-                    cityObjectOrigin.Altitude,
-                    splitCityObject.CityObject.ReferenceSystem.Geocentric)
-                : null;
-
-            foreach (MaterialBinding material in request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
-                         && string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
-                            ? CityGmlSurfaceMaterialResolver.CreateDemTerrainGridMaterials(
-                                splitCityObject.CityObject,
-                                cityObjectOrigin,
-                                cityObjectCartesian,
-                                splitCityObject.Overlay,
-                                request.MeshCode,
-                                requestedMeshCodeBounds,
-                                materialResolver)
-                            : CityGmlSurfaceMaterialResolver.CreateSharedCommonMaterialBindings(
-                                splitCityObject.CityObject,
-                                cityObjectOrigin,
-                                cityObjectCartesian,
-                                splitCityObject.Overlay,
-                                materialResolver))
-            {
-                yield return material;
-            }
-        }
-    }
-
-    private static ImportedCityObject ProjectTerrainMeshModeCityObject(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject,
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint globalOriginPoint,
-        LocalCartesian? globalCartesian,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        PlateauImportRequest request,
-        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
-        IDefaultMaterialResolver materialResolver,
-        Action<string>? progressReporter,
-        CancellationToken cancellationToken)
-    {
-        bool isDem = string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase);
-        if (!isDem || request.TerrainMeshMode == TerrainMeshMode.Static)
-        {
-            return ProjectCityObject(cityObject, globalOriginPoint, globalCartesian, demTerrainTextureOverlay, materialResolver);
-        }
-
-        bool hasGrid = TryProjectDemTerrainGridCityObject(
-            cityObject,
+        return CityGmlParsedCityObjectProjection.EnumerateCommonMaterials(
+            parsedCityObject,
             globalOriginPoint,
             globalCartesian,
-            demTerrainTextureOverlay,
-            request,
+            demTerrainTextureOverlays,
             requestedMeshCodeBounds,
-            materialResolver,
-            progressReporter,
-            cancellationToken,
-            out ImportedCityObject? heightMapCityObject);
-        if (!hasGrid)
-        {
-            return request.TerrainMeshMode == TerrainMeshMode.Dynamic
-                ? CreateNonRenderableCityObject(cityObject)
-                : ProjectCityObject(cityObject, globalOriginPoint, globalCartesian, demTerrainTextureOverlay, materialResolver);
-        }
-
-        if (request.TerrainMeshMode == TerrainMeshMode.Grid)
-        {
-            return heightMapCityObject!;
-        }
-
-        ImportedCityObject staticCityObject = ProjectCityObject(
-            cityObject,
-            globalOriginPoint,
-            globalCartesian,
-            demTerrainTextureOverlay,
-            materialResolver);
-        TriangleMeshGeometry staticMesh = AssertTriangleMeshGeometry(staticCityObject);
-        TriangleMeshGeometry rebasedStaticMesh = TriangleMeshTransformRebaser.Rebase(
-            staticMesh,
-            staticCityObject.Transform,
-            heightMapCityObject!.Transform);
-        return heightMapCityObject with
-        {
-            Geometry = new DynamicTerrainGeometry(rebasedStaticMesh, AssertTerrainGridGeometry(heightMapCityObject)),
-            Materials = staticCityObject.Materials,
-        };
-    }
-
-    private static ImportedCityObject CreateNonRenderableCityObject(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject)
-    {
-        return new ImportedCityObject(
-            cityObject.SlotKey,
-            cityObject.DisplayName,
-            cityObject.PackageName,
-            cityObject.ActualMeshCode,
-            cityObject.LodLevel,
-            new Transform3D(new Float3(0.0, 0.0, 0.0)),
-            new TriangleMeshGeometry(new ImportedMesh([], [])),
-            [],
-            SourceFileRelativePath: cityObject.SourceFileRelativePath);
-    }
-
-    private static global::PlateauResoniteLink.Application.Importing.ParsedCityObject ConformCityObjectToTerrain(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject parsedCityObject,
-        ProjectionTerrainHeightSampler? terrainHeightSampler)
-    {
-        if (terrainHeightSampler is null
-            || !ShouldTerrainAlignCityObject(parsedCityObject))
-        {
-            return parsedCityObject;
-        }
-
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject subdividedCityObject =
-            SubdivideTerrainAlignedCityObject(parsedCityObject);
-        global::PlateauResoniteLink.Application.Importing.GeodeticPoint cityObjectOrigin = ResolveParsedCityObjectOrigin(subdividedCityObject);
-        LocalCartesian? cityObjectCartesian = subdividedCityObject.ReferenceSystem.IsGeographic
-            ? new LocalCartesian(
-                cityObjectOrigin.Latitude,
-                cityObjectOrigin.Longitude,
-                cityObjectOrigin.Altitude,
-                subdividedCityObject.ReferenceSystem.Geocentric)
-            : null;
-
-        TerrainConformanceResult conformance = CityGmlTerrainConformer.Conform(
-            subdividedCityObject,
             terrainHeightSampler,
-            cityObjectOrigin,
-            cityObjectCartesian);
-
-        return conformance.TerrainAligned
-            ? subdividedCityObject with
-            {
-                Surfaces = conformance.Surfaces,
-                TerrainAligned = true,
-            }
-            : subdividedCityObject;
-    }
-
-    private static global::PlateauResoniteLink.Application.Importing.ParsedCityObject SubdivideTerrainAlignedCityObject(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject)
-    {
-        if (!ShouldSubdivideTerrainAlignedCityObject(cityObject))
-        {
-            return cityObject;
-        }
-
-        List<global::PlateauResoniteLink.Application.Importing.ParsedSurface> subdividedSurfaces = [];
-        foreach (global::PlateauResoniteLink.Application.Importing.ParsedSurface surface in cityObject.Surfaces)
-        {
-            subdividedSurfaces.AddRange(SubdivideTransportationSurfaceForTerrainAlignment(surface, cityObject));
-        }
-
-        return subdividedSurfaces.Count == cityObject.Surfaces.Length
-            ? cityObject
-            : cityObject with { Surfaces = subdividedSurfaces.ToArray() };
-    }
-
-    private static bool ShouldSubdivideTerrainAlignedCityObject(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject)
-    {
-        return ShouldSubdivideTerrainAlignedCityObject(cityObject.PackageName, cityObject.LodLevel);
-    }
-
-    private static bool ShouldTerrainAlignCityObject(
-        global::PlateauResoniteLink.Application.Importing.ParsedCityObject cityObject)
-    {
-        return CityGmlTerrainConformer.ShouldTerrainAlign(cityObject.PackageName, cityObject.LodLevel);
-    }
-
-    private static bool ShouldSubdivideTerrainAlignedCityObject(string packageName, int? lodLevel)
-    {
-        return PlateauPackageCatalog.IsRoadPackage(packageName)
-            && (!lodLevel.HasValue || lodLevel.Value < 3);
-    }
-
-    private static bool ShouldTerrainAlignCityObject(string packageName, int? lodLevel)
-    {
-        return CityGmlTerrainConformer.ShouldTerrainAlign(packageName, lodLevel);
+            request,
+            materialResolver);
     }
 
     private static MaterialBinding[] CreateCommonMaterialBindings(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -3608,28 +3608,21 @@ public sealed class LocalCityGmlObjectProjectionTests
         GeodeticPoint globalOriginPoint,
         PlateauImportRequest request)
     {
-        MethodInfo method = typeof(LocalCityGmlObjectProjection).GetMethod(
-                "ProjectTerrainMeshModeCityObject",
-                BindingFlags.NonPublic | BindingFlags.Static)
-            ?? throw new InvalidOperationException("Failed to resolve ProjectTerrainMeshModeCityObject.");
         IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds =
             MeshCodeBounds.TryParse(request.MeshCode) is { } parsedRequestedMeshCodeBounds
                 ? [parsedRequestedMeshCodeBounds]
                 : [];
 
-        return (ImportedCityObject)method.Invoke(
-            null,
-            [
-                cityObject,
-                globalOriginPoint,
-                null,
-                null,
-                request,
-                requestedMeshCodeBounds,
-                new DefaultMaterialResolver(CommonMaterialCatalog.Create()),
-                null,
-                CancellationToken.None,
-            ])!;
+        return CityGmlParsedCityObjectProjection.ProjectTerrainMeshModeCityObject(
+            cityObject,
+            globalOriginPoint,
+            globalCartesian: null,
+            demTerrainTextureOverlay: null,
+            request,
+            requestedMeshCodeBounds,
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create()),
+            progressReporter: null,
+            CancellationToken.None);
     }
 
     private static void AssertGeneratedUpperFacadeTrianglesFaceOutward(


### PR DESCRIPTION
## Summary
- Extract top-level parsed CityGML object orchestration into `CityGmlParsedCityObjectProjection`.
- Extract top-level triangle mesh object projection into `CityGmlTriangleMeshCityObjectProjection`.
- Keep `LocalCityGmlObjectProjection` as a compatibility entrypoint while removing parsed projection orchestration, terrain mesh mode selection, road-marking emission, and dynamic terrain mesh assembly from it.
- Move the dynamic terrain mode reflection test to the new projection boundary instead of preserving the old private method shape.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (863 passed)