### PR TITLE
Type observed source root positions

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneAnchorResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneAnchorResolver.cs
@@ -50,14 +50,15 @@ internal sealed class ResoniteSceneAnchorResolver : IResoniteSceneAnchorResolver
         ObservedSourceRootSlot[] sourceFileRoots = datasetRootSnapshot.Root?.Children?
             .Where(static child => !string.Equals(child.Name?.Value, "Assets", StringComparison.Ordinal))
             .Select(static child => ObservedSourceRootSlot.TryCreate(child, out ObservedSourceRootSlot sourceRoot)
-                ? (SourceRoot: sourceRoot, HasPosition: true)
+                ? (SourceRoot: sourceRoot, HasSourceRoot: true)
                 : default)
-            .Where(static candidate => candidate.HasPosition)
+            .Where(static candidate => candidate.HasSourceRoot)
             .Select(static candidate => candidate.SourceRoot)
             .ToArray()
             ?? [];
         ObservedSourceRootSlot completionSourceFileRoot = sourceFileRoots.FirstOrDefault(
-            child => string.Equals(child.MeshCode, completionMeshCode, StringComparison.Ordinal));
+            child => child.TryGetConcreteMeshCode(out string meshCode)
+                && string.Equals(meshCode, completionMeshCode, StringComparison.Ordinal));
         if (!string.IsNullOrEmpty(completionSourceFileRoot.SlotName))
         {
             return new SceneAnchor(
@@ -68,9 +69,13 @@ internal sealed class ResoniteSceneAnchorResolver : IResoniteSceneAnchorResolver
         }
 
         (ObservedSourceRootSlot Slot, string MeshCode) referenceSourceFileRoot = sourceFileRoots
-            .Select(static child => (Slot: child, MeshCode: child.MeshCode))
+            .Select(static child => child.TryGetConcreteMeshCode(out string meshCode)
+                ? (Slot: child, MeshCode: meshCode, HasMeshCode: true)
+                : default)
+            .Where(static candidate => candidate.HasMeshCode)
             .OrderBy(static candidate => candidate.MeshCode, StringComparer.Ordinal)
             .ThenBy(static candidate => candidate.Slot.SlotId, StringComparer.Ordinal)
+            .Select(static candidate => (candidate.Slot, candidate.MeshCode))
             .FirstOrDefault();
         if (!string.IsNullOrEmpty(referenceSourceFileRoot.Slot.SlotName))
         {

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneAnchorResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneAnchorResolver.cs
@@ -47,40 +47,40 @@ internal sealed class ResoniteSceneAnchorResolver : IResoniteSceneAnchorResolver
             datasetRootSlot,
             1,
             cancellationToken);
-        Slot[] sourceFileRoots = datasetRootSnapshot.Root?.Children?
+        ObservedSourceRootSlot[] sourceFileRoots = datasetRootSnapshot.Root?.Children?
             .Where(static child => !string.Equals(child.Name?.Value, "Assets", StringComparison.Ordinal))
-            .Where(static child => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(child.Name?.Value ?? string.Empty, out _))
+            .Select(static child => ObservedSourceRootSlot.TryCreate(child, out ObservedSourceRootSlot sourceRoot)
+                ? (SourceRoot: sourceRoot, HasPosition: true)
+                : default)
+            .Where(static candidate => candidate.HasPosition)
+            .Select(static candidate => candidate.SourceRoot)
             .ToArray()
             ?? [];
-        Slot? completionSourceFileRoot = sourceFileRoots.FirstOrDefault(
-            child => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(child.Name?.Value ?? string.Empty, out string meshCode)
-                && string.Equals(meshCode, completionMeshCode, StringComparison.Ordinal));
-        if (completionSourceFileRoot is not null)
+        ObservedSourceRootSlot completionSourceFileRoot = sourceFileRoots.FirstOrDefault(
+            child => string.Equals(child.MeshCode, completionMeshCode, StringComparison.Ordinal));
+        if (!string.IsNullOrEmpty(completionSourceFileRoot.SlotName))
         {
             return new SceneAnchor(
-                new ResoniteSlotLocator(completionSourceFileRoot.ID ?? datasetRootSlot.Value),
+                new ResoniteSlotLocator(completionSourceFileRoot.SlotId),
                 completionMeshCode,
-                GetRequiredSourceRootPosition(completionSourceFileRoot),
-                new ResoniteSlotLocator(completionSourceFileRoot.ID ?? datasetRootSlot.Value));
+                completionSourceFileRoot.Position,
+                new ResoniteSlotLocator(completionSourceFileRoot.SlotId));
         }
 
