### PR TITLE
Extract DEM overlay assignment policies

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
@@ -10,10 +10,6 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal static class DemTerrainOverlayAssignment
 {
-    private const double BoundarySliverMaxThicknessMeters = 0.10;
-    private const double BoundarySliverMaxAreaRatio = 0.01;
-    private const double BoundarySliverMaxAreaSquareMeters = 4.0;
-
     public static bool HasOverlayCoverage(
         ParsedCityObject parsedCityObject,
         IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
@@ -61,7 +57,7 @@ internal static class DemTerrainOverlayAssignment
                 }
 
                 GeographicRectangle surfaceBounds = GetSurfaceGeographicBounds(requestedMeshClippedSurface);
-                TerrainOverlayCoverage coverage = ResolveTerrainOverlayCoverage(
+                TerrainOverlayCoverage coverage = DemTerrainOverlayCoverageResolver.Resolve(
                     surfaceBounds,
                     demTerrainTextureOverlays);
                 if (coverage.Kind == TerrainOverlayCoverageKind.Contained)
@@ -181,7 +177,7 @@ internal static class DemTerrainOverlayAssignment
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 GeographicRectangle surfaceBounds = GetSurfaceGeographicBounds(requestedMeshClippedSurface);
-                TerrainOverlayCoverage coverage = ResolveTerrainOverlayCoverage(
+                TerrainOverlayCoverage coverage = DemTerrainOverlayCoverageResolver.Resolve(
                     surfaceBounds,
                     demTerrainTextureOverlays);
                 if (coverage.Kind == TerrainOverlayCoverageKind.Contained)
@@ -213,7 +209,7 @@ internal static class DemTerrainOverlayAssignment
         }
 
         IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> groupedGeneratedSurfaces =
-            TryPruneBoundarySliverGroups(
+            DemTerrainOverlayBoundarySliverPruner.TryPruneGroups(
                 splitGeneratedSurfaces,
                 out IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> prunedGeneratedSurfaces)
                 ? prunedGeneratedSurfaces
@@ -318,194 +314,6 @@ internal static class DemTerrainOverlayAssignment
             requestedMeshBounds).ToArray();
     }
 
-    private static TerrainOverlayCoverage ResolveTerrainOverlayCoverage(
-        GeographicRectangle surfaceBounds,
-        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays)
-    {
-        TerrainTextureOverlay? containingOverlay = demTerrainTextureOverlays.FirstOrDefault(overlay =>
-            Contains(overlay.GeographicBounds, surfaceBounds));
-        if (containingOverlay is not null)
-        {
-            return TerrainOverlayCoverage.Contained(containingOverlay);
-        }
-
-        TerrainTextureOverlay[] intersectingOverlays = demTerrainTextureOverlays
-            .Where(overlay => Intersects(overlay.GeographicBounds, surfaceBounds))
-            .ToArray();
-        return intersectingOverlays.Length == 0
-            ? TerrainOverlayCoverage.None
-            : TerrainOverlayCoverage.Intersecting(intersectingOverlays);
-    }
-
-    private static bool Contains(
-        GeographicRectangle container,
-        GeographicRectangle subject)
-    {
-        return subject.MinLatitude >= container.MinLatitude
-            && subject.MaxLatitude <= container.MaxLatitude
-            && subject.MinLongitude >= container.MinLongitude
-            && subject.MaxLongitude <= container.MaxLongitude;
-    }
-
-    private static bool Intersects(
-        GeographicRectangle left,
-        GeographicRectangle right)
-    {
-        return right.MaxLatitude >= left.MinLatitude
-            && right.MinLatitude <= left.MaxLatitude
-            && right.MaxLongitude >= left.MinLongitude
-            && right.MinLongitude <= left.MaxLongitude;
-    }
-
-    private static bool TryPruneBoundarySliverSplit(
-        IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> clippedSurfaces,
-        out IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> prunedSurfaces)
-    {
-        prunedSurfaces = [];
-        if (clippedSurfaces.Count <= 1)
-        {
-            return false;
-        }
-
-        SurfaceMetrics[] metrics = clippedSurfaces
-            .Select(static entry => ComputeSurfaceMetrics(entry.Surface))
-            .ToArray();
-        double totalArea = metrics.Sum(static metric => metric.AreaSquareMeters);
-        if (totalArea <= 1e-9)
-        {
-            return false;
-        }
-
-        int dominantIndex = 0;
-        for (int index = 1; index < metrics.Length; index++)
-        {
-            if (metrics[index].AreaSquareMeters > metrics[dominantIndex].AreaSquareMeters)
-            {
-                dominantIndex = index;
-            }
-        }
-
-        List<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> keptSurfaces =
-        [
-            clippedSurfaces[dominantIndex],
-        ];
-        bool prunedBoundarySliver = false;
-        for (int index = 0; index < metrics.Length; index++)
-        {
-            if (index == dominantIndex)
-            {
-                continue;
-            }
-
-            double areaRatio = metrics[index].AreaSquareMeters / totalArea;
-            bool isBoundarySliver = IsBoundarySliver(metrics[index], areaRatio);
-            if (!isBoundarySliver)
-            {
-                keptSurfaces.Add(clippedSurfaces[index]);
-                continue;
-            }
-
-            prunedBoundarySliver = true;
-        }
-
-        if (!prunedBoundarySliver)
-        {
-            return false;
-        }
-
-        if (keptSurfaces.Count == 1)
-        {
-            prunedSurfaces = [keptSurfaces[0]];
-            return true;
-        }
-
-        prunedSurfaces = keptSurfaces
-            .OrderBy(static entry => entry.Overlay.PackageName, StringComparer.Ordinal)
-            .ThenBy(static entry => entry.Overlay.GeographicBounds.MinLatitude)
-            .ThenBy(static entry => entry.Overlay.GeographicBounds.MinLongitude)
-            .ToArray();
-        return true;
-    }
-
-    private static bool TryPruneBoundarySliverGroups(
-        List<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> surfaces,
-        out IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> prunedSurfaces)
-    {
-        prunedSurfaces = [];
-        if (surfaces.Count <= 1)
-        {
-            return false;
-        }
-
-        GroupMetrics[] groups = surfaces
-            .GroupBy(static surface => surface.Overlay)
-            .Select(static group =>
-            {
-                (ParsedSurface Surface, TerrainTextureOverlay Overlay)[] groupSurfaces = group.ToArray();
-                SurfaceMetrics[] metrics = groupSurfaces
-                    .Select(static entry => ComputeSurfaceMetrics(entry.Surface))
-                    .ToArray();
-                return new GroupMetrics(
-                    group.Key,
-                    groupSurfaces,
-                    metrics.Sum(static metric => metric.AreaSquareMeters),
-                    metrics);
-            })
-            .ToArray();
-        if (groups.Length <= 1)
-        {
-            return false;
-        }
-
-        double totalArea = groups.Sum(static group => group.AreaSquareMeters);
-        if (totalArea <= 1e-9)
-        {
-            return false;
-        }
-
-        int dominantIndex = 0;
-        for (int index = 1; index < groups.Length; index++)
-        {
-            if (groups[index].AreaSquareMeters > groups[dominantIndex].AreaSquareMeters)
-            {
-                dominantIndex = index;
-            }
-        }
-
-        List<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> keptSurfaces = [];
-        bool prunedBoundarySliver = false;
-        for (int index = 0; index < groups.Length; index++)
-        {
-            GroupMetrics group = groups[index];
-            if (index != dominantIndex)
-            {
-                double areaRatio = group.AreaSquareMeters / totalArea;
-                bool isBoundarySliverGroup = group.SurfaceMetrics.Count > 0
-                    && group.SurfaceMetrics.All(metric => IsBoundarySliver(metric, areaRatio));
-                if (isBoundarySliverGroup)
-                {
-                    prunedBoundarySliver = true;
-                    continue;
-                }
-            }
-
-            keptSurfaces.AddRange(group.Surfaces);
-        }
-
-        if (!prunedBoundarySliver || keptSurfaces.Count == surfaces.Count || keptSurfaces.Count == 0)
-        {
-            return false;
-        }
-
-        prunedSurfaces = keptSurfaces
-            .OrderBy(static entry => entry.Overlay.PackageName, StringComparer.Ordinal)
-            .ThenBy(static entry => entry.Overlay.GeographicBounds.MinLatitude)
-            .ThenBy(static entry => entry.Overlay.GeographicBounds.MinLongitude)
-            .ThenBy(static entry => entry.Surface.PolygonId, StringComparer.Ordinal)
-            .ToArray();
-        return true;
-    }
-
     private static GeodeticPoint GetCityObjectOrigin(
         ParsedCityObject cityObject)
     {
@@ -551,97 +359,4 @@ internal static class DemTerrainOverlayAssignment
             MaxLongitude: surface.Vertices.Max(static point => point.Longitude));
     }
 
