### PR TITLE
Require data source usages on execution results

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/ImportExecutionResult.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ImportExecutionResult.cs
@@ -2,7 +2,28 @@ using System.Collections.Generic;
 
 namespace PlateauResoniteLink.Application.Importing;
 
-public sealed record ImportExecutionResult(
-    ImportedSceneMetadata Metadata,
-    IReadOnlyList<string> Destinations,
-    IReadOnlyList<ImportDataSourceUsage>? DataSourceUsages = null);
+public sealed record ImportExecutionResult
+{
+    public ImportExecutionResult(
+        ImportedSceneMetadata Metadata,
+        IReadOnlyList<string> Destinations)
+        : this(Metadata, Destinations, [])
+    {
+    }
+
+    public ImportExecutionResult(
+        ImportedSceneMetadata Metadata,
+        IReadOnlyList<string> Destinations,
+        IReadOnlyList<ImportDataSourceUsage> DataSourceUsages)
+    {
+        this.Metadata = Metadata;
+        this.Destinations = Destinations;
+        this.DataSourceUsages = DataSourceUsages;
+    }
+
+    public ImportedSceneMetadata Metadata { get; init; }
+
+    public IReadOnlyList<string> Destinations { get; init; }
+
+    public IReadOnlyList<ImportDataSourceUsage> DataSourceUsages { get; init; }
+}

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
@@ -154,7 +154,7 @@ internal sealed class PlateauImportService(
                 UsedCount: 1))
             .ToList();
 
-        if (executionResult.DataSourceUsages is { Count: > 0 })
+        if (executionResult.DataSourceUsages.Count > 0)
         {
             usages.AddRange(executionResult.DataSourceUsages);
         }

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionResult.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionResult.cs
@@ -6,8 +6,41 @@ namespace PlateauResoniteLink.Application.Importing;
 /// Target-side execution summary for one scene import run.
 /// ProcessedCityObjectCount represents successful sends, not source-side geometry availability.
 /// </summary>
-public sealed record SceneImportExecutionResult(
-    IReadOnlyList<string> Destinations,
-    int ProcessedCityObjectCount,
-    int FailedCityObjectCount = 0,
-    IReadOnlyList<ImportDataSourceUsage>? DataSourceUsages = null);
+public sealed record SceneImportExecutionResult
+{
+    public SceneImportExecutionResult(
+        IReadOnlyList<string> Destinations,
+        int ProcessedCityObjectCount,
+        int FailedCityObjectCount = 0)
+        : this(Destinations, ProcessedCityObjectCount, FailedCityObjectCount, [])
+    {
+    }
+
+    public SceneImportExecutionResult(
+        IReadOnlyList<string> Destinations,
+        int ProcessedCityObjectCount,
+        IReadOnlyList<ImportDataSourceUsage> DataSourceUsages)
+        : this(Destinations, ProcessedCityObjectCount, 0, DataSourceUsages)
+    {
+    }
+
+    public SceneImportExecutionResult(
+        IReadOnlyList<string> Destinations,
+        int ProcessedCityObjectCount,
+        int FailedCityObjectCount,
+        IReadOnlyList<ImportDataSourceUsage> DataSourceUsages)
+    {
+        this.Destinations = Destinations;
+        this.ProcessedCityObjectCount = ProcessedCityObjectCount;
+        this.FailedCityObjectCount = FailedCityObjectCount;
+        this.DataSourceUsages = DataSourceUsages;
+    }
+
+    public IReadOnlyList<string> Destinations { get; init; }
+
+    public int ProcessedCityObjectCount { get; init; }
+
+    public int FailedCityObjectCount { get; init; }
+
+    public IReadOnlyList<ImportDataSourceUsage> DataSourceUsages { get; init; }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -704,7 +704,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             .ToArray();
         Assert.Contains(creditStrings, static creditString => creditString.Contains("GSI Maps Terms", StringComparison.Ordinal));
         Assert.Contains(creditStrings, static creditString => !creditString.Contains("GSI Maps Terms", StringComparison.Ordinal));
-        ImportDataSourceUsage demSourceUsage = Assert.Single(executionResult.DataSourceUsages ?? []);
+        ImportDataSourceUsage demSourceUsage = Assert.Single(executionResult.DataSourceUsages);
         Assert.Equal(ImportDataSourceCategory.DemTextureSource, demSourceUsage.Category);
         Assert.Equal(
             new TerrainTextureTileSource(
@@ -772,10 +772,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             CreateImportedObjectUnits(
                 CreateDemCityObject("dem-mixed", "udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml", overlay)));
 
-        ImportDataSourceUsage[] usages = executionResult.DataSourceUsages?
+        ImportDataSourceUsage[] usages = executionResult.DataSourceUsages
             .OrderBy(static usage => usage.Identity, StringComparer.Ordinal)
-            .ToArray()
-            ?? [];
+            .ToArray();
         Assert.Equal(2, usages.Length);
         Assert.Contains(
             usages,

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
@@ -90,14 +90,14 @@ public sealed class PlateauImportServiceTests
         Assert.Equal(source.Metadata.SceneName, result.Metadata.SceneName);
         Assert.Equal(source.Metadata.SourceDataset.PackageNames, result.Metadata.SourceDataset.PackageNames);
         Assert.Equal(["stub://destination"], result.Destinations);
-        Assert.Equal(1 + readResult.DocumentSet.RelativeSourceFiles.Count, result.DataSourceUsages?.Count);
+        Assert.Equal(1 + readResult.DocumentSet.RelativeSourceFiles.Count, result.DataSourceUsages.Count);
         Assert.Contains(
-            result.DataSourceUsages ?? [],
+            result.DataSourceUsages,
             static usage => usage.Category == ImportDataSourceCategory.CityGmlSourceFile
                 && string.Equals(usage.Identity, "udx/bldg/53394525/building.gml", StringComparison.Ordinal)
                 && usage.UsedCount == 1);
         Assert.Contains(
-            result.DataSourceUsages ?? [],
+            result.DataSourceUsages,
             static usage => usage.Category == ImportDataSourceCategory.DemTextureSource
                 && string.Equals(usage.Identity, "terrain://ortho-primary", StringComparison.Ordinal)
                 && usage.UsedCount == 2);


### PR DESCRIPTION
## Summary
- make SceneImportExecutionResult and ImportExecutionResult always expose non-null DataSourceUsages
- preserve omission at construction time through empty-list overloads instead of nullable result state
- remove downstream null coalescing in service/test assertions

## Verification
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~PlateauImportServiceTests|FullyQualifiedName~CliApplicationTests|FullyQualifiedName~ResoniteLiveSceneImportTargetLifecycleTests"
- dotnet run --project src\PlateauResoniteLink.Cli\PlateauResoniteLink.Cli.csproj --configuration Release --no-restore -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-archive-5039b16c4b1c.zip --geotiff-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-ortho-cc68652cc45c.7z --work-root runtime\windows\resonite --terrain-mesh grid --canonical-scene-dump runtime\windows\resonite\semantic-baselines\type-execution-result-data-source-usages\current\higashi-53395325-dem-bldg-grid-geotiff.json
- git diff --no-index -- runtime\windows\resonite\semantic-baselines\type-dem-grid-projection-result\baseline-parent\higashi-53395325-dem-bldg-grid-geotiff.json runtime\windows\resonite\semantic-baselines\type-execution-result-data-source-usages\current\higashi-53395325-dem-bldg-grid-geotiff.json
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false