### PR TITLE
Hide texture raw texture materialization behind import sources

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Threading;
 
 using System.Xml.Linq;
 
@@ -190,17 +188,15 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
     {
         if (!texturePayloadsByResolvedPath.TryGetValue(resolvedTexturePath, out TexturePayload? texturePayload))
         {
-            using Stream stream = datasetSource.OpenReadAsync(resolvedTexturePath, CancellationToken.None)
-                .AsTask()
-                .GetAwaiter()
-                .GetResult();
-            using MemoryStream encodedPayloadStream = new();
-            stream.CopyTo(encodedPayloadStream);
             texturePayload = new TexturePayload(
                 null,
                 null,
                 "sRGB",
-                encodedPayloadStream.ToArray(),
+                TextureImportSourceFactory.CreateDatasetEncodedImage(
+                    datasetSource,
+                    resolvedTexturePath,
+                    "sRGB",
+                    $"dataset:{resolvedTexturePath}"),
                 $"dataset:{resolvedTexturePath}",
                 TexturePayloadFormat.EncodedImage);
             texturePayloadsByResolvedPath[resolvedTexturePath] = texturePayload;

--- a/src/PlateauResoniteLink/Application/Importing/IPlateauDatasetContentSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/IPlateauDatasetContentSource.cs
@@ -24,3 +24,8 @@ internal interface IPlateauDatasetContentSource
         string outputRoot,
         CancellationToken cancellationToken = default);
 }
+
+internal interface IPlateauDatasetContentLengthSource
+{
+    long? TryGetFileLength(string relativePath);
+}

--- a/src/PlateauResoniteLink/Application/Importing/PlateauDatasetContentSourceFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauDatasetContentSourceFactory.cs
@@ -86,7 +86,7 @@ internal static class PlateauDatasetContentSourceFactory
 
     private sealed class LocalPlateauDatasetContentSource(
         string datasetRoot,
-        IArchiveFileLayoutPolicy archiveFileLayoutPolicy) : IPlateauDatasetContentSource
+        IArchiveFileLayoutPolicy archiveFileLayoutPolicy) : IPlateauDatasetContentSource, IPlateauDatasetContentLengthSource
     {
         public string SourcePath => datasetRoot;
 
@@ -103,6 +103,23 @@ internal static class PlateauDatasetContentSourceFactory
         {
             string absolutePath = Path.Combine(datasetRoot, archiveFileLayoutPolicy.NormalizeRelativePath(relativePath));
             return File.Exists(absolutePath);
+        }
+
+        public long? TryGetFileLength(string relativePath)
+        {
+            string absolutePath = Path.Combine(datasetRoot, archiveFileLayoutPolicy.NormalizeRelativePath(relativePath));
+            try
+            {
+                return File.Exists(absolutePath) ? new FileInfo(absolutePath).Length : null;
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return null;
+            }
         }
 
         public string? ResolveRelativePath(string baseRelativePath, string candidatePath)
@@ -145,14 +162,16 @@ internal static class PlateauDatasetContentSourceFactory
         }
     }
 
-    private sealed class ArchivePlateauDatasetContentSource : IPlateauDatasetContentSource
+    private sealed class ArchivePlateauDatasetContentSource : IPlateauDatasetContentSource, IPlateauDatasetContentLengthSource
     {
         private sealed record ArchiveFileAccessor(
             string RelativePath,
+            long? Length,
             Func<CancellationToken, ValueTask<Stream>> OpenReadAsync);
 
         private sealed record RawArchiveFileAccessor(
             string RelativePath,
+            long? Length,
             Func<CancellationToken, ValueTask<Stream>> OpenReadAsync);
 
         private string ArchivePath { get; }
@@ -190,13 +209,14 @@ internal static class PlateauDatasetContentSourceFactory
                 .Select(file => new
                 {
                     RelativePath = archiveFileLayoutPolicy.StripDatasetRootPrefix(file.RelativePath, datasetRootPrefix),
+                    file.Length,
                     file.OpenReadAsync,
                 })
                 .Where(static file => !string.IsNullOrWhiteSpace(file.RelativePath))
                 .DistinctBy(static file => file.RelativePath, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(
                     static file => file.RelativePath,
-                    static file => new ArchiveFileAccessor(file.RelativePath, file.OpenReadAsync),
+                    static file => new ArchiveFileAccessor(file.RelativePath, file.Length, file.OpenReadAsync),
                     StringComparer.OrdinalIgnoreCase);
 
             return new ArchivePlateauDatasetContentSource(archivePath, indexedFiles, archiveFileLayoutPolicy);
@@ -210,6 +230,14 @@ internal static class PlateauDatasetContentSourceFactory
         public bool FileExists(string relativePath)
         {
             return Files.ContainsKey(ArchiveFileLayoutPolicy.NormalizeRelativePath(relativePath));
+        }
+
+        public long? TryGetFileLength(string relativePath)
+        {
+            string normalizedPath = ArchiveFileLayoutPolicy.NormalizeRelativePath(relativePath);
+            return Files.TryGetValue(normalizedPath, out ArchiveFileAccessor? fileAccessor)
+                ? fileAccessor.Length
+                : null;
         }
 
         public string? ResolveRelativePath(string baseRelativePath, string candidatePath)
@@ -322,6 +350,7 @@ internal static class PlateauDatasetContentSourceFactory
                 string relativePath = archiveFileLayoutPolicy.CombineRelativePaths(prefix, entryKey);
                 results.Add(new RawArchiveFileAccessor(
                     relativePath,
+                    entry.Size,
                     ct => OpenEntryStreamAsync(archivePath, openArchiveStreamAsync, entryKey, archiveFileLayoutPolicy, ct)));
             }
         }

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -112,6 +112,31 @@ public sealed record TexturePayload
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
         Identity = identity;
         Format = format;
+        Source = TextureImportSourceFactory.CreateInMemory(
+            width,
+            height,
+            colorProfile,
+            binaryPayload,
+            identity ?? Guid.NewGuid().ToString("N"),
+            format);
+    }
+
+    public TexturePayload(
+        int? width,
+        int? height,
+        string? colorProfile,
+        ITextureImportSource source,
+        string? identity = null,
+        TexturePayloadFormat format = TexturePayloadFormat.EncodedImage)
+    {
+        Width = width;
+        Height = height;
+        ColorProfile = colorProfile;
+        ArgumentNullException.ThrowIfNull(source);
+        BinaryPayload = [];
+        Identity = identity ?? source.Identity;
+        Format = format;
+        Source = source;
     }
 
     public int? Width { get; init; }
@@ -125,6 +150,8 @@ public sealed record TexturePayload
     public string? Identity { get; init; }
 
     public TexturePayloadFormat Format { get; init; }
