### PR TITLE
Extract stable material variant selector

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/BuildingAttributePredicates.cs
+++ b/src/PlateauResoniteLink/Application/Importing/BuildingAttributePredicates.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Linq;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class BuildingAttributePredicates
+{
+    public static bool HasFacadeLikeMidriseUse(BuildingAttributeContext attributes)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+
+        return HasUse(attributes, PlateauBuildingUse.Office)
+            || HasUse(attributes, PlateauBuildingUse.Commercial)
+            || HasUse(attributes, PlateauBuildingUse.Public)
+            || HasUse(attributes, PlateauBuildingUse.Education)
+            || HasUse(attributes, PlateauBuildingUse.Apartment)
+            || HasUse(attributes, PlateauBuildingUse.MixedResidential)
+            || HasRawBuildingCode(attributes, "403");
+    }
+
+    public static bool HasNightOccupancy(BuildingAttributeContext attributes)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+
+        return HasUse(attributes, PlateauBuildingUse.Apartment)
+            || HasUse(attributes, PlateauBuildingUse.MixedResidential)
+            || HasRawBuildingCode(attributes, "403");
+    }
+
+    public static bool IsRobustStructure(BuildingAttributeContext attributes)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+
+        return attributes.Structures.Any(static structure => structure.Value is PlateauBuildingStructure.ReinforcedConcrete
+            or PlateauBuildingStructure.SteelReinforcedConcrete
+            or PlateauBuildingStructure.NonWood);
+    }
+
+    public static bool HasBrickLikeStructure(BuildingAttributeContext attributes)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+
+        return attributes.Structures.Any(static structure => structure.Value is PlateauBuildingStructure.ConcreteBlock);
+    }
+
+    public static bool HasUse(BuildingAttributeContext attributes, PlateauBuildingUse use)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+
+        return attributes.Uses.Any(candidate => candidate.Value == use)
+            || attributes.DetailedUses.Any(candidate => candidate.Value == use)
+            || attributes.CityGmlFunctionCodes.Any(code => HasRawBuildingCode(code, use));
+    }
+
+    public static bool HasRawBuildingCode(BuildingAttributeContext attributes, string code)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+
+        return attributes.CityGmlFunctionCodes.Any(candidate => IsSameBroadCode(candidate, code))
+            || attributes.CityGmlClassCodes.Any(candidate => IsSameBroadCode(candidate, code));
+    }
+
+    private static bool HasRawBuildingCode(string code, PlateauBuildingUse use)
+    {
+        string broadCode = CreateBroadBuildingCode(code);
+        return use switch
+        {
+            PlateauBuildingUse.DetachedResidential => broadCode is "411" or "111",
+            PlateauBuildingUse.Apartment => broadCode is "412" or "112" or "113",
+            PlateauBuildingUse.MixedResidential => broadCode is "413" or "414" or "415" or "114" or "115" or "116",
+            PlateauBuildingUse.Office => broadCode is "401" or "131",
+            PlateauBuildingUse.Commercial => broadCode is "402" or "403" or "404" or "151" or "152",
+            PlateauBuildingUse.Warehouse => broadCode is "431" or "171" or "172",
+            PlateauBuildingUse.Factory => broadCode is "441" or "174",
+            PlateauBuildingUse.Education => broadCode is "422" or "181",
+            PlateauBuildingUse.Public => broadCode is "421" or "191" or "192" or "193",
+            _ => false,
+        };
+    }
+
+    private static bool IsSameBroadCode(string candidate, string expected)
+    {
+        return string.Equals(CreateBroadBuildingCode(candidate), expected, StringComparison.Ordinal);
+    }
+
+    private static string CreateBroadBuildingCode(string code)
+    {
+        string trimmed = code.Trim();
+        return trimmed.Length <= 3 ? trimmed : trimmed[..3];
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/BuildingFacadeScale.cs
+++ b/src/PlateauResoniteLink/Application/Importing/BuildingFacadeScale.cs
@@ -1,0 +1,73 @@
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal readonly record struct BuildingFacadeScale(
+    bool LowRise,
+    bool MidOrHighRise,
+    bool Midrise,
+    bool Highrise,
+    bool Landmark,
+    bool LargeLowRise)
+{
+    public static BuildingFacadeScale Classify(
+        int? floorCount,
+        double? measuredHeightMeters,
+        double? geometryHeightMeters,
+        double? footprintAreaSquareMeters)
+    {
+        double? effectiveHeightMeters = GetEffectiveHeightMeters(measuredHeightMeters, geometryHeightMeters);
+        bool lowRise = IsLowRise(floorCount, effectiveHeightMeters);
+
+        return new BuildingFacadeScale(
+            lowRise,
+            IsMidOrHighRise(floorCount, effectiveHeightMeters),
+            IsMidrise(floorCount, effectiveHeightMeters),
+            IsHighrise(floorCount, effectiveHeightMeters),
+            IsLandmarkScale(floorCount, effectiveHeightMeters),
+            lowRise && footprintAreaSquareMeters is >= 1000.0);
+    }
+
+    private static bool IsLowRise(int? floorCount, double? heightMeters)
+    {
+        return (!FacadeFloorMetrics.IsUsableFloorCount(floorCount) || floorCount <= 3)
+            && (!heightMeters.HasValue || heightMeters.Value < 12.0);
+    }
+
+    private static bool IsMidOrHighRise(int? floorCount, double? heightMeters)
+    {
+        return (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount >= 4)
+            || heightMeters is >= 12.0;
+    }
+
+    private static bool IsMidrise(int? floorCount, double? heightMeters)
+    {
+        return (heightMeters is >= 25.0 and < 80.0)
+            || (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount is >= 8 and < 20);
+    }
+
+    private static bool IsHighrise(int? floorCount, double? heightMeters)
+    {
+        return (heightMeters is >= 80.0 and < 150.0)
+            || (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount is >= 20 and < 35);
+    }
+
+    private static bool IsLandmarkScale(int? floorCount, double? heightMeters)
+    {
+        return heightMeters is >= 150.0
+            || (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount >= 35);
+    }
+
+    private static double? GetEffectiveHeightMeters(double? measuredHeightMeters, double? geometryHeightMeters)
+    {
+        return TryGetPositiveValue(measuredHeightMeters)
+            ?? TryGetPositiveValue(geometryHeightMeters);
+    }
+
+    private static double? TryGetPositiveValue(double? value)
+    {
+        return value is > 0.0 && !double.IsNaN(value.Value) && !double.IsInfinity(value.Value)
+            ? value.Value
+            : null;
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Buffers.Binary;
 using System.Linq;
-
-using System.Security.Cryptography;
-using System.Text;
 
 using PlateauResoniteLink.Domain.Importing;
 
@@ -373,11 +369,11 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
 
     private static bool IsWeightedAlternate(string variantSelectionKey)
     {
-        return SelectStableBucket($"{variantSelectionKey}:residential-wall-weight", 5) == 0;
+        return StableVariantSelector.SelectBucket($"{variantSelectionKey}:residential-wall-weight", 5) == 0;
     }
 
     private static DefaultCommonMaterialMember SelectCityFurnitureMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 6) switch
+        StableVariantSelector.SelectBucket(key, 6) switch
         {
             0 => commonMaterials.CityFurniture.Plaster002,
             1 => commonMaterials.CityFurniture.Plaster001,
@@ -388,7 +384,7 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         };
 
     private static DefaultCommonMaterialMember SelectFacadeHighriseGlassMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 3) switch
+        StableVariantSelector.SelectBucket(key, 3) switch
         {
             0 => commonMaterials.FacadeHighriseGlass.Facade001,
             1 => commonMaterials.FacadeHighriseGlass.Facade005,
@@ -396,17 +392,17 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         };
 
     private static DefaultCommonMaterialMember SelectFacadeHighriseNightLowMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 2) == 0
