### PR TITLE
Separate CityGML surfaces from construction roles

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -51,6 +51,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             return false;
         }
 
+        ConstructionCityObjectDraft draft = ConstructionCityObjectDraft.FromParsedCityObject(cityObject);
         Float3 slotPosition = CreateScenePosition(cityObjectOrigin, globalOriginPoint, globalCartesian);
         Float3[] positions = cityObject.Surfaces
             .SelectMany(static surface => surface.Vertices)
@@ -119,7 +120,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         double maxHeight = localHeights.Max();
 
         MaterialBinding[] materials = CityGmlSurfaceMaterialResolver.CreateDemTerrainGridMaterials(
-            cityObject,
+            draft,
             cityObjectOrigin,
             cityObjectCartesian,
             demTerrainTextureOverlay,
@@ -132,7 +133,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         }
 
         TextureUvRect? heightMapOccupiedUvRect = TryCreateDemTerrainGridOccupiedUvRect(
-            cityObject,
+            draft,
             cityObjectOrigin,
             cityObjectCartesian,
             demTerrainTextureOverlay,
@@ -175,7 +176,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
     }
 
     private static TextureUvRect? TryCreateDemTerrainGridOccupiedUvRect(
-        ParsedCityObject cityObject,
+        ConstructionCityObjectDraft cityObject,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
@@ -186,7 +187,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             return null;
         }
 
-        GeographicRectangle? demObjectBounds = TryGetDemObjectGeographicBounds(cityObject, demTerrainTextureOverlay);
+        GeographicRectangle? demObjectBounds = TryGetDemObjectGeographicBounds(cityObject.Source, demTerrainTextureOverlay);
         ResolvedSurfaceMaterial? representativeSurface = CityGmlSurfaceMaterialResolver.EnumerateSurfaces(
                 cityObject,
                 cityObjectOrigin,
@@ -200,7 +201,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         }
 
         TextureUvRect? occupiedUvRect = DemTerrainOverlayUvMapper.TryCreateTerrainGridOccupiedUvRect(
-            cityObject,
+            cityObject.Source,
             representativeSurface,
             demTerrainTextureOverlay,
             demObjectBounds);

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -230,11 +230,12 @@ internal static class CityGmlParsedCityObjectProjection
                     cityObjectOrigin.Altitude,
                     splitCityObject.CityObject.ReferenceSystem.Geocentric)
                 : null;
+            ConstructionCityObjectDraft draft = ConstructionCityObjectDraft.FromParsedCityObject(splitCityObject.CityObject);
 
             foreach (MaterialBinding material in request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
                          && string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
                             ? CityGmlSurfaceMaterialResolver.CreateDemTerrainGridMaterials(
-                                splitCityObject.CityObject,
+                                draft,
                                 cityObjectOrigin,
                                 cityObjectCartesian,
                                 splitCityObject.Overlay,
@@ -242,7 +243,7 @@ internal static class CityGmlParsedCityObjectProjection
                                 requestedMeshCodeBounds,
                                 materialResolver)
                             : CityGmlSurfaceMaterialResolver.CreateSharedCommonMaterialBindings(
-                                splitCityObject.CityObject,
+                                draft,
                                 cityObjectOrigin,
                                 cityObjectCartesian,
                                 splitCityObject.Overlay,

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -12,24 +12,8 @@ internal static class CityGmlSurfaceMaterialResolver
 {
     internal static readonly MaterialDepthOffset TerrainAlignedDepthOffset = new(-10.0, -10.0);
 
-    private const double UnknownRoofBottomAltitudeToleranceMeters = 0.1;
     private static readonly ColorRgba DefaultMaterialColor = new(1.0, 1.0, 1.0, 1.0);
     private static readonly ColorRgba DefaultVegetationMaterialColor = new(0.32, 0.58, 0.24, 1.0);
-
-    internal static ResolvedSurfaceMaterial[] ResolveSurfaces(
-        ParsedCityObject cityObject,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        IDefaultMaterialResolver materialResolver)
-    {
-        return ResolveSurfaces(
-            ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
-            cityObjectOrigin,
-            cityObjectCartesian,
-            demTerrainTextureOverlay,
-            materialResolver);
-    }
 
     internal static ResolvedSurfaceMaterial[] ResolveSurfaces(
         ConstructionCityObjectDraft cityObject,
@@ -45,21 +29,6 @@ internal static class CityGmlSurfaceMaterialResolver
                 demTerrainTextureOverlay,
                 materialResolver)
             .ToArray();
-    }
-
-    internal static IEnumerable<ResolvedSurfaceMaterial> EnumerateSurfaces(
-        ParsedCityObject cityObject,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        IDefaultMaterialResolver materialResolver)
-    {
-        return EnumerateSurfaces(
-            ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
-            cityObjectOrigin,
-            cityObjectCartesian,
-            demTerrainTextureOverlay,
-            materialResolver);
     }
 
     internal static IEnumerable<ResolvedSurfaceMaterial> EnumerateSurfaces(
@@ -98,21 +67,6 @@ internal static class CityGmlSurfaceMaterialResolver
     }
 
     internal static MaterialBinding[] CreateSharedCommonMaterialBindings(
-        ParsedCityObject cityObject,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        IDefaultMaterialResolver materialResolver)
-    {
-        return CreateSharedCommonMaterialBindings(
-            ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
-            cityObjectOrigin,
-            cityObjectCartesian,
-            demTerrainTextureOverlay,
-            materialResolver);
-    }
-
-    internal static MaterialBinding[] CreateSharedCommonMaterialBindings(
         ConstructionCityObjectDraft cityObject,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
@@ -140,25 +94,6 @@ internal static class CityGmlSurfaceMaterialResolver
                 materialIndex))
             .Where(static material => material.ReuseScope == MaterialReuseScope.Shared)
             .ToArray();
-    }
-
-    internal static MaterialBinding[] CreateDemTerrainGridMaterials(
-        ParsedCityObject cityObject,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian,
-        TerrainTextureOverlay? demTerrainTextureOverlay,
-        string requestedMeshCode,
-        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
-        IDefaultMaterialResolver materialResolver)
-    {
-        return CreateDemTerrainGridMaterials(
-            ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
-            cityObjectOrigin,
-            cityObjectCartesian,
-            demTerrainTextureOverlay,
-            requestedMeshCode,
-            requestedMeshCodeBounds,
-            materialResolver);
     }
 
     internal static MaterialBinding[] CreateDemTerrainGridMaterials(
@@ -373,12 +308,15 @@ internal static class CityGmlSurfaceMaterialResolver
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
-        ParsedSurface surface = face.Surface;
         if (demTerrainTextureOverlay is null
             || TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, demTerrainTextureOverlay) is null
-            || surface.TexturePayload is not null
+            || face.Surface.TexturePayload is not null
             || !PlateauPackageCatalog.IsBuildingPackage(packageName)
-            || !IsRoofTerrainTextureSurface(face, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian))
+            || !RoofTerrainTextureSurfacePolicy.IsRoofTerrainTextureSurface(
+                face,
+                cityObjectMinAltitude,
+                cityObjectOrigin,
+                cityObjectCartesian))
         {
             return null;
         }
