### PR TITLE
Map scene contract enums explicitly

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -113,10 +113,10 @@ internal static class SceneImportContractMapper
     {
         return new ResoniteMaterialBinding(
             ToInternal(binding.BaseColor),
-            (ResoniteMaterialType)binding.MaterialType,
+            ToInternal(binding.MaterialType),
             binding.TexturePayload is null ? null : ToInternal(binding.TexturePayload),
-            (ResoniteTextureSourceKind)binding.TextureSourceKind,
-            (ResoniteMaterialProjection)binding.Projection,
+            ToInternal(binding.TextureSourceKind),
+            ToInternal(binding.Projection),
             binding.DepthOffset is null ? null : ToInternal(binding.DepthOffset),
             binding.SubmeshIndices,
             binding.TextureScale is null ? null : ToInternal(binding.TextureScale),
@@ -139,7 +139,48 @@ internal static class SceneImportContractMapper
             payload.ColorProfile,
             payload.Source,
             payload.Identity,
-            (ResoniteTexturePayloadFormat)payload.Format);
+            ToInternal(payload.Format));
+    }
+
+    private static ResoniteMaterialType ToInternal(MaterialType materialType)
+    {
+        return materialType switch
+        {
+            MaterialType.Standard => ResoniteMaterialType.Standard,
+            MaterialType.Wireframe => ResoniteMaterialType.Wireframe,
+            MaterialType.VertexColor => ResoniteMaterialType.VertexColor,
+            _ => throw new ArgumentOutOfRangeException(nameof(materialType), materialType, "Unsupported material type."),
+        };
+    }
+
+    private static ResoniteTextureSourceKind ToInternal(TextureSourceKind sourceKind)
+    {
+        return sourceKind switch
+        {
+            TextureSourceKind.Dataset => ResoniteTextureSourceKind.Dataset,
+            TextureSourceKind.Bundled => ResoniteTextureSourceKind.Bundled,
+            _ => throw new ArgumentOutOfRangeException(nameof(sourceKind), sourceKind, "Unsupported texture source kind."),
+        };
+    }
+
+    private static ResoniteMaterialProjection ToInternal(MaterialProjection projection)
+    {
+        return projection switch
+        {
+            MaterialProjection.Uv => ResoniteMaterialProjection.Uv,
+            MaterialProjection.Triplanar => ResoniteMaterialProjection.Triplanar,
+            _ => throw new ArgumentOutOfRangeException(nameof(projection), projection, "Unsupported material projection."),
+        };
+    }
+
+    private static ResoniteTexturePayloadFormat ToInternal(TexturePayloadFormat format)
+    {
+        return format switch
+        {
+            TexturePayloadFormat.RawRgba32 => ResoniteTexturePayloadFormat.RawRgba32,
+            TexturePayloadFormat.EncodedImage => ResoniteTexturePayloadFormat.EncodedImage,
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported texture payload format."),
+        };
     }
 
     private static ResoniteMaterialDepthOffset ToInternal(MaterialDepthOffset value) => new(value.Factor, value.Units);

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
@@ -38,6 +40,26 @@ public sealed class SceneImportContractMapperTests
         Assert.Equal(0.125, mapped.TextureOffset!.Y, 9);
         Assert.Equal(ResoniteMaterialAssetScope.Common, mapped.AssetScope);
         Assert.Equal(3, mapped.BundledVariantIndex);
+    }
+
+    [Theory]
+    [InlineData("materialType")]
+    [InlineData("textureSourceKind")]
+    [InlineData("projection")]
+    [InlineData("texturePayloadFormat")]
+    public void ToInternalMaterialBindingsRejectsUnsupportedContractEnumValues(string invalidField)
+    {
+        MaterialBinding binding = CreateValidBinding() with
+        {
+            MaterialType = invalidField == "materialType" ? (MaterialType)999 : MaterialType.Standard,
+            TextureSourceKind = invalidField == "textureSourceKind" ? (TextureSourceKind)999 : TextureSourceKind.Dataset,
+            Projection = invalidField == "projection" ? (MaterialProjection)999 : MaterialProjection.Uv,
+            TexturePayload = invalidField == "texturePayloadFormat"
+                ? new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", (TexturePayloadFormat)999)
+                : new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => SceneImportContractMapper.ToInternal(binding));
     }
 
     [Fact]