+        StableVariantSelector.SelectBucket(key, 2) == 0
             ? commonMaterials.FacadeHighriseNightLow.Facade002
             : commonMaterials.FacadeHighriseNightLow.Facade011;
 
     private static DefaultCommonMaterialMember SelectFacadeMidriseGridMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 2) == 0
+        StableVariantSelector.SelectBucket(key, 2) == 0
             ? commonMaterials.FacadeMidriseGrid.Facade014
             : commonMaterials.FacadeMidriseGrid.Facade015;
 
     private static DefaultCommonMaterialMember SelectOtherMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 9) switch
+        StableVariantSelector.SelectBucket(key, 9) switch
         {
             0 => commonMaterials.Other.Concrete012,
             1 => commonMaterials.Other.Ground054,
@@ -420,7 +416,7 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         };
 
     private static DefaultCommonMaterialMember SelectRoadTriplanarMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 4) switch
+        StableVariantSelector.SelectBucket(key, 4) switch
         {
             0 => commonMaterials.RoadTriplanar.Road012A,
             1 => commonMaterials.RoadTriplanar.Road013A,
@@ -429,7 +425,7 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         };
 
     private static DefaultCommonMaterialMember SelectRoadUvMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 4) switch
+        StableVariantSelector.SelectBucket(key, 4) switch
         {
             0 => commonMaterials.RoadUv.Road012A,
             1 => commonMaterials.RoadUv.Road013A,
@@ -438,7 +434,7 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         };
 
     private static DefaultCommonMaterialMember SelectRoofMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 4) switch