+
+    public ITextureImportSource Source { get; init; }
 }
 
 public enum TextureSourceKind

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -1,0 +1,295 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+public enum RawTexturePayloadFormat
+{
+    Rgba32 = 0,
+    RgbaFloat32 = 1,
+}
+
+public sealed record RawTexturePayload(
+    int Width,
+    int Height,
+    string? ColorProfile,
+    byte[] Bytes,
+    RawTexturePayloadFormat Format = RawTexturePayloadFormat.Rgba32);
+
+public interface ITextureImportSource
+{
+    string Identity { get; }
+
+    string Description { get; }
+
+    string? ColorProfile { get; }
+
+    long? EstimatedByteLength { get; }
+}
+
+internal interface IRawTexturePayloadSource : ITextureImportSource
+{
+    ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken);
+}
+
+internal static class TextureImportSourceMaterializer
+{
+    public static ValueTask<RawTexturePayload> MaterializeRawAsync(
+        ITextureImportSource source,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (source is not IRawTexturePayloadSource rawSource)
+        {
+            throw new InvalidOperationException(
+                $"Texture import source '{source.GetType().Name}' cannot materialize a raw texture payload.");
+        }
+
+        return rawSource.MaterializeRawAsync(cancellationToken);
+    }
+}
+
+internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
+{
+    private readonly byte[] bytes;
+
+    public InMemoryTextureImportSource(
+        int? width,
+        int? height,
+        string? colorProfile,
+        byte[] bytes,
+        string identity,
+        TexturePayloadFormat sourceFormat)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        Width = width;
+        Height = height;
+        ColorProfile = colorProfile;
+        this.bytes = (byte[])bytes.Clone();
+        Identity = identity;
+        SourceFormat = sourceFormat;
+    }
+
+    public int? Width { get; }
+
+    public int? Height { get; }
+
+    public string Identity { get; }
+
+    public string Description => $"memory:{Identity}";
+
+    public string? ColorProfile { get; }
+
+    public long? EstimatedByteLength => bytes.Length;
+
+    public TexturePayloadFormat SourceFormat { get; }
+
+    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return SourceFormat switch
+        {
+            TexturePayloadFormat.RawRgba32 => CreateRawPayload(),
+            TexturePayloadFormat.EncodedImage => await DecodeEncodedImageAsync(cancellationToken),
+            _ => throw new InvalidOperationException($"Unsupported texture payload format '{SourceFormat}'."),
+        };
+    }
+
+    private RawTexturePayload CreateRawPayload()
+    {
+        if (Width is null || Height is null)
+        {
+            throw new InvalidOperationException("Raw RGBA texture payload must include width and height.");
+        }
+
+        return new RawTexturePayload(
+            Width.Value,
+            Height.Value,
+            ColorProfile,
+            (byte[])bytes.Clone());
+    }
+
+    private async ValueTask<RawTexturePayload> DecodeEncodedImageAsync(CancellationToken cancellationToken)
+    {
+        using MemoryStream stream = new(bytes, writable: false);
+        using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream, cancellationToken);
+        return TextureImportSourceFactory.CreateRawPayloadFromImage(
+            image,
+            ColorProfile);
+    }
+}
+
+internal sealed class DatasetTextureImportSource(
+    IPlateauDatasetContentSource datasetSource,
+    string relativePath,
+    string? colorProfile,
+    string identity) : IRawTexturePayloadSource
+{
+    public string Identity { get; } = identity;
+
+    public string Description => $"dataset:{relativePath}";
+
+    public string? ColorProfile { get; } = colorProfile;
+
+    public long? EstimatedByteLength => null;
+
+    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    {
+        await using Stream stream = await datasetSource.OpenReadAsync(relativePath, cancellationToken);
+        using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream, cancellationToken);
+        return TextureImportSourceFactory.CreateRawPayloadFromImage(image, ColorProfile);
+    }
+}
+
+internal sealed class FileTextureImportSource(
+    string absolutePath,
+    string colorProfile,
+    string identity) : IRawTexturePayloadSource
+{
+    public string Identity { get; } = identity;
+
+    public string Description => $"file:{Path.GetFileName(absolutePath)}";
+
+    public string? ColorProfile { get; } = colorProfile;
+
+    public long? EstimatedByteLength
+    {
+        get
+        {
+            try
+            {
+                return File.Exists(absolutePath) ? new FileInfo(absolutePath).Length : null;
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return null;
+            }
+        }
+    }
+
+    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    {
+        using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(absolutePath, cancellationToken);
+        return TextureImportSourceFactory.CreateRawPayloadFromImage(image, ColorProfile);
+    }
+}
+
+internal sealed class GeneratedTextureImportSource(
+    Func<CancellationToken, ValueTask<RawTexturePayload>> materializeRawAsync,
+    string identity,
+    string description,
+    string? colorProfile,
+    long? estimatedByteLength = null) : IRawTexturePayloadSource
+{
+    public string Identity { get; } = identity;
+
+    public string Description { get; } = description;
+
+    public string? ColorProfile { get; } = colorProfile;
+
+    public long? EstimatedByteLength { get; } = estimatedByteLength;
+
+    public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    {
+        return materializeRawAsync(cancellationToken);
+    }
+}
+
+internal static class TextureImportSourceFactory
+{
+    public static ITextureImportSource CreateInMemory(
+        int? width,
+        int? height,
+        string? colorProfile,
+        byte[] bytes,
+        string identity,
+        TexturePayloadFormat sourceFormat)
+    {
+        return new InMemoryTextureImportSource(width, height, colorProfile, bytes, identity, sourceFormat);
+    }
+
+    public static ITextureImportSource CreateDatasetEncodedImage(
+        IPlateauDatasetContentSource datasetSource,
+        string relativePath,
+        string? colorProfile,
+        string identity)
+    {
+        return new DatasetTextureImportSource(datasetSource, relativePath, colorProfile, identity);
+    }
+
+    public static ITextureImportSource CreateFileImage(
+        string absolutePath,
+        string colorProfile,
+        string? identity = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(absolutePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(colorProfile);
+        return new FileTextureImportSource(
+            absolutePath,
+            colorProfile,
+            identity ?? $"file:{Path.GetFullPath(absolutePath)}:{colorProfile}");
+    }
+
+    public static ITextureImportSource CreateGeneratedImage(
+        Func<CancellationToken, ValueTask<RawTexturePayload>> materializeRawAsync,
+        string identity,
+        string description,
+        string? colorProfile,
+        long? estimatedByteLength = null)
+    {
+        return new GeneratedTextureImportSource(
+            materializeRawAsync,
+            identity,
+            description,
+            colorProfile,
+            estimatedByteLength);
+    }
+
+    public static ITextureImportSource CreateGeneratedImageFromClone(
+        Image<Rgba32> image,
+        string identity,
+        string description,
+        string? colorProfile)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+        Image<Rgba32> retainedImage = image.Clone();
+        object gate = new();
+        return CreateGeneratedImage(
+            cancellationToken =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                lock (gate)
+                {
+                    return ValueTask.FromResult(CreateRawPayloadFromImage(retainedImage, colorProfile));
+                }
+            },
+            identity,
+            description,
+            colorProfile,
+            (long)image.Width * image.Height * 4);
+    }
+
+    public static RawTexturePayload CreateRawPayloadFromImage(
+        Image<Rgba32> image,
+        string? colorProfile)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+        byte[] rawBytes = new byte[image.Width * image.Height * 4];
+        image.CopyPixelDataTo(rawBytes);
+        return new RawTexturePayload(
+            image.Width,
+            image.Height,
+            colorProfile,
+            rawBytes);
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -137,7 +137,9 @@ internal sealed class DatasetTextureImportSource(
 
     public string? ColorProfile { get; } = colorProfile;
 
-    public long? EstimatedByteLength => null;
+    public long? EstimatedByteLength => datasetSource is IPlateauDatasetContentLengthSource lengthSource
+        ? lengthSource.TryGetFileLength(relativePath)
+        : null;
 
     public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
     {

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClient.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClient.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 using ResoniteLink;
@@ -32,7 +33,9 @@ internal class SceneSinkRecordingClient : IResoniteLinkClient
 
     public List<ResoniteRawHdrTextureImport> ImportedRawHdrTextures { get; } = [];
 
-    public List<ResoniteTextureImport> ImportedTextures { get; } = [];
+    public List<ITextureImportSource> ImportedTextures { get; } = [];
+
+    public List<RawTexturePayload> ImportedTexturePayloads { get; } = [];
 
     public List<IReadOnlyList<DataModelOperation>> Batches { get; } = [];
 
@@ -216,27 +219,39 @@ internal class SceneSinkRecordingClient : IResoniteLinkClient
         }
     }
 
-    public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+    public async Task<Uri> ImportTextureAsync(ITextureImportSource textureSource, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            textureSource,
+            cancellationToken);
         lock (gate)
         {
             OperationNames.Add("ImportTexture");
-            switch (textureImport)
+            switch (rawPayload.Format)
             {
-                case ResoniteRawTextureImport rawImport:
+                case RawTexturePayloadFormat.Rgba32:
+                    ResoniteRawTextureImport rawImport = new(
+                        rawPayload.Width,
+                        rawPayload.Height,
+                        rawPayload.ColorProfile ?? ResoniteTextureColorProfiles.Srgb,
+                        rawPayload.Bytes);
                     ImportedRawTextures.Add(rawImport);
-                    ImportedTextures.Add(rawImport);
                     break;
-                case ResoniteRawHdrTextureImport rawHdrImport:
+                case RawTexturePayloadFormat.RgbaFloat32:
+                    ResoniteRawHdrTextureImport rawHdrImport = new(
+                        rawPayload.Width,
+                        rawPayload.Height,
+                        rawPayload.Bytes);
                     ImportedRawHdrTextures.Add(rawHdrImport);
-                    ImportedTextures.Add(rawHdrImport);
                     break;
                 default:
-                    throw new InvalidOperationException($"Unsupported texture import type '{textureImport.GetType().Name}'.");
+                    throw new InvalidOperationException($"Unsupported texture payload format '{rawPayload.Format}'.");
             }
 
-            return Task.FromResult(new Uri($"resdb:///texture/{ImportedTextures.Count - 1}", UriKind.Absolute));
+            ImportedTextures.Add(textureSource);
+            ImportedTexturePayloads.Add(rawPayload);
+            return new Uri($"resdb:///texture/{ImportedTextures.Count - 1}", UriKind.Absolute);
         }
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClientCanonicalDump.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClientCanonicalDump.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 using ResoniteLink;
@@ -370,14 +371,9 @@ internal static class SceneSinkRecordingClientCanonicalDump
         if (value.StartsWith("resdb:///texture/", StringComparison.Ordinal)
             && int.TryParse(value["resdb:///texture/".Length..], NumberStyles.None, CultureInfo.InvariantCulture, out int textureIndex))
         {
-            if (textureIndex >= 0 && textureIndex < client.ImportedTextures.Count)
+            if (textureIndex >= 0 && textureIndex < client.ImportedTexturePayloads.Count)
             {
-                return client.ImportedTextures[textureIndex] switch
-                {
-                    ResoniteRawTextureImport rawTexture => CreateTextureToken(rawTexture),
-                    ResoniteRawHdrTextureImport hdrTexture => CreateHdrTextureToken(hdrTexture),
-                    _ => value,
-                };
+                return CreateTextureToken(client.ImportedTexturePayloads[textureIndex]);
             }
         }
 