-        (Slot Slot, string MeshCode) referenceSourceFileRoot = sourceFileRoots
-            .Select(static child => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(child.Name?.Value ?? string.Empty, out string meshCode)
-                ? (Slot: child, MeshCode: meshCode)
-                : default)
-            .Where(static candidate => candidate.Slot is not null)
+        (ObservedSourceRootSlot Slot, string MeshCode) referenceSourceFileRoot = sourceFileRoots
+            .Select(static child => (Slot: child, MeshCode: child.MeshCode))
             .OrderBy(static candidate => candidate.MeshCode, StringComparer.Ordinal)
-            .ThenBy(static candidate => candidate.Slot.ID ?? string.Empty, StringComparer.Ordinal)
+            .ThenBy(static candidate => candidate.Slot.SlotId, StringComparer.Ordinal)
             .FirstOrDefault();
-        if (referenceSourceFileRoot.Slot is not null)
+        if (!string.IsNullOrEmpty(referenceSourceFileRoot.Slot.SlotName))
         {
             return new SceneAnchor(
-                new ResoniteSlotLocator(referenceSourceFileRoot.Slot.ID ?? datasetRootSlot.Value),
+                new ResoniteSlotLocator(referenceSourceFileRoot.Slot.SlotId),
                 completionMeshCode,
                 Add(
-                    GetRequiredSourceRootPosition(referenceSourceFileRoot.Slot),
+                    referenceSourceFileRoot.Slot.Position,
                     ComputeMeshCodeOffset(referenceSourceFileRoot.MeshCode, completionMeshCode)),
-                new ResoniteSlotLocator(referenceSourceFileRoot.Slot.ID ?? datasetRootSlot.Value));
+                new ResoniteSlotLocator(referenceSourceFileRoot.Slot.SlotId));
         }
 
         return new SceneAnchor(
@@ -117,18 +117,6 @@ internal sealed class ResoniteSceneAnchorResolver : IResoniteSceneAnchorResolver
         }
 
         return new ResoniteFloat3(0.0, 0.0, 0.0);
-    }
-
-    private static ResoniteFloat3 GetRequiredSourceRootPosition(Slot slot)
-    {
-        if (slot.Position is Field_float3 position)
-        {
-            return new ResoniteFloat3(position.Value.x, position.Value.y, position.Value.z);
-        }
-
-        throw new InvalidOperationException(
-            $"Source-file root '{slot.Name?.Value ?? slot.ID ?? "<unnamed>"}' did not expose a Position. "
-            + "Append anchor recovery requires positioned source-file roots.");
     }
 
     private static ResoniteFloat3 ComputeMeshCodeOffset(string referenceMeshCode, string meshCode)

--- a/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootPlacementResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootPlacementResolver.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using ResoniteLink;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal static class ObservedSourceRootPlacementResolver
@@ -14,14 +12,14 @@ internal static class ObservedSourceRootPlacementResolver
     public static ObservedSourceRootPlacement? TryResolve(
         string sourceFileSlotName,
         string rootMeshCode,
-        IReadOnlyList<Slot> directSourceRoots)
+        IReadOnlyList<ObservedSourceRootSlot> directSourceRoots)
     {
         ObservedSourceRootPlacement[] exactSourceRoots = directSourceRoots
-            .Where(slot => string.Equals(slot.Name?.Value, sourceFileSlotName, StringComparison.Ordinal))
+            .Where(slot => string.Equals(slot.SlotName, sourceFileSlotName, StringComparison.Ordinal))
             .Select(slot => new ObservedSourceRootPlacement(
-                GetRequiredSourceRootPosition(slot),
+                slot.Position,
                 ReferenceMeshCode: rootMeshCode,
-                SlotId: slot.ID ?? string.Empty))
+                slot.SlotId))
             .ToArray();
         if (exactSourceRoots.Length > 0)
         {
@@ -32,32 +30,24 @@ internal static class ObservedSourceRootPlacementResolver
         }
 
         ObservedSourceRootPlacement[] ancestorCandidates = directSourceRoots
