### PR TITLE
Use texture source identities

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -197,7 +197,6 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
                     resolvedTexturePath,
                     "sRGB",
                     $"dataset:{resolvedTexturePath}"),
-                $"dataset:{resolvedTexturePath}",
                 TexturePayloadFormat.EncodedImage);
             texturePayloadsByResolvedPath[resolvedTexturePath] = texturePayload;
         }

--- a/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
@@ -33,7 +33,7 @@ internal static class MaterialGroupingPolicy
 
         return new MaterialGroupingKey(
             material.MaterialType,
-            material.TexturePayload?.Identity,
+            material.TexturePayload?.Source.Identity,
             material.TextureSourceKind,
             material.Projection,
             depthOffset,

--- a/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
@@ -18,7 +18,7 @@ internal static class MaterialGroupingPolicy
         {
             return new MaterialGroupingKey(
                 material.MaterialType,
-                TexturePayloadIdentity: null,
+                TextureSourceIdentity: null,
                 material.TextureSourceKind,
                 material.Projection,
                 depthOffset,
@@ -63,7 +63,7 @@ internal static class MaterialGroupingPolicy
 
 internal sealed record MaterialGroupingKey(
     MaterialType MaterialType,
-    string? TexturePayloadIdentity,
+    TextureImportSourceIdentity? TextureSourceIdentity,
     TextureSourceKind TextureSourceKind,
     MaterialProjection Projection,
     MaterialDepthOffset? DepthOffset,

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -142,7 +142,9 @@ public sealed record TexturePayload
         ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
-        Identity = identity ?? source.Identity;
+        string resolvedIdentity = identity ?? source.Identity;
+        ArgumentException.ThrowIfNullOrWhiteSpace(resolvedIdentity, nameof(identity));
+        Identity = resolvedIdentity;
         Format = format;
         Source = source;
     }

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -139,7 +139,7 @@ public sealed record TexturePayload
         Height = height;
         ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(source);
-        ArgumentException.ThrowIfNullOrWhiteSpace(source.Identity, nameof(source));
+        ArgumentException.ThrowIfNullOrWhiteSpace(source.Identity.Value, nameof(source));
         BinaryPayload = [];
         Format = format;
         Source = source;

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -109,13 +109,14 @@ public sealed record TexturePayload
         int? height,
         string? colorProfile,
         byte[] binaryPayload,
-        string? identity = null,
+        string identity,
         TexturePayloadFormat format = TexturePayloadFormat.RawRgba32)
     {
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(binaryPayload);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
         Identity = identity;
         Format = format;
@@ -124,7 +125,7 @@ public sealed record TexturePayload
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"),
+            identity,
             format);
     }
 
@@ -154,7 +155,7 @@ public sealed record TexturePayload
 
     public ImmutableArray<byte> BinaryPayload { get; init; }
 
-    public string? Identity { get; init; }
+    public string Identity { get; init; }
 
     public TexturePayloadFormat Format { get; init; }
 

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -118,7 +118,6 @@ public sealed record TexturePayload
         ArgumentNullException.ThrowIfNull(binaryPayload);
         ArgumentException.ThrowIfNullOrWhiteSpace(identity);
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
-        Identity = identity;
         Format = format;
         Source = TextureImportSourceFactory.CreateInMemory(
             width,
@@ -134,17 +133,14 @@ public sealed record TexturePayload
         int? height,
         string? colorProfile,
         ITextureImportSource source,
-        string? identity = null,
         TexturePayloadFormat format = TexturePayloadFormat.EncodedImage)
     {
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(source.Identity, nameof(source));
         BinaryPayload = [];
-        string resolvedIdentity = identity ?? source.Identity;
-        ArgumentException.ThrowIfNullOrWhiteSpace(resolvedIdentity, nameof(identity));
-        Identity = resolvedIdentity;
         Format = format;
         Source = source;
     }
@@ -156,8 +152,6 @@ public sealed record TexturePayload
     public string? ColorProfile { get; init; }
 
     public ImmutableArray<byte> BinaryPayload { get; init; }
-
-    public string Identity { get; init; }
 
     public TexturePayloadFormat Format { get; init; }
 

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -23,7 +23,7 @@ public sealed record RawTexturePayload(
 
 public interface ITextureImportSource
 {
-    string Identity { get; }
+    TextureImportSourceIdentity Identity { get; }
 
     string Description { get; }
 
@@ -67,12 +67,12 @@ internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
         TexturePayloadFormat sourceFormat)
     {
         ArgumentNullException.ThrowIfNull(bytes);
-        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        TextureImportSourceIdentity resolvedIdentity = new(identity);
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         this.bytes = (byte[])bytes.Clone();
-        Identity = identity;
+        Identity = resolvedIdentity;
         SourceFormat = sourceFormat;
     }
 
@@ -80,7 +80,7 @@ internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
 
     public int? Height { get; }
 
-    public string Identity { get; }
+    public TextureImportSourceIdentity Identity { get; }
 
     public string Description => $"memory:{Identity}";
 
@@ -131,7 +131,7 @@ internal sealed class DatasetTextureImportSource(
     string? colorProfile,
     string identity) : IRawTexturePayloadSource
 {
-    public string Identity { get; } = identity;
+    public TextureImportSourceIdentity Identity { get; } = new(identity);
 
     public string Description => $"dataset:{relativePath}";
 
@@ -154,7 +154,7 @@ internal sealed class FileTextureImportSource(
     string colorProfile,
     string identity) : IRawTexturePayloadSource
 {
-    public string Identity { get; } = identity;
+    public TextureImportSourceIdentity Identity { get; } = new(identity);
 
     public string Description => $"file:{Path.GetFileName(absolutePath)}";
 
@@ -193,7 +193,7 @@ internal sealed class GeneratedTextureImportSource(
     string? colorProfile,
     long? estimatedByteLength = null) : IRawTexturePayloadSource
 {
-    public string Identity { get; } = identity;
+    public TextureImportSourceIdentity Identity { get; } = new(identity);
 
     public string Description { get; } = description;
 

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -226,6 +226,7 @@ internal static class TextureImportSourceFactory
         string? colorProfile,
         string identity)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
         return new DatasetTextureImportSource(datasetSource, relativePath, colorProfile, identity);
     }
 
@@ -236,10 +237,12 @@ internal static class TextureImportSourceFactory
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(absolutePath);
         ArgumentException.ThrowIfNullOrWhiteSpace(colorProfile);
+        string resolvedIdentity = identity ?? $"file:{Path.GetFullPath(absolutePath)}:{colorProfile}";
+        ArgumentException.ThrowIfNullOrWhiteSpace(resolvedIdentity, nameof(identity));
         return new FileTextureImportSource(
             absolutePath,
             colorProfile,
-            identity ?? $"file:{Path.GetFullPath(absolutePath)}:{colorProfile}");
+            resolvedIdentity);
     }
 
     public static ITextureImportSource CreateGeneratedImage(
@@ -249,6 +252,7 @@ internal static class TextureImportSourceFactory
         string? colorProfile,
         long? estimatedByteLength = null)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
         return new GeneratedTextureImportSource(
             materializeRawAsync,
             identity,

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSourceIdentity.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSourceIdentity.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+public readonly record struct TextureImportSourceIdentity
+{
+    public TextureImportSourceIdentity(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    public string Value { get; }
+
+    public override string ToString() => Value;
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
@@ -25,11 +25,12 @@ internal static class ResoniteTextureImportFactory
 
     public static ResoniteTexturePayload CreatePayloadFromImage(
         Image<Rgba32> image,
-        string colorProfile = ResoniteTextureColorProfiles.Srgb,
-        string? identity = null)
+        string identity,
+        string colorProfile = ResoniteTextureColorProfiles.Srgb)
     {
         ArgumentNullException.ThrowIfNull(image);
         ArgumentException.ThrowIfNullOrWhiteSpace(colorProfile);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
 
         RawTexturePayload rawPayload = TextureImportSourceFactory.CreateRawPayloadFromImage(
             image,
@@ -39,7 +40,7 @@ internal static class ResoniteTextureImportFactory
             image.Height,
             colorProfile,
             rawPayload.Bytes,
-            identity ?? Guid.NewGuid().ToString("N"),
+            identity,
             ResoniteTexturePayloadFormat.RawRgba32);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -51,7 +51,9 @@ public sealed record ResoniteTexturePayload
         ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
-        Identity = identity ?? source.Identity;
+        string resolvedIdentity = identity ?? source.Identity;
+        ArgumentException.ThrowIfNullOrWhiteSpace(resolvedIdentity, nameof(identity));
+        Identity = resolvedIdentity;
         Format = format;
         Source = source;
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -48,7 +48,7 @@ public sealed record ResoniteTexturePayload
         Height = height;
         ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(source);
-        ArgumentException.ThrowIfNullOrWhiteSpace(source.Identity, nameof(source));
+        ArgumentException.ThrowIfNullOrWhiteSpace(source.Identity.Value, nameof(source));
         BinaryPayload = [];
         Format = format;
         Source = source;

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -27,7 +27,6 @@ public sealed record ResoniteTexturePayload
         ArgumentNullException.ThrowIfNull(binaryPayload);
         ArgumentException.ThrowIfNullOrWhiteSpace(identity);
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
-        Identity = identity;
         Format = format;
         Source = TextureImportSourceFactory.CreateInMemory(
             width,
@@ -43,17 +42,14 @@ public sealed record ResoniteTexturePayload
         int? height,
         string? colorProfile,
         ITextureImportSource source,
-        string? identity = null,
         ResoniteTexturePayloadFormat format = ResoniteTexturePayloadFormat.EncodedImage)
     {
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(source.Identity, nameof(source));
         BinaryPayload = [];
-        string resolvedIdentity = identity ?? source.Identity;
-        ArgumentException.ThrowIfNullOrWhiteSpace(resolvedIdentity, nameof(identity));
-        Identity = resolvedIdentity;
         Format = format;
         Source = source;
     }
@@ -65,8 +61,6 @@ public sealed record ResoniteTexturePayload
     public string? ColorProfile { get; init; }
 
     public ImmutableArray<byte> BinaryPayload { get; init; }
-
-    public string Identity { get; init; }
 
     public ResoniteTexturePayloadFormat Format { get; init; }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -18,13 +18,14 @@ public sealed record ResoniteTexturePayload
         int? height,
         string? colorProfile,
         byte[] binaryPayload,
-        string? identity = null,
+        string identity,
         ResoniteTexturePayloadFormat format = ResoniteTexturePayloadFormat.RawRgba32)
     {
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(binaryPayload);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
         Identity = identity;
         Format = format;
@@ -33,7 +34,7 @@ public sealed record ResoniteTexturePayload
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"),
+            identity,
             (TexturePayloadFormat)format);
     }
 
@@ -63,7 +64,7 @@ public sealed record ResoniteTexturePayload
 
     public ImmutableArray<byte> BinaryPayload { get; init; }
 
-    public string? Identity { get; init; }
+    public string Identity { get; init; }
 
     public ResoniteTexturePayloadFormat Format { get; init; }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -138,7 +138,6 @@ internal static class SceneImportContractMapper
             payload.Height,
             payload.ColorProfile,
             payload.Source,
-            payload.Identity,
             ToInternal(payload.Format));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
 
@@ -17,24 +18,52 @@ public sealed class TexturePayloadTests
         Assert.Equal<byte>([1, 2, 3, 4], payload.BinaryPayload);
     }
 