-    private static SurfaceMetrics ComputeSurfaceMetrics(ParsedSurface surface)
-    {
-        GeodeticPoint[] vertices = surface.ExteriorRing.Vertices;
-        if (vertices.Length < 3)
-        {
-            return new SurfaceMetrics(0.0, 0.0);
-        }
-
-        double referenceLatitude = vertices.Average(static point => point.Latitude) * (Math.PI / 180.0);
-        double referenceLongitude = vertices.Average(static point => point.Longitude);
-        double metersPerLatitudeDegree = 111_320.0;
-        double metersPerLongitudeDegree = metersPerLatitudeDegree * Math.Cos(referenceLatitude);
-
-        ProjectedPoint[] projected = vertices
-            .Select(point => new ProjectedPoint(
-                (point.Longitude - referenceLongitude) * metersPerLongitudeDegree,
-                (point.Latitude - vertices[0].Latitude) * metersPerLatitudeDegree))
-            .ToArray();
-
-        double signedArea = 0.0;
-        double maxDistance = 0.0;
-        for (int index = 0; index < projected.Length; index++)
-        {
-            ProjectedPoint current = projected[index];
-            ProjectedPoint next = projected[(index + 1) % projected.Length];
-            signedArea += (current.X * next.Y) - (next.X * current.Y);
-            maxDistance = Math.Max(maxDistance, Distance(current, next));
-        }
-
-        double areaSquareMeters = Math.Abs(signedArea) * 0.5;
-        double estimatedThicknessMeters = maxDistance <= 1e-9
-            ? 0.0
-            : (2.0 * areaSquareMeters) / maxDistance;
-        return new SurfaceMetrics(areaSquareMeters, estimatedThicknessMeters);
-    }
-
-    private static bool IsBoundarySliver(SurfaceMetrics metrics, double areaRatio)
-    {
-        return metrics.EstimatedThicknessMeters <= BoundarySliverMaxThicknessMeters
-            && (areaRatio <= BoundarySliverMaxAreaRatio
-                || metrics.AreaSquareMeters <= BoundarySliverMaxAreaSquareMeters);
-    }
-
-    private static double Distance(ProjectedPoint left, ProjectedPoint right)
-    {
-        double deltaX = right.X - left.X;
-        double deltaY = right.Y - left.Y;
-        return Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY));
-    }
-
-    private readonly record struct ProjectedPoint(double X, double Y);
-
-    private readonly record struct SurfaceMetrics(double AreaSquareMeters, double EstimatedThicknessMeters);
-
-    private readonly record struct TerrainOverlayCoverage(
-        TerrainOverlayCoverageKind Kind,
-        TerrainTextureOverlay? ContainingOverlay,
-        IReadOnlyList<TerrainTextureOverlay> IntersectingOverlays)
-    {
-        public static TerrainOverlayCoverage None { get; } = new(
-            TerrainOverlayCoverageKind.None,
-            ContainingOverlay: null,
-            IntersectingOverlays: []);
-
-        public static TerrainOverlayCoverage Contained(TerrainTextureOverlay containingOverlay)
-        {
-            return new TerrainOverlayCoverage(
-                TerrainOverlayCoverageKind.Contained,
-                containingOverlay,
-                IntersectingOverlays: []);
-        }
-
-        public static TerrainOverlayCoverage Intersecting(IReadOnlyList<TerrainTextureOverlay> intersectingOverlays)
-        {
-            return new TerrainOverlayCoverage(
-                TerrainOverlayCoverageKind.Intersecting,
-                ContainingOverlay: null,
-                intersectingOverlays);
-        }
-    }
-
-    private enum TerrainOverlayCoverageKind
-    {
-        None,
-        Contained,
-        Intersecting,
-    }
-
-    private readonly record struct GroupMetrics(
-        TerrainTextureOverlay Overlay,
-        IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> Surfaces,
-        double AreaSquareMeters,
-        IReadOnlyList<SurfaceMetrics> SurfaceMetrics);
 }

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayBoundarySliverPruner.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayBoundarySliverPruner.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class DemTerrainOverlayBoundarySliverPruner
+{
+    private const double BoundarySliverMaxThicknessMeters = 0.10;
+    private const double BoundarySliverMaxAreaRatio = 0.01;
+    private const double BoundarySliverMaxAreaSquareMeters = 4.0;
+
+    public static bool TryPruneGroups(
+        IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> surfaces,
+        out IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> prunedSurfaces)
+    {
+        prunedSurfaces = [];
+        if (surfaces.Count <= 1)
+        {
+            return false;
+        }
+
+        GroupMetrics[] groups = surfaces
+            .GroupBy(static surface => surface.Overlay)
+            .Select(static group =>
+            {
+                (ParsedSurface Surface, TerrainTextureOverlay Overlay)[] groupSurfaces = group.ToArray();
+                SurfaceMetrics[] metrics = groupSurfaces
+                    .Select(static entry => ComputeSurfaceMetrics(entry.Surface))
+                    .ToArray();
+                return new GroupMetrics(
+                    group.Key,
+                    groupSurfaces,
+                    metrics.Sum(static metric => metric.AreaSquareMeters),
+                    metrics);
+            })
+            .ToArray();
+        if (groups.Length <= 1)
+        {
+            return false;
+        }
+
+        double totalArea = groups.Sum(static group => group.AreaSquareMeters);
+        if (totalArea <= 1e-9)
+        {
+            return false;
+        }
+
+        int dominantIndex = 0;
+        for (int index = 1; index < groups.Length; index++)
+        {
+            if (groups[index].AreaSquareMeters > groups[dominantIndex].AreaSquareMeters)
+            {
+                dominantIndex = index;
+            }
+        }
+
+        List<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> keptSurfaces = [];
+        bool prunedBoundarySliver = false;
+        for (int index = 0; index < groups.Length; index++)
+        {
+            GroupMetrics group = groups[index];
+            if (index != dominantIndex)
+            {
+                double areaRatio = group.AreaSquareMeters / totalArea;
+                bool isBoundarySliverGroup = group.SurfaceMetrics.Count > 0
+                    && group.SurfaceMetrics.All(metric => IsBoundarySliver(metric, areaRatio));
+                if (isBoundarySliverGroup)
+                {
+                    prunedBoundarySliver = true;
+                    continue;
+                }
+            }
+
+            keptSurfaces.AddRange(group.Surfaces);
+        }
+
+        if (!prunedBoundarySliver || keptSurfaces.Count == surfaces.Count || keptSurfaces.Count == 0)
+        {
+            return false;
+        }
+
+        prunedSurfaces = keptSurfaces
+            .OrderBy(static entry => entry.Overlay.PackageName, StringComparer.Ordinal)
+            .ThenBy(static entry => entry.Overlay.GeographicBounds.MinLatitude)
+            .ThenBy(static entry => entry.Overlay.GeographicBounds.MinLongitude)
+            .ThenBy(static entry => entry.Surface.PolygonId, StringComparer.Ordinal)
+            .ToArray();
+        return true;
+    }
+
+    private static SurfaceMetrics ComputeSurfaceMetrics(ParsedSurface surface)
+    {
+        GeodeticPoint[] vertices = surface.ExteriorRing.Vertices;
+        if (vertices.Length < 3)
+        {
+            return new SurfaceMetrics(0.0, 0.0);
+        }
+
+        double referenceLatitude = vertices.Average(static point => point.Latitude) * (Math.PI / 180.0);
+        double referenceLongitude = vertices.Average(static point => point.Longitude);
+        double metersPerLatitudeDegree = 111_320.0;
+        double metersPerLongitudeDegree = metersPerLatitudeDegree * Math.Cos(referenceLatitude);
+
+        ProjectedPoint[] projected = vertices
+            .Select(point => new ProjectedPoint(
+                (point.Longitude - referenceLongitude) * metersPerLongitudeDegree,
+                (point.Latitude - vertices[0].Latitude) * metersPerLatitudeDegree))
+            .ToArray();
+
+        double signedArea = 0.0;
+        double maxDistance = 0.0;
+        for (int index = 0; index < projected.Length; index++)
+        {
+            ProjectedPoint current = projected[index];
+            ProjectedPoint next = projected[(index + 1) % projected.Length];
+            signedArea += (current.X * next.Y) - (next.X * current.Y);
+            maxDistance = Math.Max(maxDistance, Distance(current, next));
+        }
+
+        double areaSquareMeters = Math.Abs(signedArea) * 0.5;
+        double estimatedThicknessMeters = maxDistance <= 1e-9
+            ? 0.0
+            : (2.0 * areaSquareMeters) / maxDistance;
+        return new SurfaceMetrics(areaSquareMeters, estimatedThicknessMeters);
+    }
+
+    private static bool IsBoundarySliver(SurfaceMetrics metrics, double areaRatio)
+    {
+        return metrics.EstimatedThicknessMeters <= BoundarySliverMaxThicknessMeters
+            && (areaRatio <= BoundarySliverMaxAreaRatio
+                || metrics.AreaSquareMeters <= BoundarySliverMaxAreaSquareMeters);
+    }
+
+    private static double Distance(ProjectedPoint left, ProjectedPoint right)
+    {
+        double deltaX = right.X - left.X;
+        double deltaY = right.Y - left.Y;
+        return Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY));
+    }
+
+    private readonly record struct ProjectedPoint(double X, double Y);
+
+    private readonly record struct SurfaceMetrics(double AreaSquareMeters, double EstimatedThicknessMeters);
+
+    private readonly record struct GroupMetrics(
+        TerrainTextureOverlay Overlay,
+        IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> Surfaces,
+        double AreaSquareMeters,
+        IReadOnlyList<SurfaceMetrics> SurfaceMetrics);
+}

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayCoverageResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayCoverageResolver.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class DemTerrainOverlayCoverageResolver
+{
+    public static TerrainOverlayCoverage Resolve(
+        GeographicRectangle surfaceBounds,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays)
+    {
+        TerrainTextureOverlay? containingOverlay = demTerrainTextureOverlays.FirstOrDefault(overlay =>
+            Contains(overlay.GeographicBounds, surfaceBounds));
+        if (containingOverlay is not null)
+        {
+            return TerrainOverlayCoverage.Contained(containingOverlay);
+        }
+
+        TerrainTextureOverlay[] intersectingOverlays = demTerrainTextureOverlays
+            .Where(overlay => Intersects(overlay.GeographicBounds, surfaceBounds))
+            .ToArray();
+        return intersectingOverlays.Length == 0
+            ? TerrainOverlayCoverage.None
+            : TerrainOverlayCoverage.Intersecting(intersectingOverlays);
+    }
+
+    private static bool Contains(
+        GeographicRectangle container,
+        GeographicRectangle subject)
+    {
+        return subject.MinLatitude >= container.MinLatitude
+            && subject.MaxLatitude <= container.MaxLatitude
+            && subject.MinLongitude >= container.MinLongitude
+            && subject.MaxLongitude <= container.MaxLongitude;
+    }
+
+    private static bool Intersects(
+        GeographicRectangle left,
+        GeographicRectangle right)
+    {
+        return right.MaxLatitude >= left.MinLatitude
+            && right.MinLatitude <= left.MaxLatitude
+            && right.MaxLongitude >= left.MinLongitude
+            && right.MinLongitude <= left.MaxLongitude;
+    }
+}
+
+internal readonly record struct TerrainOverlayCoverage(
+    TerrainOverlayCoverageKind Kind,
+    TerrainTextureOverlay? ContainingOverlay,
+    IReadOnlyList<TerrainTextureOverlay> IntersectingOverlays)
+{
+    public static TerrainOverlayCoverage None { get; } = new(
+        TerrainOverlayCoverageKind.None,
+        ContainingOverlay: null,
+        IntersectingOverlays: []);
+
+    public static TerrainOverlayCoverage Contained(TerrainTextureOverlay containingOverlay)
+    {
+        return new TerrainOverlayCoverage(
+            TerrainOverlayCoverageKind.Contained,
+            containingOverlay,
+            IntersectingOverlays: []);
+    }
+
+    public static TerrainOverlayCoverage Intersecting(IReadOnlyList<TerrainTextureOverlay> intersectingOverlays)
+    {
+        return new TerrainOverlayCoverage(
+            TerrainOverlayCoverageKind.Intersecting,
+            ContainingOverlay: null,
+            intersectingOverlays);
+    }
+}
+
+internal enum TerrainOverlayCoverageKind
+{
+    None,
+    Contained,
+    Intersecting,
+}

