### PR TITLE
Type main texture override planning

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -647,43 +647,21 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
         PlannedMainTextureOverrideRendererMaterialBinding binding,
         ref int nextComponentLocator)
     {
-        if (binding is PlannedTerrainMainTextureOverrideRendererMaterialBinding
-            {
-                SharedMainTexturePropertyBlockComponent: { } sharedMainTexturePropertyBlockComponent,
-            })
+        if (binding is PlannedTerrainMainTextureOverrideRendererMaterialBinding terrainBinding
+            && terrainBinding.PropertyBlock.TryGetSharedComponent(out ResoniteComponentLocator sharedMainTexturePropertyBlockComponent))
         {
             return PlannedMembers.Reference(PlannedWorldElementReference.Canonical(sharedMainTexturePropertyBlockComponent));
         }
 
-        PlannedWorldElementReference? sharedTextureTarget = binding is PlannedTerrainMainTextureOverrideRendererMaterialBinding
-        {
-            SharedMainTextureComponent: { } sharedMainTextureComponent,
-        }
-            ? PlannedWorldElementReference.Canonical(sharedMainTextureComponent)
-            : null;
-        BatchPlanComponentLocator? textureId = sharedTextureTarget is null
-            ? CreateBatchPlanComponentLocator(ref nextComponentLocator)
-            : null;
-        ResoniteSceneMaterialConventions.TextureMemberRole textureRole = binding switch
-        {
-            PlannedAlbedoMainTextureOverrideRendererMaterialBinding =>
-                ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
-            PlannedTerrainMainTextureOverrideRendererMaterialBinding =>
-                ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride,
-            _ => throw new InvalidOperationException(
-                $"Unsupported planned main texture override binding type '{binding.GetType().Name}'."),
-        };
-        if (textureId is { } plannedTextureId)
-        {
-            componentEmissions.Add(new PlannedBatchComponentEmission(
-                plannedTextureId,
-                PlannedSlotTargetReference.PlannedSlot(assetSlotId),
-                "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(
-                    binding.MainTexture.AssetUri,
-                    textureRole)
-                    .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal)));
-        }
+        BatchPlanComponentLocator textureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
+        componentEmissions.Add(new PlannedBatchComponentEmission(
+            textureId,
+            PlannedSlotTargetReference.PlannedSlot(assetSlotId),
+            "[FrooxEngine]FrooxEngine.StaticTexture2D",
+            ResoniteSceneMaterialConventions.CreateTextureMembers(
+                binding.MainTexture.AssetUri,
+                binding.TextureRole)
+                .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal)));
 
         BatchPlanComponentLocator propertyBlockId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
         componentEmissions.Add(new PlannedBatchComponentEmission(
@@ -692,7 +670,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
             "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
             new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
             {
-                ["Texture"] = PlannedMembers.Reference(sharedTextureTarget ?? PlannedWorldElementReference.Planned(textureId!.Value)),
+                ["Texture"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(textureId)),
             }));
 
         return PlannedMembers.Reference(PlannedWorldElementReference.Planned(propertyBlockId));

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -126,7 +126,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         return textures.FirstOrDefault(texture => texture.Identity == identity)?.AssetUri;
     }
 
-    public static PlannedTextureAsset? PlanMainTextureOverride(
+    public static MainTextureOverridePlan PlanMainTextureOverride(
         ResoniteMaterialBinding material,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
         IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay)
@@ -144,12 +144,13 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             : null;
         if (textureUri is null)
         {
-            return null;
+            return MainTextureOverridePlan.None;
         }
 
-        return new PlannedTextureAsset(
-            new TextureIdentity("main"),
-            textureUri);
+        return MainTextureOverridePlan.Texture(
+            new PlannedTextureAsset(
+                new TextureIdentity("main"),
+                textureUri));
     }
 
     public static ResoniteBatchOperations.PendingBatchComponent AddCommonMaterialComponents(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -127,11 +126,10 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         return textures.FirstOrDefault(texture => texture.Identity == identity)?.AssetUri;
     }
 