-            .Select(static slot => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name?.Value ?? string.Empty, out string meshCode)
-                ? (Slot: slot, MeshCode: meshCode)
-                : default)
-            .Where(candidate => candidate.Slot is not null
-                && rootMeshCode.StartsWith(candidate.MeshCode, StringComparison.Ordinal))
+            .Where(slot => rootMeshCode.StartsWith(slot.MeshCode, StringComparison.Ordinal))
             .Select(candidate => new ObservedSourceRootPlacement(
                 ResonitePlacementPolicy.Add(
-                    GetRequiredSourceRootPosition(candidate.Slot),
+                    candidate.Position,
                     ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
                 ReferenceMeshCode: candidate.MeshCode,
-                SlotId: candidate.Slot.ID ?? string.Empty))
+                SlotId: candidate.SlotId))
             .OrderByDescending(static candidate => candidate.ReferenceMeshCode.Length)
             .ToArray();
         if (ancestorCandidates.Length == 0)
         {
             ObservedSourceRootPlacement[] observedMeshCodeRoots = directSourceRoots
-                .Select(static slot => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name?.Value ?? string.Empty, out string meshCode)
-                    ? (Slot: slot, MeshCode: meshCode)
-                    : default)
-                .Where(static candidate => candidate.Slot is not null)
                 .Select(candidate => new ObservedSourceRootPlacement(
                     ResonitePlacementPolicy.Add(
-                        GetRequiredSourceRootPosition(candidate.Slot),
+                        candidate.Position,
                         ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
                     ReferenceMeshCode: candidate.MeshCode,
-                    SlotId: candidate.Slot.ID ?? string.Empty))
+                    SlotId: candidate.SlotId))
                 .ToArray();
             return observedMeshCodeRoots.Length == 0
                 ? null
@@ -101,17 +91,6 @@ internal static class ObservedSourceRootPlacementResolver
             && Math.Abs(left.Z - right.Z) <= tolerance;
     }
 
-    private static ResoniteFloat3 GetRequiredSourceRootPosition(Slot slot)
-    {
-        if (slot.Position is not Field_float3 position)
-        {
-            throw new InvalidOperationException(
-                $"Observed source-file root '{slot.Name?.Value ?? slot.ID ?? "<unnamed>"}' did not expose a Position. "
-                + "Append placement requires positioned source-file roots.");
-        }
-
-        return new ResoniteFloat3(position.Value.x, position.Value.y, position.Value.z);
-    }
 }
 
 internal readonly record struct ObservedSourceRootPlacement(

--- a/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootPlacementResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootPlacementResolver.cs
@@ -30,24 +30,32 @@ internal static class ObservedSourceRootPlacementResolver
         }
 
         ObservedSourceRootPlacement[] ancestorCandidates = directSourceRoots
-            .Where(slot => rootMeshCode.StartsWith(slot.MeshCode, StringComparison.Ordinal))
+            .Select(static slot => slot.TryGetConcreteMeshCode(out string meshCode)
+                ? (Slot: slot, MeshCode: meshCode, HasMeshCode: true)
+                : default)
+            .Where(static candidate => candidate.HasMeshCode)
+            .Where(candidate => rootMeshCode.StartsWith(candidate.MeshCode, StringComparison.Ordinal))
             .Select(candidate => new ObservedSourceRootPlacement(
                 ResonitePlacementPolicy.Add(
-                    candidate.Position,
+                    candidate.Slot.Position,
                     ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
                 ReferenceMeshCode: candidate.MeshCode,
-                SlotId: candidate.SlotId))
+                SlotId: candidate.Slot.SlotId))
             .OrderByDescending(static candidate => candidate.ReferenceMeshCode.Length)
             .ToArray();
         if (ancestorCandidates.Length == 0)
         {
             ObservedSourceRootPlacement[] observedMeshCodeRoots = directSourceRoots
+                .Select(static slot => slot.TryGetConcreteMeshCode(out string meshCode)
+                    ? (Slot: slot, MeshCode: meshCode, HasMeshCode: true)
+                    : default)
+                .Where(static candidate => candidate.HasMeshCode)
                 .Select(candidate => new ObservedSourceRootPlacement(
                     ResonitePlacementPolicy.Add(
-                        candidate.Position,
+                        candidate.Slot.Position,
                         ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
                     ReferenceMeshCode: candidate.MeshCode,
-                    SlotId: candidate.SlotId))
+                    SlotId: candidate.Slot.SlotId))
                 .ToArray();
             return observedMeshCodeRoots.Length == 0
                 ? null

