### PR TITLE
Type concrete PLATEAU mesh codes

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -142,7 +142,7 @@ internal static class CityGmlSurfaceMaterialResolver
         TerrainOverlayMaterialBinding? terrainOverlayMaterial = representativeSurface.Material.TerrainOverlay is null
             ? null
             : new TerrainOverlayMaterialBinding(
-                terrainMeshCode!.Value,
+                terrainMeshCode!,
                 representativeSurface.Material.TerrainOverlay);
         ColorRgba baseColor = representativeSurface.Material.TerrainOverlay is null
             ? ToContractColor(representativeSurface.Surface.BaseColor)

--- a/src/PlateauResoniteLink/Application/Importing/DemSourceDiscoverySupport.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemSourceDiscoverySupport.cs
@@ -91,7 +91,7 @@ internal static class DemSourceDiscoverySupport
         List<DemTerrainOverlayRegion> overlays = [];
         foreach (string meshCode in ExpandToThirdMeshCodes(requestedMeshCodes))
         {
-            if (!ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode thirdMeshCode))
+            if (!ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode? thirdMeshCode))
             {
                 continue;
             }
@@ -124,7 +124,7 @@ internal static class DemSourceDiscoverySupport
         List<DemTerrainOverlayRegion> overlays = [];
         foreach (string meshCode in ExpandToThirdMeshCodes(requestedMeshCodes))
         {
-            if (!ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode thirdMeshCode))
+            if (!ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode? thirdMeshCode))
             {
                 continue;
             }

--- a/src/PlateauResoniteLink/Application/Importing/DemSourceDiscoverySupport.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemSourceDiscoverySupport.cs
@@ -248,4 +248,17 @@ internal sealed record DemDiscoveryAggregation(
 
 internal sealed record DemTerrainOverlayRegion(
     ThirdRegionalMeshCode MeshCode,
-    GeographicRectangle GeographicBounds);
+    GeographicRectangle GeographicBounds)
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Style",
+        "IDE0032:Use auto property",
+        Justification = "The init setter validates with-expression updates before changing mesh-code identity state.")]
+    private ThirdRegionalMeshCode meshCode = MeshCode ?? throw new ArgumentNullException(nameof(MeshCode));
+
+    public ThirdRegionalMeshCode MeshCode
+    {
+        get => meshCode;
+        init => meshCode = value ?? throw new ArgumentNullException(nameof(value));
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/DemTextureSourcePolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTextureSourcePolicy.cs
@@ -43,6 +43,7 @@ internal readonly record struct DemTerrainRasterCacheKey
         GeographicRectangle overlayBounds)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(datasetName);
+        ArgumentNullException.ThrowIfNull(meshCode);
 
         DatasetName = datasetName;
         SourceScope = sourceScope;

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -200,7 +200,20 @@ public enum MaterialReuseScope
 
 public sealed record TerrainOverlayMaterialBinding(
     ThirdRegionalMeshCode MeshCode,
-    TerrainTextureOverlay Overlay);
+    TerrainTextureOverlay Overlay)
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Style",
+        "IDE0032:Use auto property",
+        Justification = "The init setter validates with-expression updates before changing mesh-code identity state.")]
+    private ThirdRegionalMeshCode meshCode = MeshCode ?? throw new ArgumentNullException(nameof(MeshCode));
+
+    public ThirdRegionalMeshCode MeshCode
+    {
+        get => meshCode;
+        init => meshCode = value ?? throw new ArgumentNullException(nameof(value));
+    }
+}
 
 public sealed record MaterialBinding(
     ColorRgba BaseColor,

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
@@ -317,6 +317,18 @@ internal static class TerrainOverlayMaterialSourcePartitioner
 
         private sealed record Third(ThirdRegionalMeshCode MeshCode) : TerrainMaterialSourceMeshCode
         {
+            [System.Diagnostics.CodeAnalysis.SuppressMessage(
+                "Style",
+                "IDE0032:Use auto property",
+                Justification = "The init setter validates with-expression updates before changing mesh-code identity state.")]
+            private ThirdRegionalMeshCode meshCode = MeshCode ?? throw new ArgumentNullException(nameof(MeshCode));
+
+            public ThirdRegionalMeshCode MeshCode
+            {
+                get => meshCode;
+                init => meshCode = value ?? throw new ArgumentNullException(nameof(value));
+            }
+
             public override bool IsThirdRegionalMesh => true;
 
             public override bool Contains(ThirdRegionalMeshCode overlayMeshCode)

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
@@ -299,12 +299,12 @@ internal static class TerrainOverlayMaterialSourcePartitioner
 
         public static TerrainMaterialSourceMeshCode ParseRequired(string meshCode)
         {
-            if (ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode thirdMeshCode))
+            if (ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode? thirdMeshCode))
             {
                 return new Third(thirdMeshCode);
             }
 
-            if (SecondRegionalMeshCode.TryParse(meshCode, out SecondRegionalMeshCode secondMeshCode))
+            if (SecondRegionalMeshCode.TryParse(meshCode, out SecondRegionalMeshCode? secondMeshCode))
             {
                 return new Second(secondMeshCode);
             }

--- a/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
@@ -7,7 +7,13 @@ public sealed record JisRegionalMeshBounds(
     double SouthLatitude,
     double NorthLatitude,
     double WestLongitude,
-    double EastLongitude);
+    double EastLongitude)
+{
+    public GeodeticCoordinate Center => new(
+        Latitude: (SouthLatitude + NorthLatitude) / 2.0,
+        Longitude: (WestLongitude + EastLongitude) / 2.0,
+        Altitude: 0.0);
+}
 
 public readonly record struct FirstRegionalMeshCode
 {
@@ -20,11 +26,13 @@ public readonly record struct FirstRegionalMeshCode
 
     public JisRegionalMeshBounds Bounds => JisRegionalMeshCodeCalculator.GetBounds(this);
 
+    public GeodeticCoordinate Center => Bounds.Center;
+
     public static bool TryParse(string? value, out FirstRegionalMeshCode meshCode)
     {
-        if (JisRegionalMeshCodeCalculator.IsValid(value, 4))
+        if (value is not null && JisRegionalMeshCodeCalculator.IsValid(value, 4))
         {
-            meshCode = new FirstRegionalMeshCode(value!);
+            meshCode = FromValidated(value);
             return true;
         }
 
@@ -40,6 +48,11 @@ public readonly record struct FirstRegionalMeshCode
     }
 
     public override string ToString() => Value;
+
+    internal static FirstRegionalMeshCode FromValidated(string value)
+    {
+        return new FirstRegionalMeshCode(value);
+    }
 }
 
 public readonly record struct SecondRegionalMeshCode
