### PR TITLE
Fix GridMesh heightmap holes

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -116,6 +116,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         width = heightSamples.Width;
         height = heightSamples.Height;
         double[] localHeights = heightSamples.LocalHeights;
+        TerrainGridSampleCoverage[] sampleCoverage = heightSamples.SampleCoverage;
         double minHeight = localHeights.Min();
         double maxHeight = localHeights.Max();
 
@@ -168,6 +169,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
                 MinHeight: minHeight,
                 MaxHeight: maxHeight,
                 HeightSamples: localHeights,
+                SampleCoverage: sampleCoverage,
                 UvScale: heightMapUvScale,
                 UvOffset: heightMapUvOffset),
             Materials: materials,
@@ -270,6 +272,11 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         double clippedMaxX = Math.Max(westPosition.X, eastPosition.X);
         double clippedMinZ = Math.Min(southPosition.Z, northPosition.Z);
         double clippedMaxZ = Math.Max(southPosition.Z, northPosition.Z);
+
+        clippedMinX = Math.Max(clippedMinX, rawMinX);
+        clippedMaxX = Math.Min(clippedMaxX, rawMaxX);
+        clippedMinZ = Math.Max(clippedMinZ, rawMinZ);
+        clippedMaxZ = Math.Min(clippedMaxZ, rawMaxZ);
 
         if ((clippedMaxX - clippedMinX) <= 1e-6 || (clippedMaxZ - clippedMinZ) <= 1e-6)
         {

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridSampler.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridSampler.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 
 namespace PlateauResoniteLink.Application.Importing;
@@ -29,7 +28,7 @@ internal static class CityGmlDemTerrainGridSampler
             2,
             maxResolution);
         double[] localHeights = new double[width * height];
-        bool[] sampledInsideTriangles = new bool[width * height];
+        TerrainGridSampleCoverage[] sampleCoverage = new TerrainGridSampleCoverage[width * height];
         TerrainGridSpatialIndex spatialIndex = TerrainGridSpatialIndex.Create(
             triangles,
             minX,
@@ -40,28 +39,28 @@ internal static class CityGmlDemTerrainGridSampler
         for (int zIndex = 0; zIndex < height; zIndex++)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            double v = (double)zIndex / (height - 1);
+            double v = ((double)zIndex + 0.5) / height;
             double sampleZ = minZ + (extentZ * v);
             for (int xIndex = 0; xIndex < width; xIndex++)
             {
-                double u = (double)xIndex / (width - 1);
+                double u = ((double)xIndex + 0.5) / width;
                 double sampleX = minX + (extentX * u);
                 int sampleIndex = (zIndex * width) + xIndex;
                 if (TrySampleLocalHeight(sampleX, sampleZ, triangles, spatialIndex, out double localHeight))
                 {
                     localHeights[sampleIndex] = localHeight;
-                    sampledInsideTriangles[sampleIndex] = true;
+                    sampleCoverage[sampleIndex] = TerrainGridSampleCoverage.Measured;
                 }
                 else
                 {
                     localHeights[sampleIndex] = fallbackHeight;
+                    sampleCoverage[sampleIndex] = TerrainGridSampleCoverage.NoSurface;
                 }
             }
         }
 
         cancellationToken.ThrowIfCancellationRequested();
-        ExtendBoundaryConnectedMissingHeightSamples(localHeights, sampledInsideTriangles, width, height);
-        return new DemTerrainGridHeightSamples(width, height, localHeights);
+        return new DemTerrainGridHeightSamples(width, height, localHeights, sampleCoverage);
     }
 
     internal static bool TrySampleLocalHeight(
@@ -82,84 +81,6 @@ internal static class CityGmlDemTerrainGridSampler
 
         height = 0.0;
         return false;
-    }
-
-    internal static void ExtendBoundaryConnectedMissingHeightSamples(
-        double[] localHeights,
-        bool[] sampledInsideTriangles,
-        int width,
-        int height)
-    {
-        bool[] boundaryConnectedMissing = FindBoundaryConnectedMissingSamples(sampledInsideTriangles, width, height);
-        if (!boundaryConnectedMissing.Any(static missing => missing))
-        {
-            return;
-        }
-
-        Queue<(int Row, int Column)> frontier = new();
-
-        for (int row = 0; row < height; row++)
-        {
-            for (int column = 0; column < width; column++)
-            {
-                int sampleIndex = (row * width) + column;
-                if (!sampledInsideTriangles[sampleIndex])
-                {
-                    continue;
-                }
-
-                if (TouchesBoundaryConnectedMissing(row, column))
-                {
-                    frontier.Enqueue((row, column));
-                }
-            }
-        }
-
-        while (frontier.Count > 0)
-        {
-            (int row, int column) = frontier.Dequeue();
-            int sourceIndex = (row * width) + column;
-            TryPropagate(row - 1, column, localHeights[sourceIndex]);
-            TryPropagate(row + 1, column, localHeights[sourceIndex]);
-            TryPropagate(row, column - 1, localHeights[sourceIndex]);
-            TryPropagate(row, column + 1, localHeights[sourceIndex]);
-        }
-
-        bool TouchesBoundaryConnectedMissing(int row, int column)
-        {
-            return IsBoundaryConnectedMissing(row - 1, column)
-                || IsBoundaryConnectedMissing(row + 1, column)
-                || IsBoundaryConnectedMissing(row, column - 1)
-                || IsBoundaryConnectedMissing(row, column + 1);
-        }
-
-        bool IsBoundaryConnectedMissing(int row, int column)
-        {
-            if ((uint)row >= (uint)height || (uint)column >= (uint)width)
-            {
-                return false;
-            }
-
-            return boundaryConnectedMissing[(row * width) + column];
-        }
-
-        void TryPropagate(int row, int column, double heightValue)
-        {
-            if ((uint)row >= (uint)height || (uint)column >= (uint)width)
-            {
-                return;
-            }
-
-            int targetIndex = (row * width) + column;
-            if (!boundaryConnectedMissing[targetIndex] || sampledInsideTriangles[targetIndex])
-            {
-                return;
-            }
-
-            localHeights[targetIndex] = heightValue;
-            sampledInsideTriangles[targetIndex] = true;
-            frontier.Enqueue((row, column));
-        }
     }
 
     private static bool TryInterpolateLocalTriangleHeight(
@@ -191,77 +112,13 @@ internal static class CityGmlDemTerrainGridSampler
         return true;
     }
 
