### PR TITLE
Consolidate projection material resolution

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -12,7 +12,6 @@ internal static class CityGmlSurfaceMaterialResolver
 {
     internal static readonly MaterialDepthOffset TerrainAlignedDepthOffset = new(-10.0, -10.0);
 
-    private const double BuildingBottomCullBandMeters = 0.1;
     private const double UnknownRoofBottomAltitudeToleranceMeters = 0.1;
     private static readonly ColorRgba DefaultMaterialColor = new(1.0, 1.0, 1.0, 1.0);
     private static readonly ColorRgba DefaultVegetationMaterialColor = new(0.32, 0.58, 0.24, 1.0);
@@ -28,7 +27,7 @@ internal static class CityGmlSurfaceMaterialResolver
         ArgumentNullException.ThrowIfNull(cityObjectOrigin);
         ArgumentNullException.ThrowIfNull(materialResolver);
 
-        HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
+        HashSet<string> culledSurfaceIds = CityGmlSurfaceProjectionPolicy.GetCulledSurfaceIdsBeforeProjection(
             cityObject.PackageName,
             cityObject.Surfaces,
             cityObjectOrigin,
@@ -332,7 +331,7 @@ internal static class CityGmlSurfaceMaterialResolver
         if (!PlateauPackageCatalog.IsBuildingPackage(packageName))
         {
             return PlateauPackageCatalog.IsPathLikePackage(packageName)
-                && IsNearHorizontalSurface(surface, cityObjectOrigin, cityObjectCartesian);
+                && CityGmlSurfaceProjectionPolicy.IsNearHorizontalSurface(surface, cityObjectOrigin, cityObjectCartesian);
         }
 
         if (surface.Semantic is ParsedSurfaceSemantic.Wall)
@@ -348,7 +347,7 @@ internal static class CityGmlSurfaceMaterialResolver
             return false;
         }
 
-        return IsFacadeSurface(surface, cityObjectOrigin, cityObjectCartesian);
+        return CityGmlSurfaceProjectionPolicy.IsFacadeSurface(surface, cityObjectOrigin, cityObjectCartesian);
     }
 
     private static DefaultMaterialSurfaceRole ToDefaultMaterialSurfaceRole(ParsedSurfaceSemantic semantic)
@@ -384,7 +383,7 @@ internal static class CityGmlSurfaceMaterialResolver
             return false;
         }
 
-        Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
+        Float3? normal = CityGmlSurfaceProjectionPolicy.ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
         return normal is not null
             && Math.Abs(normal.Y) >= 0.98
             && surface.Vertices.Min(static vertex => vertex.Altitude) > cityObjectMinAltitude + UnknownRoofBottomAltitudeToleranceMeters;
@@ -404,144 +403,5 @@ internal static class CityGmlSurfaceMaterialResolver
                 || Math.Abs(color.A - 1.0) > 1e-6);
     }
 
-    private static HashSet<string> GetCulledSurfaceIdsBeforeProjection(
-        string packageName,
-        IEnumerable<ParsedSurface> surfaces,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        if (!PlateauPackageCatalog.IsBuildingPackage(packageName))
-        {
-            return [];
-        }
-
-        SurfaceProjectionInfo[] candidates = surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
-
-        if (candidates.Length == 0)
-        {
-            return [];
-        }
-
-        double objectMinimumY = candidates.Min(static info => info.MinimumY!.Value);
-        double objectMaximumY = candidates.Max(static info => info.MaximumY!.Value);
-
-        return candidates
-            .Where(static info => info.IsNearHorizontal)
-            .Where(info => info.MaximumY!.Value <= objectMinimumY + BuildingBottomCullBandMeters)
-            .Where(info => objectMaximumY > info.MaximumY!.Value + BuildingBottomCullBandMeters)
-            .Select(static info => info.Surface.PolygonId)
-            .ToHashSet(StringComparer.Ordinal);
-    }
-
-    private static bool IsFacadeSurface(
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        if (ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian) is not Float3 normal)
-        {
-            return false;
-        }
-
-        return Math.Abs(normal.Y) < 0.45;
-    }
-
-    private static bool IsNearHorizontalSurface(
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
-        return normal is not null && Math.Abs(normal.Y) >= 0.98;
-    }
-
-    private static SurfaceProjectionInfo CreateSurfaceProjectionInfo(
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        Float3[] positions = surface.Vertices
-            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
-            .ToArray();
-        if (positions.Length == 0)
-        {
-            return new SurfaceProjectionInfo(surface, null, null, false);
-        }
-
-        Float3? normal = ComputePolygonNormal(positions);
-        bool isNearHorizontal = normal is not null && Math.Abs(normal.Y) >= 0.98;
-
-        return new SurfaceProjectionInfo(
-            surface,
-            positions.Min(static position => position.Y),
-            positions.Max(static position => position.Y),
-            isNearHorizontal);
-    }
-
-    private static Float3? ComputeSurfaceNormal(
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        Float3[] positions = surface.Vertices
-            .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
-            .ToArray();
-        return ComputePolygonNormal(positions);
-    }
-
-    private static Float3 CreateScenePosition(
-        GeodeticPoint point,
-        GeodeticPoint origin,
-        LocalCartesian? cartesian)
-    {
-        return SceneAxisMapper.CreatePosition(
-            point.Latitude,
-            point.Longitude,
-            point.Altitude,
-            origin.Latitude,
-            origin.Longitude,
-            origin.Altitude,
-            cartesian);
-    }
-
-    private static Float3? ComputePolygonNormal(IEnumerable<Float3> positions)
-    {
-        Float3[] points = positions.ToArray();
-        if (points.Length < 3)
-        {
-            return null;
-        }
-
-        double normalX = 0.0;
-        double normalY = 0.0;
-        double normalZ = 0.0;
-
-        for (int index = 0; index < points.Length; index++)
-        {
-            Float3 current = points[index];
-            Float3 next = points[(index + 1) % points.Length];
-            normalX += (current.Y - next.Y) * (current.Z + next.Z);
-            normalY += (current.Z - next.Z) * (current.X + next.X);
-            normalZ += (current.X - next.X) * (current.Y + next.Y);
-        }
-
-        double magnitude = Math.Sqrt((normalX * normalX) + (normalY * normalY) + (normalZ * normalZ));
-        if (magnitude < 1e-8)
-        {
-            return null;
-        }
-
-        return new Float3(normalX / magnitude, normalY / magnitude, normalZ / magnitude);
-    }
-
     private static ColorRgba ToContractColor(ColorRgba value) => new(value.R, value.G, value.B, value.A);
