### PR TITLE
Hide raw materialization across texture and terrain boundaries

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
@@ -14,19 +14,22 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
     private readonly string? directRasterPath;
     private readonly string? singleRelativeRasterPath;
     private readonly IPlateauDatasetContentSource? contentSource;
-    private readonly string outputRoot;
+    private readonly string? outputRoot;
     private readonly IReadOnlyList<string> orderedRelativeRasterPaths;
     private readonly IReadOnlyDictionary<string, string> relativeRasterPathsByStem;
     private readonly object cachedRasterSourceTaskGate = new();
     private readonly Dictionary<DemTerrainRasterCacheKey, Task<TerrainTextureGeoReferencedRasterSource?>> cachedRasterSourceTasksByCacheKey =
         [];
+    private readonly object cachedLocalRasterFileTaskGate = new();
+    private readonly Dictionary<string, Task<string>> cachedLocalRasterFileTasksByRelativePath =
+        new(StringComparer.OrdinalIgnoreCase);
 
     private DemTerrainGeoReferencedRasterCatalog(
         string? directRasterPath,
         string? singleRelativeRasterPath,
         IPlateauDatasetContentSource? contentSource,
         string sourceScopePath,
-        string outputRoot,
+        string? outputRoot,
         IReadOnlyList<string> orderedRelativeRasterPaths,
         IReadOnlyDictionary<string, string> relativeRasterPathsByStem)
     {
@@ -62,7 +65,7 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
                 singleRelativeRasterPath: null,
                 contentSource: null,
                 sourceScopePath: fullSourcePath,
-                outputRoot: Path.GetDirectoryName(fullSourcePath) ?? fullSourcePath,
+                outputRoot: null,
                 orderedRelativeRasterPaths: [],
                 relativeRasterPathsByStem: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
         }
@@ -154,10 +157,10 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
         GeographicRectangle overlayBounds,
         CancellationToken cancellationToken)
     {
-        foreach (string rasterPath in await ResolveCandidateRasterPathsAsync(meshCode, cancellationToken))
+        foreach (TerrainTextureGeoReferencedRasterSource rasterSource in ResolveCandidateRasterSources(meshCode))
         {
             GeoReferencedRasterMetadata? metadata = await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(
-                rasterPath,
+                rasterSource,
                 cancellationToken);
             if (metadata is null
                 || !metadata.IsUsable
@@ -166,7 +169,7 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
                 continue;
             }
 
-            return new TerrainTextureGeoReferencedRasterSource(rasterPath, metadata);
+            return rasterSource with { Metadata = metadata };
         }
 
         return null;
@@ -191,13 +194,11 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
         }
     }
 
-    private async Task<IReadOnlyList<string>> ResolveCandidateRasterPathsAsync(
-        string meshCode,
-        CancellationToken cancellationToken)
+    private TerrainTextureGeoReferencedRasterSource[] ResolveCandidateRasterSources(string meshCode)
     {
         if (directRasterPath is not null)
         {
-            return [directRasterPath];
+            return [new TerrainTextureGeoReferencedRasterSource(directRasterPath)];
         }
 
         if (contentSource is null)
@@ -227,13 +228,86 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
             }
         }
 
-        List<string> localPaths = [];
-        foreach (string relativePath in relativePaths)
+        return relativePaths
+            .Select(relativePath => new TerrainTextureGeoReferencedRasterSource(
+                new DatasetTerrainTextureRasterContentSource(
+                    $"dataset:{contentSource.SourcePath}:{relativePath}",
+                    relativePath,
+                    EnsureLocalRasterFileAsync)))
+            .ToArray();
+    }
+
+    private Task<string> EnsureLocalRasterFileAsync(string relativePath, CancellationToken cancellationToken)
+    {
+        if (contentSource is null || outputRoot is null)
         {
-            localPaths.Add(await contentSource.EnsureLocalFileAsync(relativePath, outputRoot, cancellationToken));
+            return Task.FromException<string>(
+                new InvalidOperationException("Dataset raster sources require a dataset content source and local-file cache root."));
         }
 
-        return localPaths;
+        Task<string> localFilePathTask;
+        lock (cachedLocalRasterFileTaskGate)
+        {
+            if (!cachedLocalRasterFileTasksByRelativePath.TryGetValue(relativePath, out localFilePathTask!))
+            {
+                localFilePathTask = contentSource.EnsureLocalFileAsync(relativePath, outputRoot, CancellationToken.None);
+                cachedLocalRasterFileTasksByRelativePath[relativePath] = localFilePathTask;
+                _ = localFilePathTask.ContinueWith(
+                    completedTask => RemoveFaultedLocalRasterFileTask(relativePath, completedTask),
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+        }
+
+        return cancellationToken.CanBeCanceled
+            ? localFilePathTask.WaitAsync(cancellationToken)
+            : localFilePathTask;
+    }
+
+    private void RemoveFaultedLocalRasterFileTask(string relativePath, Task<string> completedTask)
+    {
+        if (!completedTask.IsFaulted && !completedTask.IsCanceled)
+        {
+            return;
+        }
+
+        lock (cachedLocalRasterFileTaskGate)
+        {
+            if (cachedLocalRasterFileTasksByRelativePath.TryGetValue(relativePath, out Task<string>? cachedTask)
+                && ReferenceEquals(cachedTask, completedTask))
+            {
+                cachedLocalRasterFileTasksByRelativePath.Remove(relativePath);
+            }
+        }
+    }
+
+    private sealed class DatasetTerrainTextureRasterContentSource(
+        string identityKey,
+        string relativePath,
+        Func<string, CancellationToken, Task<string>> ensureLocalFileAsync) : ITerrainTextureRasterContentSource
+    {
+        public string IdentityKey => identityKey;
+
+        public string Description => relativePath;
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "The caller owns the returned stream and disposes it after raster decoding.")]
+        public async ValueTask<Stream> OpenReadAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string localFilePath = await ensureLocalFileAsync(relativePath, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            return new FileStream(
+                localFilePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                bufferSize: 16 * 1024,
+                useAsync: true);
+        }
     }
 
     private static bool IsSupportedArchive(string path)

--- a/src/PlateauResoniteLink/Application/Importing/GeoTiffTagReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeoTiffTagReader.cs
@@ -52,10 +52,15 @@ internal static class GeoTiffTagReader
         }
     }
 
-    private static async Task<GeoTiffTagSnapshot?> TryReadAsync(
-        FileStream stream,
+    internal static async Task<GeoTiffTagSnapshot?> TryReadAsync(
+        Stream stream,
         CancellationToken cancellationToken)
     {
+        if (!stream.CanSeek)
+        {
+            return null;
+        }
+
         byte[] classicHeader = new byte[8];
         if (!await TryReadExactAsync(stream, 0, classicHeader, cancellationToken))
         {
@@ -161,7 +166,7 @@ internal static class GeoTiffTagReader
     }
 
     private static async Task<GeoTiffTagSnapshot?> TryReadClassicAsync(
-        FileStream stream,
+        Stream stream,
         bool littleEndian,
         uint ifdOffset,
         CancellationToken cancellationToken)
@@ -200,7 +205,7 @@ internal static class GeoTiffTagReader
     }
 
     private static async Task<GeoTiffTagSnapshot?> TryReadBigTiffAsync(
-        FileStream stream,
+        Stream stream,
         bool littleEndian,
         CancellationToken cancellationToken)
     {
@@ -273,7 +278,7 @@ internal static class GeoTiffTagReader
     }
 
     private static async Task TryReadClassicEntryAsync(
-        FileStream stream,
+        Stream stream,
         ReadOnlyMemory<byte> entryBytes,
         bool littleEndian,
         Dictionary<ushort, object> values,
@@ -329,7 +334,7 @@ internal static class GeoTiffTagReader
     }
 
     private static async Task TryReadBigTiffEntryAsync(
-        FileStream stream,
+        Stream stream,
         ReadOnlyMemory<byte> entryBytes,
         bool littleEndian,
         Dictionary<ushort, object> values,
@@ -405,7 +410,7 @@ internal static class GeoTiffTagReader
     }
 
     private static async Task<object?> TryReadEntryValueAsync(
-        FileStream stream,
+        Stream stream,
         ushort type,
         ulong count,
         ulong valueOrOffset,
@@ -462,7 +467,7 @@ internal static class GeoTiffTagReader
     }
 
     private static async Task<bool> TryReadExactAsync(
-        FileStream stream,
+        Stream stream,
         long offset,
         Memory<byte> buffer,
         CancellationToken cancellationToken)

--- a/src/PlateauResoniteLink/Application/Importing/PlateauDatasetContentSourceFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauDatasetContentSourceFactory.cs
@@ -278,15 +278,50 @@ internal static class PlateauDatasetContentSourceFactory
             }
 
             await using Stream sourceStream = await OpenReadAsync(normalizedPath, cancellationToken);
-            await using FileStream destinationStream = new(
-                destinationPath,
-                FileMode.Create,
-                FileAccess.Write,
-                FileShare.None,
-                bufferSize: 16 * 1024,
-                useAsync: true);
-            await sourceStream.CopyToAsync(destinationStream, cancellationToken);
+            string temporaryPath = $"{destinationPath}.{Guid.NewGuid():N}.tmp";
+            try
+            {
+                await using (FileStream destinationStream = new(
+                    temporaryPath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None,
+                    bufferSize: 16 * 1024,
+                    useAsync: true))
+                {
+                    await sourceStream.CopyToAsync(destinationStream, cancellationToken);
+                }
+
+                try
+                {
+                    File.Move(temporaryPath, destinationPath);
+                }
+                catch (IOException) when (File.Exists(destinationPath))
+                {
+                    TryDeleteFile(temporaryPath);
+                }
+            }
+            catch
+            {
+                TryDeleteFile(temporaryPath);
+                throw;
+            }
+
             return destinationPath;
