### PR TITLE
Extract building facade scale classification

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/BuildingFacadeScale.cs
+++ b/src/PlateauResoniteLink/Application/Importing/BuildingFacadeScale.cs
@@ -1,0 +1,73 @@
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal readonly record struct BuildingFacadeScale(
+    bool LowRise,
+    bool MidOrHighRise,
+    bool Midrise,
+    bool Highrise,
+    bool Landmark,
+    bool LargeLowRise)
+{
+    public static BuildingFacadeScale Classify(
+        int? floorCount,
+        double? measuredHeightMeters,
+        double? geometryHeightMeters,
+        double? footprintAreaSquareMeters)
+    {
+        double? effectiveHeightMeters = GetEffectiveHeightMeters(measuredHeightMeters, geometryHeightMeters);
+        bool lowRise = IsLowRise(floorCount, effectiveHeightMeters);
+
+        return new BuildingFacadeScale(
+            lowRise,
+            IsMidOrHighRise(floorCount, effectiveHeightMeters),
+            IsMidrise(floorCount, effectiveHeightMeters),
+            IsHighrise(floorCount, effectiveHeightMeters),
+            IsLandmarkScale(floorCount, effectiveHeightMeters),
+            lowRise && footprintAreaSquareMeters is >= 1000.0);
+    }
+
+    private static bool IsLowRise(int? floorCount, double? heightMeters)
+    {
+        return (!FacadeFloorMetrics.IsUsableFloorCount(floorCount) || floorCount <= 3)
+            && (!heightMeters.HasValue || heightMeters.Value < 12.0);
+    }
+
+    private static bool IsMidOrHighRise(int? floorCount, double? heightMeters)
+    {
+        return (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount >= 4)
+            || heightMeters is >= 12.0;
+    }
+
+    private static bool IsMidrise(int? floorCount, double? heightMeters)
+    {
+        return (heightMeters is >= 25.0 and < 80.0)
+            || (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount is >= 8 and < 20);
+    }
+
+    private static bool IsHighrise(int? floorCount, double? heightMeters)
+    {
+        return (heightMeters is >= 80.0 and < 150.0)
+            || (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount is >= 20 and < 35);
+    }
+
+    private static bool IsLandmarkScale(int? floorCount, double? heightMeters)
+    {
+        return heightMeters is >= 150.0
+            || (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount >= 35);
+    }
+
+    private static double? GetEffectiveHeightMeters(double? measuredHeightMeters, double? geometryHeightMeters)
+    {
+        return TryGetPositiveValue(measuredHeightMeters)
+            ?? TryGetPositiveValue(geometryHeightMeters);
+    }
+
+    private static double? TryGetPositiveValue(double? value)
+    {
+        return value is > 0.0 && !double.IsNaN(value.Value) && !double.IsInfinity(value.Value)
+            ? value.Value
+            : null;
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
@@ -160,31 +160,27 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials)
     {
         BuildingAttributeContext attributes = request.BuildingAttributes ?? BuildingAttributeContext.Empty;
-        int? floorCount = request.FloorsAboveGround;
-        double? heightMeters = GetEffectiveHeightMeters(request);
-        double? footprintArea = request.FootprintAreaSquareMeters;
-        bool lowRise = IsLowRise(floorCount, heightMeters);
-        bool midOrHighRise = IsMidOrHighRise(floorCount, heightMeters);
-        bool midrise = IsMidrise(floorCount, heightMeters);
-        bool highrise = IsHighrise(floorCount, heightMeters);
-        bool landmark = IsLandmarkScale(floorCount, heightMeters);
-        bool largeLowRise = lowRise && footprintArea is >= 1000.0;
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            request.FloorsAboveGround,
+            request.MeasuredHeightMeters,
+            request.GeometryHeightMeters,
+            request.FootprintAreaSquareMeters);
 
-        if (landmark)
+        if (scale.Landmark)
         {
             return BuildingAttributePredicates.HasNightOccupancy(attributes)
                 ? SelectFacadeHighriseNightLowMember(commonMaterials, request.VariantSelectionKey)
                 : SelectFacadeHighriseGlassMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (highrise)
+        if (scale.Highrise)
         {
             return BuildingAttributePredicates.HasNightOccupancy(attributes)
                 ? SelectFacadeHighriseNightLowMember(commonMaterials, request.VariantSelectionKey)
                 : SelectFacadeHighriseGlassMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (midrise && BuildingAttributePredicates.HasFacadeLikeMidriseUse(attributes))
+        if (scale.Midrise && BuildingAttributePredicates.HasFacadeLikeMidriseUse(attributes))
         {
             return SelectFacadeMidriseGridMember(commonMaterials, request.VariantSelectionKey);
         }
@@ -193,7 +189,7 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
             || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Warehouse)
             || BuildingAttributePredicates.HasRawBuildingCode(attributes, "441")
             || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Factory)
-            || largeLowRise)
+            || scale.LargeLowRise)
         {
             return commonMaterials.WallFactoryMetal.FactoryMetal;
         }
