### PR TITLE
Require generated terrain texture sources

### DIFF
--- a/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -98,6 +99,24 @@ public sealed record TerrainTextureGeoReferencedRasterSource(
 
 public sealed record TerrainTextureOverlay
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Style",
+        "IDE0032:Use auto property",
+        Justification = "The init setter validates with-expression updates before changing overlay identity state.")]
+    private string packageName = "";
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Style",
+        "IDE0032:Use auto property",
+        Justification = "The init setter validates with-expression updates before changing overlay identity state.")]
+    private int maxTextureSize;
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Style",
+        "IDE0032:Use auto property",
+        Justification = "The init setter snapshots and rejects null source elements for with-expression updates.")]
+    private IReadOnlyList<TerrainTextureSource> sources = [];
+
     public TerrainTextureOverlay(
         string PackageName,
         ThirdRegionalMeshCode MeshCode,
@@ -106,17 +125,11 @@ public sealed record TerrainTextureOverlay
         IReadOnlyList<TerrainTextureSource> Sources,
         TerrainTextureLicenseMode LicenseMode = TerrainTextureLicenseMode.Unknown)
     {
-        this.PackageName = string.IsNullOrWhiteSpace(PackageName)
-            ? throw new ArgumentException("Terrain texture package name must be provided.", nameof(PackageName))
-            : PackageName.ToLowerInvariant();
+        this.PackageName = PackageName;
         this.MeshCode = MeshCode;
         this.GeographicBounds = GeographicBounds;
-        this.MaxTextureSize = MaxTextureSize > 0
-            ? MaxTextureSize
-            : throw new ArgumentOutOfRangeException(nameof(MaxTextureSize));
-        this.Sources = Sources is { Count: > 0 }
-            ? Sources.ToArray()
-            : throw new ArgumentException("At least one terrain texture source must be provided.", nameof(Sources));
+        this.MaxTextureSize = MaxTextureSize;
+        this.Sources = Sources;
         this.LicenseMode = LicenseMode;
     }
 
@@ -159,15 +172,31 @@ public sealed record TerrainTextureOverlay
     {
     }
 
-    public string PackageName { get; init; }
+    public string PackageName
+    {
+        get => packageName;
+        init => packageName = string.IsNullOrWhiteSpace(value)
+            ? throw new ArgumentException("Terrain texture package name must be provided.", nameof(value))
+            : value.ToLowerInvariant();
+    }
 
     public ThirdRegionalMeshCode MeshCode { get; init; }
 
     public GeographicRectangle GeographicBounds { get; init; }
 
-    public int MaxTextureSize { get; init; }
+    public int MaxTextureSize
+    {
+        get => maxTextureSize;
+        init => maxTextureSize = value > 0
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(value));
+    }
 
-    public IReadOnlyList<TerrainTextureSource> Sources { get; init; }
+    public IReadOnlyList<TerrainTextureSource> Sources
+    {
+        get => sources;
+        init => sources = CreateSourceSnapshot(value);
+    }
 
     public TerrainTextureLicenseMode LicenseMode { get; init; }
 
@@ -231,6 +260,25 @@ public sealed record TerrainTextureOverlay
                 $"Terrain texture source '{source.GetType().Name}' does not provide a web tile URL.");
     }
 