+        StableVariantSelector.SelectBucket(key, 4) switch
         {
             0 => commonMaterials.Roof.Concrete012,
             1 => commonMaterials.Roof.Concrete033,
@@ -447,37 +443,37 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         };
 
     private static DefaultCommonMaterialMember SelectVegetationMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 2) == 0
+        StableVariantSelector.SelectBucket(key, 2) == 0
             ? commonMaterials.Vegetation.Ground054
             : commonMaterials.Vegetation.Concrete012;
 
     private static DefaultCommonMaterialMember SelectWallApartmentTileMidMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 2) == 0
+        StableVariantSelector.SelectBucket(key, 2) == 0
             ? commonMaterials.WallApartmentTileMid.ApartmentTileMid
             : commonMaterials.WallApartmentTileMid.ApartmentTileDark;
 
     private static DefaultCommonMaterialMember SelectWallBrickRetroMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 2) == 0
+        StableVariantSelector.SelectBucket(key, 2) == 0
             ? commonMaterials.WallBrickRetro.BrickRetro
             : commonMaterials.WallBrickRetro.BrickDark;
 
     private static DefaultCommonMaterialMember SelectWallCommercialPanelMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 2) == 0
+        StableVariantSelector.SelectBucket(key, 2) == 0
             ? commonMaterials.WallCommercialPanel.CommercialPanel
             : commonMaterials.WallCommercialPanel.CommercialPanelDark;
 
     private static DefaultCommonMaterialMember SelectWallRcPaintedMidMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 2) == 0
+        StableVariantSelector.SelectBucket(key, 2) == 0
             ? commonMaterials.WallRcPaintedMid.RcPaintedMid
             : commonMaterials.WallRcPaintedMid.RcPaintedDark;
 
     private static DefaultCommonMaterialMember SelectWallResidentialPlasterLowMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 2) == 0
+        StableVariantSelector.SelectBucket(key, 2) == 0
             ? commonMaterials.WallResidentialPlasterLow.ResidentialPlasterLow
             : commonMaterials.WallResidentialPlasterLow.ResidentialPlasterDark;
 
     private static DefaultCommonMaterialMember SelectWallResidentialTileLowMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 4) switch
+        StableVariantSelector.SelectBucket(key, 4) switch
         {
             0 => commonMaterials.WallResidentialTileLow.ResidentialTileLow,
             1 => commonMaterials.WallResidentialTileLow.ResidentialTileDark,
@@ -486,17 +482,9 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         };
 
     private static DefaultCommonMaterialMember SelectWallSchoolPublicBandMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        SelectStableBucket(key, 2) == 0
+        StableVariantSelector.SelectBucket(key, 2) == 0
             ? commonMaterials.WallSchoolPublicBand.SchoolPublicBand
             : commonMaterials.WallSchoolPublicBand.SchoolPublicDark;
-
-    private static int SelectStableBucket(string variantSelectionKey, int bucketCount)
-    {
-        byte[] keyBytes = Encoding.UTF8.GetBytes(variantSelectionKey);
-        byte[] hashBytes = SHA256.HashData(keyBytes);
-        int hashCode = BinaryPrimitives.ReadInt32LittleEndian(hashBytes) & int.MaxValue;
-        return hashCode % bucketCount;
-    }
 
     private static Float2 ToContractFloat2(Domain.Importing.ScalarPair value) => new(value.X, value.Y);
 }

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 
 using PlateauResoniteLink.Domain.Importing;
 
