### PR TITLE
Extract DEM overlay UV mapper

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -199,7 +199,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             return null;
         }
 
-        TextureUvRect? occupiedUvRect = DemTerrainOverlayAssignment.TryCreateTerrainGridOccupiedUvRect(
+        TextureUvRect? occupiedUvRect = DemTerrainOverlayUvMapper.TryCreateTerrainGridOccupiedUvRect(
             cityObject,
             representativeSurface,
             demTerrainTextureOverlay,

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
@@ -357,75 +357,6 @@ internal static class DemTerrainOverlayAssignment
             && right.MinLongitude <= left.MaxLongitude;
     }
 
-    public static (Float2? TextureScale, Float2? TextureOffset) TryCreateTerrainGridTextureTransform(
-        ParsedCityObject cityObject,
-        ResolvedSurfaceMaterial materializedSurface,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        GeographicRectangle? cityObjectGeographicBounds = null)
-    {
-        TextureUvRect? occupiedUvRect = TryCreateTerrainGridOccupiedUvRect(
-            cityObject,
-            materializedSurface,
-            demTerrainTextureOverlay,
-            cityObjectGeographicBounds);
-        return occupiedUvRect is null
-            ? (null, null)
-            : (
-                new Float2(occupiedUvRect.Value.ScaleValue.X, occupiedUvRect.Value.ScaleValue.Y),
-                new Float2(occupiedUvRect.Value.OffsetValue.X, occupiedUvRect.Value.OffsetValue.Y));
-    }
-
-    public static TextureUvRect? TryCreateTerrainGridOccupiedUvRect(
-        ParsedCityObject cityObject,
-        ResolvedSurfaceMaterial materializedSurface,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        GeographicRectangle? cityObjectGeographicBounds = null)
-    {
-        if (demTerrainTextureOverlay is null
-            || !string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
-            || !materializedSurface.Surface.UsesGeneratedDemTexture)
-        {
-            return null;
-        }
-
-        GeographicRectangle overlayBounds = demTerrainTextureOverlay.GeographicBounds;
-        GeographicRectangle objectBounds = IntersectGeographicBounds(
-            cityObjectGeographicBounds ?? GetCityObjectGeographicBounds(cityObject),
-            overlayBounds);
-        if (objectBounds.MaxLongitude <= objectBounds.MinLongitude
-            || objectBounds.MaxLatitude <= objectBounds.MinLatitude)
-        {
-            return null;
-        }
-
-        double overlayWest = WebMercatorTileMath.LongitudeToNormalizedX(overlayBounds.MinLongitude);
-        double overlayEast = WebMercatorTileMath.LongitudeToNormalizedX(overlayBounds.MaxLongitude);
-        double overlayNorth = WebMercatorTileMath.LatitudeToNormalizedY(overlayBounds.MaxLatitude);
-        double overlaySouth = WebMercatorTileMath.LatitudeToNormalizedY(overlayBounds.MinLatitude);
-        double overlayWidth = overlayEast - overlayWest;
-        double overlayHeight = overlaySouth - overlayNorth;
-        if (overlayWidth <= 1e-12 || overlayHeight <= 1e-12)
-        {
-            return null;
-        }
-
-        double objectWest = WebMercatorTileMath.LongitudeToNormalizedX(objectBounds.MinLongitude);
-        double objectEast = WebMercatorTileMath.LongitudeToNormalizedX(objectBounds.MaxLongitude);
-        double objectNorth = WebMercatorTileMath.LatitudeToNormalizedY(objectBounds.MaxLatitude);
-        double objectSouth = WebMercatorTileMath.LatitudeToNormalizedY(objectBounds.MinLatitude);
-
-        double uMin = Math.Clamp((objectWest - overlayWest) / overlayWidth, 0.0, 1.0);
-        double uMax = Math.Clamp((objectEast - overlayWest) / overlayWidth, 0.0, 1.0);
-        double vMin = Math.Clamp((overlaySouth - objectSouth) / overlayHeight, 0.0, 1.0);
-        double vMax = Math.Clamp((overlaySouth - objectNorth) / overlayHeight, 0.0, 1.0);
-
-        return new TextureUvRect(
-            uMin,
-            vMin,
-            Math.Max(uMax - uMin, 1e-6),
-            Math.Max(vMax - vMin, 1e-6));
-    }
-
     private static bool TryPruneBoundarySliverSplit(
         IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> clippedSurfaces,
         out IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> prunedSurfaces)
@@ -610,45 +541,6 @@ internal static class DemTerrainOverlayAssignment
         return origin!;
     }
 
