### PR TITLE
Fix source root placement and roof terrain overlay selection

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -232,22 +232,12 @@ internal static class CityGmlParsedCityObjectProjection
                 : null;
             ConstructionCityObjectDraft draft = ConstructionCityObjectDraft.FromParsedCityObject(partitionedCityObject.CityObject);
 
-            foreach (MaterialBinding material in request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
-                         && string.Equals(partitionedCityObject.CityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
-                            ? CityGmlSurfaceMaterialResolver.CreateDemTerrainGridMaterials(
-                                draft,
-                                cityObjectOrigin,
-                                cityObjectCartesian,
-                                partitionedCityObject.Overlay,
-                                request.MeshCode,
-                                requestedMeshCodeBounds,
-                                materialResolver)
-                            : CityGmlSurfaceMaterialResolver.CreateSharedCommonMaterialBindings(
-                                draft,
-                                cityObjectOrigin,
-                                cityObjectCartesian,
-                                partitionedCityObject.Overlay,
-                                materialResolver))
+            foreach (MaterialBinding material in CityGmlSurfaceMaterialResolver.CreateSharedCommonMaterialBindings(
+                         draft,
+                         cityObjectOrigin,
+                         cityObjectCartesian,
+                         partitionedCityObject.Overlay,
+                         materialResolver))
             {
                 yield return material;
             }

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectReader.cs
@@ -101,7 +101,8 @@ internal static class CityGmlParsedCityObjectReader
             SharedAcrossMeshCodes: sharedAcrossMeshCodes,
             FloorsAboveGround: floorsAboveGround,
             MeasuredHeightMeters: measuredHeightMeters,
-            BuildingAttributes: buildingAttributes);
+            BuildingAttributes: buildingAttributes,
+            SourceMeshCode: actualMeshCode);
     }
 
     private static string? GetAttribute(XElement element, XName attributeName)

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -79,6 +79,7 @@ internal static class CityGmlSurfaceMaterialResolver
                 cityObjectCartesian,
                 demTerrainTextureOverlay,
                 materialResolver)
+            .Where(static resolvedSurface => resolvedSurface.Material.TerrainOverlay is null)
             .GroupBy(
                 resolvedSurface => MaterialGroupingPolicy.CreateKey(
                     cityObject.ActualMeshCode,
@@ -154,6 +155,11 @@ internal static class CityGmlSurfaceMaterialResolver
                     requestedMeshCode: null,
                     requestedMeshCodeBounds: null,
                     representativeSurface.Material.TerrainOverlay);
+        TerrainOverlayMaterialBinding? terrainOverlayMaterial = representativeSurface.Material.TerrainOverlay is null
+            ? null
+            : new TerrainOverlayMaterialBinding(
+                ThirdRegionalMeshCode.Parse(terrainMeshCode!),
+                representativeSurface.Material.TerrainOverlay);
         ColorRgba baseColor = representativeSurface.Material.TerrainOverlay is null
             ? ToContractColor(representativeSurface.Surface.BaseColor)
             : new ColorRgba(1.0, 1.0, 1.0, 1.0);
@@ -180,9 +186,8 @@ internal static class CityGmlSurfaceMaterialResolver
             Family: representativeSurface.Material.Family,
             TextureOffset: representativeSurface.Material.TextureOffset,
             ReuseScope: representativeSurface.Material.ReuseScope,
-            TerrainOverlay: representativeSurface.Material.TerrainOverlay,
+            TerrainOverlayMaterial: terrainOverlayMaterial,
             BundledVariantIndex: representativeSurface.Material.BundledVariantIndex,
-            TerrainMeshCode: terrainMeshCode,
             CommonMaterial: commonMaterial);
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -146,7 +146,7 @@ internal static class CityGmlSurfaceMaterialResolver
         ResolvedSurfaceMaterial representativeSurface,
         int materialIndex)
     {
-        string? terrainMeshCode = representativeSurface.Material.TerrainOverlay is null
+        ThirdRegionalMeshCode? terrainMeshCode = representativeSurface.Material.TerrainOverlay is null
             ? null
             : TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, representativeSurface.Material.TerrainOverlay)
                 ?? throw TerrainOverlayDiagnostics.CreateMeshCodeMismatchException(
@@ -158,7 +158,7 @@ internal static class CityGmlSurfaceMaterialResolver
         TerrainOverlayMaterialBinding? terrainOverlayMaterial = representativeSurface.Material.TerrainOverlay is null
             ? null
             : new TerrainOverlayMaterialBinding(
-                ThirdRegionalMeshCode.Parse(terrainMeshCode!),
+                terrainMeshCode!.Value,
                 representativeSurface.Material.TerrainOverlay);
         ColorRgba baseColor = representativeSurface.Material.TerrainOverlay is null
             ? ToContractColor(representativeSurface.Surface.BaseColor)

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
@@ -134,12 +134,12 @@ internal static class CityGmlTriangleMeshCityObjectProjection
         TerrainTextureOverlay? demTerrainTextureOverlay)
     {
         if (demTerrainTextureOverlay is null
-            || TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, demTerrainTextureOverlay) is not { } terrainMeshCode
-            || MeshCodeBounds.TryParse(terrainMeshCode) is not { } meshCodeBounds)
+            || TerrainOverlayMeshCodeResolver.ResolveMeshCode(actualMeshCode, demTerrainTextureOverlay) is not { } terrainMeshCode)
         {
             return null;
         }
 
+        JisRegionalMeshBounds meshCodeBounds = terrainMeshCode.Bounds;
         return CreateDemUvProjection(
             meshCodeBounds.WestLongitude,
             meshCodeBounds.EastLongitude,

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedObjectModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedObjectModels.cs
@@ -48,4 +48,5 @@ internal sealed record ParsedCityObject(
     int? FloorsAboveGround = null,
     double? MeasuredHeightMeters = null,
     BuildingAttributeContext? BuildingAttributes = null,
-    double? GeometryHeightMeters = null);
+    double? GeometryHeightMeters = null,
+    string? SourceMeshCode = null);

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -191,6 +191,10 @@ public enum MaterialReuseScope
     Shared = 1,
 }
 