@@ -173,78 +172,78 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
 
         if (landmark)
         {
-            return HasNightOccupancy(attributes)
+            return BuildingAttributePredicates.HasNightOccupancy(attributes)
                 ? SelectFacadeHighriseNightLowMember(commonMaterials, request.VariantSelectionKey)
                 : SelectFacadeHighriseGlassMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (highrise)
         {
-            return HasNightOccupancy(attributes)
+            return BuildingAttributePredicates.HasNightOccupancy(attributes)
                 ? SelectFacadeHighriseNightLowMember(commonMaterials, request.VariantSelectionKey)
                 : SelectFacadeHighriseGlassMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (midrise && IsFacadeLikeMidriseUse(attributes))
+        if (midrise && BuildingAttributePredicates.HasFacadeLikeMidriseUse(attributes))
         {
             return SelectFacadeMidriseGridMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (HasRawBuildingCode(attributes, "431")
-            || HasUse(attributes, PlateauBuildingUse.Warehouse)
-            || HasRawBuildingCode(attributes, "441")
-            || HasUse(attributes, PlateauBuildingUse.Factory)
+        if (BuildingAttributePredicates.HasRawBuildingCode(attributes, "431")
+            || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Warehouse)
+            || BuildingAttributePredicates.HasRawBuildingCode(attributes, "441")
+            || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Factory)
             || largeLowRise)
         {
             return commonMaterials.WallFactoryMetal.FactoryMetal;
         }
 
-        if (HasRawBuildingCode(attributes, "451"))
+        if (BuildingAttributePredicates.HasRawBuildingCode(attributes, "451"))
         {
             return commonMaterials.WallWoodRural.WoodRuralLight;
         }
 
-        if (HasBrickLikeStructure(attributes))
+        if (BuildingAttributePredicates.HasBrickLikeStructure(attributes))
         {
             return SelectWallBrickRetroMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (HasUse(attributes, PlateauBuildingUse.Commercial)
-            || HasUse(attributes, PlateauBuildingUse.Office))
+        if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Commercial)
+            || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Office))
         {
             return lowRise
                 ? SelectWallCommercialPanelMember(commonMaterials, request.VariantSelectionKey)
                 : SelectWallRcPaintedMidMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (HasUse(attributes, PlateauBuildingUse.Public)
-            || HasUse(attributes, PlateauBuildingUse.Education))
+        if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Public)
+            || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Education))
         {
             return SelectWallSchoolPublicBandMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (HasUse(attributes, PlateauBuildingUse.Apartment))
+        if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Apartment))
         {
             return lowRise
                 ? SelectWallResidentialTileLowMember(commonMaterials, request.VariantSelectionKey)
                 : SelectWallApartmentTileMidMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (HasUse(attributes, PlateauBuildingUse.MixedResidential))
+        if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.MixedResidential))
         {
             return lowRise
                 ? SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey)
                 : SelectWallApartmentTileMidMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (HasUse(attributes, PlateauBuildingUse.DetachedResidential))
+        if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.DetachedResidential))
         {
             return IsWeightedAlternate(request.VariantSelectionKey)
                 ? SelectWallResidentialTileLowMember(commonMaterials, request.VariantSelectionKey)
                 : SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (IsRobustStructure(attributes) || midOrHighRise)
+        if (BuildingAttributePredicates.IsRobustStructure(attributes) || midOrHighRise)
         {
             return SelectWallRcPaintedMidMember(commonMaterials, request.VariantSelectionKey);
         }
@@ -293,78 +292,6 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         return value is > 0.0 && !double.IsNaN(value.Value) && !double.IsInfinity(value.Value)
             ? value.Value
             : null;
-    }
-
-    private static bool IsFacadeLikeMidriseUse(BuildingAttributeContext attributes)
-    {
-        return HasUse(attributes, PlateauBuildingUse.Office)
-            || HasUse(attributes, PlateauBuildingUse.Commercial)
-            || HasUse(attributes, PlateauBuildingUse.Public)
-            || HasUse(attributes, PlateauBuildingUse.Education)
-            || HasUse(attributes, PlateauBuildingUse.Apartment)
-            || HasUse(attributes, PlateauBuildingUse.MixedResidential)
-            || HasRawBuildingCode(attributes, "403");
-    }
-
-    private static bool HasNightOccupancy(BuildingAttributeContext attributes)
-    {
-        return HasUse(attributes, PlateauBuildingUse.Apartment)
-            || HasUse(attributes, PlateauBuildingUse.MixedResidential)
-            || HasRawBuildingCode(attributes, "403");
-    }
-
-    private static bool IsRobustStructure(BuildingAttributeContext attributes)
-    {
-        return attributes.Structures.Any(static structure => structure.Value is PlateauBuildingStructure.ReinforcedConcrete
-            or PlateauBuildingStructure.SteelReinforcedConcrete
-            or PlateauBuildingStructure.NonWood);
-    }
-
-    private static bool HasBrickLikeStructure(BuildingAttributeContext attributes)
-    {
-        return attributes.Structures.Any(static structure => structure.Value is PlateauBuildingStructure.ConcreteBlock);
-    }
-
-    private static bool HasUse(BuildingAttributeContext attributes, PlateauBuildingUse use)
-    {
-        return attributes.Uses.Any(candidate => candidate.Value == use)
-            || attributes.DetailedUses.Any(candidate => candidate.Value == use)
-            || attributes.CityGmlFunctionCodes.Any(code => HasRawBuildingCode(code, use));
-    }
-
-    private static bool HasRawBuildingCode(BuildingAttributeContext attributes, string code)
-    {
-        return attributes.CityGmlFunctionCodes.Any(candidate => IsSameBroadCode(candidate, code))
-            || attributes.CityGmlClassCodes.Any(candidate => IsSameBroadCode(candidate, code));
-    }
-
-    private static bool HasRawBuildingCode(string code, PlateauBuildingUse use)
-    {
-        string broadCode = CreateBroadBuildingCode(code);
-        return use switch
-        {
-            PlateauBuildingUse.DetachedResidential => broadCode is "411" or "111",
-            PlateauBuildingUse.Apartment => broadCode is "412" or "112" or "113",
-            PlateauBuildingUse.MixedResidential => broadCode is "413" or "414" or "415" or "114" or "115" or "116",
-            PlateauBuildingUse.Office => broadCode is "401" or "131",
-            PlateauBuildingUse.Commercial => broadCode is "402" or "403" or "404" or "151" or "152",
-            PlateauBuildingUse.Warehouse => broadCode is "431" or "171" or "172",
-            PlateauBuildingUse.Factory => broadCode is "441" or "174",
-            PlateauBuildingUse.Education => broadCode is "422" or "181",
-            PlateauBuildingUse.Public => broadCode is "421" or "191" or "192" or "193",
-            _ => false,
-        };
-    }
-
-    private static bool IsSameBroadCode(string candidate, string expected)
-    {
-        return string.Equals(CreateBroadBuildingCode(candidate), expected, StringComparison.Ordinal);
-    }
-
-    private static string CreateBroadBuildingCode(string code)
-    {
-        string trimmed = code.Trim();
-        return trimmed.Length <= 3 ? trimmed : trimmed[..3];
     }
 
     private static bool IsWeightedAlternate(string variantSelectionKey)

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
@@ -160,31 +160,27 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials)
     {
         BuildingAttributeContext attributes = request.BuildingAttributes ?? BuildingAttributeContext.Empty;
-        int? floorCount = request.FloorsAboveGround;
-        double? heightMeters = GetEffectiveHeightMeters(request);
-        double? footprintArea = request.FootprintAreaSquareMeters;
-        bool lowRise = IsLowRise(floorCount, heightMeters);
-        bool midOrHighRise = IsMidOrHighRise(floorCount, heightMeters);
-        bool midrise = IsMidrise(floorCount, heightMeters);
-        bool highrise = IsHighrise(floorCount, heightMeters);
-        bool landmark = IsLandmarkScale(floorCount, heightMeters);
-        bool largeLowRise = lowRise && footprintArea is >= 1000.0;
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            request.FloorsAboveGround,
+            request.MeasuredHeightMeters,
+            request.GeometryHeightMeters,
+            request.FootprintAreaSquareMeters);
 