+    private static ReadOnlyCollection<TerrainTextureSource> CreateSourceSnapshot(
+        IReadOnlyList<TerrainTextureSource> sources)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+
+        if (sources.Count == 0)
+        {
+            throw new ArgumentException("At least one terrain texture source must be provided.", nameof(sources));
+        }
+
+        TerrainTextureSource[] snapshot = new TerrainTextureSource[sources.Count];
+        for (int index = 0; index < sources.Count; index++)
+        {
+            snapshot[index] = sources[index]
+                ?? throw new ArgumentException("Terrain texture sources cannot contain null.", nameof(sources));
+        }
+
+        return Array.AsReadOnly(snapshot);
+    }
 }
 
 internal static class TerrainTextureDescriptorFormatting

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
@@ -151,7 +151,7 @@ internal sealed class DeterministicTerrainTextureAssetGenerator : ITerrainTextur
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        TerrainTextureSource? usedSource = terrainTextureOverlay.GetRequiredPrimaryTileSource();
+        TerrainTextureSource usedSource = terrainTextureOverlay.GetRequiredPrimaryTileSource();
         return Task.FromResult(new GeneratedTerrainTexture(
             TextureImportSourceFactory.CreateInMemory(
                 2,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
@@ -89,7 +89,7 @@ internal sealed class ResoniteQueuedTexturePreparer(
         GeneratedTerrainTexture terrainTexture = await terrainTextureAssetGenerator.EnsureTextureAsync(
             terrainTextureOverlay,
             cancellationToken);
-        TerrainTextureSource[] usedSources = GetTrackedTerrainTextureSources(terrainTexture, terrainTextureOverlay);
+        TerrainTextureSource[] usedSources = GetTrackedTerrainTextureSources(terrainTexture);
         foreach (TerrainTextureSource usedSource in usedSources)
         {
             int useCount = state.DemSourceUseCounts.AddOrUpdate(
@@ -119,20 +119,11 @@ internal sealed class ResoniteQueuedTexturePreparer(
     }
 
     private static TerrainTextureSource[] GetTrackedTerrainTextureSources(
-        GeneratedTerrainTexture terrainTexture,
-        TerrainTextureOverlay terrainTextureOverlay)
+        GeneratedTerrainTexture terrainTexture)
     {
-        if (terrainTexture.UsedSources is { Count: > 0 })
-        {
-            return terrainTexture.UsedSources
-                .Distinct()
-                .ToArray();
-        }
-
-        return
-        [
-            terrainTexture.UsedSource ?? terrainTextureOverlay.PrimarySource,
-        ];
+        return terrainTexture.UsedSources
+            .Distinct()
+            .ToArray();
     }
 
     private async Task EnsureGsiFallbackLicenseAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -35,7 +35,7 @@ internal sealed record GeneratedTerrainTexture
             TextureUvRect.FromScaleOffsetValue(
                 new ScalarPair(canvasScale.X, canvasScale.Y),
                 new ScalarPair(canvasOffset.X, canvasOffset.Y)),
-            [usedSource])
+            CreateSingleUsedSourceSnapshot(usedSource))
     {
     }
 
@@ -59,9 +59,8 @@ internal sealed record GeneratedTerrainTexture
         IReadOnlyList<TerrainTextureSource> usedSources)
     {
         ArgumentNullException.ThrowIfNull(textureSource);
-        ArgumentNullException.ThrowIfNull(usedSources);
 
-        TerrainTextureSource[] trackedSources = usedSources.Distinct().ToArray();
+        TerrainTextureSource[] trackedSources = CreateUsedSourceSnapshot(usedSources);
         if (trackedSources.Length == 0)
         {
             throw new ArgumentException("Generated terrain texture must track at least one source.", nameof(usedSources));
@@ -79,6 +78,26 @@ internal sealed record GeneratedTerrainTexture
     public TerrainTextureSource UsedSource => UsedSources[0];
 
     public IReadOnlyList<TerrainTextureSource> UsedSources { get; }
+
+    private static TerrainTextureSource[] CreateSingleUsedSourceSnapshot(TerrainTextureSource usedSource)
+    {
+        ArgumentNullException.ThrowIfNull(usedSource);
+        return [usedSource];
+    }
+
+    private static TerrainTextureSource[] CreateUsedSourceSnapshot(IReadOnlyList<TerrainTextureSource> usedSources)
+    {
+        ArgumentNullException.ThrowIfNull(usedSources);
+
+        TerrainTextureSource[] sources = new TerrainTextureSource[usedSources.Count];
+        for (int index = 0; index < usedSources.Count; index++)
+        {
+            sources[index] = usedSources[index]
+                ?? throw new ArgumentException("Generated terrain texture sources cannot contain null.", nameof(usedSources));
+        }
+
+        return sources.Distinct().ToArray();
+    }
 }
 
 internal sealed class TerrainTextureAssetGenerator(

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -35,7 +35,6 @@ internal sealed record GeneratedTerrainTexture
             TextureUvRect.FromScaleOffsetValue(
                 new ScalarPair(canvasScale.X, canvasScale.Y),
                 new ScalarPair(canvasOffset.X, canvasOffset.Y)),
-            usedSource,
             [usedSource])
     {
     }
@@ -44,14 +43,12 @@ internal sealed record GeneratedTerrainTexture
         ITextureImportSource textureSource,
         ResoniteFloat2 canvasScale,
         ResoniteFloat2 canvasOffset,
-        TerrainTextureSource usedSource,
         IReadOnlyList<TerrainTextureSource> usedSources)
         : this(
             textureSource,
             TextureUvRect.FromScaleOffsetValue(
                 new ScalarPair(canvasScale.X, canvasScale.Y),
                 new ScalarPair(canvasOffset.X, canvasOffset.Y)),
-            usedSource,
             usedSources)
     {
     }
@@ -59,11 +56,9 @@ internal sealed record GeneratedTerrainTexture
     public GeneratedTerrainTexture(
         ITextureImportSource textureSource,
         TextureUvRect occupiedUvRect,
-        TerrainTextureSource usedSource,
         IReadOnlyList<TerrainTextureSource> usedSources)
     {
         ArgumentNullException.ThrowIfNull(textureSource);
-        ArgumentNullException.ThrowIfNull(usedSource);
         ArgumentNullException.ThrowIfNull(usedSources);
 
         TerrainTextureSource[] trackedSources = usedSources.Distinct().ToArray();
@@ -72,16 +67,8 @@ internal sealed record GeneratedTerrainTexture
             throw new ArgumentException("Generated terrain texture must track at least one source.", nameof(usedSources));
         }
 
-        if (!trackedSources.Contains(usedSource))
-        {
-            throw new ArgumentException(
-                "Generated terrain texture identity source must be included in the tracked source collection.",
-                nameof(usedSources));
-        }
-
         TextureSource = textureSource;
         OccupiedUvRect = occupiedUvRect;
-        UsedSource = usedSource;
         UsedSources = trackedSources;
     }
 
@@ -89,7 +76,7 @@ internal sealed record GeneratedTerrainTexture
 
     public TextureUvRect OccupiedUvRect { get; }
 
-    public TerrainTextureSource UsedSource { get; }
+    public TerrainTextureSource UsedSource => UsedSources[0];
 
     public IReadOnlyList<TerrainTextureSource> UsedSources { get; }
 }