@@ -108,5 +130,17 @@ public sealed class SceneImportContractMapperTests
         Assert.Same(overlay, mapped.TerrainOverlay);
         Assert.Equal("53394525", mapped.TerrainMeshCode);
         Assert.Null(mapped.CommonMaterial);
+    }
+
+    private static MaterialBinding CreateValidBinding()
+    {
+        return new MaterialBinding(
+            BaseColor: new ColorRgba(0.1, 0.2, 0.3, 0.4),
+            MaterialType: MaterialType.Standard,
+            TexturePayload: new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
+            TextureSourceKind: TextureSourceKind.Dataset,
+            Projection: MaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0]);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -43,18 +43,18 @@ public sealed class SceneImportContractMapperTests
     }
 
     [Theory]
-    [InlineData("materialType")]
-    [InlineData("textureSourceKind")]
-    [InlineData("projection")]
-    [InlineData("texturePayloadFormat")]
+    [InlineData(nameof(MaterialBinding.MaterialType))]
+    [InlineData(nameof(MaterialBinding.TextureSourceKind))]
+    [InlineData(nameof(MaterialBinding.Projection))]
+    [InlineData(nameof(TexturePayload.Format))]
     public void ToInternalMaterialBindingsRejectsUnsupportedContractEnumValues(string invalidField)
     {
         MaterialBinding binding = CreateValidBinding() with
         {
-            MaterialType = invalidField == "materialType" ? (MaterialType)999 : MaterialType.Standard,
-            TextureSourceKind = invalidField == "textureSourceKind" ? (TextureSourceKind)999 : TextureSourceKind.Dataset,
-            Projection = invalidField == "projection" ? (MaterialProjection)999 : MaterialProjection.Uv,
-            TexturePayload = invalidField == "texturePayloadFormat"
+            MaterialType = invalidField == nameof(MaterialBinding.MaterialType) ? (MaterialType)999 : MaterialType.Standard,
+            TextureSourceKind = invalidField == nameof(MaterialBinding.TextureSourceKind) ? (TextureSourceKind)999 : TextureSourceKind.Dataset,
+            Projection = invalidField == nameof(MaterialBinding.Projection) ? (MaterialProjection)999 : MaterialProjection.Uv,
+            TexturePayload = invalidField == nameof(TexturePayload.Format)
                 ? new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", (TexturePayloadFormat)999)
                 : new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
         };


### PR DESCRIPTION
## Summary
- Replace SceneImportContractMapper enum casts with explicit switch mappings for material type, texture source kind, material projection, and texture payload format.
- Add mapper regression coverage so unsupported contract enum values cannot silently flow into Resonite target enums.

## Verification
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~SceneImportContractMapperTests"
- dotnet run --project src\PlateauResoniteLink.Cli\PlateauResoniteLink.Cli.csproj --configuration Release --no-restore -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-archive-5039b16c4b1c.zip --geotiff-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-ortho-cc68652cc45c.7z --work-root runtime\windows\resonite --terrain-mesh grid --canonical-scene-dump runtime\windows\resonite\semantic-baselines\type-scene-contract-enum-mapping\current\higashi-53395325-dem-bldg-grid-geotiff.json
- git diff --no-index -- runtime\windows\resonite\semantic-baselines\type-dem-grid-projection-result\baseline-parent\higashi-53395325-dem-bldg-grid-geotiff.json runtime\windows\resonite\semantic-baselines\type-scene-contract-enum-mapping\current\higashi-53395325-dem-bldg-grid-geotiff.json
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false