+    [Fact]
+    public void SourceBackedConstructorUsesSourceAsIdentityCarrier()
+    {
+        FakeTextureImportSource source = new("source:texture");
+
+        TexturePayload payload = new(
+            width: 1,
+            height: 1,
+            colorProfile: "sRGB",
+            source: source);
+
+        Assert.Same(source, payload.Source);
+        Assert.Equal("source:texture", payload.Source.Identity);
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
-    public void SourceBackedConstructorRejectsBlankResolvedIdentity(string identity)
+    public void SourceBackedConstructorRejectsBlankSourceIdentity(string identity)
     {
-        FakeTextureImportSource source = new(identity);
+        Assert.Throws<ArgumentException>(() => new TexturePayload(
+            width: 1,
+            height: 1,
+            colorProfile: "sRGB",
+            source: new FakeTextureImportSource(identity)));
+    }
 
-        Assert.Throws<ArgumentException>(() => new TexturePayload(
-            width: 1,
-            height: 1,
-            colorProfile: "sRGB",
-            source: source));
-        Assert.Throws<ArgumentException>(() => new TexturePayload(
-            width: 1,
-            height: 1,
-            colorProfile: "sRGB",
-            source: new FakeTextureImportSource("source:texture"),
-            identity: identity));
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void TextureImportSourceFactoryRejectsBlankSourceIdentities(string identity)
+    {
+        Assert.Throws<ArgumentException>(() => TextureImportSourceFactory.CreateDatasetEncodedImage(
+            null!,
+            "textures/albedo.png",
+            "sRGB",
+            identity));
+        Assert.Throws<ArgumentException>(() => TextureImportSourceFactory.CreateFileImage(
+            "textures/albedo.png",
+            "sRGB",
+            identity));
+        Assert.Throws<ArgumentException>(() => TextureImportSourceFactory.CreateGeneratedImage(
+            static _ => ValueTask.FromResult(new RawTexturePayload(1, 1, "sRGB", [0, 0, 0, 255])),
+            identity,
+            "generated",
+            "sRGB"));
     }
 
     private sealed class FakeTextureImportSource(string identity) : ITextureImportSource

--- a/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
@@ -30,7 +30,7 @@ public sealed class TexturePayloadTests
             source: source);
 
         Assert.Same(source, payload.Source);