-
-    private readonly record struct SurfaceProjectionInfo(
-        ParsedSurface Surface,
-        double? MinimumY,
-        double? MaximumY,
-        bool IsNearHorizontal);
 }

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -17,7 +17,6 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal static class LocalCityGmlObjectProjection
 {
-    private const double UnknownRoofBottomAltitudeToleranceMeters = 0.1;
     public const string DefaultDemTerrainTexturePath = DemTerrainTextureDefaults.PlateauOrthoPath;
     public const string DefaultDemTerrainTextureUrlTemplate = DemTerrainTextureDefaults.PlateauOrthoUrlTemplate;
     public const string DefaultDemTerrainTextureFallbackUrlTemplate = DemTerrainTextureDefaults.GsiFallbackUrlTemplate;
@@ -36,8 +35,6 @@ internal static class LocalCityGmlObjectProjection
         Y: 0.0,
         Z: 0.0,
         W: Math.Sqrt(0.5));
-    private static readonly ColorRgba DefaultMaterialColor = new(1.0, 1.0, 1.0, 1.0);
-    private static readonly ColorRgba DefaultVegetationMaterialColor = new(0.32, 0.58, 0.24, 1.0);
     private static readonly XNamespace Gml = "http://www.opengis.net/gml";
 
     internal static TerrainTextureOverlay[] CreateDemTerrainTextureOverlays(
@@ -238,13 +235,6 @@ internal static class LocalCityGmlObjectProjection
             cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
     }
 