-    private static bool[] FindBoundaryConnectedMissingSamples(
-        bool[] sampledInsideTriangles,
-        int width,
-        int height)
-    {
-        bool[] boundaryConnectedMissing = new bool[width * height];
-        Queue<(int Row, int Column)> frontier = new();
-
-        for (int column = 0; column < width; column++)
-        {
-            EnqueueIfBoundaryMissing(0, column);
-            EnqueueIfBoundaryMissing(height - 1, column);
-        }
-
-        for (int row = 1; row < height - 1; row++)
-        {
-            EnqueueIfBoundaryMissing(row, 0);
-            EnqueueIfBoundaryMissing(row, width - 1);
-        }
-
-        while (frontier.Count > 0)
-        {
-            (int row, int column) = frontier.Dequeue();
-            TryVisit(row - 1, column);
-            TryVisit(row + 1, column);
-            TryVisit(row, column - 1);
-            TryVisit(row, column + 1);
-        }
-
-        return boundaryConnectedMissing;
-
-        void EnqueueIfBoundaryMissing(int row, int column)
-        {
-            if ((uint)row >= (uint)height || (uint)column >= (uint)width)
-            {
-                return;
-            }
-
-            int sampleIndex = (row * width) + column;
-            if (sampledInsideTriangles[sampleIndex] || boundaryConnectedMissing[sampleIndex])
-            {
-                return;
-            }
-
-            boundaryConnectedMissing[sampleIndex] = true;
-            frontier.Enqueue((row, column));
-        }
-
-        void TryVisit(int row, int column)
-        {
-            if ((uint)row >= (uint)height || (uint)column >= (uint)width)
-            {
-                return;
-            }
-
-            int sampleIndex = (row * width) + column;
-            if (sampledInsideTriangles[sampleIndex] || boundaryConnectedMissing[sampleIndex])
-            {
-                return;
-            }
-
-            boundaryConnectedMissing[sampleIndex] = true;
-            frontier.Enqueue((row, column));
-        }
-    }
 }
 
 internal sealed record DemTerrainGridHeightSamples(
     int Width,
     int Height,
-    double[] LocalHeights);
+    double[] LocalHeights,
+    TerrainGridSampleCoverage[] SampleCoverage);
 
 internal sealed record TerrainGridTriangle(
     Float3 A,

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -95,6 +95,7 @@ internal static class CityGmlParsedCityObjectProjection
                      terrainAlignedParsedCityObject,
                      demTerrainTextureOverlays,
                      requestedMeshCodeBounds,
+                     AllowMissingGeneratedDemOverlayCoverage(terrainAlignedParsedCityObject),
                      progressReporter,
                      cancellationToken))
         {
@@ -206,7 +207,8 @@ internal static class CityGmlParsedCityObjectProjection
                  in TerrainOverlayMaterialSourcePartitioner.PartitionParsedCityObject(
                      terrainAlignedParsedCityObject,
                      demTerrainTextureOverlays,
-                     requestedMeshCodeBounds))
+                     requestedMeshCodeBounds,
+                     AllowMissingGeneratedDemOverlayCoverage(terrainAlignedParsedCityObject)))
         {
             if (!TerrainOverlayMaterialSourcePartitioner.IsPartitionCompatibleWithRequest(
                     partitionedCityObject.CityObject.ActualMeshCode,
@@ -242,6 +244,12 @@ internal static class CityGmlParsedCityObjectProjection
                 yield return material;
             }
         }
+    }
+
+    private static bool AllowMissingGeneratedDemOverlayCoverage(
+        ParsedCityObject parsedCityObject)
+    {
+        return string.Equals(parsedCityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase);
     }
 
     internal static ImportedCityObject ProjectTerrainMeshModeCityObject(

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -13,6 +13,7 @@ internal static class CityGmlSurfaceMaterialResolver
     internal static readonly MaterialDepthOffset TerrainAlignedDepthOffset = new(-10.0, -10.0);
 
     private static readonly ColorRgba DefaultMaterialColor = new(1.0, 1.0, 1.0, 1.0);
+    private static readonly ColorRgba DefaultDemGroundMaterialColor = new(181.0 / 255.0, 176.0 / 255.0, 166.0 / 255.0, 1.0);
     private static readonly ColorRgba DefaultVegetationMaterialColor = new(0.32, 0.58, 0.24, 1.0);
 
     internal static ResolvedSurfaceMaterial[] ResolveSurfaces(
@@ -203,8 +204,11 @@ internal static class CityGmlSurfaceMaterialResolver
         ParsedSurface surface = face.Surface;
         if (surface.UsesGeneratedDemTexture)
         {
+            ConstructionFace resolvedFace = demTerrainTextureOverlay is null
+                ? face with { Surface = surface with { BaseColor = DefaultDemGroundMaterialColor } }
+                : face;
             return new ResolvedSurfaceMaterial(
-                face,
+                resolvedFace,
                 new ResolvedMaterial(
                     MaterialType.Standard,
                     TexturePayload: null,

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainGridChunkBoundaryAlignmentPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainGridChunkBoundaryAlignmentPolicy.cs
@@ -19,7 +19,6 @@ internal static class DemTerrainGridChunkBoundaryAlignmentPolicy
         TerrainGridChunkAlignmentState[] chunkStates = states
             .Select(static state => state!)
             .ToArray();
-        const double seaLevelWorldHeightTolerance = 1e-6;
         Dictionary<DemBoundarySampleKey, List<BoundaryHeightSampleReference>> sampleReferencesByKey = [];
         foreach (TerrainGridChunkAlignmentState state in chunkStates)
         {
@@ -45,27 +44,17 @@ internal static class DemTerrainGridChunkBoundaryAlignmentPolicy
             }
 
             foundSharedBoundary = true;
-            double worldHeightSum = 0.0;
-            int sampleCount = 0;
-            double nonSeaLevelWorldHeightSum = 0.0;
-            int nonSeaLevelSampleCount = 0;
-            foreach (BoundaryHeightSampleReference reference in references)
+            BoundaryHeightSampleReference[] referencesToAlign = references
+                .Where(static reference => reference.State.SampleCoverage[reference.SampleIndex] == TerrainGridSampleCoverage.Measured)
+                .ToArray();
+            if (referencesToAlign.Length == 0)
             {
-                double worldHeight = reference.State.BaseHeight + reference.State.HeightSamples[reference.SampleIndex];
-                bool isSeaLevelFallbackCandidate = Math.Abs(worldHeight) <= seaLevelWorldHeightTolerance;
-                worldHeightSum += worldHeight;
-                sampleCount++;
-                if (!isSeaLevelFallbackCandidate)
-                {
-                    nonSeaLevelWorldHeightSum += worldHeight;
-                    nonSeaLevelSampleCount++;
-                }
+                continue;
             }
 
-            double alignedWorldHeight = nonSeaLevelSampleCount > 0
-                ? nonSeaLevelWorldHeightSum / nonSeaLevelSampleCount
-                : worldHeightSum / sampleCount;
-            foreach (BoundaryHeightSampleReference reference in references)
+            double alignedWorldHeight = referencesToAlign
+                .Average(static reference => reference.State.BaseHeight + reference.State.HeightSamples[reference.SampleIndex]);
+            foreach (BoundaryHeightSampleReference reference in referencesToAlign)
             {
                 reference.State.HeightSamples[reference.SampleIndex] = alignedWorldHeight - reference.State.BaseHeight;
             }
@@ -138,6 +127,12 @@ internal static class DemTerrainGridChunkBoundaryAlignmentPolicy
             CityObject = cityObject;
             Geometry = geometry;
             HeightSamples = heightSamples;
+            SampleCoverage = geometry.SampleCoverage.ToArray();
+            if (SampleCoverage.Length != heightSamples.Length)
+            {
+                throw new InvalidOperationException(
+                    $"Terrain grid sample coverage count {SampleCoverage.Length} does not match height sample count {heightSamples.Length}.");
+            }
             BaseHeight = cityObject.Transform.Position.Y - geometry.MaxHeight;
         }
 
@@ -146,6 +141,8 @@ internal static class DemTerrainGridChunkBoundaryAlignmentPolicy
         public TerrainGridGeometry Geometry { get; }
 
         public double[] HeightSamples { get; }
+
+        public TerrainGridSampleCoverage[] SampleCoverage { get; }
 
         public double BaseHeight { get; }
 

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainOverlayAssignment.cs
@@ -92,6 +92,7 @@ internal static class DemTerrainOverlayAssignment
         ParsedCityObject parsedCityObject,
         IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
         IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds = null,
+        bool allowMissingGeneratedDemOverlayCoverage = false,
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default)
     {
@@ -145,14 +146,14 @@ internal static class DemTerrainOverlayAssignment
 
         if (demTerrainTextureOverlays.Count == 0)
         {
-            ParsedSurface[] texturelessGeneratedSurfaces = generatedSurfaces
+            ParsedSurface[] allTexturelessGeneratedSurfaces = generatedSurfaces
                 .SelectMany(generatedSurface => ClipGeneratedSurfaceToRequestedMeshCodeBounds(
                     generatedSurface,
                     requestedMeshBounds,
                     progressReporter,
                     cancellationToken))
                 .ToArray();
-            ParsedSurface[] texturelessSurfaces = [.. texturelessGeneratedSurfaces, .. nonGeneratedSurfaces];
+            ParsedSurface[] texturelessSurfaces = [.. allTexturelessGeneratedSurfaces, .. nonGeneratedSurfaces];
             if (texturelessSurfaces.Length == 0)
             {
                 yield break;
@@ -163,6 +164,7 @@ internal static class DemTerrainOverlayAssignment
         }
 
         List<(ParsedSurface Surface, TerrainTextureOverlay Overlay)> splitGeneratedSurfaces = [];
+        List<ParsedSurface> texturelessGeneratedSurfaces = [];
         foreach (ParsedSurface generatedSurface in generatedSurfaces)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -192,6 +194,12 @@ internal static class DemTerrainOverlayAssignment
 
                 if (coverage.Kind == TerrainOverlayCoverageKind.None)
                 {
+                    if (allowMissingGeneratedDemOverlayCoverage)
+                    {
+                        texturelessGeneratedSurfaces.Add(requestedMeshClippedSurface);
+                        continue;
+                    }
+
                     throw new InvalidOperationException(
                         $"Mesh-code-bounds-clipped DEM surface '{requestedMeshClippedSurface.PolygonId}' has no matching terrain overlay coverage.");
                 }
@@ -202,8 +210,23 @@ internal static class DemTerrainOverlayAssignment
                         coverage.IntersectingOverlays,
                         progressReporter,
                         cancellationToken);
+                if (allowMissingGeneratedDemOverlayCoverage)
+                {
+                    texturelessGeneratedSurfaces.AddRange(
+                        ClipGeneratedSurfaceOutsideOverlays(
+                            requestedMeshClippedSurface,
+                            coverage.IntersectingOverlays,
+                            progressReporter,
+                            cancellationToken));
+                }
+
                 if (clippedSurfaces.Count == 0)
                 {
+                    if (allowMissingGeneratedDemOverlayCoverage)
+                    {
+                        continue;
+                    }
+
                     throw new InvalidOperationException(
                         $"Mesh-code-bounds-clipped DEM surface '{requestedMeshClippedSurface.PolygonId}' did not produce any terrain-overlay-clipped geometry.");
                 }
@@ -228,6 +251,7 @@ internal static class DemTerrainOverlayAssignment
 
         if (groups.Length == 1
             && nonGeneratedSurfaces.Length == 0
+            && texturelessGeneratedSurfaces.Count == 0
             && groupedGeneratedSurfaces.Count > 0)
         {
             yield return (
@@ -240,7 +264,7 @@ internal static class DemTerrainOverlayAssignment
             yield break;
         }
 
-        bool suffixGeneratedObjects = groups.Length > 1 || nonGeneratedSurfaces.Length > 0;
+        bool suffixGeneratedObjects = groups.Length > 1 || nonGeneratedSurfaces.Length > 0 || texturelessGeneratedSurfaces.Count > 0;
 
         for (int index = 0; index < groups.Length; index++)
         {
@@ -259,7 +283,7 @@ internal static class DemTerrainOverlayAssignment
                 group.First().Overlay);
         }
 
-        ParsedSurface[] untexturedSurfaces = nonGeneratedSurfaces;
+        ParsedSurface[] untexturedSurfaces = [.. texturelessGeneratedSurfaces, .. nonGeneratedSurfaces];
         if (untexturedSurfaces.Length == 0)
         {
             yield break;
@@ -318,6 +342,80 @@ internal static class DemTerrainOverlayAssignment
             requestedMeshBounds).ToArray();
     }
 
+    private static IReadOnlyList<ParsedSurface> ClipGeneratedSurfaceOutsideOverlays(
+        ParsedSurface generatedSurface,
+        IReadOnlyList<TerrainTextureOverlay> overlays,
+        Action<string>? progressReporter,
+        CancellationToken cancellationToken)
+    {
+        GeographicRectangle surfaceBounds = GetSurfaceGeographicBounds(generatedSurface);
+        GeographicRectangle[] uncoveredBounds = CreateUncoveredOverlayCellBounds(surfaceBounds, overlays);
+        if (uncoveredBounds.Length == 0)
+        {
+            return [];
+        }
+
+        return DemTerrainOverlaySurfaceClipper.ClipGeneratedSurfaceToBounds(
+            generatedSurface,
+            uncoveredBounds,
+            progressReporter,
+            cancellationToken);
+    }
+
+    private static GeographicRectangle[] CreateUncoveredOverlayCellBounds(
+        GeographicRectangle surfaceBounds,
+        IReadOnlyList<TerrainTextureOverlay> overlays)
+    {
+        SortedSet<double> latitudes = [surfaceBounds.MinLatitude, surfaceBounds.MaxLatitude];
+        SortedSet<double> longitudes = [surfaceBounds.MinLongitude, surfaceBounds.MaxLongitude];
+        foreach (TerrainTextureOverlay overlay in overlays)
+        {
+            GeographicRectangle bounds = overlay.GeographicBounds;
+            if (!Intersects(surfaceBounds, bounds))
+            {
+                continue;
+            }
+
+            latitudes.Add(Math.Clamp(bounds.MinLatitude, surfaceBounds.MinLatitude, surfaceBounds.MaxLatitude));
+            latitudes.Add(Math.Clamp(bounds.MaxLatitude, surfaceBounds.MinLatitude, surfaceBounds.MaxLatitude));
+            longitudes.Add(Math.Clamp(bounds.MinLongitude, surfaceBounds.MinLongitude, surfaceBounds.MaxLongitude));
+            longitudes.Add(Math.Clamp(bounds.MaxLongitude, surfaceBounds.MinLongitude, surfaceBounds.MaxLongitude));
+        }
+
+        double[] latitudeEdges = latitudes.ToArray();
+        double[] longitudeEdges = longitudes.ToArray();
+        List<GeographicRectangle> uncoveredBounds = [];
+        for (int latitudeIndex = 0; latitudeIndex < latitudeEdges.Length - 1; latitudeIndex++)
+        {
+            double minLatitude = latitudeEdges[latitudeIndex];
+            double maxLatitude = latitudeEdges[latitudeIndex + 1];
+            if (maxLatitude - minLatitude <= 0.0)
+            {
+                continue;
+            }
+
+            double centerLatitude = (minLatitude + maxLatitude) / 2.0;
+            for (int longitudeIndex = 0; longitudeIndex < longitudeEdges.Length - 1; longitudeIndex++)
+            {
+                double minLongitude = longitudeEdges[longitudeIndex];
+                double maxLongitude = longitudeEdges[longitudeIndex + 1];
+                if (maxLongitude - minLongitude <= 0.0)
+                {
+                    continue;
+                }
+
+                double centerLongitude = (minLongitude + maxLongitude) / 2.0;
+                bool covered = overlays.Any(overlay => ContainsPoint(overlay.GeographicBounds, centerLatitude, centerLongitude));
+                if (!covered)
+                {
+                    uncoveredBounds.Add(new GeographicRectangle(minLatitude, maxLatitude, minLongitude, maxLongitude));
+                }
+            }
+        }
+
+        return uncoveredBounds.ToArray();
+    }
+
     private static TerrainOverlayCoverage ResolveTerrainOverlayCoverage(
         GeographicRectangle surfaceBounds,
         IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays)
@@ -335,6 +433,17 @@ internal static class DemTerrainOverlayAssignment
         return intersectingOverlays.Length == 0
             ? TerrainOverlayCoverage.None
             : TerrainOverlayCoverage.Intersecting(intersectingOverlays);
+    }
+
+    private static bool ContainsPoint(
+        GeographicRectangle rectangle,
+        double latitude,
+        double longitude)
+    {
+        return latitude >= rectangle.MinLatitude
+            && latitude <= rectangle.MaxLatitude
+            && longitude >= rectangle.MinLongitude
+            && longitude <= rectangle.MaxLongitude;
     }
 
     private static bool Contains(

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -66,9 +66,16 @@ public sealed record TerrainGridGeometry(
     double MinHeight,
     double MaxHeight,
     IReadOnlyList<double> HeightSamples,
+    IReadOnlyList<TerrainGridSampleCoverage> SampleCoverage,
     Float2? UvScale = null,
     Float2? UvOffset = null)
     : ConstructionGeometry;
+
+public enum TerrainGridSampleCoverage
+{
+    Measured = 0,
+    NoSurface = 1,
+}
 
 public sealed record DynamicTerrainGeometry(
     TriangleMeshGeometry StaticMesh,

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
@@ -15,6 +15,7 @@ internal static class TerrainOverlayMaterialSourcePartitioner
         ParsedCityObject cityObject,
         IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
         IReadOnlyList<MeshCodeBounds>? requestedMeshCodeBounds,
+        bool allowMissingGeneratedDemOverlayCoverage = false,
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default)
     {
@@ -23,6 +24,7 @@ internal static class TerrainOverlayMaterialSourcePartitioner
                      cityObject,
                      demTerrainTextureOverlays,
                      requestedMeshCodeBounds,
+                     allowMissingGeneratedDemOverlayCoverage,
                      progressReporter,
                      cancellationToken))
         {

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlDemTerrainGridSamplerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlDemTerrainGridSamplerTests.cs
@@ -17,6 +17,10 @@ public sealed class CityGmlDemTerrainGridSamplerTests
                 new Float3(0.0, 10.0, 0.0),
                 new Float3(1.0, 20.0, 0.0),
                 new Float3(0.0, 30.0, 1.0)),
+            new(
+                new Float3(1.0, 20.0, 0.0),
+                new Float3(1.0, 40.0, 1.0),
+                new Float3(0.0, 30.0, 1.0)),
         ];
 
         DemTerrainGridHeightSamples samples = CityGmlDemTerrainGridSampler.Sample(
@@ -31,44 +35,104 @@ public sealed class CityGmlDemTerrainGridSamplerTests
 
         Assert.Equal(3, samples.Width);
         Assert.Equal(3, samples.Height);
-        Assert.Equal(10.0, samples.LocalHeights[0], precision: 6);
-        Assert.Equal(15.0, samples.LocalHeights[1], precision: 6);
-        Assert.Equal(20.0, samples.LocalHeights[2], precision: 6);
-        Assert.Equal(20.0, samples.LocalHeights[3], precision: 6);
-        Assert.Equal(30.0, samples.LocalHeights[6], precision: 6);
+        Assert.Equal(15.0, samples.LocalHeights[0], precision: 6);
+        Assert.Equal(18.333333, samples.LocalHeights[1], precision: 6);
+        Assert.Equal(21.666667, samples.LocalHeights[2], precision: 6);
+        Assert.Equal(21.666667, samples.LocalHeights[3], precision: 6);
+        Assert.Equal(28.333333, samples.LocalHeights[6], precision: 6);
+        Assert.All(samples.SampleCoverage, static coverage => Assert.Equal(TerrainGridSampleCoverage.Measured, coverage));
     }
 
     [Fact]
-    public void ExtendBoundaryConnectedMissingHeightSamplesKeepsInteriorFallback()
+    public void SampleUsesTexelCentersForSurfaceCoveredEdges()
     {
-        double[] heights =
+        TerrainGridTriangle[] triangles =
         [
-            -10.0, 1.0, -10.0, 1.0, -10.0,
-            -10.0, 1.0, 1.0, 1.0, -10.0,
-            -10.0, 1.0, -99.0, 1.0, -10.0,
-            -10.0, 2.0, 2.0, 2.0, -10.0,
-            -10.0, 2.0, -10.0, 2.0, -10.0,
-        ];
-        bool[] sampled =
-        [
-            false, true, false, true, false,
-            false, true, true, true, false,
-            false, true, false, true, false,
-            false, true, true, true, false,
-            false, true, false, true, false,
+            new(
+                new Float3(0.0, 10.0, 0.0),
+                new Float3(2.0, 20.0, 0.0),
+                new Float3(0.0, 30.0, 2.0)),
+            new(
+                new Float3(2.0, 20.0, 0.0),
+                new Float3(2.0, 40.0, 2.0),
+                new Float3(0.0, 30.0, 2.0)),
         ];
 
-        CityGmlDemTerrainGridSampler.ExtendBoundaryConnectedMissingHeightSamples(
-            heights,
-            sampled,
-            width: 5,
-            height: 5);
+        DemTerrainGridHeightSamples samples = CityGmlDemTerrainGridSampler.Sample(
+            minX: 0.0,
+            maxX: 2.0,
+            minZ: 0.0,
+            maxZ: 2.0,
+            metersPerVertex: 1.0,
+            maxResolution: 3,
+            fallbackHeight: -100.0,
+            triangles);
 
-        Assert.Equal(1.0, heights[0], precision: 6);
-        Assert.Equal(1.0, heights[2], precision: 6);
-        Assert.Equal(2.0, heights[20], precision: 6);
-        Assert.Equal(2.0, heights[24], precision: 6);
-        Assert.Equal(-99.0, heights[12], precision: 6);
+        Assert.Equal(15.0, samples.LocalHeights[0], precision: 6);
+        Assert.Equal(21.666667, samples.LocalHeights[2], precision: 6);
+        Assert.Equal(25.0, samples.LocalHeights[4], precision: 6);
+        Assert.Equal(28.333333, samples.LocalHeights[6], precision: 6);
+        Assert.Equal(35.0, samples.LocalHeights[8], precision: 6);
+        Assert.DoesNotContain(samples.LocalHeights, sample => Math.Abs(sample - -100.0) <= 1e-6);
+        Assert.All(samples.SampleCoverage, static coverage => Assert.Equal(TerrainGridSampleCoverage.Measured, coverage));
+    }
+
+    [Fact]
+    public void SampleKeepsSurfaceMissingSamplesAtSeaLevelWithCoverage()
+    {
+        TerrainGridTriangle[] triangles =
+        [
+            new(
+                new Float3(0.0, 10.0, 0.0),
+                new Float3(2.0, 20.0, 0.0),
+                new Float3(0.0, 30.0, 2.0)),
+        ];
+
+        DemTerrainGridHeightSamples samples = CityGmlDemTerrainGridSampler.Sample(
+            minX: 0.0,
+            maxX: 2.0,
+            minZ: 0.0,
+            maxZ: 2.0,
+            metersPerVertex: 1.0,
+            maxResolution: 3,
+            fallbackHeight: -100.0,
+            triangles);
+
+        Assert.Equal(15.0, samples.LocalHeights[0], precision: 6);
+        Assert.Equal(25.0, samples.LocalHeights[4], precision: 6);
+        Assert.Equal(-100.0, samples.LocalHeights[5], precision: 6);
+        Assert.Equal(-100.0, samples.LocalHeights[7], precision: 6);
+        Assert.Equal(-100.0, samples.LocalHeights[8], precision: 6);
+        Assert.Equal(TerrainGridSampleCoverage.NoSurface, samples.SampleCoverage[5]);
+        Assert.Equal(TerrainGridSampleCoverage.NoSurface, samples.SampleCoverage[7]);
+        Assert.Equal(TerrainGridSampleCoverage.NoSurface, samples.SampleCoverage[8]);
+    }
+
+    [Fact]
+    public void SampleSeparatesMeasuredSeaLevelFromNoSurfaceSeaLevel()
+    {
+        TerrainGridTriangle[] triangles =
+        [
+            new(
+                new Float3(0.0, 0.0, 0.0),
+                new Float3(1.0, 0.0, 0.0),
+                new Float3(0.0, 0.0, 1.0)),
+        ];
+
+        DemTerrainGridHeightSamples samples = CityGmlDemTerrainGridSampler.Sample(
+            minX: 0.0,
+            maxX: 2.0,
+            minZ: 0.0,
+            maxZ: 2.0,
+            metersPerVertex: 1.0,
+            maxResolution: 3,
+            fallbackHeight: 0.0,
+            triangles);
+
+        Assert.Equal(0.0, samples.LocalHeights[0], precision: 6);
+        Assert.Equal(0.0, samples.LocalHeights[8], precision: 6);
+        Assert.Equal(TerrainGridSampleCoverage.Measured, samples.SampleCoverage[0]);
+        Assert.Equal(TerrainGridSampleCoverage.NoSurface, samples.SampleCoverage[8]);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGridChunkBoundaryAlignmentPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGridChunkBoundaryAlignmentPolicyTests.cs
@@ -90,6 +90,70 @@ public sealed class DemTerrainGridChunkBoundaryAlignmentPolicyTests
         Assert.NotEqual(left.Transform.Position.Y, aligned[0].Transform.Position.Y);
     }
 
+    [Fact]
+    public void AlignUsesMeasuredCoverageInsteadOfSeaLevelSentinel()
+    {
+        ImportedCityObject left = CreateTerrainGridCityObject(
+            "left-dem",
+            new Float3(0.0, 1.0, 0.0),
+            width: 2,
+            height: 2,
+            sizeX: 2.0,
+            sizeZ: 2.0,
+            [1.0, 0.0, 1.0, 0.0],
+            [Measured, Measured, Measured, Measured]);
+        ImportedCityObject right = CreateTerrainGridCityObject(
+            "right-dem",
+            new Float3(2.0, 9.0, 0.0),
+            width: 2,
+            height: 2,
+            sizeX: 2.0,
+            sizeZ: 2.0,
+            [4.0, 9.0, 4.0, 9.0],
+            [Measured, Measured, Measured, Measured]);
+
+        ImportedCityObject[] aligned = DemTerrainGridChunkBoundaryAlignmentPolicy.Align([left, right]);
+
+        TerrainGridGeometry alignedLeft = Assert.IsType<TerrainGridGeometry>(aligned[0].Geometry);
+        TerrainGridGeometry alignedRight = Assert.IsType<TerrainGridGeometry>(aligned[1].Geometry);
+        Assert.Equal(2.0, alignedLeft.HeightSamples[1], 6);
+        Assert.Equal(2.0, alignedLeft.HeightSamples[3], 6);
+        Assert.Equal(2.0, alignedRight.HeightSamples[0], 6);
+        Assert.Equal(2.0, alignedRight.HeightSamples[2], 6);
+    }
+
+    [Fact]
+    public void AlignDoesNotRaiseNoSurfaceBoundarySamplesToMeasuredHeight()
+    {
+        ImportedCityObject left = CreateTerrainGridCityObject(
+            "left-dem",
+            new Float3(0.0, 10.0, 0.0),
+            width: 2,
+            height: 2,
+            sizeX: 2.0,
+            sizeZ: 2.0,
+            [1.0, 10.0, 1.0, 10.0],
+            [Measured, Measured, Measured, Measured]);
+        ImportedCityObject right = CreateTerrainGridCityObject(
+            "right-dem",
+            new Float3(2.0, 2.0, 0.0),
+            width: 2,
+            height: 2,
+            sizeX: 2.0,
+            sizeZ: 2.0,
+            [0.0, 2.0, 0.0, 2.0],
+            [NoSurface, Measured, NoSurface, Measured]);
+
+        ImportedCityObject[] aligned = DemTerrainGridChunkBoundaryAlignmentPolicy.Align([left, right]);
+
+        TerrainGridGeometry alignedLeft = Assert.IsType<TerrainGridGeometry>(aligned[0].Geometry);
+        TerrainGridGeometry alignedRight = Assert.IsType<TerrainGridGeometry>(aligned[1].Geometry);
+        Assert.Equal(10.0, alignedLeft.HeightSamples[1], 6);
+        Assert.Equal(10.0, alignedLeft.HeightSamples[3], 6);
+        Assert.Equal(0.0, alignedRight.HeightSamples[0], 6);
+        Assert.Equal(0.0, alignedRight.HeightSamples[2], 6);
+    }
+
     private static ImportedCityObject CreateDynamicTerrainCityObject(
         string slotKey,
         Float3 position,
@@ -128,7 +192,8 @@ public sealed class DemTerrainGridChunkBoundaryAlignmentPolicyTests
         int height,
         double sizeX,
         double sizeZ,
-        IReadOnlyList<double> heightSamples)
+        IReadOnlyList<double> heightSamples,
+        IReadOnlyList<TerrainGridSampleCoverage>? sampleCoverage = null)
     {
         MaterialBinding material = new(
             BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
@@ -151,8 +216,18 @@ public sealed class DemTerrainGridChunkBoundaryAlignmentPolicyTests
                 Size: new Float2(sizeX, sizeZ),
                 MinHeight: heightSamples.Min(),
                 MaxHeight: heightSamples.Max(),
-                HeightSamples: heightSamples),
+                HeightSamples: heightSamples,
+                SampleCoverage: sampleCoverage ?? CreateMeasuredCoverage(heightSamples.Count)),
             Materials: [material],
             SourceFileRelativePath: $"udx/dem/53394525/{slotKey}.gml");
     }