+        }
+
+        private static void TryDeleteFile(string path)
+        {
+            try
+            {
+                File.Delete(path);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
         }
 
         private static string ResolveLocalFilePath(string archiveCacheRoot, string normalizedRelativePath)

--- a/src/PlateauResoniteLink/Application/Importing/TerrainTextureGeoReferencedRasterMetadataReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainTextureGeoReferencedRasterMetadataReader.cs
@@ -19,6 +19,16 @@ internal static class TerrainTextureGeoReferencedRasterMetadataReader
 {
     private const int GeographicTypeGeoKey = 2048;
     private const int ProjectedCSTypeGeoKey = 3072;
+
+    public static async Task<GeoReferencedRasterMetadata?> TryReadMetadataAsync(
+        TerrainTextureGeoReferencedRasterSource source,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        await using Stream stream = await source.OpenReadAsync(cancellationToken);
+        return await TryReadMetadataAsync(stream, cancellationToken);
+    }
+
     public static async Task<GeoReferencedRasterMetadata?> TryReadMetadataAsync(
         string sourcePath,
         CancellationToken cancellationToken)
@@ -41,6 +51,56 @@ internal static class TerrainTextureGeoReferencedRasterMetadataReader
 
         ExifProfile? exifProfile = imageInfo.Metadata.ExifProfile;
         GeoTiffTagSnapshot? tiffTags = await GeoTiffTagReader.TryReadAsync(sourcePath, cancellationToken);
+
+        double[]? tiePoints = TryGetDoubleArray(exifProfile, ExifTag.ModelTiePoint)
+            ?? tiffTags?.ModelTiePoint;
+        double[]? pixelScale = TryGetDoubleArray(exifProfile, ExifTag.PixelScale)
+            ?? tiffTags?.PixelScale;
+        double[]? modelTransform = TryGetDoubleArray(exifProfile, ExifTag.ModelTransform)
+            ?? tiffTags?.ModelTransform;
+        ushort[]? geoKeyDirectory = TryGetUnsignedShortArray(exifProfile, "GeoKeyDirectoryTag")
+            ?? tiffTags?.GeoKeyDirectory;
+        double[]? geoDoubleParams = TryGetNamedDoubleArray(exifProfile, "GeoDoubleParamsTag")
+            ?? tiffTags?.GeoDoubleParams;
+        string? geoAsciiParams = TryGetNamedString(exifProfile, "GeoAsciiParamsTag")
+            ?? tiffTags?.GeoAsciiParams;
+
+        return TryCreateMetadata(
+            imageInfo.Width,
+            imageInfo.Height,
+            tiePoints,
+            pixelScale,
+            modelTransform,
+            geoKeyDirectory,
+            geoDoubleParams,
+            geoAsciiParams);
+    }
+
+    public static async Task<GeoReferencedRasterMetadata?> TryReadMetadataAsync(
+        Stream stream,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        if (!stream.CanSeek)
+        {
+            return null;
+        }
+
+        ImageInfo imageInfo;
+        try
+        {
+            stream.Seek(0, SeekOrigin.Begin);
+            imageInfo = await Image.IdentifyAsync(stream, cancellationToken)
+                ?? throw new InvalidOperationException("Failed to identify raster stream.");
+        }
+        catch (UnknownImageFormatException)
+        {
+            return null;
+        }
+
+        ExifProfile? exifProfile = imageInfo.Metadata.ExifProfile;
+        stream.Seek(0, SeekOrigin.Begin);
+        GeoTiffTagSnapshot? tiffTags = await GeoTiffTagReader.TryReadAsync(stream, cancellationToken);
 
         double[]? tiePoints = TryGetDoubleArray(exifProfile, ExifTag.ModelTiePoint)
             ?? tiffTags?.ModelTiePoint;

--- a/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace PlateauResoniteLink.Domain.Importing;
 
@@ -40,18 +43,57 @@ public sealed record GeoReferencedRasterMetadata(
             $"georaster-meta-crs-{CoordinateSystemIdentifier ?? "none"}-pixel-{TerrainTextureDescriptorFormatting.FormatRounded(PixelWidthMeters)}x{TerrainTextureDescriptorFormatting.FormatRounded(PixelHeightMeters)}-bounds-{TerrainTextureDescriptorFormatting.FormatBounds(GeographicBounds)}");
 }
 
-public sealed record TerrainTextureGeoReferencedRasterSource(
-    string SourcePath,
-    GeoReferencedRasterMetadata? Metadata = null) : TerrainTextureSource
+public interface ITerrainTextureRasterContentSource
+{
+    string IdentityKey { get; }
+
+    string Description { get; }
+
+    ValueTask<Stream> OpenReadAsync(CancellationToken cancellationToken);
+}
+
+public sealed record LocalTerrainTextureRasterContentSource(string SourcePath) : ITerrainTextureRasterContentSource
 {
     public string SourcePath { get; init; } = string.IsNullOrWhiteSpace(SourcePath)
         ? throw new ArgumentException("Terrain texture raster source path must be provided.", nameof(SourcePath))
         : SourcePath;
 
+    public string IdentityKey => $"file:{Path.GetFullPath(SourcePath)}";
+
+    public string Description => Path.GetFileName(SourcePath.Replace('\\', '/'));
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "The caller owns the returned stream and disposes it after raster decoding.")]
+    public ValueTask<Stream> OpenReadAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult<Stream>(File.OpenRead(SourcePath));
+    }
+}
+
+public sealed record TerrainTextureGeoReferencedRasterSource(
+    ITerrainTextureRasterContentSource ContentSource,
+    GeoReferencedRasterMetadata? Metadata = null) : TerrainTextureSource
+{
+    public TerrainTextureGeoReferencedRasterSource(
+        string sourcePath,
+        GeoReferencedRasterMetadata? metadata = null)
+        : this(new LocalTerrainTextureRasterContentSource(sourcePath), metadata)
+    {
+    }
+
+    public ITerrainTextureRasterContentSource ContentSource { get; init; } =
+        ContentSource ?? throw new ArgumentNullException(nameof(ContentSource));
+
     public GeoReferencedRasterMetadata? Metadata { get; init; } = Metadata;
 
     public override string IdentityKey =>
-        string.Create(CultureInfo.InvariantCulture, $"georaster-{SourcePath}-meta-{Metadata?.IdentityKey ?? "none"}");
+        string.Create(CultureInfo.InvariantCulture, $"georaster-{ContentSource.IdentityKey}-meta-{Metadata?.IdentityKey ?? "none"}");
+
+    public ValueTask<Stream> OpenReadAsync(CancellationToken cancellationToken) =>
+        ContentSource.OpenReadAsync(cancellationToken);
 }
 
 public sealed record TerrainTextureOverlay

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
@@ -153,11 +153,13 @@ internal sealed class DeterministicTerrainTextureAssetGenerator : ITerrainTextur
         cancellationToken.ThrowIfCancellationRequested();
         TerrainTextureSource? usedSource = terrainTextureOverlay.GetRequiredPrimaryTileSource();
         return Task.FromResult(new GeneratedTerrainTexture(
-            new ResoniteRawTextureImport(
+            TextureImportSourceFactory.CreateInMemory(
                 2,
                 2,
                 ResoniteTextureColorProfiles.Srgb,
-                RawTextureBytes),
+                RawTextureBytes,
+                "canonical-dump-terrain-texture",
+                TexturePayloadFormat.RawRgba32),
             new ResoniteFloat2(1.0, 1.0),
             new ResoniteFloat2(0.0, 0.0),
             usedSource));

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClient.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClient.cs
@@ -31,10 +31,6 @@ internal class SceneSinkRecordingClient : IResoniteLinkClient
 
     public List<IGeometryImportSource> ImportedGeometrySources { get; } = [];
 
-    public List<ResoniteRawTextureImport> ImportedRawTextures { get; } = [];
-
-    public List<ResoniteRawHdrTextureImport> ImportedRawHdrTextures { get; } = [];
-
     public List<ITextureImportSource> ImportedTextures { get; } = [];
 
     public List<RawTexturePayload> ImportedTexturePayloads { get; } = [];
