### PR TITLE
Require material request building attributes

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -277,7 +277,7 @@ internal static class CityGmlSurfaceMaterialResolver
             preferUvProjection,
             FamilyOverride: null,
             VariantSelectionKey: $"{cityObject.SlotKey}:{(preferUvProjection ? "uv" : "triplanar")}",
-            BuildingAttributes: cityObject.BuildingAttributes,
+            BuildingAttributes: cityObject.BuildingAttributes ?? BuildingAttributeContext.Empty,
             FloorsAboveGround: cityObject.FloorsAboveGround,
             MeasuredHeightMeters: cityObject.MeasuredHeightMeters,
             GeometryHeightMeters: cityObject.GeometryHeightMeters,

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -277,13 +277,11 @@ internal static class CityGmlSurfaceMaterialResolver
             preferUvProjection,
             FamilyOverride: null,
             VariantSelectionKey: $"{cityObject.SlotKey}:{(preferUvProjection ? "uv" : "triplanar")}",
-            BuildingAttributes: cityObject.BuildingAttributes ?? BuildingAttributeContext.Empty,
+            BuildingAttributes: cityObject.BuildingAttributes,
             FloorsAboveGround: cityObject.FloorsAboveGround,
             MeasuredHeightMeters: cityObject.MeasuredHeightMeters,
             GeometryHeightMeters: cityObject.GeometryHeightMeters,
-            FootprintAreaSquareMeters: cityObject.BuildingAttributes is null
-                ? null
-                : BuildingAttributeQueries.TryGetKnownPositiveMetric(cityObject.BuildingAttributes.BuildingFootprintArea),
+            FootprintAreaSquareMeters: BuildingAttributeQueries.TryGetKnownPositiveMetric(cityObject.BuildingAttributes.BuildingFootprintArea),
             SurfaceRole: ToDefaultMaterialSurfaceRole(face.Role)));
         MaterialDepthOffset? depthOffset = cityObject.TerrainAligned
             ? TerrainAlignedDepthOffset

--- a/src/PlateauResoniteLink/Application/Importing/ConstructionCityObjectDraft.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ConstructionCityObjectDraft.cs
@@ -47,7 +47,7 @@ internal sealed record ConstructionCityObjectDraft(
 
     public double? MeasuredHeightMeters => Source.MeasuredHeightMeters;
 
-    public BuildingAttributeContext? BuildingAttributes => Source.BuildingAttributes;
+    public BuildingAttributeContext BuildingAttributes => Source.BuildingAttributes;
 
     public double? GeometryHeightMeters => Source.GeometryHeightMeters;
 

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialRequest.cs
@@ -17,7 +17,7 @@ internal sealed record DefaultMaterialRequest(
     bool PreferUvProjection,
     string? FamilyOverride,
     string VariantSelectionKey,
-    BuildingAttributeContext? BuildingAttributes = null,
+    BuildingAttributeContext BuildingAttributes,
     int? FloorsAboveGround = null,
     double? MeasuredHeightMeters = null,
     double? GeometryHeightMeters = null,

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
@@ -159,7 +159,7 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         DefaultMaterialRequest request,
         CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials)
     {
-        BuildingAttributeContext attributes = request.BuildingAttributes ?? BuildingAttributeContext.Empty;
+        BuildingAttributeContext attributes = request.BuildingAttributes;
         BuildingFacadeScale scale = BuildingFacadeScale.Classify(
             request.FloorsAboveGround,
             request.MeasuredHeightMeters,

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -90,7 +90,6 @@ internal static class GeneratedLod1RoofCityObjectFactory
     private static bool IsNoWallBuilding(ParsedCityObject cityObject)
     {
         return cityObject.LodLevel >= 1
-            && cityObject.BuildingAttributes is not null
             && NoWallBuildingClassCodes.Any(code => BuildingAttributePredicates.HasExactCityGmlClassCode(cityObject.BuildingAttributes, code));
     }
 
@@ -491,7 +490,7 @@ internal static class GeneratedLod1RoofCityObjectFactory
             length,
             width,
             geometryHeight,
-            cityObject.BuildingAttributes ?? BuildingAttributeContext.Empty,
+            cityObject.BuildingAttributes,
             firstEdgeIsLongAxis);
         return true;
     }

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedObjectModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedObjectModels.cs
@@ -43,10 +43,10 @@ internal sealed record ParsedCityObject(
     CoordinateReferenceSystem ReferenceSystem,
     string SourceFileRelativePath,
     bool SharedAcrossMeshCodes,
+    BuildingAttributeContext BuildingAttributes,
     bool TerrainAligned = false,
     GeodeticPoint? GeodeticOriginOverride = null,
     int? FloorsAboveGround = null,
     double? MeasuredHeightMeters = null,
-    BuildingAttributeContext? BuildingAttributes = null,
     double? GeometryHeightMeters = null,
     string? SourceMeshCode = null);

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceMaterialResolverTests.cs
@@ -24,7 +24,8 @@ public sealed class CityGmlSurfaceMaterialResolverTests
             ],
             ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
             SourceFileRelativePath: "udx/dem/53394525/sample.gml",
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
 
         ResolvedSurfaceMaterial? representativeSurface = CityGmlSurfaceMaterialResolver.EnumerateSurfaces(
                 ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
@@ -161,7 +162,8 @@ public sealed class CityGmlSurfaceMaterialResolverTests
             Surfaces: surfaces,
             ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
             SourceFileRelativePath: "udx/bldg/53394525/sample.gml",
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private static TerrainTextureOverlay CreateOverlay(string meshCode)

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlTerrainConformerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlTerrainConformerTests.cs
@@ -63,6 +63,7 @@ public sealed class CityGmlTerrainConformerTests
             ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4979"),
             SourceFileRelativePath: $"udx/{packageName}/53394525/{packageName}.gml",
             SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty,
             TerrainAligned: false);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