@@ -196,7 +183,7 @@ internal sealed class TerrainTextureAssetGenerator(
                 terrainTextureSource,
                 usedSources,
                 composedOccupiedUvRect);
-            return new CachedTerrainTexture(generatedTexture, terrainTextureSource);
+            return new CachedTerrainTexture(generatedTexture);
         }
     }
 
@@ -313,9 +300,21 @@ internal sealed class TerrainTextureAssetGenerator(
         generatedTexture = new GeneratedTerrainTexture(
             CreateTextureSource(canvasImage, usedSource),
             occupiedUvRect,
-            usedSource,
-            usedSources.Distinct().ToArray());
+            CreateUsedSourcesWithIdentityFirst(usedSource, usedSources));
         return true;
+    }
+
+    private static TerrainTextureSource[] CreateUsedSourcesWithIdentityFirst(
+        TerrainTextureSource identitySource,
+        IReadOnlyList<TerrainTextureSource> usedSources)
+    {
+        return
+        [
+            identitySource,
+            .. usedSources
+                .Where(source => source != identitySource)
+                .Distinct(),
+        ];
     }
 
     private static TextureUvRect CreateOccupiedUvRect(
@@ -462,8 +461,6 @@ internal sealed class TerrainTextureAssetGenerator(
             ResoniteTextureColorProfiles.Srgb);
     }
 
-    private sealed record CachedTerrainTexture(
-        GeneratedTerrainTexture GeneratedTexture,
-        TerrainTextureSource UsedSource);
+    private sealed record CachedTerrainTexture(GeneratedTerrainTexture GeneratedTexture);
 
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -69,7 +69,7 @@ internal sealed record GeneratedTerrainTexture
 
         TextureSource = textureSource;
         OccupiedUvRect = occupiedUvRect;
-        UsedSources = trackedSources;
+        UsedSources = Array.AsReadOnly(trackedSources);
     }
 
     public ITextureImportSource TextureSource { get; }
@@ -312,8 +312,7 @@ internal sealed class TerrainTextureAssetGenerator(
         [
             identitySource,
             .. usedSources
-                .Where(source => source != identitySource)
-                .Distinct(),
+                .Where(source => source != identitySource),
         ];
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -23,18 +23,29 @@ internal interface ITerrainTextureAssetGenerator
         CancellationToken cancellationToken);
 }
 
