### PR TITLE
Extract terrain overlay material-source flow boundaries

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -91,12 +91,12 @@ internal static class CityGmlParsedCityObjectProjection
         List<ImportedCityObject> generatedRoadMarkings = [];
 
         foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) partitionedCityObject
-             in TerrainOverlayMaterialSourcePartitioner.PartitionParsedCityObject(
-                 terrainAlignedParsedCityObject,
-                 demTerrainTextureOverlays,
-                 requestedMeshCodeBounds,
-                 progressReporter,
-                 cancellationToken))
+                 in TerrainOverlayMaterialSourcePartitioner.PartitionParsedCityObject(
+                     terrainAlignedParsedCityObject,
+                     demTerrainTextureOverlays,
+                     requestedMeshCodeBounds,
+                     progressReporter,
+                     cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (!TerrainOverlayMaterialSourcePartitioner.IsPartitionCompatibleWithRequest(

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -90,34 +90,34 @@ internal static class CityGmlParsedCityObjectProjection
         List<ImportedCityObject> projectedCityObjects = [];
         List<ImportedCityObject> generatedRoadMarkings = [];
 
-        foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
-                 in TerrainOverlayProjectionSplitPolicy.SplitParsedCityObject(
-                     terrainAlignedParsedCityObject,
-                     demTerrainTextureOverlays,
-                     requestedMeshCodeBounds,
-                     progressReporter,
-                     cancellationToken))
+        foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) partitionedCityObject
+             in TerrainOverlayMaterialSourcePartitioner.PartitionParsedCityObject(
+                 terrainAlignedParsedCityObject,
+                 demTerrainTextureOverlays,
+                 requestedMeshCodeBounds,
+                 progressReporter,
+                 cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!TerrainOverlayProjectionSplitPolicy.ShouldProjectSplit(
-                    splitCityObject.CityObject.ActualMeshCode,
+            if (!TerrainOverlayMaterialSourcePartitioner.IsPartitionCompatibleWithRequest(
+                    partitionedCityObject.CityObject.ActualMeshCode,
                     request.MeshCode,
                     requestedMeshCodeBounds,
-                    splitCityObject.Overlay))
+                    partitionedCityObject.Overlay))
             {
                 throw CreateTerrainOverlayMeshCodeMismatchException(
                     "project",
-                    splitCityObject.CityObject.ActualMeshCode,
+                    partitionedCityObject.CityObject.ActualMeshCode,
                     request.MeshCode,
                     requestedMeshCodeBounds,
-                    splitCityObject.Overlay);
+                    partitionedCityObject.Overlay);
             }
 
             ImportedCityObject cityObject = ProjectTerrainMeshModeCityObject(
-                splitCityObject.CityObject,
+                partitionedCityObject.CityObject,
                 globalOriginPoint,
                 globalCartesian,
-                splitCityObject.Overlay,
+                partitionedCityObject.Overlay,
                 request,
                 requestedMeshCodeBounds,
                 materialResolver,
@@ -129,16 +129,16 @@ internal static class CityGmlParsedCityObjectProjection
                 projectedCityObjects.Add(cityObject);
             }
 
-            GeodeticPoint markingOrigin = ResolveCityObjectOrigin(splitCityObject.CityObject);
-            LocalCartesian? markingCartesian = splitCityObject.CityObject.ReferenceSystem.IsGeographic
+            GeodeticPoint markingOrigin = ResolveCityObjectOrigin(partitionedCityObject.CityObject);
+            LocalCartesian? markingCartesian = partitionedCityObject.CityObject.ReferenceSystem.IsGeographic
                 ? new LocalCartesian(
                     markingOrigin.Latitude,
                     markingOrigin.Longitude,
                     markingOrigin.Altitude,
-                    splitCityObject.CityObject.ReferenceSystem.Geocentric)
+                    partitionedCityObject.CityObject.ReferenceSystem.Geocentric)
                 : null;
             ParsedCityObject? roadMarkingCityObject = GeneratedRoadMarkingCityObjectFactory.Create(
-                splitCityObject.CityObject,
+                partitionedCityObject.CityObject,
                 markingOrigin,
                 markingCartesian);
             if (roadMarkingCityObject is null)
@@ -150,7 +150,7 @@ internal static class CityGmlParsedCityObjectProjection
                 roadMarkingCityObject,
                 globalOriginPoint,
                 globalCartesian,
-                splitCityObject.Overlay,
+                partitionedCityObject.Overlay,
                 materialResolver) with
             {
                 CollisionEnabled = false,
@@ -202,43 +202,43 @@ internal static class CityGmlParsedCityObjectProjection
                 GeometryHeightMeters = geometryHeightMeters,
             };
 
-        foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
-                 in TerrainOverlayProjectionSplitPolicy.SplitParsedCityObject(
+        foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) partitionedCityObject
+                 in TerrainOverlayMaterialSourcePartitioner.PartitionParsedCityObject(
                      terrainAlignedParsedCityObject,
                      demTerrainTextureOverlays,
                      requestedMeshCodeBounds))
         {
-            if (!TerrainOverlayProjectionSplitPolicy.ShouldProjectSplit(
-                    splitCityObject.CityObject.ActualMeshCode,
+            if (!TerrainOverlayMaterialSourcePartitioner.IsPartitionCompatibleWithRequest(
+                    partitionedCityObject.CityObject.ActualMeshCode,
                     request.MeshCode,
                     requestedMeshCodeBounds ?? [],
-                    splitCityObject.Overlay))
+                    partitionedCityObject.Overlay))
             {
                 throw CreateTerrainOverlayMeshCodeMismatchException(
                     "common-material-enumeration",
-                    splitCityObject.CityObject.ActualMeshCode,
+                    partitionedCityObject.CityObject.ActualMeshCode,
                     request.MeshCode,
                     requestedMeshCodeBounds,
-                    splitCityObject.Overlay);
+                    partitionedCityObject.Overlay);
             }
 