+public sealed record TerrainOverlayMaterialBinding(
+    ThirdRegionalMeshCode MeshCode,
+    TerrainTextureOverlay Overlay);
+
 public sealed record MaterialBinding(
     ColorRgba BaseColor,
     MaterialType MaterialType,
@@ -203,7 +207,11 @@ public sealed record MaterialBinding(
     string? Family = null,
     Float2? TextureOffset = null,
     MaterialReuseScope ReuseScope = MaterialReuseScope.PerObject,
-    TerrainTextureOverlay? TerrainOverlay = null,
+    TerrainOverlayMaterialBinding? TerrainOverlayMaterial = null,
     int? BundledVariantIndex = null,
-    string? TerrainMeshCode = null,
-    DefaultCommonMaterialMember? CommonMaterial = null);
+    DefaultCommonMaterialMember? CommonMaterial = null)
+{
+    public TerrainTextureOverlay? TerrainOverlay => TerrainOverlayMaterial?.Overlay;
+
+    public string? TerrainMeshCode => TerrainOverlayMaterial?.MeshCode.Value;
+}

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
@@ -205,7 +205,7 @@ internal static class TerrainOverlayMaterialSourcePartitioner
         {
             if (terrainMaterialGroups.Length == 1)
             {
-                string terrainMeshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
+                ThirdRegionalMeshCode terrainMeshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
                         materialSourceMeshCode,
                         materialSourceMeshCode,
                         requestedMeshCodeBounds,
@@ -219,7 +219,7 @@ internal static class TerrainOverlayMaterialSourcePartitioner
                 yield return (
                     cityObject with
                     {
-                        ActualMeshCode = terrainMeshCode,
+                        ActualMeshCode = terrainMeshCode.Value,
                         Surfaces = terrainMaterialGroups[0].Select(static entry => MarkTerrainOverlayMaterialSource(entry.Surface)).ToArray(),
                         GeodeticOriginOverride = cityObjectOrigin,
                     },
@@ -241,7 +241,7 @@ internal static class TerrainOverlayMaterialSourcePartitioner
         foreach (IGrouping<TerrainTextureOverlay, (ParsedSurface Surface, TerrainTextureOverlay Overlay)> group in terrainMaterialGroups)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            string terrainMeshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
+            ThirdRegionalMeshCode terrainMeshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
                     materialSourceMeshCode,
                     materialSourceMeshCode,
                     requestedMeshCodeBounds,
@@ -255,7 +255,7 @@ internal static class TerrainOverlayMaterialSourcePartitioner
             yield return (
                 cityObject with
                 {
-                    ActualMeshCode = terrainMeshCode,
+                    ActualMeshCode = terrainMeshCode.Value,
                     SlotKey = $"{cityObject.SlotKey}_terrain_{terrainMeshCode}",
                     DisplayName = $"{cityObject.DisplayName} ({partitionIndex + 1})",
                     Surfaces = group.Select(static entry => MarkTerrainOverlayMaterialSource(entry.Surface)).ToArray(),

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
@@ -103,6 +103,9 @@ internal static class TerrainOverlayMaterialSourcePartitioner
         }
 
         double cityObjectMinAltitude = CityObjectAltitudeMetricsResolver.GetMinimumAltitude(cityObjectVertices);
+        string materialSourceMeshCode = string.IsNullOrWhiteSpace(cityObject.SourceMeshCode)
+            ? cityObject.ActualMeshCode
+            : cityObject.SourceMeshCode;
 
         List<ParsedSurface> untexturedSurfaces = [];
         List<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> terrainOverlayMaterialSurfaces = [];
@@ -119,13 +122,26 @@ internal static class TerrainOverlayMaterialSourcePartitioner
 
             ParsedSurface terrainMaterialSurface = PrepareTerrainOverlayMaterialSurface(face);
 
-            TerrainTextureOverlay[] candidateOverlays = demTerrainTextureOverlays
-                .Where(overlay => TerrainOverlayMeshCodeResolver.IsRequestedOverlay(overlay, requestedMeshCodeBounds)
-                    || TerrainOverlayMeshCodeResolver.ResolveMeshCode(cityObject.ActualMeshCode, overlay) is not null)
-                .Where(overlay => TerrainOverlayMeshCodeResolver.BoundsOverlap(surfaceBounds, overlay.GeographicBounds))
-                .OrderBy(static overlay => overlay.GeographicBounds.MinLatitude)
-                .ThenBy(static overlay => overlay.GeographicBounds.MinLongitude)
+            TerrainTextureOverlay[] materialSourceOverlays = demTerrainTextureOverlays
+                .Where(overlay => TerrainOverlayMeshCodeResolver.ResolveMeshCode(materialSourceMeshCode, overlay) is not null)
                 .ToArray();
+            TerrainTextureOverlay[] candidateOverlays = materialSourceOverlays.Length == 0
+                ? demTerrainTextureOverlays
+                    .Where(overlay => TerrainOverlayMeshCodeResolver.IsRequestedOverlay(overlay, requestedMeshCodeBounds))
+                    .Where(overlay => TerrainOverlayMeshCodeResolver.BoundsOverlap(surfaceBounds, overlay.GeographicBounds))
+                    .OrderBy(static overlay => overlay.GeographicBounds.MinLatitude)
+                    .ThenBy(static overlay => overlay.GeographicBounds.MinLongitude)
+                    .ToArray()
+                : IsConcreteThirdMeshCode(materialSourceMeshCode)
+                    ? materialSourceOverlays
+                        .OrderBy(static overlay => overlay.GeographicBounds.MinLatitude)
+                        .ThenBy(static overlay => overlay.GeographicBounds.MinLongitude)
+                        .ToArray()
+                : materialSourceOverlays
+                    .Where(overlay => TerrainOverlayMeshCodeResolver.BoundsOverlap(surfaceBounds, overlay.GeographicBounds))
+                    .OrderBy(static overlay => overlay.GeographicBounds.MinLatitude)
+                    .ThenBy(static overlay => overlay.GeographicBounds.MinLongitude)
+                    .ToArray();
             if (candidateOverlays.Length == 0)
             {
                 TerrainTextureOverlay? overlappingOverlay = demTerrainTextureOverlays
@@ -134,8 +150,8 @@ internal static class TerrainOverlayMaterialSourcePartitioner
                 {
                     throw CreateTerrainOverlayMeshCodeMismatchException(
                         "non-dem-terrain-candidate",
-                        cityObject.ActualMeshCode,
-                        cityObject.ActualMeshCode,
+                        materialSourceMeshCode,
+                        materialSourceMeshCode,
                         requestedMeshCodeBounds,
                         overlappingOverlay);
                 }
@@ -190,14 +206,14 @@ internal static class TerrainOverlayMaterialSourcePartitioner
             if (terrainMaterialGroups.Length == 1)
             {
                 string terrainMeshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
-                        cityObject.ActualMeshCode,
-                        cityObject.ActualMeshCode,
+                        materialSourceMeshCode,
+                        materialSourceMeshCode,
                         requestedMeshCodeBounds,
                         terrainMaterialGroups[0].Key)
                     ?? throw CreateTerrainOverlayMeshCodeMismatchException(
                         "non-dem-terrain-single-partition",
-                        cityObject.ActualMeshCode,
-                        cityObject.ActualMeshCode,
+                        materialSourceMeshCode,
+                        materialSourceMeshCode,
                         requestedMeshCodeBounds,
                         terrainMaterialGroups[0].Key);
                 yield return (
@@ -226,14 +242,14 @@ internal static class TerrainOverlayMaterialSourcePartitioner
         {
             cancellationToken.ThrowIfCancellationRequested();
             string terrainMeshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
-                    cityObject.ActualMeshCode,
-                    cityObject.ActualMeshCode,
+                    materialSourceMeshCode,
+                    materialSourceMeshCode,
                     requestedMeshCodeBounds,
                     group.Key)
                 ?? throw CreateTerrainOverlayMeshCodeMismatchException(
                     "non-dem-terrain-partition",
-                    cityObject.ActualMeshCode,
-                    cityObject.ActualMeshCode,
+                    materialSourceMeshCode,
+                    materialSourceMeshCode,
                     requestedMeshCodeBounds,
                     group.Key);
             yield return (
@@ -279,6 +295,12 @@ internal static class TerrainOverlayMaterialSourcePartitioner
         return surface.Semantic == ParsedSurfaceSemantic.Roof
             ? surface
             : surface with { Semantic = ParsedSurfaceSemantic.Roof };
+    }
+
+    private static bool IsConcreteThirdMeshCode(string meshCode)
+    {
+        return meshCode.Length == 8
+            && meshCode.All(static character => character is >= '0' and <= '9');
     }
 
     private static bool CanUseTerrainOverlayMaterialSource(

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMeshCodeResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMeshCodeResolver.cs
@@ -9,19 +9,17 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal static class TerrainOverlayMeshCodeResolver
 {
-    internal static string? ResolveMeshCode(
+    internal static ThirdRegionalMeshCode? ResolveMeshCode(
         string actualMeshCode,
         TerrainTextureOverlay terrainOverlay)
     {
-        if (actualMeshCode.Length == 8
-            && MeshCodeBounds.TryParse(actualMeshCode) is { } actualMeshBounds
-            && BoundsApproximatelyEqual(actualMeshBounds, terrainOverlay.GeographicBounds))
+        if (ThirdRegionalMeshCode.TryParse(actualMeshCode, out ThirdRegionalMeshCode actualThirdMeshCode)
+            && BoundsApproximatelyEqual(actualThirdMeshCode.Bounds, terrainOverlay.GeographicBounds))
         {
-            return actualMeshCode;
+            return actualThirdMeshCode;
         }
 
-        if (actualMeshCode.Length != 6
-            || !actualMeshCode.All(static character => character is >= '0' and <= '9'))
+        if (!SecondRegionalMeshCode.TryParse(actualMeshCode, out SecondRegionalMeshCode secondMeshCode))
         {
             return null;
         }
@@ -32,11 +30,11 @@ internal static class TerrainOverlayMeshCodeResolver
             {
                 string thirdMeshCode = string.Create(
                     CultureInfo.InvariantCulture,
-                    $"{actualMeshCode}{latitudeIndex}{longitudeIndex}");
-                if (MeshCodeBounds.TryParse(thirdMeshCode) is { } thirdMeshBounds
-                    && BoundsApproximatelyEqual(thirdMeshBounds, terrainOverlay.GeographicBounds))
+                    $"{secondMeshCode.Value}{latitudeIndex}{longitudeIndex}");
+                if (ThirdRegionalMeshCode.TryParse(thirdMeshCode, out ThirdRegionalMeshCode candidateThirdMeshCode)
+                    && BoundsApproximatelyEqual(candidateThirdMeshCode.Bounds, terrainOverlay.GeographicBounds))
                 {
-                    return thirdMeshCode;
+                    return candidateThirdMeshCode;
                 }
             }
         }
@@ -56,16 +54,16 @@ internal static class TerrainOverlayMeshCodeResolver
             return actualMeshCode;
         }
 
-        return ResolveMeshCode(requestedMeshCode, terrainOverlay)
+        return ResolveMeshCode(requestedMeshCode, terrainOverlay)?.Value
             ?? ResolveFromRequestedMeshCodeBounds(
                 actualMeshCode,
                 requestedMeshCode,
                 requestedMeshCodeBounds,
-                terrainOverlay)
+                terrainOverlay)?.Value
             ?? requestedMeshCode;
     }
 
-    internal static string? ResolveForOverlay(
+    internal static ThirdRegionalMeshCode? ResolveForOverlay(
         string actualMeshCode,
         string requestedMeshCode,
         IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
@@ -113,7 +111,7 @@ internal static class TerrainOverlayMeshCodeResolver
             && inner.MaxLongitude <= outer.MaxLongitude;
     }
 
-    private static string? ResolveFromRequestedMeshCodeBounds(
+    private static ThirdRegionalMeshCode? ResolveFromRequestedMeshCodeBounds(
         string actualMeshCode,
         string requestedMeshCode,
         IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
@@ -149,7 +147,7 @@ internal static class TerrainOverlayMeshCodeResolver
         return null;
     }
 
-    private static string? ResolveThirdMeshCodeFromOverlayBounds(TerrainTextureOverlay terrainOverlay)
+    private static ThirdRegionalMeshCode? ResolveThirdMeshCodeFromOverlayBounds(TerrainTextureOverlay terrainOverlay)
     {
         const double firstLatitudeSpan = 40.0 / 60.0;
         const double firstLongitudeSpan = 1.0;
@@ -197,6 +195,17 @@ internal static class TerrainOverlayMeshCodeResolver
             .Where(static meshCode => meshCode.Length >= 6 && meshCode.All(static character => character is >= '0' and <= '9'))
             .Select(static meshCode => meshCode[..6])
             .Distinct(StringComparer.Ordinal);
+    }
+
+    private static bool BoundsApproximatelyEqual(
+        JisRegionalMeshBounds meshBounds,
+        GeographicRectangle geographicBounds)
+    {
+        const double tolerance = 1e-8;
+        return Math.Abs(meshBounds.SouthLatitude - geographicBounds.MinLatitude) <= tolerance
+            && Math.Abs(meshBounds.NorthLatitude - geographicBounds.MaxLatitude) <= tolerance
+            && Math.Abs(meshBounds.WestLongitude - geographicBounds.MinLongitude) <= tolerance
+            && Math.Abs(meshBounds.EastLongitude - geographicBounds.MaxLongitude) <= tolerance;
     }
 
     private static bool BoundsApproximatelyEqual(

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
@@ -4,10 +4,19 @@ using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Application.Importing;
 
-public abstract record ValidatedDatasetLocation(DatasetSourceKind SourceKind);
+public abstract record ValidatedDatasetLocation(DatasetSourceKind SourceKind)
+{
+    public abstract DatasetLocation ToDatasetLocation();
+}
 
 public sealed record ValidatedLocalDatasetLocation(string LocalSourcePath)
-    : ValidatedDatasetLocation(DatasetSourceKind.Local);
+    : ValidatedDatasetLocation(DatasetSourceKind.Local)
+{
+    public override DatasetLocation ToDatasetLocation() => new LocalDatasetLocation(LocalSourcePath);
+}
 
 public sealed record ValidatedRemoteDatasetLocation(Uri ServerUri)
-    : ValidatedDatasetLocation(DatasetSourceKind.Remote);
+    : ValidatedDatasetLocation(DatasetSourceKind.Remote)
+{
+    public override DatasetLocation ToDatasetLocation() => new RemoteDatasetLocation(ServerUri);
+}

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedPlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedPlateauImportRequest.cs
@@ -36,19 +36,8 @@ public sealed record ValidatedPlateauImportRequest(
 
     public PlateauImportRequest ToImportRequest()
     {
-        DatasetLocation rawCityGmlSource = CityGmlSource switch
-        {
-            ValidatedLocalDatasetLocation localSource => new LocalDatasetLocation(localSource.LocalSourcePath),
-            ValidatedRemoteDatasetLocation remoteSource => new RemoteDatasetLocation(remoteSource.ServerUri),
-            _ => throw new InvalidOperationException($"Unsupported validated CityGML source kind '{CityGmlSourceKind}'."),
-        };
-        DatasetLocation? rawDemTextureSource = DemTextureSource switch
-        {
-            null => null,
-            ValidatedLocalDatasetLocation localSource => new LocalDatasetLocation(localSource.LocalSourcePath),
-            ValidatedRemoteDatasetLocation remoteSource => new RemoteDatasetLocation(remoteSource.ServerUri),
-            _ => throw new InvalidOperationException($"Unsupported validated terrain texture source kind '{DemTextureSourceKind}'."),
-        };
+        DatasetLocation rawCityGmlSource = CityGmlSource.ToDatasetLocation();
+        DatasetLocation? rawDemTextureSource = DemTextureSource?.ToDatasetLocation();
 
         return new PlateauImportRequest(
             Dataset,

--- a/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Globalization;
+using System.Linq;
+
+namespace PlateauResoniteLink.Domain.Importing;
+
+public sealed record JisRegionalMeshBounds(
+    double SouthLatitude,
+    double NorthLatitude,
+    double WestLongitude,
+    double EastLongitude);
+
+public readonly record struct FirstRegionalMeshCode
+{
+    private FirstRegionalMeshCode(string value)
+    {
+        Value = value;
+    }
+
+    public string Value { get; }
+
+    public JisRegionalMeshBounds Bounds => JisRegionalMeshCodeCalculator.GetBounds(Value);
+
+    public static bool TryParse(string? value, out FirstRegionalMeshCode meshCode)
+    {
+        if (JisRegionalMeshCodeCalculator.IsValid(value, 4))
+        {
+            meshCode = new FirstRegionalMeshCode(value!);
+            return true;
+        }
+
+        meshCode = default;
+        return false;
+    }
+
+    public static FirstRegionalMeshCode Parse(string value)
+    {
+        return TryParse(value, out FirstRegionalMeshCode meshCode)
+            ? meshCode
+            : throw new ArgumentException("JIS X 0410 first regional mesh code must be a valid 4-digit code.", nameof(value));
+    }
+
+    public override string ToString() => Value;
+}
+
+public readonly record struct SecondRegionalMeshCode
+{
+    private SecondRegionalMeshCode(string value)
+    {
+        Value = value;
+    }
+
+    public string Value { get; }
+
+    public JisRegionalMeshBounds Bounds => JisRegionalMeshCodeCalculator.GetBounds(Value);
+
+    public FirstRegionalMeshCode Parent => FirstRegionalMeshCode.Parse(Value[..4]);
+
+    public static bool TryParse(string? value, out SecondRegionalMeshCode meshCode)
+    {
+        if (JisRegionalMeshCodeCalculator.IsValid(value, 6))
+        {
+            meshCode = new SecondRegionalMeshCode(value!);
+            return true;
+        }
+
+        meshCode = default;
+        return false;
+    }
+
+    public static SecondRegionalMeshCode Parse(string value)
+    {
+        return TryParse(value, out SecondRegionalMeshCode meshCode)
+            ? meshCode
+            : throw new ArgumentException("JIS X 0410 second regional mesh code must be a valid 6-digit code.", nameof(value));
+    }
+
+    public override string ToString() => Value;
+}
+
+public readonly record struct ThirdRegionalMeshCode
+{
+    private ThirdRegionalMeshCode(string value)
+    {
+        Value = value;
+    }
+
+    public string Value { get; }
+
+    public JisRegionalMeshBounds Bounds => JisRegionalMeshCodeCalculator.GetBounds(Value);
+
+    public SecondRegionalMeshCode Parent => SecondRegionalMeshCode.Parse(Value[..6]);
+
+    public FirstRegionalMeshCode FirstMesh => FirstRegionalMeshCode.Parse(Value[..4]);
+
+    public static bool TryParse(string? value, out ThirdRegionalMeshCode meshCode)
+    {
+        if (JisRegionalMeshCodeCalculator.IsValid(value, 8))
+        {
+            meshCode = new ThirdRegionalMeshCode(value!);
+            return true;
+        }
+
+        meshCode = default;
+        return false;
+    }
+
+    public static ThirdRegionalMeshCode Parse(string value)
+    {
+        return TryParse(value, out ThirdRegionalMeshCode meshCode)
+            ? meshCode
+            : throw new ArgumentException("JIS X 0410 third regional mesh code must be a valid 8-digit code.", nameof(value));
+    }
+
+    public override string ToString() => Value;
+}
+
+internal static class JisRegionalMeshCodeCalculator
+{
+    internal static bool IsValid(string? meshCode, int length)
+    {
+        return meshCode is not null
+            && meshCode.Length == length
+            && meshCode.All(static character => character is >= '0' and <= '9')
+            && TryGetBounds(meshCode, out _);
+    }
+
+    internal static JisRegionalMeshBounds GetBounds(string meshCode)
+    {
+        return TryGetBounds(meshCode, out JisRegionalMeshBounds? bounds)
+            ? bounds!
+            : throw new ArgumentException("JIS X 0410 regional mesh code is invalid.", nameof(meshCode));
+    }
+
+    internal static bool TryGetBounds(string meshCode, out JisRegionalMeshBounds? bounds)
+    {
+        bounds = null;
+
+        if (string.IsNullOrWhiteSpace(meshCode)
+            || (meshCode.Length != 4 && meshCode.Length != 6 && meshCode.Length != 8)
+            || !meshCode.All(static character => character is >= '0' and <= '9'))
+        {
+            return false;
+        }
+
+        int firstLatitudeIndex = int.Parse(meshCode[..2], CultureInfo.InvariantCulture);
+        int firstLongitudeIndex = int.Parse(meshCode[2..4], CultureInfo.InvariantCulture);
+
+        double southLatitude = firstLatitudeIndex / 1.5;
+        double westLongitude = 100.0 + firstLongitudeIndex;
+        double latitudeSpan = 40.0 / 60.0;
+        double longitudeSpan = 1.0;
+
+        if (meshCode.Length >= 6)
+        {
+            int secondLatitudeIndex = int.Parse(meshCode[4].ToString(), CultureInfo.InvariantCulture);
+            int secondLongitudeIndex = int.Parse(meshCode[5].ToString(), CultureInfo.InvariantCulture);
+            if (secondLatitudeIndex > 7 || secondLongitudeIndex > 7)
+            {
+                return false;
+            }
+
+            latitudeSpan /= 8.0;
+            longitudeSpan /= 8.0;
+            southLatitude += secondLatitudeIndex * latitudeSpan;
+            westLongitude += secondLongitudeIndex * longitudeSpan;
+        }
+
+        if (meshCode.Length >= 8)
+        {
+            int thirdLatitudeIndex = int.Parse(meshCode[6].ToString(), CultureInfo.InvariantCulture);
+            int thirdLongitudeIndex = int.Parse(meshCode[7].ToString(), CultureInfo.InvariantCulture);
+            if (thirdLatitudeIndex > 9 || thirdLongitudeIndex > 9)
+            {
+                return false;
+            }
+
+            latitudeSpan /= 10.0;
+            longitudeSpan /= 10.0;
+            southLatitude += thirdLatitudeIndex * latitudeSpan;
+            westLongitude += thirdLongitudeIndex * longitudeSpan;
+        }
+
+        bounds = new JisRegionalMeshBounds(
+            southLatitude,
+            southLatitude + latitudeSpan,
+            westLongitude,
+            westLongitude + longitudeSpan);
+        return true;
+    }
+}

--- a/src/PlateauResoniteLink/Domain/Importing/PlateauMeshCode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/PlateauMeshCode.cs
@@ -1,6 +1,3 @@
-using System.Globalization;
-using System.Linq;
-
 namespace PlateauResoniteLink.Domain.Importing;
 
 public static class PlateauMeshCode
@@ -27,56 +24,17 @@ public static class PlateauMeshCode
     {
         bounds = default;
 
-        if (string.IsNullOrWhiteSpace(meshCode)
-            || (meshCode.Length != 6 && meshCode.Length != 8)
-            || !meshCode.All(char.IsDigit))
+        if (!JisRegionalMeshCodeCalculator.TryGetBounds(meshCode, out JisRegionalMeshBounds? jisBounds)
+            || meshCode.Length == 4)
         {
             return false;
         }
 
-        int firstLatitudeIndex = int.Parse(meshCode[..2], CultureInfo.InvariantCulture);
-        int firstLongitudeIndex = int.Parse(meshCode[2..4], CultureInfo.InvariantCulture);
-
-        double southLatitude = firstLatitudeIndex / 1.5;
-        double westLongitude = 100.0 + firstLongitudeIndex;
-        double latitudeSpan = 40.0 / 60.0;
-        double longitudeSpan = 1.0;
-
-        if (meshCode.Length >= 6)
-        {
-            int secondLatitudeIndex = int.Parse(meshCode[4].ToString(), CultureInfo.InvariantCulture);
-            int secondLongitudeIndex = int.Parse(meshCode[5].ToString(), CultureInfo.InvariantCulture);
-            if (secondLatitudeIndex > 7 || secondLongitudeIndex > 7)
-            {
-                return false;
-            }
-
-            latitudeSpan /= 8.0;
-            longitudeSpan /= 8.0;
-            southLatitude += secondLatitudeIndex * latitudeSpan;
-            westLongitude += secondLongitudeIndex * longitudeSpan;
-        }
-
-        if (meshCode.Length >= 8)
-        {
-            int thirdLatitudeIndex = int.Parse(meshCode[6].ToString(), CultureInfo.InvariantCulture);
-            int thirdLongitudeIndex = int.Parse(meshCode[7].ToString(), CultureInfo.InvariantCulture);
-            if (thirdLatitudeIndex > 9 || thirdLongitudeIndex > 9)
-            {
-                return false;
-            }
-
-            latitudeSpan /= 10.0;
-            longitudeSpan /= 10.0;
-            southLatitude += thirdLatitudeIndex * latitudeSpan;
-            westLongitude += thirdLongitudeIndex * longitudeSpan;
-        }
-
         bounds = (
-            SouthLatitude: southLatitude,
-            NorthLatitude: southLatitude + latitudeSpan,
-            WestLongitude: westLongitude,
-            EastLongitude: westLongitude + longitudeSpan);
+            SouthLatitude: jisBounds!.SouthLatitude,
+            NorthLatitude: jisBounds.NorthLatitude,
+            WestLongitude: jisBounds.WestLongitude,
+            EastLongitude: jisBounds.EastLongitude);
         return true;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
@@ -13,7 +13,7 @@ namespace PlateauResoniteLink.Targets.Resonite.Execution;
 
 internal interface IResoniteGeometryAssetAssembler
 {
-    Task<UploadedGeometryAssetBatch> PrepareTriangleMeshAsync(
+    Task<UploadedTriangleMeshAssetBatch> PrepareTriangleMeshAsync(
         IResoniteLinkClient importClient,
         string meshAssetSlotName,
         string displayName,
@@ -21,7 +21,7 @@ internal interface IResoniteGeometryAssetAssembler
         Action<string>? progressReporter,
         CancellationToken cancellationToken);
 
-    Task<UploadedGeometryAssetBatch> PrepareTerrainGridAsync(
+    Task<UploadedTerrainGridAssetBatch> PrepareTerrainGridAsync(
         IResoniteLinkClient importClient,
         string meshAssetSlotName,
         string heightMapAssetSlotName,
@@ -36,7 +36,7 @@ internal interface IResoniteGeometryAssetAssembler
 
 internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAssembler
 {
-    public async Task<UploadedGeometryAssetBatch> PrepareTriangleMeshAsync(
+    public async Task<UploadedTriangleMeshAssetBatch> PrepareTriangleMeshAsync(
         IResoniteLinkClient importClient,
         string meshAssetSlotName,
         string displayName,
@@ -54,7 +54,7 @@ internal sealed class ResoniteGeometryAssetAssembler : IResoniteGeometryAssetAss
         return new UploadedTriangleMeshAssetBatch(meshAssetSlotName, assetUri);
     }
 
-    public async Task<UploadedGeometryAssetBatch> PrepareTerrainGridAsync(
+    public async Task<UploadedTerrainGridAssetBatch> PrepareTerrainGridAsync(
         IResoniteLinkClient importClient,
         string meshAssetSlotName,
         string heightMapAssetSlotName,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
@@ -93,7 +93,7 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
             TextureScale = null,
             TextureOffset = null,
             Family = null,
-            TerrainOverlay = null,
+            TerrainOverlayMaterial = null,
             AssetScope = ResoniteMaterialAssetScope.Common,
             SubmeshIndices = [submeshIndex],
             CommonMaterial = material.DepthOffset is null

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
@@ -357,10 +357,17 @@ internal sealed record PreparedCityObject(
     PreparedConstructionGeometry Geometry,
     IReadOnlyList<PreparedTextureReference> Textures);
 
-internal sealed record PreparedTextureReference(
+internal abstract record PreparedTextureReference(
+    ITextureImportSource TextureSource);
+
+internal sealed record PreparedMaterialTextureReference(
     ResoniteTexturePayload? TexturePayload,
     ResoniteTextureSourceKind TextureSourceKind,
-    ITextureImportSource TextureSource,
-    ThirdRegionalMeshCode? TerrainMeshCode = null,
-    TerrainTextureOverlay? TerrainOverlay = null,
-    GeneratedTerrainTexture? GeneratedTerrainTexture = null);
+    ITextureImportSource TextureSource)
+    : PreparedTextureReference(TextureSource);
+
+internal sealed record PreparedTerrainOverlayTextureReference(
+    ThirdRegionalMeshCode MeshCode,
+    TerrainTextureOverlay Overlay,
+    GeneratedTerrainTexture GeneratedTerrainTexture)
+    : PreparedTextureReference(GeneratedTerrainTexture.TextureSource);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
@@ -361,6 +361,6 @@ internal sealed record PreparedTextureReference(
     ResoniteTexturePayload? TexturePayload,
     ResoniteTextureSourceKind TextureSourceKind,
     ITextureImportSource TextureSource,
-    string? TerrainMeshCode = null,
+    ThirdRegionalMeshCode? TerrainMeshCode = null,
     TerrainTextureOverlay? TerrainOverlay = null,
     GeneratedTerrainTexture? GeneratedTerrainTexture = null);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialAsset.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialAsset.cs
@@ -114,8 +114,6 @@ internal static class ResoniteCommonMaterialSlots
 {
     public static string GetSlotName(ResoniteMaterialBinding material)
     {
-        return ResoniteSceneMaterialConventions.CreateMaterialSlotName(
-            material,
-            useCommonMaterialAssets: true);
+        return ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteGeometryAssetPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteGeometryAssetPlanner.cs
@@ -65,14 +65,14 @@ internal sealed class ResoniteGeometryAssetPlanner(
                     cancellationToken)),
             PreparedDynamicTerrainGeometry dynamicTerrain => CreatePlannedDynamicTerrainGeometryAsset(
                 cityObject,
-                AssertUploadedTriangleMeshAssetBatch(await geometryAssetAssembler.PrepareTriangleMeshAsync(
+                await geometryAssetAssembler.PrepareTriangleMeshAsync(
                     importClient,
                     CreateMeshAssetSlotName(cityObject),
                     cityObject.DisplayName,
                     dynamicTerrain.StaticMesh.MeshSource,
                     progressReporter,
-                    cancellationToken)),
-                AssertUploadedTerrainGridAssetBatch(await geometryAssetAssembler.PrepareTerrainGridAsync(
+                    cancellationToken),
+                await geometryAssetAssembler.PrepareTerrainGridAsync(
                     importClient,
                     CreateMeshAssetSlotName(cityObject),
                     CreateTerrainGridAssetSlotName(cityObject),
@@ -82,38 +82,44 @@ internal sealed class ResoniteGeometryAssetPlanner(
                     ResoniteCityObjectPreparation.ResolveTerrainGridUvScale(cityObject, dynamicTerrain.GridMesh.Geometry, preparedTerrainTextureDataByOverlay),
                     ResoniteCityObjectPreparation.ResolveTerrainGridUvOffset(cityObject, dynamicTerrain.GridMesh.Geometry, preparedTerrainTextureDataByOverlay),
                     progressReporter,
-                    cancellationToken))),
+                    cancellationToken)),
             _ => throw new InvalidOperationException(
                 $"Unsupported prepared geometry type '{preparedCityObject.Geometry.GetType().Name}'."),
         };
     }
 
-    private static PlannedGeometryAsset CreatePlannedGeometryAsset(
+    private static PlannedTriangleMeshGeometryAsset CreatePlannedGeometryAsset(
         ResoniteConstructionCityObject cityObject,
-        UploadedGeometryAssetBatch uploadedGeometryBatch)
+        UploadedTriangleMeshAssetBatch uploadedGeometryBatch)
     {
         GeometryIdentity identity = new(
             string.Create(
                 CultureInfo.InvariantCulture,
                 $"geometry-{cityObject.PackageName}-{cityObject.SlotKey}-{uploadedGeometryBatch.MeshAssetSlotName}"));
 
-        return uploadedGeometryBatch switch
-        {
-            UploadedTriangleMeshAssetBatch triangleMesh => new PlannedTriangleMeshGeometryAsset(
-                identity,
-                triangleMesh.MeshAssetSlotName,
-                triangleMesh.MeshUri),
-            UploadedTerrainGridAssetBatch heightMap => new PlannedTerrainGridGeometryAsset(
-                identity,
-                heightMap.MeshAssetSlotName,
-                heightMap.TerrainGridAssetSlotName,
-                heightMap.Geometry,
-                heightMap.HeightTextureUri,
-                heightMap.UvScale,
-                heightMap.UvOffset),
-            _ => throw new InvalidOperationException(
-                $"Unsupported uploaded geometry asset batch type '{uploadedGeometryBatch.GetType().Name}'."),
-        };
+        return new PlannedTriangleMeshGeometryAsset(
+            identity,
+            uploadedGeometryBatch.MeshAssetSlotName,
+            uploadedGeometryBatch.MeshUri);
+    }
+
+    private static PlannedTerrainGridGeometryAsset CreatePlannedGeometryAsset(
+        ResoniteConstructionCityObject cityObject,
+        UploadedTerrainGridAssetBatch uploadedGeometryBatch)
+    {
+        GeometryIdentity identity = new(
+            string.Create(
+                CultureInfo.InvariantCulture,
+                $"geometry-{cityObject.PackageName}-{cityObject.SlotKey}-{uploadedGeometryBatch.MeshAssetSlotName}"));
+
+        return new PlannedTerrainGridGeometryAsset(
+            identity,
+            uploadedGeometryBatch.MeshAssetSlotName,
+            uploadedGeometryBatch.TerrainGridAssetSlotName,
+            uploadedGeometryBatch.Geometry,
+            uploadedGeometryBatch.HeightTextureUri,
+            uploadedGeometryBatch.UvScale,
+            uploadedGeometryBatch.UvOffset);
     }
 
     private static PlannedDynamicTerrainGeometryAsset CreatePlannedDynamicTerrainGeometryAsset(
@@ -135,22 +141,6 @@ internal sealed class ResoniteGeometryAssetPlanner(
             gridMeshBatch.HeightTextureUri,
             gridMeshBatch.UvScale,
             gridMeshBatch.UvOffset);
-    }
-
-    private static UploadedTriangleMeshAssetBatch AssertUploadedTriangleMeshAssetBatch(
-        UploadedGeometryAssetBatch uploadedGeometryBatch)
-    {
-        return uploadedGeometryBatch as UploadedTriangleMeshAssetBatch
-            ?? throw new InvalidOperationException(
-                $"Unsupported uploaded static terrain asset batch type '{uploadedGeometryBatch.GetType().Name}'.");
-    }
-
-    private static UploadedTerrainGridAssetBatch AssertUploadedTerrainGridAssetBatch(
-        UploadedGeometryAssetBatch uploadedGeometryBatch)
-    {
-        return uploadedGeometryBatch as UploadedTerrainGridAssetBatch
-            ?? throw new InvalidOperationException(
-                $"Unsupported uploaded terrain grid asset batch type '{uploadedGeometryBatch.GetType().Name}'.");
     }
 
     private static string CreateMeshAssetSlotName(ResoniteConstructionCityObject cityObject)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialBinding.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialBinding.cs
@@ -17,7 +17,11 @@ public sealed record ResoniteMaterialBinding(
     string? Family = null,
     ResoniteFloat2? TextureOffset = null,
     ResoniteMaterialAssetScope AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped,
-    TerrainTextureOverlay? TerrainOverlay = null,
+    TerrainOverlayMaterialBinding? TerrainOverlayMaterial = null,
     int? BundledVariantIndex = null,
-    string? TerrainMeshCode = null,
-    DefaultCommonMaterialMember? CommonMaterial = null);
+    DefaultCommonMaterialMember? CommonMaterial = null)
+{
+    public TerrainTextureOverlay? TerrainOverlay => TerrainOverlayMaterial?.Overlay;
+
+    public string? TerrainMeshCode => TerrainOverlayMaterial?.MeshCode.Value;
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedCityObjectImporter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedCityObjectImporter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -152,12 +153,9 @@ internal sealed class ResonitePreparedCityObjectImporter(
         PreparedCityObject preparedCityObject)
     {
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> generatedTerrainTexturesByOverlay = [];
-        foreach (PreparedTextureReference texture in preparedCityObject.Textures)
+        foreach (PreparedTerrainOverlayTextureReference texture in preparedCityObject.Textures.OfType<PreparedTerrainOverlayTextureReference>())
         {
-            if (texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
-            {
-                generatedTerrainTexturesByOverlay.TryAdd(texture.TerrainOverlay, texture.GeneratedTerrainTexture);
-            }
+            generatedTerrainTexturesByOverlay.TryAdd(texture.Overlay, texture.GeneratedTerrainTexture);
         }
 
         return generatedTerrainTexturesByOverlay;

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedTextureUploader.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedTextureUploader.cs
@@ -16,7 +16,7 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal sealed record ResoniteUploadedTextureAssetSet(
     Dictionary<ResoniteTexturePayload, Uri> TextureUrisByPayload,
     Dictionary<TerrainTextureOverlay, Uri> TerrainTextureUrisByOverlay,
-    Dictionary<string, ResoniteComponentLocator> TerrainTexturePropertyBlockComponentsByMeshCode);
+    Dictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> TerrainTexturePropertyBlockComponentsByMeshCode);
 
 internal static class ResonitePreparedTextureUploader
 {
@@ -28,35 +28,38 @@ internal static class ResonitePreparedTextureUploader
     {
         Dictionary<ResoniteTexturePayload, Uri> textureUrisByPayload = new(ResoniteTexturePayloadReferenceComparer.Instance);
         Dictionary<TerrainTextureOverlay, Uri> terrainTextureUrisByOverlay = [];
-        Dictionary<string, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode = new(StringComparer.Ordinal);
+        Dictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode = [];
         HashSet<ResoniteTexturePayload> queuedPayloads = new(ResoniteTexturePayloadReferenceComparer.Instance);
-        List<(PreparedTextureReference Texture, Task<Uri> ImportTask)> textureImportTasks = [];
-        List<(PreparedTextureReference Texture, Task<SharedTerrainTextureAsset> ImportTask)> terrainTextureImportTasks = [];
+        List<(PreparedMaterialTextureReference Texture, Task<Uri> ImportTask)> textureImportTasks = [];
+        List<(PreparedTerrainOverlayTextureReference Texture, Task<SharedTerrainTextureAsset> ImportTask)> terrainTextureImportTasks = [];
 
         foreach (PreparedTextureReference texture in preparedCityObject.Textures)
         {
-            if (texture.TexturePayload is not null && !queuedPayloads.Add(texture.TexturePayload))
+            if (texture is PreparedMaterialTextureReference materialTexture)
             {
+                if (materialTexture.TexturePayload is not null && !queuedPayloads.Add(materialTexture.TexturePayload))
+                {
+                    continue;
+                }
+
+                textureImportTasks.Add((
+                    materialTexture,
+                    importClient.ImportTextureAsync(materialTexture.TextureSource, cancellationToken)));
                 continue;
             }
 
-            if (texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
+            if (texture is PreparedTerrainOverlayTextureReference terrainTexture)
             {
-                string meshCode = ResolveTerrainTextureMeshCode(texture);
                 terrainTextureImportTasks.Add((
-                    texture,
+                    terrainTexture,
                     EnsureSharedTerrainTextureAssetAsync(
                         state,
                         importClient,
-                        meshCode,
-                        texture.TextureSource,
+                        terrainTexture.MeshCode,
+                        terrainTexture.TextureSource,
                         cancellationToken)));
                 continue;
             }
-
-            textureImportTasks.Add((
-                texture,
-                importClient.ImportTextureAsync(texture.TextureSource, cancellationToken)));
         }
 
         Task[] importTasks = textureImportTasks
@@ -65,7 +68,7 @@ internal static class ResonitePreparedTextureUploader
             .ToArray();
         await Task.WhenAll(importTasks);
 
-        foreach ((PreparedTextureReference texture, Task<Uri> importTask) in textureImportTasks)
+        foreach ((PreparedMaterialTextureReference texture, Task<Uri> importTask) in textureImportTasks)
         {
             Uri textureUri = await importTask;
             if (texture.TexturePayload is not null)
@@ -74,12 +77,11 @@ internal static class ResonitePreparedTextureUploader
             }
         }
 
-        foreach ((PreparedTextureReference texture, Task<SharedTerrainTextureAsset> importTask) in terrainTextureImportTasks)
+        foreach ((PreparedTerrainOverlayTextureReference texture, Task<SharedTerrainTextureAsset> importTask) in terrainTextureImportTasks)
         {
             SharedTerrainTextureAsset sharedTexture = await importTask;
-            string meshCode = ResolveTerrainTextureMeshCode(texture);
-            terrainTextureUrisByOverlay.Add(texture.TerrainOverlay!, sharedTexture.TextureUri);
-            terrainTexturePropertyBlockComponentsByMeshCode.TryAdd(meshCode, sharedTexture.MainTexturePropertyBlockComponent.Locator);
+            terrainTextureUrisByOverlay.Add(texture.Overlay, sharedTexture.TextureUri);
+            terrainTexturePropertyBlockComponentsByMeshCode.TryAdd(texture.MeshCode, sharedTexture.MainTexturePropertyBlockComponent.Locator);
         }
 
         return new ResoniteUploadedTextureAssetSet(
@@ -91,12 +93,12 @@ internal static class ResonitePreparedTextureUploader
     private static Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetAsync(
         LiveSendRunState state,
         IResoniteLinkClient importClient,
-        string meshCode,
+        ThirdRegionalMeshCode meshCode,
         ITextureImportSource textureSource,
         CancellationToken cancellationToken)
     {
         return state.TerrainTextures.AssetsByMeshCode.GetOrCreateAsync(
-            meshCode,
+            meshCode.Value,
             () => EnsureSharedTerrainTextureAssetCoreAsync(state, importClient, meshCode, textureSource, cancellationToken),
             cancellationToken);
     }
@@ -104,7 +106,7 @@ internal static class ResonitePreparedTextureUploader
     private static async Task<SharedTerrainTextureAsset> EnsureSharedTerrainTextureAssetCoreAsync(
         LiveSendRunState state,
         IResoniteLinkClient importClient,
-        string meshCode,
+        ThirdRegionalMeshCode meshCode,
         ITextureImportSource textureSource,
         CancellationToken cancellationToken)
     {
@@ -116,7 +118,7 @@ internal static class ResonitePreparedTextureUploader
         CreatedSlot meshSlot = await state.Placement.GetOrCreateSharedChildSlotAsync(
             importClient,
             terrainTexturesRoot.Locator,
-            meshCode,
+            meshCode.Value,
             cancellationToken);
         SharedTerrainTextureAsset? existingTexture = await TryFindSharedTerrainTextureAssetAsync(
             importClient,
@@ -246,15 +248,4 @@ internal static class ResonitePreparedTextureUploader
             && wrapModeVMember is Field_Enum { Value: "Clamp" };
     }
 
-    private static string ResolveTerrainTextureMeshCode(PreparedTextureReference texture)
-    {
-        if (texture.TerrainMeshCode is not { } meshCode)
-        {
-            throw new InvalidOperationException(
-                "Terrain texture overlay preparation requires a valid third-level mesh-code. "
-                + $"provided_mesh='{texture.TerrainMeshCode?.Value ?? "<null>"}'.");
-        }
-
-        return meshCode.Value;
-    }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedTextureUploader.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedTextureUploader.cs
@@ -248,15 +248,13 @@ internal static class ResonitePreparedTextureUploader
 
     private static string ResolveTerrainTextureMeshCode(PreparedTextureReference texture)
     {
-        if (texture.TerrainMeshCode is not { Length: > 0 } meshCode
-            || meshCode.Length != 8
-            || !PlateauMeshCode.TryGetBounds(meshCode, out _))
+        if (texture.TerrainMeshCode is not { } meshCode)
         {
             throw new InvalidOperationException(
                 "Terrain texture overlay preparation requires a valid third-level mesh-code. "
-                + $"provided_mesh='{texture.TerrainMeshCode ?? "<null>"}'.");
+                + $"provided_mesh='{texture.TerrainMeshCode?.Value ?? "<null>"}'.");
         }
 
-        return meshCode;
+        return meshCode.Value;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparation.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparation.cs
@@ -109,10 +109,10 @@ internal sealed class ResoniteQueuedCityObjectPreparation(
             cancellationToken);
         PreparedConstructionGeometry preparedGeometry = await geometryPreparationTask.WaitAsync(cancellationToken);
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextureDataByOverlay = preparedTextures
-            .Where(static texture => texture is { TerrainOverlay: not null, GeneratedTerrainTexture: not null })
+            .OfType<PreparedTerrainOverlayTextureReference>()
             .ToDictionary(
-                static texture => texture.TerrainOverlay!,
-                static texture => texture.GeneratedTerrainTexture!);
+                static texture => texture.Overlay,
+                static texture => texture.GeneratedTerrainTexture);
         cityObject = ResoniteCityObjectPreparation.ApplyTerrainTextureCanvasUv(
             cityObject,
             preparedTerrainTextureDataByOverlay,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
@@ -112,13 +112,10 @@ internal sealed class ResoniteQueuedTexturePreparer(
             }
         }
 
-        return new PreparedTextureReference(
-            TexturePayload: null,
-            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-            TextureSource: terrainTexture.TextureSource,
-            TerrainMeshCode: terrainMeshCode,
-            TerrainOverlay: terrainTextureOverlay,
-            GeneratedTerrainTexture: terrainTexture);
+        return new PreparedTerrainOverlayTextureReference(
+            terrainMeshCode,
+            terrainTextureOverlay,
+            terrainTexture);
     }
 
     private static TerrainTextureSource[] GetTrackedTerrainTextureSources(
@@ -197,12 +194,10 @@ internal sealed class ResoniteQueuedTexturePreparer(
         ArgumentNullException.ThrowIfNull(material.TexturePayload);
 
         return Task.FromResult<PreparedTextureReference?>(
-            new PreparedTextureReference(
+            new PreparedMaterialTextureReference(
                 TexturePayload: material.TexturePayload,
                 TextureSourceKind: material.TextureSourceKind,
-                TextureSource: ResoniteTextureImportFactory.CreateSourceFromPayload(material.TexturePayload),
-                TerrainMeshCode: null,
-                TerrainOverlay: null));
+                TextureSource: ResoniteTextureImportFactory.CreateSourceFromPayload(material.TexturePayload)));
     }
 
     private static void ReportProgress(Action<string>? progressReporter, string message)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
@@ -42,15 +42,15 @@ internal sealed class ResoniteQueuedTexturePreparer(
 
         (ThirdRegionalMeshCode TerrainMeshCode, TerrainTextureOverlay TerrainOverlay)[] distinctTerrainOverlays = cityObject.Materials
             .Select((material, materialIndex) => (Material: material, MaterialIndex: materialIndex))
-            .Where(static entry => entry.Material.TerrainOverlay is not null && entry.Material.TerrainMeshCode is not null)
+            .Where(static entry => entry.Material.TerrainOverlayMaterial is not null)
             .Select(entry => (
                 TerrainMeshCode: ResoniteTerrainOverlayMaterialContract.ValidateMeshCode(
                     cityObject,
                     entry.MaterialIndex,
                     entry.Material,
-                    entry.Material.TerrainMeshCode!,
-                    entry.Material.TerrainOverlay!),
-                TerrainOverlay: entry.Material.TerrainOverlay!))
+                    entry.Material.TerrainOverlayMaterial!.MeshCode,
+                    entry.Material.TerrainOverlayMaterial.Overlay),
+                TerrainOverlay: entry.Material.TerrainOverlayMaterial!.Overlay))
             .Distinct()
             .OrderBy(static entry => entry.TerrainMeshCode.Value, StringComparer.Ordinal)
             .ThenBy(static entry => entry.TerrainOverlay.PackageName, StringComparer.Ordinal)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
@@ -40,7 +40,7 @@ internal sealed class ResoniteQueuedTexturePreparer(
         ArgumentNullException.ThrowIfNull(routedClient);
         ArgumentNullException.ThrowIfNull(cityObject);
 
-        (string TerrainMeshCode, TerrainTextureOverlay TerrainOverlay)[] distinctTerrainOverlays = cityObject.Materials
+        (ThirdRegionalMeshCode TerrainMeshCode, TerrainTextureOverlay TerrainOverlay)[] distinctTerrainOverlays = cityObject.Materials
             .Select((material, materialIndex) => (Material: material, MaterialIndex: materialIndex))
             .Where(static entry => entry.Material.TerrainOverlay is not null && entry.Material.TerrainMeshCode is not null)
             .Select(entry => (
@@ -52,7 +52,7 @@ internal sealed class ResoniteQueuedTexturePreparer(
                     entry.Material.TerrainOverlay!),
                 TerrainOverlay: entry.Material.TerrainOverlay!))
             .Distinct()
-            .OrderBy(static entry => entry.TerrainMeshCode, StringComparer.Ordinal)
+            .OrderBy(static entry => entry.TerrainMeshCode.Value, StringComparer.Ordinal)
             .ThenBy(static entry => entry.TerrainOverlay.PackageName, StringComparer.Ordinal)
             .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLatitude)
             .ThenBy(static entry => entry.TerrainOverlay.GeographicBounds.MinLongitude)
@@ -82,7 +82,7 @@ internal sealed class ResoniteQueuedTexturePreparer(
         LiveSendRunState state,
         IResoniteLinkClient routedClient,
         Action<string>? progressReporter,
-        string terrainMeshCode,
+        ThirdRegionalMeshCode terrainMeshCode,
         TerrainTextureOverlay terrainTextureOverlay,
         CancellationToken cancellationToken)
     {

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -28,15 +28,10 @@ internal static class ResoniteSceneMaterialConventions
         string? PreferredProfile,
         string? WrapMode);
 
-    public static string CreateMaterialSlotName(ResoniteMaterialBinding material, bool useCommonMaterialAssets)
+    public static string CreateMaterialSlotName(ResoniteMaterialBinding material)
     {
         ArgumentNullException.ThrowIfNull(material);
         ResoniteMaterialBinding normalizedMaterial = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
-
-        if (!useCommonMaterialAssets)
-        {
-            throw new InvalidOperationException("Dedicated material slot names require a material index.");
-        }
 
         return CreateCommonMaterialSlotName(normalizedMaterial);
     }
@@ -60,7 +55,7 @@ internal static class ResoniteSceneMaterialConventions
             return EmptyLookupNames;
         }
 
-        return [CreateMaterialSlotName(material, useCommonMaterialAssets: true)];
+        return [CreateMaterialSlotName(material)];
     }
 
     public static ResoniteMaterialProjection GetBundledCommonMaterialProjection(string family)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
@@ -133,8 +133,7 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
             ? sourceMaterial
             : sourceMaterial with
             {
-                TerrainOverlay = null,
-                TerrainMeshCode = null,
+                TerrainOverlayMaterial = null,
                 TextureScale = null,
                 TextureOffset = null,
             };

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
@@ -19,7 +19,7 @@ internal interface IResoniteSceneMaterialPlanComposer
         ResoniteConstructionCityObject cityObject,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
         IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
-        IReadOnlyDictionary<string, ResoniteComponentLocator> preparedTerrainTexturePropertyBlockComponentsByMeshCode,
+        IReadOnlyDictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> preparedTerrainTexturePropertyBlockComponentsByMeshCode,
         Action<string> reportMaterialStep,
         CancellationToken cancellationToken);
 }
@@ -32,7 +32,7 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
         ResoniteConstructionCityObject cityObject,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
         IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
-        IReadOnlyDictionary<string, ResoniteComponentLocator> preparedTerrainTexturePropertyBlockComponentsByMeshCode,
+        IReadOnlyDictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> preparedTerrainTexturePropertyBlockComponentsByMeshCode,
         Action<string> reportMaterialStep,
         CancellationToken cancellationToken)
     {
@@ -87,7 +87,7 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
         ResoniteMaterialBinding sourceMaterial,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
         IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
-        IReadOnlyDictionary<string, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode,
+        IReadOnlyDictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode,
         CancellationToken cancellationToken)
     {
         DefaultCommonMaterialMember member = sourceMaterial.CommonMaterial
@@ -125,7 +125,7 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
         int materialIndex,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
         IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
-        IReadOnlyDictionary<string, ResoniteComponentLocator> preparedTerrainTexturePropertyBlockComponentsByMeshCode,
+        IReadOnlyDictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> preparedTerrainTexturePropertyBlockComponentsByMeshCode,
         bool preserveDedicatedMaterialSlot,
         CancellationToken cancellationToken)
     {
@@ -184,7 +184,7 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
     private static PlannedMainTextureOverrideRendererMaterialBinding CreateMainTextureOverrideRendererBinding(
         PlannedMaterialAsset materialAsset,
         PlannedTextureAsset mainTexture,
-        IReadOnlyDictionary<string, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode,
+        IReadOnlyDictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode,
         ResoniteMaterialBinding sourceMaterial)
     {
         if (sourceMaterial.TerrainOverlay is null)
@@ -196,8 +196,8 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
             materialAsset,
             mainTexture,
             null,
-            sourceMaterial.TerrainMeshCode is not null
-            && terrainTexturePropertyBlockComponentsByMeshCode.TryGetValue(sourceMaterial.TerrainMeshCode, out ResoniteComponentLocator propertyBlockComponent)
+            sourceMaterial.TerrainOverlayMaterial is not null
+            && terrainTexturePropertyBlockComponentsByMeshCode.TryGetValue(sourceMaterial.TerrainOverlayMaterial.MeshCode, out ResoniteComponentLocator propertyBlockComponent)
                 ? propertyBlockComponent
                 : null);
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -207,7 +207,6 @@ internal sealed class ResoniteSharedSlotIndex(
             sourceFileSlotName,
             rootMeshCode,
             requestLocalOrigin,
-            SceneAnchor,
             slotSnapshotIndex.GetObservedDatasetSourceRoots());
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTerrainOverlayMaterialContract.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTerrainOverlayMaterialContract.cs
@@ -17,20 +17,11 @@ internal static class ResoniteTerrainOverlayMaterialContract
             return material with { TerrainOverlayMaterial = null };
         }
 
-        if (material.TerrainMeshCode is null)
-        {
-            throw CreateException(
-                cityObject,
-                materialIndex,
-                material,
-                "missing terrain mesh-code");
-        }
-
         _ = ValidateMeshCode(
             cityObject,
             materialIndex,
             material,
-            material.TerrainMeshCode,
+            material.TerrainOverlayMaterial!.MeshCode,
             material.TerrainOverlay);
         return material;
     }
@@ -39,13 +30,12 @@ internal static class ResoniteTerrainOverlayMaterialContract
         ResoniteConstructionCityObject cityObject,
         int materialIndex,
         ResoniteMaterialBinding material,
-        string meshCode,
+        ThirdRegionalMeshCode meshCode,
         TerrainTextureOverlay terrainOverlay)
     {
-        if (ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode thirdMeshCode)
-            && BoundsApproximatelyEqual(thirdMeshCode.Bounds, terrainOverlay.GeographicBounds))
+        if (BoundsApproximatelyEqual(meshCode.Bounds, terrainOverlay.GeographicBounds))
         {
-            return thirdMeshCode;
+            return meshCode;
         }
 
         throw CreateException(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTerrainOverlayMaterialContract.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTerrainOverlayMaterialContract.cs
@@ -14,7 +14,7 @@ internal static class ResoniteTerrainOverlayMaterialContract
     {
         if (material.TerrainOverlay is null)
         {
-            return material with { TerrainMeshCode = null };
+            return material with { TerrainOverlayMaterial = null };
         }
 
         if (material.TerrainMeshCode is null)
@@ -26,29 +26,26 @@ internal static class ResoniteTerrainOverlayMaterialContract
                 "missing terrain mesh-code");
         }
 
-        return material with
-        {
-            TerrainMeshCode = ValidateMeshCode(
-                cityObject,
-                materialIndex,
-                material,
-                material.TerrainMeshCode,
-                material.TerrainOverlay),
-        };
+        _ = ValidateMeshCode(
+            cityObject,
+            materialIndex,
+            material,
+            material.TerrainMeshCode,
+            material.TerrainOverlay);
+        return material;
     }
 
-    public static string ValidateMeshCode(
+    public static ThirdRegionalMeshCode ValidateMeshCode(
         ResoniteConstructionCityObject cityObject,
         int materialIndex,
         ResoniteMaterialBinding material,
         string meshCode,
         TerrainTextureOverlay terrainOverlay)
     {
-        if (meshCode.Length == 8
-            && PlateauMeshCode.TryGetBounds(meshCode, out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds)
-            && BoundsApproximatelyEqual(bounds, terrainOverlay.GeographicBounds))
+        if (ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode thirdMeshCode)
+            && BoundsApproximatelyEqual(thirdMeshCode.Bounds, terrainOverlay.GeographicBounds))
         {
-            return meshCode;
+            return thirdMeshCode;
         }
 
         throw CreateException(
@@ -90,7 +87,7 @@ internal static class ResoniteTerrainOverlayMaterialContract
     }
 
     private static bool BoundsApproximatelyEqual(
-        (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds,
+        JisRegionalMeshBounds bounds,
         GeographicRectangle geographicBounds)
     {
         const double tolerance = 1e-8;

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -123,12 +123,11 @@ internal static class SceneImportContractMapper
             binding.Family,
             binding.TextureOffset is null ? null : ToInternal(binding.TextureOffset),
             binding.ReuseScope == MaterialReuseScope.Shared
-                && (binding.TerrainOverlay is null || binding.CommonMaterial is not null)
+                && (binding.TerrainOverlayMaterial is null || binding.CommonMaterial is not null)
                 ? ResoniteMaterialAssetScope.Common
                 : ResoniteMaterialAssetScope.PresentationSlotScoped,
-            binding.TerrainOverlay,
+            binding.TerrainOverlayMaterial,
             binding.BundledVariantIndex,
-            binding.TerrainMeshCode,
             binding.CommonMaterial);
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/SourceRootPlacementResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SourceRootPlacementResolver.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 
-using PlateauResoniteLink.Targets.Resonite.Execution;
-
 using ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -12,7 +10,6 @@ internal static class SourceRootPlacementResolver
         string sourceFileSlotName,
         string rootMeshCode,
         ResoniteLocalOrigin requestLocalOrigin,
-        SceneAnchor? sceneAnchor,
         IReadOnlyList<Slot> observedDatasetSourceRoots)
     {
         ObservedSourceRootPlacement? observedRootPlacement = ObservedSourceRootPlacementResolver.TryResolve(
@@ -20,22 +17,9 @@ internal static class SourceRootPlacementResolver
             rootMeshCode,
             observedDatasetSourceRoots);
         ResoniteFloat3 rootPosition = observedRootPlacement?.Position
-            ?? ResolveDatasetRootAnchoredSourceRootPosition(sceneAnchor, rootMeshCode)
             ?? ResonitePlacementPolicy.ResolveMeshRootPosition(requestLocalOrigin, rootMeshCode);
 
         return new SourceRootPlacement(rootPosition, rootPosition);
-    }
-
-    private static ResoniteFloat3? ResolveDatasetRootAnchoredSourceRootPosition(
-        SceneAnchor? sceneAnchor,
-        string rootMeshCode)
-    {
-        if (sceneAnchor is not { ReferenceSourceFileRoot: null } anchor)
-        {
-            return null;
-        }
-
-        return ResonitePlacementPolicy.ComputeMeshCodeOffset(anchor.MeshCode, rootMeshCode);
     }
 }
 

--- a/tests/PlateauResoniteLink.Tests/Domain/JisRegionalMeshCodeTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Domain/JisRegionalMeshCodeTests.cs
@@ -1,0 +1,47 @@
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Tests.Domain;
+
+public sealed class JisRegionalMeshCodeTests
+{
+    [Fact]
+    public void TryParseAcceptsOnlyMatchingMeshOrder()
+    {
+        Assert.True(FirstRegionalMeshCode.TryParse("5339", out FirstRegionalMeshCode first));
+        Assert.True(SecondRegionalMeshCode.TryParse("533945", out SecondRegionalMeshCode second));
+        Assert.True(ThirdRegionalMeshCode.TryParse("53394525", out ThirdRegionalMeshCode third));
+
+        Assert.Equal("5339", first.Value);
+        Assert.Equal("533945", second.Value);
+        Assert.Equal("53394525", third.Value);
+        Assert.False(FirstRegionalMeshCode.TryParse("533945", out _));
+        Assert.False(SecondRegionalMeshCode.TryParse("53394525", out _));
+        Assert.False(ThirdRegionalMeshCode.TryParse("533945", out _));
+        Assert.False(ThirdRegionalMeshCode.TryParse(".*", out _));
+    }
+
+    [Fact]
+    public void BoundsMatchJisRegionalMeshOrder()
+    {
+        JisRegionalMeshBounds first = FirstRegionalMeshCode.Parse("5339").Bounds;
+        JisRegionalMeshBounds second = SecondRegionalMeshCode.Parse("533945").Bounds;
+        JisRegionalMeshBounds third = ThirdRegionalMeshCode.Parse("53394525").Bounds;
+
+        Assert.Equal(35.333333333333336, first.SouthLatitude, precision: 12);
+        Assert.Equal(139.0, first.WestLongitude, precision: 12);
+        Assert.Equal(35.666666666666664, second.SouthLatitude, precision: 12);
+        Assert.Equal(139.625, second.WestLongitude, precision: 12);
+        Assert.Equal(35.68333333333333, third.SouthLatitude, precision: 12);
+        Assert.Equal(139.6875, third.WestLongitude, precision: 12);
+    }
+
+    [Fact]
+    public void ThirdMeshExposesSecondAndFirstParents()
+    {
+        ThirdRegionalMeshCode third = ThirdRegionalMeshCode.Parse("53394525");
+
+        Assert.Equal("533945", third.Parent.Value);
+        Assert.Equal("5339", third.FirstMesh.Value);
+        Assert.Equal("5339", third.Parent.Parent.Value);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Profiles/ImportedDynamicMaterialUvNormalizerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/ImportedDynamicMaterialUvNormalizerTests.cs
@@ -275,6 +275,8 @@ public sealed class ImportedDynamicMaterialUvNormalizerTests
             SubmeshIndices: [0],
             TextureScale: textureScale,
             TextureOffset: textureOffset,
-            TerrainOverlay: terrainOverlay);
+            TerrainOverlayMaterial: terrainOverlay is null
+                ? null
+                : new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), terrainOverlay));
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -1150,7 +1150,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public void ProjectParsedCityObjectAssignsSelectedAdjacentOverlayToTexturelessBuildingRoof()
+    public void ProjectParsedCityObjectUsesSourceOverlayForTexturelessBuildingRoofOutsideSourceBounds()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
         TerrainTextureOverlay selectedRequestOverlay = CreateThirdMeshOverlay("53394525");
@@ -1182,8 +1182,81 @@ public sealed class LocalCityGmlObjectProjectionTests
             new DefaultMaterialResolver(CommonMaterialCatalog.Create())));
 
         MaterialBinding material = Assert.Single(projected.Materials);
-        Assert.Same(selectedAdjacentOverlay, material.TerrainOverlay);
-        Assert.Equal("53394526", material.TerrainMeshCode);
+        Assert.Same(selectedRequestOverlay, material.TerrainOverlay);
+        Assert.Equal("53394525", material.TerrainMeshCode);
+    }
+
+    [Fact]
+    public void ProjectParsedCityObjectUsesSourceMeshOverlayBeforeActualMeshOverlay()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay sourceOverlay = CreateThirdMeshOverlay("53394525");
+        TerrainTextureOverlay actualOverlay = CreateThirdMeshOverlay("53394526");
+        GeodeticPoint origin = CreateMeshCenterPoint("53394526", altitudeMeters: 8.0);
+        ParsedSurface roofSurface = CreateParsedSurface(
+            "actual-mesh-textureless-roof",
+            ParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394526", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        ParsedCityObject cityObject = CreateParsedCityObject("bldg", [roofSurface], referenceSystem) with
+        {
+            ActualMeshCode = "53394526",
+            SourceMeshCode = "53394525",
+        };
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            CityGmlSource: DatasetLocation.Local("/tmp/plateau"),
+            PackageNames: ["dem", "bldg"]);
+
+        ImportedCityObject projected = Assert.Single(LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            origin,
+            globalCartesian: null,
+            demTerrainTextureOverlays: [sourceOverlay, actualOverlay],
+            requestedMeshCodeBounds: [MeshCodeBounds.TryParse("53394525")!, MeshCodeBounds.TryParse("53394526")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create())));
+
+        MaterialBinding material = Assert.Single(projected.Materials);
+        Assert.Same(sourceOverlay, material.TerrainOverlay);
+        Assert.Equal("53394525", material.TerrainMeshCode);
+    }
+
+    [Fact]
+    public void ProjectParsedCityObjectDoesNotUseUnrelatedParentSourceOverlayForTexturelessBuildingRoof()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay unrelatedSourceParentOverlay = CreateThirdMeshOverlay("53394525");
+        GeodeticPoint origin = CreateMeshCenterPoint("53394526", altitudeMeters: 8.0);
+        ParsedSurface roofSurface = CreateParsedSurface(
+            "parent-source-partial-coverage-roof",
+            ParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394526", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null);
+        ParsedCityObject cityObject = CreateParsedCityObject("bldg", [roofSurface], referenceSystem) with
+        {
+            ActualMeshCode = "53394526",
+            SourceMeshCode = "533945",
+        };
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "533945",
+            CityGmlSource: DatasetLocation.Local("/tmp/plateau"),
+            PackageNames: ["dem", "bldg"]);
+
+        ImportedCityObject projected = Assert.Single(LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            origin,
+            globalCartesian: null,
+            demTerrainTextureOverlays: [unrelatedSourceParentOverlay],
+            requestedMeshCodeBounds: [MeshCodeBounds.TryParse("533945")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create())));
+
+        Assert.DoesNotContain(projected.Materials, static material => material.TerrainOverlay is not null);
     }
 
     [Fact]
@@ -1256,6 +1329,43 @@ public sealed class LocalCityGmlObjectProjectionTests
             globalCartesian: null,
             demTerrainTextureOverlays: [firstOverlay, secondOverlay],
             requestedMeshCodeBounds: [MeshCodeBounds.TryParse("533945")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create())).ToArray();
+
+        Assert.Empty(materialBindings);
+    }
+
+    [Fact]
+    public void EnumerateCommonMaterialsForParsedCityObjectExcludesTerrainOverlayDemGridForRegexMeshSelector()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        TerrainTextureOverlay overlay = CreateThirdMeshOverlay("53394525");
+        ParsedSurface demSurface = CreateParsedSurface(
+            "regex-dem-grid-terrain-overlay",
+            ParsedSurfaceSemantic.Roof,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 8.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: true),
+            texturePayload: null) with
+        {
+            UsesGeneratedDemTexture = true,
+        };
+        ParsedCityObject cityObject = CreateParsedCityObject("dem", [demSurface], referenceSystem) with
+        {
+            ActualMeshCode = "533945",
+        };
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: ".*",
+            CityGmlSource: DatasetLocation.Local("/tmp/plateau"),
+            PackageNames: ["dem"],
+            TerrainMeshMode: TerrainMeshMode.Grid);
+
+        MaterialBinding[] materialBindings = LocalCityGmlObjectProjection.EnumerateCommonMaterialsForParsedCityObject(
+            cityObject,
+            CreateMeshCenterPoint("53394525", altitudeMeters: 8.0),
+            globalCartesian: null,
+            demTerrainTextureOverlays: [overlay],
+            requestedMeshCodeBounds: [],
             terrainHeightSampler: null,
             request,
             new DefaultMaterialResolver(CommonMaterialCatalog.Create())).ToArray();