-    private static double ResolveProjectionMinimumAltitude(IEnumerable<ParsedSurface> surfaces)
-    {
-        return CityObjectAltitudeMetricsResolver.GetMinimumAltitude(
-            surfaces.SelectMany(static surface => surface.Vertices),
-            static point => point.Altitude);
-    }
-
     private static double ResolveParsedMinimumAltitude(
         IEnumerable<global::PlateauResoniteLink.Application.Importing.ParsedSurface> surfaces)
     {
@@ -257,182 +247,6 @@ internal static class LocalCityGmlObjectProjection
     {
         return CityObjectAltitudeMetricsResolver.TryGetGeometryHeightMeters(
             surfaces.SelectMany(static surface => surface.Vertices));
-    }
-
-    private static ResolvedSurfaceMaterial ResolveSurfaceMaterial(
-        ParsedCityObject cityObject,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian,
-        ParsedSurface surface,
-        double cityObjectMinAltitude,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        IDefaultMaterialResolver materialResolver)
-    {
-        global::PlateauResoniteLink.Application.Importing.ParsedSurface resolvedSurface =
-            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(surface);
-        if (surface.UsesGeneratedDemTexture)
-        {
-            return new ResolvedSurfaceMaterial(
-                resolvedSurface,
-                new ResolvedMaterial(
-                    MaterialType.Standard,
-                    TexturePayload: null,
-                    TextureSourceKind.Dataset,
-                    MaterialProjection.Uv,
-                    Family: null,
-                    TextureScale: null,
-                    ReuseScope: MaterialReuseScope.PerObject,
-                    TerrainOverlay: demTerrainTextureOverlay),
-                DepthOffset: null);
-        }
-
-        ResolvedMaterial? roofTerrainTextureMaterial = TryCreateRoofTerrainTextureMaterial(
-            cityObject.ActualMeshCode,
-            cityObject.PackageName,
-            surface,
-            cityObjectMinAltitude,
-            demTerrainTextureOverlay,
-            cityObjectOrigin,
-            cityObjectCartesian);
-        if (roofTerrainTextureMaterial is not null)
-        {
-            return new ResolvedSurfaceMaterial(
-                resolvedSurface with { BaseColor = DefaultMaterialColor },
-                roofTerrainTextureMaterial,
-                DepthOffset: null);
-        }
-
-        if (string.Equals(cityObject.PackageName, "veg", StringComparison.OrdinalIgnoreCase)
-            && surface.TexturePayload is null)
-        {
-            if (HasExplicitMaterialColor(surface.BaseColor))
-            {
-                return new ResolvedSurfaceMaterial(
-                    resolvedSurface,
-                    new ResolvedMaterial(
-                        MaterialType.VertexColor,
-                        TexturePayload: null,
-                        TextureSourceKind.Bundled,
-                        MaterialProjection.Uv,
-                        Family: null,
-                        TextureScale: null,
-                        ReuseScope: MaterialReuseScope.PerObject),
-                    DepthOffset: null);
-            }
-
-            return new ResolvedSurfaceMaterial(
-                resolvedSurface with { BaseColor = DefaultVegetationMaterialColor },
-                new ResolvedMaterial(
-                    MaterialType.Standard,
-                    TexturePayload: null,
-                    TextureSourceKind.Bundled,
-                    MaterialProjection.Uv,
-                    Family: null,
-                    TextureScale: null,
-                    ReuseScope: MaterialReuseScope.PerObject),
-                DepthOffset: null);
-        }
-
-        if (IsGeneratedRoadMarkingSurface(surface))
-        {
-            return new ResolvedSurfaceMaterial(
-                resolvedSurface,
-                new ResolvedMaterial(
-                    MaterialType.VertexColor,
-                    TexturePayload: null,
-                    TextureSourceKind.Bundled,
-                    MaterialProjection.Uv,
-                    Family: null,
-                    TextureScale: null,
-                    ReuseScope: MaterialReuseScope.PerObject),
-                DefaultTerrainAlignedMaterialDepthOffset);
-        }
-
-        bool preferUvProjection = ShouldPreferUvProjection(
-            cityObject.PackageName,
-            surface,
-            cityObjectOrigin,
-            cityObjectCartesian);
-        ResolvedMaterial resolvedMaterial = materialResolver.ResolveMaterial(new DefaultMaterialRequest(
-            cityObject.PackageName,
-            surface.TexturePayload,
-            preferUvProjection,
-            FamilyOverride: null,
-            VariantSelectionKey: $"{cityObject.SlotKey}:{(preferUvProjection ? "uv" : "triplanar")}",
-            BuildingAttributes: cityObject.BuildingAttributes,
-            FloorsAboveGround: cityObject.FloorsAboveGround,
-            MeasuredHeightMeters: cityObject.MeasuredHeightMeters,
-            GeometryHeightMeters: cityObject.GeometryHeightMeters,
-            FootprintAreaSquareMeters: cityObject.BuildingAttributes is null
-                ? null
-                : BuildingAttributeQueries.TryGetKnownPositiveMetric(cityObject.BuildingAttributes.BuildingFootprintArea),
-            SurfaceRole: ToDefaultMaterialSurfaceRole(surface.Semantic)));
-        MaterialDepthOffset? depthOffset = cityObject.TerrainAligned
-            ? DefaultTerrainAlignedMaterialDepthOffset
-            : null;
-        return new ResolvedSurfaceMaterial(resolvedSurface, resolvedMaterial, depthOffset);
-    }
-
-    private static ResolvedMaterial? TryCreateRoofTerrainTextureMaterial(
-        string actualMeshCode,
-        string packageName,
-        ParsedSurface surface,
-        double cityObjectMinAltitude,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        if (demTerrainTextureOverlay is null
-            || TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, demTerrainTextureOverlay) is null
-            || surface.TexturePayload is not null
-            || !IsBuildingPackage(packageName)
-            || !IsRoofTerrainTextureSurface(surface, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian))
-        {
-            return null;
-        }
-
-        return new ResolvedMaterial(
-            MaterialType.Standard,
-            TexturePayload: null,
-            TextureSourceKind.Dataset,
-            MaterialProjection.Uv,
-            Family: null,
-            TextureScale: null,
-            ReuseScope: MaterialReuseScope.PerObject,
-            TerrainOverlay: demTerrainTextureOverlay);
-    }
-
-    private static bool IsRoofTerrainTextureSurface(
-        ParsedSurface surface,
-        double cityObjectMinAltitude,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        if (surface.Semantic == ParsedSurfaceSemantic.Roof)
-        {
-            return true;
-        }
-
-        if (surface.Semantic is not (ParsedSurfaceSemantic.Unknown
-            or ParsedSurfaceSemantic.Ground
-            or ParsedSurfaceSemantic.OuterCeiling
-            or ParsedSurfaceSemantic.OuterFloor))
-        {
-            return false;
-        }
-
-        Float3? normal = ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
-        return normal is not null
-            && Math.Abs(normal.Y) >= 0.98
-            && IsAboveCityObjectBottomAltitude(surface, cityObjectMinAltitude);
-    }
-
-    private static bool IsAboveCityObjectBottomAltitude(
-        ParsedSurface surface,
-        double cityObjectMinAltitude)
-    {
-        double surfaceMinAltitude = surface.Vertices.Min(static vertex => vertex.Altitude);
-        return surfaceMinAltitude > cityObjectMinAltitude + UnknownRoofBottomAltitudeToleranceMeters;
     }
 
     private static DemUvProjection? TryCreateDemUvProjection(
@@ -492,12 +306,6 @@ internal static class LocalCityGmlObjectProjection
         double height = Math.Max(south - north, 1e-12);
 
         return new DemUvProjection(west, south, width, height);
-    }
-
-    private static bool IsBuildingPackage(string packageName)
-    {
-        return string.Equals(packageName, "bldg", StringComparison.Ordinal)
-            || string.Equals(packageName, "ubld", StringComparison.Ordinal);
     }
 
     private static Float3? ComputePolygonNormal(IEnumerable<Float3> positions)
@@ -594,122 +402,6 @@ internal static class LocalCityGmlObjectProjection
     private static string FormatRounded(double value) =>
         TerrainOverlayDiagnostics.FormatRounded(value);
 
