### PR TITLE
Type default material family overrides

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialFamilyOverride.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialFamilyOverride.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal sealed class DefaultMaterialFamilyOverride
+{
+    public static readonly DefaultMaterialFamilyOverride CityFurniture = new(
+        BundledDefaultMaterialFamilies.CityFurniture,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 6) switch
+        {
+            0 => catalog.CityFurniture.Plaster002,
+            1 => catalog.CityFurniture.Plaster001,
+            2 => catalog.CityFurniture.Plaster003,
+            3 => catalog.CityFurniture.Plaster004,
+            4 => catalog.CityFurniture.Plaster005,
+            _ => catalog.CityFurniture.Plaster006,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride FacadeHighriseGlass = new(
+        BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 3) switch
+        {
+            0 => catalog.FacadeHighriseGlass.Facade001,
+            1 => catalog.FacadeHighriseGlass.Facade005,
+            _ => catalog.FacadeHighriseGlass.Facade006,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride FacadeHighriseNightLow = new(
+        BundledDefaultMaterialFamilies.FacadeHighriseNightLow,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.FacadeHighriseNightLow.Facade002
+            : catalog.FacadeHighriseNightLow.Facade011);
+
+    public static readonly DefaultMaterialFamilyOverride FacadeMidriseGrid = new(
+        BundledDefaultMaterialFamilies.FacadeMidriseGrid,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.FacadeMidriseGrid.Facade014
+            : catalog.FacadeMidriseGrid.Facade015);
+
+    public static readonly DefaultMaterialFamilyOverride Other = new(
+        BundledDefaultMaterialFamilies.Other,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 9) switch
+        {
+            0 => catalog.Other.Concrete012,
+            1 => catalog.Other.Ground054,
+            2 => catalog.Other.Plaster002,
+            3 => catalog.Other.Plaster001,
+            4 => catalog.Other.Plaster003,
+            5 => catalog.Other.Plaster004,
+            6 => catalog.Other.Plaster005,
+            7 => catalog.Other.Plaster006,
+            _ => catalog.Other.TextureCanFacade0022,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride RoadTriplanar = new(
+        BundledDefaultMaterialFamilies.RoadTriplanar,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 4) switch
+        {
+            0 => catalog.RoadTriplanar.Road012A,
+            1 => catalog.RoadTriplanar.Road013A,
+            2 => catalog.RoadTriplanar.Road014A,
+            _ => catalog.RoadTriplanar.Road015A,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride RoadUv = new(
+        BundledDefaultMaterialFamilies.RoadUv,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 4) switch
+        {
+            0 => catalog.RoadUv.Road012A,
+            1 => catalog.RoadUv.Road013A,
+            2 => catalog.RoadUv.Road014A,
+            _ => catalog.RoadUv.Road015A,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride Roof = new(
+        BundledDefaultMaterialFamilies.Roof,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 4) switch
+        {
+            0 => catalog.Roof.Concrete012,
+            1 => catalog.Roof.Concrete033,
+            2 => catalog.Roof.RoofingTiles012A,
+            _ => catalog.Roof.RoofingTiles014B,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride Vegetation = new(
+        BundledDefaultMaterialFamilies.Vegetation,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.Vegetation.Ground054
+            : catalog.Vegetation.Concrete012);
+
+    public static readonly DefaultMaterialFamilyOverride WallApartmentTileMid = new(
+        BundledDefaultMaterialFamilies.WallApartmentTileMid,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.WallApartmentTileMid.ApartmentTileMid
+            : catalog.WallApartmentTileMid.ApartmentTileDark);
+
+    public static readonly DefaultMaterialFamilyOverride WallBrickRetro = new(
+        BundledDefaultMaterialFamilies.WallBrickRetro,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.WallBrickRetro.BrickRetro
+            : catalog.WallBrickRetro.BrickDark);
+
+    public static readonly DefaultMaterialFamilyOverride WallCommercialPanel = new(
+        BundledDefaultMaterialFamilies.WallCommercialPanel,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.WallCommercialPanel.CommercialPanel
+            : catalog.WallCommercialPanel.CommercialPanelDark);
+
+    public static readonly DefaultMaterialFamilyOverride WallFactoryMetal = new(
+        BundledDefaultMaterialFamilies.WallFactoryMetal,
+        static (catalog, _) => catalog.WallFactoryMetal.FactoryMetal);
+
+    public static readonly DefaultMaterialFamilyOverride WallRcPaintedMid = new(
+        BundledDefaultMaterialFamilies.WallRcPaintedMid,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.WallRcPaintedMid.RcPaintedMid
+            : catalog.WallRcPaintedMid.RcPaintedDark);
+
+    public static readonly DefaultMaterialFamilyOverride WallResidentialPlasterLow = new(
+        BundledDefaultMaterialFamilies.WallResidentialPlasterLow,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.WallResidentialPlasterLow.ResidentialPlasterLow
+            : catalog.WallResidentialPlasterLow.ResidentialPlasterDark);
+
+    public static readonly DefaultMaterialFamilyOverride WallResidentialTileLow = new(
+        BundledDefaultMaterialFamilies.WallResidentialTileLow,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 4) switch
+        {
+            0 => catalog.WallResidentialTileLow.ResidentialTileLow,
+            1 => catalog.WallResidentialTileLow.ResidentialTileDark,
+            2 => catalog.WallResidentialTileLow.ResidentialTileDarkIrregular,
+            _ => catalog.WallResidentialTileLow.ResidentialSidingBrickGray,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride WallSchoolPublicBand = new(
+        BundledDefaultMaterialFamilies.WallSchoolPublicBand,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.WallSchoolPublicBand.SchoolPublicBand
+            : catalog.WallSchoolPublicBand.SchoolPublicDark);
+
+    public static readonly DefaultMaterialFamilyOverride WallWoodRural = new(
+        BundledDefaultMaterialFamilies.WallWoodRural,
+        static (catalog, _) => catalog.WallWoodRural.WoodRuralLight);
+
+    public static readonly IReadOnlyList<DefaultMaterialFamilyOverride> All =
+    [
+        CityFurniture,
+        FacadeHighriseGlass,
+        FacadeHighriseNightLow,
+        FacadeMidriseGrid,
+        Other,
+        RoadTriplanar,
+        RoadUv,
+        Roof,
+        Vegetation,
+        WallApartmentTileMid,
+        WallBrickRetro,
+        WallCommercialPanel,
+        WallFactoryMetal,
+        WallRcPaintedMid,
+        WallResidentialPlasterLow,
+        WallResidentialTileLow,
+        WallSchoolPublicBand,
+        WallWoodRural,
+    ];
+
+    private readonly Func<CommonMaterialCatalog<DefaultCommonMaterialMember>, string, DefaultCommonMaterialMember> selectMember;
+
+    private DefaultMaterialFamilyOverride(
+        string family,
+        Func<CommonMaterialCatalog<DefaultCommonMaterialMember>, string, DefaultCommonMaterialMember> selectMember)
+    {
+        Family = family;
+        this.selectMember = selectMember;
+    }
+
+    public string Family { get; }
+
+    internal DefaultCommonMaterialMember SelectMember(
+        CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials,
+        string variantSelectionKey)
+    {
+        return selectMember(commonMaterials, variantSelectionKey);
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialRequest.cs
@@ -15,7 +15,7 @@ internal sealed record DefaultMaterialRequest(
     string PackageName,
     TexturePayload? TexturePayload,
     bool PreferUvProjection,
-    string? FamilyOverride,
+    DefaultMaterialFamilyOverride? FamilyOverride,
     string VariantSelectionKey,
     BuildingAttributeContext? BuildingAttributes = null,
     int? FloorsAboveGround = null,

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
@@ -53,7 +53,7 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
 
         DefaultCommonMaterialMember commonMaterial = request.FamilyOverride is null
             ? SelectBundledMemberForRequest(request, commonMaterials)
-            : SelectFamilyOverrideMember(commonMaterials, request.FamilyOverride, request.VariantSelectionKey);
+            : request.FamilyOverride.SelectMember(commonMaterials, request.VariantSelectionKey);
         string family = commonMaterial.Family
             ?? throw new InvalidOperationException("Selected default material member is not a bundled material.");
         int bundledVariantIndex = commonMaterial.BundledVariantIndex
@@ -123,36 +123,6 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         }
 
         return SelectOtherMember(commonMaterials, request.VariantSelectionKey);
-    }
-
-    private static DefaultCommonMaterialMember SelectFamilyOverrideMember(
-        CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials,
-        string family,
-        string variantSelectionKey)
-    {
-        return family switch
-        {
-            BundledDefaultMaterialFamilies.CityFurniture => SelectCityFurnitureMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.FacadeHighriseGlass => SelectFacadeHighriseGlassMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.FacadeHighriseNightLow => SelectFacadeHighriseNightLowMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.FacadeMidriseGrid => SelectFacadeMidriseGridMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.Other => SelectOtherMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.RoadTriplanar => SelectRoadTriplanarMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.RoadUv => SelectRoadUvMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.Roof => SelectRoofMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.Vegetation => SelectVegetationMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallApartmentTileMid => SelectWallApartmentTileMidMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallBrickRetro => SelectWallBrickRetroMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallCommercialPanel => SelectWallCommercialPanelMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallFactoryMetal => commonMaterials.WallFactoryMetal.FactoryMetal,
-            BundledDefaultMaterialFamilies.WallRcPaintedMid => SelectWallRcPaintedMidMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallResidentialPlasterLow => SelectWallResidentialPlasterLowMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallResidentialTileLow => SelectWallResidentialTileLowMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallSchoolPublicBand => SelectWallSchoolPublicBandMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallWoodRural => commonMaterials.WallWoodRural.WoodRuralLight,
-            _ => throw new InvalidOperationException(
-                $"Bundled material family override '{family}' is not codebase-reachable and is not part of the common material catalog."),
-        };
     }
 
     private static DefaultCommonMaterialMember SelectBuildingFacadeMember(

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
@@ -101,28 +101,28 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
 
         if (PlateauPackageCatalog.IsBuildingPackage(request.PackageName))
         {
-            return SelectRoofMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.Roof.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (PlateauPackageCatalog.IsRoadPackage(request.PackageName)
             || PlateauPackageCatalog.IsPathLikePackage(request.PackageName))
         {
             return request.PreferUvProjection
-                ? SelectRoadUvMember(commonMaterials, request.VariantSelectionKey)
-                : SelectRoadTriplanarMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.RoadUv.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.RoadTriplanar.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (PlateauPackageCatalog.IsVegetationPackage(request.PackageName))
         {
-            return SelectVegetationMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.Vegetation.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (PlateauPackageCatalog.IsCityFurniturePackage(request.PackageName))
         {
-            return SelectCityFurnitureMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.CityFurniture.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        return SelectOtherMember(commonMaterials, request.VariantSelectionKey);
+        return DefaultMaterialFamilyOverride.Other.SelectMember(commonMaterials, request.VariantSelectionKey);
     }
 
     private static DefaultCommonMaterialMember SelectBuildingFacadeMember(
@@ -139,20 +139,20 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         if (scale.Landmark)
         {
             return BuildingAttributePredicates.HasNightOccupancy(attributes)
-                ? SelectFacadeHighriseNightLowMember(commonMaterials, request.VariantSelectionKey)
-                : SelectFacadeHighriseGlassMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.FacadeHighriseNightLow.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.FacadeHighriseGlass.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (scale.Highrise)
         {
             return BuildingAttributePredicates.HasNightOccupancy(attributes)
-                ? SelectFacadeHighriseNightLowMember(commonMaterials, request.VariantSelectionKey)
-                : SelectFacadeHighriseGlassMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.FacadeHighriseNightLow.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.FacadeHighriseGlass.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (scale.Midrise && BuildingAttributePredicates.HasFacadeLikeMidriseUse(attributes))
         {
-            return SelectFacadeMidriseGridMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.FacadeMidriseGrid.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasRawBuildingCode(attributes, "431")
@@ -171,170 +171,56 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
 
         if (BuildingAttributePredicates.HasBrickLikeStructure(attributes))
         {
-            return SelectWallBrickRetroMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.WallBrickRetro.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Commercial)
             || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Office))
         {
             return scale.LowRise
-                ? SelectWallCommercialPanelMember(commonMaterials, request.VariantSelectionKey)
-                : SelectWallRcPaintedMidMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.WallCommercialPanel.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.WallRcPaintedMid.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Public)
             || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Education))
         {
-            return SelectWallSchoolPublicBandMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.WallSchoolPublicBand.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Apartment))
         {
             return scale.LowRise
-                ? SelectWallResidentialTileLowMember(commonMaterials, request.VariantSelectionKey)
-                : SelectWallApartmentTileMidMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.WallResidentialTileLow.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.WallApartmentTileMid.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.MixedResidential))
         {
             return scale.LowRise
-                ? SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey)
-                : SelectWallApartmentTileMidMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.WallResidentialPlasterLow.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.WallApartmentTileMid.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.DetachedResidential))
         {
             return IsWeightedAlternate(request.VariantSelectionKey)
-                ? SelectWallResidentialTileLowMember(commonMaterials, request.VariantSelectionKey)
-                : SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.WallResidentialTileLow.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.WallResidentialPlasterLow.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.IsRobustStructure(attributes) || scale.MidOrHighRise)
         {
-            return SelectWallRcPaintedMidMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.WallRcPaintedMid.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        return SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey);
+        return DefaultMaterialFamilyOverride.WallResidentialPlasterLow.SelectMember(commonMaterials, request.VariantSelectionKey);
     }
 
     private static bool IsWeightedAlternate(string variantSelectionKey)
     {
         return StableVariantSelector.SelectBucket($"{variantSelectionKey}:residential-wall-weight", 5) == 0;
     }
-
-    private static DefaultCommonMaterialMember SelectCityFurnitureMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 6) switch
-        {
-            0 => commonMaterials.CityFurniture.Plaster002,
-            1 => commonMaterials.CityFurniture.Plaster001,
-            2 => commonMaterials.CityFurniture.Plaster003,
-            3 => commonMaterials.CityFurniture.Plaster004,
-            4 => commonMaterials.CityFurniture.Plaster005,
-            _ => commonMaterials.CityFurniture.Plaster006,
-        };
-
-    private static DefaultCommonMaterialMember SelectFacadeHighriseGlassMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 3) switch
-        {
-            0 => commonMaterials.FacadeHighriseGlass.Facade001,
-            1 => commonMaterials.FacadeHighriseGlass.Facade005,
-            _ => commonMaterials.FacadeHighriseGlass.Facade006,
-        };
-
-    private static DefaultCommonMaterialMember SelectFacadeHighriseNightLowMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.FacadeHighriseNightLow.Facade002
-            : commonMaterials.FacadeHighriseNightLow.Facade011;
-
-    private static DefaultCommonMaterialMember SelectFacadeMidriseGridMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.FacadeMidriseGrid.Facade014
-            : commonMaterials.FacadeMidriseGrid.Facade015;
-
-    private static DefaultCommonMaterialMember SelectOtherMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 9) switch
-        {
-            0 => commonMaterials.Other.Concrete012,
-            1 => commonMaterials.Other.Ground054,
-            2 => commonMaterials.Other.Plaster002,
-            3 => commonMaterials.Other.Plaster001,
-            4 => commonMaterials.Other.Plaster003,
-            5 => commonMaterials.Other.Plaster004,
-            6 => commonMaterials.Other.Plaster005,
-            7 => commonMaterials.Other.Plaster006,
-            _ => commonMaterials.Other.TextureCanFacade0022,
-        };
-
-    private static DefaultCommonMaterialMember SelectRoadTriplanarMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 4) switch
-        {
-            0 => commonMaterials.RoadTriplanar.Road012A,
-            1 => commonMaterials.RoadTriplanar.Road013A,
-            2 => commonMaterials.RoadTriplanar.Road014A,
-            _ => commonMaterials.RoadTriplanar.Road015A,
-        };
-
-    private static DefaultCommonMaterialMember SelectRoadUvMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 4) switch
-        {
-            0 => commonMaterials.RoadUv.Road012A,
-            1 => commonMaterials.RoadUv.Road013A,
-            2 => commonMaterials.RoadUv.Road014A,
-            _ => commonMaterials.RoadUv.Road015A,
-        };
-
-    private static DefaultCommonMaterialMember SelectRoofMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 4) switch
-        {
-            0 => commonMaterials.Roof.Concrete012,
-            1 => commonMaterials.Roof.Concrete033,
-            2 => commonMaterials.Roof.RoofingTiles012A,
-            _ => commonMaterials.Roof.RoofingTiles014B,
-        };
-
-    private static DefaultCommonMaterialMember SelectVegetationMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.Vegetation.Ground054
-            : commonMaterials.Vegetation.Concrete012;
-
-    private static DefaultCommonMaterialMember SelectWallApartmentTileMidMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.WallApartmentTileMid.ApartmentTileMid
-            : commonMaterials.WallApartmentTileMid.ApartmentTileDark;
-
-    private static DefaultCommonMaterialMember SelectWallBrickRetroMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.WallBrickRetro.BrickRetro
-            : commonMaterials.WallBrickRetro.BrickDark;
-
-    private static DefaultCommonMaterialMember SelectWallCommercialPanelMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.WallCommercialPanel.CommercialPanel
-            : commonMaterials.WallCommercialPanel.CommercialPanelDark;
-
-    private static DefaultCommonMaterialMember SelectWallRcPaintedMidMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.WallRcPaintedMid.RcPaintedMid
-            : commonMaterials.WallRcPaintedMid.RcPaintedDark;
-
-    private static DefaultCommonMaterialMember SelectWallResidentialPlasterLowMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.WallResidentialPlasterLow.ResidentialPlasterLow
-            : commonMaterials.WallResidentialPlasterLow.ResidentialPlasterDark;
-
-    private static DefaultCommonMaterialMember SelectWallResidentialTileLowMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 4) switch
-        {
-            0 => commonMaterials.WallResidentialTileLow.ResidentialTileLow,
-            1 => commonMaterials.WallResidentialTileLow.ResidentialTileDark,
-            2 => commonMaterials.WallResidentialTileLow.ResidentialTileDarkIrregular,
-            _ => commonMaterials.WallResidentialTileLow.ResidentialSidingBrickGray,
-        };
-
-    private static DefaultCommonMaterialMember SelectWallSchoolPublicBandMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.WallSchoolPublicBand.SchoolPublicBand
-            : commonMaterials.WallSchoolPublicBand.SchoolPublicDark;
 
     private static Float2 ToContractFloat2(Domain.Importing.ScalarPair value) => new(value.X, value.Y);
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
@@ -463,18 +463,22 @@ public sealed class DefaultMaterialResolverTests
     }
 
     [Fact]