-        Assert.Equal("source:texture", payload.Source.Identity);
+        Assert.Equal(new TextureImportSourceIdentity("source:texture"), payload.Source.Identity);
     }
 
     [Theory]
@@ -43,6 +43,16 @@ public sealed class TexturePayloadTests
             height: 1,
             colorProfile: "sRGB",
             source: new FakeTextureImportSource(identity)));
+    }
+
+    [Fact]
+    public void SourceBackedConstructorRejectsDefaultSourceIdentity()
+    {
+        Assert.ThrowsAny<ArgumentException>(() => new TexturePayload(
+            width: 1,
+            height: 1,
+            colorProfile: "sRGB",
+            source: new DefaultIdentityTextureImportSource()));
     }
 
     [Theory]
@@ -68,7 +78,18 @@ public sealed class TexturePayloadTests
 
     private sealed class FakeTextureImportSource(string identity) : ITextureImportSource
     {
-        public string Identity { get; } = identity;
+        public TextureImportSourceIdentity Identity { get; } = new(identity);
+
+        public string Description => "fake texture";
+
+        public string? ColorProfile => "sRGB";
+
+        public long? EstimatedByteLength => null;
+    }
+
+    private sealed class DefaultIdentityTextureImportSource : ITextureImportSource
+    {
+        public TextureImportSourceIdentity Identity => default;
 
         public string Description => "fake texture";
 

--- a/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using PlateauResoniteLink.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.Application;
@@ -13,5 +15,36 @@ public sealed class TexturePayloadTests
         source[0] = 9;
 
         Assert.Equal<byte>([1, 2, 3, 4], payload.BinaryPayload);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void SourceBackedConstructorRejectsBlankResolvedIdentity(string identity)
+    {
+        FakeTextureImportSource source = new(identity);
+
+        Assert.Throws<ArgumentException>(() => new TexturePayload(
+            width: 1,
+            height: 1,
+            colorProfile: "sRGB",
+            source: source));
+        Assert.Throws<ArgumentException>(() => new TexturePayload(
+            width: 1,
+            height: 1,
+            colorProfile: "sRGB",
+            source: new FakeTextureImportSource("source:texture"),
+            identity: identity));
+    }
+
+    private sealed class FakeTextureImportSource(string identity) : ITextureImportSource
+    {
+        public string Identity { get; } = identity;
+
+        public string Description => "fake texture";
+
+        public string? ColorProfile => "sRGB";
+
+        public long? EstimatedByteLength => null;
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -2072,10 +2072,10 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Equal(3, projected.Materials.Count);
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "ground");
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "ground-reversed");
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "outer-floor");
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity == "high-outer-floor");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "ground");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "ground-reversed");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "outer-floor");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "high-outer-floor");
     }
 
     [Fact]