--- a/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayMeshCodeResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayMeshCodeResolverTests.cs
@@ -10,9 +10,9 @@ public sealed class TerrainOverlayMeshCodeResolverTests
     {
         TerrainTextureOverlay overlay = CreateOverlay("53394525");
 
-        string? meshCode = TerrainOverlayMeshCodeResolver.ResolveMeshCode("53394525", overlay);
+        ThirdRegionalMeshCode? meshCode = TerrainOverlayMeshCodeResolver.ResolveMeshCode("53394525", overlay);
 
-        Assert.Equal("53394525", meshCode);
+        Assert.Equal("53394525", meshCode?.Value);
     }
 
     [Fact]
@@ -20,9 +20,9 @@ public sealed class TerrainOverlayMeshCodeResolverTests
     {
         TerrainTextureOverlay overlay = CreateOverlay("53394525");
 
-        string? meshCode = TerrainOverlayMeshCodeResolver.ResolveMeshCode("533945", overlay);
+        ThirdRegionalMeshCode? meshCode = TerrainOverlayMeshCodeResolver.ResolveMeshCode("533945", overlay);
 
-        Assert.Equal("53394525", meshCode);
+        Assert.Equal("53394525", meshCode?.Value);
     }
 
     [Fact]
@@ -30,13 +30,13 @@ public sealed class TerrainOverlayMeshCodeResolverTests
     {
         TerrainTextureOverlay overlay = CreateOverlay("53394525");
 
-        string? meshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
+        ThirdRegionalMeshCode? meshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
             actualMeshCode: "53394600",
             requestedMeshCode: "533945",
             requestedMeshCodeBounds: [],
             overlay);
 