-    public static bool TryPlanMainTextureOverride(
+    public static PlannedTextureAsset? PlanMainTextureOverride(
         ResoniteMaterialBinding material,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
-        IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
-        [NotNullWhen(true)] out PlannedTextureAsset? mainTexture)
+        IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay)
     {
         ArgumentNullException.ThrowIfNull(material);
         ArgumentNullException.ThrowIfNull(preparedTextureUrisByPayload);
@@ -146,14 +144,12 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             : null;
         if (textureUri is null)
         {
-            mainTexture = null;
-            return false;
+            return null;
         }
 
-        mainTexture = new PlannedTextureAsset(
+        return new PlannedTextureAsset(
             new TextureIdentity("main"),
             textureUri);
-        return true;
     }
 
     public static ResoniteBatchOperations.PendingBatchComponent AddCommonMaterialComponents(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -126,10 +127,11 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         return textures.FirstOrDefault(texture => texture.Identity == identity)?.AssetUri;
     }
 
-    public static MainTextureOverridePlan PlanMainTextureOverride(
+    public static bool TryPlanMainTextureOverride(
         ResoniteMaterialBinding material,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
-        IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay)
+        IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
+        [NotNullWhen(true)] out PlannedTextureAsset? mainTexture)
     {
         ArgumentNullException.ThrowIfNull(material);
         ArgumentNullException.ThrowIfNull(preparedTextureUrisByPayload);
@@ -144,13 +146,14 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             : null;
         if (textureUri is null)
         {
-            return MainTextureOverridePlan.None;
+            mainTexture = null;
+            return false;
         }
 
-        return MainTextureOverridePlan.Texture(
-            new PlannedTextureAsset(
-                new TextureIdentity("main"),
-                textureUri));
+        mainTexture = new PlannedTextureAsset(
+            new TextureIdentity("main"),
+            textureUri);
+        return true;
     }
 
     public static ResoniteBatchOperations.PendingBatchComponent AddCommonMaterialComponents(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -42,6 +42,46 @@ internal sealed record PlannedTextureAsset(
     TextureIdentity Identity,
     Uri AssetUri);
 
+internal abstract record MainTextureOverridePlan
+{
+    private MainTextureOverridePlan()
+    {
+    }
+
+    public static MainTextureOverridePlan None { get; } = new NoMainTextureOverridePlan();
+
+    public static MainTextureOverridePlan Texture(PlannedTextureAsset mainTexture)
+    {
+        return new TextureMainTextureOverridePlan(mainTexture);
+    }
+
+    public abstract TResult Select<TResult>(
+        Func<TResult> none,
+        Func<PlannedTextureAsset, TResult> texture);
+
+    private sealed record NoMainTextureOverridePlan : MainTextureOverridePlan
+    {
+        public override TResult Select<TResult>(
+            Func<TResult> none,
+            Func<PlannedTextureAsset, TResult> texture)
+        {
+            _ = texture;
+            return none();
+        }
+    }
+
+    private sealed record TextureMainTextureOverridePlan(PlannedTextureAsset MainTexture) : MainTextureOverridePlan
+    {
+        public override TResult Select<TResult>(
+            Func<TResult> none,
+            Func<PlannedTextureAsset, TResult> texture)
+        {
+            _ = none;
+            return texture(MainTexture);
+        }
+    }
+}
+
 internal abstract record PlannedMaterialAsset;
 
 internal sealed record PlannedReusableMaterialAsset(
@@ -63,19 +103,87 @@ internal sealed record PlannedDirectRendererMaterialBinding(PlannedMaterialAsset
 internal abstract record PlannedMainTextureOverrideRendererMaterialBinding(
     PlannedMaterialAsset MaterialAsset,
     PlannedTextureAsset MainTexture)
-    : PlannedRendererMaterialBinding(MaterialAsset);
+    : PlannedRendererMaterialBinding(MaterialAsset)
+{
+    public abstract ResoniteSceneMaterialConventions.TextureMemberRole TextureRole { get; }
+}
 
 internal sealed record PlannedAlbedoMainTextureOverrideRendererMaterialBinding(
     PlannedMaterialAsset MaterialAsset,
     PlannedTextureAsset MainTexture)
-    : PlannedMainTextureOverrideRendererMaterialBinding(MaterialAsset, MainTexture);
+    : PlannedMainTextureOverrideRendererMaterialBinding(MaterialAsset, MainTexture)
+{
+    public override ResoniteSceneMaterialConventions.TextureMemberRole TextureRole =>
+        ResoniteSceneMaterialConventions.TextureMemberRole.Albedo;
+}
+
+internal abstract record PlannedTerrainMainTexturePropertyBlock
+{
+    private PlannedTerrainMainTexturePropertyBlock()
+    {
+    }
+
+    public static PlannedTerrainMainTexturePropertyBlock CreatePerRenderer()
+    {
+        return new PerRendererTerrainMainTexturePropertyBlock();
+    }
+
+    public static PlannedTerrainMainTexturePropertyBlock Shared(ResoniteComponentLocator component)
+    {
+        return new SharedTerrainMainTexturePropertyBlock(component);
+    }
+
+    public abstract TResult Select<TResult>(
+        Func<TResult> createPerRenderer,
+        Func<ResoniteComponentLocator, TResult> shared);
+
+    public abstract bool TryGetSharedComponent(out ResoniteComponentLocator component);
+
+    private sealed record PerRendererTerrainMainTexturePropertyBlock : PlannedTerrainMainTexturePropertyBlock
+    {
+        public override TResult Select<TResult>(
+            Func<TResult> createPerRenderer,
+            Func<ResoniteComponentLocator, TResult> shared)
+        {
+            _ = shared;
+            return createPerRenderer();
+        }
+
+        public override bool TryGetSharedComponent(out ResoniteComponentLocator component)
+        {
+            component = default;
+            return false;
+        }
+    }
+
+    private sealed record SharedTerrainMainTexturePropertyBlock(ResoniteComponentLocator Component)
+        : PlannedTerrainMainTexturePropertyBlock
+    {
+        public override TResult Select<TResult>(
+            Func<TResult> createPerRenderer,
+            Func<ResoniteComponentLocator, TResult> shared)
+        {
+            _ = createPerRenderer;
+            return shared(Component);
+        }
+
+        public override bool TryGetSharedComponent(out ResoniteComponentLocator component)
+        {
+            component = Component;
+            return true;
+        }
+    }
+}
 
 internal sealed record PlannedTerrainMainTextureOverrideRendererMaterialBinding(
     PlannedMaterialAsset MaterialAsset,
     PlannedTextureAsset MainTexture,
-    ResoniteComponentLocator? SharedMainTextureComponent = null,
-    ResoniteComponentLocator? SharedMainTexturePropertyBlockComponent = null)
-    : PlannedMainTextureOverrideRendererMaterialBinding(MaterialAsset, MainTexture);
+    PlannedTerrainMainTexturePropertyBlock PropertyBlock)
+    : PlannedMainTextureOverrideRendererMaterialBinding(MaterialAsset, MainTexture)
+{
+    public override ResoniteSceneMaterialConventions.TextureMemberRole TextureRole =>
+        ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride;
+}
 
 internal sealed record PlannedRenderer(
     GeometryIdentity GeometryIdentity,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -42,46 +42,6 @@ internal sealed record PlannedTextureAsset(
     TextureIdentity Identity,
     Uri AssetUri);
 
-internal abstract record MainTextureOverridePlan
-{
-    private MainTextureOverridePlan()
-    {
-    }
-
-    public static MainTextureOverridePlan None { get; } = new NoMainTextureOverridePlan();
-
-    public static MainTextureOverridePlan Texture(PlannedTextureAsset mainTexture)
-    {
-        return new TextureMainTextureOverridePlan(mainTexture);
-    }
-
-    public abstract TResult Select<TResult>(
-        Func<TResult> none,
-        Func<PlannedTextureAsset, TResult> texture);
-
-    private sealed record NoMainTextureOverridePlan : MainTextureOverridePlan
-    {
-        public override TResult Select<TResult>(
-            Func<TResult> none,
-            Func<PlannedTextureAsset, TResult> texture)
-        {
-            _ = texture;
-            return none();
-        }
-    }
-
-    private sealed record TextureMainTextureOverridePlan(PlannedTextureAsset MainTexture) : MainTextureOverridePlan
-    {
-        public override TResult Select<TResult>(
-            Func<TResult> none,
-            Func<PlannedTextureAsset, TResult> texture)
-        {
-            _ = none;
-            return texture(MainTexture);
-        }
-    }
-}
-
 internal abstract record PlannedMaterialAsset;
 
 internal sealed record PlannedReusableMaterialAsset(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
@@ -105,17 +105,17 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
                 $"Setup did not resolve common material ({ResoniteMaterialComponentPolicy.DescribeForDiagnostics(sourceMaterial)}) before runtime emission.");
         }
         PlannedReusableMaterialAsset sharedMaterialAsset = new(existingMaterialAsset.MaterialComponent);
-        PlannedTextureAsset? mainTextureOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
+        MainTextureOverridePlan mainTextureOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
             sourceMaterial,
             preparedTextureUrisByPayload,
             preparedTerrainTextureUrisByOverlay);
-        PlannedRendererMaterialBinding rendererBinding = mainTextureOverride is null
-            ? new PlannedDirectRendererMaterialBinding(sharedMaterialAsset)
-            : CreateMainTextureOverrideRendererBinding(
+        PlannedRendererMaterialBinding rendererBinding = mainTextureOverride.Select<PlannedRendererMaterialBinding>(
+            () => new PlannedDirectRendererMaterialBinding(sharedMaterialAsset),
+            mainTexture => CreateMainTextureOverrideRendererBinding(
                 sharedMaterialAsset,
-                mainTextureOverride,
+                mainTexture,
                 terrainTexturePropertyBlockComponentsByMeshCode,
-                sourceMaterial);
+                sourceMaterial));
         return (sharedMaterialAsset, rendererBinding);
     }
 
@@ -147,20 +147,19 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
             cancellationToken);
         if (sourceMaterial.TerrainOverlay is not null)
         {
-            PlannedTextureAsset? mainTextureOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
+            MainTextureOverridePlan mainTextureOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
                 sourceMaterial,
                 preparedTextureUrisByPayload,
                 preparedTerrainTextureUrisByOverlay);