-internal sealed record GeneratedTerrainTexture(
-    ITextureImportSource TextureSource,
-    TextureUvRect OccupiedUvRect,
-    TerrainTextureSource? UsedSource = null,
-    IReadOnlyList<TerrainTextureSource>? UsedSources = null)
+internal sealed record GeneratedTerrainTexture
 {
     public GeneratedTerrainTexture(
         ITextureImportSource textureSource,
         ResoniteFloat2 canvasScale,
         ResoniteFloat2 canvasOffset,
-        TerrainTextureSource? usedSource = null,
-        IReadOnlyList<TerrainTextureSource>? usedSources = null)
+        TerrainTextureSource usedSource)
+        : this(
+            textureSource,
+            TextureUvRect.FromScaleOffsetValue(
+                new ScalarPair(canvasScale.X, canvasScale.Y),
+                new ScalarPair(canvasOffset.X, canvasOffset.Y)),
+            usedSource,
+            [usedSource])
+    {
+    }
+
+    public GeneratedTerrainTexture(
+        ITextureImportSource textureSource,
+        ResoniteFloat2 canvasScale,
+        ResoniteFloat2 canvasOffset,
+        TerrainTextureSource usedSource,
+        IReadOnlyList<TerrainTextureSource> usedSources)
         : this(
             textureSource,
             TextureUvRect.FromScaleOffsetValue(
@@ -44,6 +55,34 @@ internal sealed record GeneratedTerrainTexture(
             usedSources)
     {
     }
+
+    public GeneratedTerrainTexture(
+        ITextureImportSource TextureSource,
+        TextureUvRect OccupiedUvRect,
+        TerrainTextureSource UsedSource,
+        IReadOnlyList<TerrainTextureSource> UsedSources)
+    {
+        ArgumentNullException.ThrowIfNull(TextureSource);
+        ArgumentNullException.ThrowIfNull(UsedSource);
+        ArgumentNullException.ThrowIfNull(UsedSources);
+        if (UsedSources.Count == 0)
+        {
+            throw new ArgumentException("Generated terrain texture must track at least one source.", nameof(UsedSources));
+        }
+
+        this.TextureSource = TextureSource;
+        this.OccupiedUvRect = OccupiedUvRect;
+        this.UsedSource = UsedSource;
+        this.UsedSources = UsedSources;
+    }
+
+    public ITextureImportSource TextureSource { get; init; }
+
+    public TextureUvRect OccupiedUvRect { get; init; }
+
+    public TerrainTextureSource UsedSource { get; init; }
+
+    public IReadOnlyList<TerrainTextureSource> UsedSources { get; init; }
 }
 
 internal sealed class TerrainTextureAssetGenerator(
@@ -79,7 +118,7 @@ internal sealed class TerrainTextureAssetGenerator(
         Image<Rgba32>? composedTexture = null;
         TextureUvRect? composedOccupiedUvRect = null;
         List<TerrainTextureSource> usedSources = [];
-        TerrainTextureSource? usedSource = null;
+        TerrainTextureSource? textureIdentitySource = null;
 
         for (int sourceIndex = 0; sourceIndex < terrainTextureOverlay.Sources.Count; sourceIndex++)
         {
@@ -113,7 +152,7 @@ internal sealed class TerrainTextureAssetGenerator(
                 {
                     composedTexture = image.Clone();
                     composedOccupiedUvRect = sourceImage.OccupiedUvRect;
-                    usedSource = terrainTextureSource;
+                    textureIdentitySource = terrainTextureSource;
                     usedSources.Add(terrainTextureSource);
                 }
                 else
@@ -121,7 +160,7 @@ internal sealed class TerrainTextureAssetGenerator(
                     using Image<Rgba32> resizedImage = ResizeSourceImage(image, composedTexture.Width, composedTexture.Height);
                     if (FillTransparentPixels(composedTexture, resizedImage))
                     {
-                        usedSource = terrainTextureSource;
+                        textureIdentitySource = terrainTextureSource;
                         usedSources.Add(terrainTextureSource);
                     }
                 }
@@ -140,7 +179,8 @@ internal sealed class TerrainTextureAssetGenerator(
 
         using (composedTexture)
         {
-            TerrainTextureSource terrainTextureSource = usedSource ?? terrainTextureOverlay.PrimarySource;
+            TerrainTextureSource terrainTextureSource = textureIdentitySource
+                ?? throw new InvalidOperationException("Generated terrain texture must have at least one rendered source.");
             GeneratedTerrainTexture generatedTexture = CreateGeneratedTexture(
                 composedTexture,
                 terrainTextureOverlay.MaxTextureSize,

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -57,32 +57,41 @@ internal sealed record GeneratedTerrainTexture
     }
 
     public GeneratedTerrainTexture(
-        ITextureImportSource TextureSource,
-        TextureUvRect OccupiedUvRect,
-        TerrainTextureSource UsedSource,
-        IReadOnlyList<TerrainTextureSource> UsedSources)
+        ITextureImportSource textureSource,
+        TextureUvRect occupiedUvRect,
+        TerrainTextureSource usedSource,
+        IReadOnlyList<TerrainTextureSource> usedSources)
     {
-        ArgumentNullException.ThrowIfNull(TextureSource);
-        ArgumentNullException.ThrowIfNull(UsedSource);
-        ArgumentNullException.ThrowIfNull(UsedSources);
-        if (UsedSources.Count == 0)
+        ArgumentNullException.ThrowIfNull(textureSource);
+        ArgumentNullException.ThrowIfNull(usedSource);
+        ArgumentNullException.ThrowIfNull(usedSources);
+
+        TerrainTextureSource[] trackedSources = usedSources.Distinct().ToArray();
+        if (trackedSources.Length == 0)
         {
-            throw new ArgumentException("Generated terrain texture must track at least one source.", nameof(UsedSources));
+            throw new ArgumentException("Generated terrain texture must track at least one source.", nameof(usedSources));
         }
 
-        this.TextureSource = TextureSource;
-        this.OccupiedUvRect = OccupiedUvRect;
-        this.UsedSource = UsedSource;
-        this.UsedSources = UsedSources;
+        if (!trackedSources.Contains(usedSource))
+        {
+            throw new ArgumentException(
+                "Generated terrain texture identity source must be included in the tracked source collection.",
+                nameof(usedSources));
+        }
+
+        TextureSource = textureSource;
+        OccupiedUvRect = occupiedUvRect;
+        UsedSource = usedSource;
+        UsedSources = trackedSources;
     }
 
-    public ITextureImportSource TextureSource { get; init; }
+    public ITextureImportSource TextureSource { get; }
 
-    public TextureUvRect OccupiedUvRect { get; init; }
+    public TextureUvRect OccupiedUvRect { get; }
 
-    public TerrainTextureSource UsedSource { get; init; }
+    public TerrainTextureSource UsedSource { get; }
 
-    public IReadOnlyList<TerrainTextureSource> UsedSources { get; init; }
+    public IReadOnlyList<TerrainTextureSource> UsedSources { get; }
 }
 
 internal sealed class TerrainTextureAssetGenerator(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -752,8 +752,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
                 new ResoniteFloat2(0.0, 0.0),
-                gsiFallbackSource,
-                [rasterSource, gsiFallbackSource]));
+                [gsiFallbackSource, rasterSource]));
         await using ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(
             routedClient,
             terrainTextureGenerator,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -146,10 +146,11 @@ public sealed class ResoniteLiveSceneImportTargetTests
         TerrainTextureOverlay demOverlay = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/dem/{z}/{x}/{y}.png");
         TerrainTextureOverlay roofOverlayWithDifferentUri = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/roof/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
-            _ => new GeneratedTerrainTexture(
+            requestedOverlay => new GeneratedTerrainTexture(
                 CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
-                new ResoniteFloat2(0.0, 0.0)));
+                new ResoniteFloat2(0.0, 0.0),
+                requestedOverlay.PrimarySource));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
             MeshCode,
@@ -226,10 +227,11 @@ public sealed class ResoniteLiveSceneImportTargetTests
         TerrainTextureOverlay firstOverlay = CreateThirdMeshOverlay("53394525", "https://tiles.example/{z}/{x}/{y}.png");
         TerrainTextureOverlay secondOverlay = CreateThirdMeshOverlay("53394526", "https://tiles.example/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
-            _ => new GeneratedTerrainTexture(
+            requestedOverlay => new GeneratedTerrainTexture(
                 CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
-                new ResoniteFloat2(0.0, 0.0)));
+                new ResoniteFloat2(0.0, 0.0),
+                requestedOverlay.PrimarySource));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
             MeshCode,
