### PR TITLE
Use overlay mesh code for material binding

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -138,12 +138,12 @@ internal static class CityGmlSurfaceMaterialResolver
         ResolvedSurfaceMaterial representativeSurface,
         int materialIndex)
     {
-        ThirdRegionalMeshCode? terrainMeshCode = representativeSurface.Material.TerrainOverlay?.MeshCode;
-        TerrainOverlayMaterialBinding? terrainOverlayMaterial = representativeSurface.Material.TerrainOverlay is null
+        TerrainTextureOverlay? terrainOverlay = representativeSurface.Material.TerrainOverlay;
+        TerrainOverlayMaterialBinding? terrainOverlayMaterial = terrainOverlay is null
             ? null
             : new TerrainOverlayMaterialBinding(
-                terrainMeshCode!.Value,
-                representativeSurface.Material.TerrainOverlay);
+                terrainOverlay.MeshCode,
+                terrainOverlay);
         ColorRgba baseColor = representativeSurface.Material.TerrainOverlay is null
             ? ToContractColor(representativeSurface.Surface.BaseColor)
             : new ColorRgba(1.0, 1.0, 1.0, 1.0);

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -144,7 +144,7 @@ internal static class CityGmlSurfaceMaterialResolver
             : new TerrainOverlayMaterialBinding(
                 terrainOverlay.MeshCode,
                 terrainOverlay);
-        ColorRgba baseColor = representativeSurface.Material.TerrainOverlay is null
+        ColorRgba baseColor = terrainOverlay is null
             ? ToContractColor(representativeSurface.Surface.BaseColor)
             : new ColorRgba(1.0, 1.0, 1.0, 1.0);
         DefaultCommonMaterialMember? commonMaterial = DefaultCommonMaterialAssignment.Resolve(


### PR DESCRIPTION
## Summary
- derive terrain overlay material binding mesh code directly from the selected TerrainTextureOverlay
- remove the nullable intermediate mesh code and null-forgiving access from material binding creation

## Verification
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~CityGmlSurfaceMaterialResolverTests|FullyQualifiedName~MaterialGroupingPolicyTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests"
- dotnet run --project src\PlateauResoniteLink.Cli\PlateauResoniteLink.Cli.csproj --configuration Release --no-restore -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-archive-5039b16c4b1c.zip --geotiff-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-ortho-cc68652cc45c.7z --work-root runtime\windows\resonite --terrain-mesh grid --canonical-scene-dump runtime\windows\resonite\semantic-baselines\type-terrain-overlay-binding-mesh-code\current\higashi-53395325-dem-bldg-grid-geotiff.json
- git diff --no-index -- runtime\windows\resonite\semantic-baselines\type-dem-grid-projection-result\baseline-parent\higashi-53395325-dem-bldg-grid-geotiff.json runtime\windows\resonite\semantic-baselines\type-terrain-overlay-binding-mesh-code\current\higashi-53395325-dem-bldg-grid-geotiff.json
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false