-            if (mainTextureOverride is not null)
-            {
-                return (
+            return mainTextureOverride.Select(
+                () => (plannedMaterial, new PlannedDirectRendererMaterialBinding(plannedMaterial)),
+                mainTexture => (
                     plannedMaterial,
-                    CreateMainTextureOverrideRendererBinding(
+                    (PlannedRendererMaterialBinding)CreateMainTextureOverrideRendererBinding(
                         plannedMaterial,
-                        mainTextureOverride,
+                        mainTexture,
                         preparedTerrainTexturePropertyBlockComponentsByMeshCode,
-                        sourceMaterial));
-            }
+                        sourceMaterial)));
         }
 
         return (plannedMaterial, new PlannedDirectRendererMaterialBinding(plannedMaterial));
@@ -192,14 +191,17 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
             return new PlannedAlbedoMainTextureOverrideRendererMaterialBinding(materialAsset, mainTexture);
         }
 
+        PlannedTerrainMainTexturePropertyBlock propertyBlock =
+            sourceMaterial.TerrainOverlayMaterial is not null
+            && terrainTexturePropertyBlockComponentsByMeshCode.TryGetValue(
+                sourceMaterial.TerrainOverlayMaterial.MeshCode,
+                out ResoniteComponentLocator propertyBlockComponent)
+                ? PlannedTerrainMainTexturePropertyBlock.Shared(propertyBlockComponent)
+                : PlannedTerrainMainTexturePropertyBlock.CreatePerRenderer();
         return new PlannedTerrainMainTextureOverrideRendererMaterialBinding(
             materialAsset,
             mainTexture,
-            null,
-            sourceMaterial.TerrainOverlayMaterial is not null
-            && terrainTexturePropertyBlockComponentsByMeshCode.TryGetValue(sourceMaterial.TerrainOverlayMaterial.MeshCode, out ResoniteComponentLocator propertyBlockComponent)
-                ? propertyBlockComponent
-                : null);
+            propertyBlock);
     }
 
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
@@ -165,11 +165,11 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
         IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
         IReadOnlyDictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode)
     {
-        return ResoniteMaterialPlanning.TryPlanMainTextureOverride(
+        PlannedTextureAsset? mainTexture = ResoniteMaterialPlanning.PlanMainTextureOverride(
             textureSourceMaterial,
             preparedTextureUrisByPayload,
-            preparedTerrainTextureUrisByOverlay,
-            out PlannedTextureAsset? mainTexture)
+            preparedTerrainTextureUrisByOverlay);
+        return mainTexture is not null
             ? CreateMainTextureOverrideRendererBinding(
                 materialAsset,
                 mainTexture,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
@@ -105,17 +105,13 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
                 $"Setup did not resolve common material ({ResoniteMaterialComponentPolicy.DescribeForDiagnostics(sourceMaterial)}) before runtime emission.");
         }
         PlannedReusableMaterialAsset sharedMaterialAsset = new(existingMaterialAsset.MaterialComponent);