@@ -276,10 +278,11 @@ public sealed class ResoniteLiveSceneImportTargetTests
         using SceneSinkRecordingClient client = new();
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
-            _ => new GeneratedTerrainTexture(
+            requestedOverlay => new GeneratedTerrainTexture(
                 CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
-                new ResoniteFloat2(0.0, 0.0)));
+                new ResoniteFloat2(0.0, 0.0),
+                requestedOverlay.PrimarySource));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
             MeshCode,
@@ -366,10 +369,11 @@ public sealed class ResoniteLiveSceneImportTargetTests
         using SceneSinkRecordingClient client = new();
         TerrainTextureOverlay mismatchedOverlay = CreateThirdMeshOverlay("53394526", "https://tiles.example/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
-            _ => new GeneratedTerrainTexture(
+            requestedOverlay => new GeneratedTerrainTexture(
                 CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
-                new ResoniteFloat2(0.0, 0.0)));
+                new ResoniteFloat2(0.0, 0.0),
+                requestedOverlay.PrimarySource));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
             MeshCode,
@@ -414,7 +418,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     ResoniteTextureColorProfiles.Srgb,
                     new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
-                new ResoniteFloat2(0.125, 0.375)));
+                new ResoniteFloat2(0.125, 0.375),
+                requestedOverlay.PrimarySource));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
             MeshCode,