@@ -403,6 +399,17 @@ internal static class SceneSinkRecordingClientCanonicalDump
         return string.Create(
             CultureInfo.InvariantCulture,
             $"hdr-texture:{texture.Width}x{texture.Height}:{HashBytes(texture.RawRgbaFloatBytes)}");
+    }
+
+    private static string CreateTextureToken(RawTexturePayload texture)
+    {
+        return texture.Format == RawTexturePayloadFormat.RgbaFloat32
+            ? string.Create(
+                CultureInfo.InvariantCulture,
+                $"hdr-texture:{texture.Width}x{texture.Height}:{HashBytes(texture.Bytes)}")
+            : string.Create(
+                CultureInfo.InvariantCulture,
+                $"texture:{texture.Width}x{texture.Height}:{texture.ColorProfile}:{HashBytes(texture.Bytes)}");
     }
 
     private static string HashBytes(byte[]? bytes)

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
@@ -447,11 +448,10 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         CancellationToken cancellationToken)
     {
         string absolutePath = bundledDefaultMaterialAssetStore.GetAbsolutePath(asset);
-        ResoniteRawTextureImport textureImport = await ResoniteTextureImportFactory.CreateRawFromFileAsync(
+        ITextureImportSource textureSource = ResoniteTextureImportFactory.CreateSourceFromFile(
             absolutePath,
-            colorProfile,
-            cancellationToken);
-        return await importClient.ImportTextureAsync(textureImport, cancellationToken);
+            colorProfile);
+        return await importClient.ImportTextureAsync(textureSource, cancellationToken);
     }
 
     private Task<Uri?> ImportBundledAlbedoTextureAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
@@ -40,7 +40,7 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
 
         TextureUvRect uvBounds = ComputeUvBounds(cityObject.Mesh.Vertices, submesh);
         using Image<Rgba32> sourceImage = await textureImageLoader.LoadAsync(
-            ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
+            ResoniteTextureImportFactory.CreateSourceFromPayload(material.TexturePayload),
             cancellationToken);
         Rgba32 detectedBackgroundColor = NonDemTextureImageProcessing.DetectRepresentativeBackgroundColor(sourceImage);
         using Image<Rgba32> preparedSourceImage = sourceImage.Clone();

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
@@ -340,7 +341,7 @@ internal sealed record PreparedCityObject(
 internal sealed record PreparedTextureReference(
     ResoniteTexturePayload? TexturePayload,
     ResoniteTextureSourceKind TextureSourceKind,
-    ResoniteTextureImport TextureImport,
+    ITextureImportSource TextureSource,
     string? TerrainMeshCode = null,
     TerrainTextureOverlay? TerrainOverlay = null,
     GeneratedTerrainTexture? GeneratedTerrainTexture = null);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectWorkingSetEstimator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectWorkingSetEstimator.cs
@@ -40,7 +40,8 @@ internal static class ResoniteCityObjectWorkingSetEstimator
             .Select(static material => material.TexturePayload!)
             .Distinct(ResoniteTexturePayloadReferenceComparer.Instance)
             .ToArray();
-        long directTexturePayloadWeightBytes = distinctTexturePayloads.Sum(static payload => (long)payload.BinaryPayload.Length);
+        long directTexturePayloadWeightBytes = distinctTexturePayloads.Sum(
+            static payload => payload.Source.EstimatedByteLength ?? 0L);
         long terrainOverlayWeightBytes = cityObject.Materials
             .Where(static material => material.TerrainOverlay is not null)
             .Select(static material => material.TerrainOverlay!)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedTextureUploader.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedTextureUploader.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
@@ -48,14 +49,14 @@ internal static class ResonitePreparedTextureUploader
                         state,
                         importClient,
                         meshCode,
-                        texture.TextureImport,
+                        texture.TextureSource,
                         cancellationToken)));
                 continue;
             }
 
             textureImportTasks.Add((
                 texture,
-                importClient.ImportTextureAsync(texture.TextureImport, cancellationToken)));
+                importClient.ImportTextureAsync(texture.TextureSource, cancellationToken)));
         }
 
         Task[] importTasks = textureImportTasks
@@ -91,12 +92,12 @@ internal static class ResonitePreparedTextureUploader
         LiveSendRunState state,
         IResoniteLinkClient importClient,
         string meshCode,
-        ResoniteTextureImport textureImport,
+        ITextureImportSource textureSource,
         CancellationToken cancellationToken)
     {
         return state.TerrainTextures.AssetsByMeshCode.GetOrCreateAsync(
             meshCode,
-            () => EnsureSharedTerrainTextureAssetCoreAsync(state, importClient, meshCode, textureImport, cancellationToken),
+            () => EnsureSharedTerrainTextureAssetCoreAsync(state, importClient, meshCode, textureSource, cancellationToken),
             cancellationToken);
     }
 
@@ -104,7 +105,7 @@ internal static class ResonitePreparedTextureUploader
         LiveSendRunState state,
         IResoniteLinkClient importClient,
         string meshCode,