-        MainTextureOverridePlan mainTextureOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
+        PlannedRendererMaterialBinding rendererBinding = CreateRendererMaterialBinding(
+            sharedMaterialAsset,
+            sourceMaterial,
             sourceMaterial,
             preparedTextureUrisByPayload,
-            preparedTerrainTextureUrisByOverlay);
-        PlannedRendererMaterialBinding rendererBinding = mainTextureOverride.Select<PlannedRendererMaterialBinding>(
-            () => new PlannedDirectRendererMaterialBinding(sharedMaterialAsset),
-            mainTexture => CreateMainTextureOverrideRendererBinding(
-                sharedMaterialAsset,
-                mainTexture,
-                terrainTexturePropertyBlockComponentsByMeshCode,
-                sourceMaterial));
+            preparedTerrainTextureUrisByOverlay,
+            terrainTexturePropertyBlockComponentsByMeshCode);
         return (sharedMaterialAsset, rendererBinding);
     }
 
@@ -147,22 +143,39 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
             cancellationToken);
         if (sourceMaterial.TerrainOverlay is not null)
         {
-            MainTextureOverridePlan mainTextureOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
-                sourceMaterial,
-                preparedTextureUrisByPayload,
-                preparedTerrainTextureUrisByOverlay);
-            return mainTextureOverride.Select(
-                () => (plannedMaterial, new PlannedDirectRendererMaterialBinding(plannedMaterial)),
-                mainTexture => (
+            return (
+                plannedMaterial,
+                CreateRendererMaterialBinding(
                     plannedMaterial,
-                    (PlannedRendererMaterialBinding)CreateMainTextureOverrideRendererBinding(
-                        plannedMaterial,
-                        mainTexture,
-                        preparedTerrainTexturePropertyBlockComponentsByMeshCode,
-                        sourceMaterial)));
+                    sourceMaterial,
+                    sourceMaterial,
+                    preparedTextureUrisByPayload,
+                    preparedTerrainTextureUrisByOverlay,
+                    preparedTerrainTexturePropertyBlockComponentsByMeshCode));
         }
 
         return (plannedMaterial, new PlannedDirectRendererMaterialBinding(plannedMaterial));
