### PR TITLE
Handle no-wall building roof slabs

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/BuildingAttributePredicates.cs
+++ b/src/PlateauResoniteLink/Application/Importing/BuildingAttributePredicates.cs
@@ -61,6 +61,14 @@ internal static class BuildingAttributePredicates
             || attributes.CityGmlClassCodes.Any(candidate => IsSameBroadCode(candidate, code));
     }
 
+    public static bool HasExactCityGmlClassCode(BuildingAttributeContext attributes, string code)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+
+        return attributes.CityGmlClassCodes.Any(candidate => string.Equals(candidate.Trim(), code, StringComparison.Ordinal));
+    }
+
     private static bool HasRawBuildingCode(string code, PlateauBuildingUse use)
     {
         string broadCode = CreateBroadBuildingCode(code);

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceProjectionPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceProjectionPolicy.cs
@@ -55,6 +55,7 @@ internal static class CityGmlSurfaceProjectionPolicy
         double objectMaximumY = candidates.Max(static info => info.MaximumY!.Value);
 
         return candidates
+            .Where(static info => !info.IsGeneratedLod1RoofSurface)
             .Where(static info => info.IsNearHorizontal)
             .Where(info => info.MaximumY!.Value <= objectMinimumY + BuildingBottomCullBandMeters)
             .Where(info => objectMaximumY > info.MaximumY!.Value + BuildingBottomCullBandMeters)
@@ -163,7 +164,8 @@ internal static class CityGmlSurfaceProjectionPolicy
     {
         return polygonId.Contains("_generated_shed-", StringComparison.Ordinal)
             || polygonId.Contains("_generated_gable-", StringComparison.Ordinal)
-            || polygonId.Contains("_generated_hip-", StringComparison.Ordinal);
+            || polygonId.Contains("_generated_hip-", StringComparison.Ordinal)
+            || polygonId.Contains("_generated_no-wall-", StringComparison.Ordinal);
     }
 
     private static Float3? ComputePolygonNormal(IEnumerable<Float3> positions)

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -11,15 +11,30 @@ namespace PlateauResoniteLink.Application.Importing;
 internal static class GeneratedLod1RoofCityObjectFactory
 {
     private const double BuildingBottomCullBandMeters = 0.1;
+    private const double NoWallRoofThicknessMeters = 0.3;
+    private static readonly string[] NoWallBuildingClassCodes = ["3003", "3004"];
 
     internal static ParsedCityObject Create(ParsedCityObject cityObject)
     {
         ArgumentNullException.ThrowIfNull(cityObject);
 
         if (!PlateauPackageCatalog.IsBuildingPackage(cityObject.PackageName)
-            || cityObject.LodLevel != 1
             || !cityObject.ReferenceSystem.IsGeographic
             || cityObject.Surfaces.Any(GeneratedLod1RoofSurfaceIdentity.IsGenerated))
+        {
+            return cityObject;
+        }
+
+        bool isNoWallBuilding = IsNoWallBuilding(cityObject);
+        if (!isNoWallBuilding && cityObject.LodLevel != 1)
+        {
+            return cityObject;
+        }
+
+        if (isNoWallBuilding
+            && (cityObject.Surfaces.Any(static surface => surface.UsesGeneratedDemTexture)
+                || !cityObject.Surfaces.Any(static surface => surface.Vertices.Any())
+                || (cityObject.LodLevel >= 2 && !cityObject.Surfaces.Any(static surface => surface.Semantic == ParsedSurfaceSemantic.Roof))))
         {
             return cityObject;
         }
@@ -32,6 +47,18 @@ internal static class GeneratedLod1RoofCityObjectFactory
             cityObjectOrigin.Longitude,
             cityObjectOrigin.Altitude,
             cityObject.ReferenceSystem.Geocentric);
+        if (isNoWallBuilding)
+        {
+            return TryCreateNoWallRoofSlab(cityObject, cityObjectOrigin, cityObjectCartesian, out ParsedCityObject? noWallRoofSlab)
+                ? noWallRoofSlab!
+                : cityObject;
+        }
+
+        if (cityObject.LodLevel != 1)
+        {
+            return cityObject;
+        }
+
         if (!TryCreateFootprint(cityObject, cityObjectOrigin, cityObjectCartesian, out Lod1RoofFootprint? footprint))
         {
             return cityObject;
@@ -63,11 +90,349 @@ internal static class GeneratedLod1RoofCityObjectFactory
         return cityObject with { Surfaces = surfaces };
     }
 
+    private static bool IsNoWallBuilding(ParsedCityObject cityObject)
+    {
+        return cityObject.LodLevel >= 1
+            && cityObject.BuildingAttributes is not null
+            && NoWallBuildingClassCodes.Any(code => BuildingAttributePredicates.HasExactCityGmlClassCode(cityObject.BuildingAttributes, code));
+    }
+
+    private static bool TryCreateNoWallRoofSlab(
+        ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian cityObjectCartesian,
+        out ParsedCityObject? noWallRoofSlab)
+    {
+        noWallRoofSlab = null;
+        if (cityObject.LodLevel == 1)
+        {
+            if (!TryGetNoWallTopSurfaces(
+                cityObject,
+                cityObjectOrigin,
+                cityObjectCartesian,
+                out ParsedSurface[]? topSurfaces))
+            {
+                return false;
+            }
+
+            ParsedSurface[] lod1RoofSurfaces = topSurfaces!
+                .Select(static surface => surface with { Semantic = ParsedSurfaceSemantic.Roof })
+                .ToArray();
+            if (!TryCreateNoWallRoofSurfaces(lod1RoofSurfaces, includeTopSurfaces: true, out ParsedSurface[]? generatedSurfaces))
+            {
+                return false;
+            }
+
+            noWallRoofSlab = cityObject with { Surfaces = generatedSurfaces! };
+            return true;
+        }
+
+        if (cityObject.LodLevel < 2)
+        {
+            return false;
+        }
+
+        ParsedSurface[] roofSurfaces = cityObject.Surfaces
+            .Where(static surface => surface.Semantic == ParsedSurfaceSemantic.Roof)
+            .ToArray();
+        if (roofSurfaces.Length == 0
+            || roofSurfaces.Any(static surface => surface.InteriorRings.Length != 0))
+        {
+            return false;
+        }
+
+        SurfaceProjectionInfo[] surfaceInfos = cityObject.Surfaces
+            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
+            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
+            .ToArray();
+        if (surfaceInfos.Length == 0)
+        {
+            return false;
+        }
+
+        Dictionary<string, SurfaceProjectionInfo> infosByPolygonId = surfaceInfos.ToDictionary(
+            static info => info.Surface.PolygonId,
+            static info => info,
+            StringComparer.Ordinal);
+        foreach (ParsedSurface roofSurface in roofSurfaces)
+        {
+            if (!infosByPolygonId.TryGetValue(roofSurface.PolygonId, out SurfaceProjectionInfo roofInfo)
+                || IsNoWallLod2BottomInCullBand(roofInfo, surfaceInfos))
+            {
+                return false;
+            }
+        }
+
+        if (!TryCreateNoWallRoofSurfaces(roofSurfaces, includeTopSurfaces: true, out ParsedSurface[]? generatedLod2Surfaces))
+        {
+            return false;
+        }
+
+        noWallRoofSlab = cityObject with { Surfaces = generatedLod2Surfaces! };
+        return true;
+    }
+
+    private static bool IsNoWallLod2BottomInCullBand(
+        SurfaceProjectionInfo roofInfo,
+        IReadOnlyList<SurfaceProjectionInfo> surfaceInfos)
+    {
+        double roofMinimumY = roofInfo.MinimumY!.Value;
+        SurfaceProjectionInfo[] lowerNonRoofInfos = surfaceInfos
+            .Where(static info => info.Surface.Semantic != ParsedSurfaceSemantic.Roof)
+            .Where(info => info.MinimumY!.Value < roofMinimumY)
+            .ToArray();
+        if (lowerNonRoofInfos.Length == 0)
+        {
+            return false;
+        }
+
+        double nearestLowerY = lowerNonRoofInfos
+            .Where(info => info.MaximumY!.Value < roofMinimumY)
+            .Select(static info => info.MaximumY!.Value)
+            .DefaultIfEmpty(double.NegativeInfinity)
+            .Max();
+        return roofMinimumY - NoWallRoofThicknessMeters <= nearestLowerY + BuildingBottomCullBandMeters;
+    }
+
+    private static bool TryGetNoWallTopSurfaces(
+        ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian cityObjectCartesian,
+        out ParsedSurface[]? topSurfaces)
+    {
+        topSurfaces = null;
+        SurfaceProjectionInfo[] surfaceInfos = cityObject.Surfaces
+            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
+            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
+            .ToArray();
+        if (surfaceInfos.Length == 0)
+        {
+            return false;
+        }
+
+        double objectMinimumY = surfaceInfos.Min(static info => info.MinimumY!.Value);
+        double objectMaximumY = surfaceInfos.Max(static info => info.MaximumY!.Value);
+        topSurfaces = surfaceInfos
+            .Where(static info => info.IsNearHorizontal)
+            .Where(info => info.MaximumY!.Value >= objectMaximumY - 0.1)
+            .Where(info => info.MinimumY!.Value > objectMinimumY + BuildingBottomCullBandMeters)
+            .Where(info => info.MinimumY!.Value - NoWallRoofThicknessMeters > objectMinimumY + BuildingBottomCullBandMeters)
+            .Select(static info => info.Surface)
+            .ToArray();
+        if (topSurfaces.Length == 0
+            || topSurfaces.Any(static surface => surface.InteriorRings.Length != 0))
+        {
+            topSurfaces = null;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryCreateNoWallRoofSurfaces(
+        IReadOnlyList<ParsedSurface> roofSurfaces,
+        bool includeTopSurfaces,
+        out ParsedSurface[]? generatedSurfaces)
+    {
+        generatedSurfaces = null;
+        Dictionary<NoWallRoofEdgeKey, int> edgeUseCounts = [];
+        Dictionary<string, NoWallRoofRing> ringsByPolygonId = new(StringComparer.Ordinal);
+        foreach (ParsedSurface roofSurface in roofSurfaces)
+        {
+            if (!TryCreateNoWallRoofRing(roofSurface, out NoWallRoofRing ring))
+            {
+                return false;
+            }
+
+            ringsByPolygonId.Add(roofSurface.PolygonId, ring);
+            for (int index = 0; index < ring.TopRing.Length; index++)
+            {
+                int nextIndex = (index + 1) % ring.TopRing.Length;
+                NoWallRoofEdgeKey edgeKey = NoWallRoofEdgeKey.Create(ring.TopRing[index], ring.TopRing[nextIndex]);
+                edgeUseCounts[edgeKey] = edgeUseCounts.TryGetValue(edgeKey, out int count) ? count + 1 : 1;
+            }
+        }
+
+        List<ParsedSurface> surfaces = includeTopSurfaces
+            ? [.. roofSurfaces.Select(surface => CreateNoWallTopSurface(surface, ringsByPolygonId[surface.PolygonId]))]
+            : [];
+        foreach (ParsedSurface roofSurface in roofSurfaces)
+        {
+            NoWallRoofRing ring = ringsByPolygonId[roofSurface.PolygonId];
+            surfaces.Add(CreateNoWallBottomSurface(roofSurface, ring));
+            for (int index = 0; index < ring.TopRing.Length; index++)
+            {
+                int nextIndex = (index + 1) % ring.TopRing.Length;
+                NoWallRoofEdgeKey edgeKey = NoWallRoofEdgeKey.Create(ring.TopRing[index], ring.TopRing[nextIndex]);
+                if (edgeUseCounts[edgeKey] == 1)
+                {
+                    surfaces.Add(CreateNoWallSideSurface(roofSurface, ring, index, nextIndex));
+                }
+            }
+        }
+
+        generatedSurfaces = surfaces.ToArray();
+        return true;
+    }
+
+    private static bool TryCreateNoWallRoofRing(
+        ParsedSurface roofSurface,
+        out NoWallRoofRing ring)
+    {
+        ring = default;
+        GeodeticPoint[] topRing = RemoveClosingPoint(roofSurface.ExteriorRing.Vertices);
+        if (topRing.Length < 3)
+        {
+            return false;
+        }
+
+        Float2[]? topUvs = NormalizeUvs(roofSurface.ExteriorRing.UVs, roofSurface.ExteriorRing.Vertices.Length, topRing.Length);
+        if (!TryOrientTopRingForDownwardParsedNormal(topRing, topUvs, out GeodeticPoint[]? orientedTopRing, out Float2[]? orientedTopUvs))
+        {
+            return false;
+        }
+
+        GeodeticPoint[] bottomRing = orientedTopRing!.Select(static point => Lower(point, NoWallRoofThicknessMeters)).ToArray();
+        ring = new NoWallRoofRing(orientedTopRing!, bottomRing, orientedTopUvs);
+        return true;
+    }
+
+    private static ParsedSurface CreateNoWallTopSurface(
+        ParsedSurface sourceSurface,
+        NoWallRoofRing ring)
+    {
+        GeodeticPoint[] vertices = ring.TopRing;
+        Float2[]? uvs = ring.TopUvs;
+        return CreateNoWallSurface(sourceSurface, sourceSurface.PolygonId, vertices, uvs, sourceSurface.UsesGeneratedDemTexture);
+    }
+
+    private static ParsedSurface CreateNoWallBottomSurface(
+        ParsedSurface topSurface,
+        NoWallRoofRing ring)
+    {
+        GeodeticPoint[] vertices = ring.BottomRing.Reverse().ToArray();
+        Float2[]? uvs = ring.TopUvs?.Reverse().ToArray();
+        string polygonId = $"{topSurface.PolygonId}_generated_no-wall-bottom";
+        return CreateNoWallSurface(topSurface, polygonId, vertices, uvs, usesGeneratedDemTexture: false);
+    }
+
+    private static ParsedSurface CreateNoWallSideSurface(
+        ParsedSurface topSurface,
+        NoWallRoofRing ring,
+        int index,
+        int nextIndex)
+    {
+        GeodeticPoint[] vertices =
+        [
+            ring.TopRing[index],
+            ring.BottomRing[index],
+            ring.BottomRing[nextIndex],
+            ring.TopRing[nextIndex],
+        ];
+        Float2[]? uvs = ring.TopUvs is null
+            ? null
+            :
+            [
+                ring.TopUvs[index],
+                ring.TopUvs[index],
+                ring.TopUvs[nextIndex],
+                ring.TopUvs[nextIndex],
+        ];
+        string polygonId = $"{topSurface.PolygonId}_generated_no-wall-side-{index}";
+        return CreateNoWallSurface(topSurface, polygonId, vertices, uvs, usesGeneratedDemTexture: false);
+    }
+
+    private static ParsedSurface CreateNoWallSurface(
+        ParsedSurface sourceSurface,
+        string polygonId,
+        GeodeticPoint[] vertices,
+        Float2[]? uvs,
+        bool usesGeneratedDemTexture)
+    {
+        GeodeticPoint[] closedVertices = [.. vertices, vertices[0]];
+        Float2[]? closedUvs = uvs is null ? null : [.. uvs, uvs[0]];
+        return new ParsedSurface(
+            polygonId,
+            ParsedSurfaceSemantic.Roof,
+            new ParsedRing($"{polygonId}-ring", closedVertices, closedUvs),
+            InteriorRings: [],
+            sourceSurface.BaseColor,
+            sourceSurface.TexturePayload,
+            usesGeneratedDemTexture,
+            sourceSurface.OpticalProperties);
+    }
+
+    private static Float2[]? NormalizeUvs(
+        IReadOnlyList<Float2>? uvs,
+        int sourceVertexCount,
+        int ringVertexCount)
+    {
+        if (uvs is null)
+        {
+            return null;
+        }
+
+        if (uvs.Count == ringVertexCount)
+        {
+            return uvs.ToArray();
+        }
+
+        if (uvs.Count == sourceVertexCount && sourceVertexCount == ringVertexCount + 1)
+        {
+            return uvs.Take(ringVertexCount).ToArray();
+        }
+
+        return null;
+    }
+
+    private static bool TryOrientTopRingForDownwardParsedNormal(
+        GeodeticPoint[] topRing,
+        Float2[]? topUvs,
+        out GeodeticPoint[]? orientedTopRing,
+        out Float2[]? orientedTopUvs)
+    {
+        orientedTopRing = topRing;
+        orientedTopUvs = topUvs;
+        Float3[] positions = CreateApproximatePositions(topRing);
+        Float3? normal = PolygonNormal.Compute(positions);
+        if (normal is null)
+        {
+            orientedTopRing = null;
+            orientedTopUvs = null;
+            return false;
+        }
+
+        if (normal.Y <= 0.0)
+        {
+            return true;
+        }
+
+        orientedTopRing = topRing.Reverse().ToArray();
+        orientedTopUvs = topUvs?.Reverse().ToArray();
+        return true;
+    }
+
+    private static Float3[] CreateApproximatePositions(GeodeticPoint[] points)
+    {
+        if (points.Length == 0)
+        {
+            return [];
+        }
+
+        double referenceLatitude = points.Average(static point => point.Latitude);
+        double referenceLongitude = points.Average(static point => point.Longitude);
+        return points
+            .Select(point => CreateApproximatePosition(point, referenceLatitude, referenceLongitude))
+            .ToArray();
+    }
+
     private static bool TryCreateFootprint(
         ParsedCityObject cityObject,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian cityObjectCartesian,
-        out Lod1RoofFootprint? footprint)
+        out Lod1RoofFootprint? footprint,
+        bool allowTexturedTop = false,
+        double? requiredBottomClearanceMeters = null)
     {
         footprint = null;
         SurfaceProjectionInfo[] surfaceInfos = cityObject.Surfaces
@@ -92,8 +457,14 @@ internal static class GeneratedLod1RoofCityObjectFactory
             return false;
         }
 
+        if (requiredBottomClearanceMeters.HasValue
+            && topCandidates[0].MinimumY!.Value - requiredBottomClearanceMeters.Value <= objectMinimumY + BuildingBottomCullBandMeters)
+        {
+            return false;
+        }
+
         ParsedSurface topSurface = topCandidates[0].Surface;
-        if (topSurface.TexturePayload is not null || topSurface.InteriorRings.Length != 0)
+        if ((!allowTexturedTop && topSurface.TexturePayload is not null) || topSurface.InteriorRings.Length != 0)
         {
             return false;
         }
@@ -285,6 +656,24 @@ internal static class GeneratedLod1RoofCityObjectFactory
         return new Float3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
     }
 
+    private static GeodeticPoint Lower(GeodeticPoint point, double meters)
+    {
+        return point with { Altitude = point.Altitude - meters };
+    }
+
+    private static Float3 CreateApproximatePosition(
+        GeodeticPoint point,
+        double referenceLatitude,
+        double referenceLongitude)
+    {
+        const double metersPerLatitudeDegree = 111_320.0;
+        double metersPerLongitudeDegree = metersPerLatitudeDegree * Math.Cos(referenceLatitude * (Math.PI / 180.0));
+        return new Float3(
+            (point.Longitude - referenceLongitude) * metersPerLongitudeDegree,
+            point.Altitude,
+            (point.Latitude - referenceLatitude) * metersPerLatitudeDegree);
+    }
+
     private static double Dot(Float3 left, Float3 right)
     {
         return (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z);
@@ -295,4 +684,51 @@ internal static class GeneratedLod1RoofCityObjectFactory
         double? MinimumY,
         double? MaximumY,
         bool IsNearHorizontal);
+
+    private readonly record struct NoWallRoofRing(
+        GeodeticPoint[] TopRing,
+        GeodeticPoint[] BottomRing,
+        Float2[]? TopUvs);
+
+    private readonly record struct NoWallRoofEdgeKey(NoWallRoofPointKey A, NoWallRoofPointKey B)
+    {
+        public static NoWallRoofEdgeKey Create(GeodeticPoint left, GeodeticPoint right)
+        {
+            NoWallRoofPointKey leftKey = NoWallRoofPointKey.Create(left);
+            NoWallRoofPointKey rightKey = NoWallRoofPointKey.Create(right);
+            return leftKey.CompareTo(rightKey) <= 0
+                ? new NoWallRoofEdgeKey(leftKey, rightKey)
+                : new NoWallRoofEdgeKey(rightKey, leftKey);
+        }
+    }
+
+    private readonly record struct NoWallRoofPointKey(long Latitude, long Longitude, long Altitude) : IComparable<NoWallRoofPointKey>
+    {
+        public static NoWallRoofPointKey Create(GeodeticPoint point)
+        {
+            return new NoWallRoofPointKey(
+                Quantize(point.Latitude, 1e8),
+                Quantize(point.Longitude, 1e8),
+                Quantize(point.Altitude, 1e3));
+        }
+
+        public int CompareTo(NoWallRoofPointKey other)
+        {
+            int latitudeComparison = Latitude.CompareTo(other.Latitude);
+            if (latitudeComparison != 0)
+            {
+                return latitudeComparison;
+            }
+
+            int longitudeComparison = Longitude.CompareTo(other.Longitude);
+            return longitudeComparison != 0
+                ? longitudeComparison
+                : Altitude.CompareTo(other.Altitude);
+        }
+
+        private static long Quantize(double value, double scale)
+        {
+            return (long)Math.Round(value * scale, MidpointRounding.AwayFromZero);
+        }
+    }
 }

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -198,22 +198,41 @@ internal static class GeneratedLod1RoofCityObjectFactory
             return false;
         }
 