-        if (landmark)
+        if (scale.Landmark)
         {
             return BuildingAttributePredicates.HasNightOccupancy(attributes)
                 ? SelectFacadeHighriseNightLowMember(commonMaterials, request.VariantSelectionKey)
                 : SelectFacadeHighriseGlassMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (highrise)
+        if (scale.Highrise)
         {
             return BuildingAttributePredicates.HasNightOccupancy(attributes)
                 ? SelectFacadeHighriseNightLowMember(commonMaterials, request.VariantSelectionKey)
                 : SelectFacadeHighriseGlassMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (midrise && BuildingAttributePredicates.HasFacadeLikeMidriseUse(attributes))
+        if (scale.Midrise && BuildingAttributePredicates.HasFacadeLikeMidriseUse(attributes))
         {
             return SelectFacadeMidriseGridMember(commonMaterials, request.VariantSelectionKey);
         }
@@ -193,7 +189,7 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
             || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Warehouse)
             || BuildingAttributePredicates.HasRawBuildingCode(attributes, "441")
             || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Factory)
-            || largeLowRise)
+            || scale.LargeLowRise)
         {
             return commonMaterials.WallFactoryMetal.FactoryMetal;
         }
@@ -211,7 +207,7 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Commercial)
             || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Office))
         {
-            return lowRise
+            return scale.LowRise
                 ? SelectWallCommercialPanelMember(commonMaterials, request.VariantSelectionKey)
                 : SelectWallRcPaintedMidMember(commonMaterials, request.VariantSelectionKey);
         }
@@ -224,14 +220,14 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Apartment))
         {
-            return lowRise
+            return scale.LowRise
                 ? SelectWallResidentialTileLowMember(commonMaterials, request.VariantSelectionKey)
                 : SelectWallApartmentTileMidMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.MixedResidential))
         {
-            return lowRise
+            return scale.LowRise
                 ? SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey)
                 : SelectWallApartmentTileMidMember(commonMaterials, request.VariantSelectionKey);
         }
@@ -243,55 +239,12 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
                 : SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (BuildingAttributePredicates.IsRobustStructure(attributes) || midOrHighRise)