@@ -2112,7 +2112,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Single(projected.Materials);
-        Assert.Equal("tran-ground", projected.Materials[0].TexturePayload?.Source.Identity);
+        Assert.Equal("tran-ground", projected.Materials[0].TexturePayload?.Source.Identity.Value);
         Assert.NotEmpty(projected.Mesh.Vertices);
     }
 
@@ -2170,10 +2170,10 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Equal(2, projected.Materials.Count);
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "lod1-bottom");
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "lod1-bottom-reversed");
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity == "lod1-roof");
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity == "lod1-wall");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "lod1-bottom");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "lod1-bottom-reversed");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "lod1-roof");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "lod1-wall");
     }
 
     [Fact]
@@ -2245,7 +2245,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Single(projected.Materials);
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity == "only-surface");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "only-surface");
     }
 
     [Fact]
@@ -2377,7 +2377,7 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.NotNull(explicitMaterial.TexturePayload);
         Assert.Contains(
             "udx/dem/53394525/appearance/mixed_surface.png",
-            explicitMaterial.TexturePayload!.Source.Identity,
+            explicitMaterial.TexturePayload!.Source.Identity.Value,
             StringComparison.Ordinal);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -2072,10 +2072,10 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Equal(3, projected.Materials.Count);
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "ground");
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "ground-reversed");
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "outer-floor");
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Identity == "high-outer-floor");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "ground");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "ground-reversed");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "outer-floor");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity == "high-outer-floor");
     }
 
     [Fact]