-    private static GeographicRectangle GetCityObjectGeographicBounds(
-        ParsedCityObject cityObject)
-    {
-        bool hasPoint = false;
-        double minLatitude = 0.0;
-        double maxLatitude = 0.0;
-        double minLongitude = 0.0;
-        double maxLongitude = 0.0;
-        foreach (ParsedSurface surface in cityObject.Surfaces)
-        {
-            foreach (GeodeticPoint point in surface.Vertices)
-            {
-                if (!hasPoint)
-                {
-                    minLatitude = maxLatitude = point.Latitude;
-                    minLongitude = maxLongitude = point.Longitude;
-                    hasPoint = true;
-                    continue;
-                }
-
-                minLatitude = Math.Min(minLatitude, point.Latitude);
-                maxLatitude = Math.Max(maxLatitude, point.Latitude);
-                minLongitude = Math.Min(minLongitude, point.Longitude);
-                maxLongitude = Math.Max(maxLongitude, point.Longitude);
-            }
-        }
-
-        if (!hasPoint)
-        {
-            throw new InvalidOperationException("DEM city object has no vertices.");
-        }
-
-        return new GeographicRectangle(
-            MinLatitude: minLatitude,
-            MaxLatitude: maxLatitude,
-            MinLongitude: minLongitude,
-            MaxLongitude: maxLongitude);
-    }
-
     private static GeographicRectangle GetSurfaceGeographicBounds(
         ParsedSurface surface)
     {
@@ -657,17 +549,6 @@ internal static class DemTerrainOverlayAssignment
             MaxLatitude: surface.Vertices.Max(static point => point.Latitude),
             MinLongitude: surface.Vertices.Min(static point => point.Longitude),
             MaxLongitude: surface.Vertices.Max(static point => point.Longitude));
-    }
-
-    private static GeographicRectangle IntersectGeographicBounds(
-        GeographicRectangle left,
-        GeographicRectangle right)
-    {
-        return new GeographicRectangle(
-            MinLatitude: Math.Max(left.MinLatitude, right.MinLatitude),
-            MaxLatitude: Math.Min(left.MaxLatitude, right.MaxLatitude),
-            MinLongitude: Math.Max(left.MinLongitude, right.MinLongitude),
-            MaxLongitude: Math.Min(left.MaxLongitude, right.MaxLongitude));
     }
 
     private static SurfaceMetrics ComputeSurfaceMetrics(ParsedSurface surface)

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayUvMapper.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayUvMapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 using PlateauResoniteLink.Domain.Importing;
 
