### PR TITLE
Type building metric values

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/BuildingAttributeModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/BuildingAttributeModels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace PlateauResoniteLink.Application.Importing;
@@ -49,28 +50,36 @@ internal enum PlateauBuildingStructure
     Other,
 }
 
-internal enum BuildingMetricValueKind
-{
-    Missing = 0,
-    Known,
-    Invalid,
-}
-
 internal sealed record BuildingCodeValue<T>(T Value, string Code);
 
-internal sealed record BuildingMetricValue(BuildingMetricValueKind Kind, double? Value, string? Raw)
+internal abstract record BuildingMetricValue
 {
-    public static BuildingMetricValue Missing { get; } = new(BuildingMetricValueKind.Missing, null, null);
+    public static BuildingMetricValue Missing { get; } = new MissingBuildingMetricValue();
 
     public static BuildingMetricValue Known(double value)
     {
-        return new BuildingMetricValue(BuildingMetricValueKind.Known, value, null);
+        return new KnownBuildingMetricValue(value);
     }
 
     public static BuildingMetricValue Invalid(string raw)
     {
-        return new BuildingMetricValue(BuildingMetricValueKind.Invalid, null, raw);
+        return new InvalidBuildingMetricValue(raw);
     }
+}
+
+internal sealed record MissingBuildingMetricValue : BuildingMetricValue;
+
+internal sealed record KnownBuildingMetricValue(double Value) : BuildingMetricValue;
+
+internal sealed record InvalidBuildingMetricValue : BuildingMetricValue
+{
+    public InvalidBuildingMetricValue(string raw)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(raw);
+        Raw = raw;
+    }
+
+    public string Raw { get; }
 }
 
 internal sealed record BuildingAttributeContext(

--- a/src/PlateauResoniteLink/Application/Importing/BuildingAttributeParser.cs
+++ b/src/PlateauResoniteLink/Application/Importing/BuildingAttributeParser.cs
@@ -133,6 +133,11 @@ internal static class BuildingAttributeParser
         }
 
         string rawValue = element.Value.Trim();
+        if (string.IsNullOrEmpty(rawValue))
+        {
+            return BuildingMetricValue.Missing;
+        }
+
         if (IsPlateauMissingMetricToken(rawValue))
         {
             return BuildingMetricValue.Missing;
@@ -152,6 +157,11 @@ internal static class BuildingAttributeParser
         }
 
         string rawValue = element.Value.Trim();
+        if (string.IsNullOrEmpty(rawValue))
+        {
+            return BuildingMetricValue.Missing;
+        }
+
         if (IsPlateauMissingMetricToken(rawValue))
         {
             return BuildingMetricValue.Missing;

--- a/src/PlateauResoniteLink/Application/Importing/BuildingAttributeQueries.cs
+++ b/src/PlateauResoniteLink/Application/Importing/BuildingAttributeQueries.cs
@@ -9,13 +9,13 @@ internal static class BuildingAttributeQueries
 {
     internal static int? TryGetKnownPositiveInteger(BuildingMetricValue metric)
     {
-        if (metric.Kind != BuildingMetricValueKind.Known || !metric.Value.HasValue)
+        if (metric is not KnownBuildingMetricValue known)
         {
             return null;
         }
 
-        int value = (int)Math.Round(metric.Value.Value, MidpointRounding.AwayFromZero);
-        return Math.Abs(metric.Value.Value - value) < 1e-9
+        int value = (int)Math.Round(known.Value, MidpointRounding.AwayFromZero);
+        return Math.Abs(known.Value - value) < 1e-9
             && (value == 0 || FacadeFloorMetrics.IsUsableFloorCount(value))
                 ? value
                 : null;
@@ -23,8 +23,8 @@ internal static class BuildingAttributeQueries
 
     internal static double? TryGetKnownPositiveMetric(BuildingMetricValue metric)
     {
-        return metric.Kind == BuildingMetricValueKind.Known && metric.Value is > 0.0
-            ? metric.Value
+        return metric is KnownBuildingMetricValue { Value: > 0.0 } known
+            ? known.Value
             : null;
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/BuildingAttributeParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/BuildingAttributeParserTests.cs
@@ -49,9 +49,9 @@ public sealed class BuildingAttributeParserTests
 
         BuildingAttributeContext attributes = BuildingAttributeParser.Parse(element);
 
-        Assert.Equal(BuildingMetricValueKind.Missing, attributes.MeasuredHeightMeters.Kind);
-        Assert.Equal(BuildingMetricValueKind.Missing, attributes.StoreysAboveGround.Kind);
-        Assert.Equal(BuildingMetricValueKind.Missing, attributes.StoreysBelowGround.Kind);
+        Assert.IsType<MissingBuildingMetricValue>(attributes.MeasuredHeightMeters);
+        Assert.IsType<MissingBuildingMetricValue>(attributes.StoreysAboveGround);
+        Assert.IsType<MissingBuildingMetricValue>(attributes.StoreysBelowGround);
     }
 
     [Fact]
@@ -70,12 +70,12 @@ public sealed class BuildingAttributeParserTests
 
         BuildingAttributeContext attributes = BuildingAttributeParser.Parse(element);
 
-        Assert.Equal(BuildingMetricValueKind.Invalid, attributes.MeasuredHeightMeters.Kind);
-        Assert.Equal("12", attributes.MeasuredHeightMeters.Raw);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.BuildingFootprintArea.Kind);
-        Assert.Equal(160.5, attributes.BuildingFootprintArea.Value);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.BuildingHeight.Kind);
-        Assert.Equal(9.25, attributes.BuildingHeight.Value);
+        InvalidBuildingMetricValue measuredHeight = Assert.IsType<InvalidBuildingMetricValue>(attributes.MeasuredHeightMeters);
+        Assert.Equal("12", measuredHeight.Raw);
+        KnownBuildingMetricValue footprintArea = Assert.IsType<KnownBuildingMetricValue>(attributes.BuildingFootprintArea);
+        Assert.Equal(160.5, footprintArea.Value);
+        KnownBuildingMetricValue buildingHeight = Assert.IsType<KnownBuildingMetricValue>(attributes.BuildingHeight);
+        Assert.Equal(9.25, buildingHeight.Value);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Profiles/BuildingAttributeParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/BuildingAttributeParserTests.cs
@@ -55,6 +55,27 @@ public sealed class BuildingAttributeParserTests
     }
 
     [Fact]
