### PR TITLE
Extract terrain texture tile source reader

### DIFF
--- a/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
@@ -16,7 +16,7 @@ public sealed record TerrainTextureTileSource(string UrlTemplate, int ZoomLevel)
         ? throw new ArgumentException("Terrain texture tile URL template must be provided.", nameof(UrlTemplate))
         : UrlTemplate;
 
-    public int ZoomLevel { get; init; } = ZoomLevel > 0
+    public int ZoomLevel { get; init; } = ZoomLevel is > 0 and <= WebMercatorTileMath.MaxZoomLevel
         ? ZoomLevel
         : throw new ArgumentOutOfRangeException(nameof(ZoomLevel));
 

--- a/src/PlateauResoniteLink/Domain/Importing/WebMercatorTileMath.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/WebMercatorTileMath.cs
@@ -7,6 +7,7 @@ namespace PlateauResoniteLink.Domain.Importing;
 public static class WebMercatorTileMath
 {
     public const int TileSizePixels = 256;
+    public const int MaxZoomLevel = 30;
     public const double MaxLatitude = 85.05112878;
     private const double DegreesToRadians = Math.PI / 180.0;
     private const double RadiansToDegrees = 180.0 / Math.PI;

--- a/src/PlateauResoniteLink/Targets/Resonite/PersistentTerrainTileCache.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/PersistentTerrainTileCache.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class PersistentTerrainTileCache
+{
+    private readonly string cacheRoot;
+
+    public PersistentTerrainTileCache(string? cacheRoot)
+    {
+        this.cacheRoot = Path.GetFullPath(cacheRoot ?? GetDefaultCacheRoot());
+    }
+
+    public async Task<byte[]?> TryReadTileBytesAsync(
+        string urlTemplate,
+        int zoomLevel,
+        int tileX,
+        int tileY,
+        CancellationToken cancellationToken)
+    {
+        string cachePath = GetCachePath(urlTemplate, zoomLevel, tileX, tileY);
+        if (!File.Exists(cachePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            return await File.ReadAllBytesAsync(cachePath, cancellationToken);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    public async Task WriteTileBytesAsync(
+        string urlTemplate,
+        int zoomLevel,
+        int tileX,
+        int tileY,
+        byte[] encodedBytes,
+        CancellationToken cancellationToken)
+    {
+        string cachePath = GetCachePath(urlTemplate, zoomLevel, tileX, tileY);
+        Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
+
+        string temporaryPath = $"{cachePath}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            await File.WriteAllBytesAsync(temporaryPath, encodedBytes, cancellationToken);
+            File.Move(temporaryPath, cachePath, overwrite: true);
+        }
+        catch
+        {
+            if (File.Exists(temporaryPath))
+            {
+                File.Delete(temporaryPath);
+            }
+
+            throw;
+        }
+    }
+
+    private string GetCachePath(string urlTemplate, int zoomLevel, int tileX, int tileY)
+    {
+        string templateDigest = Convert.ToHexString(
+                SHA256.HashData(Encoding.UTF8.GetBytes(urlTemplate)))
+            .ToLowerInvariant();
+        return Path.Combine(
+            cacheRoot,
+            templateDigest,
+            zoomLevel.ToString(CultureInfo.InvariantCulture),
+            tileX.ToString(CultureInfo.InvariantCulture),
+            $"{tileY.ToString(CultureInfo.InvariantCulture)}.tile");
+    }
+
+    private static string GetDefaultCacheRoot()
+    {
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "PlateauResoniteLink",
+            "terrain-tile-cache");
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -53,15 +51,13 @@ internal sealed class TerrainTextureAssetGenerator(
     string? persistentCacheRoot = null,
     bool disablePersistentCache = false) : ITerrainTextureAssetGenerator
 {
-    private const int MaxTileDownloadAttempts = 4;
     // Approximate dry brown soil tone (Munsell 10YR 5/3 family) for uncovered DEM texels.
     internal static readonly Rgba32 DefaultDemGroundFillColor = new(181, 176, 166, byte.MaxValue);
 
-    private readonly HttpClient httpClient = httpClient ?? new HttpClient();
     private readonly AsyncCompletedResultCache<TerrainTextureOverlay, CachedTerrainTexture> cachedTextures = new();
-    private readonly PersistentTerrainTileCache? persistentTileCache = disablePersistentCache
-        ? null
-        : new PersistentTerrainTileCache(persistentCacheRoot);
+    private readonly TerrainTextureTileSourceReader tileSourceReader = new(
+        httpClient ?? new HttpClient(),
+        disablePersistentCache ? null : new PersistentTerrainTileCache(persistentCacheRoot));
 
     public async Task<GeneratedTerrainTexture> EnsureTextureAsync(
         TerrainTextureOverlay terrainTextureOverlay,
@@ -90,7 +86,7 @@ internal sealed class TerrainTextureAssetGenerator(
             TerrainTextureSource terrainTextureSource = terrainTextureOverlay.Sources[sourceIndex];
             TerrainTextureSourceImage? sourceImage = terrainTextureSource switch
             {
-                TerrainTextureTileSource tileSource => await TryCreateTextureFromTileSourceAsync(
+                TerrainTextureTileSource tileSource => await tileSourceReader.TryCreateAsync(
                     terrainTextureOverlay,
                     tileSource,
                     cancellationToken),
@@ -155,123 +151,6 @@ internal sealed class TerrainTextureAssetGenerator(
         }
     }
 
-    private static ExpandedTileCrop CreateExpandedTileCrop(
-        TerrainTextureLayoutPlan layoutPlan,
-        int zoomLevel,
-        int maxTextureSize)
-    {
-        int canvasWidth = RoundUpToPowerOfTwo(layoutPlan.CropWidth);
-        int canvasHeight = RoundUpToPowerOfTwo(layoutPlan.CropHeight);
-        if (canvasWidth > maxTextureSize || canvasHeight > maxTextureSize)
-        {
-            return ExpandedTileCrop.FromLayout(layoutPlan);
-        }
-
-        int occupiedLeft = (canvasWidth - layoutPlan.CropWidth) / 2;
-        int occupiedTop = (canvasHeight - layoutPlan.CropHeight) / 2;
-        int layoutGlobalLeft = (layoutPlan.MinTileX * WebMercatorTileMath.TileSizePixels) + layoutPlan.CropLeft;
-        int layoutGlobalTop = (layoutPlan.MinTileY * WebMercatorTileMath.TileSizePixels) + layoutPlan.CropTop;
-        int expandedGlobalLeft = layoutGlobalLeft - occupiedLeft;
-        int expandedGlobalTop = layoutGlobalTop - occupiedTop;
-        int expandedGlobalRight = expandedGlobalLeft + canvasWidth;
-        int expandedGlobalBottom = expandedGlobalTop + canvasHeight;
-        int maxTileIndex = (1 << zoomLevel) - 1;
-        int minTileX = Math.Clamp((int)Math.Floor(expandedGlobalLeft / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
-        int maxTileX = Math.Clamp((int)Math.Floor((expandedGlobalRight - 1) / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
-        int minTileY = Math.Clamp((int)Math.Floor(expandedGlobalTop / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
-        int maxTileY = Math.Clamp((int)Math.Floor((expandedGlobalBottom - 1) / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
-        int stitchedWidth = (maxTileX - minTileX + 1) * WebMercatorTileMath.TileSizePixels;
-        int stitchedHeight = (maxTileY - minTileY + 1) * WebMercatorTileMath.TileSizePixels;
-        int cropLeft = Math.Clamp(expandedGlobalLeft - (minTileX * WebMercatorTileMath.TileSizePixels), 0, Math.Max(0, stitchedWidth - canvasWidth));
-        int cropTop = Math.Clamp(expandedGlobalTop - (minTileY * WebMercatorTileMath.TileSizePixels), 0, Math.Max(0, stitchedHeight - canvasHeight));
-        int actualCropWidth = Math.Min(canvasWidth, stitchedWidth - cropLeft);
-        int actualCropHeight = Math.Min(canvasHeight, stitchedHeight - cropTop);
-        if (actualCropWidth <= 0 || actualCropHeight <= 0)
-        {
-            return ExpandedTileCrop.FromLayout(layoutPlan);
-        }
-
-        int occupiedX = Math.Clamp(
-            layoutGlobalLeft - ((minTileX * WebMercatorTileMath.TileSizePixels) + cropLeft),
-            0,
-            actualCropWidth - 1);
-        int occupiedY = Math.Clamp(
-            layoutGlobalTop - ((minTileY * WebMercatorTileMath.TileSizePixels) + cropTop),
-            0,
-            actualCropHeight - 1);
-        TextureUvRect occupiedUvRect = TextureUvRect.FromTopLeftPixelRect(
-            occupiedX,
-            occupiedY,
-            Math.Min(layoutPlan.CropWidth, actualCropWidth - occupiedX),
-            Math.Min(layoutPlan.CropHeight, actualCropHeight - occupiedY),
-            actualCropWidth,
-            actualCropHeight);
-        return new ExpandedTileCrop(
-            minTileX,
-            maxTileX,
-            minTileY,
-            maxTileY,
-            stitchedWidth,
-            stitchedHeight,
-            cropLeft,
-            cropTop,
-            actualCropWidth,
-            actualCropHeight,
-            occupiedUvRect);
-    }
-
-    private async Task<TerrainTextureSourceImage?> TryCreateTextureFromTileSourceAsync(
-        TerrainTextureOverlay terrainTextureOverlay,
-        TerrainTextureTileSource tileSource,
-        CancellationToken cancellationToken)
-    {
-        TerrainTextureLayoutPlan layoutPlan = TerrainTextureLayoutPlanner.Create(
-            terrainTextureOverlay.GeographicBounds,
-            tileSource.ZoomLevel);
-        ExpandedTileCrop tileCrop = CreateExpandedTileCrop(layoutPlan, tileSource.ZoomLevel, terrainTextureOverlay.MaxTextureSize);
-        using Image<Rgba32> stitchedImage = new(tileCrop.StitchedWidth, tileCrop.StitchedHeight);
-        bool anyTileRendered = false;
-        for (int tileY = tileCrop.MinTileY; tileY <= tileCrop.MaxTileY; tileY++)
-        {
-            for (int tileX = tileCrop.MinTileX; tileX <= tileCrop.MaxTileX; tileX++)
-            {
-                Image<Rgba32>? tileImage = await TryDownloadTileAsync(
-                    tileSource,
-                    tileX,
-                    tileY,
-                    cancellationToken);
-                if (tileImage is null)
-                {
-                    continue;
-                }
-
-                using (tileImage)
-                {
-                    anyTileRendered = true;
-                    stitchedImage.Mutate(context => context.DrawImage(
-                        tileImage,
-                        new Point(
-                            (tileX - tileCrop.MinTileX) * WebMercatorTileMath.TileSizePixels,
-                            (tileY - tileCrop.MinTileY) * WebMercatorTileMath.TileSizePixels),
-                        1.0f));
-                }
-            }
-        }
-
-        if (!anyTileRendered)
-        {
-            return null;
-        }
-
-        return new TerrainTextureSourceImage(
-            stitchedImage.Clone(context => context.Crop(new Rectangle(
-                tileCrop.CropLeft,
-                tileCrop.CropTop,
-                tileCrop.CropWidth,
-                tileCrop.CropHeight))),
-            tileCrop.OccupiedUvRect);
-    }
-
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Reliability",
         "CA2000:Dispose objects before losing scope",
@@ -333,7 +212,7 @@ internal sealed class TerrainTextureAssetGenerator(
             return generatedTexture!;
         }
 
-        int fallbackMaxTextureSize = RoundDownToPowerOfTwo(maxTextureSize);
+        int fallbackMaxTextureSize = TexturePowerOfTwo.RoundDown(maxTextureSize);
         using Image<Rgba32> resizedImage = ResizeToMaxTextureSize(opaqueImage, fallbackMaxTextureSize);
         if (TryCreatePowerOfTwoCanvasTexture(resizedImage, fallbackMaxTextureSize, usedSource, usedSources, null, out generatedTexture))
         {
@@ -352,8 +231,8 @@ internal sealed class TerrainTextureAssetGenerator(
         TextureUvRect? sourceOccupiedUvRect,
         out GeneratedTerrainTexture? generatedTexture)
     {
-        int canvasWidth = RoundUpToPowerOfTwo(image.Width);
-        int canvasHeight = RoundUpToPowerOfTwo(image.Height);
+        int canvasWidth = TexturePowerOfTwo.RoundUp(image.Width);
+        int canvasHeight = TexturePowerOfTwo.RoundUp(image.Height);
         if (canvasWidth > maxTextureSize || canvasHeight > maxTextureSize)
         {
             generatedTexture = null;
@@ -431,32 +310,6 @@ internal sealed class TerrainTextureAssetGenerator(
             Size = new Size(maxTextureSize, maxTextureSize),
             Sampler = KnownResamplers.Lanczos3,
         }));
-    }
-
-    private static int RoundUpToPowerOfTwo(int value)
-    {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
-
-        int rounded = 1;
-        while (rounded < value)
-        {
-            rounded <<= 1;
-        }
-
-        return rounded;
-    }
-
-    private static int RoundDownToPowerOfTwo(int value)
-    {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
-
-        int rounded = 1;
-        while ((rounded << 1) > 0 && (rounded << 1) <= value)
-        {
-            rounded <<= 1;
-        }
-
-        return rounded;
     }
 
     private static Image<Rgba32> ResizeSourceImage(Image<Rgba32> image, int width, int height)
@@ -551,117 +404,6 @@ internal sealed class TerrainTextureAssetGenerator(
             }));
     }
 
-    private async Task<Image<Rgba32>?> TryDownloadTileAsync(
-        TerrainTextureTileSource tileSource,
-        int tileX,
-        int tileY,
-        CancellationToken cancellationToken)
-    {
-        string tileUrl = WebMercatorTileMath.FormatTileUrl(tileSource.UrlTemplate, tileSource.ZoomLevel, tileX, tileY);
-        if (persistentTileCache is not null)
-        {
-            byte[]? cachedBytes = await persistentTileCache.TryReadTileBytesAsync(
-                tileSource.UrlTemplate,
-                tileSource.ZoomLevel,
-                tileX,
-                tileY,
-                cancellationToken);
-            if (cachedBytes is not null)
-            {
-                try
-                {
-                    return await LoadTileImageAsync(cachedBytes, cancellationToken);
-                }
-                catch (UnknownImageFormatException)
-                {
-                }
-                catch (InvalidImageContentException)
-                {
-                }
-            }
-        }
-
-        for (int attempt = 1; attempt <= MaxTileDownloadAttempts; attempt++)
-        {
-            try
-            {
-                using HttpResponseMessage response = await httpClient.GetAsync(
-                    tileUrl,
-                    HttpCompletionOption.ResponseHeadersRead,
-                    cancellationToken);
-                if (!response.IsSuccessStatusCode)
-                {
-                    if (attempt < MaxTileDownloadAttempts && IsTransientStatusCode((int)response.StatusCode))
-                    {
-                        await Task.Delay(GetRetryDelay(attempt), cancellationToken);
-                        continue;
-                    }
-
-                    return null;
-                }
-
-                byte[] encodedBytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
-                if (persistentTileCache is not null)
-                {
-                    await TryWritePersistentTileBytesAsync(
-                        tileSource.UrlTemplate,
-                        tileSource.ZoomLevel,
-                        tileX,
-                        tileY,
-                        encodedBytes,
-                        cancellationToken);
-                }
-
-                return await LoadTileImageAsync(encodedBytes, cancellationToken);
-            }
-            catch (HttpRequestException) when (attempt < MaxTileDownloadAttempts)
-            {
-                await Task.Delay(GetRetryDelay(attempt), cancellationToken);
-            }
-        }
-
-        return null;
-    }
-
-    private async Task TryWritePersistentTileBytesAsync(
-        string urlTemplate,
-        int zoomLevel,
-        int tileX,
-        int tileY,
-        byte[] encodedBytes,
-        CancellationToken cancellationToken)
-    {
-        if (persistentTileCache is null)
-        {
-            return;
-        }
-
-        try
-        {
-            await persistentTileCache.WriteTileBytesAsync(
-                urlTemplate,
-                zoomLevel,
-                tileX,
-                tileY,
-                encodedBytes,
-                cancellationToken);
-        }
-        catch (IOException)
-        {
-        }
-        catch (UnauthorizedAccessException)
-        {
-        }
-    }
-
-    private static async Task<Image<Rgba32>> LoadTileImageAsync(
-        byte[] encodedBytes,
-        CancellationToken cancellationToken)
-    {
-        using MemoryStream stream = new(encodedBytes, writable: false);
-        return await Image.LoadAsync<Rgba32>(stream, cancellationToken);
-    }
-
     private static ResoniteRawTextureImport CreateRawTextureImport(Image<Rgba32> image)
     {
         byte[] rawBytes = new byte[image.Width * image.Height * 4];
@@ -677,142 +419,4 @@ internal sealed class TerrainTextureAssetGenerator(
         GeneratedTerrainTexture GeneratedTexture,
         TerrainTextureSource UsedSource);
 
-    private sealed record TerrainTextureSourceImage(
-        Image<Rgba32> Image,
-        TextureUvRect? OccupiedUvRect) : IDisposable
-    {
-        public void Dispose()
-        {
-            Image.Dispose();
-        }
-    }
-
-    private sealed record ExpandedTileCrop(
-        int MinTileX,
-        int MaxTileX,
-        int MinTileY,
-        int MaxTileY,
-        int StitchedWidth,
-        int StitchedHeight,
-        int CropLeft,
-        int CropTop,
-        int CropWidth,
-        int CropHeight,
-        TextureUvRect? OccupiedUvRect)
-    {
-        public static ExpandedTileCrop FromLayout(TerrainTextureLayoutPlan layoutPlan)
-        {
-            return new ExpandedTileCrop(
-                layoutPlan.MinTileX,
-                layoutPlan.MaxTileX,
-                layoutPlan.MinTileY,
-                layoutPlan.MaxTileY,
-                layoutPlan.StitchedWidth,
-                layoutPlan.StitchedHeight,
-                layoutPlan.CropLeft,
-                layoutPlan.CropTop,
-                layoutPlan.CropWidth,
-                layoutPlan.CropHeight,
-                null);
-        }
-    }
-
-    private static bool IsTransientStatusCode(int statusCode)
-    {
-        return statusCode == 408
-            || statusCode == 425
-            || statusCode == 429
-            || statusCode >= 500;
-    }
-
-    private static TimeSpan GetRetryDelay(int attempt)
-    {
-        return TimeSpan.FromMilliseconds(250 * attempt);
-    }
-}
-
-internal sealed class PersistentTerrainTileCache
-{
-    private readonly string cacheRoot;
-
-    public PersistentTerrainTileCache(string? cacheRoot)
-    {
-        this.cacheRoot = Path.GetFullPath(cacheRoot ?? GetDefaultCacheRoot());
-    }
-
-    public async Task<byte[]?> TryReadTileBytesAsync(
-        string urlTemplate,
-        int zoomLevel,
-        int tileX,
-        int tileY,
-        CancellationToken cancellationToken)
-    {
-        string cachePath = GetCachePath(urlTemplate, zoomLevel, tileX, tileY);
-        if (!File.Exists(cachePath))
-        {
-            return null;
-        }
-
-        try
-        {
-            return await File.ReadAllBytesAsync(cachePath, cancellationToken);
-        }
-        catch (IOException)
-        {
-            return null;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return null;
-        }
-    }
-
-    public async Task WriteTileBytesAsync(
-        string urlTemplate,
-        int zoomLevel,
-        int tileX,
-        int tileY,
-        byte[] encodedBytes,
-        CancellationToken cancellationToken)
-    {
-        string cachePath = GetCachePath(urlTemplate, zoomLevel, tileX, tileY);
-        Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
-
-        string temporaryPath = $"{cachePath}.{Guid.NewGuid():N}.tmp";
-        try
-        {
-            await File.WriteAllBytesAsync(temporaryPath, encodedBytes, cancellationToken);
-            File.Move(temporaryPath, cachePath, overwrite: true);
-        }
-        catch
-        {
-            if (File.Exists(temporaryPath))
-            {
-                File.Delete(temporaryPath);
-            }
-
-            throw;
-        }
-    }
-
-    private string GetCachePath(string urlTemplate, int zoomLevel, int tileX, int tileY)
-    {
-        string templateDigest = Convert.ToHexString(
-                SHA256.HashData(Encoding.UTF8.GetBytes(urlTemplate)))
-            .ToLowerInvariant();
-        return Path.Combine(
-            cacheRoot,
-            templateDigest,
-            zoomLevel.ToString(System.Globalization.CultureInfo.InvariantCulture),
-            tileX.ToString(System.Globalization.CultureInfo.InvariantCulture),
-            $"{tileY.ToString(System.Globalization.CultureInfo.InvariantCulture)}.tile");
-    }
-
-    private static string GetDefaultCacheRoot()
-    {
-        return Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "PlateauResoniteLink",
-            "terrain-tile-cache");
-    }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureSourceImage.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureSourceImage.cs
@@ -7,10 +7,14 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed record TerrainTextureSourceImage(
-    Image<Rgba32> Image,
-    TextureUvRect? OccupiedUvRect) : IDisposable
+internal sealed class TerrainTextureSourceImage(
+    Image<Rgba32> image,
+    TextureUvRect? occupiedUvRect) : IDisposable
 {
+    public Image<Rgba32> Image { get; } = image;
+
+    public TextureUvRect? OccupiedUvRect { get; } = occupiedUvRect;
+
     public void Dispose()
     {
         Image.Dispose();

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureSourceImage.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureSourceImage.cs
@@ -1,0 +1,18 @@
+using System;
+
+using PlateauResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record TerrainTextureSourceImage(
+    Image<Rgba32> Image,
+    TextureUvRect? OccupiedUvRect) : IDisposable
+{
+    public void Dispose()
+    {
+        Image.Dispose();
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureTileSourceReader.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureTileSourceReader.cs
@@ -91,7 +91,7 @@ internal sealed class TerrainTextureTileSourceReader(
         int expandedGlobalTop = layoutGlobalTop - occupiedTop;
         int expandedGlobalRight = expandedGlobalLeft + canvasWidth;
         int expandedGlobalBottom = expandedGlobalTop + canvasHeight;
-        int maxTileIndex = (1 << zoomLevel) - 1;
+        int maxTileIndex = checked((int)((1U << zoomLevel) - 1U));
         int minTileX = Math.Clamp((int)Math.Floor(expandedGlobalLeft / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
         int maxTileX = Math.Clamp((int)Math.Floor((expandedGlobalRight - 1) / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
         int minTileY = Math.Clamp((int)Math.Floor(expandedGlobalTop / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureTileSourceReader.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureTileSourceReader.cs
@@ -1,0 +1,292 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed class TerrainTextureTileSourceReader(
+    HttpClient httpClient,
+    PersistentTerrainTileCache? persistentTileCache)
+{
+    private const int MaxTileDownloadAttempts = 4;
+
+    public async Task<TerrainTextureSourceImage?> TryCreateAsync(
+        TerrainTextureOverlay terrainTextureOverlay,
+        TerrainTextureTileSource tileSource,
+        CancellationToken cancellationToken)
+    {
+        TerrainTextureLayoutPlan layoutPlan = TerrainTextureLayoutPlanner.Create(
+            terrainTextureOverlay.GeographicBounds,
+            tileSource.ZoomLevel);
+        ExpandedTileCrop tileCrop = CreateExpandedTileCrop(layoutPlan, tileSource.ZoomLevel, terrainTextureOverlay.MaxTextureSize);
+        using Image<Rgba32> stitchedImage = new(tileCrop.StitchedWidth, tileCrop.StitchedHeight);
+        bool anyTileRendered = false;
+        for (int tileY = tileCrop.MinTileY; tileY <= tileCrop.MaxTileY; tileY++)
+        {
+            for (int tileX = tileCrop.MinTileX; tileX <= tileCrop.MaxTileX; tileX++)
+            {
+                Image<Rgba32>? tileImage = await TryDownloadTileAsync(
+                    tileSource,
+                    tileX,
+                    tileY,
+                    cancellationToken);
+                if (tileImage is null)
+                {
+                    continue;
+                }
+
+                using (tileImage)
+                {
+                    anyTileRendered = true;
+                    stitchedImage.Mutate(context => context.DrawImage(
+                        tileImage,
+                        new Point(
+                            (tileX - tileCrop.MinTileX) * WebMercatorTileMath.TileSizePixels,
+                            (tileY - tileCrop.MinTileY) * WebMercatorTileMath.TileSizePixels),
+                        1.0f));
+                }
+            }
+        }
+
+        if (!anyTileRendered)
+        {
+            return null;
+        }
+
+        return new TerrainTextureSourceImage(
+            stitchedImage.Clone(context => context.Crop(new Rectangle(
+                tileCrop.CropLeft,
+                tileCrop.CropTop,
+                tileCrop.CropWidth,
+                tileCrop.CropHeight))),
+            tileCrop.OccupiedUvRect);
+    }
+
+    private static ExpandedTileCrop CreateExpandedTileCrop(
+        TerrainTextureLayoutPlan layoutPlan,
+        int zoomLevel,
+        int maxTextureSize)
+    {
+        int canvasWidth = TexturePowerOfTwo.RoundUp(layoutPlan.CropWidth);
+        int canvasHeight = TexturePowerOfTwo.RoundUp(layoutPlan.CropHeight);
+        if (canvasWidth > maxTextureSize || canvasHeight > maxTextureSize)
+        {
+            return ExpandedTileCrop.FromLayout(layoutPlan);
+        }
+
+        int occupiedLeft = (canvasWidth - layoutPlan.CropWidth) / 2;
+        int occupiedTop = (canvasHeight - layoutPlan.CropHeight) / 2;
+        int layoutGlobalLeft = (layoutPlan.MinTileX * WebMercatorTileMath.TileSizePixels) + layoutPlan.CropLeft;
+        int layoutGlobalTop = (layoutPlan.MinTileY * WebMercatorTileMath.TileSizePixels) + layoutPlan.CropTop;
+        int expandedGlobalLeft = layoutGlobalLeft - occupiedLeft;
+        int expandedGlobalTop = layoutGlobalTop - occupiedTop;
+        int expandedGlobalRight = expandedGlobalLeft + canvasWidth;
+        int expandedGlobalBottom = expandedGlobalTop + canvasHeight;
+        int maxTileIndex = (1 << zoomLevel) - 1;
+        int minTileX = Math.Clamp((int)Math.Floor(expandedGlobalLeft / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
+        int maxTileX = Math.Clamp((int)Math.Floor((expandedGlobalRight - 1) / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
+        int minTileY = Math.Clamp((int)Math.Floor(expandedGlobalTop / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
+        int maxTileY = Math.Clamp((int)Math.Floor((expandedGlobalBottom - 1) / (double)WebMercatorTileMath.TileSizePixels), 0, maxTileIndex);
+        int stitchedWidth = (maxTileX - minTileX + 1) * WebMercatorTileMath.TileSizePixels;
+        int stitchedHeight = (maxTileY - minTileY + 1) * WebMercatorTileMath.TileSizePixels;
+        int cropLeft = Math.Clamp(expandedGlobalLeft - (minTileX * WebMercatorTileMath.TileSizePixels), 0, Math.Max(0, stitchedWidth - canvasWidth));
+        int cropTop = Math.Clamp(expandedGlobalTop - (minTileY * WebMercatorTileMath.TileSizePixels), 0, Math.Max(0, stitchedHeight - canvasHeight));
+        int actualCropWidth = Math.Min(canvasWidth, stitchedWidth - cropLeft);
+        int actualCropHeight = Math.Min(canvasHeight, stitchedHeight - cropTop);
+        if (actualCropWidth <= 0 || actualCropHeight <= 0)
+        {
+            return ExpandedTileCrop.FromLayout(layoutPlan);
+        }
+
+        int occupiedX = Math.Clamp(
+            layoutGlobalLeft - ((minTileX * WebMercatorTileMath.TileSizePixels) + cropLeft),
+            0,
+            actualCropWidth - 1);
+        int occupiedY = Math.Clamp(
+            layoutGlobalTop - ((minTileY * WebMercatorTileMath.TileSizePixels) + cropTop),
+            0,
+            actualCropHeight - 1);
+        TextureUvRect occupiedUvRect = TextureUvRect.FromTopLeftPixelRect(
+            occupiedX,
+            occupiedY,
+            Math.Min(layoutPlan.CropWidth, actualCropWidth - occupiedX),
+            Math.Min(layoutPlan.CropHeight, actualCropHeight - occupiedY),
+            actualCropWidth,
+            actualCropHeight);
+        return new ExpandedTileCrop(
+            minTileX,
+            maxTileX,
+            minTileY,
+            maxTileY,
+            stitchedWidth,
+            stitchedHeight,
+            cropLeft,
+            cropTop,
+            actualCropWidth,
+            actualCropHeight,
+            occupiedUvRect);
+    }
+
+    private async Task<Image<Rgba32>?> TryDownloadTileAsync(
+        TerrainTextureTileSource tileSource,
+        int tileX,
+        int tileY,
+        CancellationToken cancellationToken)
+    {
+        string tileUrl = WebMercatorTileMath.FormatTileUrl(tileSource.UrlTemplate, tileSource.ZoomLevel, tileX, tileY);
+        if (persistentTileCache is not null)
+        {
+            byte[]? cachedBytes = await persistentTileCache.TryReadTileBytesAsync(
+                tileSource.UrlTemplate,
+                tileSource.ZoomLevel,
+                tileX,
+                tileY,
+                cancellationToken);
+            if (cachedBytes is not null)
+            {
+                try
+                {
+                    return await LoadTileImageAsync(cachedBytes, cancellationToken);
+                }
+                catch (UnknownImageFormatException)
+                {
+                }
+                catch (InvalidImageContentException)
+                {
+                }
+            }
+        }
+
+        for (int attempt = 1; attempt <= MaxTileDownloadAttempts; attempt++)
+        {
+            try
+            {
+                using HttpResponseMessage response = await httpClient.GetAsync(
+                    tileUrl,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    cancellationToken);
+                if (!response.IsSuccessStatusCode)
+                {
+                    if (attempt < MaxTileDownloadAttempts && IsTransientStatusCode((int)response.StatusCode))
+                    {
+                        await Task.Delay(GetRetryDelay(attempt), cancellationToken);
+                        continue;
+                    }
+
+                    return null;
+                }
+
+                byte[] encodedBytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+                if (persistentTileCache is not null)
+                {
+                    await TryWritePersistentTileBytesAsync(
+                        tileSource.UrlTemplate,
+                        tileSource.ZoomLevel,
+                        tileX,
+                        tileY,
+                        encodedBytes,
+                        cancellationToken);
+                }
+
+                return await LoadTileImageAsync(encodedBytes, cancellationToken);
+            }
+            catch (HttpRequestException) when (attempt < MaxTileDownloadAttempts)
+            {
+                await Task.Delay(GetRetryDelay(attempt), cancellationToken);
+            }
+        }
+
+        return null;
+    }
+
+    private async Task TryWritePersistentTileBytesAsync(
+        string urlTemplate,
+        int zoomLevel,
+        int tileX,
+        int tileY,
+        byte[] encodedBytes,
+        CancellationToken cancellationToken)
+    {
+        if (persistentTileCache is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await persistentTileCache.WriteTileBytesAsync(
+                urlTemplate,
+                zoomLevel,
+                tileX,
+                tileY,
+                encodedBytes,
+                cancellationToken);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static async Task<Image<Rgba32>> LoadTileImageAsync(
+        byte[] encodedBytes,
+        CancellationToken cancellationToken)
+    {
+        using MemoryStream stream = new(encodedBytes, writable: false);
+        return await Image.LoadAsync<Rgba32>(stream, cancellationToken);
+    }
+
+    private static bool IsTransientStatusCode(int statusCode)
+    {
+        return statusCode == 408
+            || statusCode == 425
+            || statusCode == 429
+            || statusCode >= 500;
+    }
+
+    private static TimeSpan GetRetryDelay(int attempt)
+    {
+        return TimeSpan.FromMilliseconds(250 * attempt);
+    }
+
+    private sealed record ExpandedTileCrop(
+        int MinTileX,
+        int MaxTileX,
+        int MinTileY,
+        int MaxTileY,
+        int StitchedWidth,
+        int StitchedHeight,
+        int CropLeft,
+        int CropTop,
+        int CropWidth,
+        int CropHeight,
+        TextureUvRect? OccupiedUvRect)
+    {
+        public static ExpandedTileCrop FromLayout(TerrainTextureLayoutPlan layoutPlan)
+        {
+            return new ExpandedTileCrop(
+                layoutPlan.MinTileX,
+                layoutPlan.MaxTileX,
+                layoutPlan.MinTileY,
+                layoutPlan.MaxTileY,
+                layoutPlan.StitchedWidth,
+                layoutPlan.StitchedHeight,
+                layoutPlan.CropLeft,
+                layoutPlan.CropTop,
+                layoutPlan.CropWidth,
+                layoutPlan.CropHeight,
+                null);
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/TexturePowerOfTwo.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TexturePowerOfTwo.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal static class TexturePowerOfTwo
+{
+    public static int RoundUp(int value)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+
+        int rounded = 1;
+        while (rounded < value)
+        {
+            rounded <<= 1;
+        }
+
+        return rounded;
+    }
+
+    public static int RoundDown(int value)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+
+        int rounded = 1;
+        while ((rounded << 1) > 0 && (rounded << 1) <= value)
+        {
+            rounded <<= 1;
+        }
+
+        return rounded;
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/TexturePowerOfTwo.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TexturePowerOfTwo.cs
@@ -1,20 +1,18 @@
 using System;
+using System.Numerics;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal static class TexturePowerOfTwo
 {
+    private const int MaxIntPowerOfTwo = 1 << 30;
+
     public static int RoundUp(int value)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(value, MaxIntPowerOfTwo);
 
-        int rounded = 1;
-        while (rounded < value)
-        {
-            rounded <<= 1;
-        }
-
-        return rounded;
+        return checked((int)BitOperations.RoundUpToPowerOf2((uint)value));
     }
 
     public static int RoundDown(int value)

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -21,6 +21,26 @@ namespace PlateauResoniteLink.Tests.Targets;
 public sealed class TerrainTextureAssetGeneratorTests
 {
     [Fact]
+    public void TexturePowerOfTwoRoundUpRejectsValuesAboveRepresentablePositivePower()
+    {
+        Assert.Equal(1 << 30, TexturePowerOfTwo.RoundUp((1 << 30) - 1));
+        Assert.Equal(1 << 30, TexturePowerOfTwo.RoundUp(1 << 30));
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            static () => TexturePowerOfTwo.RoundUp((1 << 30) + 1));
+    }
+
+    [Fact]
+    public void TerrainTextureTileSourceRejectsZoomLevelsThatOverflowIntTileIndexes()
+    {
+        TerrainTextureTileSource source = new("https://tiles.example/{z}/{x}/{y}.png", WebMercatorTileMath.MaxZoomLevel);
+
+        Assert.Equal(WebMercatorTileMath.MaxZoomLevel, source.ZoomLevel);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            static () => new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", WebMercatorTileMath.MaxZoomLevel + 1));
+    }
+
+    [Fact]
     public async Task EnsureTextureAsyncStitchesTilesAndCachesOutput()
     {
         using FakeMapTileHandler handler = new();


### PR DESCRIPTION
## Summary
- move tile source layout, stitching, download retry, and persistent tile cache access out of TerrainTextureAssetGenerator
- keep TerrainTextureAssetGenerator focused on source fallback composition and final raw texture/canvas output
- share power-of-two sizing through a small texture-specific value helper

## Verification
- dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~TerrainTextureAssetGeneratorTests|FullyQualifiedName~TerrainTextureGeoReferencedRasterSupportTests|FullyQualifiedName~ResoniteSemanticGateTests" --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
