### PR TITLE
Type non-DEM source file batch scope

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -34,8 +34,14 @@ internal sealed class NonDemCityObjectBaker(
             return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: false, []));
         }
 
+        NonDemSourceFileScopeResolution sourceFileScopeResolution = NonDemSourceFileScope.Resolve(cityObject);
+        if (sourceFileScopeResolution is not NonDemSourceFileScopeResolution.Available sourceFileScope)
+        {
+            return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: false, []));
+        }
+
         cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
-        NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(cityObject, policy);
+        NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(cityObject, policy, sourceFileScope.Scope);
         List<ResoniteConstructionCityObject> readyCityObjects = [];
         sourceFileBuffer.Add(sourceFileKey, new NonDemBufferedCityObject(cityObject, policy));
         BakedInputCityObjectCount++;

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBatchKey.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBatchKey.cs
@@ -5,4 +5,7 @@ internal readonly record struct NonDemSourceFileBatchKey(
     string PackageName,
     int? LodLevel,
     string PolicyContext,
-    string SourceFileRelativePath);
+    NonDemSourceFileScope SourceFileScope)
+{
+    public string SourceFileRelativePath => SourceFileScope.RelativePath;
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBatching.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBatching.cs
@@ -11,23 +11,17 @@ internal static class NonDemSourceFileBatching
 
     public static NonDemSourceFileBatchKey CreateKey(
         ResoniteConstructionCityObject cityObject,
-        NonDemCityObjectBakePolicy policy)
+        NonDemCityObjectBakePolicy policy,
+        NonDemSourceFileScope sourceFileScope)
     {
         string context = policy.Name;
-        string? sourceFileRelativePath = string.IsNullOrWhiteSpace(cityObject.SourceFileRelativePath) ? null : cityObject.SourceFileRelativePath;
-        if (sourceFileRelativePath is null)
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM batch candidate '{cityObject.DisplayName}' did not provide source scope. "
-                + "source-file-owned batching requires SourceFileRelativePath.");
-        }
 
         return new NonDemSourceFileBatchKey(
             cityObject.ActualMeshCode,
             cityObject.PackageName.ToLowerInvariant(),
             cityObject.LodLevel,
             context,
-            SourceFileRelativePath: sourceFileRelativePath);
+            sourceFileScope);
     }
 
     public static string CreateBatchSlotKey(NonDemSourceFileBatchKey sourceFileKey, int batchIndex)
@@ -35,7 +29,7 @@ internal static class NonDemSourceFileBatching
         string lodToken = sourceFileKey.LodLevel?.ToString(CultureInfo.InvariantCulture) ?? "none";
         return string.Create(
             CultureInfo.InvariantCulture,
-            $"atlasbake-{Path.GetFileNameWithoutExtension(sourceFileKey.SourceFileRelativePath)}-{sourceFileKey.PackageName}-lod{lodToken}-{batchIndex + 1}");
+            $"atlasbake-{Path.GetFileNameWithoutExtension(sourceFileKey.SourceFileScope.RelativePath)}-{sourceFileKey.PackageName}-lod{lodToken}-{batchIndex + 1}");
     }
 
     public static string CreateBatchDisplayName(NonDemSourceFileBatchKey sourceFileKey, int batchIndex, string batchSlotKey)
@@ -50,7 +44,7 @@ internal static class NonDemSourceFileBatching
     {
         return string.Create(
             CultureInfo.InvariantCulture,
-            $"atlastex-{sourceFileKey.SourceFileRelativePath}-{batchIndex + 1}");
+            $"atlastex-{sourceFileKey.SourceFileScope.RelativePath}-{batchIndex + 1}");
     }
 
     private sealed class SourceFileBatchKeyComparer : IComparer<NonDemSourceFileBatchKey>
@@ -81,7 +75,7 @@ internal static class NonDemSourceFileBatching
                 return compare;
             }
 