-        ResoniteTextureImport textureImport,
+        ITextureImportSource textureSource,
         CancellationToken cancellationToken)
     {
         CreatedSlot terrainTexturesRoot = await state.Placement.GetOrCreateSharedChildSlotAsync(
@@ -123,7 +124,7 @@ internal static class ResonitePreparedTextureUploader
             cancellationToken);
         if (existingTexture is not null)
         {
-            Uri refreshedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
+            Uri refreshedTextureUri = await importClient.ImportTextureAsync(textureSource, cancellationToken);
             await importClient.UpdateComponentAsync(
                 new ResoniteComponentUpdate
                 {
@@ -139,7 +140,7 @@ internal static class ResonitePreparedTextureUploader
             };
         }
 
-        Uri importedTextureUri = await importClient.ImportTextureAsync(textureImport, cancellationToken);
+        Uri importedTextureUri = await importClient.ImportTextureAsync(textureSource, cancellationToken);
         CreatedComponent textureComponent = await ResoniteMaterialPlanning.CreateComponentAsync(
             importClient,
             meshSlot.Locator,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
@@ -116,7 +116,7 @@ internal sealed class ResoniteQueuedTexturePreparer(
         return new PreparedTextureReference(
             TexturePayload: null,
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-            TextureImport: terrainTexture.TextureImport,
+            TextureSource: terrainTexture.TextureSource,
             TerrainMeshCode: terrainMeshCode,
             TerrainOverlay: terrainTextureOverlay,
             GeneratedTerrainTexture: terrainTexture);
@@ -201,7 +201,7 @@ internal sealed class ResoniteQueuedTexturePreparer(
             new PreparedTextureReference(
                 TexturePayload: material.TexturePayload,
                 TextureSourceKind: material.TextureSourceKind,
-                TextureImport: ResoniteTextureImportFactory.CreateRawFromPayload(material.TexturePayload),
+                TextureSource: ResoniteTextureImportFactory.CreateSourceFromPayload(material.TexturePayload),
                 TerrainMeshCode: null,
                 TerrainOverlay: null));
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImageLoader.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImageLoader.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Transport.ResoniteLink;
+using PlateauResoniteLink.Application.Importing;
 
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -13,21 +13,31 @@ internal sealed class ResoniteTextureImageLoader
 {
 #pragma warning disable CA1822
     public Task<Image<Rgba32>> LoadAsync(
-        ResoniteTextureImport textureImport,
+        ITextureImportSource textureSource,
         CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(textureImport);
+        ArgumentNullException.ThrowIfNull(textureSource);
 
-        return textureImport switch
+        return LoadCoreAsync(textureSource, cancellationToken);
+    }
+
+    private static async Task<Image<Rgba32>> LoadCoreAsync(
+        ITextureImportSource textureSource,
+        CancellationToken cancellationToken)
+    {
+        RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            textureSource,
+            cancellationToken);
+        if (rawPayload.Format != RawTexturePayloadFormat.Rgba32)
         {
-            ResoniteRawTextureImport rawTextureImport => Task.FromResult(
-                Image.LoadPixelData<Rgba32>(
-                    rawTextureImport.RawRgba32Bytes,
-                    rawTextureImport.Width,
-                    rawTextureImport.Height)),
-            _ => throw new InvalidOperationException(
-                $"Unsupported texture import type '{textureImport.GetType().Name}'."),
-        };
+            throw new InvalidOperationException(
+                $"Unsupported texture payload format '{rawPayload.Format}' for image loading.");
+        }
+
+        return Image.LoadPixelData<Rgba32>(
+            rawPayload.Bytes,
+            rawPayload.Width,
+            rawPayload.Height);
     }
 #pragma warning restore CA1822
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 using SixLabors.ImageSharp;
@@ -22,6 +23,13 @@ internal static class ResoniteTextureImportFactory
 
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(absolutePath, cancellationToken);
         return CreateRawFromImage(image, colorProfile);
+    }
+
+    public static ITextureImportSource CreateSourceFromFile(
+        string absolutePath,
+        string colorProfile = ResoniteTextureColorProfiles.Srgb)
+    {
+        return TextureImportSourceFactory.CreateFileImage(absolutePath, colorProfile);
     }
 
     public static async Task<ResoniteRawTextureImport> CreateRawFromStreamAsync(
@@ -59,6 +67,12 @@ internal static class ResoniteTextureImportFactory
         };
     }
 
+    public static ITextureImportSource CreateSourceFromPayload(ResoniteTexturePayload payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        return payload.Source;
+    }
+
     public static ResoniteTexturePayload CreatePayloadFromImage(
         Image<Rgba32> image,
         string colorProfile = ResoniteTextureColorProfiles.Srgb,
@@ -67,13 +81,14 @@ internal static class ResoniteTextureImportFactory
         ArgumentNullException.ThrowIfNull(image);
         ArgumentException.ThrowIfNullOrWhiteSpace(colorProfile);
 
-        byte[] rawBytes = new byte[image.Width * image.Height * 4];
-        image.CopyPixelDataTo(rawBytes);
+        RawTexturePayload rawPayload = TextureImportSourceFactory.CreateRawPayloadFromImage(
+            image,
+            colorProfile);
         return new ResoniteTexturePayload(
             image.Width,
             image.Height,
             colorProfile,
-            rawBytes,
+            rawPayload.Bytes,
             identity ?? Guid.NewGuid().ToString("N"),
             ResoniteTexturePayloadFormat.RawRgba32);
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Immutable;
 
+using PlateauResoniteLink.Application.Importing;
+
 namespace PlateauResoniteLink.Targets.Resonite;
 
 public enum ResoniteTexturePayloadFormat
@@ -26,6 +28,31 @@ public sealed record ResoniteTexturePayload
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
         Identity = identity;
         Format = format;
+        Source = TextureImportSourceFactory.CreateInMemory(
+            width,
+            height,
+            colorProfile,
+            binaryPayload,
+            identity ?? Guid.NewGuid().ToString("N"),
+            (TexturePayloadFormat)format);
+    }
+
+    public ResoniteTexturePayload(
+        int? width,
+        int? height,
+        string? colorProfile,
+        ITextureImportSource source,
+        string? identity = null,
+        ResoniteTexturePayloadFormat format = ResoniteTexturePayloadFormat.EncodedImage)
+    {
+        Width = width;
+        Height = height;
+        ColorProfile = colorProfile;
+        ArgumentNullException.ThrowIfNull(source);
+        BinaryPayload = [];
+        Identity = identity ?? source.Identity;
+        Format = format;
+        Source = source;
     }
 
     public int? Width { get; init; }
@@ -39,4 +66,6 @@ public sealed record ResoniteTexturePayload
     public string? Identity { get; init; }
 
     public ResoniteTexturePayloadFormat Format { get; init; }
+
+    public ITextureImportSource Source { get; init; }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -138,7 +138,7 @@ internal static class SceneImportContractMapper
             payload.Width,
             payload.Height,
             payload.ColorProfile,
-            payload.BinaryPayload.ToArray(),
+            payload.Source,
             payload.Identity,
             (ResoniteTexturePayloadFormat)payload.Format);
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -24,19 +24,19 @@ internal interface ITerrainTextureAssetGenerator
 }
 
 internal sealed record GeneratedTerrainTexture(
-    ResoniteRawTextureImport TextureImport,
+    ITextureImportSource TextureSource,
     TextureUvRect OccupiedUvRect,
     TerrainTextureSource? UsedSource = null,
     IReadOnlyList<TerrainTextureSource>? UsedSources = null)
 {
     public GeneratedTerrainTexture(
-        ResoniteRawTextureImport textureImport,
+        ITextureImportSource textureSource,
         ResoniteFloat2 canvasScale,
         ResoniteFloat2 canvasOffset,
         TerrainTextureSource? usedSource = null,
         IReadOnlyList<TerrainTextureSource>? usedSources = null)
         : this(
-            textureImport,
+            textureSource,
             TextureUvRect.FromScaleOffsetValue(
                 new ScalarPair(canvasScale.X, canvasScale.Y),
                 new ScalarPair(canvasOffset.X, canvasOffset.Y)),
@@ -262,7 +262,7 @@ internal sealed class TerrainTextureAssetGenerator(
                 canvasWidth,
                 canvasHeight);
         generatedTexture = new GeneratedTerrainTexture(
-            CreateRawTextureImport(canvasImage),
+            CreateTextureSource(canvasImage, usedSource),
             occupiedUvRect,
             usedSource,
             usedSources.Distinct().ToArray());
@@ -404,15 +404,13 @@ internal sealed class TerrainTextureAssetGenerator(
             }));
     }
 
-    private static ResoniteRawTextureImport CreateRawTextureImport(Image<Rgba32> image)
+    private static ITextureImportSource CreateTextureSource(Image<Rgba32> image, TerrainTextureSource usedSource)
     {
-        byte[] rawBytes = new byte[image.Width * image.Height * 4];
-        image.CopyPixelDataTo(rawBytes);
-        return new ResoniteRawTextureImport(
-            image.Width,
-            image.Height,
-            "sRGB",
-            rawBytes);
+        return TextureImportSourceFactory.CreateGeneratedImageFromClone(
+            image,
+            $"terrain:{usedSource.IdentityKey}:{image.Width}x{image.Height}",
+            $"terrain:{usedSource.GetType().Name}",
+            ResoniteTextureColorProfiles.Srgb);
     }
 
     private sealed record CachedTerrainTexture(

--- a/src/PlateauResoniteLink/Transport/ResoniteLink/LoadBalancingResoniteLinkClient.cs
+++ b/src/PlateauResoniteLink/Transport/ResoniteLink/LoadBalancingResoniteLinkClient.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
 
 using ResoniteLink;
@@ -86,11 +87,11 @@ internal sealed class LoadBalancingResoniteLinkClient : IResoniteLinkClient
         return ExecuteOnLeastBusyRouteAsync("import_mesh", (client, ct) => client.ImportMeshAsync(request, ct), cancellationToken);
     }
 
-    public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+    public Task<Uri> ImportTextureAsync(ITextureImportSource textureSource, CancellationToken cancellationToken)
     {
         return ExecuteOnLeastBusyRouteAsync(
             "import_texture",
-            (client, ct) => client.ImportTextureAsync(textureImport, ct),
+            (client, ct) => client.ImportTextureAsync(textureSource, ct),
             cancellationToken);
     }
 

--- a/src/PlateauResoniteLink/Transport/ResoniteLink/MetricsResoniteLinkClient.cs
+++ b/src/PlateauResoniteLink/Transport/ResoniteLink/MetricsResoniteLinkClient.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+using PlateauResoniteLink.Application.Importing;
+
 using ResoniteLink;
 
 namespace PlateauResoniteLink.Transport.ResoniteLink;