-        double objectMinimumY = surfaceInfos.Min(static info => info.MinimumY!.Value);
         double objectMaximumY = surfaceInfos.Max(static info => info.MaximumY!.Value);
-        topSurfaces = surfaceInfos
+        SurfaceProjectionInfo[] topSurfaceInfos = surfaceInfos
             .Where(static info => info.IsNearHorizontal)
             .Where(info => info.MaximumY!.Value >= objectMaximumY - 0.1)
-            .Where(info => info.MinimumY!.Value > objectMinimumY + BuildingBottomCullBandMeters)
-            .Where(info => info.MinimumY!.Value - NoWallRoofThicknessMeters > objectMinimumY + BuildingBottomCullBandMeters)
-            .Select(static info => info.Surface)
             .ToArray();
-        if (topSurfaces.Length == 0
-            || topSurfaces.Any(static surface => surface.InteriorRings.Length != 0))
+        if (topSurfaceInfos.Length == 0
+            || topSurfaceInfos.Any(static info => info.Surface.InteriorRings.Length != 0))
         {
             topSurfaces = null;
             return false;
         }
 
+        HashSet<string> topSurfaceIds = topSurfaceInfos
+            .Select(static info => info.Surface.PolygonId)
+            .ToHashSet(StringComparer.Ordinal);
+        SurfaceProjectionInfo[] lowerSurfaceInfos = surfaceInfos
+            .Where(info => !topSurfaceIds.Contains(info.Surface.PolygonId))
+            .ToArray();
+        if (lowerSurfaceInfos.Length != 0)
+        {
+            double objectMinimumY = lowerSurfaceInfos.Min(static info => info.MinimumY!.Value);
+            topSurfaceInfos = topSurfaceInfos
+                .Where(info => info.MinimumY!.Value > objectMinimumY + BuildingBottomCullBandMeters)
+                .Where(info => info.MinimumY!.Value - NoWallRoofThicknessMeters > objectMinimumY + BuildingBottomCullBandMeters)
+                .ToArray();
+            if (topSurfaceInfos.Length == 0)
+            {
+                topSurfaces = null;
+                return false;
+            }
+        }
+
+        topSurfaces = topSurfaceInfos
+            .Select(static info => info.Surface)
+            .ToArray();
         return true;
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -192,10 +192,12 @@ internal static class GeneratedLod1RoofCityObjectFactory
         IReadOnlyList<SurfaceProjectionInfo> surfaceInfos)
     {
         double roofMinimumY = roofInfo.MinimumY!.Value;
+        double roofMaximumY = roofInfo.MaximumY!.Value;
         double slabBottomY = roofMinimumY - NoWallRoofThicknessMeters;
         return surfaceInfos
             .Where(static info => info.Surface.Semantic != ParsedSurfaceSemantic.Roof)
-            .Where(info => info.MinimumY!.Value < roofMinimumY)
+            .Where(info => info.MinimumY!.Value < roofMaximumY)
+            .Where(info => info.MaximumY!.Value < roofMaximumY)
             .Any(info => slabBottomY <= info.MaximumY!.Value + BuildingBottomCullBandMeters);
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -162,14 +162,9 @@ internal static class GeneratedLod1RoofCityObjectFactory
             return false;
         }
 