+        if (BuildingAttributePredicates.IsRobustStructure(attributes) || scale.MidOrHighRise)
         {
             return SelectWallRcPaintedMidMember(commonMaterials, request.VariantSelectionKey);
         }
 
         return SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey);
-    }
-
-    private static bool IsLowRise(int? floorCount, double? heightMeters)
-    {
-        return (!FacadeFloorMetrics.IsUsableFloorCount(floorCount) || floorCount <= 3)
-            && (!heightMeters.HasValue || heightMeters.Value < 12.0);
-    }
-
-    private static bool IsMidOrHighRise(int? floorCount, double? heightMeters)
-    {
-        return (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount >= 4)
-            || heightMeters is >= 12.0;
-    }
-
-    private static bool IsMidrise(int? floorCount, double? heightMeters)
-    {
-        return (heightMeters is >= 25.0 and < 80.0)
-            || (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount is >= 8 and < 20);
-    }
-
-    private static bool IsHighrise(int? floorCount, double? heightMeters)
-    {
-        return (heightMeters is >= 80.0 and < 150.0)
-            || (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount is >= 20 and < 35);
-    }
-
-    private static bool IsLandmarkScale(int? floorCount, double? heightMeters)
-    {
-        return heightMeters is >= 150.0
-            || (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount >= 35);
-    }
-
-    private static double? GetEffectiveHeightMeters(DefaultMaterialRequest request)
-    {
-        return TryGetPositiveValue(request.MeasuredHeightMeters)
-            ?? TryGetPositiveValue(request.GeometryHeightMeters);
-    }
-
-    private static double? TryGetPositiveValue(double? value)
-    {
-        return value is > 0.0 && !double.IsNaN(value.Value) && !double.IsInfinity(value.Value)
-            ? value.Value
-            : null;
     }
 
     private static bool IsWeightedAlternate(string variantSelectionKey)

--- a/src/PlateauResoniteLink/Application/Importing/StableVariantSelector.cs
+++ b/src/PlateauResoniteLink/Application/Importing/StableVariantSelector.cs
@@ -9,7 +9,7 @@ internal static class StableVariantSelector
 {
     public static int SelectBucket(string variantSelectionKey, int bucketCount)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(variantSelectionKey);
+        ArgumentNullException.ThrowIfNull(variantSelectionKey);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bucketCount);
 
         byte[] keyBytes = Encoding.UTF8.GetBytes(variantSelectionKey);