+
+    private static TerrainGridSampleCoverage[] CreateMeasuredCoverage(int count)
+    {
+        return Enumerable.Repeat(TerrainGridSampleCoverage.Measured, count).ToArray();
+    }
+
+    private const TerrainGridSampleCoverage Measured = TerrainGridSampleCoverage.Measured;
+
+    private const TerrainGridSampleCoverage NoSurface = TerrainGridSampleCoverage.NoSurface;
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -2422,7 +2422,183 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public async Task DemTerrainGridModeExtendsBoundaryConnectedMissingSamplesWithoutSeaLevelDrop()
+    public void DemTerrainStaticModeDoesNotRequireGeneratedDemOverlayCoverage()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        ParsedSurface generatedSurface = (CreateParsedSurface(
+                "dem-generated",
+                ParsedSurfaceSemantic.Ground,
+                CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 1.0, minRatio: 0.1, maxRatio: 0.9, reverseWinding: false)) with
+        {
+            UsesGeneratedDemTexture = true,
+        });
+        ParsedCityObject cityObject = CreateParsedCityObject("dem", [generatedSurface], referenceSystem);
+        GeodeticPoint origin = CreateMeshCenterPoint("53394525", 0.0);
+        TerrainTextureOverlay unrelatedOverlay = CreateThirdMeshOverlay("53394526");
+        PlateauImportRequest request = new(
+            Dataset: "test-dataset",
+            MeshCode: "53394525",
+            CityGmlSource: DatasetLocation.Local("C:\\dataset"),
+            TerrainMeshMode: TerrainMeshMode.Static);
+
+        ImportedCityObject[] projected = LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            origin,
+            new GeographicLib.LocalCartesian(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric),
+            [unrelatedOverlay],
+            requestedMeshCodeBounds: [MeshCodeBounds.TryParse("53394525")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create())).ToArray();
+
+        ImportedCityObject result = Assert.Single(projected);
+        Assert.IsType<TriangleMeshGeometry>(result.Geometry);
+        Assert.DoesNotContain(result.Materials, static material => material.TerrainOverlay is not null);
+        MaterialBinding material = Assert.Single(result.Materials);
+        Assert.Equal(181.0 / 255.0, material.BaseColor.R, precision: 6);
+        Assert.Equal(176.0 / 255.0, material.BaseColor.G, precision: 6);
+        Assert.Equal(166.0 / 255.0, material.BaseColor.B, precision: 6);
+    }
+
+    [Fact]
+    public void DemTerrainGridModeDoesNotRequireGeneratedDemOverlayCoverage()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        ParsedSurface generatedSurface = (CreateParsedSurface(
+                "dem-generated",
+                ParsedSurfaceSemantic.Ground,
+                CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 1.0, minRatio: 0.1, maxRatio: 0.9, reverseWinding: false)) with
+        {
+            UsesGeneratedDemTexture = true,
+        });
+        ParsedCityObject cityObject = CreateParsedCityObject("dem", [generatedSurface], referenceSystem);
+        GeodeticPoint origin = CreateMeshCenterPoint("53394525", 0.0);
+        TerrainTextureOverlay unrelatedOverlay = CreateThirdMeshOverlay("53394526");
+        PlateauImportRequest request = new(
+            Dataset: "test-dataset",
+            MeshCode: "53394525",
+            CityGmlSource: DatasetLocation.Local("C:\\dataset"),
+            TerrainMeshMode: TerrainMeshMode.Grid);
+
+        ImportedCityObject[] projected = LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            origin,
+            new GeographicLib.LocalCartesian(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric),
+            [unrelatedOverlay],
+            requestedMeshCodeBounds: [MeshCodeBounds.TryParse("53394525")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create())).ToArray();
+
+        ImportedCityObject result = Assert.Single(projected);
+        Assert.IsType<TerrainGridGeometry>(result.Geometry);
+        Assert.DoesNotContain(result.Materials, static material => material.TerrainOverlay is not null);
+        MaterialBinding material = Assert.Single(result.Materials);
+        Assert.Equal(181.0 / 255.0, material.BaseColor.R, precision: 6);
+        Assert.Equal(176.0 / 255.0, material.BaseColor.G, precision: 6);
+        Assert.Equal(166.0 / 255.0, material.BaseColor.B, precision: 6);
+    }
+
+    [Fact]
+    public void DemTerrainStaticModePreservesCoveredGeneratedDemOverlayPartitions()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        ParsedSurface coveredSurface = (CreateParsedSurface(
+                "dem-covered",
+                ParsedSurfaceSemantic.Ground,
+                CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 1.0, minRatio: 0.1, maxRatio: 0.2, reverseWinding: false)) with
+        {
+            UsesGeneratedDemTexture = true,
+        });
+        ParsedSurface uncoveredSurface = (CreateParsedSurface(
+                "dem-uncovered",
+                ParsedSurfaceSemantic.Ground,
+                CreateMeshRelativeQuadVertices("53394526", altitudeMeters: 1.0, minRatio: 0.1, maxRatio: 0.2, reverseWinding: false)) with
+        {
+            UsesGeneratedDemTexture = true,
+        });
+        ParsedCityObject cityObject = CreateParsedCityObject("dem", [coveredSurface, uncoveredSurface], referenceSystem);
+        GeodeticPoint origin = CreateMeshCenterPoint("53394525", 0.0);
+        TerrainTextureOverlay coveredOverlay = CreateThirdMeshOverlay("53394525");
+        PlateauImportRequest request = new(
+            Dataset: "test-dataset",
+            MeshCode: "53394525",
+            CityGmlSource: DatasetLocation.Local("C:\\dataset"),
+            TerrainMeshMode: TerrainMeshMode.Static);
+
+        ImportedCityObject[] projected = LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            origin,
+            new GeographicLib.LocalCartesian(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric),
+            [coveredOverlay],
+            requestedMeshCodeBounds: [MeshCodeBounds.TryParse("53394525")!, MeshCodeBounds.TryParse("53394526")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create())).ToArray();
+
+        Assert.Equal(2, projected.Length);
+        Assert.Contains(projected, static cityObject => cityObject.Materials.Any(static material => material.TerrainOverlay is not null));
+        ImportedCityObject uncoveredCityObject = Assert.Single(
+            projected,
+            static cityObject => cityObject.Materials.All(static material => material.TerrainOverlay is null));
+        MaterialBinding uncoveredMaterial = Assert.Single(uncoveredCityObject.Materials);
+        Assert.Equal(181.0 / 255.0, uncoveredMaterial.BaseColor.R, precision: 6);
+        Assert.Equal(176.0 / 255.0, uncoveredMaterial.BaseColor.G, precision: 6);
+        Assert.Equal(166.0 / 255.0, uncoveredMaterial.BaseColor.B, precision: 6);
+    }
+
+    [Fact]
+    public void DemTerrainStaticModeKeepsUncoveredPartOfPartiallyCoveredGeneratedDemSurface()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        (double south, double north, double west, double east) = GetMeshBounds("53394525");
+        (double _, double _, double eastWest, double eastEast) = GetMeshBounds("53394526");
+        ParsedSurface generatedSurface = (CreateParsedSurface(
+                "dem-partial",
+                ParsedSurfaceSemantic.Ground,
+                [
+                    new(south + ((north - south) * 0.1), west + ((east - west) * 0.25), 1.0),
+                    new(south + ((north - south) * 0.1), eastWest + ((eastEast - eastWest) * 0.25), 1.0),
+                    new(south + ((north - south) * 0.2), eastWest + ((eastEast - eastWest) * 0.25), 1.0),
+                    new(south + ((north - south) * 0.2), west + ((east - west) * 0.25), 1.0),
+                    new(south + ((north - south) * 0.1), west + ((east - west) * 0.25), 1.0),
+                ]) with
+        {
+            UsesGeneratedDemTexture = true,
+        });
+        ParsedCityObject cityObject = CreateParsedCityObject("dem", [generatedSurface], referenceSystem);
+        GeodeticPoint origin = CreateMeshCenterPoint("53394525", 0.0);
+        TerrainTextureOverlay coveredOverlay = CreateThirdMeshOverlay("53394525");
+        PlateauImportRequest request = new(
+            Dataset: "test-dataset",
+            MeshCode: "53394525",
+            CityGmlSource: DatasetLocation.Local("C:\\dataset"),
+            TerrainMeshMode: TerrainMeshMode.Static);
+
+        ImportedCityObject[] projected = LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            origin,
+            new GeographicLib.LocalCartesian(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric),
+            [coveredOverlay],
+            requestedMeshCodeBounds: [MeshCodeBounds.TryParse("53394525")!, MeshCodeBounds.TryParse("53394526")!],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create())).ToArray();
+
+        Assert.Equal(2, projected.Length);
+        Assert.Contains(projected, static cityObject => cityObject.Materials.Any(static material => material.TerrainOverlay is not null));
+        ImportedCityObject uncoveredCityObject = Assert.Single(
+            projected,
+            static cityObject => cityObject.Materials.All(static material => material.TerrainOverlay is null));
+        MaterialBinding uncoveredMaterial = Assert.Single(uncoveredCityObject.Materials);
+        Assert.Equal(181.0 / 255.0, uncoveredMaterial.BaseColor.R, precision: 6);
+        Assert.Equal(176.0 / 255.0, uncoveredMaterial.BaseColor.G, precision: 6);
+        Assert.Equal(166.0 / 255.0, uncoveredMaterial.BaseColor.B, precision: 6);
+        Assert.All(projected, static cityObject => Assert.NotEmpty(((TriangleMeshGeometry)cityObject.Geometry).Mesh.Vertices));
+    }
+
+    [Fact]
+    public async Task DemTerrainGridModeKeepsSurfaceCoveredBoundarySamplesMeasured()
     {
         using TemporaryDirectory datasetRoot = new();
         CreateRuntimeDemChunkFixture(datasetRoot.Path);
@@ -2458,11 +2634,29 @@ public sealed class LocalCityGmlObjectProjectionTests
         double[] rightEdge = Enumerable.Range(0, geometry.Height)
             .Select(index => geometry.HeightSamples[(index * geometry.Width) + (geometry.Width - 1)])
             .ToArray();
+        TerrainGridSampleCoverage[] topCoverage = Enumerable.Range(0, geometry.Width)
+            .Select(index => geometry.SampleCoverage![index])
+            .ToArray();
+        TerrainGridSampleCoverage[] bottomCoverage = Enumerable.Range(0, geometry.Width)
+            .Select(index => geometry.SampleCoverage![((geometry.Height - 1) * geometry.Width) + index])
+            .ToArray();
+        TerrainGridSampleCoverage[] leftCoverage = Enumerable.Range(0, geometry.Height)
+            .Select(index => geometry.SampleCoverage![index * geometry.Width])
+            .ToArray();
+        TerrainGridSampleCoverage[] rightCoverage = Enumerable.Range(0, geometry.Height)
+            .Select(index => geometry.SampleCoverage![(index * geometry.Width) + (geometry.Width - 1)])
+            .ToArray();
 
-        Assert.True(bottomEdge.Min() > -1.0, $"Bottom edge dropped to sea-level fallback: min={bottomEdge.Min():F6}");
-        Assert.True(leftEdge.Min() > -1.0, $"Left edge dropped to sea-level fallback: min={leftEdge.Min():F6}");
-        Assert.True(rightEdge.Min() > -1.0, $"Right edge dropped to sea-level fallback: min={rightEdge.Min():F6}");
-        Assert.True(topEdge.Min() > -1.0, $"Top edge dropped to sea-level fallback: min={topEdge.Min():F6}");
+        double[] boundarySamples = [.. topEdge, .. bottomEdge, .. leftEdge, .. rightEdge];
+        Assert.True(geometry.HeightSamples.Max() > 0.0, "Measured DEM surface heights were unexpectedly lost.");
+        Assert.True(boundarySamples.Min() > -1.0, $"Surface-covered boundary dropped to sea-level fallback: min={boundarySamples.Min():F6}");
+        Assert.NotNull(geometry.SampleCoverage);
+        Assert.Equal(geometry.Width * geometry.Height, geometry.SampleCoverage.Count);
+        Assert.Contains(geometry.SampleCoverage, static coverage => coverage == TerrainGridSampleCoverage.Measured);
+        Assert.Contains(topCoverage, static coverage => coverage == TerrainGridSampleCoverage.Measured);
+        Assert.Contains(bottomCoverage, static coverage => coverage == TerrainGridSampleCoverage.Measured);
+        Assert.Contains(leftCoverage, static coverage => coverage == TerrainGridSampleCoverage.Measured);
+        Assert.Contains(rightCoverage, static coverage => coverage == TerrainGridSampleCoverage.Measured);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -466,6 +466,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                     heightMap.MinHeight,
                     heightMap.MaxHeight,
                     heightMap.HeightSamples,
+                    CreateMeasuredTerrainGridCoverage(heightMap.HeightSamples.Count),
                     heightMap.UvScale is null ? null : ToContractFloat2(heightMap.UvScale),
                     heightMap.UvOffset is null ? null : ToContractFloat2(heightMap.UvOffset)),
                 cityObject.Materials.Select(ToContractMaterial).ToArray(),