-        Dictionary<string, SurfaceProjectionInfo> infosByPolygonId = surfaceInfos.ToDictionary(
-            static info => info.Surface.PolygonId,
-            static info => info,
-            StringComparer.Ordinal);
         foreach (ParsedSurface roofSurface in roofSurfaces)
         {
-            if (!infosByPolygonId.TryGetValue(roofSurface.PolygonId, out SurfaceProjectionInfo roofInfo)
-                || IsNoWallLod2BottomInCullBand(roofInfo, surfaceInfos))
+            if (!surfaceInfos.Any(info => string.Equals(info.Surface.PolygonId, roofSurface.PolygonId, StringComparison.Ordinal)))
             {
                 return false;
             }
@@ -185,20 +180,6 @@ internal static class GeneratedLod1RoofCityObjectFactory
 
         noWallRoofSlab = cityObject with { Surfaces = generatedLod2Surfaces! };
         return true;
-    }
-
-    private static bool IsNoWallLod2BottomInCullBand(
-        SurfaceProjectionInfo roofInfo,
-        IReadOnlyList<SurfaceProjectionInfo> surfaceInfos)
-    {
-        double roofMinimumY = roofInfo.MinimumY!.Value;
-        double roofMaximumY = roofInfo.MaximumY!.Value;
-        double slabBottomY = roofMinimumY - NoWallRoofThicknessMeters;
-        return surfaceInfos
-            .Where(static info => info.Surface.Semantic != ParsedSurfaceSemantic.Roof)
-            .Where(info => info.MinimumY!.Value < roofMaximumY)
-            .Where(info => info.MaximumY!.Value < roofMaximumY)
-            .Any(info => slabBottomY <= info.MaximumY!.Value + BuildingBottomCullBandMeters);
     }
 
     private static bool TryGetNoWallTopSurfaces(

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -31,10 +31,7 @@ internal static class GeneratedLod1RoofCityObjectFactory
             return cityObject;
         }
 
-        if (isNoWallBuilding
-            && (cityObject.Surfaces.Any(static surface => surface.UsesGeneratedDemTexture)
-                || !cityObject.Surfaces.Any(static surface => surface.Vertices.Any())
-                || (cityObject.LodLevel >= 2 && !cityObject.Surfaces.Any(static surface => surface.Semantic == ParsedSurfaceSemantic.Roof))))
+        if (isNoWallBuilding && !HasProcessableNoWallGeometry(cityObject))
         {
             return cityObject;
         }
@@ -95,6 +92,18 @@ internal static class GeneratedLod1RoofCityObjectFactory
         return cityObject.LodLevel >= 1
             && cityObject.BuildingAttributes is not null
             && NoWallBuildingClassCodes.Any(code => BuildingAttributePredicates.HasExactCityGmlClassCode(cityObject.BuildingAttributes, code));
+    }
+
+    private static bool HasProcessableNoWallGeometry(ParsedCityObject cityObject)
+    {
+        if (cityObject.Surfaces.Any(static surface => surface.UsesGeneratedDemTexture)
+            || !cityObject.Surfaces.Any(static surface => surface.Vertices.Any()))
+        {
+            return false;
+        }
+
+        return cityObject.LodLevel < 2
+            || cityObject.Surfaces.Any(static surface => surface.Semantic == ParsedSurfaceSemantic.Roof);
     }
 
     private static bool TryCreateNoWallRoofSlab(
@@ -183,21 +192,11 @@ internal static class GeneratedLod1RoofCityObjectFactory
         IReadOnlyList<SurfaceProjectionInfo> surfaceInfos)
     {
         double roofMinimumY = roofInfo.MinimumY!.Value;
-        SurfaceProjectionInfo[] lowerNonRoofInfos = surfaceInfos
+        double slabBottomY = roofMinimumY - NoWallRoofThicknessMeters;
+        return surfaceInfos
             .Where(static info => info.Surface.Semantic != ParsedSurfaceSemantic.Roof)
             .Where(info => info.MinimumY!.Value < roofMinimumY)
-            .ToArray();
-        if (lowerNonRoofInfos.Length == 0)
-        {
-            return false;
-        }
-
-        double nearestLowerY = lowerNonRoofInfos
-            .Where(info => info.MaximumY!.Value < roofMinimumY)
-            .Select(static info => info.MaximumY!.Value)
-            .DefaultIfEmpty(double.NegativeInfinity)
-            .Max();
-        return roofMinimumY - NoWallRoofThicknessMeters <= nearestLowerY + BuildingBottomCullBandMeters;
+            .Any(info => slabBottomY <= info.MaximumY!.Value + BuildingBottomCullBandMeters);
     }
 
     private static bool TryGetNoWallTopSurfaces(
@@ -312,7 +311,7 @@ internal static class GeneratedLod1RoofCityObjectFactory
     {
         GeodeticPoint[] vertices = ring.TopRing;
         Float2[]? uvs = ring.TopUvs;
-        return CreateNoWallSurface(sourceSurface, sourceSurface.PolygonId, vertices, uvs, sourceSurface.UsesGeneratedDemTexture);
+        return CreateNoWallRoofSurface(sourceSurface, sourceSurface.PolygonId, vertices, uvs, sourceSurface.UsesGeneratedDemTexture);
     }
 
     private static ParsedSurface CreateNoWallBottomSurface(
@@ -322,7 +321,7 @@ internal static class GeneratedLod1RoofCityObjectFactory
         GeodeticPoint[] vertices = ring.BottomRing.Reverse().ToArray();
         Float2[]? uvs = ring.TopUvs?.Reverse().ToArray();
         string polygonId = $"{topSurface.PolygonId}_generated_no-wall-bottom";
-        return CreateNoWallSurface(topSurface, polygonId, vertices, uvs, usesGeneratedDemTexture: false);
+        return CreateNoWallRoofSurface(topSurface, polygonId, vertices, uvs, usesGeneratedDemTexture: false);
     }
 
     private static ParsedSurface CreateNoWallSideSurface(
@@ -348,10 +347,10 @@ internal static class GeneratedLod1RoofCityObjectFactory
                 ring.TopUvs[nextIndex],
         ];
         string polygonId = $"{topSurface.PolygonId}_generated_no-wall-side-{index}";
-        return CreateNoWallSurface(topSurface, polygonId, vertices, uvs, usesGeneratedDemTexture: false);
+        return CreateNoWallRoofSurface(topSurface, polygonId, vertices, uvs, usesGeneratedDemTexture: false);
     }
 