-    public void ResolveMaterialRejectsExplicitFacadeOverrideOutsideCodebaseReachableFamilies()
+    public void ResolveMaterialAcceptsEveryTypedFamilyOverride()
     {
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
-            () => resolver.ResolveMaterial(new DefaultMaterialRequest(
+        foreach (DefaultMaterialFamilyOverride familyOverride in DefaultMaterialFamilyOverride.All)
+        {
+            ResolvedMaterial material = resolver.ResolveMaterial(new DefaultMaterialRequest(
                 "bldg",
                 TexturePayload: null,
                 PreferUvProjection: true,
-                FamilyOverride: BundledDefaultMaterialFamilies.Facade,
-                VariantSelectionKey: "bldg:uv:0",
-                SurfaceRole: DefaultMaterialSurfaceRole.Wall)));
+                FamilyOverride: familyOverride,
+                VariantSelectionKey: $"typed-family:{familyOverride.Family}:0",
+                SurfaceRole: DefaultMaterialSurfaceRole.Wall));
 
-        Assert.Contains("not codebase-reachable", error.Message, StringComparison.Ordinal);
+            Assert.Equal(familyOverride.Family, material.Family);
+            Assert.Equal(TextureSourceKind.Bundled, material.TextureSourceKind);
+            Assert.Null(material.TexturePayload);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Replace `DefaultMaterialRequest.FamilyOverride` string input with a typed `DefaultMaterialFamilyOverride` catalog.
- Move codebase-reachable override selection into typed override instances so unsupported override families cannot be represented by callers.
- Replace the invalid facade override exception test with coverage that every typed override resolves to its declared family.

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~DefaultMaterialResolverTests"`
- `dotnet run --project src\PlateauResoniteLink.Cli\PlateauResoniteLink.Cli.csproj --configuration Release --no-restore -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-archive-5039b16c4b1c.zip --geotiff-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-ortho-cc68652cc45c.7z --work-root runtime\windows\resonite --terrain-mesh grid --canonical-scene-dump runtime\windows\resonite\semantic-baselines\type-default-material-family-override\current\higashi-53395325-dem-bldg-grid-geotiff.json`
- `git diff --no-index -- runtime\windows\resonite\semantic-baselines\type-dem-grid-projection-result\baseline-parent\higashi-53395325-dem-bldg-grid-geotiff.json runtime\windows\resonite\semantic-baselines\type-default-material-family-override\current\higashi-53395325-dem-bldg-grid-geotiff.json`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`