### PR TITLE
Type DEM terrain grid projection result

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -18,7 +18,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         Z: 0.0,
         W: Math.Sqrt(0.5));
 
-    internal static bool TryProject(
+    internal static DemTerrainGridProjectionResult Project(
         ParsedCityObject cityObject,
         GeodeticPoint globalOriginPoint,
         LocalCartesian? globalCartesian,
@@ -27,15 +27,13 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
         IDefaultMaterialResolver materialResolver,
         Action<string>? progressReporter,
-        CancellationToken cancellationToken,
-        out ImportedCityObject? heightMapCityObject)
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        heightMapCityObject = null;
 
         if (cityObject.Surfaces.SelectMany(static surface => surface.Vertices).Take(3).Count() < 3)
         {
-            return false;
+            return DemTerrainGridProjectionResult.Skipped.Instance;
         }
 
         GeodeticPoint cityObjectOrigin = ResolveCityObjectOrigin(cityObject);
@@ -48,7 +46,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             : null;
         if (cityObjectCartesian is null)
         {
-            return false;
+            return DemTerrainGridProjectionResult.Skipped.Instance;
         }
 
         ConstructionCityObjectDraft draft = ConstructionCityObjectDraft.FromParsedCityObject(cityObject);
@@ -65,7 +63,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             globalCartesian).Y;
         if (positions.Length < 3)
         {
-            return false;
+            return DemTerrainGridProjectionResult.Skipped.Instance;
         }
 
         DemTerrainGridBounds heightMapBounds = CreateDemTerrainGridBounds(
@@ -86,7 +84,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         double extentZ = maxZ - minZ;
         if (extentX <= 1e-6 || extentZ <= 1e-6)
         {
-            return false;
+            return DemTerrainGridProjectionResult.Skipped.Instance;
         }
 
         int width = Math.Clamp(
@@ -128,7 +126,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             materialResolver);
         if (materials.Length == 0)
         {
-            return false;
+            return DemTerrainGridProjectionResult.Skipped.Instance;
         }
 
         TextureUvRect? heightMapOccupiedUvRect = TryCreateDemTerrainGridOccupiedUvRect(
@@ -151,7 +149,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             Z = slotPosition.Z + centerZ,
         };
 
-        heightMapCityObject = new ImportedCityObject(
+        return new DemTerrainGridProjectionResult.Projected(new ImportedCityObject(
             ObjectKey: cityObject.SlotKey,
             DisplayName: cityObject.DisplayName,
             PackageName: cityObject.PackageName,
@@ -171,8 +169,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
                 UvScale: heightMapUvScale,
                 UvOffset: heightMapUvOffset),
             Materials: materials,
-            SourceFileRelativePath: cityObject.SourceFileRelativePath);
-        return true;
+            SourceFileRelativePath: cityObject.SourceFileRelativePath));
     }
 
     private static TextureUvRect? TryCreateDemTerrainGridOccupiedUvRect(
@@ -374,4 +371,22 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         double MaxX,
         double MinZ,
         double MaxZ);
+}
+
+internal abstract record DemTerrainGridProjectionResult
+{
+    private DemTerrainGridProjectionResult()
+    {
+    }
+
+    public sealed record Projected(ImportedCityObject CityObject) : DemTerrainGridProjectionResult;
+
+    public sealed record Skipped : DemTerrainGridProjectionResult
+    {
+        public static Skipped Instance { get; } = new();
+
+        private Skipped()
+        {
+        }
+    }
 }

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -241,7 +241,7 @@ internal static class CityGmlParsedCityObjectProjection
             return CityGmlTriangleMeshCityObjectProjection.Project(cityObject, globalOriginPoint, globalCartesian, demTerrainTextureOverlay, materialResolver);
         }
 
-        bool hasGrid = CityGmlDemTerrainGridCityObjectProjection.TryProject(
+        DemTerrainGridProjectionResult gridProjection = CityGmlDemTerrainGridCityObjectProjection.Project(
             cityObject,
             globalOriginPoint,
             globalCartesian,
@@ -250,18 +250,18 @@ internal static class CityGmlParsedCityObjectProjection
             requestedMeshCodeBounds,
             materialResolver,
             progressReporter,
-            cancellationToken,
-            out ImportedCityObject? heightMapCityObject);
-        if (!hasGrid)
+            cancellationToken);
+        if (gridProjection is not DemTerrainGridProjectionResult.Projected projectedGrid)
         {
             return request.TerrainMeshMode == TerrainMeshMode.Dynamic
                 ? CreateNonRenderableCityObject(cityObject)
                 : CityGmlTriangleMeshCityObjectProjection.Project(cityObject, globalOriginPoint, globalCartesian, demTerrainTextureOverlay, materialResolver);
         }
 
+        ImportedCityObject heightMapCityObject = projectedGrid.CityObject;
         if (request.TerrainMeshMode == TerrainMeshMode.Grid)
         {
-            return heightMapCityObject!;
+            return heightMapCityObject;
         }
 
         ImportedCityObject staticCityObject = CityGmlTriangleMeshCityObjectProjection.Project(
@@ -274,7 +274,7 @@ internal static class CityGmlParsedCityObjectProjection
         TriangleMeshGeometry rebasedStaticMesh = TriangleMeshTransformRebaser.Rebase(
             staticMesh,
             staticCityObject.Transform,
-            heightMapCityObject!.Transform);
+            heightMapCityObject.Transform);
         return heightMapCityObject with
         {
             Geometry = new DynamicTerrainGeometry(rebasedStaticMesh, AssertTerrainGridGeometry(heightMapCityObject)),


### PR DESCRIPTION
## Summary
- replace the DEM terrain grid projection `TryProject(..., out ImportedCityObject?)` API with an explicit `DemTerrainGridProjectionResult`
- remove the downstream null-forgiving path by pattern-matching the projected result before using the grid city object
- keep all former skip cases as an explicit `Skipped` result so the fallback path remains unchanged without nullable/out-state coupling

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~LocalCityGmlObjectProjectionTests|FullyQualifiedName~CityGmlDemTerrainGridSamplerTests|FullyQualifiedName~DemTerrainGridChunkBoundaryAlignmentPolicyTests"` (92 passed)
- real-data Fake Live Sink dump for `plateau-13213-higashimurayama-shi-2020`, mesh `53395325`, packages `dem,bldg`, terrain mesh `grid`
- `git diff --no-index -- runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/current/higashi-53395325-dem-bldg-grid-geotiff.json` (no diff)
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (982 passed)