-    private static ParsedSurface CreateNoWallSurface(
+    private static ParsedSurface CreateNoWallRoofSurface(
         ParsedSurface sourceSurface,
         string polygonId,
         GeodeticPoint[] vertices,

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -118,7 +118,10 @@ internal static class GeneratedLod1RoofCityObjectFactory
             ParsedSurface[] lod1RoofSurfaces = topSurfaces!
                 .Select(static surface => surface with { Semantic = ParsedSurfaceSemantic.Roof })
                 .ToArray();
-            if (!TryCreateNoWallRoofSurfaces(lod1RoofSurfaces, includeTopSurfaces: true, out ParsedSurface[]? generatedSurfaces))
+            if (!TryCreateNoWallRoofSurfaces(
+                lod1RoofSurfaces,
+                topSurfaceMode: NoWallRoofTopSurfaceMode.Generated,
+                out ParsedSurface[]? generatedSurfaces))
             {
                 return false;
             }
@@ -163,7 +166,10 @@ internal static class GeneratedLod1RoofCityObjectFactory
             }
         }
 
-        if (!TryCreateNoWallRoofSurfaces(roofSurfaces, includeTopSurfaces: true, out ParsedSurface[]? generatedLod2Surfaces))
+        if (!TryCreateNoWallRoofSurfaces(
+            roofSurfaces,
+            topSurfaceMode: NoWallRoofTopSurfaceMode.PreserveSource,
+            out ParsedSurface[]? generatedLod2Surfaces))
         {
             return false;
         }
@@ -231,7 +237,7 @@ internal static class GeneratedLod1RoofCityObjectFactory
 
     private static bool TryCreateNoWallRoofSurfaces(
         IReadOnlyList<ParsedSurface> roofSurfaces,
-        bool includeTopSurfaces,
+        NoWallRoofTopSurfaceMode topSurfaceMode,
         out ParsedSurface[]? generatedSurfaces)
     {
         generatedSurfaces = null;
@@ -253,9 +259,12 @@ internal static class GeneratedLod1RoofCityObjectFactory
             }
         }
 
-        List<ParsedSurface> surfaces = includeTopSurfaces
-            ? [.. roofSurfaces.Select(surface => CreateNoWallTopSurface(surface, ringsByPolygonId[surface.PolygonId]))]
-            : [];
+        List<ParsedSurface> surfaces = topSurfaceMode switch
+        {
+            NoWallRoofTopSurfaceMode.Generated => [.. roofSurfaces.Select(surface => CreateNoWallTopSurface(surface, ringsByPolygonId[surface.PolygonId]))],
+            NoWallRoofTopSurfaceMode.PreserveSource => [.. roofSurfaces],
+            _ => [],
+        };
         foreach (ParsedSurface roofSurface in roofSurfaces)
         {
             NoWallRoofRing ring = ringsByPolygonId[roofSurface.PolygonId];
@@ -430,9 +439,7 @@ internal static class GeneratedLod1RoofCityObjectFactory
         ParsedCityObject cityObject,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian cityObjectCartesian,
-        out Lod1RoofFootprint? footprint,
-        bool allowTexturedTop = false,
-        double? requiredBottomClearanceMeters = null)
+        out Lod1RoofFootprint? footprint)
     {
         footprint = null;
         SurfaceProjectionInfo[] surfaceInfos = cityObject.Surfaces
@@ -457,14 +464,8 @@ internal static class GeneratedLod1RoofCityObjectFactory
             return false;
         }
 
-        if (requiredBottomClearanceMeters.HasValue
-            && topCandidates[0].MinimumY!.Value - requiredBottomClearanceMeters.Value <= objectMinimumY + BuildingBottomCullBandMeters)
-        {
-            return false;
-        }
-
         ParsedSurface topSurface = topCandidates[0].Surface;
-        if ((!allowTexturedTop && topSurface.TexturePayload is not null) || topSurface.InteriorRings.Length != 0)
+        if (topSurface.TexturePayload is not null || topSurface.InteriorRings.Length != 0)
         {
             return false;
         }
@@ -689,6 +690,12 @@ internal static class GeneratedLod1RoofCityObjectFactory
         GeodeticPoint[] TopRing,
         GeodeticPoint[] BottomRing,
         Float2[]? TopUvs);
+
+    private enum NoWallRoofTopSurfaceMode
+    {
+        Generated,
+        PreserveSource,
+    }
 
     private readonly record struct NoWallRoofEdgeKey(NoWallRoofPointKey A, NoWallRoofPointKey B)
     {

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofSurfaceIdentity.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofSurfaceIdentity.cs
@@ -8,6 +8,12 @@ internal static class GeneratedLod1RoofSurfaceIdentity
     {
         return surface.PolygonId.Contains("_generated_shed-", StringComparison.Ordinal)
             || surface.PolygonId.Contains("_generated_gable-", StringComparison.Ordinal)
-            || surface.PolygonId.Contains("_generated_hip-", StringComparison.Ordinal);
+            || surface.PolygonId.Contains("_generated_hip-", StringComparison.Ordinal)
+            || surface.PolygonId.Contains("_generated_no-wall-", StringComparison.Ordinal);
+    }
+
+    internal static bool IsGeneratedNoWallSlabPart(ParsedSurface surface)
+    {
+        return surface.PolygonId.Contains("_generated_no-wall-", StringComparison.Ordinal);
     }
 }

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayProjectionSplitPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayProjectionSplitPolicy.cs
@@ -282,6 +282,7 @@ internal static class TerrainOverlayProjectionSplitPolicy
     {
         return surface.TexturePayload is null
             && !surface.UsesGeneratedDemTexture
+            && !GeneratedLod1RoofSurfaceIdentity.IsGeneratedNoWallSlabPart(surface)
             && RoofTerrainTextureSurfacePolicy.IsRoofTerrainTextureSurface(
                 surface,
                 cityObjectMinAltitude,

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayProjectionSplitPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayProjectionSplitPolicy.cs
@@ -280,6 +280,7 @@ internal static class TerrainOverlayProjectionSplitPolicy
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
+        // Generated no-wall slab parts are extruded from the top roof surface, so terrain imagery follows the slab.
         return surface.TexturePayload is null
             && !surface.UsesGeneratedDemTexture
             && RoofTerrainTextureSurfacePolicy.IsRoofTerrainTextureSurface(

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayProjectionSplitPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayProjectionSplitPolicy.cs
@@ -282,7 +282,6 @@ internal static class TerrainOverlayProjectionSplitPolicy
     {
         return surface.TexturePayload is null
             && !surface.UsesGeneratedDemTexture
-            && !GeneratedLod1RoofSurfaceIdentity.IsGeneratedNoWallSlabPart(surface)
             && RoofTerrainTextureSurfacePolicy.IsRoofTerrainTextureSurface(
                 surface,
                 cityObjectMinAltitude,

--- a/tests/PlateauResoniteLink.Tests/Profiles/BuildingAttributePredicatesTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/BuildingAttributePredicatesTests.cs
@@ -40,6 +40,21 @@ public sealed class BuildingAttributePredicatesTests
     }
 
     [Theory]
+    [InlineData("3003", "3003", true)]
+    [InlineData(" 3003 ", "3003", true)]
+    [InlineData("30030", "3003", false)]
+    [InlineData("300", "3003", false)]
+    public void HasExactCityGmlClassCodeUsesTrimmedExactMatch(string rawCode, string expectedCode, bool expected)
+    {
+        BuildingAttributeContext attributes = BuildingAttributeContext.Empty with
+        {
+            CityGmlClassCodes = [rawCode],
+        };
+
+        Assert.Equal(expected, BuildingAttributePredicates.HasExactCityGmlClassCode(attributes, expectedCode));
+    }
+
+    [Theory]
     [InlineData((int)PlateauBuildingUse.Apartment)]
     [InlineData((int)PlateauBuildingUse.MixedResidential)]
     public void HasNightOccupancyIncludesResidentialSharedOccupancyUses(int useValue)

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceProjectionPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceProjectionPolicyTests.cs
@@ -69,6 +69,64 @@ public sealed class CityGmlSurfaceProjectionPolicyTests
         Assert.InRange(context.Value.MaximumY, 6.0 - 1e-5, 6.0 + 1e-5);
     }
 
+    [Fact]
+    public void TryCreateFacadeUvProjectionContextIgnoresGeneratedNoWallRoofSurfacesWhenWallRangeExists()
+    {
+        GeodeticPoint origin = new(35.0, 139.0, 0.0);
+        LocalCartesian cartesian = CreateCartesian(origin);
+        ParsedSurface wall = CreateSurface(
+            "wall",
+            ParsedSurfaceSemantic.Wall,
+            CreateVerticalQuadVertices(origin, widthMeters: 8.0, heightMeters: 6.0));
+        ParsedSurface generatedNoWallBottom = CreateSurface(
+            "bldg_generated_no-wall-bottom",
+            ParsedSurfaceSemantic.Roof,
+            CreateHorizontalQuadVertices(origin, altitudeMeters: 8.7, sizeMeters: 8.0, reverseWinding: true));
+
+        HashSet<string> culledSurfaceIds = CityGmlSurfaceProjectionPolicy.GetCulledSurfaceIdsBeforeProjection(
+            "bldg",
+            [wall, generatedNoWallBottom],
+            origin,
+            cartesian);
+        FacadeUvProjectionContext? context = CityGmlSurfaceProjectionPolicy.TryCreateFacadeUvProjectionContext(
+            "bldg",
+            [wall, generatedNoWallBottom],
+            origin,
+            cartesian);
+
+        Assert.Empty(culledSurfaceIds);
+        Assert.NotNull(context);
+        Assert.InRange(context.Value.MinimumY, -1e-5, 1e-5);
+        Assert.InRange(context.Value.MaximumY, 6.0 - 1e-5, 6.0 + 1e-5);
+    }
+
+    [Fact]
+    public void GetCulledSurfaceIdsBeforeProjectionKeepsGeneratedNoWallRoofBottomAtObjectMinimum()
+    {
+        GeodeticPoint origin = new(35.0, 139.0, 0.0);
+        LocalCartesian cartesian = CreateCartesian(origin);
+        ParsedSurface generatedNoWallBottom = CreateSurface(
+            "roof_generated_no-wall-bottom",
+            ParsedSurfaceSemantic.Roof,
+            CreateHorizontalQuadVertices(origin, altitudeMeters: 9.7, sizeMeters: 8.0));
+        ParsedSurface generatedNoWallSide = CreateSurface(
+            "roof_generated_no-wall-side-0",
+            ParsedSurfaceSemantic.Roof,
+            CreateVerticalQuadVertices(origin with { Altitude = 9.7 }, widthMeters: 8.0, heightMeters: 0.3));
+        ParsedSurface roof = CreateSurface(
+            "roof",
+            ParsedSurfaceSemantic.Roof,
+            CreateHorizontalQuadVertices(origin, altitudeMeters: 10.0, sizeMeters: 8.0, reverseWinding: true));
+
+        HashSet<string> culledSurfaceIds = CityGmlSurfaceProjectionPolicy.GetCulledSurfaceIdsBeforeProjection(
+            "bldg",
+            [roof, generatedNoWallBottom, generatedNoWallSide],
+            origin,
+            cartesian);
+
+        Assert.Empty(culledSurfaceIds);
+    }
+
     private static LocalCartesian CreateCartesian(GeodeticPoint origin)
     {
         return new LocalCartesian(origin.Latitude, origin.Longitude, origin.Altitude, Geocentric.WGS84);

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -301,7 +301,7 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
     }
 
     [Fact]
-    public void CreateLeavesLod2NoWallBuildingWhenGeneratedBottomWouldEnterLowerNonRoofCullBand()
+    public void CreateGeneratesLod2NoWallSlabWithoutTreatingLowerNonRoofSurfacesAsRealWalls()
     {
         ParsedCityObject cityObject = CreateCityObject(
             [
@@ -318,11 +318,13 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
 
         ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
 
-        Assert.Same(cityObject, generated);
+        Assert.NotSame(cityObject, generated);
+        Assert.DoesNotContain(generated.Surfaces, static surface => surface.Semantic == ParsedSurfaceSemantic.Ground);
+        Assert.Single(generated.Surfaces, static surface => surface.PolygonId == "lod2-roof_generated_no-wall-bottom");
     }
 
     [Fact]
-    public void CreateLeavesLod2NoWallBuildingWhenLowerNonRoofSurfaceEntersSlopedRoofSlabBand()
+    public void CreateGeneratesLod2NoWallSlabWithoutTreatingSlopedLowerNonRoofSurfacesAsRealWalls()
     {
         ParsedCityObject cityObject = CreateCityObject(
             [
@@ -341,7 +343,9 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
 
         ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
 
-        Assert.Same(cityObject, generated);
+        Assert.NotSame(cityObject, generated);
+        Assert.DoesNotContain(generated.Surfaces, static surface => surface.Semantic == ParsedSurfaceSemantic.Wall);
+        Assert.Single(generated.Surfaces, static surface => surface.PolygonId == "lod2-roof_generated_no-wall-bottom");
     }
 
     [Theory]

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -69,11 +69,9 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
     }
 
     [Theory]
-    [InlineData(1, false)]
-    [InlineData(1, true)]
-    [InlineData(2, false)]
-    [InlineData(2, true)]
-    public void CreateOrientsNoWallTopSurfaceForResoniteOutput(int lodLevel, bool reverseSourceRing)
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CreateOrientsLod1NoWallTopSurfaceForResoniteOutput(bool reverseSourceRing)
     {
         TexturePayload texture = CreateTexturePayload("textures/no-wall-top.png");
         GeodeticPoint[] vertices = CreateClosedQuadVertices(altitude: 10.0, longitudeOffset: 0.0, longitudeWidth: 0.00020);
@@ -98,13 +96,52 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
             ],
             CoordinateReferenceSystem.Parse("EPSG:6697"),
             BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] },
-            lodLevel);
+            lodLevel: 1);
 
         ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
 
         ParsedSurface generatedTop = Assert.Single(generated.Surfaces, static surface => surface.PolygonId == "lod1-top");
         Assert.Same(texture, generatedTop.TexturePayload);
         Assert.True(ComputeResoniteNormal(generatedTop).Y > 0.9);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CreatePreservesLod2NoWallTopSurfaceWinding(bool reverseSourceRing)
+    {
+        TexturePayload texture = CreateTexturePayload("textures/no-wall-top.png");
+        GeodeticPoint[] vertices = CreateClosedQuadVertices(altitude: 10.0, longitudeOffset: 0.0, longitudeWidth: 0.00020);
+        Float2[] uvs = CreateClosedQuadUvs();
+        if (reverseSourceRing)
+        {
+            vertices = ReverseClosedRing(vertices);
+            uvs = ReverseClosedUvs(uvs);
+        }
+
+        ParsedSurface top = CreateSurface(
+            "lod2-top",
+            ParsedSurfaceSemantic.Roof,
+            vertices,
+            uvs,
+            texture);
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                top,
+                CreateSurface("lod2-bottom", ParsedSurfaceSemantic.Ground, altitude: 0.0),
+                CreateSurface("lod2-wall", ParsedSurfaceSemantic.Wall, altitude: 4.0),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] },
+            lodLevel: 2);
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        ParsedSurface generatedTop = Assert.Single(generated.Surfaces, static surface => surface.PolygonId == "lod2-top");
+        Assert.Same(top, generatedTop);
+        Assert.Equal(vertices, generatedTop.ExteriorRing.Vertices);
+        Assert.Equal(uvs, generatedTop.ExteriorRing.UVs);
+        Assert.Same(texture, generatedTop.TexturePayload);
     }
 
     [Fact]