--- a/tests/PlateauResoniteLink.Tests/EndToEnd/ResoniteSemanticGateTests.cs
+++ b/tests/PlateauResoniteLink.Tests/EndToEnd/ResoniteSemanticGateTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
 using PlateauResoniteLink.Tests.Targets;
 
 using CanonicalSceneDumpSink = PlateauResoniteLink.Targets.Resonite.Diagnostics.CanonicalSceneDumpSink;
@@ -34,6 +35,8 @@ public sealed class ResoniteSemanticGateTests
             PackageNames: ["bldg", "dem", "tran", "luse"]);
         IImportedSceneSource source = await CreateImportedSceneSourceFactory().CreateAsync(request);
         using TemporaryDirectory workDirectory = new();
+        using IDisposable bundledMaterialExtractionRoot = new BundledDefaultMaterialAssetStore()
+            .PushExtractionRootOverride(Path.Combine(workDirectory.Path, "bundled-default-materials"));
         string actualPath = Path.Combine(workDirectory.Path, "canonical-scene.json");
         SceneSinkRecordingClient client = new();
         await using CanonicalSceneDumpSink dumpSink = new(


### PR DESCRIPTION
## Summary
- move DEM overlay coverage classification into DemTerrainOverlayCoverageResolver
- move boundary sliver pruning into DemTerrainOverlayBoundarySliverPruner
- keep DemTerrainOverlayAssignment focused on DEM object split flow and overlay grouping output

## Verification
- dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~DemTerrainOverlayAssignmentTests|FullyQualifiedName~ResoniteSemanticGateTests" --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

## Notes
- C: was full during local target-test retry; cleared repo artifacts and generated PlateauResoniteLink temp material cache before rerunning with TEMP/TMP set to D:\Temp\PlateauResoniteLinkCodex.