@@ -211,7 +207,7 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Commercial)
             || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Office))
         {
-            return lowRise
+            return scale.LowRise
                 ? SelectWallCommercialPanelMember(commonMaterials, request.VariantSelectionKey)
                 : SelectWallRcPaintedMidMember(commonMaterials, request.VariantSelectionKey);
         }
@@ -224,14 +220,14 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Apartment))
         {
-            return lowRise
+            return scale.LowRise
                 ? SelectWallResidentialTileLowMember(commonMaterials, request.VariantSelectionKey)
                 : SelectWallApartmentTileMidMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.MixedResidential))
         {
-            return lowRise
+            return scale.LowRise
                 ? SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey)
                 : SelectWallApartmentTileMidMember(commonMaterials, request.VariantSelectionKey);
         }
@@ -243,55 +239,12 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
                 : SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        if (BuildingAttributePredicates.IsRobustStructure(attributes) || midOrHighRise)
+        if (BuildingAttributePredicates.IsRobustStructure(attributes) || scale.MidOrHighRise)
         {
             return SelectWallRcPaintedMidMember(commonMaterials, request.VariantSelectionKey);
         }
 
         return SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey);
-    }
-
-    private static bool IsLowRise(int? floorCount, double? heightMeters)
-    {
-        return (!FacadeFloorMetrics.IsUsableFloorCount(floorCount) || floorCount <= 3)
-            && (!heightMeters.HasValue || heightMeters.Value < 12.0);
-    }
-
-    private static bool IsMidOrHighRise(int? floorCount, double? heightMeters)
-    {
-        return (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount >= 4)
-            || heightMeters is >= 12.0;
-    }
-
-    private static bool IsMidrise(int? floorCount, double? heightMeters)
-    {
-        return (heightMeters is >= 25.0 and < 80.0)
-            || (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount is >= 8 and < 20);
-    }
-
-    private static bool IsHighrise(int? floorCount, double? heightMeters)
-    {
-        return (heightMeters is >= 80.0 and < 150.0)
-            || (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount is >= 20 and < 35);
-    }
-
-    private static bool IsLandmarkScale(int? floorCount, double? heightMeters)
-    {
-        return heightMeters is >= 150.0
-            || (FacadeFloorMetrics.IsUsableFloorCount(floorCount) && floorCount >= 35);
-    }
-
-    private static double? GetEffectiveHeightMeters(DefaultMaterialRequest request)
-    {
-        return TryGetPositiveValue(request.MeasuredHeightMeters)
-            ?? TryGetPositiveValue(request.GeometryHeightMeters);
-    }
-
-    private static double? TryGetPositiveValue(double? value)
-    {
-        return value is > 0.0 && !double.IsNaN(value.Value) && !double.IsInfinity(value.Value)
-            ? value.Value
-            : null;
     }
 
     private static bool IsWeightedAlternate(string variantSelectionKey)