@@ -217,8 +254,8 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
 
         ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
 
-        Assert.Contains(generated.Surfaces, static surface => surface.PolygonId == "lod2-roof-a");
-        Assert.Contains(generated.Surfaces, static surface => surface.PolygonId == "lod2-roof-b");
+        Assert.Same(roofA, Assert.Single(generated.Surfaces, static surface => surface.PolygonId == "lod2-roof-a"));
+        Assert.Same(roofB, Assert.Single(generated.Surfaces, static surface => surface.PolygonId == "lod2-roof-b"));
         Assert.DoesNotContain(generated.Surfaces, static surface => surface.Semantic == ParsedSurfaceSemantic.Wall);
         Assert.DoesNotContain(generated.Surfaces, static surface => surface.Semantic == ParsedSurfaceSemantic.Ground);
         Assert.Equal(10, generated.Surfaces.Length);

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -68,6 +68,33 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
         Assert.True(resoniteSideNormal.Z < -0.9);
     }
 
+    [Fact]
+    public void CreateReplacesRoofOnlyLod1NoWallBuildingWithThinRoofSlab()
+    {
+        TexturePayload texture = CreateTexturePayload("textures/no-wall-lod1-roof-only.png");
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                CreateSurface(
+                    "lod1-roof-only",
+                    ParsedSurfaceSemantic.Roof,
+                    CreateClosedQuadVertices(altitude: 10.0, longitudeOffset: 0.0, longitudeWidth: 0.00020),
+                    CreateClosedQuadUvs(),
+                    texture),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] },
+            lodLevel: 1);
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.NotSame(cityObject, generated);
+        Assert.Equal(6, generated.Surfaces.Length);
+        ParsedSurface generatedTop = Assert.Single(generated.Surfaces, static surface => surface.PolygonId == "lod1-roof-only");
+        Assert.Same(texture, generatedTop.TexturePayload);
+        Assert.Single(generated.Surfaces, static surface => surface.PolygonId == "lod1-roof-only_generated_no-wall-bottom");
+        Assert.Equal(4, generated.Surfaces.Count(static surface => surface.PolygonId.Contains("_generated_no-wall-side-", System.StringComparison.Ordinal)));
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -321,6 +321,26 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
         Assert.Same(cityObject, generated);
     }
 
+    [Fact]
+    public void CreateLeavesLod2NoWallBuildingWhenLowerNonRoofSurfaceReachesRoofPlane()
+    {
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                CreateSurface("lod2-roof", ParsedSurfaceSemantic.Roof, altitude: 10.0),
+                CreateSurface(
+                    "lod2-wall-to-roof",
+                    ParsedSurfaceSemantic.Wall,
+                    CreateVerticalClosedQuadVertices(minimumAltitude: 0.0, maximumAltitude: 10.0)),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] },
+            lodLevel: 2);
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Same(cityObject, generated);
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("3001")]
@@ -623,6 +643,20 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
             new(35.0, 139.00020, maximumAltitude),
             new(35.00010, 139.00020, maximumAltitude),
             new(35.00010, 139.0, minimumAltitude),
+            new(35.0, 139.0, minimumAltitude),
+        ];
+    }
+
+    private static GeodeticPoint[] CreateVerticalClosedQuadVertices(
+        double minimumAltitude,
+        double maximumAltitude)
+    {
+        return
+        [
+            new(35.0, 139.0, minimumAltitude),
+            new(35.0, 139.0, maximumAltitude),
+            new(35.0, 139.00020, maximumAltitude),
+            new(35.0, 139.00020, minimumAltitude),
             new(35.0, 139.0, minimumAltitude),
         ];
     }

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
 using System.Linq;
+
+using GeographicLib;
 
 using PlateauResoniteLink.Application.Importing;
 