-        Assert.Equal("53394525", meshCode);
+        Assert.Equal("53394525", meshCode?.Value);
     }
 
     [Fact]
@@ -44,13 +44,13 @@ public sealed class TerrainOverlayMeshCodeResolverTests
     {
         TerrainTextureOverlay overlay = CreateOverlay("53394525");
 
-        string? meshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
+        ThirdRegionalMeshCode? meshCode = TerrainOverlayMeshCodeResolver.ResolveForOverlay(
             actualMeshCode: "533946",
             requestedMeshCode: "533947",
             requestedMeshCodeBounds: [MeshCodeBounds.TryParse("53394525")!],
             overlay);
 
-        Assert.Equal("53394525", meshCode);
+        Assert.Equal("53394525", meshCode?.Value);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -844,8 +844,7 @@ public sealed class NonDemCityObjectBakerTests
                     DepthOffset: null,
                     SubmeshIndices: [0],
                     AssetScope: ResoniteMaterialAssetScope.Common,
-                    TerrainOverlay: overlay,
-                    TerrainMeshCode: "53394525",
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay),
                     CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
             ],
         };

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
@@ -294,6 +295,8 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
             TextureScale: textureScale,
             TextureOffset: textureOffset,
             AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
-            TerrainOverlay: terrainOverlay);
+            TerrainOverlayMaterial: terrainOverlay is null
+                ? null
+                : new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), terrainOverlay));
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -1134,8 +1134,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     ResoniteMaterialProjection.Uv,
                     null,
                     [0],