@@ -234,27 +230,6 @@ internal class SceneSinkRecordingClient : IResoniteLinkClient
         lock (gate)
         {
             OperationNames.Add("ImportTexture");
-            switch (rawPayload.Format)
-            {
-                case RawTexturePayloadFormat.Rgba32:
-                    ResoniteRawTextureImport rawImport = new(
-                        rawPayload.Width,
-                        rawPayload.Height,
-                        rawPayload.ColorProfile ?? ResoniteTextureColorProfiles.Srgb,
-                        rawPayload.Bytes);
-                    ImportedRawTextures.Add(rawImport);
-                    break;
-                case RawTexturePayloadFormat.RgbaFloat32:
-                    ResoniteRawHdrTextureImport rawHdrImport = new(
-                        rawPayload.Width,
-                        rawPayload.Height,
-                        rawPayload.Bytes);
-                    ImportedRawHdrTextures.Add(rawHdrImport);
-                    break;
-                default:
-                    throw new InvalidOperationException($"Unsupported texture payload format '{rawPayload.Format}'.");
-            }
-
             ImportedTextures.Add(textureSource);
             ImportedTexturePayloads.Add(rawPayload);
             return new Uri($"resdb:///texture/{ImportedTextures.Count - 1}", UriKind.Absolute);

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClientCanonicalDump.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClientCanonicalDump.cs
@@ -8,7 +8,6 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 
 using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Transport.ResoniteLink;
 
 using ResoniteLink;
 
@@ -138,16 +137,21 @@ internal static class SceneSinkRecordingClientCanonicalDump
 
         JsonArray textures = [];
         List<JsonObject> textureNodes = [];
-        for (int index = 0; index < client.ImportedRawTextures.Count; index++)
+        for (int index = 0; index < client.ImportedTexturePayloads.Count; index++)
         {
-            ResoniteRawTextureImport texture = client.ImportedRawTextures[index];
+            RawTexturePayload texture = client.ImportedTexturePayloads[index];
+            if (texture.Format != RawTexturePayloadFormat.Rgba32)
+            {
+                continue;
+            }
+
             textureNodes.Add(new JsonObject
             {
                 ["uri"] = CreateTextureToken(texture),
                 ["width"] = texture.Width,
                 ["height"] = texture.Height,
                 ["colorProfile"] = texture.ColorProfile,
-                ["payloadHash"] = HashBytes(texture.RawRgba32Bytes),
+                ["payloadHash"] = HashBytes(texture.Bytes),
             });
         }
 
@@ -158,15 +162,20 @@ internal static class SceneSinkRecordingClientCanonicalDump
 
         JsonArray hdrTextures = [];
         List<JsonObject> hdrTextureNodes = [];
-        for (int index = 0; index < client.ImportedRawHdrTextures.Count; index++)
+        for (int index = 0; index < client.ImportedTexturePayloads.Count; index++)
         {
-            ResoniteRawHdrTextureImport texture = client.ImportedRawHdrTextures[index];
+            RawTexturePayload texture = client.ImportedTexturePayloads[index];
+            if (texture.Format != RawTexturePayloadFormat.RgbaFloat32)
+            {
+                continue;
+            }
+
             hdrTextureNodes.Add(new JsonObject
             {
                 ["uri"] = CreateHdrTextureToken(texture),
                 ["width"] = texture.Width,
                 ["height"] = texture.Height,
-                ["payloadHash"] = HashBytes(texture.RawRgbaFloatBytes),
+                ["payloadHash"] = HashBytes(texture.Bytes),
             });
         }
 
@@ -387,20 +396,6 @@ internal static class SceneSinkRecordingClientCanonicalDump
             $"mesh:{mesh.VertexCount}:{mesh.Submeshes.Count}:{HashBytes(mesh.RawBinaryPayload)}");
     }
 
-    private static string CreateTextureToken(ResoniteRawTextureImport texture)
-    {
-        return string.Create(
-            CultureInfo.InvariantCulture,
-            $"texture:{texture.Width}x{texture.Height}:{texture.ColorProfile}:{HashBytes(texture.RawRgba32Bytes)}");
-    }
-
-    private static string CreateHdrTextureToken(ResoniteRawHdrTextureImport texture)
-    {
-        return string.Create(
-            CultureInfo.InvariantCulture,
-            $"hdr-texture:{texture.Width}x{texture.Height}:{HashBytes(texture.RawRgbaFloatBytes)}");
-    }
-
     private static string CreateTextureToken(RawTexturePayload texture)
     {
         return texture.Format == RawTexturePayloadFormat.RgbaFloat32
@@ -410,6 +405,13 @@ internal static class SceneSinkRecordingClientCanonicalDump
             : string.Create(
                 CultureInfo.InvariantCulture,
                 $"texture:{texture.Width}x{texture.Height}:{texture.ColorProfile}:{HashBytes(texture.Bytes)}");
+    }
+
+    private static string CreateHdrTextureToken(RawTexturePayload texture)
+    {
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"hdr-texture:{texture.Width}x{texture.Height}:{HashBytes(texture.Bytes)}");
     }
 
     private static string HashBytes(byte[]? bytes)

--- a/src/PlateauResoniteLink/Targets/Resonite/PersistentTerrainTileCache.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/PersistentTerrainTileCache.cs
@@ -17,7 +17,7 @@ internal sealed class PersistentTerrainTileCache
         this.cacheRoot = Path.GetFullPath(cacheRoot ?? GetDefaultCacheRoot());
     }
 