@@ -6,6 +9,385 @@ namespace PlateauResoniteLink.Tests.Profiles;
 
 public sealed class GeneratedLod1RoofCityObjectFactoryTests
 {
+    [Theory]
+    [InlineData("3003")]
+    [InlineData("3004")]
+    public void CreateReplacesLod1NoWallBuildingWithThinRoofSlab(string classCode)
+    {
+        TexturePayload texture = CreateTexturePayload("textures/no-wall-top.png");
+        ParsedSurface top = CreateSurface(
+            "lod1-top",
+            ParsedSurfaceSemantic.Roof,
+            altitude: 10.0,
+            uvs: CreateClosedQuadUvs(),
+            texturePayload: texture);
+        ParsedSurface bottom = CreateSurface(
+            "lod1-bottom",
+            ParsedSurfaceSemantic.Ground,
+            altitude: 0.0);
+        ParsedSurface wall = CreateSurface(
+            "lod1-wall",
+            ParsedSurfaceSemantic.Wall,
+            altitude: 4.0);
+        ParsedCityObject cityObject = CreateCityObject(
+            [top, bottom, wall],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with
+            {
+                CityGmlClassCodes = [classCode],
+                RoofShape = new BuildingCodeValue<CityGmlRoofShape>(CityGmlRoofShape.Shed, "shed"),
+            });
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.DoesNotContain(generated.Surfaces, static surface => surface.PolygonId.Contains("_generated_shed-", System.StringComparison.Ordinal));
+        Assert.DoesNotContain(generated.Surfaces, static surface => surface.Semantic == ParsedSurfaceSemantic.Wall);
+        Assert.DoesNotContain(generated.Surfaces, static surface => surface.Semantic == ParsedSurfaceSemantic.Ground);
+        Assert.Equal(6, generated.Surfaces.Length);
+        Assert.Contains(generated.Surfaces, static surface => surface.PolygonId == "lod1-top");
+
+        ParsedSurface underside = Assert.Single(
+            generated.Surfaces,
+            static surface => surface.PolygonId == "lod1-top_generated_no-wall-bottom");
+        Assert.Same(texture, underside.TexturePayload);
+        Assert.All(underside.ExteriorRing.Vertices, vertex => Assert.InRange(vertex.Altitude, 9.7 - 1e-8, 10.0 + 1e-8));
+        Assert.True(ComputeParsedNormalY(underside) > 0.9);
+        Assert.Equal(
+            [new Float2(0.0, 1.0), new Float2(1.0, 1.0), new Float2(1.0, 0.0), new Float2(0.0, 0.0), new Float2(0.0, 1.0)],
+            underside.ExteriorRing.UVs);
+
+        ParsedSurface side = Assert.Single(
+            generated.Surfaces,
+            static surface => surface.PolygonId == "lod1-top_generated_no-wall-side-0");
+        Assert.Same(texture, side.TexturePayload);
+        Assert.True(ComputeParsedNormalY(side) is < 0.1 and > -0.1);
+        Assert.Equal(
+            [new Float2(0.0, 0.0), new Float2(0.0, 0.0), new Float2(1.0, 0.0), new Float2(1.0, 0.0), new Float2(0.0, 0.0)],
+            side.ExteriorRing.UVs);
+        Float3 resoniteSideNormal = ComputeResoniteNormal(side);
+        Assert.True(resoniteSideNormal.Z < -0.9);
+    }
+
+    [Theory]
+    [InlineData(1, false)]
+    [InlineData(1, true)]
+    [InlineData(2, false)]
+    [InlineData(2, true)]
+    public void CreateOrientsNoWallTopSurfaceForResoniteOutput(int lodLevel, bool reverseSourceRing)
+    {
+        TexturePayload texture = CreateTexturePayload("textures/no-wall-top.png");
+        GeodeticPoint[] vertices = CreateClosedQuadVertices(altitude: 10.0, longitudeOffset: 0.0, longitudeWidth: 0.00020);
+        Float2[] uvs = CreateClosedQuadUvs();
+        if (reverseSourceRing)
+        {
+            vertices = ReverseClosedRing(vertices);
+            uvs = ReverseClosedUvs(uvs);
+        }
+
+        ParsedSurface top = CreateSurface(
+            "lod1-top",
+            ParsedSurfaceSemantic.Roof,
+            vertices,
+            uvs,
+            texture);
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                top,
+                CreateSurface("lod1-bottom", ParsedSurfaceSemantic.Ground, altitude: 0.0),
+                CreateSurface("lod1-wall", ParsedSurfaceSemantic.Wall, altitude: 4.0),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] },
+            lodLevel);
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        ParsedSurface generatedTop = Assert.Single(generated.Surfaces, static surface => surface.PolygonId == "lod1-top");
+        Assert.Same(texture, generatedTop.TexturePayload);
+        Assert.True(ComputeResoniteNormal(generatedTop).Y > 0.9);
+    }
+
+    [Fact]
+    public void CreateReplacesNonRectangularLod1NoWallBuildingWithThinRoofSlab()
+    {
+        ParsedSurface top = CreateSurface(
+            "lod1-pentagon-top",
+            ParsedSurfaceSemantic.Roof,
+            CreateClosedPentagonVertices(altitude: 10.0));
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                top,
+                CreateSurface("lod1-bottom", ParsedSurfaceSemantic.Ground, altitude: 0.0),
+                CreateSurface("lod1-wall", ParsedSurfaceSemantic.Wall, altitude: 4.0),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] });
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Contains(generated.Surfaces, static surface => surface.PolygonId == "lod1-pentagon-top");
+        Assert.DoesNotContain(generated.Surfaces, static surface => surface.Semantic == ParsedSurfaceSemantic.Wall);
+        Assert.DoesNotContain(generated.Surfaces, static surface => surface.Semantic == ParsedSurfaceSemantic.Ground);
+        Assert.Equal(7, generated.Surfaces.Length);
+        Assert.Equal(5, generated.Surfaces.Count(static surface => surface.PolygonId.Contains("_generated_no-wall-side-", System.StringComparison.Ordinal)));
+        Assert.Single(generated.Surfaces, static surface => surface.PolygonId == "lod1-pentagon-top_generated_no-wall-bottom");
+    }
+
+    [Fact]
+    public void CreateReplacesMultipleLod1NoWallTopSurfacesAndSkipsSharedSideEdges()
+    {
+        ParsedSurface roofA = CreateSurface(
+            "lod1-roof-a",
+            ParsedSurfaceSemantic.Roof,
+            CreateClosedQuadVertices(altitude: 10.0, longitudeOffset: 0.0, longitudeWidth: 0.00010),
+            CreateClosedQuadUvs());
+        ParsedSurface roofB = CreateSurface(
+            "lod1-roof-b",
+            ParsedSurfaceSemantic.Roof,
+            CreateClosedQuadVertices(altitude: 10.0, longitudeOffset: 0.00010, longitudeWidth: 0.00010),
+            CreateClosedQuadUvs());
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                roofA,
+                roofB,
+                CreateSurface("lod1-bottom", ParsedSurfaceSemantic.Ground, altitude: 0.0),
+                CreateSurface("lod1-wall", ParsedSurfaceSemantic.Wall, altitude: 4.0),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] });
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Contains(generated.Surfaces, static surface => surface.PolygonId == "lod1-roof-a");
+        Assert.Contains(generated.Surfaces, static surface => surface.PolygonId == "lod1-roof-b");
+        Assert.Equal(10, generated.Surfaces.Length);
+        Assert.Equal(6, generated.Surfaces.Count(static surface => surface.PolygonId.Contains("_generated_no-wall-side-", System.StringComparison.Ordinal)));
+        Assert.Equal(2, generated.Surfaces.Count(static surface => surface.PolygonId.Contains("_generated_no-wall-bottom", System.StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void CreateLeavesLod1NoWallBuildingWithTopInteriorRingUnchanged()
+    {
+        ParsedSurface top = CreateSurfaceWithInteriorRing(
+            "lod1-top-with-hole",
+            ParsedSurfaceSemantic.Roof,
+            altitude: 10.0);
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                top,
+                CreateSurface("lod1-bottom", ParsedSurfaceSemantic.Ground, altitude: 0.0),
+                CreateSurface("lod1-wall", ParsedSurfaceSemantic.Wall, altitude: 4.0),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] });
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Same(cityObject, generated);
+    }
+
+    [Theory]
+    [InlineData("3003")]
+    [InlineData("3004")]
+    public void CreateKeepsLod2NoWallRoofTopologyAndDropsWallAndGroundSurfaces(string classCode)
+    {
+        TexturePayload texture = CreateTexturePayload("textures/no-wall-lod2.png");
+        ParsedSurface roofA = CreateSurface(
+            "lod2-roof-a",
+            ParsedSurfaceSemantic.Roof,
+            CreateClosedQuadVertices(altitude: 10.0, longitudeOffset: 0.0, longitudeWidth: 0.00010),
+            CreateClosedQuadUvs(),
+            texture);
+        ParsedSurface roofB = CreateSurface(
+            "lod2-roof-b",
+            ParsedSurfaceSemantic.Roof,
+            CreateClosedQuadVertices(altitude: 10.0, longitudeOffset: 0.00010, longitudeWidth: 0.00010),
+            CreateClosedQuadUvs(),
+            texture);
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                roofA,
+                roofB,
+                CreateSurface("lod2-wall", ParsedSurfaceSemantic.Wall, altitude: 5.0),
+                CreateSurface("lod2-ground", ParsedSurfaceSemantic.Ground, altitude: 0.0),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with { CityGmlClassCodes = [classCode] },
+            lodLevel: 2);
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Contains(generated.Surfaces, static surface => surface.PolygonId == "lod2-roof-a");
+        Assert.Contains(generated.Surfaces, static surface => surface.PolygonId == "lod2-roof-b");
+        Assert.DoesNotContain(generated.Surfaces, static surface => surface.Semantic == ParsedSurfaceSemantic.Wall);
+        Assert.DoesNotContain(generated.Surfaces, static surface => surface.Semantic == ParsedSurfaceSemantic.Ground);
+        Assert.Equal(10, generated.Surfaces.Length);
+        Assert.Equal(6, generated.Surfaces.Count(static surface => surface.PolygonId.Contains("_generated_no-wall-side-", System.StringComparison.Ordinal)));
+        Assert.Equal(2, generated.Surfaces.Count(static surface => surface.PolygonId.Contains("_generated_no-wall-bottom", System.StringComparison.Ordinal)));
+        Assert.All(generated.Surfaces, static surface => Assert.Equal(ParsedSurfaceSemantic.Roof, surface.Semantic));
+
+        ParsedSurface underside = Assert.Single(
+            generated.Surfaces,
+            static surface => surface.PolygonId == "lod2-roof-a_generated_no-wall-bottom");
+        Assert.True(ComputeResoniteNormal(underside).Y < -0.9);
+        ParsedSurface side = Assert.Single(
+            generated.Surfaces,
+            static surface => surface.PolygonId == "lod2-roof-a_generated_no-wall-side-0");
+        Assert.True(ComputeResoniteNormal(side).Z < -0.9);
+    }
+
+    [Fact]
+    public void CreateGeneratesLod2NoWallSlabForRoofOnlyInput()
+    {
+        TexturePayload texture = CreateTexturePayload("textures/no-wall-lod2-roof-only.png");
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                CreateSurface(
+                    "lod2-roof-only",
+                    ParsedSurfaceSemantic.Roof,
+                    CreateClosedQuadVertices(altitude: 10.0, longitudeOffset: 0.0, longitudeWidth: 0.00020),
+                    CreateClosedQuadUvs(),
+                    texture),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] },
+            lodLevel: 2);
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.NotSame(cityObject, generated);
+        Assert.Equal(6, generated.Surfaces.Length);
+        ParsedSurface generatedTop = Assert.Single(generated.Surfaces, static surface => surface.PolygonId == "lod2-roof-only");
+        Assert.Same(texture, generatedTop.TexturePayload);
+        Assert.Single(generated.Surfaces, static surface => surface.PolygonId == "lod2-roof-only_generated_no-wall-bottom");
+        Assert.Equal(4, generated.Surfaces.Count(static surface => surface.PolygonId.Contains("_generated_no-wall-side-", System.StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void CreateLeavesLod2NoWallBuildingWhenGeneratedBottomWouldEnterLowerNonRoofCullBand()
+    {
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                CreateSurface("lod2-roof", ParsedSurfaceSemantic.Roof, altitude: 10.0),
+                CreateSurface("lod2-ground", ParsedSurfaceSemantic.Ground, altitude: 0.0),
+                CreateSurface(
+                    "lod2-sloped-near-bottom",
+                    ParsedSurfaceSemantic.Ground,
+                    CreateSlopedClosedQuadVertices(minimumAltitude: 9.0, maximumAltitude: 9.85)),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] },
+            lodLevel: 2);
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Same(cityObject, generated);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("3001")]
+    [InlineData("3002")]
+    [InlineData("3000")]
+    [InlineData("30030")]
+    [InlineData("x3003")]
+    public void CreateDoesNotInferNoWallBuildingFromMissingOrNonExactClassCode(string classCode)
+    {
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                CreateSurface("lod2-roof", ParsedSurfaceSemantic.Roof, altitude: 10.0),
+                CreateSurface("lod2-wall", ParsedSurfaceSemantic.Wall, altitude: 5.0),
+                CreateSurface("lod2-ground", ParsedSurfaceSemantic.Ground, altitude: 0.0),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with
+            {
+                CityGmlClassCodes = string.IsNullOrEmpty(classCode) ? [] : [classCode],
+            },
+            lodLevel: 2);
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Same(cityObject, generated);
+    }
+
+    [Fact]
+    public void CreateLeavesNonNoWallLod2BuildingBeforeResolvingLocalOrigin()
+    {
+        ParsedSurface emptyRoof = new(
+            "lod2-empty-roof",
+            ParsedSurfaceSemantic.Roof,
+            new ParsedRing("lod2-empty-roof-ring", [], null),
+            InteriorRings: [],
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null);
+        ParsedCityObject cityObject = CreateCityObject(
+            [emptyRoof],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty,
+            lodLevel: 2);
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Same(cityObject, generated);
+    }
+
+    [Fact]
+    public void CreateLeavesNoWallLod2BuildingWithEmptyGeometryBeforeResolvingLocalOrigin()
+    {
+        ParsedSurface emptyRoof = new(
+            "lod2-empty-no-wall-roof",
+            ParsedSurfaceSemantic.Roof,
+            new ParsedRing("lod2-empty-no-wall-roof-ring", [], null),
+            InteriorRings: [],
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null);
+        ParsedCityObject cityObject = CreateCityObject(
+            [emptyRoof],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] },
+            lodLevel: 2);
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Same(cityObject, generated);
+    }
+
+    [Fact]
+    public void CreateLeavesNoWallTerrainOverlaySplitBeforeRegeneratingSlabParts()
+    {
+        ParsedSurface terrainRoof = CreateSurface("lod2-terrain-roof", ParsedSurfaceSemantic.Roof, altitude: 10.0) with
+        {
+            UsesGeneratedDemTexture = true,
+        };
+        ParsedCityObject cityObject = CreateCityObject(
+            [terrainRoof],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] },
+            lodLevel: 2);
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Same(cityObject, generated);
+    }
+
+    [Fact]
+    public void CreateLeavesLod2NoWallBuildingWithoutRoofSurfacesUnchanged()
+    {
+        ParsedCityObject cityObject = CreateCityObject(
+            [
+                CreateSurface("lod2-wall", ParsedSurfaceSemantic.Wall, altitude: 5.0),
+                CreateSurface("lod2-ground", ParsedSurfaceSemantic.Ground, altitude: 0.0),
+            ],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] },
+            lodLevel: 2);
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.Same(cityObject, generated);
+    }
+
     [Fact]
     public void CreateReplacesSingleTexturelessTopSurfaceWithGeneratedRoofSurfaces()
     {
@@ -117,14 +499,15 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
     private static ParsedCityObject CreateCityObject(
         ParsedSurface[] surfaces,
         CoordinateReferenceSystem referenceSystem,
-        BuildingAttributeContext attributes)
+        BuildingAttributeContext attributes,
+        int? lodLevel = 1)
     {
         return new ParsedCityObject(
             SlotKey: "bldg-lod1",
             DisplayName: "bldg-lod1",
             PackageName: "bldg",
             ActualMeshCode: "53394525",
-            LodLevel: 1,
+            LodLevel: lodLevel,
             Surfaces: surfaces,
             ReferenceSystem: referenceSystem,
             SourceFileRelativePath: "udx/bldg/53394525/bldg.gml",
@@ -135,22 +518,161 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
     private static ParsedSurface CreateSurface(
         string polygonId,
         ParsedSurfaceSemantic semantic,
-        double altitude)
+        double altitude,
+        IReadOnlyList<Float2>? uvs = null,
+        TexturePayload? texturePayload = null)
     {
-        GeodeticPoint[] vertices =
-        [
-            new(35.0, 139.0, altitude),
-            new(35.0, 139.00020, altitude),
-            new(35.00010, 139.00020, altitude),
-            new(35.00010, 139.0, altitude),
-            new(35.0, 139.0, altitude),
-        ];
+        GeodeticPoint[] vertices = CreateClosedQuadVertices(altitude, longitudeOffset: 0.0, longitudeWidth: 0.00020);
+        return CreateSurface(polygonId, semantic, vertices, uvs, texturePayload);
+    }
+
+    private static ParsedSurface CreateSurface(
+        string polygonId,
+        ParsedSurfaceSemantic semantic,
+        GeodeticPoint[] vertices,
+        IReadOnlyList<Float2>? uvs = null,
+        TexturePayload? texturePayload = null)
+    {
         return new ParsedSurface(
             polygonId,
             semantic,
-            new ParsedRing($"{polygonId}-ring", vertices, UVs: null),
+            new ParsedRing($"{polygonId}-ring", vertices, uvs),
             InteriorRings: [],
             BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            texturePayload);
+    }
+
+    private static ParsedSurface CreateSurfaceWithInteriorRing(
+        string polygonId,
+        ParsedSurfaceSemantic semantic,
+        double altitude)
+    {
+        return new ParsedSurface(
+            polygonId,
+            semantic,
+            new ParsedRing($"{polygonId}-ring", CreateClosedQuadVertices(altitude, longitudeOffset: 0.0, longitudeWidth: 0.00020), null),
+            [
+                new ParsedRing(
+                    $"{polygonId}-interior",
+                    CreateClosedQuadVertices(altitude, longitudeOffset: 0.00005, longitudeWidth: 0.00005),
+                    null),
+            ],
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
             TexturePayload: null);
+    }
+
+    private static GeodeticPoint[] CreateClosedQuadVertices(
+        double altitude,
+        double longitudeOffset,
+        double longitudeWidth)
+    {
+        return
+        [
+            new(35.0, 139.0 + longitudeOffset, altitude),
+            new(35.0, 139.0 + longitudeOffset + longitudeWidth, altitude),
+            new(35.00010, 139.0 + longitudeOffset + longitudeWidth, altitude),
+            new(35.00010, 139.0 + longitudeOffset, altitude),
+            new(35.0, 139.0 + longitudeOffset, altitude),
+        ];
+    }
+
+    private static GeodeticPoint[] CreateSlopedClosedQuadVertices(
+        double minimumAltitude,
+        double maximumAltitude)
+    {
+        return
+        [
+            new(35.0, 139.0, minimumAltitude),
+            new(35.0, 139.00020, maximumAltitude),
+            new(35.00010, 139.00020, maximumAltitude),
+            new(35.00010, 139.0, minimumAltitude),
+            new(35.0, 139.0, minimumAltitude),
+        ];
+    }
+
+    private static GeodeticPoint[] CreateClosedPentagonVertices(double altitude)
+    {
+        return
+        [
+            new(35.0, 139.0, altitude),
+            new(35.0, 139.00020, altitude),
+            new(35.00008, 139.00025, altitude),
+            new(35.00015, 139.00010, altitude),
+            new(35.00010, 139.0, altitude),
+            new(35.0, 139.0, altitude),
+        ];
+    }
+
+    private static Float2[] CreateClosedQuadUvs()
+    {
+        return
+        [
+            new Float2(0.0, 0.0),
+            new Float2(1.0, 0.0),
+            new Float2(1.0, 1.0),
+            new Float2(0.0, 1.0),
+            new Float2(0.0, 0.0),
+        ];
+    }
+
+    private static GeodeticPoint[] ReverseClosedRing(GeodeticPoint[] vertices)
+    {
+        GeodeticPoint[] reversed = vertices.Take(vertices.Length - 1).Reverse().ToArray();
+        return [.. reversed, reversed[0]];
+    }
+
+    private static Float2[] ReverseClosedUvs(Float2[] uvs)
+    {
+        Float2[] reversed = uvs.Take(uvs.Length - 1).Reverse().ToArray();
+        return [.. reversed, reversed[0]];
+    }
+
+    private static TexturePayload CreateTexturePayload(string identity)
+    {
+        return new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], identity);
+    }
+
+    private static double ComputeParsedNormalY(ParsedSurface surface)
+    {
+        GeodeticPoint origin = surface.ExteriorRing.Vertices[0];
+        LocalCartesian cartesian = new(origin.Latitude, origin.Longitude, origin.Altitude, Geocentric.WGS84);
+        return CityGmlSurfaceProjectionPolicy.ComputeSurfaceNormal(surface, origin, cartesian)?.Y ?? double.NaN;
+    }
+
+    private static Float3 ComputeResoniteNormal(ParsedSurface surface)
+    {
+        GeodeticPoint origin = surface.ExteriorRing.Vertices[0];
+        LocalCartesian cartesian = new(origin.Latitude, origin.Longitude, origin.Altitude, Geocentric.WGS84);
+        Float3[] positions = surface.ExteriorRing.Vertices
+            .Take(3)
+            .Select(point => SceneAxisMapper.CreatePosition(
+                point.Latitude,
+                point.Longitude,
+                point.Altitude,
+                origin.Latitude,
+                origin.Longitude,
+                origin.Altitude,
+                cartesian))
+            .ToArray();
+        return Normalize(Cross(Subtract(positions[2], positions[0]), Subtract(positions[1], positions[0])));
+    }
+
+    private static Float3 Subtract(Float3 left, Float3 right)
+    {
+        return new Float3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
+    }
+
+    private static Float3 Cross(Float3 left, Float3 right)
+    {
+        return new Float3(
+            (left.Y * right.Z) - (left.Z * right.Y),
+            (left.Z * right.X) - (left.X * right.Z),
+            (left.X * right.Y) - (left.Y * right.X));
+    }
+
+    private static Float3 Normalize(Float3 value)
+    {
+        double length = System.Math.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z));
+        return new Float3(value.X / length, value.Y / length, value.Z / length);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -322,15 +322,18 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
     }
 
     [Fact]