@@ -21,6 +21,7 @@ public sealed class DefaultMaterialResolverTests
             PreferUvProjection: true,
             FamilyOverride: null,
             VariantSelectionKey: "bldg:uv",
+            BuildingAttributes: BuildingAttributeContext.Empty,
             SurfaceRole: DefaultMaterialSurfaceRole.Wall));
 
         Assert.Equal(MaterialType.Standard, material.MaterialType);
@@ -48,6 +49,7 @@ public sealed class DefaultMaterialResolverTests
             PreferUvProjection: true,
             FamilyOverride: null,
             VariantSelectionKey: $"bldg:{surfaceRole}:texture",
+            BuildingAttributes: BuildingAttributeContext.Empty,
             SurfaceRole: surfaceRole));
 
         Assert.Equal(MaterialType.Standard, material.MaterialType);
@@ -115,6 +117,7 @@ public sealed class DefaultMaterialResolverTests
             PreferUvProjection: true,
             FamilyOverride: null,
             VariantSelectionKey: $"bldg:{surfaceRole}:fallback",
+            BuildingAttributes: BuildingAttributeContext.Empty,
             SurfaceRole: surfaceRole));
 
         Assert.Equal(MaterialType.Standard, material.MaterialType);
@@ -134,7 +137,8 @@ public sealed class DefaultMaterialResolverTests
             TexturePayload: null,
             PreferUvProjection: false,
             FamilyOverride: null,
-            VariantSelectionKey: "luse:tri"));
+            VariantSelectionKey: "luse:tri",
+            BuildingAttributes: BuildingAttributeContext.Empty));
 
         Assert.Equal(MaterialType.Wireframe, material.MaterialType);
         Assert.Null(material.TexturePayload);
@@ -472,6 +476,7 @@ public sealed class DefaultMaterialResolverTests
                 PreferUvProjection: true,
                 FamilyOverride: BundledDefaultMaterialFamilies.Facade,
                 VariantSelectionKey: "bldg:uv:0",
+                BuildingAttributes: BuildingAttributeContext.Empty,
                 SurfaceRole: DefaultMaterialSurfaceRole.Wall)));
 
         Assert.Contains("not codebase-reachable", error.Message, StringComparison.Ordinal);
@@ -516,7 +521,8 @@ public sealed class DefaultMaterialResolverTests
             TexturePayload: null,
             PreferUvProjection: false,
             FamilyOverride: null,