+    }
+
+    private static PlannedRendererMaterialBinding CreateRendererMaterialBinding(
+        PlannedMaterialAsset materialAsset,
+        ResoniteMaterialBinding sourceMaterial,
+        ResoniteMaterialBinding textureSourceMaterial,
+        IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
+        IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
+        IReadOnlyDictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode)
+    {
+        return ResoniteMaterialPlanning.TryPlanMainTextureOverride(
+            textureSourceMaterial,
+            preparedTextureUrisByPayload,
+            preparedTerrainTextureUrisByOverlay,
+            out PlannedTextureAsset? mainTexture)
+            ? CreateMainTextureOverrideRendererBinding(
+                materialAsset,
+                mainTexture,
+                terrainTexturePropertyBlockComponentsByMeshCode,
+                sourceMaterial)
+            : new PlannedDirectRendererMaterialBinding(materialAsset);
     }
 
     private static ResoniteMaterialBinding ResolveTerrainTextureMaterialForEmission(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -347,7 +347,7 @@ public sealed class ResoniteMaterialPlanningTests
     }
 
     [Fact]
-    public void TryPlanMainTextureOverrideUsesPreparedUriWithRoleIdentity()
+    public void PlanMainTextureOverrideUsesPreparedUriWithRoleIdentity()
     {
         ResoniteMaterialBinding firstMaterial = new(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
@@ -369,31 +369,23 @@ public sealed class ResoniteMaterialPlanningTests
             [secondMaterial.TexturePayload!] = new Uri("resdb:///texture/second", UriKind.Absolute),
         };
 
-        bool hasFirstOverride = ResoniteMaterialPlanning.TryPlanMainTextureOverride(
+        PlannedTextureAsset? firstOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
             firstMaterial,
             firstPreparedUris,
-            new Dictionary<TerrainTextureOverlay, Uri>(),
-            out PlannedTextureAsset? firstOverride);
-        bool hasRepeatedFirstOverride = ResoniteMaterialPlanning.TryPlanMainTextureOverride(
+            new Dictionary<TerrainTextureOverlay, Uri>());
+        PlannedTextureAsset? repeatedFirstOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
             firstMaterial,
             firstPreparedUris,
-            new Dictionary<TerrainTextureOverlay, Uri>(),
-            out PlannedTextureAsset? repeatedFirstOverride);
-        bool hasSecondOverride = ResoniteMaterialPlanning.TryPlanMainTextureOverride(
+            new Dictionary<TerrainTextureOverlay, Uri>());
+        PlannedTextureAsset? secondOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
             secondMaterial,
             secondPreparedUris,
-            new Dictionary<TerrainTextureOverlay, Uri>(),
-            out PlannedTextureAsset? secondOverride);
-        bool hasThirdOverride = ResoniteMaterialPlanning.TryPlanMainTextureOverride(
+            new Dictionary<TerrainTextureOverlay, Uri>());
+        PlannedTextureAsset? thirdOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
             firstMaterial,
             firstPreparedUris,
-            new Dictionary<TerrainTextureOverlay, Uri>(),
-            out PlannedTextureAsset? thirdOverride);
+            new Dictionary<TerrainTextureOverlay, Uri>());
 
-        Assert.True(hasFirstOverride);
-        Assert.True(hasRepeatedFirstOverride);
-        Assert.True(hasSecondOverride);
-        Assert.True(hasThirdOverride);
         PlannedTextureAsset firstOverrideAsset = firstOverride
             ?? throw new InvalidOperationException("Expected the first main texture override.");
         PlannedTextureAsset repeatedFirstOverrideAsset = repeatedFirstOverride
@@ -413,7 +405,7 @@ public sealed class ResoniteMaterialPlanningTests
     }
 
     [Fact]