-    public void CreateLeavesLod2NoWallBuildingWhenLowerNonRoofSurfaceReachesRoofPlane()
+    public void CreateLeavesLod2NoWallBuildingWhenLowerNonRoofSurfaceEntersSlopedRoofSlabBand()
     {
         ParsedCityObject cityObject = CreateCityObject(
             [
-                CreateSurface("lod2-roof", ParsedSurfaceSemantic.Roof, altitude: 10.0),
                 CreateSurface(
-                    "lod2-wall-to-roof",
+                    "lod2-roof",
+                    ParsedSurfaceSemantic.Roof,
+                    CreateSlopedClosedQuadVertices(minimumAltitude: 10.0, maximumAltitude: 12.0)),
+                CreateSurface(
+                    "lod2-detail-under-sloped-roof",
                     ParsedSurfaceSemantic.Wall,
-                    CreateVerticalClosedQuadVertices(minimumAltitude: 0.0, maximumAltitude: 10.0)),
+                    CreateSlopedClosedQuadVertices(minimumAltitude: 11.0, maximumAltitude: 11.2)),
             ],
             CoordinateReferenceSystem.Parse("EPSG:6697"),
             BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] },
@@ -643,20 +646,6 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
             new(35.0, 139.00020, maximumAltitude),
             new(35.00010, 139.00020, maximumAltitude),
             new(35.00010, 139.0, minimumAltitude),