-    public async Task<byte[]?> TryReadTileBytesAsync(
+    public Task<Stream?> TryOpenTileReadAsync(
         string urlTemplate,
         int zoomLevel,
         int tileX,
@@ -27,38 +27,45 @@ internal sealed class PersistentTerrainTileCache
         string cachePath = GetCachePath(urlTemplate, zoomLevel, tileX, tileY);
         if (!File.Exists(cachePath))
         {
-            return null;
+            return Task.FromResult<Stream?>(null);
         }
 
         try
         {
-            return await File.ReadAllBytesAsync(cachePath, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<Stream?>(File.OpenRead(cachePath));
         }
         catch (IOException)
         {
-            return null;
+            return Task.FromResult<Stream?>(null);
         }
         catch (UnauthorizedAccessException)
         {
-            return null;
+            return Task.FromResult<Stream?>(null);
         }
     }
 
-    public async Task WriteTileBytesAsync(
+    public async Task WriteTileAsync(
         string urlTemplate,
         int zoomLevel,
         int tileX,
         int tileY,
-        byte[] encodedBytes,
+        Stream encodedContent,
         CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(encodedContent);
+
         string cachePath = GetCachePath(urlTemplate, zoomLevel, tileX, tileY);
         Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
 
         string temporaryPath = $"{cachePath}.{Guid.NewGuid():N}.tmp";
         try
         {
-            await File.WriteAllBytesAsync(temporaryPath, encodedBytes, cancellationToken);
+            await using (FileStream temporaryStream = File.Create(temporaryPath))
+            {
+                await encodedContent.CopyToAsync(temporaryStream, cancellationToken);
+            }
+
             File.Move(temporaryPath, cachePath, overwrite: true);
         }
         catch

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -180,7 +179,7 @@ internal sealed class ResoniteQueuedTexturePreparer(
         {
             TerrainTextureGeoReferencedRasterSource rasterSource => string.Create(
                 CultureInfo.InvariantCulture,
-                $"GeoTIFF(path='{Path.GetFileName(rasterSource.SourcePath)}', crs='{rasterSource.Metadata?.CoordinateSystemIdentifier ?? "unknown"}')"),
+                $"GeoTIFF(source='{rasterSource.ContentSource.Description}', crs='{rasterSource.Metadata?.CoordinateSystemIdentifier ?? "unknown"}')"),
             TerrainTextureTileSource tileSource when IsGsiFallbackSource(tileSource) => string.Create(
                 CultureInfo.InvariantCulture,
                 $"GSI seamless photo tile(z={tileSource.ZoomLevel})"),

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
@@ -1,7 +1,4 @@
 using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
@@ -13,58 +10,11 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal static class ResoniteTextureImportFactory
 {
-    public static async Task<ResoniteRawTextureImport> CreateRawFromFileAsync(
-        string absolutePath,
-        string colorProfile = ResoniteTextureColorProfiles.Srgb,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(absolutePath);
-        ArgumentException.ThrowIfNullOrWhiteSpace(colorProfile);
-
-        using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(absolutePath, cancellationToken);
-        return CreateRawFromImage(image, colorProfile);
-    }
-
     public static ITextureImportSource CreateSourceFromFile(
         string absolutePath,
         string colorProfile = ResoniteTextureColorProfiles.Srgb)
     {
         return TextureImportSourceFactory.CreateFileImage(absolutePath, colorProfile);
-    }
-
-    public static async Task<ResoniteRawTextureImport> CreateRawFromStreamAsync(
-        Stream stream,
-        string colorProfile = ResoniteTextureColorProfiles.Srgb,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(stream);
-        ArgumentException.ThrowIfNullOrWhiteSpace(colorProfile);
-
-        using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream, cancellationToken);
-        return CreateRawFromImage(image, colorProfile);
-    }
-
-    public static ResoniteRawTextureImport CreateRawFromImage(
-        Image<Rgba32> image,
-        string colorProfile = ResoniteTextureColorProfiles.Srgb)
-    {
-        ArgumentNullException.ThrowIfNull(image);
-        ArgumentException.ThrowIfNullOrWhiteSpace(colorProfile);
-
-        return CreateRawFromImageCore(
-            image,
-            colorProfile);
-    }
-
-    public static ResoniteRawTextureImport CreateRawFromPayload(ResoniteTexturePayload payload)
-    {
-        ArgumentNullException.ThrowIfNull(payload);
-        return payload.Format switch
-        {
-            ResoniteTexturePayloadFormat.RawRgba32 => CreateRawFromRawPayload(payload),
-            ResoniteTexturePayloadFormat.EncodedImage => CreateRawFromEncodedPayload(payload),
-            _ => throw new InvalidOperationException($"Unsupported texture payload format '{payload.Format}'."),
-        };
     }
 
     public static ITextureImportSource CreateSourceFromPayload(ResoniteTexturePayload payload)
@@ -91,42 +41,5 @@ internal static class ResoniteTextureImportFactory
             rawPayload.Bytes,
             identity ?? Guid.NewGuid().ToString("N"),
             ResoniteTexturePayloadFormat.RawRgba32);
-    }
-
-    private static ResoniteRawTextureImport CreateRawFromRawPayload(ResoniteTexturePayload payload)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(payload.ColorProfile);
-        if (payload.Width is null || payload.Height is null)
-        {
-            throw new InvalidOperationException("Raw RGBA texture payload must include width and height.");
-        }
-
-        return new ResoniteRawTextureImport(
-            payload.Width.Value,
-            payload.Height.Value,
-            payload.ColorProfile,
-            payload.BinaryPayload.AsSpan().ToArray());
-    }
-
-    private static ResoniteRawTextureImport CreateRawFromEncodedPayload(ResoniteTexturePayload payload)
-    {
-        using MemoryStream stream = new(payload.BinaryPayload.AsSpan().ToArray(), writable: false);
-        using Image<Rgba32> image = Image.Load<Rgba32>(stream);
-        return CreateRawFromImageCore(
-            image,
-            payload.ColorProfile ?? ResoniteTextureColorProfiles.Srgb);
-    }
-
-    private static ResoniteRawTextureImport CreateRawFromImageCore(
-        Image<Rgba32> image,
-        string colorProfile)
-    {
-        byte[] rawBytes = new byte[image.Width * image.Height * 4];
-        image.CopyPixelDataTo(rawBytes);
-        return new ResoniteRawTextureImport(
-            image.Width,
-            image.Height,
-            colorProfile,
-            rawBytes);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -160,17 +160,17 @@ internal sealed class TerrainTextureAssetGenerator(
         TerrainTextureGeoReferencedRasterSource rasterSource,
         CancellationToken cancellationToken)
     {
-        string sourcePath = Path.GetFullPath(rasterSource.SourcePath);
-        GeoReferencedRasterMetadata? metadata = rasterSource.Metadata
-            ?? await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(sourcePath, cancellationToken);
-        if (metadata is null || !metadata.IsUsable)
-        {
-            return null;
-        }
-
         try
         {
-            using Image<Rgba32> sourceImage = await Image.LoadAsync<Rgba32>(sourcePath, cancellationToken);
+            GeoReferencedRasterMetadata? metadata = rasterSource.Metadata
+                ?? await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(rasterSource, cancellationToken);
+            if (metadata is null || !metadata.IsUsable)
+            {
+                return null;
+            }
+
+            await using Stream sourceStream = await rasterSource.OpenReadAsync(cancellationToken);
+            using Image<Rgba32> sourceImage = await Image.LoadAsync<Rgba32>(sourceStream, cancellationToken);
             Image<Rgba32>? cropped = TerrainTextureGeoReferencedRasterCropper.TryCrop(
                 sourceImage,
                 metadata,
@@ -399,7 +399,7 @@ internal sealed class TerrainTextureAssetGenerator(
             sources.Select(static source => source switch
             {
                 TerrainTextureTileSource tileSource => $"tile:{tileSource.ZoomLevel}:{tileSource.UrlTemplate}",
-                TerrainTextureGeoReferencedRasterSource rasterSource => $"georaster:{rasterSource.SourcePath}",
+                TerrainTextureGeoReferencedRasterSource rasterSource => $"georaster:{rasterSource.ContentSource.Description}",
                 _ => source.GetType().Name,
             }));
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureTileSourceReader.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureTileSourceReader.cs
@@ -145,17 +145,17 @@ internal sealed class TerrainTextureTileSourceReader(
         string tileUrl = WebMercatorTileMath.FormatTileUrl(tileSource.UrlTemplate, tileSource.ZoomLevel, tileX, tileY);
         if (persistentTileCache is not null)
         {
-            byte[]? cachedBytes = await persistentTileCache.TryReadTileBytesAsync(
+            await using Stream? cachedStream = await persistentTileCache.TryOpenTileReadAsync(
                 tileSource.UrlTemplate,
                 tileSource.ZoomLevel,
                 tileX,
                 tileY,
                 cancellationToken);
-            if (cachedBytes is not null)
+            if (cachedStream is not null)
             {
                 try
                 {
-                    return await LoadTileImageAsync(cachedBytes, cancellationToken);
+                    return await LoadTileImageAsync(cachedStream, cancellationToken);
                 }
                 catch (UnknownImageFormatException)
                 {
@@ -185,19 +185,24 @@ internal sealed class TerrainTextureTileSourceReader(
                     return null;
                 }
 
-                byte[] encodedBytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+                await using Stream responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
                 if (persistentTileCache is not null)
                 {
-                    await TryWritePersistentTileBytesAsync(
+                    using MemoryStream retainedContent = new();
+                    await responseStream.CopyToAsync(retainedContent, cancellationToken);
+                    retainedContent.Position = 0;
+                    await TryWritePersistentTileAsync(
                         tileSource.UrlTemplate,
                         tileSource.ZoomLevel,
                         tileX,
                         tileY,
-                        encodedBytes,
+                        retainedContent,
                         cancellationToken);
+                    retainedContent.Position = 0;
+                    return await LoadTileImageAsync(retainedContent, cancellationToken);
                 }
 
-                return await LoadTileImageAsync(encodedBytes, cancellationToken);
+                return await LoadTileImageAsync(responseStream, cancellationToken);
             }
             catch (HttpRequestException) when (attempt < MaxTileDownloadAttempts)
             {
@@ -208,12 +213,12 @@ internal sealed class TerrainTextureTileSourceReader(
         return null;
     }
 
-    private async Task TryWritePersistentTileBytesAsync(
+    private async Task TryWritePersistentTileAsync(
         string urlTemplate,
         int zoomLevel,
         int tileX,
         int tileY,
-        byte[] encodedBytes,
+        Stream encodedContent,
         CancellationToken cancellationToken)
     {
         if (persistentTileCache is null)
@@ -223,12 +228,12 @@ internal sealed class TerrainTextureTileSourceReader(
 
         try
         {
-            await persistentTileCache.WriteTileBytesAsync(
+            await persistentTileCache.WriteTileAsync(
                 urlTemplate,
                 zoomLevel,
                 tileX,
                 tileY,
-                encodedBytes,
+                encodedContent,
                 cancellationToken);
         }
         catch (IOException)
@@ -240,11 +245,10 @@ internal sealed class TerrainTextureTileSourceReader(
     }
 
     private static async Task<Image<Rgba32>> LoadTileImageAsync(
-        byte[] encodedBytes,
+        Stream encodedContent,
         CancellationToken cancellationToken)
     {
-        using MemoryStream stream = new(encodedBytes, writable: false);
-        return await Image.LoadAsync<Rgba32>(stream, cancellationToken);
+        return await Image.LoadAsync<Rgba32>(encodedContent, cancellationToken);
     }
 
     private static bool IsTransientStatusCode(int statusCode)

--- a/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteTextureImport.cs
+++ b/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteTextureImport.cs
@@ -1,74 +1,7 @@
-using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
-
-using PlateauResoniteLink.Application.Importing;
-
 namespace PlateauResoniteLink.Transport.ResoniteLink;
-
-internal abstract record ResoniteTextureImport : IRawTexturePayloadSource
-{
-    public abstract string Identity { get; }
-
-    public abstract string Description { get; }
-
-    public abstract string ColorProfile { get; init; }
-
-    public abstract long? EstimatedByteLength { get; }
-
-    public abstract ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken);
-}
 
 internal static class ResoniteTextureColorProfiles
 {
     public const string Linear = "Linear";
     public const string Srgb = "sRGB";
-}
-
-internal sealed record ResoniteRawTextureImport(
-    int Width,
-    int Height,
-    string ColorProfile,
-    byte[] RawRgba32Bytes) : ResoniteTextureImport
-{
-    public override string Identity => $"raw-rgba32:{Width}:{Height}:{RuntimeHelpers.GetHashCode(RawRgba32Bytes)}";
-
-    public override string Description => "raw-rgba32-memory";
-
-    public override long? EstimatedByteLength => RawRgba32Bytes.Length;
-
-    public override ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        return ValueTask.FromResult(new RawTexturePayload(
-            Width,
-            Height,
-            ColorProfile,
-            (byte[])RawRgba32Bytes.Clone()));
-    }
-}
-
-internal sealed record ResoniteRawHdrTextureImport(
-    int Width,
-    int Height,
-    byte[] RawRgbaFloatBytes) : ResoniteTextureImport
-{
-    public override string Identity => $"raw-rgba-float32:{Width}:{Height}:{RuntimeHelpers.GetHashCode(RawRgbaFloatBytes)}";
-
-    public override string Description => "raw-rgba-float32-memory";
-
-    public override string ColorProfile { get; init; } = string.Empty;
-
-    public override long? EstimatedByteLength => RawRgbaFloatBytes.Length;
-
-    public override ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        return ValueTask.FromResult(new RawTexturePayload(
-            Width,
-            Height,
-            ColorProfile,
-            (byte[])RawRgbaFloatBytes.Clone(),
-            RawTexturePayloadFormat.RgbaFloat32));
-    }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
@@ -39,7 +39,7 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
     }
 
     [Fact]
-    public async Task TryResolveRasterSourceAsyncDoesNotReuseFallbackMaterializationAcrossDistinctBoundsKeys()
+    public async Task TryResolveRasterSourceAsyncReusesDatasetRasterMaterializationAcrossDistinctBoundsKeys()
     {
         using TemporaryDirectory datasetRoot = new();
         RecordingDatasetContentSource datasetSource = CreateDatasetSource(datasetRoot.Path);
@@ -58,7 +58,8 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
             secondBounds,
             CancellationToken.None);
 
-        Assert.Equal(4, datasetSource.EnsureLocalFileCallCount);
+        Assert.Equal(2, datasetSource.EnsureLocalFileCallCount);
+        Assert.Equal(0, datasetSource.OpenReadCallCount);
     }
 
     [Fact]
@@ -82,6 +83,64 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
             CancellationToken.None);
 
         Assert.Equal(2, datasetSource.EnsureLocalFileCallCount);
+        Assert.Equal(0, datasetSource.OpenReadCallCount);
+    }
+
+    [Fact]
+    public async Task TryResolveRasterSourceAsyncMaterializesDatasetRasterOnceForMetadataAndImageRead()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        LocalFileReadableDatasetContentSource datasetSource = CreateLocalFileReadableDatasetSource(datasetRoot.Path);
+        DemTerrainGeoReferencedRasterCatalog catalog = await CreateCatalogAsync(datasetSource);
+        GeographicRectangle bounds = new(35.0, 35.1, 139.0, 139.1);
+
+        TerrainTextureGeoReferencedRasterSource? result = await catalog.TryResolveRasterSourceAsync(
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "local", bounds),
+            "local",
+            bounds,
+            CancellationToken.None);
+
+        TerrainTextureGeoReferencedRasterSource resolvedResult = Assert.IsType<TerrainTextureGeoReferencedRasterSource>(result);
+        Assert.Equal("EPSG:4326", resolvedResult.Metadata?.CoordinateSystemIdentifier);
+        Assert.Equal(1, datasetSource.EnsureLocalFileCallCount);
+        Assert.Equal(0, datasetSource.OpenReadCallCount);
+
+        await using Stream _ = await resolvedResult.OpenReadAsync(CancellationToken.None);
+
+        Assert.Equal(1, datasetSource.EnsureLocalFileCallCount);
+        Assert.Equal(0, datasetSource.OpenReadCallCount);
+    }
+
+    [Fact]
+    public async Task TryResolveRasterSourceAsyncSharesConcurrentDatasetRasterMaterializationAcrossBoundsKeys()
+    {
+        using TemporaryDirectory datasetRoot = new();
+        SucceedingGateableDatasetContentSource datasetSource = CreateSucceedingGateableDatasetSource(datasetRoot.Path);
+        DemTerrainGeoReferencedRasterCatalog catalog = await CreateCatalogAsync(datasetSource);
+        GeographicRectangle firstBounds = new(35.0, 35.01, 139.0, 139.01);
+        GeographicRectangle secondBounds = new(35.02, 35.03, 139.02, 139.03);
+
+        Task<TerrainTextureGeoReferencedRasterSource?> firstCall = catalog.TryResolveRasterSourceAsync(
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", firstBounds),
+            "dem-fallback",
+            firstBounds,
+            CancellationToken.None);
+        await datasetSource.OpenReadStarted.Task.WaitAsync(CancellationToken.None);
+        Task<TerrainTextureGeoReferencedRasterSource?> secondCall = catalog.TryResolveRasterSourceAsync(
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", secondBounds),
+            "dem-fallback",
+            secondBounds,
+            CancellationToken.None);
+
+        datasetSource.ReleaseOpenRead.TrySetResult();
+
+        TerrainTextureGeoReferencedRasterSource? firstResult = await firstCall;
+        TerrainTextureGeoReferencedRasterSource? secondResult = await secondCall;
+
+        Assert.NotNull(firstResult);
+        Assert.NotNull(secondResult);
+        Assert.Equal(1, datasetSource.EnsureLocalFileCallCount);
+        Assert.Equal(0, datasetSource.OpenReadCallCount);
     }
 
     [Fact]
@@ -98,7 +157,7 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
             "dem-fallback",
             bounds,
             firstCallerCancellation.Token);
-        await datasetSource.EnsureLocalFileStarted.Task.WaitAsync(CancellationToken.None);
+        await datasetSource.OpenReadStarted.Task.WaitAsync(CancellationToken.None);
         Task<TerrainTextureGeoReferencedRasterSource?> secondCall = catalog.TryResolveRasterSourceAsync(
             new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", bounds),
             "dem-fallback",
@@ -106,7 +165,7 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
             CancellationToken.None);
 
         await firstCallerCancellation.CancelAsync();
-        datasetSource.ReleaseEnsureLocalFile.TrySetResult();
+        datasetSource.ReleaseOpenRead.TrySetResult();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await firstCall);
         TerrainTextureGeoReferencedRasterSource? secondResult = await secondCall;
@@ -120,6 +179,7 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
             CancellationToken.None);
         Assert.Same(secondResult, thirdResult);
         Assert.Equal(1, datasetSource.EnsureLocalFileCallCount);
+        Assert.Equal(0, datasetSource.OpenReadCallCount);
     }
 
     [Fact]
@@ -136,15 +196,16 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
             "dem-fallback",
             bounds,
             firstCallerCancellation.Token);
-        await datasetSource.EnsureLocalFileStarted.Task.WaitAsync(CancellationToken.None);
+        await datasetSource.OpenReadStarted.Task.WaitAsync(CancellationToken.None);
 
         await firstCallerCancellation.CancelAsync();
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await firstCall);
-        datasetSource.ReleaseEnsureLocalFile.TrySetResult();
+        datasetSource.ReleaseOpenRead.TrySetResult();
         await datasetSource.BackgroundCompletion.Task.WaitAsync(CancellationToken.None);
 
         await AssertEventuallyRetriesFaultedBackgroundTaskAsync(catalog, datasetSource, bounds);
         Assert.Equal(2, datasetSource.EnsureLocalFileCallCount);
+        Assert.Equal(0, datasetSource.OpenReadCallCount);
     }
 
     private static async Task AssertEventuallyRetriesFaultedBackgroundTaskAsync(
@@ -155,10 +216,10 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         for (int attempt = 0; attempt < 50; attempt++)
         {
             await Assert.ThrowsAnyAsync<IOException>(async () => await catalog.TryResolveRasterSourceAsync(
-                new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", bounds),
-                "dem-fallback",
-                bounds,
-                CancellationToken.None));
+                    new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, "dem-fallback", bounds),
+                    "dem-fallback",
+                    bounds,
+                    CancellationToken.None));
 
             if (datasetSource.EnsureLocalFileCallCount == 2)
             {
@@ -205,6 +266,22 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
                     2048, 0, 1, 4326,
                 ]));
         return new SucceedingGateableDatasetContentSource(datasetRoot, [Path.GetFileName(rasterPath)]);