@@ -60,10 +62,10 @@ internal sealed class MetricsResoniteLinkClient(
         return await inner.ImportMeshAsync(request, cancellationToken);
     }
 
-    public async Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+    public async Task<Uri> ImportTextureAsync(ITextureImportSource textureSource, CancellationToken cancellationToken)
     {
         diagnostics.RecordRpcCall("import_texture");
-        return await inner.ImportTextureAsync(textureImport, cancellationToken);
+        return await inner.ImportTextureAsync(textureSource, cancellationToken);
     }
 
     public async Task UpdateComponentAsync(ResoniteComponentUpdate request, CancellationToken cancellationToken)

--- a/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkClient.cs
+++ b/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkClient.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
 
 using ResoniteLink;
@@ -31,7 +32,7 @@ internal interface IResoniteLinkClient : IDisposable
 
     Task<Uri> ImportMeshAsync(ImportMeshRawData request, CancellationToken cancellationToken);
 
-    Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken);
+    Task<Uri> ImportTextureAsync(ITextureImportSource textureSource, CancellationToken cancellationToken);
 
     Task UpdateComponentAsync(ResoniteComponentUpdate request, CancellationToken cancellationToken);
 }
@@ -151,16 +152,19 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
         return result.AssetURL ?? throw new InvalidOperationException("ResoniteLink returned a null mesh asset URL.");
     }
 
-    public async Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+    public async Task<Uri> ImportTextureAsync(ITextureImportSource textureSource, CancellationToken cancellationToken)
     {
         ThrowIfUnavailable();
         cancellationToken.ThrowIfCancellationRequested();
-        ArgumentNullException.ThrowIfNull(textureImport);
-        AssetData result = textureImport switch
+        ArgumentNullException.ThrowIfNull(textureSource);
+        RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            textureSource,
+            cancellationToken);
+        AssetData result = rawPayload.Format switch
         {
-            ResoniteRawTextureImport rawImport => await ImportRawTextureAsync(rawImport, cancellationToken),
-            ResoniteRawHdrTextureImport rawHdrImport => await ImportRawHdrTextureAsync(rawHdrImport, cancellationToken),
-            _ => throw new InvalidOperationException($"Unsupported texture import type '{textureImport.GetType().Name}'."),
+            RawTexturePayloadFormat.Rgba32 => await ImportRawTextureAsync(rawPayload, cancellationToken),
+            RawTexturePayloadFormat.RgbaFloat32 => await ImportRawHdrTextureAsync(rawPayload, cancellationToken),
+            _ => throw new InvalidOperationException($"Unsupported texture payload format '{rawPayload.Format}'."),
         };
 
         EnsureSuccess(result, "import texture");
@@ -245,31 +249,31 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
             "component");
     }
 
-    private Task<AssetData> ImportRawTextureAsync(ResoniteRawTextureImport rawImport, CancellationToken cancellationToken)
+    private Task<AssetData> ImportRawTextureAsync(RawTexturePayload rawPayload, CancellationToken cancellationToken)
     {
         return ExecuteSerializedAsync(
             "import_texture",
             _ => link.ImportTextureRawAsync(
                 new ImportTexture2DRawData
                 {
-                    Width = rawImport.Width,
-                    Height = rawImport.Height,
-                    ColorProfile = rawImport.ColorProfile,
-                    RawBinaryPayload = rawImport.RawRgba32Bytes,
+                    Width = rawPayload.Width,
+                    Height = rawPayload.Height,
+                    ColorProfile = rawPayload.ColorProfile ?? ResoniteTextureColorProfiles.Srgb,
+                    RawBinaryPayload = rawPayload.Bytes,
                 }),
             cancellationToken);
     }
 
-    private Task<AssetData> ImportRawHdrTextureAsync(ResoniteRawHdrTextureImport rawHdrImport, CancellationToken cancellationToken)
+    private Task<AssetData> ImportRawHdrTextureAsync(RawTexturePayload rawPayload, CancellationToken cancellationToken)
     {
         return ExecuteSerializedAsync(
             "import_texture",
             _ => link.ImportTextureRawHdrAsync(
                 new ImportTexture2DRawDataHDR
                 {
-                    Width = rawHdrImport.Width,
-                    Height = rawHdrImport.Height,
-                    RawBinaryPayload = rawHdrImport.RawRgbaFloatBytes,
+                    Width = rawPayload.Width,
+                    Height = rawPayload.Height,
+                    RawBinaryPayload = rawPayload.Bytes,
                 }),
             cancellationToken);
     }

--- a/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteTextureImport.cs
+++ b/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteTextureImport.cs
@@ -1,6 +1,23 @@
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+
 namespace PlateauResoniteLink.Transport.ResoniteLink;
 
-internal abstract record ResoniteTextureImport;
+internal abstract record ResoniteTextureImport : IRawTexturePayloadSource
+{
+    public abstract string Identity { get; }
+
+    public abstract string Description { get; }
+
+    public abstract string ColorProfile { get; init; }
+
+    public abstract long? EstimatedByteLength { get; }
+
+    public abstract ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken);
+}
 
 internal static class ResoniteTextureColorProfiles
 {
@@ -12,9 +29,46 @@ internal sealed record ResoniteRawTextureImport(
     int Width,
     int Height,
     string ColorProfile,
-    byte[] RawRgba32Bytes) : ResoniteTextureImport;
+    byte[] RawRgba32Bytes) : ResoniteTextureImport
+{
+    public override string Identity => $"raw-rgba32:{Width}:{Height}:{RuntimeHelpers.GetHashCode(RawRgba32Bytes)}";
+
+    public override string Description => "raw-rgba32-memory";
+
+    public override long? EstimatedByteLength => RawRgba32Bytes.Length;
+
+    public override ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(new RawTexturePayload(
+            Width,
+            Height,
+            ColorProfile,
+            (byte[])RawRgba32Bytes.Clone()));
+    }
+}
 
 internal sealed record ResoniteRawHdrTextureImport(
     int Width,
     int Height,
-    byte[] RawRgbaFloatBytes) : ResoniteTextureImport;
+    byte[] RawRgbaFloatBytes) : ResoniteTextureImport
+{
+    public override string Identity => $"raw-rgba-float32:{Width}:{Height}:{RuntimeHelpers.GetHashCode(RawRgbaFloatBytes)}";
+
+    public override string Description => "raw-rgba-float32-memory";
+
+    public override string ColorProfile { get; init; } = string.Empty;
+
+    public override long? EstimatedByteLength => RawRgbaFloatBytes.Length;
+
+    public override ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(new RawTexturePayload(
+            Width,
+            Height,
+            ColorProfile,
+            (byte[])RawRgbaFloatBytes.Clone(),
+            RawTexturePayloadFormat.RgbaFloat32));
+    }
+}

--- a/src/PlateauResoniteLink/Transport/ResoniteLink/RetryingResoniteLinkClient.cs
+++ b/src/PlateauResoniteLink/Transport/ResoniteLink/RetryingResoniteLinkClient.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Application.Logging;
 
 using ResoniteLink;
@@ -153,11 +154,11 @@ internal sealed class RetryingResoniteLinkClient : IResoniteLinkClient
             static _ => null);
     }
 