-            new(35.0, 139.0, minimumAltitude),
-        ];
-    }
-
-    private static GeodeticPoint[] CreateVerticalClosedQuadVertices(
-        double minimumAltitude,
-        double maximumAltitude)
-    {
-        return
-        [
-            new(35.0, 139.0, minimumAltitude),
-            new(35.0, 139.0, maximumAltitude),
-            new(35.0, 139.00020, maximumAltitude),
-            new(35.0, 139.00020, minimumAltitude),
             new(35.0, 139.0, minimumAltitude),
         ];
     }

--- a/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayProjectionSplitPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayProjectionSplitPolicyTests.cs
@@ -1,0 +1,111 @@
+using System.Linq;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Tests.Profiles;
+
+public sealed class TerrainOverlayProjectionSplitPolicyTests
+{
+    [Fact]
+    public void SplitParsedCityObjectExcludesGeneratedNoWallSlabPartsFromTerrainRoofProjection()
+    {
+        MeshCodeBounds meshBounds = MeshCodeBounds.TryParse("53394525")!;
+        ParsedSurface top = CreateHorizontalSurface("roof", altitude: 10.0, meshBounds: meshBounds);
+        ParsedSurface bottom = CreateHorizontalSurface("roof_generated_no-wall-bottom", altitude: 9.7, meshBounds: meshBounds);
+        ParsedSurface side = CreateVerticalSurface("roof_generated_no-wall-side-0", meshBounds);
+        ParsedCityObject cityObject = new(
+            SlotKey: "bldg-no-wall",
+            DisplayName: "No-wall building",
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 2,
+            Surfaces: [top, bottom, side],
+            ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
+            SourceFileRelativePath: "udx/bldg/53394525/bldg.gml",
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] });
+        TerrainTextureOverlay overlay = CreateOverlay(meshBounds);
+        MeshCodeBounds[] requestedMeshCodeBounds =
+        [
+            meshBounds,
+        ];
+
+        (ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)[] results =
+            TerrainOverlayProjectionSplitPolicy.SplitParsedCityObject(
+                cityObject,
+                [overlay],
+                requestedMeshCodeBounds)
+            .ToArray();
+        ParsedCityObject[] regeneratedSplitObjects = results
+            .Select(static result => GeneratedLod1RoofCityObjectFactory.Create(result.CityObject))
+            .ToArray();
+
+        ParsedSurface[] generatedTerrainSurfaces = regeneratedSplitObjects
+            .SelectMany(static cityObject => cityObject.Surfaces)
+            .Where(static surface => surface.UsesGeneratedDemTexture)
+            .ToArray();
+        ParsedSurface generatedTop = Assert.Single(generatedTerrainSurfaces);
+        Assert.Equal("roof", generatedTop.PolygonId);
+
+        ParsedSurface[] noWallSlabParts = regeneratedSplitObjects
+            .SelectMany(static cityObject => cityObject.Surfaces)
+            .Where(static surface => surface.PolygonId.Contains("_generated_no-wall-", System.StringComparison.Ordinal))
+            .ToArray();
+        Assert.Equal(2, noWallSlabParts.Length);
+        Assert.All(noWallSlabParts, static surface => Assert.False(surface.UsesGeneratedDemTexture));
+    }
+
+    private static ParsedSurface CreateHorizontalSurface(string polygonId, double altitude, MeshCodeBounds meshBounds)
+    {
+        return new ParsedSurface(
+            polygonId,
+            ParsedSurfaceSemantic.Roof,
+            new ParsedRing(
+                $"{polygonId}-ring",
+                [
+                    new GeodeticPoint(meshBounds.SouthLatitude, meshBounds.WestLongitude, altitude),
+                    new GeodeticPoint(meshBounds.SouthLatitude, meshBounds.EastLongitude, altitude),
+                    new GeodeticPoint(meshBounds.NorthLatitude, meshBounds.EastLongitude, altitude),
+                    new GeodeticPoint(meshBounds.NorthLatitude, meshBounds.WestLongitude, altitude),
+                    new GeodeticPoint(meshBounds.SouthLatitude, meshBounds.WestLongitude, altitude),
+                ],
+                UVs: null),
+            InteriorRings: [],
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null);
+    }
+
+    private static ParsedSurface CreateVerticalSurface(string polygonId, MeshCodeBounds meshBounds)
+    {
+        return new ParsedSurface(
+            polygonId,
+            ParsedSurfaceSemantic.Roof,
+            new ParsedRing(
+                $"{polygonId}-ring",
+                [
+                    new GeodeticPoint(meshBounds.SouthLatitude, meshBounds.WestLongitude, 10.0),
+                    new GeodeticPoint(meshBounds.SouthLatitude, meshBounds.WestLongitude, 9.7),
+                    new GeodeticPoint(meshBounds.SouthLatitude, meshBounds.EastLongitude, 9.7),
+                    new GeodeticPoint(meshBounds.SouthLatitude, meshBounds.EastLongitude, 10.0),
+                    new GeodeticPoint(meshBounds.SouthLatitude, meshBounds.WestLongitude, 10.0),
+                ],
+                UVs: null),
+            InteriorRings: [],
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null);
+    }
+
+    private static TerrainTextureOverlay CreateOverlay(MeshCodeBounds meshBounds)
+    {
+        return new TerrainTextureOverlay(
+            PackageName: "dem",
+            GeographicBounds: new GeographicRectangle(
+                meshBounds.SouthLatitude,
+                meshBounds.NorthLatitude,
+                meshBounds.WestLongitude,
+                meshBounds.EastLongitude),
+            MaxTextureSize: DemTerrainTextureDefaults.MaxTextureSize,
+            Sources: [new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", 18)]);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayProjectionSplitPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayProjectionSplitPolicyTests.cs
@@ -8,7 +8,7 @@ namespace PlateauResoniteLink.Tests.Profiles;
 public sealed class TerrainOverlayProjectionSplitPolicyTests
 {
     [Fact]
-    public void SplitParsedCityObjectExcludesGeneratedNoWallSlabPartsFromTerrainRoofProjection()
+    public void SplitParsedCityObjectProjectsGeneratedNoWallSlabPartsWithTerrainRoofProjection()
     {
         MeshCodeBounds meshBounds = MeshCodeBounds.TryParse("53394525")!;
         ParsedSurface top = CreateHorizontalSurface("roof", altitude: 10.0, meshBounds: meshBounds);
@@ -45,15 +45,15 @@ public sealed class TerrainOverlayProjectionSplitPolicyTests
             .SelectMany(static cityObject => cityObject.Surfaces)
             .Where(static surface => surface.UsesGeneratedDemTexture)
             .ToArray();
-        ParsedSurface generatedTop = Assert.Single(generatedTerrainSurfaces);
-        Assert.Equal("roof", generatedTop.PolygonId);
+        Assert.Equal(3, generatedTerrainSurfaces.Length);
+        Assert.Contains(generatedTerrainSurfaces, static surface => surface.PolygonId == "roof");
 
         ParsedSurface[] noWallSlabParts = regeneratedSplitObjects
             .SelectMany(static cityObject => cityObject.Surfaces)
             .Where(static surface => surface.PolygonId.Contains("_generated_no-wall-", System.StringComparison.Ordinal))
             .ToArray();
         Assert.Equal(2, noWallSlabParts.Length);
-        Assert.All(noWallSlabParts, static surface => Assert.False(surface.UsesGeneratedDemTexture));
+        Assert.All(noWallSlabParts, static surface => Assert.True(surface.UsesGeneratedDemTexture));
     }
 
     private static ParsedSurface CreateHorizontalSurface(string polygonId, double altitude, MeshCodeBounds meshBounds)


### PR DESCRIPTION
## Summary
- Treat exact `bldg:class` codes `3003` and `3004` as no-wall buildings without fallback inference.
- Generate thin 0.30m roof slabs for no-wall LOD1 surfaces, including non-rectangular and multi-top cases.
- Preserve LOD2+ `RoofSurface` topology while excluding solid-boundary `WallSurface` / `GroundSurface` and adding deterministic bottom/exterior side faces.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (938 passed)
- Canonical dump: Sendai `57403710` bldg, Osaka `51357371` bldg
- Live-send: Sendai `57403710` with `dem,bldg`, static terrain, workspace3, sent 14/14 objects