### PR TITLE
Type cached source file reference systems

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -32,7 +32,7 @@ internal static class CityGmlParsedCityObjectProjection
 
         LocalCityGmlObjectProjection.ValidateCompatibleReferenceSystem(
             referenceSystem,
-            sourceFile.CityObjects.FirstOrDefault()?.ReferenceSystem ?? referenceSystem);
+            sourceFile.ReferenceSystem);
 
         ParsedCityObject[] projectedInputCityObjects =
             DemCityObjectAggregation.AggregateBySourceFileAndThirdMesh(

--- a/src/PlateauResoniteLink/Application/Importing/DemSourceDiscoverySupport.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemSourceDiscoverySupport.cs
@@ -16,7 +16,10 @@ internal static class DemSourceDiscoverySupport
 
         CachedSourceFileDescriptor[] cachedDemSourceFiles = demParsedSourceFiles
             .Where(static parsed => parsed.CityObjects.Length > 0)
-            .Select(static parsed => new CachedSourceFileDescriptor(parsed.SourceFile, parsed.CityObjects))
+            .Select(static parsed => new CachedSourceFileDescriptor(
+                parsed.SourceFile,
+                parsed.CityObjects,
+                parsed.ReferenceSystem))
             .ToArray();
         TerrainHeightTriangle[] terrainTriangles = demParsedSourceFiles
             .SelectMany(static parsed => parsed.TerrainTriangles)

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedSourceFileModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedSourceFileModels.cs
@@ -13,7 +13,8 @@ internal sealed record SourceFileDescriptor(
 
 internal sealed record CachedSourceFileDescriptor(
     SourceFileDescriptor SourceFile,
-    ParsedCityObject[] CityObjects)
+    ParsedCityObject[] CityObjects,
+    CoordinateReferenceSystem ReferenceSystem)
 {
     public string RelativePath => SourceFile.RelativePath;
 
@@ -69,6 +70,6 @@ internal sealed class SourceFilePipeline
 internal sealed record ParsedSourceFileResult(
     SourceFileDescriptor SourceFile,
     ParsedCityObject[] CityObjects,
-    CoordinateReferenceSystem? ReferenceSystem,
+    CoordinateReferenceSystem ReferenceSystem,
     TerrainHeightTriangle[] TerrainTriangles,
     TimeSpan Elapsed);

--- a/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
@@ -209,7 +209,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
         int yieldedCount = 0;
         ProjectionTerrainOverlayContext projectionTerrainOverlayContext = await terrainOverlayContextResolver.GetAsync(cancellationToken);
         bool isDemSourceFile = string.Equals(sourceFile.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase);
-        List<ParsedCityObject> parsedDemCityObjects = [];
+        StreamingDemProjectionSource? demProjectionSource = null;
         X3DMaterialWarningStatistics fileWarningStatistics = new();
 
         await foreach (ParsedCityObject parsedCityObject in sourceFile.StreamParsedCityObjectsAsync(cancellationToken))
@@ -222,12 +222,13 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
             globalCartesian ??= CreateGlobalCartesian(resolvedReferenceSystem);
             if (isDemSourceFile)
             {
-                parsedDemCityObjects.Add(parsedCityObject);
+                demProjectionSource ??= new StreamingDemProjectionSource(sourceFile.SourceFile, resolvedReferenceSystem);
+                demProjectionSource.Add(parsedCityObject);
                 continue;
             }
 
             foreach (ImportedCityObject cityObject in geometryProjector.ProjectCityObjects(
-                         new CachedSourceFileDescriptor(sourceFile.SourceFile, [parsedCityObject]),
+                         new CachedSourceFileDescriptor(sourceFile.SourceFile, [parsedCityObject], resolvedReferenceSystem),
                          resolvedReferenceSystem,
                          globalOriginPoint,
                          globalCartesian,
@@ -244,17 +245,18 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
             }
         }
 
-        if (isDemSourceFile && parsedDemCityObjects.Count > 0)
+        if (demProjectionSource is not null)
         {
             ParsedCityObject[] aggregatedDemCityObjects =
                 DemCityObjectAggregation.AggregateBySourceFileAndThirdMesh(
-                    sourceFile.SourceFile,
-                    parsedDemCityObjects);
+                    demProjectionSource.SourceFile,
+                    demProjectionSource.CityObjects);
             foreach (ImportedCityObject cityObject in geometryProjector.ProjectCityObjects(
-                         new CachedSourceFileDescriptor(sourceFile.SourceFile, aggregatedDemCityObjects),
-                         resolvedReferenceSystem
-                             ?? throw new PlateauImportValidationException(
-                                 [$"CityGML file '{sourceFile.SourceFile.RelativePath}' does not declare a supported coordinate reference system."]),
+                         new CachedSourceFileDescriptor(
+                             demProjectionSource.SourceFile,
+                             aggregatedDemCityObjects,
+                             demProjectionSource.ReferenceSystem),
+                         demProjectionSource.ReferenceSystem,
                          globalOriginPoint,
                          globalCartesian,
                          projectionTerrainOverlayContext.Overlays,
@@ -277,6 +279,24 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
                 "import",
                 $"City object producer projected '{sourceFile.SourceFile.RelativePath}' "
                 + $"(parsed_city_objects={parsedCount}, yielded={yieldedCount}, elapsed={fileStopwatch.Elapsed.TotalSeconds:F3}s)."));
+    }
+
+    private sealed class StreamingDemProjectionSource(
+        SourceFileDescriptor sourceFile,
+        CoordinateReferenceSystem referenceSystem)
+    {
+        private readonly List<ParsedCityObject> cityObjects = [];
+
+        public SourceFileDescriptor SourceFile { get; } = sourceFile;
+
+        public CoordinateReferenceSystem ReferenceSystem { get; } = referenceSystem;
+
+        public IReadOnlyList<ParsedCityObject> CityObjects => cityObjects;
+
+        public void Add(ParsedCityObject cityObject)
+        {
+            cityObjects.Add(cityObject);
+        }
     }
 
     private async IAsyncEnumerable<ImportedObjectUnit> CreateObjectUnitsAsync(
@@ -338,9 +358,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
 
     private CoordinateReferenceSystem ResolveReferenceSystem(ParsedSourceFileResult parsedSourceFile)
     {
-        return ResolveReferenceSystem(parsedSourceFile.ReferenceSystem
-            ?? throw new PlateauImportValidationException(
-                [$"CityGML file '{parsedSourceFile.SourceFile.RelativePath}' does not declare a supported coordinate reference system."]));
+        return ResolveReferenceSystem(parsedSourceFile.ReferenceSystem);
     }
 
     private static void ValidateCompatibleReferenceSystem(

--- a/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
@@ -218,17 +218,19 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
             parsedCount++;
             fileWarningStatistics.Add(parsedCityObject);
             x3DMaterialWarningStatistics.Add(parsedCityObject);
-            resolvedReferenceSystem ??= ResolveReferenceSystem(parsedCityObject.ReferenceSystem);
+            CoordinateReferenceSystem parsedReferenceSystem = parsedCityObject.ReferenceSystem;
+            CoordinateReferenceSystem resolvedObjectReferenceSystem = ResolveReferenceSystem(parsedReferenceSystem);
+            resolvedReferenceSystem ??= resolvedObjectReferenceSystem;
             globalCartesian ??= CreateGlobalCartesian(resolvedReferenceSystem);
             if (isDemSourceFile)
             {
-                demProjectionSource ??= new StreamingDemProjectionSource(sourceFile.SourceFile, resolvedReferenceSystem);
+                demProjectionSource ??= new StreamingDemProjectionSource(sourceFile.SourceFile);
                 demProjectionSource.Add(parsedCityObject);
                 continue;
             }
 
             foreach (ImportedCityObject cityObject in geometryProjector.ProjectCityObjects(
-                         new CachedSourceFileDescriptor(sourceFile.SourceFile, [parsedCityObject], resolvedReferenceSystem),
+                         new CachedSourceFileDescriptor(sourceFile.SourceFile, [parsedCityObject], parsedReferenceSystem),
                          resolvedReferenceSystem,
                          globalOriginPoint,
                          globalCartesian,
@@ -281,20 +283,22 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
                 + $"(parsed_city_objects={parsedCount}, yielded={yieldedCount}, elapsed={fileStopwatch.Elapsed.TotalSeconds:F3}s)."));
     }
 
-    private sealed class StreamingDemProjectionSource(
-        SourceFileDescriptor sourceFile,
-        CoordinateReferenceSystem referenceSystem)
+    private sealed class StreamingDemProjectionSource(SourceFileDescriptor sourceFile)
     {
         private readonly List<ParsedCityObject> cityObjects = [];
+        private CoordinateReferenceSystem? referenceSystem;
 
         public SourceFileDescriptor SourceFile { get; } = sourceFile;
 
-        public CoordinateReferenceSystem ReferenceSystem { get; } = referenceSystem;
+        public CoordinateReferenceSystem ReferenceSystem => referenceSystem
+            ?? CoordinateReferenceSystem.Parse((string?)null);
 
         public IReadOnlyList<ParsedCityObject> CityObjects => cityObjects;
 
         public void Add(ParsedCityObject cityObject)
         {
+            referenceSystem ??= cityObject.ReferenceSystem;
+            ValidateCompatibleReferenceSystem(referenceSystem, cityObject.ReferenceSystem);
             cityObjects.Add(cityObject);
         }
     }

--- a/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
@@ -291,7 +291,8 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
         public SourceFileDescriptor SourceFile { get; } = sourceFile;
 
         public CoordinateReferenceSystem ReferenceSystem => referenceSystem
-            ?? CoordinateReferenceSystem.Parse((string?)null);
+            ?? throw new InvalidOperationException(
+                $"DEM projection source '{SourceFile.RelativePath}' has no parsed city objects and no reference system.");
 
         public IReadOnlyList<ParsedCityObject> CityObjects => cityObjects;
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemSourceDiscoverySupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemSourceDiscoverySupportTests.cs
@@ -35,6 +35,7 @@ public sealed class DemSourceDiscoverySupportTests
 
         CachedSourceFileDescriptor cachedSourceFile = Assert.Single(result.CachedDemSourceFiles);
         Assert.Equal("udx/dem/53394525/sample.gml", cachedSourceFile.RelativePath);
+        Assert.Equal(CoordinateReferenceSystem.Parse("EPSG:4326"), cachedSourceFile.ReferenceSystem);
         Assert.Equal(3, result.TerrainTriangles.Length);
         Assert.Equal(1, result.ParsedCityObjectCount);
     }

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlGeometryProjectorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlGeometryProjectorTests.cs
@@ -34,6 +34,7 @@ public sealed class LocalCityGmlGeometryProjectorTests
     public void ProjectCityObjectsValidatesReferenceSystemBeforeProjectingCanonicalObjects()
     {
         LocalCityGmlGeometryProjector projector = new(new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
+        CoordinateReferenceSystem sourceReferenceSystem = CoordinateReferenceSystem.Parse("EPSG:6697");
         CachedSourceFileDescriptor sourceFile = new(
             new SourceFileDescriptor(
                 RelativePath: "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml",
@@ -48,10 +49,42 @@ public sealed class LocalCityGmlGeometryProjectorTests
                     ActualMeshCode: "53394525",
                     LodLevel: 1,
                     Surfaces: [],
-                    ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:6697"),
+                    ReferenceSystem: sourceReferenceSystem,
                     SourceFileRelativePath: "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml",
                     SharedAcrossMeshCodes: false),
-            ]);
+            ],
+            sourceReferenceSystem);
+
+        PlateauImportValidationException exception = Assert.Throws<PlateauImportValidationException>(
+            () => projector.ProjectCityObjects(
+                    sourceFile,
+                    CoordinateReferenceSystem.Parse("EPSG:6696"),
+                    new GeodeticPoint(35.0, 139.0, 0.0),
+                    globalCartesian: new LocalCartesian(35.0, 139.0, 0.0, new Geocentric(Ellipsoid.GRS80)),
+                    demTerrainTextureOverlays: [],
+                    requestedMeshCodeBounds: [],
+                    request: new PlateauImportRequest(
+                        Dataset: "tokyo23ku",
+                        MeshCode: "53394525",
+                        CityGmlSource: DatasetLocation.Local("C:\\fixture"),
+                        PackageNames: ["bldg"]))
+                .ToArray());
+
+        Assert.Contains("Mixed CityGML coordinate reference systems are not supported", exception.Errors.Single());
+    }
+
+    [Fact]
+    public void ProjectCityObjectsValidatesSourceFileReferenceSystemWhenSourceFileHasNoCityObjects()
+    {
+        LocalCityGmlGeometryProjector projector = new(new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
+        CachedSourceFileDescriptor sourceFile = new(
+            new SourceFileDescriptor(
+                RelativePath: "udx/bldg/53394525/empty.gml",
+                PackageName: "bldg",
+                MatchedMeshCode: "53394525",
+                RequiresMeshCodeBoundsFilter: false),
+            [],
+            CoordinateReferenceSystem.Parse("EPSG:6697"));
 
         PlateauImportValidationException exception = Assert.Throws<PlateauImportValidationException>(
             () => projector.ProjectCityObjects(

--- a/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
@@ -54,6 +54,89 @@ public sealed class StreamingImportedSceneSourceStreamingTests
     }
 
     [Fact]
+    public async Task ReadCityObjectsAsync_UsesCurrentParsedObjectReferenceSystemForDescriptor()
+    {
+        CoordinateReferenceSystem firstReferenceSystem =
+            CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        CoordinateReferenceSystem secondReferenceSystem =
+            CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6668");
+        GeodeticPoint globalOriginPoint = new(35.0, 139.0, 0.0);
+        RecordingGeometryProjector geometryProjector = new();
+
+        SourceFilePipeline bldgPipeline = CreatePipeline(
+            new SourceFileDescriptor("udx/bldg/53394525/building.gml", "bldg", "53394525", RequiresMeshCodeBoundsFilter: false),
+            [
+                CreateParsedCityObject("bldg", "first-building", "First Building", firstReferenceSystem, lodLevel: 1),
+                CreateParsedCityObject("bldg", "second-building", "Second Building", secondReferenceSystem, lodLevel: 1),
+            ],
+            streamFactory: static (sourceFile, cityObjects, beforeYield, cancellationToken) =>
+                StreamSingleParsedCityObjectAsync(sourceFile, cityObjects, beforeYield, cancellationToken));
+
+        StreamingImportedSceneSource source = CreateSource(
+            firstReferenceSystem,
+            globalOriginPoint,
+            [bldgPipeline],
+            geometryProjector);
+
+        List<ImportedCityObject> yieldedObjects = [];
+        await foreach (ImportedCityObject cityObject in source.ReadCityObjectsAsync())
+        {
+            yieldedObjects.Add(cityObject);
+        }
+
+        Assert.Equal(2, yieldedObjects.Count);
+        Assert.Collection(
+            geometryProjector.CallRecords,
+            first =>
+            {
+                Assert.Equal(firstReferenceSystem.SrsName, first.SourceFileReferenceSystem.SrsName);
+                Assert.Equal(firstReferenceSystem.SrsName, first.CityObjectReferenceSystem.SrsName);
+            },
+            second =>
+            {
+                Assert.Equal(secondReferenceSystem.SrsName, second.SourceFileReferenceSystem.SrsName);
+                Assert.Equal(secondReferenceSystem.SrsName, second.CityObjectReferenceSystem.SrsName);
+            });
+    }
+
+    [Fact]
+    public async Task ReadCityObjectsAsync_RejectsIncompatibleReferenceSystemAfterFirstStreamedObject()
+    {
+        CoordinateReferenceSystem firstReferenceSystem =
+            CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        CoordinateReferenceSystem secondReferenceSystem =
+            CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6696");
+        GeodeticPoint globalOriginPoint = new(35.0, 139.0, 0.0);
+
+        SourceFilePipeline bldgPipeline = CreatePipeline(
+            new SourceFileDescriptor("udx/bldg/53394525/building.gml", "bldg", "53394525", RequiresMeshCodeBoundsFilter: false),
+            [
+                CreateParsedCityObject("bldg", "first-building", "First Building", firstReferenceSystem, lodLevel: 1),
+                CreateParsedCityObject("bldg", "second-building", "Second Building", secondReferenceSystem, lodLevel: 1),
+            ],
+            streamFactory: static (sourceFile, cityObjects, beforeYield, cancellationToken) =>
+                StreamSingleParsedCityObjectAsync(sourceFile, cityObjects, beforeYield, cancellationToken));
+
+        StreamingImportedSceneSource source = CreateSource(
+            firstReferenceSystem,
+            globalOriginPoint,
+            [bldgPipeline]);
+
+        PlateauImportValidationException exception = await Assert.ThrowsAsync<PlateauImportValidationException>(
+            async () =>
+            {
+                await foreach (ImportedCityObject _ in source.ReadCityObjectsAsync())
+                {
+                }
+            });
+
+        Assert.Contains(
+            "Mixed CityGML coordinate reference systems are not supported",
+            exception.Errors.Single(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ReadCityObjectsAsync_CompletesAfterDelayedDemPipelineIsReleased()
     {
         CoordinateReferenceSystem referenceSystem =
@@ -199,8 +282,10 @@ public sealed class StreamingImportedSceneSourceStreamingTests
     private static StreamingImportedSceneSource CreateSource(
         CoordinateReferenceSystem referenceSystem,
         GeodeticPoint globalOriginPoint,
-        IReadOnlyList<SourceFilePipeline> sourceFilePipelines)
+        IReadOnlyList<SourceFilePipeline> sourceFilePipelines,
+        RecordingGeometryProjector? geometryProjector = null)
     {
+        _ = referenceSystem;
         string[] packageNames = sourceFilePipelines
             .Select(static pipeline => pipeline.SourceFile.PackageName)
             .Distinct(StringComparer.Ordinal)
@@ -236,7 +321,7 @@ public sealed class StreamingImportedSceneSourceStreamingTests
             metadata,
             request,
             readResult,
-            new RecordingGeometryProjector(),
+            geometryProjector ?? new RecordingGeometryProjector(),
             new StubDemTextureSourcePolicy(),
             new PassthroughImportedObjectUnitOptimizer());
     }
@@ -300,8 +385,11 @@ public sealed class StreamingImportedSceneSourceStreamingTests
     private sealed class RecordingGeometryProjector : ICityGmlGeometryProjector
     {
         private readonly ConcurrentQueue<string> calls = [];
+        private readonly ConcurrentQueue<ReferenceSystemCallRecord> callRecords = [];
 
         public IReadOnlyCollection<string> Calls => calls.ToArray();
+
+        public IReadOnlyCollection<ReferenceSystemCallRecord> CallRecords => callRecords.ToArray();
 
         public IEnumerable<ImportedCityObject> ProjectCityObjects(
             CachedSourceFileDescriptor sourceFile,
@@ -331,6 +419,9 @@ public sealed class StreamingImportedSceneSourceStreamingTests
                 }
 
                 calls.Enqueue(cityObject.PackageName);
+                callRecords.Enqueue(new ReferenceSystemCallRecord(
+                    sourceFile.ReferenceSystem,
+                    cityObject.ReferenceSystem));
                 yield return new ImportedCityObject(
                     cityObject.SlotKey,
                     cityObject.DisplayName,
@@ -351,6 +442,10 @@ public sealed class StreamingImportedSceneSourceStreamingTests
             }
         }
     }
+
+    private sealed record ReferenceSystemCallRecord(
+        CoordinateReferenceSystem SourceFileReferenceSystem,
+        CoordinateReferenceSystem CityObjectReferenceSystem);
 
     private sealed class EmptyDatasetContentSource : IPlateauDatasetContentSource
     {

--- a/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
@@ -168,7 +168,9 @@ public sealed class StreamingImportedSceneSourceStreamingTests
         return new ParsedSourceFileResult(
             sourceFile,
             cityObjects,
-            cityObjects.Length == 0 ? null : cityObjects[0].ReferenceSystem,
+            cityObjects.Length == 0
+                ? CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697")
+                : cityObjects[0].ReferenceSystem,
             string.Equals(sourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
                 ? DemSourceDiscoverySupport.CreateTerrainHeightTriangles(cityObjects)
                 : [],


### PR DESCRIPTION
## Summary
- require parsed/cached source-file descriptors to carry a concrete CoordinateReferenceSystem
- stop deriving source-file CRS from the first city object or falling back to the caller CRS during projection
- keep streaming DEM projection CRS attached to the accumulated source-file batch instead of using an impossible null guard

## Verification
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~LocalCityGmlGeometryProjectorTests|FullyQualifiedName~DemSourceDiscoverySupportTests|FullyQualifiedName~StreamingImportedSceneSourceTests|FullyQualifiedName~StreamingImportedSceneSourceStreamingTests"
- dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj --configuration Release --no-restore -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-archive-5039b16c4b1c.zip --geotiff-source runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-ortho-cc68652cc45c.7z --work-root runtime/windows/resonite --terrain-mesh grid --canonical-scene-dump runtime/windows/resonite/semantic-baselines/type-source-file-reference-system/current/higashi-53395325-dem-bldg-grid-geotiff.json
- git diff --no-index -- runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json runtime/windows/resonite/semantic-baselines/type-source-file-reference-system/current/higashi-53395325-dem-bldg-grid-geotiff.json
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false