+    }
+
+    private static LocalFileReadableDatasetContentSource CreateLocalFileReadableDatasetSource(string datasetRoot)
+    {
+        string rasterPath = Path.Combine(datasetRoot, "local.tif");
+        File.WriteAllBytes(
+            rasterPath,
+            CreateClassicLittleEndianGeoTiffBytes(
+                modelTiePoint: [0.0, 0.0, 0.0, 139.0, 35.1, 0.0],
+                pixelScale: [0.01, 0.01, 0.0],
+                geoKeyDirectory:
+                [
+                    1, 1, 0, 1,
+                    2048, 0, 1, 4326,
+                ]));
+        return new LocalFileReadableDatasetContentSource(datasetRoot, [Path.GetFileName(rasterPath)]);
     }
 
     private static byte[] CreateClassicLittleEndianGeoTiffBytes(
@@ -319,6 +396,8 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
     {
         public string SourcePath { get; } = sourcePath;
 
+        public int OpenReadCallCount { get; private set; }
+
         public int EnsureLocalFileCallCount { get; private set; }
 
         public IReadOnlyList<string> EnumerateFiles() => files;
@@ -327,9 +406,15 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
 
         public string? ResolveRelativePath(string baseRelativePath, string candidatePath) => null;
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "The catalog owns disposal of the returned stream during metadata probing.")]
         public ValueTask<Stream> OpenReadAsync(string relativePath, CancellationToken cancellationToken = default)
         {
-            throw new NotSupportedException();
+            OpenReadCallCount++;
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult<Stream>(File.OpenRead(Path.Combine(SourcePath, relativePath)));
         }
 
         public Task<string> EnsureLocalFileAsync(
@@ -338,7 +423,8 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
             CancellationToken cancellationToken = default)
         {
             EnsureLocalFileCallCount++;
-            _ = outputRoot;
+            cancellationToken.ThrowIfCancellationRequested();
+            Assert.Equal(Path.GetDirectoryName(SourcePath), outputRoot);
             return Task.FromResult(Path.Combine(SourcePath, relativePath));
         }
     }