@@ -2112,7 +2112,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Single(projected.Materials);
-        Assert.Equal("tran-ground", projected.Materials[0].TexturePayload?.Identity);
+        Assert.Equal("tran-ground", projected.Materials[0].TexturePayload?.Source.Identity);
         Assert.NotEmpty(projected.Mesh.Vertices);
     }
 
@@ -2170,10 +2170,10 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Equal(2, projected.Materials.Count);
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "lod1-bottom");
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "lod1-bottom-reversed");
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Identity == "lod1-roof");
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Identity == "lod1-wall");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "lod1-bottom");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "lod1-bottom-reversed");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity == "lod1-roof");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity == "lod1-wall");
     }
 
     [Fact]
@@ -2245,7 +2245,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Single(projected.Materials);
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Identity == "only-surface");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity == "only-surface");
     }
 
     [Fact]
@@ -2377,7 +2377,7 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.NotNull(explicitMaterial.TexturePayload);
         Assert.Contains(
             "udx/dem/53394525/appearance/mixed_surface.png",
-            explicitMaterial.TexturePayload!.Identity,
+            explicitMaterial.TexturePayload!.Source.Identity,
             StringComparison.Ordinal);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -122,7 +122,7 @@ public sealed class NonDemCityObjectBakerTests
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
 
         string?[] identities = cityObject.Materials
-            .Select(static material => material.TexturePayload?.Identity)
+            .Select(static material => material.TexturePayload?.Source.Identity)
             .ToArray();
         Assert.Collection(
             identities,
@@ -151,7 +151,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(CommonMaterialCatalog.Create().Generic.Uv, material.CommonMaterial);
         Assert.NotSame(payload, material.TexturePayload);
         Assert.NotNull(material.TexturePayload);
-        Assert.Contains("atlastex-", material.TexturePayload.Identity, StringComparison.Ordinal);
+        Assert.Contains("atlastex-", material.TexturePayload.Source.Identity, StringComparison.Ordinal);
         Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, material.TexturePayload.Format);
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
@@ -193,7 +193,7 @@ public sealed class NonDemCityObjectBakerTests
             double averageX = submesh.TriangleVertexIndices
                 .Select(index => cityObject.Mesh.Vertices[index].Position.X)
                 .Average();
