### PR TITLE
Isolate canonical gate material extraction

### DIFF
--- a/tests/PlateauResoniteLink.Tests/EndToEnd/ResoniteSemanticGateTests.cs
+++ b/tests/PlateauResoniteLink.Tests/EndToEnd/ResoniteSemanticGateTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
 using PlateauResoniteLink.Tests.Targets;
 
 using CanonicalSceneDumpSink = PlateauResoniteLink.Targets.Resonite.Diagnostics.CanonicalSceneDumpSink;
@@ -34,6 +35,8 @@ public sealed class ResoniteSemanticGateTests
             PackageNames: ["bldg", "dem", "tran", "luse"]);
         IImportedSceneSource source = await CreateImportedSceneSourceFactory().CreateAsync(request);
         using TemporaryDirectory workDirectory = new();
+        using IDisposable bundledMaterialExtractionRoot = new BundledDefaultMaterialAssetStore()
+            .PushExtractionRootOverride(Path.Combine(workDirectory.Path, "bundled-default-materials"));
         string actualPath = Path.Combine(workDirectory.Path, "canonical-scene.json");
         SceneSinkRecordingClient client = new();
         await using CanonicalSceneDumpSink dumpSink = new(


### PR DESCRIPTION
## Summary
- scope the canonical Fake Link gate bundled-material extraction root to the test work directory
- prevent the canonical gate from leaving multi-GB default-material extracts under the shared user temp cache
- keep the generated canonical output unchanged while making the test cleanup-owned

## Verification
- dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~ResoniteSemanticGateTests" --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- confirmed `%LOCALAPPDATA%\Temp\PlateauResoniteLink` was not recreated by the targeted canonical gate run
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