-    private static bool ShouldPreferUvProjection(
-        string packageName,
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        if (surface.TexturePayload is not null)
-        {
-            return true;
-        }
-
-        if (string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        if (!IsBuildingPackage(packageName))
-        {
-            return PlateauPackageCatalog.IsPathLikePackage(packageName)
-                && IsNearHorizontalSurface(surface, cityObjectOrigin, cityObjectCartesian);
-        }
-
-        if (surface.Semantic is ParsedSurfaceSemantic.Wall)
-        {
-            return true;
-        }
-
-        if (surface.Semantic is ParsedSurfaceSemantic.Roof
-            or ParsedSurfaceSemantic.Ground
-            or ParsedSurfaceSemantic.OuterCeiling
-            or ParsedSurfaceSemantic.OuterFloor)
-        {
-            return false;
-        }
-
-        return IsFacadeSurface(surface, cityObjectOrigin, cityObjectCartesian);
-    }
-
-    private static DefaultMaterialSurfaceRole ToDefaultMaterialSurfaceRole(ParsedSurfaceSemantic semantic)
-    {
-        return semantic switch
-        {
-            ParsedSurfaceSemantic.Wall => DefaultMaterialSurfaceRole.Wall,
-            ParsedSurfaceSemantic.Roof => DefaultMaterialSurfaceRole.Roof,
-            ParsedSurfaceSemantic.Ground => DefaultMaterialSurfaceRole.Ground,
-            ParsedSurfaceSemantic.Closure => DefaultMaterialSurfaceRole.Closure,
-            ParsedSurfaceSemantic.OuterCeiling => DefaultMaterialSurfaceRole.OuterCeiling,
-            ParsedSurfaceSemantic.OuterFloor => DefaultMaterialSurfaceRole.OuterFloor,
-            _ => DefaultMaterialSurfaceRole.Unknown,
-        };
-    }
-
-    private static bool IsFacadeSurface(
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        return CityGmlSurfaceProjectionPolicy.IsFacadeSurface(
-            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(surface),
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
-            cityObjectCartesian);
-    }
-
-    private static bool IsNearHorizontalSurface(
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        return CityGmlSurfaceProjectionPolicy.IsNearHorizontalSurface(
-            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(surface),
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
-            cityObjectCartesian);
-    }
-
-    private static HashSet<string> GetCulledSurfaceIdsBeforeProjection(
-        string packageName,
-        IEnumerable<ParsedSurface> surfaces,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        return CityGmlSurfaceProjectionPolicy.GetCulledSurfaceIdsBeforeProjection(
-            packageName,
-            surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel),
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
-            cityObjectCartesian);
-    }
-
-    private static Float3? ComputeSurfaceNormal(
-        ParsedSurface surface,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        return CityGmlSurfaceProjectionPolicy.ComputeSurfaceNormal(
-            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(surface),
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
-            cityObjectCartesian);
-    }
-
-    private static FacadeUvProjectionContext? TryCreateFacadeUvProjectionContext(
-        string packageName,
-        IEnumerable<ParsedSurface> surfaces,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        return CityGmlSurfaceProjectionPolicy.TryCreateFacadeUvProjectionContext(
-            packageName,
-            surfaces.Select(global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel),
-            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
-            cityObjectCartesian);
-    }
-
-    private static bool IsGeneratedRoadMarkingSurface(ParsedSurface surface)
-    {
-        return surface.PolygonId.Contains("_generated_marking", StringComparison.Ordinal);
-    }
-
     private static string NormalizePath(string path)
     {
         return path.Replace(Path.DirectorySeparatorChar, '/');
@@ -720,14 +412,6 @@ internal static class LocalCityGmlObjectProjection
         return Math.Abs(left.Latitude - right.Latitude) < 1e-8
             && Math.Abs(left.Longitude - right.Longitude) < 1e-8
             && Math.Abs(left.Altitude - right.Altitude) < 1e-8;
-    }
-
-    private static bool HasExplicitMaterialColor(ColorRgba color)
-    {
-        return Math.Abs(color.R - DefaultMaterialColor.R) >= 1e-8
-            || Math.Abs(color.G - DefaultMaterialColor.G) >= 1e-8
-            || Math.Abs(color.B - DefaultMaterialColor.B) >= 1e-8
-            || Math.Abs(color.A - DefaultMaterialColor.A) >= 1e-8;
     }
 
     internal static IEnumerable<ImportedCityObject> ProjectCityObjects(
@@ -810,46 +494,12 @@ internal static class LocalCityGmlObjectProjection
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
-        HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
-            cityObject.PackageName,
-            cityObject.Surfaces,
-            cityObjectOrigin,
-            cityObjectCartesian);
-        double cityObjectMinAltitude = ResolveProjectionMinimumAltitude(cityObject.Surfaces);
-        List<ResolvedSurfaceMaterial> resolvedSurfaces =
-        [
-            .. cityObject.Surfaces
-                .Where(surface => !culledSurfaceIds.Contains(surface.PolygonId))
-                .Select(surface => ResolveSurfaceMaterial(
-                    cityObject,
-                    cityObjectOrigin,
-                    cityObjectCartesian,
-                    surface,
-                    cityObjectMinAltitude,
-                    demTerrainTextureOverlay,
-                    materialResolver)),
-        ];
-
-        return resolvedSurfaces
-            .GroupBy(
-                resolvedSurface => MaterialGroupingPolicy.CreateKey(
-                    cityObject.ActualMeshCode,
-                    resolvedSurface.Material,
-                    resolvedSurface.DepthOffset,
-                    resolvedSurface.Material.TextureScale,
-                    resolvedSurface.Surface.BaseColor,
-                    resolvedSurface.Material.TextureOffset))
-            .OrderBy(static group => group.Min(static surface => ParsedSurfaceStableSortKey.Create(surface.Surface)), StringComparer.Ordinal)
-            .Select((group, materialIndex) =>
-            {
-                ResolvedSurfaceMaterial representativeSurface = group.First();
-                return CreateMaterialBinding(
-                    cityObject.ActualMeshCode,
-                    representativeSurface,
-                    materialIndex);
-            })
-            .Where(static material => material.ReuseScope == MaterialReuseScope.Shared)
-            .ToArray();
+        return CityGmlSurfaceMaterialResolver.CreateSharedCommonMaterialBindings(
+            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(cityObject),
+            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            cityObjectCartesian,
+            demTerrainTextureOverlay,
+            materialResolver);
     }
 
     private static bool TryProjectDemTerrainGridCityObject(
@@ -1021,123 +671,14 @@ internal static class LocalCityGmlObjectProjection
         IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
         IDefaultMaterialResolver materialResolver)
     {
-        HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjection(
-            cityObject.PackageName,
-            cityObject.Surfaces,
-            cityObjectOrigin,
-            cityObjectCartesian);
-        double cityObjectMinAltitude = ResolveProjectionMinimumAltitude(cityObject.Surfaces);
-        List<ResolvedSurfaceMaterial> resolvedSurfaces =
-        [
-            .. cityObject.Surfaces
-                .Where(surface => !culledSurfaceIds.Contains(surface.PolygonId))
-                .Select(surface => ResolveSurfaceMaterial(
-                    cityObject,
-                    cityObjectOrigin,
-                    cityObjectCartesian,
-                    surface,
-                    cityObjectMinAltitude,
-                    demTerrainTextureOverlay,
-                    materialResolver)),
-        ];
-
-        return resolvedSurfaces
-            .GroupBy(
-                resolvedSurface => MaterialGroupingPolicy.CreateKey(
-                    TerrainOverlayMeshCodeResolver.ResolveMaterialMeshCodeSource(
-                        cityObject.ActualMeshCode,
-                        requestedMeshCode,
-                        requestedMeshCodeBounds,
-                        resolvedSurface.Material.TerrainOverlay),
-                    resolvedSurface.Material,
-                    resolvedSurface.DepthOffset,
-                    resolvedSurface.Material.TextureScale,
-                    resolvedSurface.Surface.BaseColor,
-                    resolvedSurface.Material.TextureOffset))
-            .OrderBy(static group => group.Min(static surface => ParsedSurfaceStableSortKey.Create(surface.Surface)), StringComparer.Ordinal)
-            .Select((group, materialIndex) =>
-            {
-                ResolvedSurfaceMaterial representativeSurface = group.First();
-                string terrainMaterialMeshCodeSource = TerrainOverlayMeshCodeResolver.ResolveMaterialMeshCodeSource(
-                    cityObject.ActualMeshCode,
-                    requestedMeshCode,
-                    requestedMeshCodeBounds,
-                    representativeSurface.Material.TerrainOverlay);
-                return CreateMaterialBinding(
-                    terrainMaterialMeshCodeSource,
-                    representativeSurface,
-                    materialIndex);
-            })
-            .ToArray();
-    }
-
-    private static MaterialBinding CreateMaterialBinding(
-        string actualMeshCode,
-        ResolvedSurfaceMaterial representativeSurface,
-        int materialIndex)
-    {
-        string? terrainMeshCode = representativeSurface.Material.TerrainOverlay is null
-            ? null
-            : TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, representativeSurface.Material.TerrainOverlay)
-                ?? throw CreateTerrainOverlayMeshCodeMismatchException(
-                    "material-binding",
-                    actualMeshCode,
-                    actualMeshCode,
-                    requestedMeshCodeBounds: null,
-                    representativeSurface.Material.TerrainOverlay);
-        ColorRgba baseColor = representativeSurface.Material.TerrainOverlay is null
-            ? ToContractColor(representativeSurface.Surface.BaseColor)
-            : new ColorRgba(1.0, 1.0, 1.0, 1.0);
-        DefaultCommonMaterialMember? commonMaterial = DefaultCommonMaterialAssignment.Resolve(
-            baseColor,
-            representativeSurface.Material.MaterialType,
-            representativeSurface.Material.TexturePayload,
-            representativeSurface.Material.TextureSourceKind,
-            representativeSurface.Material.Projection,
-            representativeSurface.DepthOffset,
-            representativeSurface.Material.TextureScale,
-            representativeSurface.Material.TextureOffset,
-            representativeSurface.Material.TerrainOverlay,
-            representativeSurface.Material.CommonMaterial);
-        return new MaterialBinding(
-            BaseColor: baseColor,
-            MaterialType: representativeSurface.Material.MaterialType,
-            TexturePayload: representativeSurface.Material.TexturePayload is null
-                ? null
-                : representativeSurface.Material.TexturePayload,
-            TextureSourceKind: representativeSurface.Material.TextureSourceKind,
-            Projection: representativeSurface.Material.Projection,
-            DepthOffset: representativeSurface.DepthOffset is null
-                ? null
-                : representativeSurface.DepthOffset,
-            SubmeshIndices: [materialIndex],
-            TextureScale: representativeSurface.Material.TextureScale is null
-                ? null
-                : representativeSurface.Material.TextureScale,
-            Family: representativeSurface.Material.Family,
-            TextureOffset: representativeSurface.Material.TextureOffset is null
-                ? null
-                : representativeSurface.Material.TextureOffset,
-            ReuseScope: representativeSurface.Material.ReuseScope,
-            TerrainOverlay: representativeSurface.Material.TerrainOverlay,
-            BundledVariantIndex: representativeSurface.Material.BundledVariantIndex,
-            TerrainMeshCode: terrainMeshCode,
-            CommonMaterial: commonMaterial);
-    }
-
-    private static InvalidOperationException CreateTerrainOverlayMeshCodeMismatchException(
-        string phase,
-        string actualMeshCode,
-        string requestedMeshCode,
-        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
-        TerrainTextureOverlay? terrainOverlay)
-    {
-        return TerrainOverlayDiagnostics.CreateMeshCodeMismatchException(
-            phase,
-            actualMeshCode,
+        return CityGmlSurfaceMaterialResolver.CreateDemTerrainGridMaterials(
+            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(cityObject),
+            global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            cityObjectCartesian,
+            demTerrainTextureOverlay,
             requestedMeshCode,
             requestedMeshCodeBounds,
-            terrainOverlay);
+            materialResolver);
     }
 
     private static Float2 ToContractFloat2(ScalarPair value) => new(value.X, value.Y);