-                    TerrainOverlay: overlay,
-                    TerrainMeshCode: "53394525"),
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay)),
             ],
             CollisionEnabled: true,
             SourceFileRelativePath: sourceFileRelativePath);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -356,8 +356,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 Projection: ResoniteMaterialProjection.Uv,
                 DepthOffset: terrainAlignedDepthOffset,
                 SubmeshIndices: [0],
-                AssetScope: ResoniteMaterialAssetScope.Common),
-            useCommonMaterialAssets: true);
+                AssetScope: ResoniteMaterialAssetScope.Common));
         bool terrainAlignedGenericSlotExistedWhenSendWorkersStarted = false;
         ResoniteMaterialPlanning materialPlanning = new(CreateBundledDefaultMaterialAssetStore());
         await using ResoniteLiveSceneImportTarget importTarget = new(
@@ -432,8 +431,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 Projection: ResoniteMaterialProjection.Uv,
                 DepthOffset: new ResoniteMaterialDepthOffset(-10.0, -10.0),
                 SubmeshIndices: [0],
-                AssetScope: ResoniteMaterialAssetScope.Common),
-            useCommonMaterialAssets: true);
+                AssetScope: ResoniteMaterialAssetScope.Common));
         bool materialSlotExistedWhenSendWorkersStarted = false;
         await using ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(
             routedClient,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -510,9 +510,8 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             binding.Family,
             binding.TextureOffset is null ? null : ToContractFloat2(binding.TextureOffset),
             binding.AssetScope == ResoniteMaterialAssetScope.Common ? MaterialReuseScope.Shared : MaterialReuseScope.PerObject,
-            binding.TerrainOverlay,
+            binding.TerrainOverlayMaterial,
             binding.BundledVariantIndex,
-            binding.TerrainMeshCode,
             binding.CommonMaterial);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -68,8 +68,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureOffset: null,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlay: overlay,