-    public void TryPlanMainTextureOverrideReturnsFalseWithoutPreparedTexture()
+    public void PlanMainTextureOverrideReturnsNullWithoutPreparedTexture()
     {
         ResoniteMaterialBinding material = new(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
@@ -424,13 +416,12 @@ public sealed class ResoniteMaterialPlanningTests
             DepthOffset: null,
             SubmeshIndices: [0]);
 
-        bool hasOverride = ResoniteMaterialPlanning.TryPlanMainTextureOverride(
+        PlannedTextureAsset? plannedOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
             material,
             new Dictionary<ResoniteTexturePayload, Uri>(),
-            new Dictionary<TerrainTextureOverlay, Uri>(),
-            out _);
+            new Dictionary<TerrainTextureOverlay, Uri>());
 
-        Assert.False(hasOverride);
+        Assert.Null(plannedOverride);
     }
 
     private static ResoniteMaterialBinding CreateRoadMaterial(ResoniteMaterialProjection projection)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -347,7 +347,7 @@ public sealed class ResoniteMaterialPlanningTests
     }
 
     [Fact]
-    public void PlanMainTextureOverrideUsesPreparedUriWithRoleIdentity()
+    public void TryPlanMainTextureOverrideUsesPreparedUriWithRoleIdentity()
     {
         ResoniteMaterialBinding firstMaterial = new(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
@@ -369,38 +369,51 @@ public sealed class ResoniteMaterialPlanningTests
             [secondMaterial.TexturePayload!] = new Uri("resdb:///texture/second", UriKind.Absolute),
         };
 
-        MainTextureOverridePlan firstOverridePlan = ResoniteMaterialPlanning.PlanMainTextureOverride(
+        bool hasFirstOverride = ResoniteMaterialPlanning.TryPlanMainTextureOverride(
             firstMaterial,
             firstPreparedUris,
-            new Dictionary<TerrainTextureOverlay, Uri>());
-        MainTextureOverridePlan repeatedFirstOverridePlan = ResoniteMaterialPlanning.PlanMainTextureOverride(
+            new Dictionary<TerrainTextureOverlay, Uri>(),
+            out PlannedTextureAsset? firstOverride);
+        bool hasRepeatedFirstOverride = ResoniteMaterialPlanning.TryPlanMainTextureOverride(
             firstMaterial,
             firstPreparedUris,
-            new Dictionary<TerrainTextureOverlay, Uri>());
-        MainTextureOverridePlan secondOverridePlan = ResoniteMaterialPlanning.PlanMainTextureOverride(
+            new Dictionary<TerrainTextureOverlay, Uri>(),
+            out PlannedTextureAsset? repeatedFirstOverride);
+        bool hasSecondOverride = ResoniteMaterialPlanning.TryPlanMainTextureOverride(
             secondMaterial,
             secondPreparedUris,
-            new Dictionary<TerrainTextureOverlay, Uri>());
-        MainTextureOverridePlan thirdOverridePlan = ResoniteMaterialPlanning.PlanMainTextureOverride(
+            new Dictionary<TerrainTextureOverlay, Uri>(),
+            out PlannedTextureAsset? secondOverride);
+        bool hasThirdOverride = ResoniteMaterialPlanning.TryPlanMainTextureOverride(
             firstMaterial,
             firstPreparedUris,
-            new Dictionary<TerrainTextureOverlay, Uri>());
-        PlannedTextureAsset firstOverride = GetMainTextureOverride(firstOverridePlan);
-        PlannedTextureAsset repeatedFirstOverride = GetMainTextureOverride(repeatedFirstOverridePlan);
-        PlannedTextureAsset secondOverride = GetMainTextureOverride(secondOverridePlan);
-        PlannedTextureAsset thirdOverride = GetMainTextureOverride(thirdOverridePlan);
+            new Dictionary<TerrainTextureOverlay, Uri>(),
+            out PlannedTextureAsset? thirdOverride);
 
-        Assert.Equal(new TextureIdentity("main"), firstOverride.Identity);
-        Assert.Equal(firstOverride.Identity, repeatedFirstOverride.Identity);
-        Assert.Equal(firstOverride.Identity, secondOverride.Identity);
-        Assert.Equal(firstOverride.Identity, thirdOverride.Identity);
-        Assert.Equal(new Uri("resdb:///texture/first", UriKind.Absolute), firstOverride.AssetUri);
-        Assert.Equal(firstOverride.AssetUri, repeatedFirstOverride.AssetUri);
-        Assert.Equal(new Uri("resdb:///texture/second", UriKind.Absolute), secondOverride.AssetUri);
+        Assert.True(hasFirstOverride);
+        Assert.True(hasRepeatedFirstOverride);
+        Assert.True(hasSecondOverride);
+        Assert.True(hasThirdOverride);
+        PlannedTextureAsset firstOverrideAsset = firstOverride
+            ?? throw new InvalidOperationException("Expected the first main texture override.");
+        PlannedTextureAsset repeatedFirstOverrideAsset = repeatedFirstOverride
+            ?? throw new InvalidOperationException("Expected the repeated first main texture override.");
+        PlannedTextureAsset secondOverrideAsset = secondOverride
+            ?? throw new InvalidOperationException("Expected the second main texture override.");
+        PlannedTextureAsset thirdOverrideAsset = thirdOverride
+            ?? throw new InvalidOperationException("Expected the third main texture override.");
+
+        Assert.Equal(new TextureIdentity("main"), firstOverrideAsset.Identity);
+        Assert.Equal(firstOverrideAsset.Identity, repeatedFirstOverrideAsset.Identity);
+        Assert.Equal(firstOverrideAsset.Identity, secondOverrideAsset.Identity);
+        Assert.Equal(firstOverrideAsset.Identity, thirdOverrideAsset.Identity);
+        Assert.Equal(new Uri("resdb:///texture/first", UriKind.Absolute), firstOverrideAsset.AssetUri);
+        Assert.Equal(firstOverrideAsset.AssetUri, repeatedFirstOverrideAsset.AssetUri);
+        Assert.Equal(new Uri("resdb:///texture/second", UriKind.Absolute), secondOverrideAsset.AssetUri);
     }
 
     [Fact]