-            averageXByPayloadIdentity.Add(material.TexturePayload?.Identity ?? string.Empty, averageX);
+            averageXByPayloadIdentity.Add(material.TexturePayload?.Source.Identity ?? string.Empty, averageX);
         }
 
         Assert.True(averageXByPayloadIdentity["textures/left.png"] < averageXByPayloadIdentity["textures/right.png"]);
@@ -590,7 +590,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(oversizedCandidate.DisplayName, cityObject.DisplayName);
         Assert.Equal(oversizedCandidate.Materials.Count, cityObject.Materials.Count);
         Assert.All(cityObject.Materials, static material => Assert.NotNull(material.TexturePayload));
-        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Source.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -615,7 +615,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(new ResoniteFloat2(0.25, 0.75), cityObject.Mesh.Vertices[0].UV0);
         Assert.Equal(new ResoniteFloat2(2.25, 0.75), cityObject.Mesh.Vertices[1].UV0);
         Assert.Equal(new ResoniteFloat2(0.25, 1.25), cityObject.Mesh.Vertices[2].UV0);
-        Assert.DoesNotContain(cityObject.Materials, static candidate => candidate.TexturePayload?.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(cityObject.Materials, static candidate => candidate.TexturePayload?.Source.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -791,7 +791,7 @@ public sealed class NonDemCityObjectBakerTests
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         Assert.Equal(oversizedCandidate.SlotKey, cityObject.SlotKey);
-        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Source.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -1025,7 +1025,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal("atlasbake-unit-a-bldg-lod2-3", cityObject.SlotKey);
         Assert.Equal(
             "atlastex-unit-a.gml-3",
-            Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Identity);
+            Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Source.Identity);
     }
 
     private static NonDemCityObjectBaker CreateBaker(

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -122,7 +122,7 @@ public sealed class NonDemCityObjectBakerTests
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
 
         string?[] identities = cityObject.Materials
-            .Select(static material => material.TexturePayload?.Source.Identity)
+            .Select(static material => material.TexturePayload?.Source.Identity.Value)
             .ToArray();
         Assert.Collection(
             identities,
@@ -151,7 +151,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(CommonMaterialCatalog.Create().Generic.Uv, material.CommonMaterial);
         Assert.NotSame(payload, material.TexturePayload);
         Assert.NotNull(material.TexturePayload);
-        Assert.Contains("atlastex-", material.TexturePayload.Source.Identity, StringComparison.Ordinal);
+        Assert.Contains("atlastex-", material.TexturePayload.Source.Identity.Value, StringComparison.Ordinal);
         Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, material.TexturePayload.Format);
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
@@ -193,7 +193,7 @@ public sealed class NonDemCityObjectBakerTests
             double averageX = submesh.TriangleVertexIndices
                 .Select(index => cityObject.Mesh.Vertices[index].Position.X)
                 .Average();
-            averageXByPayloadIdentity.Add(material.TexturePayload?.Source.Identity ?? string.Empty, averageX);
+            averageXByPayloadIdentity.Add(material.TexturePayload?.Source.Identity.Value ?? string.Empty, averageX);
         }
 
         Assert.True(averageXByPayloadIdentity["textures/left.png"] < averageXByPayloadIdentity["textures/right.png"]);
@@ -590,7 +590,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(oversizedCandidate.DisplayName, cityObject.DisplayName);
         Assert.Equal(oversizedCandidate.Materials.Count, cityObject.Materials.Count);
         Assert.All(cityObject.Materials, static material => Assert.NotNull(material.TexturePayload));