-                    TerrainMeshCode: MeshCode),
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(MeshCode), overlay)),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -402,56 +401,6 @@ public sealed class ResoniteLiveSceneImportTargetTests
     }
 
     [Fact]
-    public async Task ExecuteAsyncRejectsTerrainOverlayMaterialWithoutMeshCode()
-    {
-        using TemporaryDirectory datasetDirectory = new();
-        using SceneSinkRecordingClient client = new();
-        TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/{z}/{x}/{y}.png");
-        RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
-            _ => new GeneratedTerrainTexture(
-                CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
-                new ResoniteFloat2(1.0, 1.0),
-                new ResoniteFloat2(0.0, 0.0)));
-        ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
-            DatasetName,
-            MeshCode,
-            datasetDirectory.Path,
-            LocalOrigin,
-            packageNames: ["dem"],
-            sourceFiles:
-            [
-                $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml",
-            ]);
-        ResoniteConstructionCityObject baseCityObject = CreateTerrainOverlayCityObject(
-            "terrain-missing-mesh-code",
-            "Terrain Missing Mesh Code",
-            "dem",
-            MeshCode,
-            overlay);
-        ResoniteConstructionCityObject cityObject = baseCityObject with
-        {
-            Materials =
-            [
-                baseCityObject.Materials[0] with
-                {
-                    TerrainMeshCode = null,
-                },
-            ],
-        };
-
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(
-                metadata,
-                [cityObject],
-                client,
-                terrainTextureGenerator));
-        Assert.Contains("matches the overlay geographic bounds", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("object_slot='terrain-missing-mesh-code'", exception.Message, StringComparison.Ordinal);
-        Assert.Contains($"actual_mesh_code='{MeshCode}'", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("terrain_mesh='<null>'", exception.Message, StringComparison.Ordinal);
-    }
-
-    [Fact]
     public async Task ExecuteAsyncDoesNotReuseExistingGenericCommonMaterialForTerrainOverlayMaterial()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -499,8 +448,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlay: overlay,
-                    TerrainMeshCode: MeshCode),
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(MeshCode), overlay)),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -882,8 +830,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlay: overlay,
-                    TerrainMeshCode: MeshCode),
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(MeshCode), overlay)),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -993,15 +940,14 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlay: overlay,
-                    TerrainMeshCode: MeshCode),
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(MeshCode), overlay)),
             ]
         );
         ResoniteConstructionCityObject withoutOverlay = withOverlay with
         {
             Materials =
             [
-                withOverlay.Materials[0] with { TerrainOverlay = null },
+                withOverlay.Materials[0] with { TerrainOverlayMaterial = null },
             ],
         };
 