-    public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+    public Task<Uri> ImportTextureAsync(ITextureImportSource textureSource, CancellationToken cancellationToken)
     {
         return ExecuteMeasuredWithReconnectAsync(
             static (client, state, ct) => client.ImportTextureAsync(state, ct),
-            textureImport,
+            textureSource,
             "ImportTexture",
             cancellationToken,
             static _ => null,

--- a/tests/PlateauResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
@@ -22,11 +22,12 @@ public sealed class CityGmlAppearanceStoreTests
         using TemporaryDirectory datasetRoot = new();
         string packageDirectory = Path.Combine(datasetRoot.Path, "udx", "bldg", "53394525");
         string appearanceDirectory = Path.Combine(packageDirectory, "appearance");
+        string texturePath = Path.Combine(appearanceDirectory, "roof.png");
         Directory.CreateDirectory(appearanceDirectory);
 
         using (Image<Rgba32> image = new(1, 1, new Rgba32(255, 255, 255, 255)))
         {
-            await image.SaveAsPngAsync(Path.Combine(appearanceDirectory, "roof.png"));
+            await image.SaveAsPngAsync(texturePath);
         }
 
         IPlateauDatasetContentSource datasetSource = await PlateauDatasetContentSourceFactory.CreateAsync(
@@ -76,6 +77,7 @@ public sealed class CityGmlAppearanceStoreTests
         Assert.NotNull(appearance.TexturePayload);
         Assert.NotNull(appearance.ParameterizedTexture);
         Assert.Equal("image/png", appearance.ParameterizedTexture!.MimeType);
+        Assert.Equal(new FileInfo(texturePath).Length, appearance.TexturePayload!.Source.EstimatedByteLength);
         Assert.NotNull(appearance.MaterialAttributes);
         Assert.Equal(0.25, appearance.MaterialAttributes!.AmbientIntensity!.Value, 6);
         Assert.Equal(0.5, appearance.MaterialAttributes.Shininess!.Value, 6);

--- a/tests/PlateauResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 
@@ -226,5 +229,83 @@ public sealed class CityGmlAppearanceStoreTests
         Assert.Null(appearance.MaterialAttributes.SpecularColor);
         Assert.Null(appearance.MaterialAttributes.Shininess);
         Assert.Null(appearance.MaterialAttributes.Transparency);
+    }
+
+    [Fact]
+    public async Task Resolve_DefersDatasetTextureReadUntilRawMaterialization()
+    {
+        byte[] pngBytes;
+        using (Image<Rgba32> image = new(1, 1, new Rgba32(255, 0, 0, 255)))
+        {
+            using MemoryStream stream = new();
+            await image.SaveAsPngAsync(stream);
+            pngBytes = stream.ToArray();
+        }
+
+        CountingDatasetContentSource datasetSource = new(pngBytes);
+        ICityGmlAppearanceStore store = new CityGmlAppearanceStoreFactory().Create(
+            "udx/bldg/53394525/example.gml",
+            datasetSource);
+        XDocument document = XDocument.Parse(
+            """
+            <core:CityModel xmlns:app="http://www.opengis.net/citygml/appearance/2.0" xmlns:core="http://www.opengis.net/citygml/2.0">
+              <app:appearanceMember>
+                <app:Appearance>
+                  <app:surfaceDataMember>
+                    <app:ParameterizedTexture>
+                      <app:imageURI>appearance/roof.png</app:imageURI>
+                      <app:target uri="#poly-1" />
+                    </app:ParameterizedTexture>
+                  </app:surfaceDataMember>
+                </app:Appearance>
+              </app:appearanceMember>
+            </core:CityModel>
+            """);
+
+        store.LoadFromDocument(document);
+        CityGmlResolvedAppearance appearance = store.Resolve("poly-1");
+
+        Assert.NotNull(appearance.TexturePayload);
+        Assert.Equal(0, datasetSource.OpenReadCallCount);
+
+        RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            appearance.TexturePayload!.Source,
+            CancellationToken.None);
+
+        Assert.Equal(1, datasetSource.OpenReadCallCount);
+        Assert.Equal(1, rawPayload.Width);
+        Assert.Equal(1, rawPayload.Height);
+        Assert.Equal([255, 0, 0, 255], rawPayload.Bytes);
+    }
+
+    private sealed class CountingDatasetContentSource(byte[] payload) : IPlateauDatasetContentSource
+    {
+        public string SourcePath => "memory";
+
+        public int OpenReadCallCount { get; private set; }
+
+        public IReadOnlyList<string> EnumerateFiles() => ["udx/bldg/53394525/appearance/roof.png"];
+
+        public bool FileExists(string relativePath) => true;
+
+        public string? ResolveRelativePath(string baseRelativePath, string candidatePath)
+        {
+            return "udx/bldg/53394525/appearance/roof.png";
+        }
+
+        public ValueTask<Stream> OpenReadAsync(string relativePath, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            OpenReadCallCount++;
+            return ValueTask.FromResult<Stream>(new MemoryStream(payload, writable: false));
+        }
+
+        public Task<string> EnsureLocalFileAsync(
+            string relativePath,
+            string outputRoot,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneAnchorResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneAnchorResolverTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using GeographicLib;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 using PlateauResoniteLink.Targets.Resonite.Execution;
@@ -406,7 +407,7 @@ public sealed class ResoniteSceneAnchorResolverTests
             throw new NotSupportedException();
         }
 
-        public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+        public Task<Uri> ImportTextureAsync(ITextureImportSource textureSource, CancellationToken cancellationToken)
         {
             throw new NotSupportedException();
         }

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
-using PlateauResoniteLink.Transport.ResoniteLink;
 
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -60,7 +59,7 @@ public sealed class TerrainTextureAssetGeneratorTests
                 (double)layout.CropHeight / RoundUpToPowerOfTwo(layout.CropHeight)),
             firstTexture.OccupiedUvRect.ScaleValue);
 
-        using Image<Rgba32> image = LoadImage(firstTexture.TextureImport);
+        using Image<Rgba32> image = LoadImage(firstTexture.TextureSource);
         Assert.Equal(RoundUpToPowerOfTwo(layout.CropWidth), image.Width);
         Rectangle occupied = ToTopLeftPixelRect(firstTexture.OccupiedUvRect, image.Width, image.Height);
         AssertColor(Sample(occupied, image, 0.25, 0.5), 255, 0, 0);
@@ -81,7 +80,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        using Image<Rgba32> image = LoadImage(texture.TextureImport);
+        using Image<Rgba32> image = LoadImage(texture.TextureSource);
         Assert.Equal(256, image.Width);
         Assert.Equal(128, image.Height);
         Assert.Equal(new ScalarPair(1.0, 1.0), texture.OccupiedUvRect.ScaleValue);
@@ -110,9 +109,9 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        using Image<Rgba32> image = LoadImage(texture.TextureImport);
-        Assert.Equal(RoundUpToPowerOfTwo(layout.CropWidth), texture.TextureImport.Width);
-        Assert.Equal(RoundUpToPowerOfTwo(layout.CropHeight), texture.TextureImport.Height);
+        using Image<Rgba32> image = LoadImage(texture.TextureSource);
+        Assert.Equal(RoundUpToPowerOfTwo(layout.CropWidth), Materialize(texture.TextureSource).Width);
+        Assert.Equal(RoundUpToPowerOfTwo(layout.CropHeight), Materialize(texture.TextureSource).Height);
         Assert.Equal(
             new ScalarPair(
                 (double)layout.CropWidth / RoundUpToPowerOfTwo(layout.CropWidth),
@@ -139,7 +138,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        using Image<Rgba32> image = LoadImage(texture.TextureImport);
+        using Image<Rgba32> image = LoadImage(texture.TextureSource);
         Assert.Equal(256, image.Width);
         Assert.Equal(128, image.Height);
         Assert.Equal(new ScalarPair(1.0, 1.0), texture.OccupiedUvRect.ScaleValue);
@@ -166,7 +165,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        using Image<Rgba32> image = LoadImage(texture.TextureImport);
+        using Image<Rgba32> image = LoadImage(texture.TextureSource);
         Assert.Equal(RoundUpToPowerOfTwo(layout.CropWidth), image.Width);
         Rectangle occupied = ToTopLeftPixelRect(texture.OccupiedUvRect, image.Width, image.Height);
         AssertColor(Sample(occupied, image, 0.25, 0.25), 255, 0, 0);
@@ -222,9 +221,9 @@ public sealed class TerrainTextureAssetGeneratorTests
         TerrainTextureAssetGenerator thirdGenerator = new(thirdClient, cacheRoot.Path);
         GeneratedTerrainTexture repeatedTexture = await thirdGenerator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        Assert.Equal(texture.TextureImport.Width, repeatedTexture.TextureImport.Width);
-        Assert.Equal(texture.TextureImport.Height, repeatedTexture.TextureImport.Height);
-        Assert.Equal(texture.TextureImport.RawRgba32Bytes, repeatedTexture.TextureImport.RawRgba32Bytes);
+        Assert.Equal(Materialize(texture.TextureSource).Width, Materialize(repeatedTexture.TextureSource).Width);
+        Assert.Equal(Materialize(texture.TextureSource).Height, Materialize(repeatedTexture.TextureSource).Height);
+        Assert.Equal(Materialize(texture.TextureSource).Bytes, Materialize(repeatedTexture.TextureSource).Bytes);
     }
 
     [Fact]
@@ -262,7 +261,7 @@ public sealed class TerrainTextureAssetGeneratorTests
         GeneratedTerrainTexture secondTexture = await generator.EnsureTextureAsync(secondOverlay, CancellationToken.None);
 
         Assert.NotSame(firstTexture, secondTexture);
-        Assert.NotEqual(firstTexture.TextureImport.Height, secondTexture.TextureImport.Height);
+        Assert.NotEqual(Materialize(firstTexture.TextureSource).Height, Materialize(secondTexture.TextureSource).Height);
     }
 
     [Fact]