-    public void PlanMainTextureOverrideReturnsNonePlanWithoutPreparedTexture()
+    public void TryPlanMainTextureOverrideReturnsFalseWithoutPreparedTexture()
     {
         ResoniteMaterialBinding material = new(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
@@ -411,12 +424,13 @@ public sealed class ResoniteMaterialPlanningTests
             DepthOffset: null,
             SubmeshIndices: [0]);
 
-        MainTextureOverridePlan plan = ResoniteMaterialPlanning.PlanMainTextureOverride(
+        bool hasOverride = ResoniteMaterialPlanning.TryPlanMainTextureOverride(
             material,
             new Dictionary<ResoniteTexturePayload, Uri>(),
-            new Dictionary<TerrainTextureOverlay, Uri>());
+            new Dictionary<TerrainTextureOverlay, Uri>(),
+            out _);
 
-        Assert.Same(MainTextureOverridePlan.None, plan);
+        Assert.False(hasOverride);
     }
 
     private static ResoniteMaterialBinding CreateRoadMaterial(ResoniteMaterialProjection projection)
@@ -457,13 +471,6 @@ public sealed class ResoniteMaterialPlanningTests
     {
         return ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedAsset.Textures, role)
             ?? throw new InvalidOperationException($"Missing planned texture role '{role}'.");
-    }
-
-    private static PlannedTextureAsset GetMainTextureOverride(MainTextureOverridePlan plan)
-    {
-        return plan.Select(
-            static () => throw new InvalidOperationException("Expected a planned main texture override."),
-            static texture => texture);
     }
 
     private sealed class TexturePayloadReferenceComparer : IEqualityComparer<ResoniteTexturePayload>

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -369,34 +369,54 @@ public sealed class ResoniteMaterialPlanningTests
             [secondMaterial.TexturePayload!] = new Uri("resdb:///texture/second", UriKind.Absolute),
         };
 
-        PlannedTextureAsset? firstOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
+        MainTextureOverridePlan firstOverridePlan = ResoniteMaterialPlanning.PlanMainTextureOverride(
             firstMaterial,
             firstPreparedUris,
             new Dictionary<TerrainTextureOverlay, Uri>());
-        PlannedTextureAsset? repeatedFirstOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
+        MainTextureOverridePlan repeatedFirstOverridePlan = ResoniteMaterialPlanning.PlanMainTextureOverride(
             firstMaterial,
             firstPreparedUris,
             new Dictionary<TerrainTextureOverlay, Uri>());
-        PlannedTextureAsset? secondOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
+        MainTextureOverridePlan secondOverridePlan = ResoniteMaterialPlanning.PlanMainTextureOverride(
             secondMaterial,
             secondPreparedUris,
             new Dictionary<TerrainTextureOverlay, Uri>());
-        PlannedTextureAsset? thirdOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
+        MainTextureOverridePlan thirdOverridePlan = ResoniteMaterialPlanning.PlanMainTextureOverride(
             firstMaterial,
             firstPreparedUris,
             new Dictionary<TerrainTextureOverlay, Uri>());
+        PlannedTextureAsset firstOverride = GetMainTextureOverride(firstOverridePlan);
+        PlannedTextureAsset repeatedFirstOverride = GetMainTextureOverride(repeatedFirstOverridePlan);
+        PlannedTextureAsset secondOverride = GetMainTextureOverride(secondOverridePlan);
+        PlannedTextureAsset thirdOverride = GetMainTextureOverride(thirdOverridePlan);
 
