### PR TITLE
Type terrain material source mesh codes

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
@@ -81,7 +81,7 @@ internal static class TerrainOverlayMaterialSourcePartitioner
         }
 
         double cityObjectMinAltitude = CityObjectAltitudeMetricsResolver.GetMinimumAltitude(cityObjectVertices);
-        TerrainMaterialSourceMeshCode materialSourceMeshCode = TerrainMaterialSourceMeshCode.Parse(
+        TerrainMaterialSourceMeshCode materialSourceMeshCode = TerrainMaterialSourceMeshCode.ParseRequired(
             string.IsNullOrWhiteSpace(cityObject.SourceMeshCode)
                 ? cityObject.ActualMeshCode
                 : cityObject.SourceMeshCode);
@@ -293,36 +293,46 @@ internal static class TerrainOverlayMaterialSourcePartitioner
             cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
     }
 
-    private readonly record struct TerrainMaterialSourceMeshCode(
-        ThirdRegionalMeshCode? ThirdMeshCode,
-        SecondRegionalMeshCode? SecondMeshCode)
+    private abstract record TerrainMaterialSourceMeshCode
     {
-        public bool IsThirdRegionalMesh => ThirdMeshCode.HasValue;
+        public abstract bool IsThirdRegionalMesh { get; }
 
-        public static TerrainMaterialSourceMeshCode Parse(string meshCode)
+        public static TerrainMaterialSourceMeshCode ParseRequired(string meshCode)
         {
             if (ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode thirdMeshCode))
             {
-                return new TerrainMaterialSourceMeshCode(thirdMeshCode, SecondMeshCode: null);
+                return new Third(thirdMeshCode);
             }
 
             if (SecondRegionalMeshCode.TryParse(meshCode, out SecondRegionalMeshCode secondMeshCode))
             {
-                return new TerrainMaterialSourceMeshCode(ThirdMeshCode: null, secondMeshCode);
+                return new Second(secondMeshCode);
             }
 
-            return new TerrainMaterialSourceMeshCode(ThirdMeshCode: null, SecondMeshCode: null);
+            throw new PlateauImportValidationException(
+                [$"Terrain overlay material source mesh-code '{meshCode}' must be a valid second- or third-level mesh-code."]);
         }
 
-        public bool Contains(ThirdRegionalMeshCode overlayMeshCode)
-        {
-            if (ThirdMeshCode is { } thirdMeshCode)
-            {
-                return thirdMeshCode == overlayMeshCode;
-            }
+        public abstract bool Contains(ThirdRegionalMeshCode overlayMeshCode);
 
-            return SecondMeshCode is { } secondMeshCode
-                && secondMeshCode == overlayMeshCode.Parent;
+        private sealed record Third(ThirdRegionalMeshCode MeshCode) : TerrainMaterialSourceMeshCode
+        {
+            public override bool IsThirdRegionalMesh => true;
+
+            public override bool Contains(ThirdRegionalMeshCode overlayMeshCode)
+            {
+                return MeshCode == overlayMeshCode;
+            }
+        }
+
+        private sealed record Second(SecondRegionalMeshCode MeshCode) : TerrainMaterialSourceMeshCode
+        {
+            public override bool IsThirdRegionalMesh => false;
+
+            public override bool Contains(ThirdRegionalMeshCode overlayMeshCode)
+            {
+                return MeshCode == overlayMeshCode.Parent;
+            }
         }
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayMaterialSourcePartitionerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayMaterialSourcePartitionerTests.cs
@@ -58,6 +58,32 @@ public sealed class TerrainOverlayMaterialSourcePartitionerTests
         Assert.Equal(ParsedSurfaceSemantic.Wall, noWallSide.Semantic);
     }
 
+    [Fact]
+    public void PartitionParsedCityObjectRejectsInvalidTerrainMaterialSourceMeshCodeBeforeOverlayFallback()
+    {
+        MeshCodeBounds meshBounds = MeshCodeBounds.TryParse("53394525")!;
+        ParsedCityObject cityObject = new(
+            SlotKey: "bldg-invalid-mesh",
+            DisplayName: "Invalid mesh building",
+            PackageName: "bldg",
+            ActualMeshCode: "not-a-mesh",
+            LodLevel: 2,
+            Surfaces: [CreateHorizontalSurface("roof", altitude: 10.0, meshBounds: meshBounds)],
+            ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
+            SourceFileRelativePath: "udx/bldg/not-a-mesh/bldg.gml",
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] });
+
+        PlateauImportValidationException exception = Assert.Throws<PlateauImportValidationException>(
+            () => TerrainOverlayMaterialSourcePartitioner.PartitionParsedCityObject(
+                    cityObject,
+                    [CreateOverlay(meshBounds)],
+                    [meshBounds])
+                .ToArray());
+        string error = Assert.Single(exception.Errors);
+        Assert.Contains("must be a valid second- or third-level mesh-code", error);
+    }
+
     private static ParsedSurface CreateHorizontalSurface(string polygonId, double altitude, MeshCodeBounds meshBounds)
     {
         return new ParsedSurface(


### PR DESCRIPTION
## Summary
- replace the nullable-field `TerrainMaterialSourceMeshCode` struct with a closed second-/third-level mesh-code union
- remove the invalid "neither second nor third" state that previously caused material-source overlay matching to fall through to requested-overlay fallback
- reject invalid terrain material source mesh codes before overlay fallback and cover that behavior with a regression test

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~TerrainOverlayMaterialSourcePartitionerTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests"` (85 passed)
- real-data Fake Live Sink dump for `plateau-13213-higashimurayama-shi-2020`, mesh `53395325`, packages `dem,bldg`, terrain mesh `grid`
- `git diff --no-index -- runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json runtime/windows/resonite/semantic-baselines/type-terrain-material-source-mesh-code/current/higashi-53395325-dem-bldg-grid-geotiff.json` (no diff)
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (983 passed)