@@ -349,11 +435,13 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
     {
         public string SourcePath { get; } = sourcePath;
 
+        public int OpenReadCallCount { get; private set; }
+
         public int EnsureLocalFileCallCount { get; private set; }
 
-        public TaskCompletionSource EnsureLocalFileStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource OpenReadStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public TaskCompletionSource ReleaseEnsureLocalFile { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ReleaseOpenRead { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public TaskCompletionSource BackgroundCompletion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -363,9 +451,25 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
 
         public string? ResolveRelativePath(string baseRelativePath, string candidatePath) => null;
 
-        public ValueTask<Stream> OpenReadAsync(string relativePath, CancellationToken cancellationToken = default)
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "The catalog owns disposal of the returned stream during metadata probing.")]
+        public async ValueTask<Stream> OpenReadAsync(
+            string relativePath,
+            CancellationToken cancellationToken = default)
         {
-            throw new NotSupportedException();
+            OpenReadCallCount++;
+            OpenReadStarted.TrySetResult();
+            try
+            {
+                await ReleaseOpenRead.Task.WaitAsync(cancellationToken);
+                throw new IOException("Simulated raster open failure.");
+            }
+            finally
+            {
+                BackgroundCompletion.TrySetResult();
+            }
         }
 
         public async Task<string> EnsureLocalFileAsync(
@@ -374,12 +478,11 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
             CancellationToken cancellationToken = default)
         {
             EnsureLocalFileCallCount++;
-            _ = outputRoot;
-            EnsureLocalFileStarted.TrySetResult();
+            OpenReadStarted.TrySetResult();
             try
             {
-                await ReleaseEnsureLocalFile.Task.WaitAsync(cancellationToken);
-                throw new IOException("Simulated ensure-local-file failure.");
+                await ReleaseOpenRead.Task.WaitAsync(cancellationToken);
+                throw new IOException("Simulated raster materialization failure.");
             }
             finally
             {
@@ -394,11 +497,13 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
     {
         public string SourcePath { get; } = sourcePath;
 
+        public int OpenReadCallCount { get; private set; }
+
         public int EnsureLocalFileCallCount { get; private set; }
 
-        public TaskCompletionSource EnsureLocalFileStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource OpenReadStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public TaskCompletionSource ReleaseEnsureLocalFile { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ReleaseOpenRead { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public IReadOnlyList<string> EnumerateFiles() => files;
 
@@ -406,21 +511,68 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
 
         public string? ResolveRelativePath(string baseRelativePath, string candidatePath) => null;
 
-        public ValueTask<Stream> OpenReadAsync(string relativePath, CancellationToken cancellationToken = default)
+        public async ValueTask<Stream> OpenReadAsync(
+            string relativePath,
+            CancellationToken cancellationToken = default)
         {
-            throw new NotSupportedException();
+            OpenReadCallCount++;
+            OpenReadStarted.TrySetResult();
+            await ReleaseOpenRead.Task.WaitAsync(cancellationToken);
+            return File.OpenRead(Path.Combine(SourcePath, relativePath));
         }
 
-        public async Task<string> EnsureLocalFileAsync(
+        public Task<string> EnsureLocalFileAsync(
             string relativePath,
             string outputRoot,
             CancellationToken cancellationToken = default)
         {
             EnsureLocalFileCallCount++;
-            _ = outputRoot;
-            EnsureLocalFileStarted.TrySetResult();
-            await ReleaseEnsureLocalFile.Task.WaitAsync(cancellationToken);
+            OpenReadStarted.TrySetResult();
+            return WaitAndReturnLocalFileAsync(relativePath, cancellationToken);
+        }
+
+        private async Task<string> WaitAndReturnLocalFileAsync(
+            string relativePath,
+            CancellationToken cancellationToken)
+        {
+            await ReleaseOpenRead.Task.WaitAsync(cancellationToken);
             return Path.Combine(SourcePath, relativePath);
+        }
+    }
+
+    private sealed class LocalFileReadableDatasetContentSource(
+        string sourcePath,
+        IReadOnlyList<string> files) : IPlateauDatasetContentSource
+    {
+        public string SourcePath { get; } = sourcePath;
+
+        public int OpenReadCallCount { get; private set; }
+
+        public int EnsureLocalFileCallCount { get; private set; }
+
+        public IReadOnlyList<string> EnumerateFiles() => files;
+
+        public bool FileExists(string relativePath) => files.Contains(relativePath, StringComparer.OrdinalIgnoreCase);
+
+        public string? ResolveRelativePath(string baseRelativePath, string candidatePath) => null;
+
+        public ValueTask<Stream> OpenReadAsync(
+            string relativePath,
+            CancellationToken cancellationToken = default)
+        {
+            OpenReadCallCount++;
+            throw new InvalidOperationException("Raster source should prefer the local file content source.");
+        }
+
+        public Task<string> EnsureLocalFileAsync(
+            string relativePath,
+            string outputRoot,
+            CancellationToken cancellationToken = default)
+        {
+            EnsureLocalFileCallCount++;
+            cancellationToken.ThrowIfCancellationRequested();
+            Assert.Equal(Path.GetDirectoryName(SourcePath), outputRoot);
+            return Task.FromResult(Path.Combine(SourcePath, relativePath));
         }
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceTests.cs
@@ -598,7 +598,7 @@ public sealed class StreamingImportedSceneSourceTests
         Assert.Single(cityObjects);
         TerrainTextureOverlay appliedOverlay = Assert.IsType<TerrainTextureOverlay>(geometryProjector.LastOverlayByPackage["dem"]);
         TerrainTextureGeoReferencedRasterSource rasterSource = Assert.Single(appliedOverlay.EnumerateGeoReferencedRasterSources());
-        Assert.Equal("C:\\ortho\\terrain.tif", rasterSource.SourcePath);
+        Assert.Equal("terrain.tif", rasterSource.ContentSource.Description);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/CanonicalSceneDumpSinkTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/CanonicalSceneDumpSinkTests.cs
@@ -12,6 +12,8 @@ using PlateauResoniteLink.Transport.ResoniteLink;
 
 using ResoniteLink;
 
+using static PlateauResoniteLink.Tests.TextureImportSourceTestFactory;
+
 namespace PlateauResoniteLink.Tests.Targets;
 
 public sealed class CanonicalSceneDumpSinkTests
@@ -85,7 +87,7 @@ public sealed class CanonicalSceneDumpSinkTests
     {
         using SceneSinkRecordingClient client = new();
         Uri textureUri = await client.ImportTextureAsync(
-            new ResoniteRawTextureImport(1, 1, ResoniteTextureColorProfiles.Srgb, [1, 2, 3, 255]),
+            CreateRawTextureSource(1, 1, ResoniteTextureColorProfiles.Srgb, [1, 2, 3, 255]),
             CancellationToken.None);
         ResoniteTransportSlotCreationResult slot = await client.AddSlotAsync(new AddSlot
         {

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -11,9 +11,10 @@ using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 using PlateauResoniteLink.Targets.Resonite.Diagnostics;
-using PlateauResoniteLink.Transport.ResoniteLink;
 
 using ResoniteLink;
+
+using static PlateauResoniteLink.Tests.TextureImportSourceTestFactory;
 
 namespace PlateauResoniteLink.Tests.Targets;
 
@@ -152,8 +153,8 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
         Assert.Equal(firstMaterialId, secondMaterialId);
         Assert.Contains(firstMaterialId, commonMaterialIds);
         Assert.NotEqual(firstPropertyBlockId, secondPropertyBlockId);
-        Assert.Contains(client.ImportedRawTextures, static texture => IsSolidColorTexture(texture, 255, 0, 0));
-        Assert.Contains(client.ImportedRawTextures, static texture => IsSolidColorTexture(texture, 0, 255, 0));
+        Assert.Contains(ImportedRgba32Textures(client), static texture => IsSolidColorTexture(texture, 255, 0, 0));
+        Assert.Contains(ImportedRgba32Textures(client), static texture => IsSolidColorTexture(texture, 0, 255, 0));
     }
 
     [Fact]
@@ -561,7 +562,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
         Assert.Contains(materialIds[1], commonMaterialIds);
         Assert.Null(propertyBlockIds[0]);
         Assert.NotNull(propertyBlockIds[1]);
-        Assert.Contains(client.ImportedRawTextures, static texture => IsSolidColorTexture(texture, 255, 0, 0));
+        Assert.Contains(ImportedRgba32Textures(client), static texture => IsSolidColorTexture(texture, 255, 0, 0));
     }
 
     [Fact]
@@ -1854,12 +1855,12 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             $"{firstUv.X:0.######},{firstUv.Y:0.######}|{secondUv.X:0.######},{secondUv.Y:0.######}|{thirdUv.X:0.######},{thirdUv.Y:0.######}");
     }
 
-    private static bool IsSolidColorTexture(ResoniteRawTextureImport texture, byte r, byte g, byte b)
+    private static bool IsSolidColorTexture(RawTexturePayload texture, byte r, byte g, byte b)
     {
         byte[] expectedPixel = [r, g, b, 255];
         return texture.Width == 2
             && texture.Height == 2
-            && texture.RawRgba32Bytes.Chunk(4).All(pixel => pixel.SequenceEqual(expectedPixel));
+            && texture.Bytes.Chunk(4).All(pixel => pixel.SequenceEqual(expectedPixel));
     }
 
     private static async Task<string> SeedEmptyCurrentGenericSharedMaterialSlotAsync(SceneSinkRecordingClient client)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -16,6 +16,8 @@ using PlateauResoniteLink.Transport.ResoniteLink;
 
 using ResoniteLink;
 
+using static PlateauResoniteLink.Tests.TextureImportSourceTestFactory;
+
 namespace PlateauResoniteLink.Tests.Targets;
 
 [SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test names describe contract cases.")]
@@ -516,7 +518,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             LicenseMode: TerrainTextureLicenseMode.PlateauOrthoOnly);
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(
+                CreateRawTextureSource(
                     2,
                     2,
                     ResoniteTextureColorProfiles.Srgb,
@@ -663,7 +665,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             LicenseMode: TerrainTextureLicenseMode.PlateauOrthoOnly);
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(
+                CreateRawTextureSource(
                     2,
                     2,
                     ResoniteTextureColorProfiles.Srgb,
@@ -741,7 +743,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             LicenseMode: TerrainTextureLicenseMode.PlateauOrthoWithGsiFallback);
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(
+                CreateRawTextureSource(
                     2,
                     2,
                     ResoniteTextureColorProfiles.Srgb,
@@ -816,7 +818,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             LicenseMode: TerrainTextureLicenseMode.PlateauOrthoWithGsiFallback);
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(
+                CreateRawTextureSource(
                     2,
                     2,
                     ResoniteTextureColorProfiles.Srgb,
@@ -882,7 +884,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             LicenseMode: TerrainTextureLicenseMode.PlateauOrthoWithGsiFallback);
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(
+                CreateRawTextureSource(
                     2,
                     2,
                     ResoniteTextureColorProfiles.Srgb,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -17,6 +17,8 @@ using ResoniteLink;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
+using static PlateauResoniteLink.Tests.TextureImportSourceTestFactory;
+
 namespace PlateauResoniteLink.Tests.Targets;
 
 [Trait("Category", "Slow")]
@@ -77,8 +79,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
             client,
             terrainTextureGenerator);
 
-        ResoniteRawTextureImport importedTexture = Assert.Single(
-            client.ImportedRawTextures,
+        RawTexturePayload importedTexture = Assert.Single(
+            ImportedRgba32Textures(client),
             texture => texture.Width == RoundUpToPowerOfTwo(layout.CropWidth)
                 && texture.Height == RoundUpToPowerOfTwo(layout.CropHeight));
         Assert.Equal(RoundUpToPowerOfTwo(layout.CropWidth), importedTexture.Width);
@@ -146,7 +148,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
         TerrainTextureOverlay roofOverlayWithDifferentUri = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/roof/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
+                CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
                 new ResoniteFloat2(0.0, 0.0)));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
@@ -226,7 +228,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
         TerrainTextureOverlay secondOverlay = CreateThirdMeshOverlay("53394526", "https://tiles.example/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
+                CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
                 new ResoniteFloat2(0.0, 0.0)));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
@@ -276,7 +278,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
+                CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
                 new ResoniteFloat2(0.0, 0.0)));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
@@ -366,7 +368,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
         TerrainTextureOverlay mismatchedOverlay = CreateThirdMeshOverlay("53394526", "https://tiles.example/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
+                CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
                 new ResoniteFloat2(0.0, 0.0)));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
@@ -407,7 +409,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
+                CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
                 new ResoniteFloat2(0.0, 0.0)));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
@@ -457,7 +459,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://example.invalid/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             requestedOverlay => new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(
+                CreateRawTextureSource(
                     2,
                     2,
                     ResoniteTextureColorProfiles.Srgb,
@@ -574,11 +576,11 @@ public sealed class ResoniteLiveSceneImportTargetTests
 
         await ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(metadata, [cityObject], client);
 
-        ResoniteRawHdrTextureImport importedTexture = Assert.Single(client.ImportedRawHdrTextures);
+        RawTexturePayload importedTexture = Assert.Single(ImportedHdrTextures(client));
         Assert.Equal(2, importedTexture.Width);
         Assert.Equal(2, importedTexture.Height);
-        float[] pixels = new float[importedTexture.RawRgbaFloatBytes.Length / sizeof(float)];
-        Buffer.BlockCopy(importedTexture.RawRgbaFloatBytes, 0, pixels, 0, importedTexture.RawRgbaFloatBytes.Length);
+        float[] pixels = new float[importedTexture.Bytes.Length / sizeof(float)];
+        Buffer.BlockCopy(importedTexture.Bytes, 0, pixels, 0, importedTexture.Bytes.Length);
         Assert.Equal(0.0f, pixels[0]);
         Assert.Equal(0.0f, pixels[1]);
         Assert.Equal(3.0f, pixels[2]);
@@ -665,7 +667,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.Equal(2, gridMeshRequests.Count);
         Assert.Equal(2, pointsGradientDriverRequests.Count);
         Assert.Equal(2, pointsProgressDriverRequests.Count);
-        Assert.Equal(2, client.ImportedRawHdrTextures.Count);
+        Assert.Equal(2, ImportedHdrTextures(client).Count);
 
         string[] pointsIds = gridMeshRequests
             .Select(static request => Assert.IsType<Field_int2>(request.Data.Members["Points"]).ID)
@@ -745,7 +747,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
             [cityObject]);
 
         Assert.Single(client.ImportedMeshes);
-        Assert.Single(client.ImportedRawHdrTextures);
+        Assert.Single(ImportedHdrTextures(client));
         int queuedMessageIndex = progressMessages.FindIndex(static message => message.Contains("First city object queued", StringComparison.Ordinal));
         int preparationMessageIndex = progressMessages.FindIndex(static message => message.Contains("City object preparation started", StringComparison.Ordinal));
         Assert.True(queuedMessageIndex >= 0);
@@ -837,7 +839,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://example.invalid/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
             _ => new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(
+                CreateRawTextureSource(
                     2,
                     2,
                     ResoniteTextureColorProfiles.Srgb,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -5,12 +5,15 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 using PlateauResoniteLink.Targets.Resonite.Execution;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 using ResoniteLink;
+
+using static PlateauResoniteLink.Tests.TextureImportSourceTestFactory;
 
 namespace PlateauResoniteLink.Tests.Targets;
 
@@ -64,7 +67,7 @@ public sealed class ResoniteMaterialPlanningTests
         int metallicImportIndex = int.Parse(
             metallicAsset.AssetUri.Segments[^1].TrimEnd('/'),
             CultureInfo.InvariantCulture);
-        ResoniteRawTextureImport metallicTexture = client.ImportedRawTextures[metallicImportIndex];
+        RawTexturePayload metallicTexture = ImportedRgba32Textures(client)[metallicImportIndex];
         Assert.Equal(ResoniteTextureColorProfiles.Linear, metallicTexture.ColorProfile);
         Assert.Contains(
             plannedAsset.Textures,
@@ -85,7 +88,7 @@ public sealed class ResoniteMaterialPlanningTests
             uvMaterial,
             bundledTextureImportTasks,
             CancellationToken.None);
-        int importCountAfterUv = client.ImportedRawTextures.Count;
+        int importCountAfterUv = ImportedRgba32Textures(client).Count;
 
         _ = await planning.PlanCommonMaterialAssetAsync(
             client,
@@ -93,7 +96,7 @@ public sealed class ResoniteMaterialPlanningTests
             bundledTextureImportTasks,
             CancellationToken.None);
 
-        Assert.Equal(importCountAfterUv, client.ImportedRawTextures.Count);
+        Assert.Equal(importCountAfterUv, ImportedRgba32Textures(client).Count);
     }
 
     [Fact]
@@ -110,7 +113,7 @@ public sealed class ResoniteMaterialPlanningTests
             baseMaterial,
             bundledTextureImportTasks,
             CancellationToken.None);
-        int importCountAfterBase = client.ImportedRawTextures.Count;
+        int importCountAfterBase = ImportedRgba32Textures(client).Count;
 
         PlannedDedicatedMaterialAsset colorVariantPlannedAsset = await planning.PlanCommonMaterialAssetAsync(
             client,
@@ -118,7 +121,7 @@ public sealed class ResoniteMaterialPlanningTests
             bundledTextureImportTasks,
             CancellationToken.None);
 
-        Assert.Equal(importCountAfterBase + 3, client.ImportedRawTextures.Count);
+        Assert.Equal(importCountAfterBase + 3, ImportedRgba32Textures(client).Count);
         Assert.NotEqual(
             GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
             GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Albedo));
@@ -150,7 +153,7 @@ public sealed class ResoniteMaterialPlanningTests
             baseMaterial,
             bundledTextureImportTasks,
             CancellationToken.None);
-        int importCountAfterBase = client.ImportedRawTextures.Count;
+        int importCountAfterBase = ImportedRgba32Textures(client).Count;
 
         PlannedDedicatedMaterialAsset colorVariantPlannedAsset = await planning.PlanCommonMaterialAssetAsync(
             client,
@@ -158,7 +161,7 @@ public sealed class ResoniteMaterialPlanningTests
             bundledTextureImportTasks,
             CancellationToken.None);
 
-        Assert.Equal(importCountAfterBase + 2, client.ImportedRawTextures.Count);
+        Assert.Equal(importCountAfterBase + 2, ImportedRgba32Textures(client).Count);
         Assert.NotEqual(
             GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
             GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Albedo));
@@ -242,7 +245,7 @@ public sealed class ResoniteMaterialPlanningTests
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextures = new()
         {
             [overlay] = new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(512, 256, ResoniteTextureColorProfiles.Srgb, new byte[512 * 256 * 4]),
+                CreateRawTextureSource(512, 256, ResoniteTextureColorProfiles.Srgb, new byte[512 * 256 * 4]),
                 new ResoniteFloat2(0.5, 0.25),
                 new ResoniteFloat2(0.0, 0.0)),
         };