-        Assert.NotNull(firstOverride);
-        Assert.NotNull(repeatedFirstOverride);
-        Assert.NotNull(secondOverride);
-        Assert.NotNull(thirdOverride);
-        Assert.Equal(new TextureIdentity("main"), firstOverride!.Identity);
-        Assert.Equal(firstOverride.Identity, repeatedFirstOverride!.Identity);
-        Assert.Equal(firstOverride.Identity, secondOverride!.Identity);
-        Assert.Equal(firstOverride.Identity, thirdOverride!.Identity);
+        Assert.Equal(new TextureIdentity("main"), firstOverride.Identity);
+        Assert.Equal(firstOverride.Identity, repeatedFirstOverride.Identity);
+        Assert.Equal(firstOverride.Identity, secondOverride.Identity);
+        Assert.Equal(firstOverride.Identity, thirdOverride.Identity);
         Assert.Equal(new Uri("resdb:///texture/first", UriKind.Absolute), firstOverride.AssetUri);
         Assert.Equal(firstOverride.AssetUri, repeatedFirstOverride.AssetUri);
         Assert.Equal(new Uri("resdb:///texture/second", UriKind.Absolute), secondOverride.AssetUri);
+    }
+
+    [Fact]
+    public void PlanMainTextureOverrideReturnsNonePlanWithoutPreparedTexture()
+    {
+        ResoniteMaterialBinding material = new(
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0]);
+
+        MainTextureOverridePlan plan = ResoniteMaterialPlanning.PlanMainTextureOverride(
+            material,
+            new Dictionary<ResoniteTexturePayload, Uri>(),
+            new Dictionary<TerrainTextureOverlay, Uri>());
+
+        Assert.Same(MainTextureOverridePlan.None, plan);
     }
 
     private static ResoniteMaterialBinding CreateRoadMaterial(ResoniteMaterialProjection projection)
@@ -437,6 +457,13 @@ public sealed class ResoniteMaterialPlanningTests
     {
         return ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedAsset.Textures, role)
             ?? throw new InvalidOperationException($"Missing planned texture role '{role}'.");
+    }
+
+    private static PlannedTextureAsset GetMainTextureOverride(MainTextureOverridePlan plan)
+    {
+        return plan.Select(
+            static () => throw new InvalidOperationException("Expected a planned main texture override."),
+            static texture => texture);
     }
 
     private sealed class TexturePayloadReferenceComparer : IEqualityComparer<ResoniteTexturePayload>

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -495,7 +495,8 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 [
                     new PlannedTerrainMainTextureOverrideRendererMaterialBinding(
                         reusableMaterial,
-                        new PlannedTextureAsset(new TextureIdentity("override"), new Uri("resdb:///texture/override"))),
+                        new PlannedTextureAsset(new TextureIdentity("override"), new Uri("resdb:///texture/override")),
+                        PlannedTerrainMainTexturePropertyBlock.CreatePerRenderer()),
                 ]),
             new PlannedCollider(
                 new GeometryIdentity("geom"),
@@ -535,8 +536,8 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                     new PlannedTerrainMainTextureOverrideRendererMaterialBinding(
                         reusableMaterial,
                         new PlannedTextureAsset(new TextureIdentity("override"), new Uri("resdb:///texture/override")),
-                        SharedMainTextureComponent: new ResoniteComponentLocator("shared-terrain-texture-id"),
-                        SharedMainTexturePropertyBlockComponent: new ResoniteComponentLocator("shared-terrain-property-block-id")),
+                        PlannedTerrainMainTexturePropertyBlock.Shared(
+                            new ResoniteComponentLocator("shared-terrain-property-block-id"))),
                 ]),
             new PlannedCollider(
                 new GeometryIdentity("geom"),


### PR DESCRIPTION
## Summary
- replace nullable main texture override planning with a typed MainTextureOverridePlan result
- make terrain main texture property block planning an explicit create-per-renderer/shared state instead of nullable component fields
- move renderer override texture role selection onto the typed binding so batch emission no longer switches through unsupported override cases

## Verification
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~ResoniteMaterialPlanningTests|FullyQualifiedName~ResoniteSceneBatchEmissionPlanningTests|FullyQualifiedName~ResoniteLiveSceneImportTargetTests"
- dotnet run --project src/PlateauResoniteLink.Cli/PlateauResoniteLink.Cli.csproj --configuration Release --no-restore -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-archive-5039b16c4b1c.zip --geotiff-source runtime/windows/resonite/plateau-13213-higashimurayama-shi-2020/source-ortho-cc68652cc45c.7z --work-root runtime/windows/resonite --terrain-mesh grid --canonical-scene-dump runtime/windows/resonite/semantic-baselines/type-main-texture-override-result/current/higashi-53395325-dem-bldg-grid-geotiff.json
- git diff --no-index -- runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json runtime/windows/resonite/semantic-baselines/type-main-texture-override-result/current/higashi-53395325-dem-bldg-grid-geotiff.json
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false