@@ -1147,8 +688,6 @@ internal static class LocalCityGmlObjectProjection
     private static Float3 ToContractFloat3(Float3 value) => new(value.X, value.Y, value.Z);
 
     private static Quaternion ToContractQuaternion(Quaternion value) => new(value.X, value.Y, value.Z, value.W);
-
-    private static ColorRgba ToContractColor(ColorRgba value) => new(value.R, value.G, value.B, value.A);
 
     private static TextureUvRect? TryCreateDemTerrainGridOccupiedUvRect(
         ParsedCityObject cityObject,
@@ -1163,16 +702,14 @@ internal static class LocalCityGmlObjectProjection
         }
 
         GeographicRectangle? demObjectBounds = TryGetDemObjectGeographicBounds(cityObject, demTerrainTextureOverlay);
-        double cityObjectMinAltitude = ResolveProjectionMinimumAltitude(cityObject.Surfaces);
-        ResolvedSurfaceMaterial? representativeSurface = cityObject.Surfaces
-            .Select(surface => ResolveSurfaceMaterial(
-                cityObject,
-                cityObjectOrigin,
+        global::PlateauResoniteLink.Application.Importing.ParsedCityObject parsedCityObject =
+            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(cityObject);
+        ResolvedSurfaceMaterial? representativeSurface = CityGmlSurfaceMaterialResolver.ResolveSurfaces(
+                parsedCityObject,
+                global::PlateauResoniteLink.Application.Importing.GeodeticPoint.FromProjectionModel(cityObjectOrigin),
                 cityObjectCartesian,
-                surface,
-                cityObjectMinAltitude,
                 demTerrainTextureOverlay,
-                materialResolver))
+                materialResolver)
             .FirstOrDefault(static resolvedSurface => resolvedSurface.Surface.UsesGeneratedDemTexture);
         if (representativeSurface is null)
         {
@@ -1180,7 +717,7 @@ internal static class LocalCityGmlObjectProjection
         }
 
         TextureUvRect? occupiedUvRect = DemTerrainOverlayAssignment.TryCreateTerrainGridOccupiedUvRect(
-            global::PlateauResoniteLink.Application.Importing.CityGmlProjectionModelAdapter.FromProjectionModel(cityObject),
+            parsedCityObject,
             representativeSurface,
             demTerrainTextureOverlay,
             demObjectBounds);

