### PR TITLE
Fix base position requirements

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/ImportedSceneSourceDiscoveryPipeline.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ImportedSceneSourceDiscoveryPipeline.cs
@@ -34,8 +34,6 @@ internal static class ImportedSceneSourceDiscoveryPipeline
         IPlateauDatasetContentSource datasetSource = await datasetContentSourceFactory.CreateAsync(
             localSource.LocalSourcePath!,
             cancellationToken);
-        MeshCodeBounds? requestedMeshCodeBoundsForExactSelector =
-            MeshCodeBounds.TryParse(request.MeshCode);
         Stopwatch totalStopwatch = Stopwatch.StartNew();
         Stopwatch scanStopwatch = Stopwatch.StartNew();
         LocalCityGmlSourceFileDiscoveryResult discoveryResult = LocalCityGmlSourceFileDiscovery.Discover(
@@ -50,9 +48,8 @@ internal static class ImportedSceneSourceDiscoveryPipeline
                 descriptor.MatchedMeshCode,
                 descriptor.RequiresMeshCodeBoundsFilter))
             .ToArray();
-        MeshCodeBounds[] requestedMeshCodeBounds = requestedMeshCodeBoundsForExactSelector is null
-            ? MeshCodeBounds.CreateManyFromSelectedMeshCodes(discoveryResult.SelectedMeshCodes)
-            : [requestedMeshCodeBoundsForExactSelector];
+        MeshCodeBounds[] requestedMeshCodeBounds =
+            MeshCodeBounds.CreateManyFromSelectedMeshCodes(discoveryResult.SelectedMeshCodes);
         MeshCodeBounds? effectiveRequestedMeshCodeBounds =
             MeshCodeBounds.TryMerge(requestedMeshCodeBounds);
         scanStopwatch.Stop();

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
@@ -307,6 +307,12 @@ internal static class LocalCityGmlSourceFileDiscovery
                 {
                     yield return candidateMeshCode;
                 }
+                else if (RequestedValue.Length == 8
+                    && candidateMeshCode.Length == 6
+                    && string.Equals(candidateMeshCode, RequestedValue[..6], StringComparison.Ordinal))
+                {
+                    yield return RequestedValue;
+                }
 
                 yield break;
             }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneAnchorResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneAnchorResolver.cs
@@ -60,7 +60,7 @@ internal sealed class ResoniteSceneAnchorResolver : IResoniteSceneAnchorResolver
             return new SceneAnchor(
                 new ResoniteSlotLocator(completionSourceFileRoot.ID ?? datasetRootSlot.Value),
                 completionMeshCode,
-                GetSlotPositionOrDefault(completionSourceFileRoot),
+                GetRequiredSourceRootPosition(completionSourceFileRoot),
                 new ResoniteSlotLocator(completionSourceFileRoot.ID ?? datasetRootSlot.Value));
         }
 
@@ -78,7 +78,7 @@ internal sealed class ResoniteSceneAnchorResolver : IResoniteSceneAnchorResolver
                 new ResoniteSlotLocator(referenceSourceFileRoot.Slot.ID ?? datasetRootSlot.Value),
                 completionMeshCode,
                 Add(
-                    GetSlotPositionOrDefault(referenceSourceFileRoot.Slot),
+                    GetRequiredSourceRootPosition(referenceSourceFileRoot.Slot),
                     ComputeMeshCodeOffset(referenceSourceFileRoot.MeshCode, completionMeshCode)),
                 new ResoniteSlotLocator(referenceSourceFileRoot.Slot.ID ?? datasetRootSlot.Value));
         }
@@ -117,6 +117,18 @@ internal sealed class ResoniteSceneAnchorResolver : IResoniteSceneAnchorResolver
         }
 
         return new ResoniteFloat3(0.0, 0.0, 0.0);
+    }
+
+    private static ResoniteFloat3 GetRequiredSourceRootPosition(Slot slot)
+    {
+        if (slot.Position is Field_float3 position)
+        {
+            return new ResoniteFloat3(position.Value.x, position.Value.y, position.Value.z);
+        }
+
+        throw new InvalidOperationException(
+            $"Source-file root '{slot.Name?.Value ?? slot.ID ?? "<unnamed>"}' did not expose a Position. "
+            + "Append anchor recovery requires positioned source-file roots.");
     }
 
     private static ResoniteFloat3 ComputeMeshCodeOffset(string referenceMeshCode, string meshCode)

