### PR TITLE
Type common material definitions

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinition.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinition.cs
@@ -1,29 +1,24 @@
+using System.Collections.Generic;
+
 using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Application.Importing;
 
-internal sealed class CommonMaterialDefinition
+internal abstract class CommonMaterialDefinition
 {
-    internal CommonMaterialDefinition(
-        DefaultCommonMaterialMemberKind kind,
+    private protected static readonly ColorRgba CanonicalBaseColor = new(1.0, 1.0, 1.0, 1.0);
+
+    private protected CommonMaterialDefinition(
         MaterialProjection projection,
         string memberName,
-        MaterialDepthOffset? depthOffset = null,
-        string? family = null,
-        int? bundledVariantIndex = null)
+        MaterialDepthOffset? depthOffset)
     {
-        Kind = kind;
         Projection = projection;
         MemberName = memberName;
         DepthOffset = depthOffset;
-        Family = family;
-        BundledVariantIndex = bundledVariantIndex;
-        BundledVariant = family is null || bundledVariantIndex is null
-            ? null
-            : BundledDefaultMaterialFamilies.GetVariantDefinition(family, bundledVariantIndex.Value);
     }
 
-    public DefaultCommonMaterialMemberKind Kind { get; }
+    public abstract DefaultCommonMaterialMemberKind Kind { get; }
 
     public MaterialProjection Projection { get; }
 
@@ -31,9 +26,121 @@ internal sealed class CommonMaterialDefinition
 
     public MaterialDepthOffset? DepthOffset { get; }
 
-    public string? Family { get; }
+    public virtual string? Family => null;
 
-    public int? BundledVariantIndex { get; }
+    public virtual int? BundledVariantIndex => null;
 
-    public BundledDefaultMaterialVariant? BundledVariant { get; }
+    public virtual BundledDefaultMaterialVariant? BundledVariant => null;
+
+    internal abstract MaterialBinding CreateBinding(
+        DefaultCommonMaterialMember member,
+        IReadOnlyList<int> submeshIndices);
+
+    private protected static Float2 ToContract(ScalarPair value) => new(value.X, value.Y);
+}
+
+internal sealed class BundledCommonMaterialDefinition : CommonMaterialDefinition
+{
+    internal BundledCommonMaterialDefinition(
+        MaterialProjection projection,
+        string memberName,
+        string family,
+        int bundledVariantIndex)
+        : base(projection, memberName, depthOffset: null)
+    {
+        Family = family;
+        VariantIndex = bundledVariantIndex;
+        BundledVariant = BundledDefaultMaterialFamilies.GetVariantDefinition(family, bundledVariantIndex);
+    }
+
+    public override DefaultCommonMaterialMemberKind Kind => DefaultCommonMaterialMemberKind.Bundled;
+
+    public override string Family { get; }
+
+    public override int? BundledVariantIndex => VariantIndex;
+
+    public int VariantIndex { get; }
+
+    public override BundledDefaultMaterialVariant BundledVariant { get; }
+
+    internal override MaterialBinding CreateBinding(
+        DefaultCommonMaterialMember member,
+        IReadOnlyList<int> submeshIndices)
+    {
+        Float2 textureScale = ToContract(BundledVariant.TextureSet.TextureScale);
+        Float2? textureOffset = BundledVariant.TextureSet.TextureOffset is null
+            ? null
+            : ToContract(BundledVariant.TextureSet.TextureOffset);
+
+        return new MaterialBinding(
+            BaseColor: CanonicalBaseColor,
+            MaterialType: MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: TextureSourceKind.Bundled,
+            Projection: Projection,
+            DepthOffset: null,
+            SubmeshIndices: submeshIndices,
+            TextureScale: textureScale,
+            Family: Family,
+            TextureOffset: textureOffset,
+            ReuseScope: MaterialReuseScope.Shared,
+            BundledVariantIndex: VariantIndex,
+            CommonMaterial: member);
+    }
+}
+
+internal sealed class GenericAlbedoCommonMaterialDefinition : CommonMaterialDefinition
+{
+    internal GenericAlbedoCommonMaterialDefinition(
+        string memberName,
+        MaterialDepthOffset? depthOffset)
+        : base(MaterialProjection.Uv, memberName, depthOffset)
+    {
+    }
+
+    public override DefaultCommonMaterialMemberKind Kind => DefaultCommonMaterialMemberKind.GenericAlbedo;
+
+    internal override MaterialBinding CreateBinding(
+        DefaultCommonMaterialMember member,
+        IReadOnlyList<int> submeshIndices)
+    {
+        return new MaterialBinding(
+            BaseColor: CanonicalBaseColor,
+            MaterialType: MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: TextureSourceKind.Dataset,
+            Projection: Projection,
+            DepthOffset: DepthOffset,
+            SubmeshIndices: submeshIndices,
+            ReuseScope: MaterialReuseScope.Shared,
+            CommonMaterial: member);
+    }
+}
+
+internal sealed class VertexColorCommonMaterialDefinition : CommonMaterialDefinition
+{
+    internal VertexColorCommonMaterialDefinition(
+        string memberName,
+        MaterialDepthOffset? depthOffset)
+        : base(MaterialProjection.Uv, memberName, depthOffset)
+    {
+    }
+
+    public override DefaultCommonMaterialMemberKind Kind => DefaultCommonMaterialMemberKind.VertexColor;
+
+    internal override MaterialBinding CreateBinding(
+        DefaultCommonMaterialMember member,
+        IReadOnlyList<int> submeshIndices)
+    {
+        return new MaterialBinding(
+            BaseColor: CanonicalBaseColor,
+            MaterialType: MaterialType.VertexColor,
+            TexturePayload: null,
+            TextureSourceKind: TextureSourceKind.Bundled,
+            Projection: Projection,
+            DepthOffset: DepthOffset,
+            SubmeshIndices: submeshIndices,
+            ReuseScope: MaterialReuseScope.Shared,
+            CommonMaterial: member);
+    }
 }