--- a/src/PlateauResoniteLink/Application/Importing/ParsedSurfaceStableSortKey.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ParsedSurfaceStableSortKey.cs
@@ -11,51 +11,16 @@ internal static class ParsedSurfaceStableSortKey
 {
     internal static string Create(ParsedSurface surface)
     {
-        return Create(
-            surface.PolygonId,
-            (int)surface.Semantic,
-            surface.ExteriorRing,
-            surface.InteriorRings,
-            static ring => ring.RingId,
-            static ring => ring.Vertices,
-            static ring => ring.UVs,
-            WritePoint);
-    }
-
-    internal static string Create(LocalCityGmlObjectProjection.ParsedSurface surface)
-    {
-        return Create(
-            surface.PolygonId,
-            (int)surface.Semantic,
-            surface.ExteriorRing,
-            surface.InteriorRings,
-            static ring => ring.RingId,
-            static ring => ring.Vertices,
-            static ring => ring.UVs,
-            WritePoint);
-    }
-
-    private static string Create<TRing, TPoint>(
-        string polygonId,
-        int semanticValue,
-        TRing exteriorRing,
-        IReadOnlyCollection<TRing> interiorRings,
-        Func<TRing, string> getRingId,
-        Func<TRing, IReadOnlyCollection<TPoint>> getVertices,
-        Func<TRing, IReadOnlyList<Float2>?> getUvs,
-        Action<BinaryWriter, TPoint> writePoint)
-        where TPoint : notnull
-    {
         using MemoryStream stream = new();
         using (BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true))
         {
-            writer.Write(polygonId);
-            writer.Write(semanticValue);
-            WriteRing(writer, exteriorRing, getRingId, getVertices, getUvs, writePoint);
-            writer.Write(interiorRings.Count);
-            foreach (TRing ring in interiorRings.OrderBy(getRingId, StringComparer.Ordinal))
+            writer.Write(surface.PolygonId);
+            writer.Write((int)surface.Semantic);
+            WriteRing(writer, surface.ExteriorRing);
+            writer.Write(surface.InteriorRings.Length);
+            foreach (ParsedRing ring in surface.InteriorRings.OrderBy(static ring => ring.RingId, StringComparer.Ordinal))
             {
-                WriteRing(writer, ring, getRingId, getVertices, getUvs, writePoint);
+                WriteRing(writer, ring);
             }
         }
 
@@ -63,24 +28,16 @@ internal static class ParsedSurfaceStableSortKey
         return Convert.ToHexString(hash.AsSpan(0, 16)).ToLowerInvariant();
     }
 