@@ -324,7 +323,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        Assert.Equal(512, texture.TextureImport.Width);
+        Assert.Equal(512, Materialize(texture.TextureSource).Width);
         Assert.Equal(4, handler.RequestCount);
     }
 
@@ -340,7 +339,7 @@ public sealed class TerrainTextureAssetGeneratorTests
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
         Assert.Same(firstTexture, texture);
-        Assert.Equal(512, texture.TextureImport.Width);
+        Assert.Equal(512, Materialize(texture.TextureSource).Width);
         Assert.Equal(4, handler.RequestCount);
     }
 
@@ -363,7 +362,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         GeneratedTerrainTexture texture = await secondGenerator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        Assert.Equal(512, texture.TextureImport.Width);
+        Assert.Equal(512, Materialize(texture.TextureSource).Width);
         Assert.Equal(1, secondHandler.RequestCount);
     }
 
@@ -387,7 +386,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        Assert.Equal(512, texture.TextureImport.Width);
+        Assert.Equal(512, Materialize(texture.TextureSource).Width);
         Assert.Equal(4, handler.RequestCount);
     }
 
@@ -402,7 +401,7 @@ public sealed class TerrainTextureAssetGeneratorTests
             "https://fallback.example/{z}/{x}/{y}.png");
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        using Image<Rgba32> image = LoadImage(texture.TextureImport);
+        using Image<Rgba32> image = LoadImage(texture.TextureSource);
         Rectangle occupied = ToTopLeftPixelRect(texture.OccupiedUvRect, image.Width, image.Height);
         AssertColor(Sample(occupied, image, 0.25, 0.5), 255, 0, 0);
         AssertColor(Sample(occupied, image, 0.75, 0.5), 0, 255, 0);
@@ -431,7 +430,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        Assert.NotEmpty(texture.TextureImport.RawRgba32Bytes);
+        Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
         Assert.IsType<TerrainTextureTileSource>(texture.UsedSource);
         Assert.Contains(("primary.example", 2), handler.HostZoomRequests);
         Assert.Contains(("primary.example", 1), handler.HostZoomRequests);
@@ -485,7 +484,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        Assert.NotEmpty(texture.TextureImport.RawRgba32Bytes);
+        Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
         Assert.Contains(
             texture.UsedSources ?? [],
             static source => source is TerrainTextureTileSource tileSource
@@ -493,7 +492,7 @@ public sealed class TerrainTextureAssetGeneratorTests
         Assert.Contains("primary.example", handler.RequestedHosts);
         Assert.Contains("fallback.example", handler.RequestedHosts);
 
-        using Image<Rgba32> image = LoadImage(texture.TextureImport);
+        using Image<Rgba32> image = LoadImage(texture.TextureSource);
         Assert.True(ContainsColor(image, 255, 0, 0));
         Assert.True(ContainsColor(image, 255, 0, 255));
     }
@@ -516,7 +515,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        using Image<Rgba32> image = LoadImage(texture.TextureImport);
+        using Image<Rgba32> image = LoadImage(texture.TextureSource);
         Assert.True(ContainsColor(image, 255, 0, 0));
         Rgba32 fillColor = TerrainTextureAssetGenerator.DefaultDemGroundFillColor;
         Assert.True(ContainsColor(image, fillColor.R, fillColor.G, fillColor.B));
@@ -555,7 +554,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        using Image<Rgba32> outputImage = LoadImage(texture.TextureImport);
+        using Image<Rgba32> outputImage = LoadImage(texture.TextureSource);
         Assert.Equal(new Rgba32(255, 0, 0, 255), outputImage[0, 0]);
         Assert.Equal(new Rgba32(255, 0, 0, 255), outputImage[1, 0]);
         Assert.NotEqual(new Rgba32(255, 0, 0, 255), outputImage[3, 0]);
@@ -570,7 +569,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        Assert.Equal(512, texture.TextureImport.Width);
+        Assert.Equal(512, Materialize(texture.TextureSource).Width);
         Assert.Equal(5, handler.RequestCount);
     }
 
@@ -589,10 +588,20 @@ public sealed class TerrainTextureAssetGeneratorTests
             FallbackUrlTemplate: fallbackUrlTemplate);
     }
 
-    private static Image<Rgba32> LoadImage(ResoniteRawTextureImport texture)
+    private static Image<Rgba32> LoadImage(ITextureImportSource texture)
     {
-        return Image.LoadPixelData<Rgba32>(texture.RawRgba32Bytes, texture.Width, texture.Height);
+        RawTexturePayload rawPayload = Materialize(texture);
+        return Image.LoadPixelData<Rgba32>(rawPayload.Bytes, rawPayload.Width, rawPayload.Height);
     }
+
+    private static RawTexturePayload Materialize(ITextureImportSource texture)
+    {
+        return TextureImportSourceMaterializer.MaterializeRawAsync(texture, CancellationToken.None)
+            .AsTask()
+            .GetAwaiter()
+            .GetResult();
+    }
+
     private static bool ContainsColor(Image<Rgba32> image, byte expectedR, byte expectedG, byte expectedB)
     {
         bool found = false;

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
@@ -274,11 +274,11 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
 
         Assert.Equal(0, handler.RequestCount);
         using Image<Rgba32> outputImage = Image.LoadPixelData<Rgba32>(
-            texture.TextureImport.RawRgba32Bytes,
-            texture.TextureImport.Width,
-            texture.TextureImport.Height);
+            Materialize(texture.TextureSource).Bytes,
+            Materialize(texture.TextureSource).Width,
+            Materialize(texture.TextureSource).Height);
         Assert.Equal(new Rgba32(12, 34, 56, 255), outputImage[0, 0]);
-        Assert.NotEmpty(texture.TextureImport.RawRgba32Bytes);
+        Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
         Assert.IsType<TerrainTextureGeoReferencedRasterSource>(texture.UsedSource);
     }
 
@@ -335,9 +335,9 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         GeneratedTerrainTexture rasterOnlyTexture = await generator.EnsureTextureAsync(rasterOnlyOverlay, CancellationToken.None);
         GeneratedTerrainTexture mixedTexture = await generator.EnsureTextureAsync(mixedOverlay, CancellationToken.None);
 
-        Assert.NotEqual(tileOnlyTexture.TextureImport.RawRgba32Bytes, rasterOnlyTexture.TextureImport.RawRgba32Bytes);
-        Assert.NotEqual(tileOnlyTexture.TextureImport.RawRgba32Bytes, mixedTexture.TextureImport.RawRgba32Bytes);
-        Assert.NotEqual(rasterOnlyTexture.TextureImport.RawRgba32Bytes, mixedTexture.TextureImport.RawRgba32Bytes);
+        Assert.NotEqual(Materialize(tileOnlyTexture.TextureSource).Bytes, Materialize(rasterOnlyTexture.TextureSource).Bytes);
+        Assert.NotEqual(Materialize(tileOnlyTexture.TextureSource).Bytes, Materialize(mixedTexture.TextureSource).Bytes);
+        Assert.NotEqual(Materialize(rasterOnlyTexture.TextureSource).Bytes, Materialize(mixedTexture.TextureSource).Bytes);
         Assert.Single(rasterOnlyTexture.UsedSources ?? []);
         Assert.Equal(2, (mixedTexture.UsedSources ?? []).Count);
     }
@@ -379,17 +379,17 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(rasterOverlay, CancellationToken.None);
 
         Assert.Equal(0, handler.RequestCount);
-        Assert.Equal(8192, texture.TextureImport.Width);
-        Assert.Equal(4096, texture.TextureImport.Height);
+        Assert.Equal(8192, Materialize(texture.TextureSource).Width);
+        Assert.Equal(4096, Materialize(texture.TextureSource).Height);
         Assert.Equal(
             new ScalarPair(
-                (double)layout.CropWidth / texture.TextureImport.Width,
-                (double)layout.CropHeight / texture.TextureImport.Height),
+                (double)layout.CropWidth / Materialize(texture.TextureSource).Width,
+                (double)layout.CropHeight / Materialize(texture.TextureSource).Height),
             texture.OccupiedUvRect.ScaleValue);
         using Image<Rgba32> outputImage = Image.LoadPixelData<Rgba32>(
-            texture.TextureImport.RawRgba32Bytes,
-            texture.TextureImport.Width,
-            texture.TextureImport.Height);
+            Materialize(texture.TextureSource).Bytes,
+            Materialize(texture.TextureSource).Width,
+            Materialize(texture.TextureSource).Height);
         int occupiedLeft = (outputImage.Width - layout.CropWidth) / 2;
         int occupiedTop = (outputImage.Height - layout.CropHeight) / 2;
         Assert.Equal(TerrainTextureAssetGenerator.DefaultDemGroundFillColor, outputImage[0, 0]);