@@ -1745,8 +1691,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureOffset: null,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlay: overlay,
-                    TerrainMeshCode: meshCode),
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(meshCode), overlay)),
             ],
             SourceFileRelativePath: $"udx/{packageName}/{meshCode}/plateau_{DatasetName}_{packageName}_{meshCode}.gml");
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
@@ -198,12 +199,14 @@ public sealed class ResoniteMaterialComponentPolicyTests
             DepthOffset: null,
             SubmeshIndices: [0],
             TextureOffset: new ResoniteFloat2(0.125, 0.75),
-            TerrainOverlay: new TerrainTextureOverlay(
+            TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(
+                ThirdRegionalMeshCode.Parse("53394525"),
+                new TerrainTextureOverlay(
                 PackageName: "dem",
                 UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
                 ZoomLevel: 17,
                 GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
-                MaxTextureSize: 512),
+                    MaxTextureSize: 512)),
             AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
 
         InvalidOperationException error = Assert.Throws<InvalidOperationException>(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -241,7 +241,7 @@ public sealed class ResoniteMaterialPlanningTests
             SubmeshIndices: [0],
             TextureScale: new ResoniteFloat2(0.4, 0.8),
             TextureOffset: new ResoniteFloat2(0.1, 0.2),
-            TerrainOverlay: overlay);
+            TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay));
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextures = new()
         {
             [overlay] = new GeneratedTerrainTexture(
@@ -327,7 +327,7 @@ public sealed class ResoniteMaterialPlanningTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
-            TerrainOverlay: overlay);
+            TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay));
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextures = new()
         {
             [overlay] = new GeneratedTerrainTexture(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -311,8 +311,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
-            TerrainOverlay: overlay,
-            TerrainMeshCode: "53394525",
+            TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay),
             Family: null,
             AssetScope: ResoniteMaterialAssetScope.Common,
             CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -93,7 +93,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             BundledVariantIndex: 0,
             AssetScope: ResoniteMaterialAssetScope.Common);
 