@@ -786,14 +791,15 @@ public sealed class ResoniteLiveSceneImportTargetTests
         using SceneSinkRecordingClient client = new();
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://example.invalid/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
-            _ => new GeneratedTerrainTexture(
+            requestedOverlay => new GeneratedTerrainTexture(
                 CreateRawTextureSource(
                     2,
                     2,
                     ResoniteTextureColorProfiles.Srgb,
                     new byte[16]),
                 new ResoniteFloat2(0.5, 0.25),
-                new ResoniteFloat2(0.125, 0.375)));
+                new ResoniteFloat2(0.125, 0.375),
+                requestedOverlay.PrimarySource));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
             MeshCode,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -248,7 +248,8 @@ public sealed class ResoniteMaterialPlanningTests
             [overlay] = new GeneratedTerrainTexture(
                 CreateRawTextureSource(512, 256, ResoniteTextureColorProfiles.Srgb, new byte[512 * 256 * 4]),
                 new ResoniteFloat2(0.5, 0.25),
-                new ResoniteFloat2(0.0, 0.0)),
+                new ResoniteFloat2(0.0, 0.0),
+                overlay.PrimarySource),
         };
 
         ResoniteMaterialBinding effectiveMaterial = ResoniteMaterialPlanning.ResolveTerrainTextureCanvasMaterial(
@@ -335,7 +336,8 @@ public sealed class ResoniteMaterialPlanningTests
             [overlay] = new GeneratedTerrainTexture(
                 CreateRawTextureSource(512, 256, ResoniteTextureColorProfiles.Srgb, new byte[512 * 256 * 4]),
                 new ResoniteFloat2(0.5, 0.25),
-                new ResoniteFloat2(0.0, 0.0)),
+                new ResoniteFloat2(0.0, 0.0),
+                overlay.PrimarySource),
         };
 
         ResoniteMaterialBinding effectiveMaterial = ResoniteMaterialPlanning.ResolveTerrainTextureCanvasMaterial(

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Transport.ResoniteLink;
 
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -37,6 +38,47 @@ public sealed class TerrainTextureAssetGeneratorTests
         Assert.Equal(WebMercatorTileMath.MaxZoomLevel, source.ZoomLevel);
         Assert.Throws<ArgumentOutOfRangeException>(
             static () => new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", WebMercatorTileMath.MaxZoomLevel + 1));
+    }
+
+    [Fact]
+    public void GeneratedTerrainTextureRequiresIdentitySourceInTrackedSources()
+    {
+        TerrainTextureTileSource usedSource = new("https://used.example/{z}/{x}/{y}.png", 17);
+        TerrainTextureTileSource otherSource = new("https://other.example/{z}/{x}/{y}.png", 17);
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            new GeneratedTerrainTexture(
+                TextureImportSourceTestFactory.CreateRawTextureSource(
+                    1,
+                    1,
+                    ResoniteTextureColorProfiles.Srgb,
+                    [255, 255, 255, 255]),
+                TextureUvRect.Identity,
+                usedSource,
+                [otherSource]));
+
+        Assert.Contains("identity source", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GeneratedTerrainTextureCopiesTrackedSourcesAndExposesReadOnlyState()
+    {
+        TerrainTextureTileSource usedSource = new("https://used.example/{z}/{x}/{y}.png", 17);
+        List<TerrainTextureSource> trackedSources = [usedSource];
+        GeneratedTerrainTexture texture = new(
+            TextureImportSourceTestFactory.CreateRawTextureSource(
+                1,
+                1,
+                ResoniteTextureColorProfiles.Srgb,
+                [255, 255, 255, 255]),
+            TextureUvRect.Identity,
+            usedSource,
+            trackedSources);
+
+        trackedSources.Clear();
+
+        Assert.Equal(usedSource, texture.UsedSource);
+        Assert.Equal([usedSource], texture.UsedSources);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -41,11 +41,8 @@ public sealed class TerrainTextureAssetGeneratorTests
     }
 
     [Fact]
-    public void GeneratedTerrainTextureRequiresIdentitySourceInTrackedSources()
+    public void GeneratedTerrainTextureRequiresTrackedSources()
     {
-        TerrainTextureTileSource usedSource = new("https://used.example/{z}/{x}/{y}.png", 17);
-        TerrainTextureTileSource otherSource = new("https://other.example/{z}/{x}/{y}.png", 17);
-
         ArgumentException exception = Assert.Throws<ArgumentException>(() =>
             new GeneratedTerrainTexture(
                 TextureImportSourceTestFactory.CreateRawTextureSource(
@@ -54,17 +51,17 @@ public sealed class TerrainTextureAssetGeneratorTests
                     ResoniteTextureColorProfiles.Srgb,
                     [255, 255, 255, 255]),
                 TextureUvRect.Identity,
-                usedSource,
-                [otherSource]));
+                []));
 
-        Assert.Contains("identity source", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("at least one source", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void GeneratedTerrainTextureCopiesTrackedSourcesAndExposesReadOnlyState()
+    public void GeneratedTerrainTextureDerivesIdentityFromFirstTrackedSourceAndExposesReadOnlyState()
     {
         TerrainTextureTileSource usedSource = new("https://used.example/{z}/{x}/{y}.png", 17);
-        List<TerrainTextureSource> trackedSources = [usedSource];
+        TerrainTextureTileSource otherSource = new("https://other.example/{z}/{x}/{y}.png", 17);
+        List<TerrainTextureSource> trackedSources = [usedSource, otherSource];
         GeneratedTerrainTexture texture = new(
             TextureImportSourceTestFactory.CreateRawTextureSource(
                 1,
@@ -72,13 +69,12 @@ public sealed class TerrainTextureAssetGeneratorTests
                 ResoniteTextureColorProfiles.Srgb,
                 [255, 255, 255, 255]),
             TextureUvRect.Identity,
-            usedSource,
             trackedSources);
 
         trackedSources.Clear();
 
         Assert.Equal(usedSource, texture.UsedSource);
-        Assert.Equal([usedSource], texture.UsedSources);
+        Assert.Equal([usedSource, otherSource], texture.UsedSources);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -57,6 +57,59 @@ public sealed class TerrainTextureAssetGeneratorTests
     }
 
     [Fact]
+    public void GeneratedTerrainTextureRejectsNullTrackedSources()
+    {
+        ITextureImportSource textureSource = TextureImportSourceTestFactory.CreateRawTextureSource(
+            1,
+            1,
+            ResoniteTextureColorProfiles.Srgb,
+            [255, 255, 255, 255]);
+
+        Assert.Throws<ArgumentNullException>(() =>
+            new GeneratedTerrainTexture(
+                textureSource,
+                new ResoniteFloat2(1.0, 1.0),
+                new ResoniteFloat2(0.0, 0.0),
+                (TerrainTextureSource)null!));
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            new GeneratedTerrainTexture(
+                textureSource,
+                TextureUvRect.Identity,
+                [new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", 17), null!]));
+
+        Assert.Contains("cannot contain null", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TerrainTextureOverlayRejectsNullSourcesFromConstructionAndWithExpressions()
+    {
+        TerrainTextureOverlay overlay = CreateFullCoverageOverlay("https://tiles.example/{z}/{x}/{y}.png");
+
+        Assert.Throws<ArgumentNullException>(() =>
+            new TerrainTextureOverlay(
+                PackageName: "dem",
+                MeshCode: ThirdRegionalMeshCode.Parse("53395325"),
+                GeographicBounds: overlay.GeographicBounds,
+                MaxTextureSize: 512,
+                Sources: null!));
+
+        ArgumentException constructionException = Assert.Throws<ArgumentException>(() =>
+            new TerrainTextureOverlay(
+                PackageName: "dem",
+                MeshCode: ThirdRegionalMeshCode.Parse("53395325"),
+                GeographicBounds: overlay.GeographicBounds,
+                MaxTextureSize: 512,
+                Sources: [null!]));
+
+        ArgumentException withExpressionException = Assert.Throws<ArgumentException>(() =>
+            overlay with { Sources = [null!] });
+
+        Assert.Contains("cannot contain null", constructionException.Message, StringComparison.Ordinal);
+        Assert.Contains("cannot contain null", withExpressionException.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void GeneratedTerrainTextureDerivesIdentityFromFirstTrackedSourceAndExposesReadOnlyState()
     {
         TerrainTextureTileSource usedSource = new("https://used.example/{z}/{x}/{y}.png", 17);

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -492,7 +492,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
         Assert.Contains(
-            texture.UsedSources ?? [],
+            texture.UsedSources,
             static source => source is TerrainTextureTileSource tileSource
                 && tileSource.UrlTemplate == "https://primary.example/{z}/{x}/{y}.png");
         Assert.Contains("primary.example", handler.RequestedHosts);

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -75,6 +75,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         Assert.Equal(usedSource, texture.UsedSource);
         Assert.Equal([usedSource, otherSource], texture.UsedSources);
+        Assert.IsNotType<TerrainTextureSource[]>(texture.UsedSources);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
@@ -342,8 +342,8 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         Assert.NotEqual(Materialize(tileOnlyTexture.TextureSource).Bytes, Materialize(rasterOnlyTexture.TextureSource).Bytes);
         Assert.NotEqual(Materialize(tileOnlyTexture.TextureSource).Bytes, Materialize(mixedTexture.TextureSource).Bytes);
         Assert.NotEqual(Materialize(rasterOnlyTexture.TextureSource).Bytes, Materialize(mixedTexture.TextureSource).Bytes);
-        Assert.Single(rasterOnlyTexture.UsedSources ?? []);
-        Assert.Equal(2, (mixedTexture.UsedSources ?? []).Count);
+        Assert.Single(rasterOnlyTexture.UsedSources);
+        Assert.Equal(2, mixedTexture.UsedSources.Count);
     }
 
     [Fact]
@@ -494,9 +494,9 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             new Rgba32(12, 34, 56, 255),
             outputImage[(layout.CropWidth * 3) / 4, occupiedTop + (layout.CropHeight / 2)]);
         Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
-        Assert.Contains(texture.UsedSources ?? [], static source => source is TerrainTextureGeoReferencedRasterSource);
+        Assert.Contains(texture.UsedSources, static source => source is TerrainTextureGeoReferencedRasterSource);
         Assert.Contains(
-            texture.UsedSources ?? [],
+            texture.UsedSources,
             static source => source is TerrainTextureTileSource tileSource
                 && tileSource.UrlTemplate == "https://tiles.example/{z}/{x}/{y}.png");
         Assert.IsType<TerrainTextureTileSource>(texture.UsedSource);


### PR DESCRIPTION
## Summary
- require every GeneratedTerrainTexture to carry a concrete UsedSource and non-empty UsedSources collection
- remove fallback from tracked terrain texture source extraction to overlay.PrimarySource
- update terrain texture tests to assert non-null tracked source collections directly

## Verification
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~TerrainTextureAssetGeneratorTests|FullyQualifiedName~TerrainTextureGeoReferencedRasterSupportTests|FullyQualifiedName~ResoniteLiveSceneImportTargetTests|FullyQualifiedName~ResoniteLiveSceneImportTargetLifecycleTests|FullyQualifiedName~ResoniteMaterialPlanningTests"
- dotnet run --project src\PlateauResoniteLink.Cli\PlateauResoniteLink.Cli.csproj --configuration Release --no-restore -- import --dataset plateau-13213-higashimurayama-shi-2020 --mesh-code 53395325 --packages dem,bldg --citygml-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-archive-5039b16c4b1c.zip --geotiff-source runtime\windows\resonite\plateau-13213-higashimurayama-shi-2020\source-ortho-cc68652cc45c.7z --work-root runtime\windows\resonite --terrain-mesh grid --canonical-scene-dump runtime\windows\resonite\semantic-baselines\type-generated-terrain-texture-sources\current\higashi-53395325-dem-bldg-grid-geotiff.json
- git diff --no-index -- runtime\windows\resonite\semantic-baselines\type-dem-grid-projection-result\baseline-parent\higashi-53395325-dem-bldg-grid-geotiff.json runtime\windows\resonite\semantic-baselines\type-generated-terrain-texture-sources\current\higashi-53395325-dem-bldg-grid-geotiff.json
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false