@@ -446,32 +384,6 @@ internal static class CityGmlSurfaceMaterialResolver
             ConstructionFaceRole.OuterFloor => DefaultMaterialSurfaceRole.OuterFloor,
             _ => DefaultMaterialSurfaceRole.Unknown,
         };
-    }
-
-    private static bool IsRoofTerrainTextureSurface(
-        ConstructionFace face,
-        double cityObjectMinAltitude,
-        GeodeticPoint cityObjectOrigin,
-        LocalCartesian? cityObjectCartesian)
-    {
-        if (face.Role is ConstructionFaceRole.Roof or ConstructionFaceRole.RoofSlab)
-        {
-            return true;
-        }
-
-        if (face.Role is not (ConstructionFaceRole.Unknown
-            or ConstructionFaceRole.Ground
-            or ConstructionFaceRole.OuterCeiling
-            or ConstructionFaceRole.OuterFloor))
-        {
-            return false;
-        }
-
-        ParsedSurface surface = face.Surface;
-        Float3? normal = CityGmlSurfaceProjectionPolicy.ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
-        return normal is not null
-            && Math.Abs(normal.Y) >= 0.98
-            && surface.Vertices.Min(static vertex => vertex.Altitude) > cityObjectMinAltitude + UnknownRoofBottomAltitudeToleranceMeters;
     }
 
     private static bool IsGeneratedRoadMarkingSurface(ParsedSurface surface)

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -23,6 +23,21 @@ internal static class CityGmlSurfaceMaterialResolver
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
+        return ResolveSurfaces(
+            ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
+            cityObjectOrigin,
+            cityObjectCartesian,
+            demTerrainTextureOverlay,
+            materialResolver);
+    }
+
+    internal static ResolvedSurfaceMaterial[] ResolveSurfaces(
+        ConstructionCityObjectDraft cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IDefaultMaterialResolver materialResolver)
+    {
         return EnumerateSurfaces(
                 cityObject,
                 cityObjectOrigin,
@@ -34,6 +49,21 @@ internal static class CityGmlSurfaceMaterialResolver
 
     internal static IEnumerable<ResolvedSurfaceMaterial> EnumerateSurfaces(
         ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IDefaultMaterialResolver materialResolver)
+    {
+        return EnumerateSurfaces(
+            ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
+            cityObjectOrigin,
+            cityObjectCartesian,
+            demTerrainTextureOverlay,
+            materialResolver);
+    }
+
+    internal static IEnumerable<ResolvedSurfaceMaterial> EnumerateSurfaces(
+        ConstructionCityObjectDraft cityObject,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
@@ -51,16 +81,16 @@ internal static class CityGmlSurfaceMaterialResolver
                 cityObjectCartesian)
             : [];
         double cityObjectMinAltitude = CityObjectAltitudeMetricsResolver.GetMinimumAltitude(
-            cityObject.Surfaces.SelectMany(static surface => surface.Vertices),
+            cityObject.Faces.SelectMany(static face => face.Surface.Vertices),
             static point => point.Altitude);
 
-        foreach (ParsedSurface surface in cityObject.Surfaces.Where(surface => !culledSurfaceIds.Contains(surface.PolygonId)))
+        foreach (ConstructionFace face in cityObject.Faces.Where(face => !culledSurfaceIds.Contains(face.Surface.PolygonId)))
         {
             yield return ResolveSurfaceMaterial(
                 cityObject,
                 cityObjectOrigin,
                 cityObjectCartesian,
-                surface,
+                face,
                 cityObjectMinAltitude,
                 demTerrainTextureOverlay,
                 materialResolver);
@@ -69,6 +99,21 @@ internal static class CityGmlSurfaceMaterialResolver
 
     internal static MaterialBinding[] CreateSharedCommonMaterialBindings(
         ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IDefaultMaterialResolver materialResolver)
+    {
+        return CreateSharedCommonMaterialBindings(
+            ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
+            cityObjectOrigin,
+            cityObjectCartesian,
+            demTerrainTextureOverlay,
+            materialResolver);
+    }
+
+    internal static MaterialBinding[] CreateSharedCommonMaterialBindings(
+        ConstructionCityObjectDraft cityObject,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
@@ -99,6 +144,25 @@ internal static class CityGmlSurfaceMaterialResolver
 
     internal static MaterialBinding[] CreateDemTerrainGridMaterials(
         ParsedCityObject cityObject,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        string requestedMeshCode,
+        IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
+        IDefaultMaterialResolver materialResolver)
+    {
+        return CreateDemTerrainGridMaterials(
+            ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
+            cityObjectOrigin,
+            cityObjectCartesian,
+            demTerrainTextureOverlay,
+            requestedMeshCode,
+            requestedMeshCodeBounds,
+            materialResolver);
+    }
+
+    internal static MaterialBinding[] CreateDemTerrainGridMaterials(
+        ConstructionCityObjectDraft cityObject,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
@@ -188,18 +252,19 @@ internal static class CityGmlSurfaceMaterialResolver
     }
 
     private static ResolvedSurfaceMaterial ResolveSurfaceMaterial(
-        ParsedCityObject cityObject,
+        ConstructionCityObjectDraft cityObject,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
-        ParsedSurface surface,
+        ConstructionFace face,
         double cityObjectMinAltitude,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
+        ParsedSurface surface = face.Surface;
         if (surface.UsesGeneratedDemTexture)
         {
             return new ResolvedSurfaceMaterial(
-                surface,
+                face,
                 new ResolvedMaterial(
                     MaterialType.Standard,
                     TexturePayload: null,
@@ -215,7 +280,7 @@ internal static class CityGmlSurfaceMaterialResolver
         ResolvedMaterial? roofTerrainTextureMaterial = TryCreateRoofTerrainTextureMaterial(
             cityObject.ActualMeshCode,
             cityObject.PackageName,
-            surface,
+            face,
             cityObjectMinAltitude,
             demTerrainTextureOverlay,
             cityObjectOrigin,
@@ -223,7 +288,7 @@ internal static class CityGmlSurfaceMaterialResolver
         if (roofTerrainTextureMaterial is not null)
         {
             return new ResolvedSurfaceMaterial(
-                surface with { BaseColor = DefaultMaterialColor },
+                face with { Surface = surface with { BaseColor = DefaultMaterialColor } },
                 roofTerrainTextureMaterial,
                 DepthOffset: null);
         }
@@ -234,7 +299,7 @@ internal static class CityGmlSurfaceMaterialResolver
             if (HasExplicitMaterialColor(surface.BaseColor))
             {
                 return new ResolvedSurfaceMaterial(
-                    surface,
+                    face,
                     new ResolvedMaterial(
                         MaterialType.VertexColor,
                         TexturePayload: null,
@@ -247,7 +312,7 @@ internal static class CityGmlSurfaceMaterialResolver
             }
 
             return new ResolvedSurfaceMaterial(
-                surface with { BaseColor = DefaultVegetationMaterialColor },
+                face with { Surface = surface with { BaseColor = DefaultVegetationMaterialColor } },
                 new ResolvedMaterial(
                     MaterialType.Standard,
                     TexturePayload: null,
@@ -262,7 +327,7 @@ internal static class CityGmlSurfaceMaterialResolver
         if (IsGeneratedRoadMarkingSurface(surface))
         {
             return new ResolvedSurfaceMaterial(
-                surface,
+                face,
                 new ResolvedMaterial(
                     MaterialType.VertexColor,
                     TexturePayload: null,
@@ -276,7 +341,7 @@ internal static class CityGmlSurfaceMaterialResolver
 
         bool preferUvProjection = ShouldPreferUvProjection(
             cityObject.PackageName,
-            surface,
+            face,
             cityObjectOrigin,
             cityObjectCartesian);
         ResolvedMaterial resolvedMaterial = materialResolver.ResolveMaterial(new DefaultMaterialRequest(
@@ -292,27 +357,28 @@ internal static class CityGmlSurfaceMaterialResolver
             FootprintAreaSquareMeters: cityObject.BuildingAttributes is null
                 ? null
                 : BuildingAttributeQueries.TryGetKnownPositiveMetric(cityObject.BuildingAttributes.BuildingFootprintArea),
-            SurfaceRole: ToDefaultMaterialSurfaceRole(surface.Semantic)));
+            SurfaceRole: ToDefaultMaterialSurfaceRole(face.Role)));
         MaterialDepthOffset? depthOffset = cityObject.TerrainAligned
             ? TerrainAlignedDepthOffset
             : null;
-        return new ResolvedSurfaceMaterial(surface, resolvedMaterial, depthOffset);
+        return new ResolvedSurfaceMaterial(face, resolvedMaterial, depthOffset);
     }
 
     private static ResolvedMaterial? TryCreateRoofTerrainTextureMaterial(
         string actualMeshCode,
         string packageName,
-        ParsedSurface surface,
+        ConstructionFace face,
         double cityObjectMinAltitude,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
+        ParsedSurface surface = face.Surface;
         if (demTerrainTextureOverlay is null
             || TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, demTerrainTextureOverlay) is null
             || surface.TexturePayload is not null
             || !PlateauPackageCatalog.IsBuildingPackage(packageName)
-            || !IsRoofTerrainTextureSurface(surface, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian))
+            || !IsRoofTerrainTextureSurface(face, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian))
         {
             return null;
         }
@@ -330,10 +396,11 @@ internal static class CityGmlSurfaceMaterialResolver
 
     private static bool ShouldPreferUvProjection(
         string packageName,
-        ParsedSurface surface,
+        ConstructionFace face,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
+        ParsedSurface surface = face.Surface;
         if (surface.TexturePayload is not null)
         {
             return true;
@@ -350,15 +417,16 @@ internal static class CityGmlSurfaceMaterialResolver
                 && CityGmlSurfaceProjectionPolicy.IsNearHorizontalSurface(surface, cityObjectOrigin, cityObjectCartesian);
         }
 
-        if (surface.Semantic is ParsedSurfaceSemantic.Wall)
+        if (face.Role is ConstructionFaceRole.Wall)
         {
             return true;
         }
 
-        if (surface.Semantic is ParsedSurfaceSemantic.Roof
-            or ParsedSurfaceSemantic.Ground
-            or ParsedSurfaceSemantic.OuterCeiling
-            or ParsedSurfaceSemantic.OuterFloor)
+        if (face.Role is ConstructionFaceRole.Roof
+            or ConstructionFaceRole.RoofSlab
+            or ConstructionFaceRole.Ground
+            or ConstructionFaceRole.OuterCeiling
+            or ConstructionFaceRole.OuterFloor)
         {
             return false;
         }
@@ -366,39 +434,40 @@ internal static class CityGmlSurfaceMaterialResolver
         return CityGmlSurfaceProjectionPolicy.IsFacadeSurface(surface, cityObjectOrigin, cityObjectCartesian);
     }
 
-    private static DefaultMaterialSurfaceRole ToDefaultMaterialSurfaceRole(ParsedSurfaceSemantic semantic)
+    private static DefaultMaterialSurfaceRole ToDefaultMaterialSurfaceRole(ConstructionFaceRole role)
     {
-        return semantic switch
+        return role switch
         {
-            ParsedSurfaceSemantic.Wall => DefaultMaterialSurfaceRole.Wall,
-            ParsedSurfaceSemantic.Roof => DefaultMaterialSurfaceRole.Roof,
-            ParsedSurfaceSemantic.Ground => DefaultMaterialSurfaceRole.Ground,
-            ParsedSurfaceSemantic.Closure => DefaultMaterialSurfaceRole.Closure,
-            ParsedSurfaceSemantic.OuterCeiling => DefaultMaterialSurfaceRole.OuterCeiling,
-            ParsedSurfaceSemantic.OuterFloor => DefaultMaterialSurfaceRole.OuterFloor,
+            ConstructionFaceRole.Wall => DefaultMaterialSurfaceRole.Wall,
+            ConstructionFaceRole.Roof or ConstructionFaceRole.RoofSlab => DefaultMaterialSurfaceRole.Roof,
+            ConstructionFaceRole.Ground => DefaultMaterialSurfaceRole.Ground,
+            ConstructionFaceRole.Closure => DefaultMaterialSurfaceRole.Closure,
+            ConstructionFaceRole.OuterCeiling => DefaultMaterialSurfaceRole.OuterCeiling,
+            ConstructionFaceRole.OuterFloor => DefaultMaterialSurfaceRole.OuterFloor,
             _ => DefaultMaterialSurfaceRole.Unknown,
         };
     }
 
     private static bool IsRoofTerrainTextureSurface(
-        ParsedSurface surface,
+        ConstructionFace face,
         double cityObjectMinAltitude,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
-        if (surface.Semantic == ParsedSurfaceSemantic.Roof)
+        if (face.Role is ConstructionFaceRole.Roof or ConstructionFaceRole.RoofSlab)
         {
             return true;
         }
 
-        if (surface.Semantic is not (ParsedSurfaceSemantic.Unknown
-            or ParsedSurfaceSemantic.Ground
-            or ParsedSurfaceSemantic.OuterCeiling
-            or ParsedSurfaceSemantic.OuterFloor))
+        if (face.Role is not (ConstructionFaceRole.Unknown
+            or ConstructionFaceRole.Ground
+            or ConstructionFaceRole.OuterCeiling
+            or ConstructionFaceRole.OuterFloor))
         {
             return false;
         }
 
+        ParsedSurface surface = face.Surface;
         Float3? normal = CityGmlSurfaceProjectionPolicy.ComputeSurfaceNormal(surface, cityObjectOrigin, cityObjectCartesian);
         return normal is not null
             && Math.Abs(normal.Y) >= 0.98

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMeshTessellator.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMeshTessellator.cs
@@ -17,27 +17,28 @@ internal static class CityGmlSurfaceMeshTessellator
     {
         List<(MeshVertex First, MeshVertex Second, MeshVertex Third, string SortKey)> triangles = [];
         bool useVertexColors = request.Material.MaterialType == MaterialType.VertexColor;
+        ParsedSurface surface = request.Face.Surface;
         DemUvProjection? generatedDemUvProjection = request.Material.TerrainOverlay is not null
             ? request.DemUvProjection
             : null;
         bool useGeneratedDemUv = generatedDemUvProjection is not null;
         SurfaceUvProjection? generatedSurfaceUvProjection = !useGeneratedDemUv
-            && request.Surface.TexturePayload is null
+            && surface.TexturePayload is null
             && request.Material.Projection == MaterialProjection.Uv
                 ? CreateGeneratedSurfaceUvProjection(
-                    request.Surface,
+                    surface,
                     request.PackageName,
                     request.CityObjectOrigin,
                     request.CityObjectCartesian,
                     request.FacadeUvProjectionContext)
                 : null;
         List<TessellatedRing> tessellatedRings = CreateSurfaceTessellatedRings(
-            request.Surface,
+            surface,
             request.CityObjectOrigin,
             request.CityObjectCartesian,
             generatedDemUvProjection,
             generatedSurfaceUvProjection,
-            useVertexColors ? request.Surface.BaseColor : null);
+            useVertexColors ? surface.BaseColor : null);
         if (tessellatedRings.Count == 0)
         {
             return SurfaceMeshTessellation.Empty;
@@ -659,7 +660,7 @@ internal static class CityGmlSurfaceMeshTessellator
 
 internal sealed record SurfaceMeshTessellationRequest(
     string PackageName,
-    ParsedSurface Surface,
+    ConstructionFace Face,
     ResolvedMaterial Material,
     GeodeticPoint CityObjectOrigin,
     LocalCartesian? CityObjectCartesian,

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
@@ -23,6 +23,7 @@ internal static class CityGmlTriangleMeshCityObjectProjection
         {
             GeometryHeightMeters = geometryHeightMeters,
         };
+        ConstructionCityObjectDraft draft = ConstructionCityObjectDraft.FromParsedCityObject(cityObject);
         GeodeticPoint cityObjectOrigin = ResolveCityObjectOrigin(cityObject);
 
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
@@ -44,7 +45,7 @@ internal static class CityGmlTriangleMeshCityObjectProjection
         List<ResolvedSurfaceMaterial> resolvedSurfaces =
         [
             .. CityGmlSurfaceMaterialResolver.ResolveSurfaces(
-                cityObject,
+                draft,
                 cityObjectOrigin,
                 cityObjectCartesian,
                 demTerrainTextureOverlay,
@@ -64,7 +65,7 @@ internal static class CityGmlTriangleMeshCityObjectProjection
             .ToArray();
         FacadeUvProjectionContext? facadeUvProjectionContext = CityGmlSurfaceProjectionPolicy.TryCreateFacadeUvProjectionContext(
             cityObject.PackageName,
-            cityObject.Surfaces,
+            draft.Surfaces,
             cityObjectOrigin,
             cityObjectCartesian);
 
@@ -79,7 +80,7 @@ internal static class CityGmlTriangleMeshCityObjectProjection
                 SurfaceMeshTessellation tessellation = CityGmlSurfaceMeshTessellator.Tessellate(
                     new SurfaceMeshTessellationRequest(
                         cityObject.PackageName,
-                        resolvedSurface.Surface,
+                        resolvedSurface.Face,
                         resolvedSurface.Material,
                         cityObjectOrigin,
                         cityObjectCartesian,

--- a/src/PlateauResoniteLink/Application/Importing/ConstructionCityObjectDraft.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ConstructionCityObjectDraft.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal enum ConstructionFaceRole
+{
+    Unknown = 0,
+    Wall,
+    Roof,
+    RoofSlab,
+    Ground,
+    Closure,
+    OuterCeiling,
+    OuterFloor,
+}
+
+// Project-stage geometry role for material and tessellation routing. This is not the input CityGML surface type.
+internal sealed record ConstructionFace(
+    ParsedSurface Surface,
+    ConstructionFaceRole Role);
+
+internal sealed record ConstructionCityObjectDraft(
+    ParsedCityObject Source,
+    ConstructionFace[] Faces)
+{
+    public string SlotKey => Source.SlotKey;
+
+    public string DisplayName => Source.DisplayName;
+
+    public string PackageName => Source.PackageName;
+
+    public string ActualMeshCode => Source.ActualMeshCode;
+
+    public int? LodLevel => Source.LodLevel;
+
+    public CoordinateReferenceSystem ReferenceSystem => Source.ReferenceSystem;
+
+    public string SourceFileRelativePath => Source.SourceFileRelativePath;
+
+    public bool TerrainAligned => Source.TerrainAligned;
+
+    public GeodeticPoint? GeodeticOriginOverride => Source.GeodeticOriginOverride;
+
+    public int? FloorsAboveGround => Source.FloorsAboveGround;
+
+    public double? MeasuredHeightMeters => Source.MeasuredHeightMeters;
+
+    public BuildingAttributeContext? BuildingAttributes => Source.BuildingAttributes;
+
+    public double? GeometryHeightMeters => Source.GeometryHeightMeters;
+
+    public ParsedSurface[] Surfaces => Faces.Select(static face => face.Surface).ToArray();
+
+    public static ConstructionCityObjectDraft FromParsedCityObject(ParsedCityObject cityObject)
+    {
+        ArgumentNullException.ThrowIfNull(cityObject);
+
+        return new ConstructionCityObjectDraft(
+            cityObject,
+            cityObject.Surfaces
+                .Select(static surface => new ConstructionFace(surface, ResolveRole(surface)))
+                .ToArray());
+    }
+
+    internal static ConstructionFaceRole ResolveRole(ParsedSurface surface)
+    {
+        if (GeneratedLod1RoofSurfaceIdentity.IsGeneratedNoWallSlabPart(surface))
+        {
+            return ConstructionFaceRole.RoofSlab;
+        }
+
+        return surface.Semantic switch
+        {
+            ParsedSurfaceSemantic.Wall => ConstructionFaceRole.Wall,
+            ParsedSurfaceSemantic.Roof => ConstructionFaceRole.Roof,
+            ParsedSurfaceSemantic.Ground => ConstructionFaceRole.Ground,
+            ParsedSurfaceSemantic.Closure => ConstructionFaceRole.Closure,
+            ParsedSurfaceSemantic.OuterCeiling => ConstructionFaceRole.OuterCeiling,
+            ParsedSurfaceSemantic.OuterFloor => ConstructionFaceRole.OuterFloor,
+            _ => ConstructionFaceRole.Unknown,
+        };
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/ConstructionCityObjectDraft.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ConstructionCityObjectDraft.cs
@@ -22,7 +22,8 @@ internal sealed record ConstructionFace(
 
 internal sealed record ConstructionCityObjectDraft(
     ParsedCityObject Source,
-    ConstructionFace[] Faces)
+    ConstructionFace[] Faces,
+    ParsedSurface[] Surfaces)
 {
     public string SlotKey => Source.SlotKey;
 
@@ -50,17 +51,17 @@ internal sealed record ConstructionCityObjectDraft(
 
     public double? GeometryHeightMeters => Source.GeometryHeightMeters;
 
-    public ParsedSurface[] Surfaces => Faces.Select(static face => face.Surface).ToArray();
-
     public static ConstructionCityObjectDraft FromParsedCityObject(ParsedCityObject cityObject)
     {
         ArgumentNullException.ThrowIfNull(cityObject);
 
+        ConstructionFace[] faces = cityObject.Surfaces
+            .Select(static surface => new ConstructionFace(surface, ResolveRole(surface)))
+            .ToArray();
         return new ConstructionCityObjectDraft(
             cityObject,
-            cityObject.Surfaces
-                .Select(static surface => new ConstructionFace(surface, ResolveRole(surface)))
-                .ToArray());
+            faces,
+            cityObject.Surfaces);
     }
 
     internal static ConstructionFaceRole ResolveRole(ParsedSurface surface)

--- a/src/PlateauResoniteLink/Application/Importing/ResolvedSurfaceMaterial.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ResolvedSurfaceMaterial.cs
@@ -8,8 +8,8 @@ internal sealed record ResolvedSurfaceMaterial(
     public ResolvedSurfaceMaterial(
         ParsedSurface surface,
         ResolvedMaterial material,
-        MaterialDepthOffset? DepthOffset)
-        : this(new ConstructionFace(surface, ConstructionCityObjectDraft.ResolveRole(surface)), material, DepthOffset)
+        MaterialDepthOffset? depthOffset)
+        : this(new ConstructionFace(surface, ConstructionCityObjectDraft.ResolveRole(surface)), material, depthOffset)
     {
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/ResolvedSurfaceMaterial.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ResolvedSurfaceMaterial.cs
@@ -1,6 +1,19 @@
 namespace PlateauResoniteLink.Application.Importing;
 
 internal sealed record ResolvedSurfaceMaterial(
-    ParsedSurface Surface,
+    ConstructionFace Face,
     ResolvedMaterial Material,
-    MaterialDepthOffset? DepthOffset);
+    MaterialDepthOffset? DepthOffset)
+{
+    public ResolvedSurfaceMaterial(
+        ParsedSurface surface,
+        ResolvedMaterial material,
+        MaterialDepthOffset? DepthOffset)
+        : this(new ConstructionFace(surface, ConstructionCityObjectDraft.ResolveRole(surface)), material, DepthOffset)
+    {
+    }
+
+    public ParsedSurface Surface => Face.Surface;
+
+    public ConstructionFaceRole Role => Face.Role;
+}

--- a/src/PlateauResoniteLink/Application/Importing/RoofTerrainTextureSurfacePolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/RoofTerrainTextureSurfacePolicy.cs
@@ -10,24 +10,25 @@ internal static class RoofTerrainTextureSurfacePolicy
     private const double UnknownRoofBottomAltitudeToleranceMeters = 0.1;
 
     internal static bool IsRoofTerrainTextureSurface(
-        ParsedSurface surface,
+        ConstructionFace face,
         double cityObjectMinAltitude,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
-        if (surface.Semantic == ParsedSurfaceSemantic.Roof)
+        if (face.Role is ConstructionFaceRole.Roof or ConstructionFaceRole.RoofSlab)
         {
             return true;
         }
 
-        if (surface.Semantic is not (ParsedSurfaceSemantic.Unknown
-            or ParsedSurfaceSemantic.Ground
-            or ParsedSurfaceSemantic.OuterCeiling
-            or ParsedSurfaceSemantic.OuterFloor))
+        if (face.Role is not (ConstructionFaceRole.Unknown
+            or ConstructionFaceRole.Ground
+            or ConstructionFaceRole.OuterCeiling
+            or ConstructionFaceRole.OuterFloor))
         {
             return false;
         }
 
+        ParsedSurface surface = face.Surface;
         Float3? normal = ComputeSurfaceNormal(
             surface,
             cityObjectOrigin,

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayProjectionSplitPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayProjectionSplitPolicy.cs
@@ -109,14 +109,15 @@ internal static class TerrainOverlayProjectionSplitPolicy
         foreach (ParsedSurface surface in cityObject.Surfaces)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!IsNonDemTerrainTextureSurface(surface, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian)
+            ConstructionFace face = new(surface, ConstructionCityObjectDraft.ResolveRole(surface));
+            if (!IsNonDemTerrainTextureSurface(face, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian)
                 || !TryCreateSurfaceGeographicBounds(surface, out GeographicRectangle surfaceBounds))
             {
                 untexturedSurfaces.Add(surface);
                 continue;
             }
 
-            ParsedSurface terrainProjectionSurface = NormalizeNonDemTerrainTextureSurface(surface);
+            ParsedSurface terrainProjectionSurface = NormalizeNonDemTerrainTextureSurface(face);
 
             TerrainTextureOverlay[] candidateOverlays = demTerrainTextureOverlays
                 .Where(overlay => TerrainOverlayMeshCodeResolver.IsRequestedOverlay(overlay, requestedMeshCodeBounds)
@@ -267,24 +268,30 @@ internal static class TerrainOverlayProjectionSplitPolicy
         return surface with { UsesGeneratedDemTexture = true };
     }
 
-    private static ParsedSurface NormalizeNonDemTerrainTextureSurface(ParsedSurface surface)
+    private static ParsedSurface NormalizeNonDemTerrainTextureSurface(ConstructionFace face)
     {
+        ParsedSurface surface = face.Surface;
+        if (face.Role is ConstructionFaceRole.RoofSlab)
+        {
+            return surface;
+        }
+
         return surface.Semantic == ParsedSurfaceSemantic.Roof
             ? surface
             : surface with { Semantic = ParsedSurfaceSemantic.Roof };
     }
 
     private static bool IsNonDemTerrainTextureSurface(
-        ParsedSurface surface,
+        ConstructionFace face,
         double cityObjectMinAltitude,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
-        // Generated no-wall slab parts are extruded from the top roof surface, so terrain imagery follows the slab.
+        ParsedSurface surface = face.Surface;
         return surface.TexturePayload is null
             && !surface.UsesGeneratedDemTexture
             && RoofTerrainTextureSurfacePolicy.IsRoofTerrainTextureSurface(
-                surface,
+                face,
                 cityObjectMinAltitude,
                 cityObjectOrigin,
                 cityObjectCartesian);

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceMaterialResolverTests.cs
@@ -28,7 +28,7 @@ public sealed class CityGmlSurfaceMaterialResolverTests
             SharedAcrossMeshCodes: false);
 
         ResolvedSurfaceMaterial? representativeSurface = CityGmlSurfaceMaterialResolver.EnumerateSurfaces(
-                cityObject,
+                ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
                 cityObjectOrigin: new GeodeticPoint(35.0, 139.0, 0.0),
                 cityObjectCartesian: null,
                 demTerrainTextureOverlay: CreateOverlay("53394525"),
@@ -53,7 +53,7 @@ public sealed class CityGmlSurfaceMaterialResolverTests
                 TextureScale: null,
                 MaterialReuseScope.Shared,
                 TerrainOverlay: CreateOverlay("53394525")),
-            DepthOffset: null);
+            depthOffset: null);
 
         InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
             () => CityGmlSurfaceMaterialResolver.CreateMaterialBinding(
@@ -76,7 +76,7 @@ public sealed class CityGmlSurfaceMaterialResolverTests
         DefaultMaterialResolver materialResolver = new(CommonMaterialCatalog.Create());
 
         ResolvedSurfaceMaterial resolvedSurface = Assert.Single(CityGmlSurfaceMaterialResolver.ResolveSurfaces(
-            cityObject,
+            ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
             cityObjectOrigin: new GeodeticPoint(35.0, 139.0, 0.0),
             cityObjectCartesian: null,
             demTerrainTextureOverlay: null,
@@ -95,7 +95,7 @@ public sealed class CityGmlSurfaceMaterialResolverTests
         DefaultMaterialResolver materialResolver = new(CommonMaterialCatalog.Create());
 
         ResolvedSurfaceMaterial resolvedSurface = Assert.Single(CityGmlSurfaceMaterialResolver.ResolveSurfaces(
-            cityObject,
+            ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
             cityObjectOrigin: new GeodeticPoint(35.0, 139.0, 0.0),
             cityObjectCartesian: null,
             demTerrainTextureOverlay: null,
@@ -144,11 +144,12 @@ public sealed class CityGmlSurfaceMaterialResolverTests
 
     private static ParsedSurface CreateSurface(string polygonId, ParsedSurfaceSemantic semantic)
     {
-        return CreateSurface() with
+        ParsedSurface surface = CreateSurface();
+        return surface with
         {
             PolygonId = polygonId,
             Semantic = semantic,
-            ExteriorRing = CreateSurface().ExteriorRing with { RingId = $"{polygonId}-ring" },
+            ExteriorRing = surface.ExteriorRing with { RingId = $"{polygonId}-ring" },
         };
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceMaterialResolverTests.cs
@@ -66,6 +66,45 @@ public sealed class CityGmlSurfaceMaterialResolverTests
         Assert.DoesNotContain("requested_mesh_code=", exception.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void EnumerateSurfacesUsesConstructionRoleInsteadOfParsedSemanticForGeneratedNoWallSlabParts()
+    {
+        ParsedSurface generatedSide = CreateSurface(
+            "lod2-roof_generated_no-wall-side-0",
+            ParsedSurfaceSemantic.Wall);
+        ParsedCityObject cityObject = CreateBuildingCityObject([generatedSide]);
+        DefaultMaterialResolver materialResolver = new(CommonMaterialCatalog.Create());
+
+        ResolvedSurfaceMaterial resolvedSurface = Assert.Single(CityGmlSurfaceMaterialResolver.ResolveSurfaces(
+            cityObject,
+            cityObjectOrigin: new GeodeticPoint(35.0, 139.0, 0.0),
+            cityObjectCartesian: null,
+            demTerrainTextureOverlay: null,
+            materialResolver));
+
+        Assert.Equal(ConstructionFaceRole.RoofSlab, resolvedSurface.Role);
+        Assert.Equal(BundledDefaultMaterialFamilies.Roof, resolvedSurface.Material.Family);
+        Assert.DoesNotContain(BundledDefaultMaterialFamilies.BuildingFacadeFamilies, family => family == resolvedSurface.Material.Family);
+    }
+
+    [Fact]
+    public void EnumerateSurfacesMapsOrdinaryBuildingWallToFacadeConstructionRole()
+    {
+        ParsedSurface wall = CreateSurface("lod2-wall", ParsedSurfaceSemantic.Wall);
+        ParsedCityObject cityObject = CreateBuildingCityObject([wall]);
+        DefaultMaterialResolver materialResolver = new(CommonMaterialCatalog.Create());
+
+        ResolvedSurfaceMaterial resolvedSurface = Assert.Single(CityGmlSurfaceMaterialResolver.ResolveSurfaces(
+            cityObject,
+            cityObjectOrigin: new GeodeticPoint(35.0, 139.0, 0.0),
+            cityObjectCartesian: null,
+            demTerrainTextureOverlay: null,
+            materialResolver));
+
+        Assert.Equal(ConstructionFaceRole.Wall, resolvedSurface.Role);
+        Assert.Contains(BundledDefaultMaterialFamilies.BuildingFacadeFamilies, family => family == resolvedSurface.Material.Family);
+    }
+
     private static ParsedSurface CreateParsedSurface(string polygonId, bool usesGeneratedDemTexture)
     {
         return new ParsedSurface(
@@ -101,6 +140,30 @@ public sealed class CityGmlSurfaceMaterialResolverTests
             InteriorRings: [],
             BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
             TexturePayload: null);
+    }
+
+    private static ParsedSurface CreateSurface(string polygonId, ParsedSurfaceSemantic semantic)
+    {
+        return CreateSurface() with
+        {
+            PolygonId = polygonId,
+            Semantic = semantic,
+            ExteriorRing = CreateSurface().ExteriorRing with { RingId = $"{polygonId}-ring" },
+        };
+    }
+
+    private static ParsedCityObject CreateBuildingCityObject(ParsedSurface[] surfaces)
+    {
+        return new ParsedCityObject(
+            SlotKey: "bldg-object",
+            DisplayName: "bldg-object",
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 2,
+            Surfaces: surfaces,
+            ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
+            SourceFileRelativePath: "udx/bldg/53394525/sample.gml",
+            SharedAcrossMeshCodes: false);
     }
 
     private static TerrainTextureOverlay CreateOverlay(string meshCode)

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
@@ -381,7 +381,7 @@ public sealed class DemTerrainOverlayAssignmentTests
                 TextureScale: null,
                 MaterialReuseScope.PerObject,
                 TerrainOverlay: overlay),
-            DepthOffset: null);
+            depthOffset: null);
 
         (Float2? textureScale, Float2? textureOffset) = DemTerrainOverlayUvMapper.TryCreateTerrainGridTextureTransform(
             cityObject,

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -3569,7 +3569,7 @@ public sealed class LocalCityGmlObjectProjectionTests
         GeographicLib.LocalCartesian cartesian)
     {
         return CityGmlSurfaceMaterialResolver.CreateSharedCommonMaterialBindings(
-            cityObject,
+            ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
             cityObjectOrigin,
             cartesian,
             demTerrainTextureOverlay: null,

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -3257,7 +3257,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             ReuseScope: MaterialReuseScope.PerObject);
         return CityGmlSurfaceMeshTessellator.Tessellate(new SurfaceMeshTessellationRequest(
             packageName,
-            surface,
+            new ConstructionFace(surface, ConstructionCityObjectDraft.ResolveRole(surface)),
             material,
             cityObjectOrigin,
             cartesian,

--- a/tests/PlateauResoniteLink.Tests/Profiles/RoofTerrainTextureSurfacePolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/RoofTerrainTextureSurfacePolicyTests.cs
@@ -35,7 +35,35 @@ public sealed class RoofTerrainTextureSurfacePolicyTests
             TexturePayload: null);
 
         bool result = RoofTerrainTextureSurfacePolicy.IsRoofTerrainTextureSurface(
-            surface,
+            new ConstructionFace(surface, ConstructionCityObjectDraft.ResolveRole(surface)),
+            cityObjectMinAltitude: 0.0,
+            cityObjectOrigin: new GeodeticPoint(35.0, 139.0, 0.0),
+            cityObjectCartesian: null);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsRoofTerrainTextureSurfaceTreatsGeneratedNoWallWallSurfaceAsRoofSlab()
+    {
+        ParsedSurface surface = new(
+            PolygonId: "roof_generated_no-wall-side-0",
+            Semantic: ParsedSurfaceSemantic.Wall,
+            ExteriorRing: new ParsedRing(
+                "roof_generated_no-wall-side-0-ring",
+                [
+                    new GeodeticPoint(35.0, 139.0, 10.0),
+                    new GeodeticPoint(35.0, 139.0, 9.7),
+                    new GeodeticPoint(35.0, 139.1, 9.7),
+                    new GeodeticPoint(35.0, 139.1, 10.0),
+                ],
+                UVs: null),
+            InteriorRings: [],
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            TexturePayload: null);
+
+        bool result = RoofTerrainTextureSurfacePolicy.IsRoofTerrainTextureSurface(
+            new ConstructionFace(surface, ConstructionCityObjectDraft.ResolveRole(surface)),
             cityObjectMinAltitude: 0.0,
             cityObjectOrigin: new GeodeticPoint(35.0, 139.0, 0.0),
             cityObjectCartesian: null);

--- a/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayProjectionSplitPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayProjectionSplitPolicyTests.cs
@@ -54,6 +54,8 @@ public sealed class TerrainOverlayProjectionSplitPolicyTests
             .ToArray();
         Assert.Equal(2, noWallSlabParts.Length);
         Assert.All(noWallSlabParts, static surface => Assert.True(surface.UsesGeneratedDemTexture));
+        ParsedSurface noWallSide = Assert.Single(noWallSlabParts, static surface => surface.PolygonId == "roof_generated_no-wall-side-0");
+        Assert.Equal(ParsedSurfaceSemantic.Wall, noWallSide.Semantic);
     }
 
     private static ParsedSurface CreateHorizontalSurface(string polygonId, double altitude, MeshCodeBounds meshBounds)
@@ -80,7 +82,7 @@ public sealed class TerrainOverlayProjectionSplitPolicyTests
     {
         return new ParsedSurface(
             polygonId,
-            ParsedSurfaceSemantic.Roof,
+            ParsedSurfaceSemantic.Wall,
             new ParsedRing(
                 $"{polygonId}-ring",
                 [


### PR DESCRIPTION
## Summary
- Introduce a project-stage construction draft with construction face roles separate from parsed CityGML surface semantics.
- Route material resolution and tessellation through construction faces instead of treating `ParsedSurfaceSemantic` as the sink-facing role.
- Mark generated no-wall roof slab parts as `RoofSlab` for material routing while preserving existing output contracts.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`