-        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
+        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
         Assert.Equal("variant-0", slotName);
         Assert.DoesNotContain(' ', slotName);
@@ -115,7 +115,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             BundledVariantIndex: 0,
             AssetScope: ResoniteMaterialAssetScope.Common);
 
-        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
+        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
         Assert.Equal("variant-0", slotName);
         Assert.DoesNotContain("scale", slotName, StringComparison.Ordinal);
@@ -138,7 +138,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             BundledVariantIndex: 1,
             AssetScope: ResoniteMaterialAssetScope.Common);
 
-        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
+        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
         Assert.Equal("variant-1", slotName);
         Assert.DoesNotContain("scale", slotName, StringComparison.Ordinal);
@@ -205,7 +205,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             BundledVariantIndex: null,
             AssetScope: ResoniteMaterialAssetScope.Common);
 
-        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
+        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
         Assert.Equal("uv", slotName);
         Assert.DoesNotContain("offset", slotName, StringComparison.Ordinal);
@@ -228,7 +228,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             BundledVariantIndex: null,
             AssetScope: ResoniteMaterialAssetScope.Common);
 
-        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
+        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
         Assert.Equal("uv", slotName);
     }
@@ -292,7 +292,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             Family: null,
             AssetScope: ResoniteMaterialAssetScope.Common);
 
-        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material, useCommonMaterialAssets: true);
+        string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
         Assert.Equal("uv", slotName);
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -63,8 +63,7 @@ public sealed class SceneImportContractMapperTests
                 DepthOffset: null,
                 SubmeshIndices: [0],
                 ReuseScope: MaterialReuseScope.Shared,
-                TerrainOverlay: overlay,
-                TerrainMeshCode: "53394525",
+                TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay),
                 CommonMaterial: commonMaterial),
         ];
 
@@ -98,8 +97,7 @@ public sealed class SceneImportContractMapperTests
                 DepthOffset: null,
                 SubmeshIndices: [0],
                 ReuseScope: MaterialReuseScope.Shared,
-                TerrainOverlay: overlay,
-                TerrainMeshCode: "53394525"),
+                TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay)),
         ];
 
         ResoniteMaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToInternal(bindings));

--- a/tests/PlateauResoniteLink.Tests/Targets/SourceRootPlacementResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SourceRootPlacementResolverTests.cs
@@ -1,5 +1,4 @@
 using PlateauResoniteLink.Targets.Resonite;
-using PlateauResoniteLink.Targets.Resonite.Execution;
 
 using ResoniteLink;
 
@@ -8,17 +7,12 @@ namespace PlateauResoniteLink.Tests.Targets;
 public sealed class SourceRootPlacementResolverTests
 {
     [Fact]
-    public void ResolveUsesObservedRootBeforeSceneAnchorFallback()
+    public void ResolveUsesObservedRootBeforeRequestOriginFallback()
     {
         SourceRootPlacement placement = SourceRootPlacementResolver.Resolve(
             "plateau_tokyo23ku_bldg_53394525",
             "53394525",
             new ResoniteLocalOrigin(35.0, 139.0, 0.0),
-            new SceneAnchor(
-                new ResoniteSlotLocator("dataset-root"),
-                "53394526",
-                new ResoniteFloat3(0.0, 0.0, 0.0),
-                ReferenceSourceFileRoot: null),
             [
                 CreateSlot(
                     "source-root",
@@ -31,21 +25,18 @@ public sealed class SourceRootPlacementResolverTests
     }
 
     [Fact]
-    public void ResolveUsesDatasetRootAnchorWhenNoObservedRootExists()
+    public void ResolveUsesRequestOriginWhenNoObservedSourceRootExists()
     {
+        ResoniteLocalOrigin requestLocalOrigin = new(35.0, 139.0, 0.0);
+
         SourceRootPlacement placement = SourceRootPlacementResolver.Resolve(
             "plateau_tokyo23ku_bldg_53394525",
             "53394525",
-            new ResoniteLocalOrigin(35.0, 139.0, 0.0),
-            new SceneAnchor(
-                new ResoniteSlotLocator("dataset-root"),
-                "53394524",
-                new ResoniteFloat3(0.0, 0.0, 0.0),
-                ReferenceSourceFileRoot: null),
+            requestLocalOrigin,
             []);
 
         Assert.Equal(
-            ResonitePlacementPolicy.ComputeMeshCodeOffset("53394524", "53394525"),
+            ResonitePlacementPolicy.ResolveMeshRootPosition(requestLocalOrigin, "53394525"),
             placement.RootPosition);
     }
 


### PR DESCRIPTION
## Summary
- Fix source root first-placement fallback so new source roots use the request origin when no matching observed source root exists, instead of falling back to the dataset root scene anchor.
- Preserve the CityGML/source mesh code on parsed city objects so textureless LOD1 roof Terrain Overlay material selection stays scoped to the source CityGML mesh.
- Keep source-mesh roof Terrain Overlay assignment even when the roof surface extends outside the overlay bounds; UV may fall outside the texture instead of switching to an adjacent overlay or a non-overlay roof material.

## Cause
- The placement regression came from `9bd464ed` and was included in `v0.12.0`: first source root placement used `SceneAnchor` as a fallback before the request origin.
- LOD1 duplicate AtlasBake groups were caused by textureless roof material partitioning selecting adjacent DEM overlays from per-surface overlap instead of source CityGML mesh scope.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Result: `964 passed`