--- a/src/PlateauResoniteLink/Application/Importing/StableVariantSelector.cs
+++ b/src/PlateauResoniteLink/Application/Importing/StableVariantSelector.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal static class StableVariantSelector
+{
+    public static int SelectBucket(string variantSelectionKey, int bucketCount)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(variantSelectionKey);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bucketCount);
+
+        byte[] keyBytes = Encoding.UTF8.GetBytes(variantSelectionKey);
+        byte[] hashBytes = SHA256.HashData(keyBytes);
+        int hashCode = BinaryPrimitives.ReadInt32LittleEndian(hashBytes) & int.MaxValue;
+        return hashCode % bucketCount;
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/BuildingAttributePredicatesTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/BuildingAttributePredicatesTests.cs
@@ -1,0 +1,97 @@
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class BuildingAttributePredicatesTests
+{
+    [Theory]
+    [InlineData("403", (int)PlateauBuildingUse.Commercial)]
+    [InlineData("403-1", (int)PlateauBuildingUse.Commercial)]
+    [InlineData("112", (int)PlateauBuildingUse.Apartment)]
+    [InlineData("131-office", (int)PlateauBuildingUse.Office)]
+    [InlineData("181", (int)PlateauBuildingUse.Education)]
+    public void HasUseMapsCityGmlFunctionCodesByBroadBuildingCode(string rawCode, int useValue)
+    {
+        PlateauBuildingUse use = (PlateauBuildingUse)useValue;
+        BuildingAttributeContext attributes = BuildingAttributeContext.Empty with
+        {
+            CityGmlFunctionCodes = [rawCode],
+        };
+
+        Assert.True(BuildingAttributePredicates.HasUse(attributes, use));
+    }
+
+    [Theory]
+    [InlineData("403-extra", "403")]
+    [InlineData("401", "401")]
+    public void HasRawBuildingCodeUsesFunctionAndClassBroadCodes(string rawCode, string expectedCode)
+    {
+        BuildingAttributeContext functionAttributes = BuildingAttributeContext.Empty with
+        {
+            CityGmlFunctionCodes = [rawCode],
+        };
+        BuildingAttributeContext classAttributes = BuildingAttributeContext.Empty with
+        {
+            CityGmlClassCodes = [rawCode],
+        };
+
+        Assert.True(BuildingAttributePredicates.HasRawBuildingCode(functionAttributes, expectedCode));
+        Assert.True(BuildingAttributePredicates.HasRawBuildingCode(classAttributes, expectedCode));
+    }
+
+    [Theory]
+    [InlineData((int)PlateauBuildingUse.Apartment)]
+    [InlineData((int)PlateauBuildingUse.MixedResidential)]
+    public void HasNightOccupancyIncludesResidentialSharedOccupancyUses(int useValue)
+    {
+        PlateauBuildingUse use = (PlateauBuildingUse)useValue;
+        BuildingAttributeContext attributes = BuildingAttributeContext.Empty with
+        {
+            Uses = [new BuildingCodeValue<PlateauBuildingUse>(use, "test")],
+        };
+
+        Assert.True(BuildingAttributePredicates.HasNightOccupancy(attributes));
+    }
+
+    [Fact]
+    public void HasNightOccupancyIncludesRaw403BuildingCode()
+    {
+        BuildingAttributeContext attributes = BuildingAttributeContext.Empty with
+        {
+            CityGmlFunctionCodes = ["403-extra"],
+        };
+
+        Assert.True(BuildingAttributePredicates.HasNightOccupancy(attributes));
+    }
+
+    [Theory]
+    [InlineData((int)PlateauBuildingStructure.ReinforcedConcrete)]
+    [InlineData((int)PlateauBuildingStructure.SteelReinforcedConcrete)]
+    [InlineData((int)PlateauBuildingStructure.NonWood)]
+    public void IsRobustStructureIncludesNonWoodAndReinforcedStructures(int structureValue)
+    {
+        PlateauBuildingStructure structure = (PlateauBuildingStructure)structureValue;
+        BuildingAttributeContext attributes = BuildingAttributeContext.Empty with
+        {
+            Structures = [new BuildingCodeValue<PlateauBuildingStructure>(structure, "test")],
+        };
+
+        Assert.True(BuildingAttributePredicates.IsRobustStructure(attributes));
+        Assert.False(BuildingAttributePredicates.HasBrickLikeStructure(attributes));
+    }
+
+    [Fact]
+    public void HasBrickLikeStructureIncludesConcreteBlock()
+    {
+        BuildingAttributeContext attributes = BuildingAttributeContext.Empty with
+        {
+            Structures =
+            [
+                new BuildingCodeValue<PlateauBuildingStructure>(PlateauBuildingStructure.ConcreteBlock, "606"),
+            ],
+        };
+
+        Assert.True(BuildingAttributePredicates.HasBrickLikeStructure(attributes));
+        Assert.False(BuildingAttributePredicates.IsRobustStructure(attributes));
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/BuildingFacadeScaleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/BuildingFacadeScaleTests.cs
@@ -1,0 +1,121 @@
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class BuildingFacadeScaleTests
+{
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(3, 11.999)]
+    [InlineData(0, 8.0)]
+    [InlineData(-1, 8.0)]
+    public void ClassifyTreatsSmallOrUnknownPositiveScaleAsLowRise(int? floorCount, double? measuredHeightMeters)
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount,
+            measuredHeightMeters,
+            geometryHeightMeters: null,
+            footprintAreaSquareMeters: null);
+
+        Assert.True(scale.LowRise);
+        Assert.False(scale.MidOrHighRise);
+        Assert.False(scale.Midrise);
+        Assert.False(scale.Highrise);
+        Assert.False(scale.Landmark);
+    }
+
+    [Theory]
+    [InlineData(4, null)]
+    [InlineData(null, 12.0)]
+    public void ClassifyTreatsFourFloorsOrTwelveMetersAsMidOrHighRise(int? floorCount, double? measuredHeightMeters)
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount,
+            measuredHeightMeters,
+            geometryHeightMeters: null,
+            footprintAreaSquareMeters: null);
+
+        Assert.False(scale.LowRise);
+        Assert.True(scale.MidOrHighRise);
+    }
+
+    [Theory]
+    [InlineData(8, null)]
+    [InlineData(null, 25.0)]
+    [InlineData(19, 79.999)]
+    public void ClassifyTreatsEightToNineteenFloorsOrTwentyFiveToUnderEightyMetersAsMidrise(
+        int? floorCount,
+        double? measuredHeightMeters)
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount,
+            measuredHeightMeters,
+            geometryHeightMeters: null,
+            footprintAreaSquareMeters: null);
+
+        Assert.True(scale.Midrise);
+        Assert.False(scale.Highrise);
+        Assert.False(scale.Landmark);
+    }
+
+    [Theory]
+    [InlineData(20, null)]
+    [InlineData(null, 80.0)]
+    [InlineData(34, 149.999)]
+    public void ClassifyTreatsTwentyToThirtyFourFloorsOrEightyToUnderOneHundredFiftyMetersAsHighrise(
+        int? floorCount,
+        double? measuredHeightMeters)
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount,
+            measuredHeightMeters,
+            geometryHeightMeters: null,
+            footprintAreaSquareMeters: null);
+
+        Assert.False(scale.Midrise);
+        Assert.True(scale.Highrise);
+        Assert.False(scale.Landmark);
+    }
+
+    [Theory]
+    [InlineData(35, null)]
+    [InlineData(null, 150.0)]
+    public void ClassifyTreatsThirtyFiveFloorsOrOneHundredFiftyMetersAsLandmark(
+        int? floorCount,
+        double? measuredHeightMeters)
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount,
+            measuredHeightMeters,
+            geometryHeightMeters: null,
+            footprintAreaSquareMeters: null);
+
+        Assert.True(scale.Landmark);
+    }
+
+    [Fact]
+    public void ClassifyFallsBackToGeometryHeightWhenMeasuredHeightIsNotUsable()
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount: null,
+            measuredHeightMeters: double.NaN,
+            geometryHeightMeters: 95.0,
+            footprintAreaSquareMeters: null);
+
+        Assert.True(scale.Highrise);
+    }
+
+    [Theory]
+    [InlineData(999.999, false)]
+    [InlineData(1000.0, true)]
+    public void ClassifyMarksOnlyLargeLowRiseFootprintsAsLargeLowRise(double footprintAreaSquareMeters, bool expected)
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount: 3,
+            measuredHeightMeters: 8.0,
+            geometryHeightMeters: null,
+            footprintAreaSquareMeters: footprintAreaSquareMeters);
+
+        Assert.Equal(expected, scale.LargeLowRise);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/StableVariantSelectorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StableVariantSelectorTests.cs
@@ -1,0 +1,23 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class StableVariantSelectorTests
+{
+    [Fact]
+    public void SelectBucketIsStableForKnownKeys()
+    {
+        Assert.Equal(2, StableVariantSelector.SelectBucket("53394525:bldg:wall", 6));
+        Assert.Equal(2, StableVariantSelector.SelectBucket("53394525:bldg:roof", 4));
+        Assert.Equal(0, StableVariantSelector.SelectBucket("53394525:other", 9));
+    }
+
+    [Fact]
+    public void SelectBucketRejectsInvalidBucketCount()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => StableVariantSelector.SelectBucket("53394525:bldg:wall", 0));
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/StableVariantSelectorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StableVariantSelectorTests.cs
@@ -14,6 +14,21 @@ public sealed class StableVariantSelectorTests
         Assert.Equal(0, StableVariantSelector.SelectBucket("53394525:other", 9));
     }
 