-    private static void WriteRing<TRing, TPoint>(
-        BinaryWriter writer,
-        TRing ring,
-        Func<TRing, string> getRingId,
-        Func<TRing, IReadOnlyCollection<TPoint>> getVertices,
-        Func<TRing, IReadOnlyList<Float2>?> getUvs,
-        Action<BinaryWriter, TPoint> writePoint)
-        where TPoint : notnull
+    private static void WriteRing(BinaryWriter writer, ParsedRing ring)
     {
-        writer.Write(getRingId(ring));
-        IReadOnlyCollection<TPoint> vertices = getVertices(ring);
-        writer.Write(vertices.Count);
-        foreach (TPoint vertex in vertices)
+        writer.Write(ring.RingId);
+        writer.Write(ring.Vertices.Length);
+        foreach (GeodeticPoint vertex in ring.Vertices)
         {
-            writePoint(writer, vertex);
+            WritePoint(writer, vertex);
         }
 
-        IReadOnlyList<Float2>? uvs = getUvs(ring);
+        IReadOnlyList<Float2>? uvs = ring.UVs;
         writer.Write(uvs?.Count ?? -1);
         if (uvs is null)
         {
@@ -101,10 +58,4 @@ internal static class ParsedSurfaceStableSortKey
         writer.Write(vertex.Altitude);
     }
 
-    private static void WritePoint(BinaryWriter writer, LocalCityGmlObjectProjection.GeodeticPoint vertex)
-    {
-        writer.Write(vertex.Latitude);
-        writer.Write(vertex.Longitude);
-        writer.Write(vertex.Altitude);
-    }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -108,7 +107,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     public void GeneratedFacadeUvProjection_UsesFloorUnitsForBuildingWalls()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
-        LocalCityGmlObjectProjection.GeodeticPoint origin = new(35.0, 139.0, 0.0);
+        GeodeticPoint origin = new(35.0, 139.0, 0.0);
         GeographicLib.LocalCartesian cartesian = new(
             origin.Latitude,
             origin.Longitude,
@@ -116,16 +115,16 @@ public sealed class LocalCityGmlObjectProjectionTests
             referenceSystem.Geocentric);
         double longitudeDelta = FacadeFloorMetrics.DefaultFloorUnitMeters
             / (111320.0 * Math.Cos(origin.Latitude * (Math.PI / 180.0)));
-        LocalCityGmlObjectProjection.GeodeticPoint[] wallVertices =
+        GeodeticPoint[] wallVertices =
         [
             origin,
             new(origin.Latitude, origin.Longitude + longitudeDelta, 0.0),
             new(origin.Latitude, origin.Longitude + longitudeDelta, FacadeFloorMetrics.DefaultFloorUnitMeters),
             new(origin.Latitude, origin.Longitude, FacadeFloorMetrics.DefaultFloorUnitMeters),
         ];
-        LocalCityGmlObjectProjection.ParsedSurface wallSurface = CreateParsedSurface(
+        ParsedSurface wallSurface = CreateParsedSurface(
             "wall",
-            LocalCityGmlObjectProjection.ParsedSurfaceSemantic.Wall,
+            ParsedSurfaceSemantic.Wall,
             [.. wallVertices, wallVertices[0]]);
 
         MeshVertex[] vertices = TessellateSurfaceForTest(wallSurface, "bldg", origin, cartesian).Vertices;
@@ -146,23 +145,23 @@ public sealed class LocalCityGmlObjectProjectionTests
     public void GeneratedFacadeUvProjection_AlignsVerticalPhaseToBuildingBottomAndTop()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
-        LocalCityGmlObjectProjection.GeodeticPoint origin = new(35.0, 139.0, 2.0);
+        GeodeticPoint origin = new(35.0, 139.0, 2.0);
         GeographicLib.LocalCartesian cartesian = new(
             origin.Latitude,
             origin.Longitude,
             origin.Altitude,
             referenceSystem.Geocentric);
         double longitudeDelta = 7.0 / (111320.0 * Math.Cos(origin.Latitude * (Math.PI / 180.0)));
-        LocalCityGmlObjectProjection.GeodeticPoint[] wallVertices =
+        GeodeticPoint[] wallVertices =
         [
             origin,
             new(origin.Latitude, origin.Longitude + longitudeDelta, 2.0),
             new(origin.Latitude, origin.Longitude + longitudeDelta, 9.0),
             new(origin.Latitude, origin.Longitude, 9.0),
         ];
-        LocalCityGmlObjectProjection.ParsedSurface wallSurface = CreateParsedSurface(
+        ParsedSurface wallSurface = CreateParsedSurface(
             "wall",
-            LocalCityGmlObjectProjection.ParsedSurfaceSemantic.Wall,
+            ParsedSurfaceSemantic.Wall,
             [.. wallVertices, wallVertices[0]]);
 
         MeshVertex[] vertices = TessellateSurfaceForTest(
@@ -1943,14 +1942,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjectionForTest(
             "bldg",
-            [
-                CityGmlProjectionModelAdapter.ToProjectionModel(wallSurface),
-                CityGmlProjectionModelAdapter.ToProjectionModel(roofSurface),
-                CityGmlProjectionModelAdapter.ToProjectionModel(groundSurface),
-                CityGmlProjectionModelAdapter.ToProjectionModel(reversedGroundSurface),
-                CityGmlProjectionModelAdapter.ToProjectionModel(outerFloorSurface),
-                CityGmlProjectionModelAdapter.ToProjectionModel(highOuterFloorSurface),
-            ],
+            [wallSurface, roofSurface, groundSurface, reversedGroundSurface, outerFloorSurface, highOuterFloorSurface],
             origin,
             cartesian);
 
@@ -1997,7 +1989,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjectionForTest(
             "tran",
-            [CityGmlProjectionModelAdapter.ToProjectionModel(groundSurface)],
+            [groundSurface],
             origin,
             cartesian);
 
@@ -2055,12 +2047,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjectionForTest(
             "bldg",
-            [
-                CityGmlProjectionModelAdapter.ToProjectionModel(wallSurface),
-                CityGmlProjectionModelAdapter.ToProjectionModel(bottomSurface),
-                CityGmlProjectionModelAdapter.ToProjectionModel(reversedBottomSurface),
-                CityGmlProjectionModelAdapter.ToProjectionModel(roofSurface),
-            ],
+            [wallSurface, bottomSurface, reversedBottomSurface, roofSurface],
             origin,
             cartesian);
 
@@ -2105,10 +2092,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjectionForTest(
             "bldg",
-            [
-                CityGmlProjectionModelAdapter.ToProjectionModel(bottomSurface),
-                CityGmlProjectionModelAdapter.ToProjectionModel(highDownwardRoofSurface),
-            ],
+            [bottomSurface, highDownwardRoofSurface],
             origin,
             cartesian);
 
@@ -2134,7 +2118,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjectionForTest(
             "bldg",
-            [CityGmlProjectionModelAdapter.ToProjectionModel(onlySurface)],
+            [onlySurface],
             origin,
             cartesian);
 
@@ -2190,12 +2174,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         HashSet<string> culledSurfaceIds = GetCulledSurfaceIdsBeforeProjectionForTest(
             "bldg",
-            [
-                CityGmlProjectionModelAdapter.ToProjectionModel(wallSurface),
-                CityGmlProjectionModelAdapter.ToProjectionModel(exactBoundaryBottomSurface),
-                CityGmlProjectionModelAdapter.ToProjectionModel(aboveBoundaryBottomSurface),
-                CityGmlProjectionModelAdapter.ToProjectionModel(roofSurface),
-            ],
+            [wallSurface, exactBoundaryBottomSurface, aboveBoundaryBottomSurface, roofSurface],
             origin,
             cartesian);
 
@@ -3257,9 +3236,9 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     private static SurfaceMeshTessellation TessellateSurfaceForTest(
-        LocalCityGmlObjectProjection.ParsedSurface surface,
+        ParsedSurface surface,
         string packageName,
-        LocalCityGmlObjectProjection.GeodeticPoint cityObjectOrigin,
+        GeodeticPoint cityObjectOrigin,
         GeographicLib.LocalCartesian cartesian,
         double minimumY = 0.0,
         double? maximumY = null,
@@ -3284,28 +3263,14 @@ public sealed class LocalCityGmlObjectProjectionTests
             ReuseScope: MaterialReuseScope.PerObject);
         return CityGmlSurfaceMeshTessellator.Tessellate(new SurfaceMeshTessellationRequest(
             packageName,
-            CityGmlProjectionModelAdapter.FromProjectionModel(surface),
+            surface,
             material,
-            GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            cityObjectOrigin,
             cartesian,
-            GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            cityObjectOrigin,
             cartesian,
             context,
             DemUvProjection: null));
-    }
-
-    private static LocalCityGmlObjectProjection.ParsedSurface CreateParsedSurface(
-        string polygonId,
-        LocalCityGmlObjectProjection.ParsedSurfaceSemantic semantic,
-        IReadOnlyList<LocalCityGmlObjectProjection.GeodeticPoint> vertices)
-    {
-        return new LocalCityGmlObjectProjection.ParsedSurface(
-            polygonId,
-            semantic,
-            new LocalCityGmlObjectProjection.ParsedRing($"{polygonId}-ring", vertices.ToArray(), null),
-            [],
-            new ColorRgba(1.0, 1.0, 1.0, 1.0),
-            TexturePayload: null);
     }
 
     private static ParsedCityObject CreateParsedCityObject(
@@ -3411,6 +3376,23 @@ public sealed class LocalCityGmlObjectProjectionTests
             PolygonId: polygonId,
             Semantic: semantic,
             ExteriorRing: new ParsedRing($"{polygonId}-ring", vertices.Select(GeodeticPoint.FromProjectionModel).ToArray(), UVs: uvs),
+            InteriorRings: [],
+            BaseColor: baseColor ?? new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: texturePayload);
+    }
+
+    private static ParsedSurface CreateParsedSurface(
+        string polygonId,
+        ParsedSurfaceSemantic semantic,
+        IReadOnlyList<GeodeticPoint> vertices,
+        TexturePayload? texturePayload = null,
+        ColorRgba? baseColor = null,
+        IReadOnlyList<Float2>? uvs = null)
+    {
+        return new ParsedSurface(
+            PolygonId: polygonId,
+            Semantic: semantic,
+            ExteriorRing: new ParsedRing($"{polygonId}-ring", vertices.ToArray(), UVs: uvs),
             InteriorRings: [],
             BaseColor: baseColor ?? new ColorRgba(1.0, 1.0, 1.0, 1.0),
             TexturePayload: texturePayload);
@@ -3573,15 +3555,15 @@ public sealed class LocalCityGmlObjectProjectionTests
 
     private static HashSet<string> GetCulledSurfaceIdsBeforeProjectionForTest(
         string packageName,
-        IEnumerable<LocalCityGmlObjectProjection.ParsedSurface> surfaces,
+        IEnumerable<ParsedSurface> surfaces,
         LocalCityGmlObjectProjection.GeodeticPoint cityObjectOrigin,
         GeographicLib.LocalCartesian cartesian)
     {
-        MethodInfo method = typeof(LocalCityGmlObjectProjection).GetMethod(
-                "GetCulledSurfaceIdsBeforeProjection",
-                BindingFlags.NonPublic | BindingFlags.Static)
-            ?? throw new InvalidOperationException("Failed to resolve GetCulledSurfaceIdsBeforeProjection.");
-        return (HashSet<string>)method.Invoke(null, [packageName, surfaces, cityObjectOrigin, cartesian])!;
+        return CityGmlSurfaceProjectionPolicy.GetCulledSurfaceIdsBeforeProjection(
+            packageName,
+            surfaces,
+            GeodeticPoint.FromProjectionModel(cityObjectOrigin),
+            cartesian);
     }
 
     private static MaterialBinding[] CreateCommonMaterialBindingsForTest(


### PR DESCRIPTION
## Summary
- route legacy projection material grouping through `CityGmlSurfaceMaterialResolver`
- remove duplicated material, culling, stable-sort, and reflection-based test paths from the compatibility edge
- keep behavior tests on parsed-model contracts while preserving legacy entry points

## Verification
- `dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~ParsedSurfaceStableSortKeyTests|FullyQualifiedName~CityGmlSurfaceProjectionPolicyTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests" --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- official sequence from CONTRIBUTING: restore, format whitespace, build Release, test Release