@@ -427,9 +427,9 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
         using Image<Rgba32> outputImage = Image.LoadPixelData<Rgba32>(
-            texture.TextureImport.RawRgba32Bytes,
-            texture.TextureImport.Width,
-            texture.TextureImport.Height);
+            Materialize(texture.TextureSource).Bytes,
+            Materialize(texture.TextureSource).Width,
+            Materialize(texture.TextureSource).Height);
         Assert.Equal(TerrainTextureAssetGenerator.DefaultDemGroundFillColor, outputImage[0, 0]);
         Assert.Equal(new Rgba32(12, 34, 56, 255), outputImage[1, 0]);
         Assert.Equal(TerrainTextureAssetGenerator.DefaultDemGroundFillColor, outputImage[0, 1]);
@@ -477,9 +477,9 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
         using Image<Rgba32> outputImage = Image.LoadPixelData<Rgba32>(
-            texture.TextureImport.RawRgba32Bytes,
-            texture.TextureImport.Width,
-            texture.TextureImport.Height);
+            Materialize(texture.TextureSource).Bytes,
+            Materialize(texture.TextureSource).Width,
+            Materialize(texture.TextureSource).Height);
         int occupiedTop = outputImage.Height - layout.CropHeight;
         Assert.NotEqual(
             TerrainTextureAssetGenerator.DefaultDemGroundFillColor,
@@ -487,7 +487,7 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         Assert.Equal(
             new Rgba32(12, 34, 56, 255),
             outputImage[(layout.CropWidth * 3) / 4, occupiedTop + (layout.CropHeight / 2)]);
-        Assert.NotEmpty(texture.TextureImport.RawRgba32Bytes);
+        Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
         Assert.Contains(texture.UsedSources ?? [], static source => source is TerrainTextureGeoReferencedRasterSource);
         Assert.Contains(
             texture.UsedSources ?? [],
@@ -517,7 +517,7 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
         Assert.Equal(4, handler.RequestCount);
-        Assert.NotEmpty(texture.TextureImport.RawRgba32Bytes);
+        Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
         Assert.IsType<TerrainTextureTileSource>(texture.UsedSource);
     }
 
@@ -631,5 +631,13 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
     {
         double radians = latitude * (Math.PI / 180.0);
         return Math.Log(Math.Tan((Math.PI / 4.0) + (radians / 2.0)));
+    }
+
+    private static RawTexturePayload Materialize(ITextureImportSource texture)
+    {
+        return TextureImportSourceMaterializer.MaterializeRawAsync(texture, CancellationToken.None)
+            .AsTask()
+            .GetAwaiter()
+            .GetResult();
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Transport/LiveSendClientSessionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Transport/LiveSendClientSessionTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 using TransportComponentLocator = PlateauResoniteLink.Transport.ResoniteLink.ResoniteTransportComponentLocator;
@@ -370,7 +371,7 @@ public sealed class LiveSendClientSessionTests
             throw new NotSupportedException();
         }
 
-        public async Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+        public async Task<Uri> ImportTextureAsync(ITextureImportSource textureSource, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             TextureImportCallCount++;

--- a/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
@@ -70,6 +71,29 @@ public sealed class ResoniteLinkClientTests
         Assert.NotNull(transport.LastRawTextureRequest);
         Assert.Equal(1, transport.LastRawTextureRequest!.Width);
         Assert.Equal(1, transport.LastRawTextureRequest.Height);
+    }
+
+    [Fact]
+    public async Task ImportTextureAsyncMaterializesSourceOnlyInsideLinkAdapter()
+    {
+        using FakeResoniteLinkTransport transport = new()
+        {
+            ImportTextureRawResult = new AssetData
+            {
+                Success = true,
+                AssetURL = new Uri("file:///tmp/lazy.png"),
+            },
+        };
+        InstrumentedTextureImportSource source = new();
+
+        Assert.Equal(0, source.MaterializeCallCount);
+
+        using ResoniteLinkClient client = new(transport);
+        Uri importedTexture = await client.ImportTextureAsync(source, CancellationToken.None);
+
+        Assert.Equal(new Uri("file:///tmp/lazy.png"), importedTexture);
+        Assert.Equal(1, source.MaterializeCallCount);
+        Assert.Equal([1, 2, 3, 4], transport.LastRawTextureRequest!.RawBinaryPayload);
     }
 
     [Fact]
@@ -313,6 +337,30 @@ public sealed class ResoniteLinkClientTests
         public void Dispose()
         {
             Environment.SetEnvironmentVariable(variableName, previousValue);
+        }
+    }
+
+    private sealed class InstrumentedTextureImportSource : IRawTexturePayloadSource
+    {
+        public int MaterializeCallCount { get; private set; }
+
+        public string Identity => "instrumented";
+
+        public string Description => "instrumented";
+
+        public string? ColorProfile => ResoniteTextureColorProfiles.Srgb;
+
+        public long? EstimatedByteLength => 4;
+
+        public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            MaterializeCallCount++;
+            return ValueTask.FromResult(new RawTexturePayload(
+                1,
+                1,
+                ResoniteTextureColorProfiles.Srgb,
+                [1, 2, 3, 4]));
         }
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkTransportSessionFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkTransportSessionFactoryTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 using TransportComponentLocator = PlateauResoniteLink.Transport.ResoniteLink.ResoniteTransportComponentLocator;
@@ -139,7 +140,7 @@ public sealed class ResoniteLinkTransportSessionFactoryTests
             throw new NotSupportedException();
         }
 
-        public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+        public Task<Uri> ImportTextureAsync(ITextureImportSource textureSource, CancellationToken cancellationToken)
         {
             throw new NotSupportedException();
         }
@@ -150,5 +151,4 @@ public sealed class ResoniteLinkTransportSessionFactoryTests
         }
     }
 }
-
 

--- a/tests/PlateauResoniteLink.Tests/Transport/RetryingResoniteLinkClientTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Transport/RetryingResoniteLinkClientTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 using TransportComponentLocator = PlateauResoniteLink.Transport.ResoniteLink.ResoniteTransportComponentLocator;
@@ -535,7 +536,7 @@ public sealed class RetryingResoniteLinkClientTests
             return new Uri("resdb:///mesh/serialized", UriKind.Absolute);
         }
 
-        public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+        public Task<Uri> ImportTextureAsync(ITextureImportSource textureSource, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(new Uri("resdb:///texture/ok", UriKind.Absolute));
@@ -648,7 +649,7 @@ public sealed class RetryingResoniteLinkClientTests
             return Task.FromResult(new Uri("resdb:///mesh/ok", UriKind.Absolute));
         }
 
-        public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+        public Task<Uri> ImportTextureAsync(ITextureImportSource textureSource, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ImportTextureCallCount++;
@@ -782,7 +783,7 @@ public sealed class RetryingResoniteLinkClientTests
             return new Uri("resdb:///mesh/serialized", UriKind.Absolute);
         }
 
-        public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+        public Task<Uri> ImportTextureAsync(ITextureImportSource textureSource, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(new Uri("resdb:///texture/ok", UriKind.Absolute));
@@ -902,7 +903,7 @@ public sealed class RetryingResoniteLinkClientTests
             return new Uri("resdb:///mesh/ok", UriKind.Absolute);
         }
 
-        public Task<Uri> ImportTextureAsync(ResoniteTextureImport textureImport, CancellationToken cancellationToken)
+        public Task<Uri> ImportTextureAsync(ITextureImportSource textureSource, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(new Uri("resdb:///texture/ok", UriKind.Absolute));
@@ -915,5 +916,4 @@ public sealed class RetryingResoniteLinkClientTests
         }
     }
 }
-
 


### PR DESCRIPTION
## Summary
- Introduce `ITextureImportSource` so dataset, bundled file, generated, and bounded in-memory textures flow through neutral source interfaces.
- Keep retry, load-balancing, metrics, preparation, and planning layers as source pass-through boundaries.
- Materialize raw texture payloads only inside `ResoniteLinkClient` immediately before calling the ResoniteLink raw texture APIs.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (`959 passed`)