-        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Source.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Source.Identity.Value.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -615,7 +615,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(new ResoniteFloat2(0.25, 0.75), cityObject.Mesh.Vertices[0].UV0);
         Assert.Equal(new ResoniteFloat2(2.25, 0.75), cityObject.Mesh.Vertices[1].UV0);
         Assert.Equal(new ResoniteFloat2(0.25, 1.25), cityObject.Mesh.Vertices[2].UV0);
-        Assert.DoesNotContain(cityObject.Materials, static candidate => candidate.TexturePayload?.Source.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(cityObject.Materials, static candidate => candidate.TexturePayload?.Source.Identity.Value.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -791,7 +791,7 @@ public sealed class NonDemCityObjectBakerTests
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         Assert.Equal(oversizedCandidate.SlotKey, cityObject.SlotKey);
-        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Source.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Source.Identity.Value.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -1025,7 +1025,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal("atlasbake-unit-a-bldg-lod2-3", cityObject.SlotKey);
         Assert.Equal(
             "atlastex-unit-a.gml-3",
-            Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Source.Identity);
+            Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Source.Identity.Value);
     }
 
     private static NonDemCityObjectBaker CreateBaker(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -546,7 +546,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             payload.Height,
             payload.ColorProfile,
             payload.BinaryPayload.AsSpan().ToArray(),
-            payload.Source.Identity,
+            payload.Source.Identity.Value,
             (TexturePayloadFormat)payload.Format);
 
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -546,7 +546,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             payload.Height,
             payload.ColorProfile,
             payload.BinaryPayload.AsSpan().ToArray(),
-            payload.Identity,
+            payload.Source.Identity,
             (TexturePayloadFormat)payload.Format);
 
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
@@ -30,7 +30,7 @@ public sealed class ResoniteTexturePayloadTests
             source: source);
 
         Assert.Same(source, payload.Source);
-        Assert.Equal("source:texture", payload.Source.Identity);
+        Assert.Equal(new TextureImportSourceIdentity("source:texture"), payload.Source.Identity);
     }
 
     [Theory]
@@ -45,9 +45,30 @@ public sealed class ResoniteTexturePayloadTests
             source: new FakeTextureImportSource(identity)));
     }
 
+    [Fact]
+    public void SourceBackedConstructorRejectsDefaultSourceIdentity()
+    {
+        Assert.ThrowsAny<ArgumentException>(() => new ResoniteTexturePayload(
+            width: 1,
+            height: 1,
+            colorProfile: "sRGB",
+            source: new DefaultIdentityTextureImportSource()));
+    }
+
     private sealed class FakeTextureImportSource(string identity) : ITextureImportSource
     {
-        public string Identity { get; } = identity;
+        public TextureImportSourceIdentity Identity { get; } = new(identity);
+
+        public string Description => "fake texture";
+
+        public string? ColorProfile => "sRGB";
+
+        public long? EstimatedByteLength => null;
+    }
+
+    private sealed class DefaultIdentityTextureImportSource : ITextureImportSource
+    {
+        public TextureImportSourceIdentity Identity => default;
 
         public string Description => "fake texture";
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
@@ -1,3 +1,6 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Targets;
@@ -13,5 +16,36 @@ public sealed class ResoniteTexturePayloadTests
         source[0] = 9;
 
         Assert.Equal<byte>([4, 3, 2, 1], payload.BinaryPayload);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void SourceBackedConstructorRejectsBlankResolvedIdentity(string identity)
+    {
+        FakeTextureImportSource source = new(identity);
+
+        Assert.Throws<ArgumentException>(() => new ResoniteTexturePayload(
+            width: 1,
+            height: 1,
+            colorProfile: "sRGB",
+            source: source));
+        Assert.Throws<ArgumentException>(() => new ResoniteTexturePayload(
+            width: 1,
+            height: 1,
+            colorProfile: "sRGB",
+            source: new FakeTextureImportSource("source:texture"),
+            identity: identity));
+    }
+
+    private sealed class FakeTextureImportSource(string identity) : ITextureImportSource
+    {
+        public string Identity { get; } = identity;
+
+        public string Description => "fake texture";
+
+        public string? ColorProfile => "sRGB";
+
+        public long? EstimatedByteLength => null;
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
@@ -18,24 +18,31 @@ public sealed class ResoniteTexturePayloadTests
         Assert.Equal<byte>([4, 3, 2, 1], payload.BinaryPayload);
     }
 
+    [Fact]
+    public void SourceBackedConstructorUsesSourceAsIdentityCarrier()
+    {
+        FakeTextureImportSource source = new("source:texture");
+
+        ResoniteTexturePayload payload = new(
+            width: 1,
+            height: 1,
+            colorProfile: "sRGB",
+            source: source);
+
+        Assert.Same(source, payload.Source);
+        Assert.Equal("source:texture", payload.Source.Identity);
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
-    public void SourceBackedConstructorRejectsBlankResolvedIdentity(string identity)
+    public void SourceBackedConstructorRejectsBlankSourceIdentity(string identity)
     {
-        FakeTextureImportSource source = new(identity);
-
         Assert.Throws<ArgumentException>(() => new ResoniteTexturePayload(
             width: 1,
             height: 1,
             colorProfile: "sRGB",
-            source: source));
-        Assert.Throws<ArgumentException>(() => new ResoniteTexturePayload(
-            width: 1,
-            height: 1,
-            colorProfile: "sRGB",
-            source: new FakeTextureImportSource("source:texture"),
-            identity: identity));
+            source: new FakeTextureImportSource(identity)));
     }
 
     private sealed class FakeTextureImportSource(string identity) : ITextureImportSource

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -32,7 +32,7 @@ public sealed class SceneImportContractMapperTests
 
         Assert.Equal(0.1, mapped.BaseColor.R, 9);
         Assert.Equal(0.2, mapped.BaseColor.G, 9);