--- a/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootPlacementResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootPlacementResolver.cs
@@ -19,7 +19,7 @@ internal static class ObservedSourceRootPlacementResolver
         ObservedSourceRootPlacement[] exactSourceRoots = directSourceRoots
             .Where(slot => string.Equals(slot.Name?.Value, sourceFileSlotName, StringComparison.Ordinal))
             .Select(slot => new ObservedSourceRootPlacement(
-                GetSlotPositionOrDefault(slot),
+                GetRequiredSourceRootPosition(slot),
                 ReferenceMeshCode: rootMeshCode,
                 SlotId: slot.ID ?? string.Empty))
             .ToArray();
@@ -39,7 +39,7 @@ internal static class ObservedSourceRootPlacementResolver
                 && rootMeshCode.StartsWith(candidate.MeshCode, StringComparison.Ordinal))
             .Select(candidate => new ObservedSourceRootPlacement(
                 ResonitePlacementPolicy.Add(
-                    GetSlotPositionOrDefault(candidate.Slot),
+                    GetRequiredSourceRootPosition(candidate.Slot),
                     ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
                 ReferenceMeshCode: candidate.MeshCode,
                 SlotId: candidate.Slot.ID ?? string.Empty))
@@ -54,7 +54,7 @@ internal static class ObservedSourceRootPlacementResolver
                 .Where(static candidate => candidate.Slot is not null)
                 .Select(candidate => new ObservedSourceRootPlacement(
                     ResonitePlacementPolicy.Add(
-                        GetSlotPositionOrDefault(candidate.Slot),
+                        GetRequiredSourceRootPosition(candidate.Slot),
                         ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
                     ReferenceMeshCode: candidate.MeshCode,
                     SlotId: candidate.Slot.ID ?? string.Empty))
@@ -101,11 +101,13 @@ internal static class ObservedSourceRootPlacementResolver
             && Math.Abs(left.Z - right.Z) <= tolerance;
     }
 
-    private static ResoniteFloat3 GetSlotPositionOrDefault(Slot slot)
+    private static ResoniteFloat3 GetRequiredSourceRootPosition(Slot slot)
     {
         if (slot.Position is not Field_float3 position)
         {
-            return new ResoniteFloat3(0.0, 0.0, 0.0);
+            throw new InvalidOperationException(
+                $"Observed source-file root '{slot.Name?.Value ?? slot.ID ?? "<unnamed>"}' did not expose a Position. "
+                + "Append placement requires positioned source-file roots.");
         }
 
         return new ResoniteFloat3(position.Value.x, position.Value.y, position.Value.z);

--- a/tests/PlateauResoniteLink.Tests/Application/LocalCityGmlDocumentReaderTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/LocalCityGmlDocumentReaderTests.cs
@@ -67,6 +67,32 @@ public sealed class LocalCityGmlDocumentReaderTests
         Assert.Equal(0, datasetSource.OpenReadCallCount);
     }
 
+    [Fact]
+    public async Task ReadAsyncUsesSelectedMeshCodesForDiscoveryOriginWhenExactRequestMatchesParentSourceFiles()
+    {
+        string fixturePath = TestData.GetFixturePath("LocalPlateauDatasetParentMeshPackages");
+        LocalCityGmlDocumentReader reader = new(
+            new DefaultPlateauDatasetContentSourceFactory(
+                new RemoteArchiveDistributionPolicy(),
+                new ArchiveFileLayoutPolicy()),
+            new CityGmlAppearanceStoreFactory(),
+            new CityGmlLodSelector());
+
+        ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlSource: DatasetLocation.Local(fixturePath),
+                PackageNames: ["dem", "tran"]
+));
+
+        GeodeticCoordinate expectedOrigin = MeshCodeBounds.TryParse("53394525")!.GetGeodeticCenter();
+        Assert.Equal(["53394525"], readResult.DocumentSet.SelectedMeshCodes);
+        Assert.Equal(expectedOrigin.Latitude, readResult.DiscoveryContext.GlobalOriginPoint.Latitude, 12);
+        Assert.Equal(expectedOrigin.Longitude, readResult.DiscoveryContext.GlobalOriginPoint.Longitude, 12);
+        Assert.Equal(expectedOrigin.Altitude, readResult.DiscoveryContext.GlobalOriginPoint.Altitude, 12);
+    }
+
     private sealed class StubDatasetContentSourceFactory(IPlateauDatasetContentSource datasetSource) : IPlateauDatasetContentSourceFactory
     {
         public Task<IPlateauDatasetContentSource> CreateAsync(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileDiscoveryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileDiscoveryTests.cs
@@ -38,12 +38,14 @@ public sealed class LocalCityGmlSourceFileDiscoveryTests
         string datasetRoot = TestData.GetFixturePath("LocalPlateauDatasetParentMeshPackages");
         IEnumerable<string> relativePaths = GetRelativeGmlPaths(datasetRoot);
 
-        LocalCityGmlSourceFileDescriptor[] result = LocalCityGmlSourceFileDiscovery.Discover(
+        LocalCityGmlSourceFileDiscoveryResult discoveryResult = LocalCityGmlSourceFileDiscovery.Discover(
             relativePaths,
             "53394525",
-            ["waterbody", "tran", "dem"]).SourceFiles.ToArray();
+            ["waterbody", "tran", "dem"]);
+        LocalCityGmlSourceFileDescriptor[] result = discoveryResult.SourceFiles.ToArray();
 
         Assert.Equal(["dem", "tran"], result.Select(static file => file.PackageName).ToArray());
+        Assert.Equal(["53394525"], discoveryResult.SelectedMeshCodes);
         Assert.Contains(
             result,
             static file =>

--- a/tests/PlateauResoniteLink.Tests/Targets/ObservedSourceRootPlacementResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ObservedSourceRootPlacementResolverTests.cs
@@ -42,6 +42,36 @@ public sealed class ObservedSourceRootPlacementResolverTests
             StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void TryResolveProjectsFromAnyPositionedSiblingSourceRoot()
+    {
+        ObservedSourceRootPlacement? placement = ObservedSourceRootPlacementResolver.TryResolve(
+            "plateau_tokyo23ku_bldg_53394527",
+            "53394527",
+            [
+                CreateSlot("sibling-root", "plateau_tokyo23ku_bldg_53394525", new ResoniteFloat3(20.0, 1.0, 30.0)),
+            ]);
+        ResoniteFloat3 expected = ResonitePlacementPolicy.Add(
+            new ResoniteFloat3(20.0, 1.0, 30.0),
+            ResonitePlacementPolicy.ComputeMeshCodeOffset("53394525", "53394527"));
+
+        Assert.Equal(expected, placement?.Position);
+        Assert.Equal("53394525", placement?.ReferenceMeshCode);
+        Assert.Equal("sibling-root", placement?.SlotId);
+    }
+
+    [Fact]
+    public void TryResolveRejectsObservedSourceRootWithoutPosition()
+    {
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => ObservedSourceRootPlacementResolver.TryResolve(
+                "plateau_tokyo23ku_bldg_53394525",
+                "53394525",
+                [CreateSlotWithoutPosition("source-root", "plateau_tokyo23ku_bldg_53394525")]));
+
+        Assert.Contains("did not expose a Position", exception.Message, StringComparison.Ordinal);
+    }
+
     private static Slot CreateSlot(string id, string name, ResoniteFloat3 position)
     {
         return new Slot
@@ -57,6 +87,15 @@ public sealed class ObservedSourceRootPlacementResolverTests
                     z = (float)position.Z,
                 },
             },
+        };
+    }
+
+    private static Slot CreateSlotWithoutPosition(string id, string name)
+    {
+        return new Slot
+        {
+            ID = id,
+            Name = new Field_string { Value = name },
         };
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -652,6 +652,54 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
+    public async Task ExecuteAsyncPositionsInitialSourceFileRootsRelativeToSelectedDataCenter()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ResoniteLocalOrigin selectedDataCenter = RequireMergedMeshCodeCenter([MeshCode, SecondaryMeshCode]);
+        ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
+            DatasetName,
+            MeshCode,
+            datasetDirectory.Path,
+            selectedDataCenter,
+            packageNames: ["bldg"],
+            sourceFiles: [PrimarySourceFile, SecondarySourceFile],
+            requestedMeshCodes: [MeshCode, SecondaryMeshCode]);
+        using SceneSinkRecordingClient client = new();
+        ResoniteFloat3 primaryWorldPosition = new(12.0, 0.0, 34.0);
+        ResoniteFloat3 secondaryWorldPosition = new(56.0, 0.0, 78.0);
+
+        await ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(
+            metadata,
+            [
+                CreateBundledTriangleCityObject(
+                    "selected-center-primary",
+                    actualMeshCode: MeshCode,
+                    sourceFileRelativePath: PrimarySourceFile,
+                    worldPosition: primaryWorldPosition),
+                CreateBundledTriangleCityObject(
+                    "selected-center-secondary",
+                    actualMeshCode: SecondaryMeshCode,
+                    sourceFileRelativePath: SecondarySourceFile,
+                    worldPosition: secondaryWorldPosition),
+            ],
+            client);
+
+        Slot primaryRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
+        Slot secondaryRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
+            client,
+            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(SecondarySourceFile)}");
+        Slot primaryObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject selected-center-primary");
+        Slot secondaryObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject selected-center-secondary");
+
+        AssertNear(ComputeOriginOffset(selectedDataCenter, MeshCode), GetSlotPosition(primaryRoot), 0.2);
+        AssertNear(ComputeOriginOffset(selectedDataCenter, SecondaryMeshCode), GetSlotPosition(secondaryRoot), 0.2);
+        AssertNear(primaryWorldPosition, GetAccumulatedPosition(client, primaryObjectSlot), 0.2);
+        AssertNear(secondaryWorldPosition, GetAccumulatedPosition(client, secondaryObjectSlot), 0.2);
+    }
+
+    [Fact]
     public async Task ExecuteAsyncCreatesIndependentSourceFileRootAcrossRuns()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -1741,6 +1789,26 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             currentCenter.Longitude,
             currentCenter.Altitude);
         return new ResoniteFloat3(eun.x, 0.0, eun.y);