--- a/tests/PlateauResoniteLink.Tests/Profiles/BuildingFacadeScaleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/BuildingFacadeScaleTests.cs
@@ -1,0 +1,121 @@
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class BuildingFacadeScaleTests
+{
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(3, 11.999)]
+    [InlineData(0, 8.0)]
+    [InlineData(-1, 8.0)]
+    public void ClassifyTreatsSmallOrUnknownPositiveScaleAsLowRise(int? floorCount, double? measuredHeightMeters)
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount,
+            measuredHeightMeters,
+            geometryHeightMeters: null,
+            footprintAreaSquareMeters: null);
+
+        Assert.True(scale.LowRise);
+        Assert.False(scale.MidOrHighRise);
+        Assert.False(scale.Midrise);
+        Assert.False(scale.Highrise);
+        Assert.False(scale.Landmark);
+    }
+
+    [Theory]
+    [InlineData(4, null)]
+    [InlineData(null, 12.0)]
+    public void ClassifyTreatsFourFloorsOrTwelveMetersAsMidOrHighRise(int? floorCount, double? measuredHeightMeters)
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount,
+            measuredHeightMeters,
+            geometryHeightMeters: null,
+            footprintAreaSquareMeters: null);
+
+        Assert.False(scale.LowRise);
+        Assert.True(scale.MidOrHighRise);
+    }
+
+    [Theory]
+    [InlineData(8, null)]
+    [InlineData(null, 25.0)]
+    [InlineData(19, 79.999)]
+    public void ClassifyTreatsEightToNineteenFloorsOrTwentyFiveToUnderEightyMetersAsMidrise(
+        int? floorCount,
+        double? measuredHeightMeters)
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount,
+            measuredHeightMeters,
+            geometryHeightMeters: null,
+            footprintAreaSquareMeters: null);
+
+        Assert.True(scale.Midrise);
+        Assert.False(scale.Highrise);
+        Assert.False(scale.Landmark);
+    }
+
+    [Theory]
+    [InlineData(20, null)]
+    [InlineData(null, 80.0)]
+    [InlineData(34, 149.999)]
+    public void ClassifyTreatsTwentyToThirtyFourFloorsOrEightyToUnderOneHundredFiftyMetersAsHighrise(
+        int? floorCount,
+        double? measuredHeightMeters)
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount,
+            measuredHeightMeters,
+            geometryHeightMeters: null,
+            footprintAreaSquareMeters: null);
+
+        Assert.False(scale.Midrise);
+        Assert.True(scale.Highrise);
+        Assert.False(scale.Landmark);
+    }
+
+    [Theory]
+    [InlineData(35, null)]
+    [InlineData(null, 150.0)]
+    public void ClassifyTreatsThirtyFiveFloorsOrOneHundredFiftyMetersAsLandmark(
+        int? floorCount,
+        double? measuredHeightMeters)
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount,
+            measuredHeightMeters,
+            geometryHeightMeters: null,
+            footprintAreaSquareMeters: null);
+
+        Assert.True(scale.Landmark);
+    }
+
+    [Fact]
+    public void ClassifyFallsBackToGeometryHeightWhenMeasuredHeightIsNotUsable()
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount: null,
+            measuredHeightMeters: double.NaN,
+            geometryHeightMeters: 95.0,
+            footprintAreaSquareMeters: null);
+
+        Assert.True(scale.Highrise);
+    }
+
+    [Theory]
+    [InlineData(999.999, false)]
+    [InlineData(1000.0, true)]
+    public void ClassifyMarksOnlyLargeLowRiseFootprintsAsLargeLowRise(double footprintAreaSquareMeters, bool expected)
+    {
+        BuildingFacadeScale scale = BuildingFacadeScale.Classify(
+            floorCount: 3,
+            measuredHeightMeters: 8.0,
+            geometryHeightMeters: null,
+            footprintAreaSquareMeters: footprintAreaSquareMeters);
+
+        Assert.Equal(expected, scale.LargeLowRise);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract building facade scale classification from DefaultMaterialResolver into BuildingFacadeScale.
- Keep resolver focused on selecting material families from classified scale and building attributes.
- Add boundary tests for low-rise, midrise, highrise, landmark, geometry-height fallback, and large low-rise footprints.

## Local real-data semantic dump
- Local-only path: runtime/windows/resonite/semantic-baselines/pr4-building-scale-classification/ (ignored by .gitignore: runtime/)
- Dataset: plateau-13213-higashimurayama-shi-2020
- Mesh/packages: 53395325 / bldg
- Source: runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-archive-5039b16c4b1c.zip
- Compare: git diff --no-index baseline/.../higashimurayama-53395325-bldg.json after/.../higashimurayama-53395325-bldg.json => no diff
- SHA256 baseline/after: 4625FF16EFE0EA72E516C376ACF53CCA19D7DA0F60A3AA1D8F504245AF01265B

## Verification
- dotnet test tests/PlateauResoniteLink.Tests/PlateauResoniteLink.Tests.csproj --filter FullyQualifiedName~BuildingFacadeScaleTests|FullyQualifiedName~DefaultMaterialResolverTests --logger console;verbosity=minimal (64 passed)
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false (908 passed)