@@ -328,7 +331,7 @@ public sealed class ResoniteMaterialPlanningTests
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextures = new()
         {
             [overlay] = new GeneratedTerrainTexture(
-                new ResoniteRawTextureImport(512, 256, ResoniteTextureColorProfiles.Srgb, new byte[512 * 256 * 4]),
+                CreateRawTextureSource(512, 256, ResoniteTextureColorProfiles.Srgb, new byte[512 * 256 * 4]),
                 new ResoniteFloat2(0.5, 0.25),
                 new ResoniteFloat2(0.0, 0.0)),
         };

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -372,12 +372,13 @@ public sealed class TerrainTextureAssetGeneratorTests
         using TemporaryDirectory cacheRoot = new();
         TerrainTextureOverlay overlay = CreateFullCoverageOverlay("https://tiles.example/{z}/{x}/{y}.png");
         PersistentTerrainTileCache persistentCache = new(cacheRoot.Path);
-        await persistentCache.WriteTileBytesAsync(
+        using MemoryStream corruptTileContent = new([1, 2, 3, 4]);
+        await persistentCache.WriteTileAsync(
             overlay.UrlTemplate,
             overlay.ZoomLevel,
             0,
             0,
-            [1, 2, 3, 4],
+            corruptTileContent,
             CancellationToken.None);
 
         using FakeMapTileHandler handler = new();

--- a/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Targets.Resonite.Diagnostics;
+
+namespace PlateauResoniteLink.Tests;
+
+internal static class TextureImportSourceTestFactory
+{
+    public static ITextureImportSource CreateRawTextureSource(
+        int width,
+        int height,
+        string colorProfile,
+        byte[] rawRgba32Bytes,
+        string? identity = null)
+    {
+        return TextureImportSourceFactory.CreateInMemory(
+            width,
+            height,
+            colorProfile,
+            rawRgba32Bytes,
+            identity ?? $"test-rgba32:{width}:{height}:{Guid.NewGuid():N}",
+            TexturePayloadFormat.RawRgba32);
+    }
+
+    public static IReadOnlyList<RawTexturePayload> ImportedRgba32Textures(SceneSinkRecordingClient client)
+    {
+        return client.ImportedTexturePayloads
+            .Where(static payload => payload.Format == RawTexturePayloadFormat.Rgba32)
+            .ToArray();
+    }
+
+    public static IReadOnlyList<RawTexturePayload> ImportedHdrTextures(SceneSinkRecordingClient client)
+    {
+        return client.ImportedTexturePayloads
+            .Where(static payload => payload.Format == RawTexturePayloadFormat.RgbaFloat32)
+            .ToArray();
+    }
+
+    public static bool IsSolidColorTexture(RawTexturePayload texture, byte r, byte g, byte b)
+    {
+        byte[] expectedPixel = [r, g, b, 255];
+        return texture.Format == RawTexturePayloadFormat.Rgba32
+            && texture.Width == 2
+            && texture.Height == 2
+            && texture.Bytes.Chunk(4).All(pixel => pixel.SequenceEqual(expectedPixel));
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Transport/LiveSendClientSessionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Transport/LiveSendClientSessionTests.cs
@@ -12,6 +12,8 @@ using TransportSlotLocator = PlateauResoniteLink.Transport.ResoniteLink.Resonite
 
 using ResoniteLink;
 
+using static PlateauResoniteLink.Tests.TextureImportSourceTestFactory;
+
 namespace PlateauResoniteLink.Tests.Transport;
 
 public sealed class LiveSendClientSessionTests
@@ -100,7 +102,7 @@ public sealed class LiveSendClientSessionTests
 
         Task<Uri>[] imports = Enumerable.Range(0, 6)
             .Select(_ => client.ImportTextureAsync(
-                new ResoniteRawTextureImport(1, 1, ResoniteTextureColorProfiles.Srgb, [255, 255, 255, 255]),
+                CreateRawTextureSource(1, 1, ResoniteTextureColorProfiles.Srgb, [255, 255, 255, 255]),
                 CancellationToken.None))
             .ToArray();
 

--- a/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
@@ -13,6 +13,8 @@ using ResoniteLink;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
+using static PlateauResoniteLink.Tests.TextureImportSourceTestFactory;
+
 namespace PlateauResoniteLink.Tests.Transport;
 
 public sealed class ResoniteLinkClientTests
@@ -59,11 +61,11 @@ public sealed class ResoniteLinkClientTests
 
         using ResoniteLinkClient client = new(transport);
         Uri importedTexture = await client.ImportTextureAsync(
-            new ResoniteRawTextureImport(
-                Width: 1,
-                Height: 1,
-                ColorProfile: ResoniteTextureColorProfiles.Srgb,
-                RawRgba32Bytes: [255, 0, 0, 255]),
+            CreateRawTextureSource(
+                width: 1,
+                height: 1,
+                colorProfile: ResoniteTextureColorProfiles.Srgb,
+                rawRgba32Bytes: [255, 0, 0, 255]),
             CancellationToken.None);
 
         Assert.Equal(new Uri("file:///tmp/albedo.png"), importedTexture);
@@ -120,17 +122,19 @@ public sealed class ResoniteLinkClientTests
     }
 
     [Fact]
-    public async Task CreateRawFromFileAsyncThrowsWhenLocalFileIsMissing()
+    public async Task CreateSourceFromFileThrowsWhenMaterializedForMissingLocalFile()
     {
         string texturePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.png");
         FileNotFoundException exception = await Assert.ThrowsAsync<FileNotFoundException>(
-            async () => await ResoniteTextureImportFactory.CreateRawFromFileAsync(texturePath, cancellationToken: CancellationToken.None));
+            async () => await TextureImportSourceMaterializer.MaterializeRawAsync(
+                ResoniteTextureImportFactory.CreateSourceFromFile(texturePath),
+                CancellationToken.None));
 
         Assert.Contains(Path.GetFileName(texturePath), exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
-    public async Task CreateRawFromFileAsyncLoadsImageWhenRunningUnderWsl()
+    public async Task CreateSourceFromFileLoadsImageWhenMaterialized()
     {
         using EnvironmentVariableScope scope = new("WSL_DISTRO_NAME", "Ubuntu-24.04");
         using TemporaryDirectory temporaryDirectory = new();
@@ -140,14 +144,14 @@ public sealed class ResoniteLinkClientTests
             await image.SaveAsPngAsync(texturePath);
         }
 
-        ResoniteRawTextureImport importedTexture = await ResoniteTextureImportFactory.CreateRawFromFileAsync(
-            texturePath,
-            cancellationToken: CancellationToken.None);
+        RawTexturePayload importedTexture = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            ResoniteTextureImportFactory.CreateSourceFromFile(texturePath),
+            CancellationToken.None);
 
         Assert.Equal(1, importedTexture.Width);
         Assert.Equal(1, importedTexture.Height);
         Assert.Equal(ResoniteTextureColorProfiles.Srgb, importedTexture.ColorProfile);
-        Assert.Equal([255, 0, 0, 255], importedTexture.RawRgba32Bytes);
+        Assert.Equal([255, 0, 0, 255], importedTexture.Bytes);
     }
 
     [Fact]
@@ -161,11 +165,11 @@ public sealed class ResoniteLinkClientTests
             gateWaitLogThreshold: TimeSpan.Zero);
 
         Task<Uri> importTask = client.ImportTextureAsync(
-            new ResoniteRawTextureImport(
-                Width: 1,
-                Height: 1,
-                RawRgba32Bytes: [255, 0, 0, 255],
-                ColorProfile: ResoniteTextureColorProfiles.Srgb),
+            CreateRawTextureSource(
+                width: 1,
+                height: 1,
+                rawRgba32Bytes: [255, 0, 0, 255],
+                colorProfile: ResoniteTextureColorProfiles.Srgb),
             CancellationToken.None);
 
         await transport.ImportTextureStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -216,11 +220,11 @@ public sealed class ResoniteLinkClientTests
             _ => throw new InvalidOperationException("Progress sink failed."));
 
         Uri texture = await client.ImportTextureAsync(
-            new ResoniteRawTextureImport(
-                Width: 1,
-                Height: 1,
-                RawRgba32Bytes: [255, 0, 0, 255],
-                ColorProfile: ResoniteTextureColorProfiles.Srgb),
+            CreateRawTextureSource(
+                width: 1,
+                height: 1,
+                rawRgba32Bytes: [255, 0, 0, 255],
+                colorProfile: ResoniteTextureColorProfiles.Srgb),
             CancellationToken.None);
 
         ResoniteTransportSlotCreationResult slot = await client.AddSlotAsync(

--- a/tests/PlateauResoniteLink.Tests/Transport/RetryingResoniteLinkClientTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Transport/RetryingResoniteLinkClientTests.cs
@@ -11,6 +11,8 @@ using TransportSlotLocator = PlateauResoniteLink.Transport.ResoniteLink.Resonite
 
 using ResoniteLink;
 
+using static PlateauResoniteLink.Tests.TextureImportSourceTestFactory;
+
 namespace PlateauResoniteLink.Tests.Transport;
 
 public sealed class RetryingResoniteLinkClientTests
@@ -142,7 +144,7 @@ public sealed class RetryingResoniteLinkClientTests
 
         await client.ConnectAsync(new Uri("ws://localhost:12345/"), CancellationToken.None);
         Uri importedTexture = await client.ImportTextureAsync(
-            new ResoniteRawTextureImport(1, 1, ResoniteTextureColorProfiles.Srgb, [1, 2, 3, 4]),
+            CreateRawTextureSource(1, 1, ResoniteTextureColorProfiles.Srgb, [1, 2, 3, 4]),
             CancellationToken.None);
 
         Assert.Equal(new Uri("resdb:///texture/ok", UriKind.Absolute), importedTexture);
@@ -176,7 +178,7 @@ public sealed class RetryingResoniteLinkClientTests
 
         await client.ConnectAsync(new Uri("ws://localhost:12345/"), CancellationToken.None);
         Uri importedTexture = await client.ImportTextureAsync(
-            new ResoniteRawTextureImport(1, 1, ResoniteTextureColorProfiles.Srgb, [1, 2, 3, 4]),
+            CreateRawTextureSource(1, 1, ResoniteTextureColorProfiles.Srgb, [1, 2, 3, 4]),
             CancellationToken.None);
 
         Assert.Equal(new Uri("resdb:///texture/ok", UriKind.Absolute), importedTexture);


### PR DESCRIPTION
## Summary
- remove raw texture compatibility records from diagnostics/tests and use `RawTexturePayload` / `ITextureImportSource` as the recording surface
- stream terrain tile encoded payloads through the persistent cache boundary instead of exposing tile `byte[]` APIs in the reader
- introduce raster content sources so GeoTIFF dataset/local raster access is opened through source interfaces, with stream metadata/image reads at the raster adapter boundary

## Commits
- `Remove raw texture import compatibility records`
- `Stream terrain tile encoded payloads through cache boundary`
- `Hide GeoTIFF raster access behind content sources`

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Result: `961 passed`