-        Assert.Equal("dataset:texture", mapped.TexturePayload!.Identity);
+        Assert.Equal("dataset:texture", mapped.TexturePayload!.Source.Identity);
         Assert.Equal(ResoniteTexturePayloadFormat.EncodedImage, mapped.TexturePayload.Format);
         Assert.Equal(-1.5, mapped.DepthOffset!.Factor, 9);
         Assert.Equal(2.5, mapped.DepthOffset.Units, 9);

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -32,7 +32,7 @@ public sealed class SceneImportContractMapperTests
 
         Assert.Equal(0.1, mapped.BaseColor.R, 9);
         Assert.Equal(0.2, mapped.BaseColor.G, 9);
-        Assert.Equal("dataset:texture", mapped.TexturePayload!.Source.Identity);
+        Assert.Equal(new TextureImportSourceIdentity("dataset:texture"), mapped.TexturePayload!.Source.Identity);
         Assert.Equal(ResoniteTexturePayloadFormat.EncodedImage, mapped.TexturePayload.Format);
         Assert.Equal(-1.5, mapped.DepthOffset!.Factor, 9);
         Assert.Equal(2.5, mapped.DepthOffset.Units, 9);

--- a/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
@@ -382,7 +382,7 @@ public sealed class ResoniteLinkClientTests
     {
         public int MaterializeCallCount { get; private set; }
 
-        public string Identity => "instrumented";
+        public TextureImportSourceIdentity Identity { get; } = new("instrumented");
 
         public string Description => "instrumented";
 


### PR DESCRIPTION
## Summary
- Remove texture payload-level identity and use `ITextureImportSource.Identity` as the single texture identity boundary.
- Require generated/in-memory texture sources to be created with a non-blank source identity instead of falling back to random `Guid` values.
- Keep grouping, mapping, and Resonite import paths reading identity from the texture source, not from a duplicate payload field.

## Review response
- The earlier payload `Identity` property was removed because it was not a separately justified domain boundary.
- The remaining invariant is narrower: a texture import source must have a stable non-blank identity before it can enter material grouping/reuse/import paths.
- This avoids carrying a second same-shape identity field on `TexturePayload` / `ResoniteTexturePayload`.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (998 passed)
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020` mesh `53395325`, packages `dem,bldg`, grid terrain, with GeoTIFF source
- `git diff --no-index` against `semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json` produced no diff; temporary dump removed