-            GeodeticPoint cityObjectOrigin = ResolveCityObjectOrigin(splitCityObject.CityObject);
-            LocalCartesian? cityObjectCartesian = splitCityObject.CityObject.ReferenceSystem.IsGeographic
+            GeodeticPoint cityObjectOrigin = ResolveCityObjectOrigin(partitionedCityObject.CityObject);
+            LocalCartesian? cityObjectCartesian = partitionedCityObject.CityObject.ReferenceSystem.IsGeographic
                 ? new LocalCartesian(
                     cityObjectOrigin.Latitude,
                     cityObjectOrigin.Longitude,
                     cityObjectOrigin.Altitude,
-                    splitCityObject.CityObject.ReferenceSystem.Geocentric)
+                    partitionedCityObject.CityObject.ReferenceSystem.Geocentric)
                 : null;
-            ConstructionCityObjectDraft draft = ConstructionCityObjectDraft.FromParsedCityObject(splitCityObject.CityObject);
+            ConstructionCityObjectDraft draft = ConstructionCityObjectDraft.FromParsedCityObject(partitionedCityObject.CityObject);
 
             foreach (MaterialBinding material in request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
-                         && string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
+                         && string.Equals(partitionedCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
                             ? CityGmlSurfaceMaterialResolver.CreateDemTerrainGridMaterials(
                                 draft,
                                 cityObjectOrigin,
                                 cityObjectCartesian,
-                                splitCityObject.Overlay,
+                                partitionedCityObject.Overlay,
                                 request.MeshCode,
                                 requestedMeshCodeBounds,
                                 materialResolver)
@@ -246,7 +246,7 @@ internal static class CityGmlParsedCityObjectProjection
                                 draft,
                                 cityObjectOrigin,
                                 cityObjectCartesian,
-                                splitCityObject.Overlay,
+                                partitionedCityObject.Overlay,
                                 materialResolver))
             {
                 yield return material;

--- a/src/PlateauResoniteLink/Application/Importing/ProjectionTerrainOverlayContextResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ProjectionTerrainOverlayContextResolver.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal sealed record ProjectionTerrainOverlayContext(IReadOnlyList<TerrainTextureOverlay> Overlays)
+{
+    public static ProjectionTerrainOverlayContext Empty { get; } = new([]);
+}
+
+internal sealed class ProjectionTerrainOverlayContextResolver
+{
+    private readonly PlateauImportRequest request;
+    private readonly SourceFilePipeline[] sourceFiles;
+    private readonly MeshCodeBounds[] requestedMeshCodeBounds;
+    private readonly string[] selectedMeshCodes;
+    private readonly TerrainTextureOverlay[] discoveryTerrainTextureOverlays;
+    private readonly bool hasDemPackage;
+    private readonly IDemTextureSourcePolicy demTextureSourcePolicy;
+    private readonly object parsedDemSourceFilesGate = new();
+    private readonly object demOverlayRegionsGate = new();
+    private readonly object demTextureSourcesGate = new();
+    private readonly object overlayContextGate = new();
+    private Task<ParsedSourceFileResult[]>? parsedDemSourceFilesTask;
+    private Task<DemTerrainOverlayRegion[]>? demOverlayRegionsTask;
+    private Task<ResolvedDemTextureSources>? demTextureSourcesTask;
+    private Task<ProjectionTerrainOverlayContext>? overlayContextTask;
+
+    internal ProjectionTerrainOverlayContextResolver(
+        PlateauImportRequest request,
+        IReadOnlyList<SourceFilePipeline> sourceFiles,
+        IReadOnlyList<TerrainTextureOverlay> discoveryTerrainTextureOverlays,
+        IReadOnlyList<string> selectedMeshCodes,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
+        bool hasDemPackage,
+        IDemTextureSourcePolicy demTextureSourcePolicy)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(sourceFiles);
+        ArgumentNullException.ThrowIfNull(discoveryTerrainTextureOverlays);
+        ArgumentNullException.ThrowIfNull(selectedMeshCodes);
+        ArgumentNullException.ThrowIfNull(requestedMeshCodeBounds);
+        ArgumentNullException.ThrowIfNull(demTextureSourcePolicy);
+
+        this.request = request;
+        this.sourceFiles = sourceFiles.ToArray();
+        this.discoveryTerrainTextureOverlays = discoveryTerrainTextureOverlays.ToArray();
+        this.selectedMeshCodes = selectedMeshCodes.ToArray();
+        this.requestedMeshCodeBounds = requestedMeshCodeBounds.ToArray();
+        this.hasDemPackage = hasDemPackage;
+        this.demTextureSourcePolicy = demTextureSourcePolicy;
+    }
+
+    public async Task ValidateBeforeSinkSetupAsync(CancellationToken cancellationToken = default)
+    {
+        if (request.DemTextureSource is null || !hasDemPackage)
+        {
+            return;
+        }
+
+        _ = await GetDemTextureSourcesAsync(useParsedDemCoverage: true, cancellationToken);
+    }
+
+    public async Task<ProjectionTerrainOverlayContext> GetAsync(CancellationToken cancellationToken = default)
+    {
+        if (!hasDemPackage)
+        {
+            return ProjectionTerrainOverlayContext.Empty;
+        }
+
+        Task<ProjectionTerrainOverlayContext> contextTask;
+        lock (overlayContextGate)
+        {
+            contextTask = overlayContextTask ??= CreateAsync(CancellationToken.None);
+        }
+
+        try
+        {
+            return await contextTask.WaitAsync(cancellationToken);
+        }
+        catch
+        {
+            if (contextTask.IsCanceled || contextTask.IsFaulted)
+            {
+                lock (overlayContextGate)
+                {
+                    if (ReferenceEquals(overlayContextTask, contextTask))
+                    {
+                        overlayContextTask = null;
+                    }
+                }
+            }
+
+            throw;
+        }
+    }
+
+    private async Task<ProjectionTerrainOverlayContext> CreateAsync(CancellationToken cancellationToken)
+    {
+        if (request.DemTextureSource is null
+            && discoveryTerrainTextureOverlays.Length > 0
+            && await HasSceneDemOverlayCoverageAsync(discoveryTerrainTextureOverlays, cancellationToken))
+        {
+            return new ProjectionTerrainOverlayContext(discoveryTerrainTextureOverlays);
+        }
+
+        bool useParsedDemCoverage = request.DemTextureSource is not null || discoveryTerrainTextureOverlays.Length > 0;
+        ResolvedDemTextureSources resolvedDemTextureSources = await GetDemTextureSourcesAsync(
+            useParsedDemCoverage,
+            cancellationToken);
+        return new ProjectionTerrainOverlayContext(resolvedDemTextureSources.Overlays);
+    }
+
+    private async Task<bool> HasSceneDemOverlayCoverageAsync(
+        IReadOnlyList<TerrainTextureOverlay> overlays,
+        CancellationToken cancellationToken)
+    {
+        ParsedSourceFileResult[] parsedDemSourceFiles = await GetParsedDemSourceFilesAsync(cancellationToken);
+        foreach (ParsedSourceFileResult parsedSourceFile in parsedDemSourceFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            foreach (ParsedCityObject parsedCityObject in parsedSourceFile.CityObjects)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (DemTerrainOverlayAssignment.HasOverlayCoverage(
+                        parsedCityObject,
+                        overlays,
+                        requestedMeshCodeBounds))
+                {
+                    continue;
+                }
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private async Task<ResolvedDemTextureSources> GetDemTextureSourcesAsync(
+        bool useParsedDemCoverage,
+        CancellationToken cancellationToken)
+    {
+        DemTerrainOverlayRegion[] overlayRegions = await GetDemOverlayRegionsAsync(
+            useParsedDemCoverage,
+            cancellationToken);
+        if (overlayRegions.Length == 0)
+        {
+            return new ResolvedDemTextureSources([]);
+        }
+
+        Task<ResolvedDemTextureSources> textureSourcesTask;
+        lock (demTextureSourcesGate)
+        {
+            textureSourcesTask = demTextureSourcesTask ??= demTextureSourcePolicy.ResolveAsync(
+                request,
+                overlayRegions,
+                CancellationToken.None);
+        }
+
+        try
+        {
+            return await textureSourcesTask.WaitAsync(cancellationToken);
+        }
+        catch
+        {
+            if (textureSourcesTask.IsCanceled || textureSourcesTask.IsFaulted)
+            {
+                lock (demTextureSourcesGate)
+                {
+                    if (ReferenceEquals(demTextureSourcesTask, textureSourcesTask))
+                    {
+                        demTextureSourcesTask = null;
+                    }
+                }
+            }
+
+            throw;
+        }
+    }
+
+    private async Task<DemTerrainOverlayRegion[]> GetDemOverlayRegionsAsync(
+        bool useParsedDemCoverage,
+        CancellationToken cancellationToken)
+    {
+        if (!useParsedDemCoverage)
+        {
+            return CreateRequestedDemOverlayRegions();
+        }
+
+        Task<DemTerrainOverlayRegion[]> overlayRegionsTask;
+        lock (demOverlayRegionsGate)
+        {
+            overlayRegionsTask = demOverlayRegionsTask ??= CreateSceneDemOverlayRegionsAsync(CancellationToken.None);
+        }
+
+        try
+        {
+            return await overlayRegionsTask.WaitAsync(cancellationToken);
+        }
+        catch
+        {
+            if (overlayRegionsTask.IsCanceled || overlayRegionsTask.IsFaulted)
+            {
+                lock (demOverlayRegionsGate)
+                {
+                    if (ReferenceEquals(demOverlayRegionsTask, overlayRegionsTask))
+                    {
+                        demOverlayRegionsTask = null;
+                    }
+                }
+            }
+
+            throw;
+        }
+    }
+
+    private async Task<DemTerrainOverlayRegion[]> CreateSceneDemOverlayRegionsAsync(
+        CancellationToken cancellationToken)
+    {
+        ParsedSourceFileResult[] parsedDemSourceFiles = await GetParsedDemSourceFilesAsync(cancellationToken);
+        DemTerrainBounds? demBounds = DemSourceDiscoverySupport.ResolveDemTerrainBounds(
+            parsedDemSourceFiles,
+            ResolveRequestedDemTerrainBounds());
+        return demBounds is null
+            ? CreateRequestedDemOverlayRegions()
+            : DemSourceDiscoverySupport.CreateDemTerrainOverlayRegions(demBounds, GetRequestedMeshCodes());
+    }
+
+    private DemTerrainOverlayRegion[] CreateRequestedDemOverlayRegions()
+    {
+        return DemSourceDiscoverySupport.CreateDemTerrainOverlayRegions(GetRequestedMeshCodes());
+    }
+
+    private string[] GetRequestedMeshCodes()
+    {
+        return selectedMeshCodes.Length == 0 ? [request.MeshCode] : selectedMeshCodes;
+    }
+
+    private async Task<ParsedSourceFileResult[]> GetParsedDemSourceFilesAsync(
+        CancellationToken cancellationToken)
+    {
+        Task<ParsedSourceFileResult[]> sourceFilesTask;
+        lock (parsedDemSourceFilesGate)
+        {
+            sourceFilesTask = parsedDemSourceFilesTask ??= Task.WhenAll(
+                sourceFiles
+                    .Where(static sourceFile => string.Equals(sourceFile.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
+                    .Select(static sourceFile => sourceFile.GetParseTask()));
+        }
+
+        try
+        {
+            return await sourceFilesTask.WaitAsync(cancellationToken);
+        }
+        catch
+        {
+            if (sourceFilesTask.IsCanceled || sourceFilesTask.IsFaulted)
+            {
+                lock (parsedDemSourceFilesGate)
+                {
+                    if (ReferenceEquals(parsedDemSourceFilesTask, sourceFilesTask))
+                    {
+                        parsedDemSourceFilesTask = null;
+                    }
+                }
+            }
+
+            throw;
+        }
+    }
+
+    private DemTerrainBounds? ResolveRequestedDemTerrainBounds()
+    {
+        return MeshCodeBounds.TryMerge(requestedMeshCodeBounds) is { } requestedMeshBounds
+            ? new DemTerrainBounds(
+                requestedMeshBounds.SouthLatitude,
+                requestedMeshBounds.NorthLatitude,
+                requestedMeshBounds.WestLongitude,
+                requestedMeshBounds.EastLongitude)
+            : null;
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
@@ -22,23 +22,12 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
     private readonly SourceFilePipeline[] sourceFiles;
     private readonly GeodeticPoint globalOriginPoint;
     private readonly ICityGmlGeometryProjector geometryProjector;
-    private readonly IDemTextureSourcePolicy demTextureSourcePolicy;
     private readonly IImportedObjectUnitOptimizer objectUnitOptimizer;
+    private readonly ProjectionTerrainOverlayContextResolver terrainOverlayContextResolver;
     private readonly Action<string>? progressReporter;
     private readonly object referenceSystemGate = new();
-    private readonly object sceneParsedDemSourceFilesGate = new();
-    private readonly object sceneDemOverlayRegionsGate = new();
-    private readonly object sceneDemTextureSourcesGate = new();
-    private readonly object projectionTerrainOverlaySetGate = new();
     private readonly X3DMaterialWarningStatistics x3DMaterialWarningStatistics = new();
     private readonly MeshCodeBounds[] requestedMeshCodeBounds;
-    private readonly string[] selectedMeshCodes;
-    private readonly TerrainTextureOverlay[] discoveryTerrainTextureOverlays;
-    private readonly bool hasDemPackage;
-    private Task<ParsedSourceFileResult[]>? sceneParsedDemSourceFilesTask;
-    private Task<DemTerrainOverlayRegion[]>? sceneDemOverlayRegionsTask;
-    private Task<ResolvedDemTextureSources>? sceneDemTextureSourcesTask;
-    private Task<ProjectionTerrainOverlaySet>? projectionTerrainOverlaySetTask;
     private CoordinateReferenceSystem? referenceSystem;
 
     public StreamingImportedSceneSource(
@@ -58,28 +47,27 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
         Metadata = metadata;
         this.request = request;
         sourceFiles = DiscoveryContext.SourceFilePipelines.ToArray();
-        discoveryTerrainTextureOverlays = documentSet.TerrainTextureOverlays.ToArray();
-        selectedMeshCodes = documentSet.SelectedMeshCodes.ToArray();
-        hasDemPackage = documentSet.PackageNames.Contains("dem", StringComparer.OrdinalIgnoreCase);
         globalOriginPoint = DiscoveryContext.GlobalOriginPoint;
         this.geometryProjector = geometryProjector;
-        this.demTextureSourcePolicy = demTextureSourcePolicy;
         this.objectUnitOptimizer = objectUnitOptimizer;
         this.progressReporter = progressReporter;
         requestedMeshCodeBounds = MeshCodeBounds.CreateManyFromSelectedMeshCodes(
             Metadata.SourceDataset.SelectedMeshCodes ?? [request.MeshCode]);
+        terrainOverlayContextResolver = new ProjectionTerrainOverlayContextResolver(
+            request,
+            sourceFiles,
+            documentSet.TerrainTextureOverlays,
+            documentSet.SelectedMeshCodes,
+            requestedMeshCodeBounds,
+            documentSet.PackageNames.Contains("dem", StringComparer.OrdinalIgnoreCase),
+            demTextureSourcePolicy);
     }
 
     public ImportedSceneMetadata Metadata { get; }
 
     public async Task ValidateBeforeSinkSetupAsync(CancellationToken cancellationToken = default)
     {
-        if (request.DemTextureSource is null || !hasDemPackage)
-        {
-            return;
-        }
-
-        _ = await GetSceneDemTextureSourcesAsync(useParsedDemCoverage: true, cancellationToken);
+        await terrainOverlayContextResolver.ValidateBeforeSinkSetupAsync(cancellationToken);
     }
 
     public async IAsyncEnumerable<ImportedObjectUnit> ReadObjectUnitsAsync(
@@ -219,7 +207,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
         LocalCartesian? globalCartesian = null;
         int parsedCount = 0;
         int yieldedCount = 0;
-        ProjectionTerrainOverlaySet projectionTerrainOverlaySet = await GetProjectionTerrainOverlaySetAsync(cancellationToken);
+        ProjectionTerrainOverlayContext projectionTerrainOverlayContext = await terrainOverlayContextResolver.GetAsync(cancellationToken);
         bool isDemSourceFile = string.Equals(sourceFile.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase);
         List<ParsedCityObject> parsedDemCityObjects = [];
         X3DMaterialWarningStatistics fileWarningStatistics = new();
@@ -243,7 +231,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
                          resolvedReferenceSystem,
                          globalOriginPoint,
                          globalCartesian,
-                         projectionTerrainOverlaySet.Overlays,
+                         projectionTerrainOverlayContext.Overlays,
                          requestedMeshCodeBounds,
                          request,
                          predicate: null,
@@ -269,7 +257,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
                                  [$"CityGML file '{sourceFile.SourceFile.RelativePath}' does not declare a supported coordinate reference system."]),
                          globalOriginPoint,
                          globalCartesian,
-                         projectionTerrainOverlaySet.Overlays,
+                         projectionTerrainOverlayContext.Overlays,
                          requestedMeshCodeBounds,
                          request,
                          predicate: null,
@@ -355,228 +343,6 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
                 [$"CityGML file '{parsedSourceFile.SourceFile.RelativePath}' does not declare a supported coordinate reference system."]));
     }
 
-    private async Task<ProjectionTerrainOverlaySet> GetProjectionTerrainOverlaySetAsync(
-        CancellationToken cancellationToken)
-    {
-        if (!hasDemPackage)
-        {
-            return ProjectionTerrainOverlaySet.Empty;
-        }
-
-        Task<ProjectionTerrainOverlaySet> overlaySetTask;
-        lock (projectionTerrainOverlaySetGate)
-        {
-            overlaySetTask = projectionTerrainOverlaySetTask ??= CreateProjectionTerrainOverlaySetAsync(CancellationToken.None);
-        }
-
-        try
-        {
-            return await overlaySetTask.WaitAsync(cancellationToken);
-        }
-        catch
-        {
-            if (overlaySetTask.IsCanceled || overlaySetTask.IsFaulted)
-            {
-                lock (projectionTerrainOverlaySetGate)
-                {
-                    if (ReferenceEquals(projectionTerrainOverlaySetTask, overlaySetTask))
-                    {
-                        projectionTerrainOverlaySetTask = null;
-                    }
-                }
-            }
-
-            throw;
-        }
-    }
-
-    private async Task<ProjectionTerrainOverlaySet> CreateProjectionTerrainOverlaySetAsync(
-        CancellationToken cancellationToken)
-    {
-        if (request.DemTextureSource is null
-            && discoveryTerrainTextureOverlays.Length > 0
-            && await HasSceneDemOverlayCoverageAsync(discoveryTerrainTextureOverlays, cancellationToken))
-        {
-            return new ProjectionTerrainOverlaySet(discoveryTerrainTextureOverlays);
-        }
-
-        bool useParsedDemCoverage = request.DemTextureSource is not null || discoveryTerrainTextureOverlays.Length > 0;
-        ResolvedDemTextureSources resolvedDemTextureSources = await GetSceneDemTextureSourcesAsync(
-            useParsedDemCoverage,
-            cancellationToken);
-        return new ProjectionTerrainOverlaySet(resolvedDemTextureSources.Overlays);
-    }
-
-    private async Task<bool> HasSceneDemOverlayCoverageAsync(
-        IReadOnlyList<TerrainTextureOverlay> overlays,
-        CancellationToken cancellationToken)
-    {
-        ParsedSourceFileResult[] parsedDemSourceFiles = await GetSceneParsedDemSourceFilesAsync(cancellationToken);
-        foreach (ParsedSourceFileResult parsedSourceFile in parsedDemSourceFiles)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            foreach (ParsedCityObject parsedCityObject in parsedSourceFile.CityObjects)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                if (DemTerrainOverlayAssignment.HasOverlayCoverage(
-                        parsedCityObject,
-                        overlays,
-                        requestedMeshCodeBounds))
-                {
-                    continue;
-                }
-
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private async Task<ResolvedDemTextureSources> GetSceneDemTextureSourcesAsync(
-        bool useParsedDemCoverage,
-        CancellationToken cancellationToken)
-    {
-        DemTerrainOverlayRegion[] overlayRegions = await GetSceneDemOverlayRegionsAsync(
-            useParsedDemCoverage,
-            cancellationToken);
-        if (overlayRegions.Length == 0)
-        {
-            return new ResolvedDemTextureSources([]);
-        }
-
-        Task<ResolvedDemTextureSources> demTextureSourcesTask;
-        lock (sceneDemTextureSourcesGate)
-        {
-            demTextureSourcesTask = sceneDemTextureSourcesTask ??= demTextureSourcePolicy.ResolveAsync(
-                request,
-                overlayRegions,
-                CancellationToken.None);
-        }
-
-        try
-        {
-            return await demTextureSourcesTask.WaitAsync(cancellationToken);
-        }
-        catch
-        {
-            if (demTextureSourcesTask.IsCanceled || demTextureSourcesTask.IsFaulted)
-            {
-                lock (sceneDemTextureSourcesGate)
-                {
-                    if (ReferenceEquals(sceneDemTextureSourcesTask, demTextureSourcesTask))
-                    {
-                        sceneDemTextureSourcesTask = null;
-                    }
-                }
-            }
-
-            throw;
-        }
-    }
-
-    private async Task<DemTerrainOverlayRegion[]> GetSceneDemOverlayRegionsAsync(
-        bool useParsedDemCoverage,
-        CancellationToken cancellationToken)
-    {
-        if (!useParsedDemCoverage)
-        {
-            return CreateRequestedDemOverlayRegions();
-        }
-
-        Task<DemTerrainOverlayRegion[]> overlayRegionsTask;
-        lock (sceneDemOverlayRegionsGate)
-        {
-            overlayRegionsTask = sceneDemOverlayRegionsTask ??= CreateSceneDemOverlayRegionsAsync(CancellationToken.None);
-        }
-
-        try
-        {
-            return await overlayRegionsTask.WaitAsync(cancellationToken);
-        }
-        catch
-        {
-            if (overlayRegionsTask.IsCanceled || overlayRegionsTask.IsFaulted)
-            {
-                lock (sceneDemOverlayRegionsGate)
-                {
-                    if (ReferenceEquals(sceneDemOverlayRegionsTask, overlayRegionsTask))
-                    {
-                        sceneDemOverlayRegionsTask = null;
-                    }
-                }
-            }
-
-            throw;
-        }
-    }
-
-    private async Task<DemTerrainOverlayRegion[]> CreateSceneDemOverlayRegionsAsync(
-        CancellationToken cancellationToken)
-    {
-        ParsedSourceFileResult[] parsedDemSourceFiles = await GetSceneParsedDemSourceFilesAsync(cancellationToken);
-        DemTerrainBounds? demBounds = DemSourceDiscoverySupport.ResolveDemTerrainBounds(
-            parsedDemSourceFiles,
-            ResolveRequestedDemTerrainBounds());
-        return demBounds is null
-            ? CreateRequestedDemOverlayRegions()
-            : DemSourceDiscoverySupport.CreateDemTerrainOverlayRegions(demBounds, GetRequestedMeshCodes());
-    }
-
-    private DemTerrainOverlayRegion[] CreateRequestedDemOverlayRegions()
-    {
-        return DemSourceDiscoverySupport.CreateDemTerrainOverlayRegions(GetRequestedMeshCodes());
-    }
-
-    private string[] GetRequestedMeshCodes()
-    {
-        return selectedMeshCodes.Length == 0 ? [request.MeshCode] : selectedMeshCodes;
-    }
-
-    private async Task<ParsedSourceFileResult[]> GetSceneParsedDemSourceFilesAsync(
-        CancellationToken cancellationToken)
-    {
-        Task<ParsedSourceFileResult[]> parsedDemSourceFilesTask;
-        lock (sceneParsedDemSourceFilesGate)
-        {
-            parsedDemSourceFilesTask = sceneParsedDemSourceFilesTask ??= Task.WhenAll(
-                sourceFiles
-                    .Where(static sourceFile => string.Equals(sourceFile.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
-                    .Select(static sourceFile => sourceFile.GetParseTask()));
-        }
-
-        try
-        {
-            return await parsedDemSourceFilesTask.WaitAsync(cancellationToken);
-        }
-        catch
-        {
-            if (parsedDemSourceFilesTask.IsCanceled || parsedDemSourceFilesTask.IsFaulted)
-            {
-                lock (sceneParsedDemSourceFilesGate)
-                {
-                    if (ReferenceEquals(sceneParsedDemSourceFilesTask, parsedDemSourceFilesTask))
-                    {
-                        sceneParsedDemSourceFilesTask = null;
-                    }
-                }
-            }
-
-            throw;
-        }
-    }
-
-    private DemTerrainBounds? ResolveRequestedDemTerrainBounds()
-    {
-        return MeshCodeBounds.TryMerge(requestedMeshCodeBounds) is { } requestedMeshBounds
-            ? new DemTerrainBounds(
-                requestedMeshBounds.SouthLatitude,
-                requestedMeshBounds.NorthLatitude,
-                requestedMeshBounds.WestLongitude,
-                requestedMeshBounds.EastLongitude)
-            : null;
-    }
-
     private static void ValidateCompatibleReferenceSystem(
         CoordinateReferenceSystem expectedReferenceSystem,
         CoordinateReferenceSystem actualReferenceSystem)
@@ -588,11 +354,6 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
 
         throw new PlateauImportValidationException(
             [$"Mixed CityGML coordinate reference systems are not supported. Found '{expectedReferenceSystem.SrsName}' and '{actualReferenceSystem.SrsName}'."]);
-    }
-
-    private sealed record ProjectionTerrainOverlaySet(IReadOnlyList<TerrainTextureOverlay> Overlays)
-    {
-        public static ProjectionTerrainOverlaySet Empty { get; } = new([]);
     }
 
     private sealed class X3DMaterialWarningStatistics

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
@@ -9,16 +9,16 @@ using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Application.Importing;
 
-internal static class TerrainOverlayProjectionSplitPolicy
+internal static class TerrainOverlayMaterialSourcePartitioner
 {
-    internal static IEnumerable<(ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> SplitParsedCityObject(
+    internal static IEnumerable<(ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> PartitionParsedCityObject(
         ParsedCityObject cityObject,
         IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
         IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default)
     {
-        foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) splitCityObject
+        foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) partitionedCityObject
                  in DemTerrainOverlayAssignment.SplitParsedCityObject(
                      cityObject,
                      demTerrainTextureOverlays,
@@ -27,27 +27,27 @@ internal static class TerrainOverlayProjectionSplitPolicy
                      cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (splitCityObject.Overlay is not null
-                || string.Equals(splitCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
+            if (partitionedCityObject.Overlay is not null
+                || string.Equals(partitionedCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
             {
-                yield return splitCityObject;
+                yield return partitionedCityObject;
                 continue;
             }
 
-            foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) nonDemSplit
-                     in SplitNonDemCityObjectByTerrainOverlay(
-                         splitCityObject.CityObject,
+            foreach ((ParsedCityObject CityObject, TerrainTextureOverlay? Overlay) nonDemPartition
+                     in PartitionBuildingByTerrainOverlayMaterialSource(
+                         partitionedCityObject.CityObject,
                          demTerrainTextureOverlays,
                          requestedMeshCodeBounds,
                          progressReporter,
                          cancellationToken))
             {
-                yield return nonDemSplit;
+                yield return nonDemPartition;
             }
         }
     }
 
-    internal static bool ShouldProjectSplit(
+    internal static bool IsPartitionCompatibleWithRequest(
         string actualMeshCode,
         string requestedMeshCode,
         IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
@@ -71,7 +71,7 @@ internal static class TerrainOverlayProjectionSplitPolicy
             is not null;
     }
 
-    private static IEnumerable<(ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> SplitNonDemCityObjectByTerrainOverlay(
+    private static IEnumerable<(ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)> PartitionBuildingByTerrainOverlayMaterialSource(
         ParsedCityObject cityObject,
         IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
         IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
@@ -105,19 +105,19 @@ internal static class TerrainOverlayProjectionSplitPolicy
         double cityObjectMinAltitude = CityObjectAltitudeMetricsResolver.GetMinimumAltitude(cityObjectVertices);
 
         List<ParsedSurface> untexturedSurfaces = [];
-        List<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> terrainOverlaySurfaces = [];
+        List<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> terrainOverlayMaterialSurfaces = [];
         foreach (ParsedSurface surface in cityObject.Surfaces)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ConstructionFace face = new(surface, ConstructionCityObjectDraft.ResolveRole(surface));
-            if (!IsNonDemTerrainTextureSurface(face, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian)
+            if (!CanUseTerrainOverlayMaterialSource(face, cityObjectMinAltitude, cityObjectOrigin, cityObjectCartesian)
                 || !TryCreateSurfaceGeographicBounds(surface, out GeographicRectangle surfaceBounds))
             {
                 untexturedSurfaces.Add(surface);
                 continue;
             }
 
-            ParsedSurface terrainProjectionSurface = NormalizeNonDemTerrainTextureSurface(face);
+            ParsedSurface terrainMaterialSurface = PrepareTerrainOverlayMaterialSurface(face);
 
             TerrainTextureOverlay[] candidateOverlays = demTerrainTextureOverlays
                 .Where(overlay => TerrainOverlayMeshCodeResolver.IsRequestedOverlay(overlay, requestedMeshCodeBounds)
@@ -146,7 +146,7 @@ internal static class TerrainOverlayProjectionSplitPolicy
 
             if (candidateOverlays.Length == 1)
             {
-                terrainOverlaySurfaces.Add((terrainProjectionSurface, candidateOverlays[0]));
+                terrainOverlayMaterialSurfaces.Add((terrainMaterialSurface, candidateOverlays[0]));
                 continue;
             }
 
@@ -154,13 +154,13 @@ internal static class TerrainOverlayProjectionSplitPolicy
                 TerrainOverlayMeshCodeResolver.ContainsBounds(overlay.GeographicBounds, surfaceBounds));
             if (containingOverlay is not null)
             {
-                terrainOverlaySurfaces.Add((terrainProjectionSurface, containingOverlay));
+                terrainOverlayMaterialSurfaces.Add((terrainMaterialSurface, containingOverlay));
                 continue;
             }
 
             IReadOnlyList<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> clippedSurfaces =
                 DemTerrainOverlaySurfaceClipper.ClipGeneratedSurfaceToOverlays(
-                    terrainProjectionSurface,
+                    terrainMaterialSurface,
                     candidateOverlays,
                     progressReporter,
                     cancellationToken);
@@ -170,44 +170,44 @@ internal static class TerrainOverlayProjectionSplitPolicy
                 continue;
             }
 
-            terrainOverlaySurfaces.AddRange(clippedSurfaces);
+            terrainOverlayMaterialSurfaces.AddRange(clippedSurfaces);
         }
 
-        IGrouping<TerrainTextureOverlay, (ParsedSurface Surface, TerrainTextureOverlay Overlay)>[] terrainGroups =
-            terrainOverlaySurfaces
+        IGrouping<TerrainTextureOverlay, (ParsedSurface Surface, TerrainTextureOverlay Overlay)>[] terrainMaterialGroups =
+            terrainOverlayMaterialSurfaces
                 .GroupBy(static entry => entry.Overlay)
                 .OrderBy(static group => group.Key.GeographicBounds.MinLatitude)
                 .ThenBy(static group => group.Key.GeographicBounds.MinLongitude)
                 .ToArray();
-        int splitCount = terrainGroups.Length + (untexturedSurfaces.Count == 0 ? 0 : 1);
-        if (splitCount == 0)
+        int partitionCount = terrainMaterialGroups.Length + (untexturedSurfaces.Count == 0 ? 0 : 1);
+        if (partitionCount == 0)
         {
             yield break;
         }
 
-        if (splitCount == 1)
+        if (partitionCount == 1)
         {
-            if (terrainGroups.Length == 1)
+            if (terrainMaterialGroups.Length == 1)
             {
                 string terrainMeshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
                         cityObject.ActualMeshCode,
                         cityObject.ActualMeshCode,
                         requestedMeshCodeBounds,
-                        terrainGroups[0].Key)
+                        terrainMaterialGroups[0].Key)
                     ?? throw CreateTerrainOverlayMeshCodeMismatchException(
-                        "non-dem-terrain-single-split",
+                        "non-dem-terrain-single-partition",
                         cityObject.ActualMeshCode,
                         cityObject.ActualMeshCode,
                         requestedMeshCodeBounds,
-                        terrainGroups[0].Key);
+                        terrainMaterialGroups[0].Key);
                 yield return (
                     cityObject with
                     {
                         ActualMeshCode = terrainMeshCode,
-                        Surfaces = terrainGroups[0].Select(static entry => MarkUsesGeneratedDemTexture(entry.Surface)).ToArray(),
+                        Surfaces = terrainMaterialGroups[0].Select(static entry => MarkTerrainOverlayMaterialSource(entry.Surface)).ToArray(),
                         GeodeticOriginOverride = cityObjectOrigin,
                     },
-                    terrainGroups[0].Key);
+                    terrainMaterialGroups[0].Key);
                 yield break;
             }
 
@@ -221,8 +221,8 @@ internal static class TerrainOverlayProjectionSplitPolicy
             yield break;
         }
 
-        int splitIndex = 0;
-        foreach (IGrouping<TerrainTextureOverlay, (ParsedSurface Surface, TerrainTextureOverlay Overlay)> group in terrainGroups)
+        int partitionIndex = 0;
+        foreach (IGrouping<TerrainTextureOverlay, (ParsedSurface Surface, TerrainTextureOverlay Overlay)> group in terrainMaterialGroups)
         {
             cancellationToken.ThrowIfCancellationRequested();
             string terrainMeshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
@@ -231,7 +231,7 @@ internal static class TerrainOverlayProjectionSplitPolicy
                     requestedMeshCodeBounds,
                     group.Key)
                 ?? throw CreateTerrainOverlayMeshCodeMismatchException(
-                    "non-dem-terrain-split",
+                    "non-dem-terrain-partition",
                     cityObject.ActualMeshCode,
                     cityObject.ActualMeshCode,
                     requestedMeshCodeBounds,
@@ -241,12 +241,12 @@ internal static class TerrainOverlayProjectionSplitPolicy
                 {
                     ActualMeshCode = terrainMeshCode,
                     SlotKey = $"{cityObject.SlotKey}_terrain_{terrainMeshCode}",
-                    DisplayName = $"{cityObject.DisplayName} ({splitIndex + 1})",
-                    Surfaces = group.Select(static entry => MarkUsesGeneratedDemTexture(entry.Surface)).ToArray(),
+                    DisplayName = $"{cityObject.DisplayName} ({partitionIndex + 1})",
+                    Surfaces = group.Select(static entry => MarkTerrainOverlayMaterialSource(entry.Surface)).ToArray(),
                     GeodeticOriginOverride = cityObjectOrigin,
                 },
                 group.Key);
-            splitIndex++;
+            partitionIndex++;
         }
 
         if (untexturedSurfaces.Count != 0)
@@ -255,7 +255,7 @@ internal static class TerrainOverlayProjectionSplitPolicy
                 cityObject with
                 {
                     SlotKey = $"{cityObject.SlotKey}_terrain_none",
-                    DisplayName = $"{cityObject.DisplayName} ({splitIndex + 1})",
+                    DisplayName = $"{cityObject.DisplayName} ({partitionIndex + 1})",
                     Surfaces = untexturedSurfaces.ToArray(),
                     GeodeticOriginOverride = cityObjectOrigin,
                 },
@@ -263,12 +263,12 @@ internal static class TerrainOverlayProjectionSplitPolicy
         }
     }
 
-    private static ParsedSurface MarkUsesGeneratedDemTexture(ParsedSurface surface)
+    private static ParsedSurface MarkTerrainOverlayMaterialSource(ParsedSurface surface)
     {
         return surface with { UsesGeneratedDemTexture = true };
     }
 
-    private static ParsedSurface NormalizeNonDemTerrainTextureSurface(ConstructionFace face)
+    private static ParsedSurface PrepareTerrainOverlayMaterialSurface(ConstructionFace face)
     {
         ParsedSurface surface = face.Surface;
         if (face.Role is ConstructionFaceRole.RoofSlab)
@@ -281,7 +281,7 @@ internal static class TerrainOverlayProjectionSplitPolicy
             : surface with { Semantic = ParsedSurfaceSemantic.Roof };
     }
 
-    private static bool IsNonDemTerrainTextureSurface(
+    private static bool CanUseTerrainOverlayMaterialSource(
         ConstructionFace face,
         double cityObjectMinAltitude,
         GeodeticPoint cityObjectOrigin,

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -445,7 +445,7 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
     }
 
     [Fact]
-    public void CreateLeavesNoWallTerrainOverlaySplitBeforeRegeneratingSlabParts()
+    public void CreateLeavesNoWallTerrainOverlayMaterialPartitionBeforeRegeneratingSlabParts()
     {
         ParsedSurface terrainRoof = CreateSurface("lod2-terrain-roof", ParsedSurfaceSemantic.Roof, altitude: 10.0) with
         {

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -852,7 +852,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public void ProjectParsedCityObjectKeepsFlatLod1TopAsTerrainAfterOverlaySplit()
+    public void ProjectParsedCityObjectKeepsFlatLod1TopAsTerrainOverlayMaterial()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
@@ -898,7 +898,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public void ProjectParsedCityObjectKeepsGeneratedShedHighWallAsFacadeAfterOverlaySplit()
+    public void ProjectParsedCityObjectKeepsGeneratedShedHighWallAsFacadeWithTerrainOverlayMaterial()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
@@ -947,7 +947,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public void ProjectParsedCityObjectPassesMatchingDemOverlayToTexturelessBuildingRoof()
+    public void ProjectParsedCityObjectUsesTerrainOverlayMaterialForTexturelessBuildingRoof()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
@@ -2220,7 +2220,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public async Task SplitParsedCityObjectPreservesNonGeneratedDemSurfacesWhenOverlaysSplit()
+    public async Task PartitionParsedCityObjectPreservesNonGeneratedDemSurfacesWhenOverlaysPartition()
     {
         using TemporaryDirectory datasetRoot = new();
         CreateRuntimeMixedSurfaceDemFixture(datasetRoot.Path);
@@ -2528,7 +2528,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public async Task DemExactMeshRequestFiltersSplitParentMeshPiecesAfterOverlaySplit()
+    public async Task DemExactMeshRequestFiltersPartitionedParentMeshPiecesAfterOverlayPartition()
     {
         using TemporaryDirectory datasetRoot = new();
         CreateRuntimeParentMeshDemFixture(datasetRoot.Path, "53394525", "53394526");

--- a/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayMaterialSourcePartitionerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayMaterialSourcePartitionerTests.cs
@@ -5,10 +5,10 @@ using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Tests.Profiles;
 
-public sealed class TerrainOverlayProjectionSplitPolicyTests
+public sealed class TerrainOverlayMaterialSourcePartitionerTests
 {
     [Fact]
-    public void SplitParsedCityObjectProjectsGeneratedNoWallSlabPartsWithTerrainRoofProjection()
+    public void PartitionParsedCityObjectAssignsTerrainOverlayMaterialSourceToGeneratedNoWallSlabParts()
     {
         MeshCodeBounds meshBounds = MeshCodeBounds.TryParse("53394525")!;
         ParsedSurface top = CreateHorizontalSurface("roof", altitude: 10.0, meshBounds: meshBounds);
@@ -32,7 +32,7 @@ public sealed class TerrainOverlayProjectionSplitPolicyTests
         ];
 
         (ParsedCityObject CityObject, TerrainTextureOverlay? Overlay)[] results =
-            TerrainOverlayProjectionSplitPolicy.SplitParsedCityObject(
+            TerrainOverlayMaterialSourcePartitioner.PartitionParsedCityObject(
                 cityObject,
                 [overlay],
                 requestedMeshCodeBounds)


### PR DESCRIPTION
## Summary
- Rename the terrain overlay projection split policy to a terrain overlay material source partitioner.
- Extract projection terrain overlay context resolution out of `StreamingImportedSceneSource`.
- Keep streaming focused on source-file object flow while preserving DEM overlay coverage, fallback, and texture-source resolution behavior.
- Keep behavior unchanged; this is a stacked refactoring PR on top of #294.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`