+    public void ParseTreatsBlankMetricElementsAsMissingMetrics()
+    {
+        XElement element = XElement.Parse(
+            """
+            <bldg:Building xmlns:bldg="urn:bldg">
+              <bldg:measuredHeight uom="m"> </bldg:measuredHeight>
+              <bldg:storeysAboveGround />
+              <bldg:BuildingDetailAttribute>
+                <bldg:buildingFootprintArea uom="m2"></bldg:buildingFootprintArea>
+              </bldg:BuildingDetailAttribute>
+            </bldg:Building>
+            """);
+
+        BuildingAttributeContext attributes = BuildingAttributeParser.Parse(element);
+
+        Assert.IsType<MissingBuildingMetricValue>(attributes.MeasuredHeightMeters);
+        Assert.IsType<MissingBuildingMetricValue>(attributes.StoreysAboveGround);
+        Assert.IsType<MissingBuildingMetricValue>(attributes.BuildingFootprintArea);
+    }
+
+    [Fact]
     public void ParseRejectsNonMeterHeightButKeepsAreaWithoutMeterRequirement()
     {
         XElement element = XElement.Parse(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
@@ -172,15 +172,15 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
         Assert.Contains(attributes.Structures, value => value.Value == PlateauBuildingStructure.Wood && value.Code == "601");
         Assert.Equal(["3001"], attributes.CityGmlClassCodes);
         Assert.Equal(["401"], attributes.CityGmlFunctionCodes);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.MeasuredHeightMeters.Kind);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.StoreysAboveGround.Kind);
-        Assert.Equal(BuildingMetricValueKind.Missing, attributes.StoreysBelowGround.Kind);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.BuildingFootprintArea.Kind);
-        Assert.Equal(BuildingMetricValueKind.Missing, attributes.BuildingRoofEdgeArea.Kind);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.BuildingHeight.Kind);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.EaveHeight.Kind);
-        Assert.InRange(attributes.BuildingFootprintArea.Value!.Value, 120.499999, 120.500001);
-        Assert.InRange(attributes.EaveHeight.Value!.Value, 9.699999, 9.700001);
+        Assert.IsType<KnownBuildingMetricValue>(attributes.MeasuredHeightMeters);
+        Assert.IsType<KnownBuildingMetricValue>(attributes.StoreysAboveGround);
+        Assert.IsType<MissingBuildingMetricValue>(attributes.StoreysBelowGround);
+        KnownBuildingMetricValue footprintArea = Assert.IsType<KnownBuildingMetricValue>(attributes.BuildingFootprintArea);
+        Assert.IsType<MissingBuildingMetricValue>(attributes.BuildingRoofEdgeArea);
+        Assert.IsType<KnownBuildingMetricValue>(attributes.BuildingHeight);
+        KnownBuildingMetricValue eaveHeight = Assert.IsType<KnownBuildingMetricValue>(attributes.EaveHeight);
+        Assert.InRange(footprintArea.Value, 120.499999, 120.500001);
+        Assert.InRange(eaveHeight.Value, 9.699999, 9.700001);
     }
 
     private static async Task<ParsedCityObject> ParseSingleBuildingWithDetailAttributeAsync(string detailAttributeXml)


### PR DESCRIPTION
## Summary
- Replace BuildingMetricValue's kind + nullable payload shape with explicit missing, known, and invalid record variants.
- Move query code to pattern match the known variant instead of checking nullable Value after Kind.
- Update parser/streaming tests to assert the metric variant types directly.

## Verification
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~BuildingAttributeParserTests|FullyQualifiedName~LocalCityGmlSourceFileParserStreamingTests|FullyQualifiedName~Lod1RoofShapePolicyTests|FullyQualifiedName~DefaultMaterialResolverTests"
- dotnet run --project src\PlateauResoniteLink.Cli\PlateauResoniteLink.Cli.csproj --configuration Release --no-restore -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-archive-5039b16c4b1c.zip --geotiff-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-ortho-cc68652cc45c.7z --work-root runtime\windows\resonite --terrain-mesh grid --canonical-scene-dump runtime\windows\resonite\semantic-baselines\type-building-metric-value\current\higashi-53395325-dem-bldg-grid-geotiff.json
- git diff --no-index -- runtime\windows\resonite\semantic-baselines\type-dem-grid-projection-result\baseline-parent\higashi-53395325-dem-bldg-grid-geotiff.json runtime\windows\resonite\semantic-baselines\type-building-metric-value\current\higashi-53395325-dem-bldg-grid-geotiff.json
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false