+    }
+
+    private static ResoniteFloat3 ComputeOriginOffset(ResoniteLocalOrigin referenceCenter, string meshCode)
+    {
+        return ResonitePlacementPolicy.ComputeOriginOffset(referenceCenter, RequireMeshCodeCenter(meshCode));
+    }
+
+    private static ResoniteLocalOrigin RequireMergedMeshCodeCenter(IReadOnlyList<string> meshCodes)
+    {
+        List<(double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude)> bounds = [];
+        foreach (string meshCode in meshCodes)
+        {
+            Assert.True(PlateauMeshCode.TryGetBounds(meshCode, out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) meshBounds));
+            bounds.Add(meshBounds);
+        }
+
+        return new ResoniteLocalOrigin(
+            (bounds.Min(static bound => bound.SouthLatitude) + bounds.Max(static bound => bound.NorthLatitude)) / 2.0,
+            (bounds.Min(static bound => bound.WestLongitude) + bounds.Max(static bound => bound.EastLongitude)) / 2.0,
+            0.0);
     }
 
     private static ResoniteLocalOrigin RequireMeshCodeCenter(string meshCode)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneAnchorResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneAnchorResolverTests.cs
@@ -145,7 +145,7 @@ public sealed class ResoniteSceneAnchorResolverTests
     }
 
     [Fact]