-            VariantSelectionKey: variantSelectionKey);
+            VariantSelectionKey: variantSelectionKey,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private static DefaultMaterialRequest CreateBuildingWallRequest(
@@ -533,7 +539,7 @@ public sealed class DefaultMaterialResolverTests
             PreferUvProjection: true,
             FamilyOverride: null,
             VariantSelectionKey: variantSelectionKey,
-            BuildingAttributes: attributes,
+            BuildingAttributes: attributes ?? BuildingAttributeContext.Empty,
             FloorsAboveGround: floorsAboveGround,
             MeasuredHeightMeters: measuredHeightMeters,
             GeometryHeightMeters: geometryHeightMeters,

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemCityObjectAggregationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemCityObjectAggregationTests.cs
@@ -85,6 +85,7 @@ public sealed class DemCityObjectAggregationTests
             Surfaces: [surface],
             referenceSystem,
             sourceFileRelativePath,
-            SharedAcrossMeshCodes: true);
+            SharedAcrossMeshCodes: true,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemSourceDiscoverySupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemSourceDiscoverySupportTests.cs
@@ -129,6 +129,7 @@ public sealed class DemSourceDiscoverySupportTests
             ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
             SourceFileRelativePath: "udx/dem/53394525/sample.gml",
             SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty,
             TerrainAligned: false,
             GeodeticOriginOverride: null);
     }
@@ -155,6 +156,7 @@ public sealed class DemSourceDiscoverySupportTests
             ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
             SourceFileRelativePath: "udx/dem/53394525/empty-geometry.gml",
             SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty,
             TerrainAligned: false,
             GeodeticOriginOverride: null);
     }

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
@@ -422,7 +422,8 @@ public sealed class DemTerrainOverlayAssignmentTests
             Surfaces: [surface],
             ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
             SourceFileRelativePath: "udx/dem/53394525/sample.gml",
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private static ParsedSurface CreateGeneratedSurface(

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
@@ -153,6 +153,7 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
             new CoordinateReferenceSystem("local", Geocentric: null, CompatibilityKey: "local"),
             "udx/tran/road.gml",
             SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty,
             TerrainAligned: true);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlGeometryProjectorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlGeometryProjectorTests.cs
@@ -50,7 +50,8 @@ public sealed class LocalCityGmlGeometryProjectorTests
                     Surfaces: [],
                     ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:6697"),
                     SourceFileRelativePath: "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml",
-                    SharedAcrossMeshCodes: false),
+                    SharedAcrossMeshCodes: false,
+                    BuildingAttributes: BuildingAttributeContext.Empty),
             ]);
 
         PlateauImportValidationException exception = Assert.Throws<PlateauImportValidationException>(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -3615,7 +3615,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             SharedAcrossMeshCodes: false,
             FloorsAboveGround: floorsAboveGround,
             MeasuredHeightMeters: measuredHeightMeters,
-            BuildingAttributes: buildingAttributes);
+            BuildingAttributes: buildingAttributes ?? BuildingAttributeContext.Empty);
     }
 
     private static BuildingAttributeContext CreateBuildingAttributes(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
@@ -162,8 +162,7 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
         Assert.NotNull(parsedCityObject.MeasuredHeightMeters);
         Assert.InRange(parsedCityObject.MeasuredHeightMeters!.Value, 11.799999, 11.800001);
 
-        Assert.NotNull(parsedCityObject.BuildingAttributes);
-        BuildingAttributeContext attributes = parsedCityObject.BuildingAttributes!;
+        BuildingAttributeContext attributes = parsedCityObject.BuildingAttributes;
         Assert.NotNull(attributes.RoofShape);
         Assert.Equal(CityGmlRoofShape.Shed, attributes.RoofShape!.Value);
         Assert.Equal("5", attributes.RoofShape.Code);
@@ -269,8 +268,7 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
         CityGmlRoofShape expectedShape = (CityGmlRoofShape)expectedShapeValue;
         ParsedCityObject parsedCityObject = await ParseSingleBuildingWithRoofTypeAsync(roofTypeCode);
 
-        Assert.NotNull(parsedCityObject.BuildingAttributes);
-        BuildingCodeValue<CityGmlRoofShape>? roofShape = parsedCityObject.BuildingAttributes!.RoofShape;
+        BuildingCodeValue<CityGmlRoofShape>? roofShape = parsedCityObject.BuildingAttributes.RoofShape;
         Assert.NotNull(roofShape);
         Assert.Equal(expectedShape, roofShape!.Value);
         Assert.Equal(roofTypeCode, roofShape.Code);
@@ -290,8 +288,7 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
             $"<uro:buildingStructureType>{structureCode}</uro:buildingStructureType>");
         PlateauBuildingStructure expectedStructure = (PlateauBuildingStructure)expectedStructureValue;
 