@@ -53,13 +66,15 @@ public readonly record struct SecondRegionalMeshCode
 
     public JisRegionalMeshBounds Bounds => JisRegionalMeshCodeCalculator.GetBounds(this);
 
-    public FirstRegionalMeshCode Parent => FirstRegionalMeshCode.Parse(Value[..4]);
+    public GeodeticCoordinate Center => Bounds.Center;
+
+    public FirstRegionalMeshCode Parent => FirstRegionalMeshCode.FromValidated(Value[..4]);
 
     public static bool TryParse(string? value, out SecondRegionalMeshCode meshCode)
     {
-        if (JisRegionalMeshCodeCalculator.IsValid(value, 6))
+        if (value is not null && JisRegionalMeshCodeCalculator.IsValid(value, 6))
         {
-            meshCode = new SecondRegionalMeshCode(value!);
+            meshCode = FromValidated(value);
             return true;
         }
 
@@ -75,6 +90,11 @@ public readonly record struct SecondRegionalMeshCode
     }
 
     public override string ToString() => Value;
+
+    internal static SecondRegionalMeshCode FromValidated(string value)
+    {
+        return new SecondRegionalMeshCode(value);
+    }
 }
 
 public readonly record struct ThirdRegionalMeshCode
@@ -88,15 +108,17 @@ public readonly record struct ThirdRegionalMeshCode
 
     public JisRegionalMeshBounds Bounds => JisRegionalMeshCodeCalculator.GetBounds(this);
 
-    public SecondRegionalMeshCode Parent => SecondRegionalMeshCode.Parse(Value[..6]);
+    public GeodeticCoordinate Center => Bounds.Center;
 
-    public FirstRegionalMeshCode FirstMesh => FirstRegionalMeshCode.Parse(Value[..4]);
+    public SecondRegionalMeshCode Parent => SecondRegionalMeshCode.FromValidated(Value[..6]);
+
+    public FirstRegionalMeshCode FirstMesh => FirstRegionalMeshCode.FromValidated(Value[..4]);
 
     public static bool TryParse(string? value, out ThirdRegionalMeshCode meshCode)
     {
-        if (JisRegionalMeshCodeCalculator.IsValid(value, 8))
+        if (value is not null && JisRegionalMeshCodeCalculator.IsValid(value, 8))
         {
-            meshCode = new ThirdRegionalMeshCode(value!);
+            meshCode = FromValidated(value);
             return true;
         }
 
@@ -112,6 +134,11 @@ public readonly record struct ThirdRegionalMeshCode
     }
 
     public override string ToString() => Value;
+
+    internal static ThirdRegionalMeshCode FromValidated(string value)
+    {
+        return new ThirdRegionalMeshCode(value);
+    }
 }
 
 internal static class JisRegionalMeshCodeCalculator

--- a/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
@@ -18,7 +18,7 @@ public readonly record struct FirstRegionalMeshCode
 
     public string Value { get; }
 
-    public JisRegionalMeshBounds Bounds => JisRegionalMeshCodeCalculator.GetBounds(Value);
+    public JisRegionalMeshBounds Bounds => JisRegionalMeshCodeCalculator.GetBounds(this);
 
     public static bool TryParse(string? value, out FirstRegionalMeshCode meshCode)
     {
@@ -51,7 +51,7 @@ public readonly record struct SecondRegionalMeshCode
 
     public string Value { get; }
 
-    public JisRegionalMeshBounds Bounds => JisRegionalMeshCodeCalculator.GetBounds(Value);
+    public JisRegionalMeshBounds Bounds => JisRegionalMeshCodeCalculator.GetBounds(this);
 
     public FirstRegionalMeshCode Parent => FirstRegionalMeshCode.Parse(Value[..4]);
 
@@ -86,7 +86,7 @@ public readonly record struct ThirdRegionalMeshCode
 
     public string Value { get; }
 
-    public JisRegionalMeshBounds Bounds => JisRegionalMeshCodeCalculator.GetBounds(Value);
+    public JisRegionalMeshBounds Bounds => JisRegionalMeshCodeCalculator.GetBounds(this);
 
     public SecondRegionalMeshCode Parent => SecondRegionalMeshCode.Parse(Value[..6]);
 
@@ -126,19 +126,32 @@ internal static class JisRegionalMeshCodeCalculator
             && (length < 6 || (ToDigit(meshCode[4]) <= 7 && ToDigit(meshCode[5]) <= 7));
     }
 
-    internal static JisRegionalMeshBounds GetBounds(string meshCode)
+    internal static JisRegionalMeshBounds GetBounds(FirstRegionalMeshCode meshCode)
     {
-        return TryGetBounds(meshCode, out JisRegionalMeshBounds bounds)
+        return CalculateBounds(meshCode.Value, out JisRegionalMeshBounds bounds)
             ? bounds
-            : throw new ArgumentException("JIS X 0410 regional mesh code is invalid.", nameof(meshCode));
+            : throw new InvalidOperationException("A valid first regional mesh code did not produce bounds.");
     }
 