--- a/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinition.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinition.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using PlateauResoniteLink.Domain.Importing;
@@ -13,6 +14,8 @@ internal abstract class CommonMaterialDefinition
         string memberName,
         MaterialDepthOffset? depthOffset)
     {
+        ArgumentNullException.ThrowIfNull(memberName);
+
         Projection = projection;
         MemberName = memberName;
         DepthOffset = depthOffset;
@@ -51,6 +54,8 @@ internal sealed class BundledCommonMaterialDefinition : CommonMaterialDefinition
         int bundledVariantIndex)
         : base(projection, memberName, depthOffset: null)
     {
+        ArgumentNullException.ThrowIfNull(family);
+
         this.family = family;
         VariantIndex = bundledVariantIndex;
         bundledVariant = BundledDefaultMaterialFamilies.GetVariantDefinition(family, bundledVariantIndex);

--- a/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinition.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinition.cs
@@ -41,6 +41,9 @@ internal abstract class CommonMaterialDefinition
 
 internal sealed class BundledCommonMaterialDefinition : CommonMaterialDefinition
 {
+    private readonly BundledDefaultMaterialVariant bundledVariant;
+    private readonly string family;
+
     internal BundledCommonMaterialDefinition(
         MaterialProjection projection,
         string memberName,
@@ -48,29 +51,29 @@ internal sealed class BundledCommonMaterialDefinition : CommonMaterialDefinition
         int bundledVariantIndex)
         : base(projection, memberName, depthOffset: null)
     {
-        Family = family;
+        this.family = family;
         VariantIndex = bundledVariantIndex;
-        BundledVariant = BundledDefaultMaterialFamilies.GetVariantDefinition(family, bundledVariantIndex);
+        bundledVariant = BundledDefaultMaterialFamilies.GetVariantDefinition(family, bundledVariantIndex);
     }
 
     public override DefaultCommonMaterialMemberKind Kind => DefaultCommonMaterialMemberKind.Bundled;
 
-    public override string Family { get; }
+    public override string? Family => family;
 
     public override int? BundledVariantIndex => VariantIndex;
 
     public int VariantIndex { get; }
 
-    public override BundledDefaultMaterialVariant BundledVariant { get; }
+    public override BundledDefaultMaterialVariant? BundledVariant => bundledVariant;
 
     internal override MaterialBinding CreateBinding(
         DefaultCommonMaterialMember member,
         IReadOnlyList<int> submeshIndices)
     {
-        Float2 textureScale = ToContract(BundledVariant.TextureSet.TextureScale);
-        Float2? textureOffset = BundledVariant.TextureSet.TextureOffset is null
+        Float2 textureScale = ToContract(bundledVariant.TextureSet.TextureScale);
+        Float2? textureOffset = bundledVariant.TextureSet.TextureOffset is null
             ? null
-            : ToContract(BundledVariant.TextureSet.TextureOffset);
+            : ToContract(bundledVariant.TextureSet.TextureOffset);
 
         return new MaterialBinding(
             BaseColor: CanonicalBaseColor,
@@ -81,7 +84,7 @@ internal sealed class BundledCommonMaterialDefinition : CommonMaterialDefinition
             DepthOffset: null,
             SubmeshIndices: submeshIndices,
             TextureScale: textureScale,
-            Family: Family,
+            Family: family,
             TextureOffset: textureOffset,
             ReuseScope: MaterialReuseScope.Shared,
             BundledVariantIndex: VariantIndex,

--- a/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinitions.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinitions.cs
@@ -71,30 +71,25 @@ internal static class CommonMaterialDefinitions
     public static readonly CommonMaterialDefinition WallSchoolPublicDark = Bundled(BundledDefaultMaterialFamilies.WallSchoolPublicBand, 1, "SchoolPublicDark");
     public static readonly CommonMaterialDefinition WallWoodRuralLight = Bundled(BundledDefaultMaterialFamilies.WallWoodRural, 0, "WoodRuralLight");
 
-    private static CommonMaterialDefinition Bundled(string family, int variantIndex, string memberName)
+    private static BundledCommonMaterialDefinition Bundled(string family, int variantIndex, string memberName)
     {
-        return new CommonMaterialDefinition(
-            DefaultCommonMaterialMemberKind.Bundled,
+        return new BundledCommonMaterialDefinition(
             GetBundledProjection(family),
             memberName,
-            family: family,
-            bundledVariantIndex: variantIndex);
+            family,
+            variantIndex);
     }
 
-    private static CommonMaterialDefinition Generic(string memberName, MaterialDepthOffset? depthOffset)
+    private static GenericAlbedoCommonMaterialDefinition Generic(string memberName, MaterialDepthOffset? depthOffset)
     {
-        return new CommonMaterialDefinition(
-            DefaultCommonMaterialMemberKind.GenericAlbedo,
-            MaterialProjection.Uv,
+        return new GenericAlbedoCommonMaterialDefinition(
             memberName,
             depthOffset);
     }
 
-    private static CommonMaterialDefinition VertexColor(string memberName, MaterialDepthOffset? depthOffset)
+    private static VertexColorCommonMaterialDefinition VertexColor(string memberName, MaterialDepthOffset? depthOffset)
     {
-        return new CommonMaterialDefinition(
-            DefaultCommonMaterialMemberKind.VertexColor,
-            MaterialProjection.Uv,
+        return new VertexColorCommonMaterialDefinition(
             memberName,
             depthOffset);
     }

--- a/src/PlateauResoniteLink/Application/Importing/DefaultCommonMaterialMember.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultCommonMaterialMember.cs
@@ -7,8 +7,6 @@ namespace PlateauResoniteLink.Application.Importing;
 
 public sealed class DefaultCommonMaterialMember : IEquatable<DefaultCommonMaterialMember>
 {
-    private static readonly ColorRgba CanonicalBaseColor = new(1.0, 1.0, 1.0, 1.0);
-
     private DefaultCommonMaterialMember(CommonMaterialDefinition definition)
     {
         Definition = definition ?? throw new ArgumentNullException(nameof(definition));
@@ -52,60 +50,8 @@ public sealed class DefaultCommonMaterialMember : IEquatable<DefaultCommonMateri
     {
         ArgumentNullException.ThrowIfNull(submeshIndices);
 
-        return Kind switch
-        {
-            DefaultCommonMaterialMemberKind.Bundled => CreateBundledBinding(submeshIndices),
-            DefaultCommonMaterialMemberKind.GenericAlbedo => new MaterialBinding(
-                BaseColor: CanonicalBaseColor,
-                MaterialType: MaterialType.Standard,
-                TexturePayload: null,
-                TextureSourceKind: TextureSourceKind.Dataset,
-                Projection: Projection,
-                DepthOffset: DepthOffset,
-                SubmeshIndices: submeshIndices,
-                ReuseScope: MaterialReuseScope.Shared,
-                CommonMaterial: this),
-            DefaultCommonMaterialMemberKind.VertexColor => new MaterialBinding(
-                BaseColor: CanonicalBaseColor,
-                MaterialType: MaterialType.VertexColor,
-                TexturePayload: null,
-                TextureSourceKind: TextureSourceKind.Bundled,
-                Projection: Projection,
-                DepthOffset: DepthOffset,
-                SubmeshIndices: submeshIndices,
-                ReuseScope: MaterialReuseScope.Shared,
-                CommonMaterial: this),
-            _ => throw new InvalidOperationException($"Unsupported common material member kind '{Kind}'."),
-        };
+        return Definition.CreateBinding(this, submeshIndices);
     }
-
-    private MaterialBinding CreateBundledBinding(IReadOnlyList<int> submeshIndices)
-    {
-        string family = Family ?? throw new InvalidOperationException("Bundled common material member requires a family.");
-        int variantIndex = BundledVariantIndex ?? 0;
-        BundledDefaultMaterialVariant variant = BundledVariant
-            ?? throw new InvalidOperationException("Bundled common material member requires a variant.");
-        Float2 textureScale = ToContract(variant.TextureSet.TextureScale);
-        Float2? textureOffset = variant.TextureSet.TextureOffset is null
-            ? null
-            : ToContract(variant.TextureSet.TextureOffset);
-        return new MaterialBinding(
-            BaseColor: CanonicalBaseColor,
-            MaterialType: MaterialType.Standard,
-            TexturePayload: null,
-            TextureSourceKind: TextureSourceKind.Bundled,
-            Projection: Projection,
-            DepthOffset: null,
-            SubmeshIndices: submeshIndices,
-            TextureScale: textureScale,
-            Family: family,
-            TextureOffset: textureOffset,
-            ReuseScope: MaterialReuseScope.Shared,
-            BundledVariantIndex: variantIndex,
-            CommonMaterial: this);
-    }
-
-    private static Float2 ToContract(ScalarPair value) => new(value.X, value.Y);
 }
 
 public enum DefaultCommonMaterialMemberKind


### PR DESCRIPTION
## Summary
- Split common material definitions into bundled, generic albedo, and vertex-color concrete types.
- Make bundled family/variant data required on bundled definitions instead of nullable fields checked at binding time.
- Move common material binding creation onto the typed definitions, removing the member-kind fallback exception from CreateBinding.

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~CommonMaterialCatalogTests|FullyQualifiedName~DefaultMaterialResolverTests|FullyQualifiedName~ResoniteCommonMaterialAssetAccumulatorTests|FullyQualifiedName~ResoniteMaterialPlanningTests"`
- `dotnet run --project src\PlateauResoniteLink.Cli\PlateauResoniteLink.Cli.csproj --configuration Release --no-restore -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-archive-5039b16c4b1c.zip --geotiff-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-ortho-cc68652cc45c.7z --work-root runtime\windows\resonite --terrain-mesh grid --canonical-scene-dump runtime\windows\resonite\semantic-baselines\type-common-material-definitions\current\higashi-53395325-dem-bldg-grid-geotiff.json`
- `git diff --no-index -- runtime\windows\resonite\semantic-baselines\type-dem-grid-projection-result\baseline-parent\higashi-53395325-dem-bldg-grid-geotiff.json runtime\windows\resonite\semantic-baselines\type-common-material-definitions\current\higashi-53395325-dem-bldg-grid-geotiff.json`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`