-            compare = string.CompareOrdinal(x.SourceFileRelativePath, y.SourceFileRelativePath);
+            compare = string.CompareOrdinal(x.SourceFileScope.RelativePath, y.SourceFileScope.RelativePath);
             if (compare != 0)
             {
                 return compare;

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileScope.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileScope.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal sealed record NonDemSourceFileScope
+{
+    public NonDemSourceFileScope(string relativePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(relativePath);
+        RelativePath = relativePath;
+    }
+
+    public string RelativePath { get; }
+
+    public static NonDemSourceFileScopeResolution Resolve(ResoniteConstructionCityObject cityObject)
+    {
+        ArgumentNullException.ThrowIfNull(cityObject);
+        if (string.IsNullOrWhiteSpace(cityObject.SourceFileRelativePath))
+        {
+            return NonDemSourceFileScopeResolution.Missing.Instance;
+        }
+
+        return new NonDemSourceFileScopeResolution.Available(new NonDemSourceFileScope(cityObject.SourceFileRelativePath));
+    }
+
+    public override string ToString() => RelativePath;
+}
+
+internal abstract record NonDemSourceFileScopeResolution
+{
+    private NonDemSourceFileScopeResolution()
+    {
+    }
+
+    public sealed record Available(NonDemSourceFileScope Scope) : NonDemSourceFileScopeResolution;
+
+    public sealed record Missing : NonDemSourceFileScopeResolution
+    {
+        public static Missing Instance { get; } = new();
+
+        private Missing()
+        {
+        }
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -893,6 +893,29 @@ public sealed class NonDemCityObjectBakerTests
     }
 
     [Fact]
+    public async Task TryBufferAsyncSkipsNonDemCityObjectsWithoutSourceFileScope()
+    {
+        NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);
+        ResoniteConstructionCityObject cityObject = CreateUvScaledLod2Building(
+            "missing-source-scope",
+            CreatePayload("textures/missing-source-scope.png", new Rgba32(255, 0, 0, 255), 4, 4),
+            "unit-a",
+            new ResoniteFloat2(2.0, 0.5),
+            new ResoniteFloat2(0.25, 0.75)) with
+        {
+            SourceFileRelativePath = null,
+        };
+
+        BufferedCityObjectBufferResult result = await baker.TryBufferAsync(cityObject);
+
+        Assert.False(result.Buffered);
+        Assert.Empty(result.ReadyCityObjects);
+        Assert.Equal(new ResoniteFloat2(2.0, 0.5), Assert.Single(cityObject.Materials).TextureScale);
+        Assert.Equal(new ResoniteFloat2(0.25, 0.75), Assert.Single(cityObject.Materials).TextureOffset);
+        Assert.Empty(await baker.FlushAllAsync());
+    }
+
+    [Fact]
     public async Task TryBufferAsyncBuffersLodlessNonDemCityObjects()
     {
         NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemSourceFileBatchingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemSourceFileBatchingTests.cs
@@ -1,5 +1,3 @@
-using System;
-
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Targets;
@@ -7,7 +5,7 @@ namespace PlateauResoniteLink.Tests.Targets;
 public sealed class NonDemSourceFileBatchingTests
 {
     [Fact]
-    public void CreateKeyNormalizesPackageNameAndRequiresSourceFileScope()
+    public void CreateKeyUsesResolvedSourceFileScope()
     {
         ResoniteConstructionCityObject cityObject = CreateCityObject() with
         {
@@ -15,15 +13,29 @@ public sealed class NonDemSourceFileBatchingTests
             SourceFileRelativePath = "udx/bldg/53394525_bldg_6697_op.gml",
         };
 
+        NonDemSourceFileScopeResolution sourceFileScope = NonDemSourceFileScope.Resolve(cityObject);
+        NonDemSourceFileScope scope = Assert.IsType<NonDemSourceFileScopeResolution.Available>(sourceFileScope).Scope;
+
         NonDemSourceFileBatchKey key = NonDemSourceFileBatching.CreateKey(
             cityObject,
-            NonDemCityObjectBakePolicies.Default);
+            NonDemCityObjectBakePolicies.Default,
+            scope);
 
         Assert.Equal("bldg", key.PackageName);
         Assert.Equal("udx/bldg/53394525_bldg_6697_op.gml", key.SourceFileRelativePath);
-        Assert.Throws<InvalidOperationException>(() => NonDemSourceFileBatching.CreateKey(
-            cityObject with { SourceFileRelativePath = null },
-            NonDemCityObjectBakePolicies.Default));
+    }
+
+    [Fact]
+    public void SourceFileScopeResolutionRepresentsMissingSourceFileWithoutCreatingBatchKey()
+    {
+        ResoniteConstructionCityObject cityObject = CreateCityObject() with
+        {
+            SourceFileRelativePath = null,
+        };
+
+        NonDemSourceFileScopeResolution sourceFileScope = NonDemSourceFileScope.Resolve(cityObject);
+
+        Assert.IsType<NonDemSourceFileScopeResolution.Missing>(sourceFileScope);
     }
 
     [Fact]
@@ -34,7 +46,7 @@ public sealed class NonDemSourceFileBatchingTests
             PackageName: "bldg",
             LodLevel: 2,
             PolicyContext: "default",
-            SourceFileRelativePath: "udx/bldg/53394525_bldg_6697_op.gml");
+            SourceFileScope: new NonDemSourceFileScope("udx/bldg/53394525_bldg_6697_op.gml"));
 
         string slotKey = NonDemSourceFileBatching.CreateBatchSlotKey(key, batchIndex: 1);
         string displayName = NonDemSourceFileBatching.CreateBatchDisplayName(key, batchIndex: 1, slotKey);
@@ -49,8 +61,8 @@ public sealed class NonDemSourceFileBatchingTests
     [Fact]
     public void KeyComparerOrdersByMeshPackageLodPolicyAndSourceFile()
     {
-        NonDemSourceFileBatchKey first = new("53394525", "bldg", 1, "a", "a.gml");
-        NonDemSourceFileBatchKey second = new("53394525", "bldg", 2, "a", "a.gml");
+        NonDemSourceFileBatchKey first = new("53394525", "bldg", 1, "a", new NonDemSourceFileScope("a.gml"));
+        NonDemSourceFileBatchKey second = new("53394525", "bldg", 2, "a", new NonDemSourceFileScope("a.gml"));
 
         Assert.True(NonDemSourceFileBatching.KeyComparer.Compare(first, second) < 0);
         Assert.True(NonDemSourceFileBatching.KeyComparer.Compare(second, first) > 0);


### PR DESCRIPTION
## Summary
- Introduce `NonDemSourceFileScope` and `NonDemSourceFileScopeResolution` so source-file batching consumes an already resolved source scope.
- Remove the runtime `InvalidOperationException` from `NonDemSourceFileBatching.CreateKey`; callers can no longer create a batch key from only a nullable `SourceFileRelativePath` string.
- Skip non-DEM bake buffering before UV normalization when a source-file scope is unavailable.

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~NonDemSourceFileBatchingTests|FullyQualifiedName~NonDemCityObjectBakerTests"`
- Fake Live Sink / canonical dump real-data check:
  - generated `runtime/windows/resonite/semantic-baselines/type-source-batch-scope/current/higashimurayama-53395325-bldg.json`
  - `git diff --no-index -- runtime/windows/resonite/semantic-baselines/pr4-building-scale-classification/after/higashimurayama-53395325-bldg.json runtime/windows/resonite/semantic-baselines/type-source-batch-scope/current/higashimurayama-53395325-bldg.json`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`