-    public async Task ResolveAsyncFallsBackToZeroWhenCompletionSourceFileRootPositionIsMissing()
+    public async Task ResolveAsyncRejectsCompletionSourceFileRootWhenPositionIsMissing()
     {
         const string datasetRootSlotId = "dataset-root";
         const string completionMeshCode = "53394525";
@@ -172,17 +172,14 @@ public sealed class ResoniteSceneAnchorResolverTests
 
         ResoniteSceneAnchorResolver resolver = new();
 
-        SceneAnchor anchor = await resolver.ResolveAsync(
-            client,
-            new ResoniteSlotLocator(datasetRootSlotId),
-            completionMeshCode,
-            CancellationToken.None);
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => resolver.ResolveAsync(
+                client,
+                new ResoniteSlotLocator(datasetRootSlotId),
+                completionMeshCode,
+                CancellationToken.None));
 
-        Assert.Equal(new ResoniteSlotLocator("source-root"), anchor.LocationSlot);
-        Assert.Equal(new ResoniteSlotLocator("source-root"), anchor.ReferenceSourceFileRoot);
-        Assert.Equal(0.0, anchor.Position.X, 4);
-        Assert.Equal(0.0, anchor.Position.Y, 4);
-        Assert.Equal(0.0, anchor.Position.Z, 4);
+        Assert.Contains("did not expose a Position", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/SourceRootPlacementResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SourceRootPlacementResolverTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using PlateauResoniteLink.Targets.Resonite;
 
 using ResoniteLink;
@@ -40,6 +42,19 @@ public sealed class SourceRootPlacementResolverTests
             placement.RootPosition);
     }
 
+    [Fact]
+    public void ResolveRejectsObservedSourceRootWithoutPosition()
+    {
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => SourceRootPlacementResolver.Resolve(
+                "plateau_tokyo23ku_bldg_53394525",
+                "53394525",
+                new ResoniteLocalOrigin(35.0, 139.0, 0.0),
+                [CreateSlotWithoutPosition("source-root", "plateau_tokyo23ku_bldg_53394525")]));
+
+        Assert.Contains("did not expose a Position", exception.Message, StringComparison.Ordinal);
+    }
+
     private static Slot CreateSlot(string id, string name, ResoniteFloat3 position)
     {
         return new Slot
@@ -55,6 +70,15 @@ public sealed class SourceRootPlacementResolverTests
                     z = (float)position.Z,
                 },
             },
+        };
+    }
+
+    private static Slot CreateSlotWithoutPosition(string id, string name)
+    {
+        return new Slot
+        {
+            ID = id,
+            Name = new Field_string { Value = name },
         };
     }
 }


### PR DESCRIPTION
## Summary
- use discovered/selected concrete mesh codes as the initial geodetic origin basis
- require positioned source-file roots for append placement recovery instead of zero fallback
- add tests for selected-data-center placement and missing source-root Position failures

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false