@@ -78,40 +79,8 @@ internal static class DemTerrainOverlayUvMapper
     private static GeographicRectangle GetCityObjectGeographicBounds(
         ParsedCityObject cityObject)
     {
-        bool hasPoint = false;
-        double minLatitude = 0.0;
-        double maxLatitude = 0.0;
-        double minLongitude = 0.0;
-        double maxLongitude = 0.0;
-        foreach (ParsedSurface surface in cityObject.Surfaces)
-        {
-            foreach (GeodeticPoint point in surface.Vertices)
-            {
-                if (!hasPoint)
-                {
-                    minLatitude = maxLatitude = point.Latitude;
-                    minLongitude = maxLongitude = point.Longitude;
-                    hasPoint = true;
-                    continue;
-                }
-
-                minLatitude = Math.Min(minLatitude, point.Latitude);
-                maxLatitude = Math.Max(maxLatitude, point.Latitude);
-                minLongitude = Math.Min(minLongitude, point.Longitude);
-                maxLongitude = Math.Max(maxLongitude, point.Longitude);
-            }
-        }
-
-        if (!hasPoint)
-        {
-            throw new InvalidOperationException("DEM city object has no vertices.");
-        }
-
-        return new GeographicRectangle(
-            MinLatitude: minLatitude,
-            MaxLatitude: maxLatitude,
-            MinLongitude: minLongitude,
-            MaxLongitude: maxLongitude);
+        return CityObjectGeographicBoundsResolver.Resolve(
+            cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
     }
 
     private static GeographicRectangle IntersectGeographicBounds(

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayUvMapper.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayUvMapper.cs
@@ -1,0 +1,127 @@
+using System;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class DemTerrainOverlayUvMapper
+{
+    public static (Float2? TextureScale, Float2? TextureOffset) TryCreateTerrainGridTextureTransform(
+        ParsedCityObject cityObject,
+        ResolvedSurfaceMaterial materializedSurface,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        GeographicRectangle? cityObjectGeographicBounds = null)
+    {
+        TextureUvRect? occupiedUvRect = TryCreateTerrainGridOccupiedUvRect(
+            cityObject,
+            materializedSurface,
+            demTerrainTextureOverlay,
+            cityObjectGeographicBounds);
+        return occupiedUvRect is null
+            ? (null, null)
+            : (
+                new Float2(occupiedUvRect.Value.ScaleValue.X, occupiedUvRect.Value.ScaleValue.Y),
+                new Float2(occupiedUvRect.Value.OffsetValue.X, occupiedUvRect.Value.OffsetValue.Y));
+    }
+
+    public static TextureUvRect? TryCreateTerrainGridOccupiedUvRect(
+        ParsedCityObject cityObject,
+        ResolvedSurfaceMaterial materializedSurface,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        GeographicRectangle? cityObjectGeographicBounds = null)
+    {
+        if (demTerrainTextureOverlay is null
+            || !string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
+            || !materializedSurface.Surface.UsesGeneratedDemTexture)
+        {
+            return null;
+        }
+
+        GeographicRectangle overlayBounds = demTerrainTextureOverlay.GeographicBounds;
+        GeographicRectangle objectBounds = IntersectGeographicBounds(
+            cityObjectGeographicBounds ?? GetCityObjectGeographicBounds(cityObject),
+            overlayBounds);
+        if (objectBounds.MaxLongitude <= objectBounds.MinLongitude
+            || objectBounds.MaxLatitude <= objectBounds.MinLatitude)
+        {
+            return null;
+        }
+
+        double overlayWest = WebMercatorTileMath.LongitudeToNormalizedX(overlayBounds.MinLongitude);
+        double overlayEast = WebMercatorTileMath.LongitudeToNormalizedX(overlayBounds.MaxLongitude);
+        double overlayNorth = WebMercatorTileMath.LatitudeToNormalizedY(overlayBounds.MaxLatitude);
+        double overlaySouth = WebMercatorTileMath.LatitudeToNormalizedY(overlayBounds.MinLatitude);
+        double overlayWidth = overlayEast - overlayWest;
+        double overlayHeight = overlaySouth - overlayNorth;
+        if (overlayWidth <= 1e-12 || overlayHeight <= 1e-12)
+        {
+            return null;
+        }
+
+        double objectWest = WebMercatorTileMath.LongitudeToNormalizedX(objectBounds.MinLongitude);
+        double objectEast = WebMercatorTileMath.LongitudeToNormalizedX(objectBounds.MaxLongitude);
+        double objectNorth = WebMercatorTileMath.LatitudeToNormalizedY(objectBounds.MaxLatitude);
+        double objectSouth = WebMercatorTileMath.LatitudeToNormalizedY(objectBounds.MinLatitude);
+
+        double uMin = Math.Clamp((objectWest - overlayWest) / overlayWidth, 0.0, 1.0);
+        double uMax = Math.Clamp((objectEast - overlayWest) / overlayWidth, 0.0, 1.0);
+        double vMin = Math.Clamp((overlaySouth - objectSouth) / overlayHeight, 0.0, 1.0);
+        double vMax = Math.Clamp((overlaySouth - objectNorth) / overlayHeight, 0.0, 1.0);
+
+        return new TextureUvRect(
+            uMin,
+            vMin,
+            Math.Max(uMax - uMin, 1e-6),
+            Math.Max(vMax - vMin, 1e-6));
+    }
+
+    private static GeographicRectangle GetCityObjectGeographicBounds(
+        ParsedCityObject cityObject)
+    {
+        bool hasPoint = false;
+        double minLatitude = 0.0;
+        double maxLatitude = 0.0;
+        double minLongitude = 0.0;
+        double maxLongitude = 0.0;
+        foreach (ParsedSurface surface in cityObject.Surfaces)
+        {
+            foreach (GeodeticPoint point in surface.Vertices)
+            {
+                if (!hasPoint)
+                {
+                    minLatitude = maxLatitude = point.Latitude;
+                    minLongitude = maxLongitude = point.Longitude;
+                    hasPoint = true;
+                    continue;
+                }
+
+                minLatitude = Math.Min(minLatitude, point.Latitude);
+                maxLatitude = Math.Max(maxLatitude, point.Latitude);
+                minLongitude = Math.Min(minLongitude, point.Longitude);
+                maxLongitude = Math.Max(maxLongitude, point.Longitude);
+            }
+        }
+
+        if (!hasPoint)
+        {
+            throw new InvalidOperationException("DEM city object has no vertices.");
+        }
+
+        return new GeographicRectangle(
+            MinLatitude: minLatitude,
+            MaxLatitude: maxLatitude,
+            MinLongitude: minLongitude,
+            MaxLongitude: maxLongitude);
+    }
+
+    private static GeographicRectangle IntersectGeographicBounds(
+        GeographicRectangle left,
+        GeographicRectangle right)
+    {
+        return new GeographicRectangle(
+            MinLatitude: Math.Max(left.MinLatitude, right.MinLatitude),
+            MaxLatitude: Math.Min(left.MaxLatitude, right.MaxLatitude),
+            MinLongitude: Math.Max(left.MinLongitude, right.MinLongitude),
+            MaxLongitude: Math.Min(left.MaxLongitude, right.MaxLongitude));
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
@@ -383,7 +383,7 @@ public sealed class DemTerrainOverlayAssignmentTests
                 TerrainOverlay: overlay),
             DepthOffset: null);
 
-        (Float2? textureScale, Float2? textureOffset) = DemTerrainOverlayAssignment.TryCreateTerrainGridTextureTransform(
+        (Float2? textureScale, Float2? textureOffset) = DemTerrainOverlayUvMapper.TryCreateTerrainGridTextureTransform(
             cityObject,
             material,
             overlay);


### PR DESCRIPTION
## Summary
- move terrain-grid overlay UV occupancy and transform calculation out of DemTerrainOverlayAssignment
- point DEM grid projection directly at the new DemTerrainOverlayUvMapper boundary
- keep assignment focused on DEM overlay coverage, clipping, grouping, and split output

## Verification
- dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~DemTerrainOverlayAssignmentTests|FullyQualifiedName~CityGmlDemTerrainGridCityObjectProjectionTests|FullyQualifiedName~ResoniteSemanticGateTests" --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