+    [Theory]
+    [InlineData("", 5)]
+    [InlineData("   ", 2)]
+    public void SelectBucketPreservesEmptyAndWhitespaceKeyHashing(string variantSelectionKey, int expectedBucket)
+    {
+        Assert.Equal(expectedBucket, StableVariantSelector.SelectBucket(variantSelectionKey, 6));
+    }
+
+    [Fact]
+    public void SelectBucketRejectsNullKey()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => StableVariantSelector.SelectBucket(null!, 6));
+    }
+
     [Fact]
     public void SelectBucketRejectsInvalidBucketCount()
     {


### PR DESCRIPTION
## Summary
- extract SHA-256 bucket selection from `DefaultMaterialResolver` into `StableVariantSelector`
- keep bundled material family and variant behavior unchanged while making variant selection independently testable
- add focused tests for stable known-key buckets and invalid bucket counts

## Local real-data canonical dump comparison
Ignored local-only dump root: `runtime/windows/resonite/semantic-baselines/pr2-import-stream-counting/` (`runtime/` is git-ignored).

Baseline and after were generated with the same `--canonical-scene-dump` Fake Sink command and compared with `git diff --no-index`.

- Yokohama: `14100_yokohama-shi_city_2024`, mesh `533915`, packages `dem`, `--terrain-mesh grid`
  - baseline: `baseline/yokohama-533915-dem-grid.json`
  - after: `after/yokohama-533915-dem-grid.json`
  - result: no diff, SHA256 `94B897DFB10EB9BC2BCFFE3EFCEE21E2D33E88E6E28A8ABCE31314FE1436A811`

## Verification
- `dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --filter "FullyQualifiedName~StableVariantSelectorTests|FullyQualifiedName~DefaultMaterialResolverTests" --logger "console;verbosity=minimal"`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`