-        Assert.NotNull(parsedCityObject.BuildingAttributes);
-        BuildingCodeValue<PlateauBuildingStructure> structure = Assert.Single(parsedCityObject.BuildingAttributes!.Structures);
+        BuildingCodeValue<PlateauBuildingStructure> structure = Assert.Single(parsedCityObject.BuildingAttributes.Structures);
         Assert.Equal(expectedStructure, structure.Value);
         Assert.Equal(structureCode, structure.Code);
     }
@@ -309,8 +306,7 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
             $"<uro:detailedUsage>{detailedUsageCode}</uro:detailedUsage>");
         PlateauBuildingUse expectedUse = (PlateauBuildingUse)expectedUseValue;
 
-        Assert.NotNull(parsedCityObject.BuildingAttributes);
-        BuildingCodeValue<PlateauBuildingUse> detailedUse = Assert.Single(parsedCityObject.BuildingAttributes!.DetailedUses);
+        BuildingCodeValue<PlateauBuildingUse> detailedUse = Assert.Single(parsedCityObject.BuildingAttributes.DetailedUses);
         Assert.Equal(expectedUse, detailedUse.Value);
         Assert.Equal(detailedUsageCode, detailedUse.Code);
     }

--- a/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
@@ -292,7 +292,8 @@ public sealed class StreamingImportedSceneSourceStreamingTests
             Surfaces: [surface],
             ReferenceSystem: referenceSystem,
             SourceFileRelativePath: $"udx/{packageName}/53394525/{objectKey}.gml",
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private sealed class RecordingGeometryProjector : ICityGmlGeometryProjector

--- a/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceTests.cs
@@ -812,7 +812,8 @@ public sealed class StreamingImportedSceneSourceTests
             Surfaces: surfaces,
             ReferenceSystem: referenceSystem,
             SourceFileRelativePath: sourceFile.RelativePath,
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private static ParsedCityObject CreateParsedCityObjectInMesh53394525(
@@ -846,7 +847,8 @@ public sealed class StreamingImportedSceneSourceTests
             ],
             ReferenceSystem: referenceSystem,
             SourceFileRelativePath: sourceFile.RelativePath,
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private static ParsedCityObject CreateRenderableParsedCityObject(
@@ -884,7 +886,8 @@ public sealed class StreamingImportedSceneSourceTests
             ],
             ReferenceSystem: referenceSystem,
             SourceFileRelativePath: sourceFile.RelativePath,
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private static async Task WaitForConditionAsync(Func<bool> predicate, TimeSpan timeout)


### PR DESCRIPTION
## Summary
- Make `DefaultMaterialRequest.BuildingAttributes` a required non-null value.
- Normalize missing CityGML building attributes at request construction instead of inside `DefaultMaterialResolver`.
- Update material resolver tests to pass explicit empty attributes for non-building or attribute-less requests.

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~DefaultMaterialResolverTests|FullyQualifiedName~CityGmlSurfaceMaterialResolver|FullyQualifiedName~LocalCityGmlObjectProjectionTests"`
- `dotnet run --project src\PlateauResoniteLink.Cli\PlateauResoniteLink.Cli.csproj --configuration Release --no-restore -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-archive-5039b16c4b1c.zip --geotiff-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-ortho-cc68652cc45c.7z --work-root runtime\windows\resonite --terrain-mesh grid --canonical-scene-dump runtime\windows\resonite\semantic-baselines\type-default-material-request-attributes\current\higashi-53395325-dem-bldg-grid-geotiff.json`
- `git diff --no-index -- runtime\windows\resonite\semantic-baselines\type-dem-grid-projection-result\baseline-parent\higashi-53395325-dem-bldg-grid-geotiff.json runtime\windows\resonite\semantic-baselines\type-default-material-request-attributes\current\higashi-53395325-dem-bldg-grid-geotiff.json`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`