-    internal static bool TryGetBounds(string? meshCode, out JisRegionalMeshBounds bounds)
+    internal static JisRegionalMeshBounds GetBounds(SecondRegionalMeshCode meshCode)
+    {
+        return CalculateBounds(meshCode.Value, out JisRegionalMeshBounds bounds)
+            ? bounds
+            : throw new InvalidOperationException("A valid second regional mesh code did not produce bounds.");
+    }
+
+    internal static JisRegionalMeshBounds GetBounds(ThirdRegionalMeshCode meshCode)
+    {
+        return CalculateBounds(meshCode.Value, out JisRegionalMeshBounds bounds)
+            ? bounds
+            : throw new InvalidOperationException("A valid third regional mesh code did not produce bounds.");
+    }
+
+    private static bool CalculateBounds(string meshCode, out JisRegionalMeshBounds bounds)
     {
         bounds = EmptyBounds;
 
-        if (string.IsNullOrWhiteSpace(meshCode)
-            || (meshCode.Length != 4 && meshCode.Length != 6 && meshCode.Length != 8)
+        if ((meshCode.Length != 4 && meshCode.Length != 6 && meshCode.Length != 8)
             || !meshCode.All(static character => character is >= '0' and <= '9'))
         {
             return false;

--- a/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
@@ -116,8 +116,6 @@ public readonly record struct ThirdRegionalMeshCode
 
 internal static class JisRegionalMeshCodeCalculator
 {
-    private static readonly JisRegionalMeshBounds EmptyBounds = new(0.0, 0.0, 0.0, 0.0);
-
     internal static bool IsValid(string? meshCode, int length)
     {
         return meshCode is not null
@@ -128,35 +126,21 @@ internal static class JisRegionalMeshCodeCalculator
 
     internal static JisRegionalMeshBounds GetBounds(FirstRegionalMeshCode meshCode)
     {
-        return CalculateBounds(meshCode.Value, out JisRegionalMeshBounds bounds)
-            ? bounds
-            : throw new InvalidOperationException("A valid first regional mesh code did not produce bounds.");
+        return CalculateFirstBounds(meshCode.Value);
     }
 
     internal static JisRegionalMeshBounds GetBounds(SecondRegionalMeshCode meshCode)
     {
-        return CalculateBounds(meshCode.Value, out JisRegionalMeshBounds bounds)
-            ? bounds
-            : throw new InvalidOperationException("A valid second regional mesh code did not produce bounds.");
+        return CalculateSecondBounds(meshCode.Value);
     }
 
     internal static JisRegionalMeshBounds GetBounds(ThirdRegionalMeshCode meshCode)
     {
-        return CalculateBounds(meshCode.Value, out JisRegionalMeshBounds bounds)
-            ? bounds
-            : throw new InvalidOperationException("A valid third regional mesh code did not produce bounds.");
+        return CalculateThirdBounds(meshCode.Value);
     }
 
-    private static bool CalculateBounds(string meshCode, out JisRegionalMeshBounds bounds)
+    private static JisRegionalMeshBounds CalculateFirstBounds(string meshCode)
     {
-        bounds = EmptyBounds;
-
-        if ((meshCode.Length != 4 && meshCode.Length != 6 && meshCode.Length != 8)
-            || !meshCode.All(static character => character is >= '0' and <= '9'))
-        {
-            return false;
-        }
-
         int firstLatitudeIndex = ToTwoDigitNumber(meshCode[0], meshCode[1]);
         int firstLongitudeIndex = ToTwoDigitNumber(meshCode[2], meshCode[3]);
 
@@ -165,42 +149,41 @@ internal static class JisRegionalMeshCodeCalculator
         double latitudeSpan = 40.0 / 60.0;
         double longitudeSpan = 1.0;
 
-        if (meshCode.Length >= 6)
-        {
-            int secondLatitudeIndex = ToDigit(meshCode[4]);
-            int secondLongitudeIndex = ToDigit(meshCode[5]);
-            if (secondLatitudeIndex > 7 || secondLongitudeIndex > 7)
-            {
-                return false;
-            }
-
-            latitudeSpan /= 8.0;
-            longitudeSpan /= 8.0;
-            southLatitude += secondLatitudeIndex * latitudeSpan;
-            westLongitude += secondLongitudeIndex * longitudeSpan;
-        }
-
-        if (meshCode.Length >= 8)
-        {
-            int thirdLatitudeIndex = ToDigit(meshCode[6]);
-            int thirdLongitudeIndex = ToDigit(meshCode[7]);
-            if (thirdLatitudeIndex > 9 || thirdLongitudeIndex > 9)
-            {
-                return false;
-            }
-
-            latitudeSpan /= 10.0;
-            longitudeSpan /= 10.0;
-            southLatitude += thirdLatitudeIndex * latitudeSpan;
-            westLongitude += thirdLongitudeIndex * longitudeSpan;
-        }
-
-        bounds = new JisRegionalMeshBounds(
+        return new JisRegionalMeshBounds(
             southLatitude,
             southLatitude + latitudeSpan,
             westLongitude,
             westLongitude + longitudeSpan);
-        return true;
+    }
+
+    private static JisRegionalMeshBounds CalculateSecondBounds(string meshCode)
+    {
+        JisRegionalMeshBounds firstBounds = CalculateFirstBounds(meshCode);
+        double latitudeSpan = (firstBounds.NorthLatitude - firstBounds.SouthLatitude) / 8.0;
+        double longitudeSpan = (firstBounds.EastLongitude - firstBounds.WestLongitude) / 8.0;
+        double southLatitude = firstBounds.SouthLatitude + (ToDigit(meshCode[4]) * latitudeSpan);
+        double westLongitude = firstBounds.WestLongitude + (ToDigit(meshCode[5]) * longitudeSpan);
+
+        return new JisRegionalMeshBounds(
+            southLatitude,
+            southLatitude + latitudeSpan,
+            westLongitude,
+            westLongitude + longitudeSpan);
+    }
+
+    private static JisRegionalMeshBounds CalculateThirdBounds(string meshCode)
+    {
+        JisRegionalMeshBounds secondBounds = CalculateSecondBounds(meshCode);
+        double latitudeSpan = (secondBounds.NorthLatitude - secondBounds.SouthLatitude) / 10.0;
+        double longitudeSpan = (secondBounds.EastLongitude - secondBounds.WestLongitude) / 10.0;
+        double southLatitude = secondBounds.SouthLatitude + (ToDigit(meshCode[6]) * latitudeSpan);
+        double westLongitude = secondBounds.WestLongitude + (ToDigit(meshCode[7]) * longitudeSpan);
+
+        return new JisRegionalMeshBounds(
+            southLatitude,
+            southLatitude + latitudeSpan,
+            westLongitude,
+            westLongitude + longitudeSpan);
     }
 
     private static int ToTwoDigitNumber(char tens, char ones)

--- a/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Globalization;
 using System.Linq;
 
 namespace PlateauResoniteLink.Domain.Importing;
@@ -117,12 +116,14 @@ public readonly record struct ThirdRegionalMeshCode
 
 internal static class JisRegionalMeshCodeCalculator
 {
+    private static readonly JisRegionalMeshBounds EmptyBounds = new(0.0, 0.0, 0.0, 0.0);
+
     internal static bool IsValid(string? meshCode, int length)
     {
         return meshCode is not null
             && meshCode.Length == length
             && meshCode.All(static character => character is >= '0' and <= '9')
-            && TryGetBounds(meshCode, out _);
+            && (length < 6 || (ToDigit(meshCode[4]) <= 7 && ToDigit(meshCode[5]) <= 7));
     }
 
     internal static JisRegionalMeshBounds GetBounds(string meshCode)
@@ -134,7 +135,7 @@ internal static class JisRegionalMeshCodeCalculator
 
     internal static bool TryGetBounds(string? meshCode, out JisRegionalMeshBounds bounds)
     {
-        bounds = new JisRegionalMeshBounds(0.0, 0.0, 0.0, 0.0);
+        bounds = EmptyBounds;
 
         if (string.IsNullOrWhiteSpace(meshCode)
             || (meshCode.Length != 4 && meshCode.Length != 6 && meshCode.Length != 8)
@@ -143,8 +144,8 @@ internal static class JisRegionalMeshCodeCalculator
             return false;
         }
 
-        int firstLatitudeIndex = int.Parse(meshCode[..2], CultureInfo.InvariantCulture);
-        int firstLongitudeIndex = int.Parse(meshCode[2..4], CultureInfo.InvariantCulture);
+        int firstLatitudeIndex = ToTwoDigitNumber(meshCode[0], meshCode[1]);
+        int firstLongitudeIndex = ToTwoDigitNumber(meshCode[2], meshCode[3]);
 
         double southLatitude = firstLatitudeIndex / 1.5;
         double westLongitude = 100.0 + firstLongitudeIndex;
@@ -153,8 +154,8 @@ internal static class JisRegionalMeshCodeCalculator
 
         if (meshCode.Length >= 6)
         {
-            int secondLatitudeIndex = int.Parse(meshCode[4].ToString(), CultureInfo.InvariantCulture);
-            int secondLongitudeIndex = int.Parse(meshCode[5].ToString(), CultureInfo.InvariantCulture);
+            int secondLatitudeIndex = ToDigit(meshCode[4]);
+            int secondLongitudeIndex = ToDigit(meshCode[5]);
             if (secondLatitudeIndex > 7 || secondLongitudeIndex > 7)
             {
                 return false;
@@ -168,8 +169,8 @@ internal static class JisRegionalMeshCodeCalculator
 
         if (meshCode.Length >= 8)
         {
-            int thirdLatitudeIndex = int.Parse(meshCode[6].ToString(), CultureInfo.InvariantCulture);
-            int thirdLongitudeIndex = int.Parse(meshCode[7].ToString(), CultureInfo.InvariantCulture);
+            int thirdLatitudeIndex = ToDigit(meshCode[6]);
+            int thirdLongitudeIndex = ToDigit(meshCode[7]);
             if (thirdLatitudeIndex > 9 || thirdLongitudeIndex > 9)
             {
                 return false;
@@ -187,5 +188,15 @@ internal static class JisRegionalMeshCodeCalculator
             westLongitude,
             westLongitude + longitudeSpan);
         return true;
+    }
+
+    private static int ToTwoDigitNumber(char tens, char ones)
+    {
+        return (ToDigit(tens) * 10) + ToDigit(ones);
+    }
+
+    private static int ToDigit(char character)
+    {
+        return character - '0';
     }
 }

--- a/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
@@ -127,14 +127,14 @@ internal static class JisRegionalMeshCodeCalculator
 
     internal static JisRegionalMeshBounds GetBounds(string meshCode)
     {
-        return TryGetBounds(meshCode, out JisRegionalMeshBounds? bounds)
-            ? bounds!
+        return TryGetBounds(meshCode, out JisRegionalMeshBounds bounds)
+            ? bounds
             : throw new ArgumentException("JIS X 0410 regional mesh code is invalid.", nameof(meshCode));
     }
 
-    internal static bool TryGetBounds(string meshCode, out JisRegionalMeshBounds? bounds)
+    internal static bool TryGetBounds(string? meshCode, out JisRegionalMeshBounds bounds)
     {
-        bounds = null;
+        bounds = new JisRegionalMeshBounds(0.0, 0.0, 0.0, 0.0);
 
         if (string.IsNullOrWhiteSpace(meshCode)
             || (meshCode.Length != 4 && meshCode.Length != 6 && meshCode.Length != 8)

--- a/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/JisRegionalMeshCode.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace PlateauResoniteLink.Domain.Importing;
@@ -15,7 +16,7 @@ public sealed record JisRegionalMeshBounds(
         Altitude: 0.0);
 }
 
-public readonly record struct FirstRegionalMeshCode
+public sealed record FirstRegionalMeshCode
 {
     private FirstRegionalMeshCode(string value)
     {
@@ -28,7 +29,7 @@ public readonly record struct FirstRegionalMeshCode
 
     public GeodeticCoordinate Center => Bounds.Center;
 
-    public static bool TryParse(string? value, out FirstRegionalMeshCode meshCode)
+    public static bool TryParse(string? value, [NotNullWhen(true)] out FirstRegionalMeshCode? meshCode)
     {
         if (value is not null && JisRegionalMeshCodeCalculator.IsValid(value, 4))
         {
@@ -36,13 +37,13 @@ public readonly record struct FirstRegionalMeshCode
             return true;
         }
 
-        meshCode = default;
+        meshCode = null;
         return false;
     }
 
     public static FirstRegionalMeshCode Parse(string value)
     {
-        return TryParse(value, out FirstRegionalMeshCode meshCode)
+        return TryParse(value, out FirstRegionalMeshCode? meshCode)
             ? meshCode
             : throw new ArgumentException("JIS X 0410 first regional mesh code must be a valid 4-digit code.", nameof(value));
     }
@@ -55,7 +56,7 @@ public readonly record struct FirstRegionalMeshCode
     }
 }
 
-public readonly record struct SecondRegionalMeshCode
+public sealed record SecondRegionalMeshCode
 {
     private SecondRegionalMeshCode(string value)
     {
@@ -70,7 +71,7 @@ public readonly record struct SecondRegionalMeshCode
 
     public FirstRegionalMeshCode Parent => FirstRegionalMeshCode.FromValidated(Value[..4]);
 
-    public static bool TryParse(string? value, out SecondRegionalMeshCode meshCode)
+    public static bool TryParse(string? value, [NotNullWhen(true)] out SecondRegionalMeshCode? meshCode)
     {
         if (value is not null && JisRegionalMeshCodeCalculator.IsValid(value, 6))
         {
@@ -78,13 +79,13 @@ public readonly record struct SecondRegionalMeshCode
             return true;
         }
 
-        meshCode = default;
+        meshCode = null;
         return false;
     }
 
     public static SecondRegionalMeshCode Parse(string value)
     {
-        return TryParse(value, out SecondRegionalMeshCode meshCode)
+        return TryParse(value, out SecondRegionalMeshCode? meshCode)
             ? meshCode
             : throw new ArgumentException("JIS X 0410 second regional mesh code must be a valid 6-digit code.", nameof(value));
     }
@@ -97,7 +98,7 @@ public readonly record struct SecondRegionalMeshCode
     }
 }
 
-public readonly record struct ThirdRegionalMeshCode
+public sealed record ThirdRegionalMeshCode
 {
     private ThirdRegionalMeshCode(string value)
     {
@@ -114,7 +115,7 @@ public readonly record struct ThirdRegionalMeshCode
 
     public FirstRegionalMeshCode FirstMesh => FirstRegionalMeshCode.FromValidated(Value[..4]);
 
-    public static bool TryParse(string? value, out ThirdRegionalMeshCode meshCode)
+    public static bool TryParse(string? value, [NotNullWhen(true)] out ThirdRegionalMeshCode? meshCode)
     {
         if (value is not null && JisRegionalMeshCodeCalculator.IsValid(value, 8))
         {
@@ -122,13 +123,13 @@ public readonly record struct ThirdRegionalMeshCode
             return true;
         }
 
-        meshCode = default;
+        meshCode = null;
         return false;
     }
 
     public static ThirdRegionalMeshCode Parse(string value)
     {
-        return TryParse(value, out ThirdRegionalMeshCode meshCode)
+        return TryParse(value, out ThirdRegionalMeshCode? meshCode)
             ? meshCode
             : throw new ArgumentException("JIS X 0410 third regional mesh code must be a valid 8-digit code.", nameof(value));
     }

--- a/src/PlateauResoniteLink/Domain/Importing/PlateauMeshCode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/PlateauMeshCode.cs
@@ -1,82 +1,52 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace PlateauResoniteLink.Domain.Importing;
-
-public abstract record PlateauRegionalMeshCode
-{
-    private PlateauRegionalMeshCode(string value, JisRegionalMeshBounds bounds)
-    {
-        Value = value;
-        Bounds = bounds;
-    }
-
-    public string Value { get; }
-
-    public JisRegionalMeshBounds Bounds { get; }
-
-    public GeodeticCoordinate Center => new(
-        Latitude: (Bounds.SouthLatitude + Bounds.NorthLatitude) / 2.0,
-        Longitude: (Bounds.WestLongitude + Bounds.EastLongitude) / 2.0,
-        Altitude: 0.0);
-
-    public static bool TryParse(string? value, [NotNullWhen(true)] out PlateauRegionalMeshCode? meshCode)
-    {
-        if (SecondRegionalMeshCode.TryParse(value, out SecondRegionalMeshCode secondMeshCode))
-        {
-            meshCode = new Second(secondMeshCode);
-            return true;
-        }
-
-        if (ThirdRegionalMeshCode.TryParse(value, out ThirdRegionalMeshCode thirdMeshCode))
-        {
-            meshCode = new Third(thirdMeshCode);
-            return true;
-        }
-
-        meshCode = null;
-        return false;
-    }
-
-    public sealed record Second(SecondRegionalMeshCode Code)
-        : PlateauRegionalMeshCode(Code.Value, Code.Bounds);
-
-    public sealed record Third(ThirdRegionalMeshCode Code)
-        : PlateauRegionalMeshCode(Code.Value, Code.Bounds);
-
-    public override string ToString() => Value;
-}
 
 public static class PlateauMeshCode
 {
     public static bool TryGetGeodeticCenter(string meshCode, out GeodeticCoordinate center)
     {
-        if (!PlateauRegionalMeshCode.TryParse(meshCode, out PlateauRegionalMeshCode? regionalMeshCode))
+        if (SecondRegionalMeshCode.TryParse(meshCode, out SecondRegionalMeshCode secondMeshCode))
         {
-            center = new GeodeticCoordinate(0.0, 0.0, 0.0);
-            return false;
+            center = secondMeshCode.Center;
+            return true;
         }
 
-        center = regionalMeshCode.Center;
-        return true;
+        if (ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode thirdMeshCode))
+        {
+            center = thirdMeshCode.Center;
+            return true;
+        }
+
+        center = new GeodeticCoordinate(0.0, 0.0, 0.0);
+        return false;
     }
 
     public static bool TryGetBounds(
         string meshCode,
         out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds)
     {
-        bounds = default;
-
-        if (!PlateauRegionalMeshCode.TryParse(meshCode, out PlateauRegionalMeshCode? regionalMeshCode))
+        if (SecondRegionalMeshCode.TryParse(meshCode, out SecondRegionalMeshCode secondMeshCode))
         {
-            return false;
+            bounds = ToTuple(secondMeshCode.Bounds);
+            return true;
         }
 
-        JisRegionalMeshBounds jisBounds = regionalMeshCode.Bounds;
-        bounds = (
-            SouthLatitude: jisBounds.SouthLatitude,
-            NorthLatitude: jisBounds.NorthLatitude,
-            WestLongitude: jisBounds.WestLongitude,
-            EastLongitude: jisBounds.EastLongitude);
-        return true;
+        if (ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode thirdMeshCode))
+        {
+            bounds = ToTuple(thirdMeshCode.Bounds);
+            return true;
+        }
+
+        bounds = default;
+        return false;
+    }
+
+    private static (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) ToTuple(
+        JisRegionalMeshBounds bounds)
+    {
+        return (
+            SouthLatitude: bounds.SouthLatitude,
+            NorthLatitude: bounds.NorthLatitude,
+            WestLongitude: bounds.WestLongitude,
+            EastLongitude: bounds.EastLongitude);
     }
 }

--- a/src/PlateauResoniteLink/Domain/Importing/PlateauMeshCode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/PlateauMeshCode.cs
@@ -4,13 +4,13 @@ public static class PlateauMeshCode
 {
     public static bool TryGetGeodeticCenter(string meshCode, out GeodeticCoordinate center)
     {
-        if (SecondRegionalMeshCode.TryParse(meshCode, out SecondRegionalMeshCode secondMeshCode))
+        if (SecondRegionalMeshCode.TryParse(meshCode, out SecondRegionalMeshCode? secondMeshCode))
         {
             center = secondMeshCode.Center;
             return true;
         }
 
-        if (ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode thirdMeshCode))
+        if (ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode? thirdMeshCode))
         {
             center = thirdMeshCode.Center;
             return true;
@@ -24,13 +24,13 @@ public static class PlateauMeshCode
         string meshCode,
         out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds)
     {
-        if (SecondRegionalMeshCode.TryParse(meshCode, out SecondRegionalMeshCode secondMeshCode))
+        if (SecondRegionalMeshCode.TryParse(meshCode, out SecondRegionalMeshCode? secondMeshCode))
         {
             bounds = ToTuple(secondMeshCode.Bounds);
             return true;
         }
 
-        if (ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode thirdMeshCode))
+        if (ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode? thirdMeshCode))
         {
             bounds = ToTuple(thirdMeshCode.Bounds);
             return true;

--- a/src/PlateauResoniteLink/Domain/Importing/PlateauMeshCode.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/PlateauMeshCode.cs
@@ -1,20 +1,62 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace PlateauResoniteLink.Domain.Importing;
+
+public abstract record PlateauRegionalMeshCode
+{
+    private PlateauRegionalMeshCode(string value, JisRegionalMeshBounds bounds)
+    {
+        Value = value;
+        Bounds = bounds;
+    }
+
+    public string Value { get; }
+
+    public JisRegionalMeshBounds Bounds { get; }
+
+    public GeodeticCoordinate Center => new(
+        Latitude: (Bounds.SouthLatitude + Bounds.NorthLatitude) / 2.0,
+        Longitude: (Bounds.WestLongitude + Bounds.EastLongitude) / 2.0,
+        Altitude: 0.0);
+
+    public static bool TryParse(string? value, [NotNullWhen(true)] out PlateauRegionalMeshCode? meshCode)
+    {
+        if (SecondRegionalMeshCode.TryParse(value, out SecondRegionalMeshCode secondMeshCode))
+        {
+            meshCode = new Second(secondMeshCode);
+            return true;
+        }
+
+        if (ThirdRegionalMeshCode.TryParse(value, out ThirdRegionalMeshCode thirdMeshCode))
+        {
+            meshCode = new Third(thirdMeshCode);
+            return true;
+        }
+
+        meshCode = null;
+        return false;
+    }
+
+    public sealed record Second(SecondRegionalMeshCode Code)
+        : PlateauRegionalMeshCode(Code.Value, Code.Bounds);
+
+    public sealed record Third(ThirdRegionalMeshCode Code)
+        : PlateauRegionalMeshCode(Code.Value, Code.Bounds);
+
+    public override string ToString() => Value;
+}
 
 public static class PlateauMeshCode
 {
     public static bool TryGetGeodeticCenter(string meshCode, out GeodeticCoordinate center)
     {
-        center = default!;
-
-        if (!TryGetBounds(meshCode, out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) bounds))
+        if (!PlateauRegionalMeshCode.TryParse(meshCode, out PlateauRegionalMeshCode? regionalMeshCode))
         {
+            center = new GeodeticCoordinate(0.0, 0.0, 0.0);
             return false;
         }
 
-        center = new GeodeticCoordinate(
-            Latitude: (bounds.SouthLatitude + bounds.NorthLatitude) / 2.0,
-            Longitude: (bounds.WestLongitude + bounds.EastLongitude) / 2.0,
-            Altitude: 0.0);
+        center = regionalMeshCode.Center;
         return true;
     }
 
@@ -24,14 +66,14 @@ public static class PlateauMeshCode
     {
         bounds = default;
 
-        if (!JisRegionalMeshCodeCalculator.TryGetBounds(meshCode, out JisRegionalMeshBounds? jisBounds)
-            || meshCode.Length == 4)
+        if (!PlateauRegionalMeshCode.TryParse(meshCode, out PlateauRegionalMeshCode? regionalMeshCode))
         {
             return false;
         }
 
+        JisRegionalMeshBounds jisBounds = regionalMeshCode.Bounds;
         bounds = (
-            SouthLatitude: jisBounds!.SouthLatitude,
+            SouthLatitude: jisBounds.SouthLatitude,
             NorthLatitude: jisBounds.NorthLatitude,
             WestLongitude: jisBounds.WestLongitude,
             EastLongitude: jisBounds.EastLongitude);

--- a/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
@@ -117,6 +117,12 @@ public sealed record TerrainTextureOverlay
         Justification = "The init setter snapshots and rejects null source elements for with-expression updates.")]
     private IReadOnlyList<TerrainTextureSource> sources = [];
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Style",
+        "IDE0032:Use auto property",
+        Justification = "The init setter validates with-expression updates before changing overlay identity state.")]
+    private ThirdRegionalMeshCode meshCode = null!;
+
     public TerrainTextureOverlay(
         string PackageName,
         ThirdRegionalMeshCode MeshCode,
@@ -180,7 +186,11 @@ public sealed record TerrainTextureOverlay
             : value.ToLowerInvariant();
     }
 
-    public ThirdRegionalMeshCode MeshCode { get; init; }
+    public ThirdRegionalMeshCode MeshCode
+    {
+        get => meshCode;
+        init => meshCode = value ?? throw new ArgumentNullException(nameof(value));
+    }
 
     public GeographicRectangle GeographicBounds { get; init; }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
@@ -370,4 +370,17 @@ internal sealed record PreparedTerrainOverlayTextureReference(
     ThirdRegionalMeshCode MeshCode,
     TerrainTextureOverlay Overlay,
     GeneratedTerrainTexture GeneratedTerrainTexture)
-    : PreparedTextureReference(GeneratedTerrainTexture.TextureSource);
+    : PreparedTextureReference(GeneratedTerrainTexture.TextureSource)
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Style",
+        "IDE0032:Use auto property",
+        Justification = "The init setter validates with-expression updates before changing mesh-code identity state.")]
+    private ThirdRegionalMeshCode meshCode = MeshCode ?? throw new ArgumentNullException(nameof(MeshCode));
+
+    public ThirdRegionalMeshCode MeshCode
+    {
+        get => meshCode;
+        init => meshCode = value ?? throw new ArgumentNullException(nameof(value));
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTerrainOverlayMaterialContract.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTerrainOverlayMaterialContract.cs
@@ -33,6 +33,9 @@ internal static class ResoniteTerrainOverlayMaterialContract
         ThirdRegionalMeshCode meshCode,
         TerrainTextureOverlay terrainOverlay)
     {
+        ArgumentNullException.ThrowIfNull(meshCode);
+        ArgumentNullException.ThrowIfNull(terrainOverlay);
+
         if (BoundsApproximatelyEqual(meshCode.Bounds, terrainOverlay.GeographicBounds))
         {
             return meshCode;

--- a/tests/PlateauResoniteLink.Tests/Application/ThirdRegionalMeshCodeBoundaryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/ThirdRegionalMeshCodeBoundaryTests.cs
@@ -1,0 +1,116 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Tests.Application;
+
+public sealed class ThirdRegionalMeshCodeBoundaryTests
+{
+    [Fact]
+    public void TerrainTextureOverlayRejectsNullMeshCodeAtConstruction()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new TerrainTextureOverlay(
+                PackageName: "dem",
+                MeshCode: null!,
+                GeographicBounds: CreateBounds(),
+                MaxTextureSize: 512,
+                Sources: [CreateTileSource()]));
+    }
+
+    [Fact]
+    public void TerrainTextureOverlayRejectsNullMeshCodeInWithExpression()
+    {
+        TerrainTextureOverlay overlay = CreateOverlay();
+
+        Assert.Throws<ArgumentNullException>(() => overlay with { MeshCode = null! });
+    }
+
+    [Fact]
+    public void TerrainOverlayMaterialBindingRejectsNullMeshCodeAtConstruction()
+    {
+        TerrainTextureOverlay overlay = CreateOverlay();
+
+        Assert.Throws<ArgumentNullException>(() => new TerrainOverlayMaterialBinding(null!, overlay));
+    }
+
+    [Fact]
+    public void TerrainOverlayMaterialBindingRejectsNullMeshCodeInWithExpression()
+    {
+        TerrainOverlayMaterialBinding binding = new(ThirdRegionalMeshCode.Parse("53394525"), CreateOverlay());
+
+        Assert.Throws<ArgumentNullException>(() => binding with { MeshCode = null! });
+    }
+
+    [Fact]
+    public void DemTerrainOverlayRegionRejectsNullMeshCodeAtConstruction()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DemTerrainOverlayRegion(null!, CreateBounds()));
+    }
+
+    [Fact]
+    public void DemTerrainOverlayRegionRejectsNullMeshCodeInWithExpression()
+    {
+        DemTerrainOverlayRegion region = new(ThirdRegionalMeshCode.Parse("53394525"), CreateBounds());
+
+        Assert.Throws<ArgumentNullException>(() => region with { MeshCode = null! });
+    }
+
+    [Fact]
+    public void DemTerrainRasterCacheKeyRejectsNullMeshCodeAtConstruction()
+    {
+        DemTerrainRasterSourceScope scope = new("raster.tif");
+
+        Assert.Throws<ArgumentNullException>(() =>
+            new DemTerrainRasterCacheKey("dataset", scope, null!, CreateBounds()));
+    }
+
+    [Fact]
+    public void PreparedTerrainOverlayTextureReferenceRejectsNullMeshCodeAtConstruction()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new PreparedTerrainOverlayTextureReference(null!, CreateOverlay(), CreateGeneratedTexture()));
+    }
+
+    [Fact]
+    public void PreparedTerrainOverlayTextureReferenceRejectsNullMeshCodeInWithExpression()
+    {
+        PreparedTerrainOverlayTextureReference reference = new(
+            ThirdRegionalMeshCode.Parse("53394525"),
+            CreateOverlay(),
+            CreateGeneratedTexture());
+
+        Assert.Throws<ArgumentNullException>(() => reference with { MeshCode = null! });
+    }
+
+    private static TerrainTextureOverlay CreateOverlay()
+    {
+        return new TerrainTextureOverlay(
+            PackageName: "dem",
+            MeshCode: ThirdRegionalMeshCode.Parse("53394525"),
+            GeographicBounds: CreateBounds(),
+            MaxTextureSize: 512,
+            Sources: [CreateTileSource()]);
+    }
+
+    private static TerrainTextureTileSource CreateTileSource() =>
+        new("https://tiles.example/{z}/{x}/{y}.png", 17);
+
+    private static GeneratedTerrainTexture CreateGeneratedTexture() =>
+        new(
+            TextureImportSourceFactory.CreateInMemory(
+                1,
+                1,
+                "sRGB",
+                [1, 2, 3, 4],
+                "terrain:texture",
+                TexturePayloadFormat.RawRgba32),
+            new ResoniteFloat2(1.0, 1.0),
+            new ResoniteFloat2(0.0, 0.0),
+            CreateTileSource());
+
+    private static GeographicRectangle CreateBounds() =>
+        new(35.0, 35.01, 139.0, 139.01);
+}

--- a/tests/PlateauResoniteLink.Tests/Domain/JisRegionalMeshCodeTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Domain/JisRegionalMeshCodeTests.cs
@@ -7,9 +7,9 @@ public sealed class JisRegionalMeshCodeTests
     [Fact]
     public void TryParseAcceptsOnlyMatchingMeshOrder()
     {
-        Assert.True(FirstRegionalMeshCode.TryParse("5339", out FirstRegionalMeshCode first));
-        Assert.True(SecondRegionalMeshCode.TryParse("533945", out SecondRegionalMeshCode second));
-        Assert.True(ThirdRegionalMeshCode.TryParse("53394525", out ThirdRegionalMeshCode third));
+        Assert.True(FirstRegionalMeshCode.TryParse("5339", out FirstRegionalMeshCode? first));
+        Assert.True(SecondRegionalMeshCode.TryParse("533945", out SecondRegionalMeshCode? second));
+        Assert.True(ThirdRegionalMeshCode.TryParse("53394525", out ThirdRegionalMeshCode? third));
 
         Assert.Equal("5339", first.Value);
         Assert.Equal("533945", second.Value);
@@ -18,6 +18,15 @@ public sealed class JisRegionalMeshCodeTests
         Assert.False(SecondRegionalMeshCode.TryParse("53394525", out _));
         Assert.False(ThirdRegionalMeshCode.TryParse("533945", out _));
         Assert.False(ThirdRegionalMeshCode.TryParse(".*", out _));
+    }
+
+    [Fact]
+    public void TryParseClearsMeshCodeWhenInputIsInvalid()
+    {
+        bool parsed = ThirdRegionalMeshCode.TryParse("invalid", out ThirdRegionalMeshCode? meshCode);
+
+        Assert.False(parsed);
+        Assert.Null(meshCode);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Domain/PlateauMeshCodeTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Domain/PlateauMeshCodeTests.cs
@@ -7,9 +7,10 @@ public sealed class PlateauMeshCodeTests
     [Fact]
     public void SecondRegionalMeshCodeCarriesBoundsAndCenterAfterParsing()
     {
-        bool parsed = SecondRegionalMeshCode.TryParse("533945", out SecondRegionalMeshCode meshCode);
+        bool parsed = SecondRegionalMeshCode.TryParse("533945", out SecondRegionalMeshCode? meshCode);
 
         Assert.True(parsed);
+        Assert.NotNull(meshCode);
         Assert.Equal("533945", meshCode.Value);
         Assert.Equal(35.708333333333343, meshCode.Center.Latitude, 9);
         Assert.Equal(139.6875, meshCode.Center.Longitude, 9);
@@ -18,9 +19,10 @@ public sealed class PlateauMeshCodeTests
     [Fact]
     public void ThirdRegionalMeshCodeCarriesBoundsAndCenterAfterParsing()
     {
-        bool parsed = ThirdRegionalMeshCode.TryParse("53394525", out ThirdRegionalMeshCode meshCode);
+        bool parsed = ThirdRegionalMeshCode.TryParse("53394525", out ThirdRegionalMeshCode? meshCode);
 
         Assert.True(parsed);
+        Assert.NotNull(meshCode);
         Assert.Equal("53394525", meshCode.Value);
         Assert.Equal(35.6875, meshCode.Center.Latitude, 9);
         Assert.Equal(139.69375, meshCode.Center.Longitude, 9);

--- a/tests/PlateauResoniteLink.Tests/Domain/PlateauMeshCodeTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Domain/PlateauMeshCodeTests.cs
@@ -5,6 +5,42 @@ namespace PlateauResoniteLink.Tests.Domain;
 public sealed class PlateauMeshCodeTests
 {
     [Fact]
+    public void PlateauRegionalMeshCodeParsesSecondLevelMeshAsSuccessType()
+    {
+        bool parsed = PlateauRegionalMeshCode.TryParse("533945", out PlateauRegionalMeshCode? meshCode);
+
+        Assert.True(parsed);
+        PlateauRegionalMeshCode.Second secondMeshCode = Assert.IsType<PlateauRegionalMeshCode.Second>(meshCode);
+        Assert.Equal("533945", secondMeshCode.Value);
+        Assert.Equal(35.708333333333343, secondMeshCode.Center.Latitude, 9);
+        Assert.Equal(139.6875, secondMeshCode.Center.Longitude, 9);
+    }
+
+    [Fact]
+    public void PlateauRegionalMeshCodeParsesThirdLevelMeshAsSuccessType()
+    {
+        bool parsed = PlateauRegionalMeshCode.TryParse("53394525", out PlateauRegionalMeshCode? meshCode);
+
+        Assert.True(parsed);
+        PlateauRegionalMeshCode.Third thirdMeshCode = Assert.IsType<PlateauRegionalMeshCode.Third>(meshCode);
+        Assert.Equal("53394525", thirdMeshCode.Value);
+        Assert.Equal(35.6875, thirdMeshCode.Center.Latitude, 9);
+        Assert.Equal(139.69375, thirdMeshCode.Center.Longitude, 9);
+    }
+
+    [Theory]
+    [InlineData("5339")]
+    [InlineData("533948")]
+    [InlineData("5339452A")]
+    public void PlateauRegionalMeshCodeRejectsNonConcreteOrInvalidMeshCodes(string meshCode)
+    {
+        bool parsed = PlateauRegionalMeshCode.TryParse(meshCode, out PlateauRegionalMeshCode? parsedMeshCode);
+
+        Assert.False(parsed);
+        Assert.Null(parsedMeshCode);
+    }
+
+    [Fact]
     public void TryGetBoundsReturnsExpectedBoundsForValidThirdLevelMesh()
     {
         bool parsed = PlateauMeshCode.TryGetBounds(

--- a/tests/PlateauResoniteLink.Tests/Domain/PlateauMeshCodeTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Domain/PlateauMeshCodeTests.cs
@@ -5,39 +5,38 @@ namespace PlateauResoniteLink.Tests.Domain;
 public sealed class PlateauMeshCodeTests
 {
     [Fact]
-    public void PlateauRegionalMeshCodeParsesSecondLevelMeshAsSuccessType()
+    public void SecondRegionalMeshCodeCarriesBoundsAndCenterAfterParsing()
     {
-        bool parsed = PlateauRegionalMeshCode.TryParse("533945", out PlateauRegionalMeshCode? meshCode);
+        bool parsed = SecondRegionalMeshCode.TryParse("533945", out SecondRegionalMeshCode meshCode);
 
         Assert.True(parsed);
-        PlateauRegionalMeshCode.Second secondMeshCode = Assert.IsType<PlateauRegionalMeshCode.Second>(meshCode);
-        Assert.Equal("533945", secondMeshCode.Value);
-        Assert.Equal(35.708333333333343, secondMeshCode.Center.Latitude, 9);
-        Assert.Equal(139.6875, secondMeshCode.Center.Longitude, 9);
+        Assert.Equal("533945", meshCode.Value);
+        Assert.Equal(35.708333333333343, meshCode.Center.Latitude, 9);
+        Assert.Equal(139.6875, meshCode.Center.Longitude, 9);
     }
 
     [Fact]
-    public void PlateauRegionalMeshCodeParsesThirdLevelMeshAsSuccessType()
+    public void ThirdRegionalMeshCodeCarriesBoundsAndCenterAfterParsing()
     {
-        bool parsed = PlateauRegionalMeshCode.TryParse("53394525", out PlateauRegionalMeshCode? meshCode);
+        bool parsed = ThirdRegionalMeshCode.TryParse("53394525", out ThirdRegionalMeshCode meshCode);
 
         Assert.True(parsed);
-        PlateauRegionalMeshCode.Third thirdMeshCode = Assert.IsType<PlateauRegionalMeshCode.Third>(meshCode);
-        Assert.Equal("53394525", thirdMeshCode.Value);
-        Assert.Equal(35.6875, thirdMeshCode.Center.Latitude, 9);
-        Assert.Equal(139.69375, thirdMeshCode.Center.Longitude, 9);
+        Assert.Equal("53394525", meshCode.Value);
+        Assert.Equal(35.6875, meshCode.Center.Latitude, 9);
+        Assert.Equal(139.69375, meshCode.Center.Longitude, 9);
     }
 
     [Theory]
     [InlineData("5339")]
     [InlineData("533948")]
     [InlineData("5339452A")]
-    public void PlateauRegionalMeshCodeRejectsNonConcreteOrInvalidMeshCodes(string meshCode)
+    public void PlateauMeshCodeRejectsNonConcreteOrInvalidMeshCodes(string meshCode)
     {
-        bool parsed = PlateauRegionalMeshCode.TryParse(meshCode, out PlateauRegionalMeshCode? parsedMeshCode);
+        bool resolved = PlateauMeshCode.TryGetBounds(
+            meshCode,
+            out (double SouthLatitude, double NorthLatitude, double WestLongitude, double EastLongitude) _);
 
-        Assert.False(parsed);
-        Assert.Null(parsedMeshCode);
+        Assert.False(resolved);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add `PlateauRegionalMeshCode` as the success type for concrete PLATEAU mesh codes, limited to second- and third-level mesh codes
- derive bounds and geodetic center from that typed success state instead of nullable bounds/default values
- keep the existing `PlateauMeshCode.TryGetBounds` / `TryGetGeodeticCenter` APIs as compatibility wrappers over the typed mesh-code result

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~PlateauMeshCodeTests|FullyQualifiedName~JisRegionalMeshCodeTests"` (14 passed)
- real-data Fake Live Sink dump for `plateau-13213-higashimurayama-shi-2020`, mesh `53395325`, packages `dem,bldg`, terrain mesh `grid`
- `git diff --no-index -- runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json runtime/windows/resonite/semantic-baselines/type-mesh-code-bounds-result/current/higashi-53395325-dem-bldg-grid-geotiff.json` (no diff)
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (987 passed)