--- a/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootSlot.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootSlot.cs
@@ -1,0 +1,29 @@
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal readonly record struct ObservedSourceRootSlot(
+    string SlotName,
+    string SlotId,
+    string MeshCode,
+    ResoniteFloat3 Position)
+{
+    public static bool TryCreate(Slot slot, out ObservedSourceRootSlot sourceRoot)
+    {
+        if (string.IsNullOrWhiteSpace(slot.ID)
+            || string.IsNullOrWhiteSpace(slot.Name?.Value)
+            || !ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name.Value, out string meshCode)
+            || slot.Position is not Field_float3 position)
+        {
+            sourceRoot = default;
+            return false;
+        }
+
+        sourceRoot = new ObservedSourceRootSlot(
+            slot.Name.Value,
+            slot.ID,
+            meshCode,
+            new ResoniteFloat3(position.Value.x, position.Value.y, position.Value.z));
+        return true;
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootSlot.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootSlot.cs
@@ -5,14 +5,12 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal readonly record struct ObservedSourceRootSlot(
     string SlotName,
     string SlotId,
-    string MeshCode,
     ResoniteFloat3 Position)
 {
     public static bool TryCreate(Slot slot, out ObservedSourceRootSlot sourceRoot)
     {
         if (string.IsNullOrWhiteSpace(slot.ID)
             || string.IsNullOrWhiteSpace(slot.Name?.Value)
-            || !ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name.Value, out string meshCode)
             || slot.Position is not Field_float3 position)
         {
             sourceRoot = default;
@@ -22,8 +20,12 @@ internal readonly record struct ObservedSourceRootSlot(
         sourceRoot = new ObservedSourceRootSlot(
             slot.Name.Value,
             slot.ID,
-            meshCode,
             new ResoniteFloat3(position.Value.x, position.Value.y, position.Value.z));
         return true;
+    }
+
+    public bool TryGetConcreteMeshCode(out string meshCode)
+    {
+        return ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(SlotName, out meshCode);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSlotSnapshotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSlotSnapshotIndex.cs
@@ -12,7 +12,7 @@ internal sealed class ResoniteSlotSnapshotIndex(CreatedSlot datasetRootSlot)
     private readonly ConcurrentDictionary<string, byte> createdSlotIds = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<SlotIndexKey, CreatedSlot> sharedSlotIndex = new();
     private readonly ConcurrentDictionary<string, Slot> observedSlotSnapshotsById = new(StringComparer.Ordinal);
-    private Slot[]? observedDatasetSourceRoots;
+    private ObservedSourceRootSlot[]? observedDatasetSourceRoots;
 
     public void IndexSetupHierarchy(ResoniteSceneSetupState setupState)
     {
@@ -55,7 +55,7 @@ internal sealed class ResoniteSlotSnapshotIndex(CreatedSlot datasetRootSlot)
         createdSlotIds[createdSlot.Locator.Value] = 0;
     }
 
-    public IReadOnlyList<Slot> GetObservedDatasetSourceRoots()
+    public IReadOnlyList<ObservedSourceRootSlot> GetObservedDatasetSourceRoots()
     {
         return observedDatasetSourceRoots ??= EnumerateObservedDatasetSourceRoots().ToArray();
     }
@@ -84,12 +84,17 @@ internal sealed class ResoniteSlotSnapshotIndex(CreatedSlot datasetRootSlot)
         }
     }
 
-    private IEnumerable<Slot> EnumerateObservedDatasetSourceRoots()
+    private IEnumerable<ObservedSourceRootSlot> EnumerateObservedDatasetSourceRoots()
     {
         return observedSlotSnapshotsById.Values
             .Where(slot => string.Equals(slot.Parent?.TargetID, datasetRootSlot.Locator.Value, StringComparison.Ordinal))
             .Where(slot => string.IsNullOrWhiteSpace(slot.ID) || !createdSlotIds.ContainsKey(slot.ID!))
-            .Where(static slot => !string.Equals(slot.Name?.Value, "Assets", StringComparison.Ordinal));
+            .Where(static slot => !string.Equals(slot.Name?.Value, "Assets", StringComparison.Ordinal))
+            .Select(static slot => ObservedSourceRootSlot.TryCreate(slot, out ObservedSourceRootSlot sourceRoot)
+                ? (SourceRoot: sourceRoot, HasPosition: true)
+                : default)
+            .Where(static candidate => candidate.HasPosition)
+            .Select(static candidate => candidate.SourceRoot);
     }
 
     private static Field_float3 CreateFloat3(ResoniteFloat3 value)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSlotSnapshotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSlotSnapshotIndex.cs
@@ -88,12 +88,12 @@ internal sealed class ResoniteSlotSnapshotIndex(CreatedSlot datasetRootSlot)
     {
         return observedSlotSnapshotsById.Values
             .Where(slot => string.Equals(slot.Parent?.TargetID, datasetRootSlot.Locator.Value, StringComparison.Ordinal))
-            .Where(slot => string.IsNullOrWhiteSpace(slot.ID) || !createdSlotIds.ContainsKey(slot.ID!))
+            .Where(slot => !createdSlotIds.ContainsKey(slot.ID!))
             .Where(static slot => !string.Equals(slot.Name?.Value, "Assets", StringComparison.Ordinal))
             .Select(static slot => ObservedSourceRootSlot.TryCreate(slot, out ObservedSourceRootSlot sourceRoot)
-                ? (SourceRoot: sourceRoot, HasPosition: true)
+                ? (SourceRoot: sourceRoot, HasSourceRoot: true)
                 : default)
-            .Where(static candidate => candidate.HasPosition)
+            .Where(static candidate => candidate.HasSourceRoot)
             .Select(static candidate => candidate.SourceRoot);
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/SourceRootPlacementResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SourceRootPlacementResolver.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 
-using ResoniteLink;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal static class SourceRootPlacementResolver
@@ -10,7 +8,7 @@ internal static class SourceRootPlacementResolver
         string sourceFileSlotName,
         string rootMeshCode,
         ResoniteLocalOrigin requestLocalOrigin,
-        IReadOnlyList<Slot> observedDatasetSourceRoots)
+        IReadOnlyList<ObservedSourceRootSlot> observedDatasetSourceRoots)
     {
         ObservedSourceRootPlacement? observedRootPlacement = ObservedSourceRootPlacementResolver.TryResolve(
             sourceFileSlotName,

--- a/tests/PlateauResoniteLink.Tests/Targets/ObservedSourceRootPlacementResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ObservedSourceRootPlacementResolverTests.cs
@@ -63,16 +63,20 @@ public sealed class ObservedSourceRootPlacementResolverTests
     [Fact]
     public void TryResolveRejectsObservedSourceRootWithoutPosition()
     {
-        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
-            () => ObservedSourceRootPlacementResolver.TryResolve(
-                "plateau_tokyo23ku_bldg_53394525",
-                "53394525",
-                [CreateSlotWithoutPosition("source-root", "plateau_tokyo23ku_bldg_53394525")]));
+        bool created = ObservedSourceRootSlot.TryCreate(
+            CreateRawSlotWithoutPosition("source-root", "plateau_tokyo23ku_bldg_53394525"),
+            out _);
 
-        Assert.Contains("did not expose a Position", exception.Message, StringComparison.Ordinal);
+        Assert.False(created);
     }
 
-    private static Slot CreateSlot(string id, string name, ResoniteFloat3 position)
+    private static ObservedSourceRootSlot CreateSlot(string id, string name, ResoniteFloat3 position)
+    {
+        Assert.True(ObservedSourceRootSlot.TryCreate(CreateRawSlot(id, name, position), out ObservedSourceRootSlot sourceRoot));
+        return sourceRoot;
+    }
+
+    private static Slot CreateRawSlot(string id, string name, ResoniteFloat3 position)
     {
         return new Slot
         {
@@ -90,7 +94,7 @@ public sealed class ObservedSourceRootPlacementResolverTests
         };
     }
 
-    private static Slot CreateSlotWithoutPosition(string id, string name)
+    private static Slot CreateRawSlotWithoutPosition(string id, string name)
     {
         return new Slot
         {

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneAnchorResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneAnchorResolverTests.cs
@@ -145,7 +145,7 @@ public sealed class ResoniteSceneAnchorResolverTests
     }
 
     [Fact]
-    public async Task ResolveAsyncRejectsCompletionSourceFileRootWhenPositionIsMissing()
+    public async Task ResolveAsyncFallsBackToDatasetRootWhenCompletionSourceFileRootIsNotPositioned()
     {
         const string datasetRootSlotId = "dataset-root";
         const string completionMeshCode = "53394525";
@@ -172,14 +172,16 @@ public sealed class ResoniteSceneAnchorResolverTests
 
         ResoniteSceneAnchorResolver resolver = new();
 
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => resolver.ResolveAsync(
-                client,
-                new ResoniteSlotLocator(datasetRootSlotId),
-                completionMeshCode,
-                CancellationToken.None));
+        SceneAnchor anchor = await resolver.ResolveAsync(
+            client,
+            new ResoniteSlotLocator(datasetRootSlotId),
+            completionMeshCode,
+            CancellationToken.None);
 
-        Assert.Contains("did not expose a Position", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(new ResoniteSlotLocator(datasetRootSlotId), anchor.LocationSlot);
+        Assert.Equal(completionMeshCode, anchor.MeshCode);
+        Assert.Null(anchor.ReferenceSourceFileRoot);
+        Assert.Equal(new ResoniteFloat3(0.0, 0.0, 0.0), anchor.Position);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSlotSnapshotIndexTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSlotSnapshotIndexTests.cs
@@ -30,9 +30,9 @@ public sealed class ResoniteSlotSnapshotIndexTests
             CreateSlot(
                 "dataset-root",
                 "PLATEAU tokyo23ku",
-                null,
+                children:
                 [
-                    CreateSlot("existing-root", "plateau_tokyo23ku_bldg_53394525", "dataset-root"),
+                    CreateSlot("existing-root", "plateau_tokyo23ku_bldg_53394525", "dataset-root", new ResoniteFloat3(1.0, 2.0, 3.0)),
                     CreateSlot("assets-root", "Assets", "dataset-root"),
                 ]),
             CommonMaterialCatalog.Create().Map(static member => new ResoniteCommonMaterialAsset(
@@ -51,14 +51,16 @@ public sealed class ResoniteSlotSnapshotIndexTests
         index.MarkCreated(createdRoot);
         index.IndexCreatedSharedSlot(datasetRoot.Locator, createdRoot, new ResoniteFloat3(1.0, 2.0, 3.0));
 
-        Slot observedRoot = Assert.Single(index.GetObservedDatasetSourceRoots());
-        Assert.Equal("existing-root", observedRoot.ID);
+        ObservedSourceRootSlot observedRoot = Assert.Single(index.GetObservedDatasetSourceRoots());
+        Assert.Equal("existing-root", observedRoot.SlotId);
+        Assert.Equal("53394525", observedRoot.MeshCode);
     }
 
     private static Slot CreateSlot(
         string id,
         string name,
         string? parentId = null,
+        ResoniteFloat3? position = null,
         Slot[]? children = null)
     {
         return new Slot
@@ -66,6 +68,15 @@ public sealed class ResoniteSlotSnapshotIndexTests
             ID = id,
             Name = new Field_string { Value = name },
             Parent = parentId is null ? null : new Reference { TargetID = parentId },
+            Position = position is null ? null : new Field_float3
+            {
+                Value = new float3
+                {
+                    x = (float)position.X,
+                    y = (float)position.Y,
+                    z = (float)position.Z,
+                },
+            },
             Children = children?.ToList(),
         };
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSlotSnapshotIndexTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSlotSnapshotIndexTests.cs
@@ -53,7 +53,8 @@ public sealed class ResoniteSlotSnapshotIndexTests
 
         ObservedSourceRootSlot observedRoot = Assert.Single(index.GetObservedDatasetSourceRoots());
         Assert.Equal("existing-root", observedRoot.SlotId);
-        Assert.Equal("53394525", observedRoot.MeshCode);
+        Assert.True(observedRoot.TryGetConcreteMeshCode(out string meshCode));
+        Assert.Equal("53394525", meshCode);
     }
 
     private static Slot CreateSlot(

--- a/tests/PlateauResoniteLink.Tests/Targets/SourceRootPlacementResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SourceRootPlacementResolverTests.cs
@@ -1,5 +1,3 @@
-using System;
-
 using PlateauResoniteLink.Targets.Resonite;
 
 using ResoniteLink;
@@ -43,19 +41,22 @@ public sealed class SourceRootPlacementResolverTests
     }
 
     [Fact]
-    public void ResolveRejectsObservedSourceRootWithoutPosition()
+    public void ObservedSourceRootSlotRejectsSourceRootWithoutPositionBeforePlacementResolution()
     {
-        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
-            () => SourceRootPlacementResolver.Resolve(
-                "plateau_tokyo23ku_bldg_53394525",
-                "53394525",
-                new ResoniteLocalOrigin(35.0, 139.0, 0.0),
-                [CreateSlotWithoutPosition("source-root", "plateau_tokyo23ku_bldg_53394525")]));
+        bool created = ObservedSourceRootSlot.TryCreate(
+            CreateRawSlotWithoutPosition("source-root", "plateau_tokyo23ku_bldg_53394525"),
+            out _);
 
-        Assert.Contains("did not expose a Position", exception.Message, StringComparison.Ordinal);
+        Assert.False(created);
     }
 
-    private static Slot CreateSlot(string id, string name, ResoniteFloat3 position)
+    private static ObservedSourceRootSlot CreateSlot(string id, string name, ResoniteFloat3 position)
+    {
+        Assert.True(ObservedSourceRootSlot.TryCreate(CreateRawSlot(id, name, position), out ObservedSourceRootSlot sourceRoot));
+        return sourceRoot;
+    }
+
+    private static Slot CreateRawSlot(string id, string name, ResoniteFloat3 position)
     {
         return new Slot
         {
@@ -73,7 +74,7 @@ public sealed class SourceRootPlacementResolverTests
         };
     }
 
-    private static Slot CreateSlotWithoutPosition(string id, string name)
+    private static Slot CreateRawSlotWithoutPosition(string id, string name)
     {
         return new Slot
         {

--- a/tests/PlateauResoniteLink.Tests/Targets/SourceRootPlacementResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SourceRootPlacementResolverTests.cs
@@ -25,6 +25,24 @@ public sealed class SourceRootPlacementResolverTests
     }
 
     [Fact]
+    public void ResolveUsesExactObservedRootWithoutConcreteMeshCode()
+    {
+        SourceRootPlacement placement = SourceRootPlacementResolver.Resolve(
+            "custom_buildings",
+            "53394525",
+            new ResoniteLocalOrigin(35.0, 139.0, 0.0),
+            [
+                CreateSlot(
+                    "source-root",
+                    "custom_buildings",
+                    new ResoniteFloat3(4.0, 5.0, 6.0)),
+            ]);
+
+        Assert.Equal(new ResoniteFloat3(4.0, 5.0, 6.0), placement.RootPosition);
+        Assert.Equal(placement.RootPosition, placement.LocalPositionReferenceRoot);
+    }
+
+    [Fact]
     public void ResolveUsesRequestOriginWhenNoObservedSourceRootExists()
     {
         ResoniteLocalOrigin requestLocalOrigin = new(35.0, 139.0, 0.0);
@@ -48,6 +66,18 @@ public sealed class SourceRootPlacementResolverTests
             out _);
 
         Assert.False(created);
+    }
+
+    [Fact]
+    public void ObservedSourceRootSlotAcceptsSourceRootWithoutConcreteMeshCode()
+    {
+        bool created = ObservedSourceRootSlot.TryCreate(
+            CreateRawSlot("source-root", "custom_buildings", new ResoniteFloat3(1.0, 2.0, 3.0)),
+            out ObservedSourceRootSlot sourceRoot);
+
+        Assert.True(created);
+        Assert.False(sourceRoot.TryGetConcreteMeshCode(out _));
+        Assert.Equal("custom_buildings", sourceRoot.SlotName);
     }
 
     private static ObservedSourceRootSlot CreateSlot(string id, string name, ResoniteFloat3 position)


### PR DESCRIPTION
## Summary
- Introduce `ObservedSourceRootSlot` so observed source-file roots carry slot id, name, concrete mesh code, and position before placement/anchor resolution.
- Change source-root placement and scene-anchor resolvers to consume typed observed roots instead of raw `Slot` snapshots.
- Remove resolver-local `Position` runtime exceptions and keep missing/non-source-root slots out at the snapshot extraction boundary.

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~ObservedSourceRootPlacementResolverTests|FullyQualifiedName~SourceRootPlacementResolverTests|FullyQualifiedName~ResoniteSlotSnapshotIndexTests|FullyQualifiedName~ResoniteSceneAnchorResolverTests"`
- Fake Live Sink / canonical dump real-data check:
  - generated `runtime/windows/resonite/semantic-baselines/type-observed-source-root-position/current/higashimurayama-53395325-bldg.json`
  - `git diff --no-index -- runtime/windows/resonite/semantic-baselines/pr4-building-scale-classification/after/higashimurayama-53395325-bldg.json runtime/windows/resonite/semantic-baselines/type-observed-source-root-position/current/higashimurayama-53395325-bldg.json`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`