@@ -487,6 +488,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                         dynamicTerrain.GridMesh.MinHeight,
                         dynamicTerrain.GridMesh.MaxHeight,
                         dynamicTerrain.GridMesh.HeightSamples,
+                        CreateMeasuredTerrainGridCoverage(dynamicTerrain.GridMesh.HeightSamples.Count),
                         dynamicTerrain.GridMesh.UvScale is null ? null : ToContractFloat2(dynamicTerrain.GridMesh.UvScale),
                         dynamicTerrain.GridMesh.UvOffset is null ? null : ToContractFloat2(dynamicTerrain.GridMesh.UvOffset))),
                 cityObject.Materials.Select(ToContractMaterial).ToArray(),
@@ -534,6 +536,9 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 new Float2(vertex.UV0.X, vertex.UV0.Y),
                 vertex.Color is null ? null : new ColorRgba(vertex.Color.R, vertex.Color.G, vertex.Color.B, vertex.Color.A))).ToArray(),
             mesh.Submeshes.Select(static submesh => new MeshSubmesh(submesh.Index, submesh.TriangleVertexIndices)).ToArray());
+
+    private static TerrainGridSampleCoverage[] CreateMeasuredTerrainGridCoverage(int count)
+        => Enumerable.Repeat(TerrainGridSampleCoverage.Measured, count).ToArray();
 
     private static TexturePayload ToContractTexturePayload(ResoniteTexturePayload payload)
         => new(


### PR DESCRIPTION
## Summary
- keep GridMesh no-face heightmap samples at sea-level fallback instead of boundary-filling them
- sample GridMesh heightmaps from the uncut DEM surface while keeping StaticMesh/cut bounds behavior unchanged
- add coastline, DEM-boundary, and StaticMesh regression coverage

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity minimal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- canonical Sendai 57403710 GridMesh import with local real dataset archive (ignored runtime output)
- live send to ws://localhost:19102/ and post-send root dump inspection (ignored runtime output)