### PR TITLE
Split raw and encoded texture payload sources

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -197,8 +197,7 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
                     resolvedTexturePath,
                     "sRGB",
                     $"dataset:{resolvedTexturePath}"),
-                $"dataset:{resolvedTexturePath}",
-                TexturePayloadFormat.EncodedImage);
+                $"dataset:{resolvedTexturePath}");
             texturePayloadsByResolvedPath[resolvedTexturePath] = texturePayload;
         }
 

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -189,15 +189,14 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
         if (!texturePayloadsByResolvedPath.TryGetValue(resolvedTexturePath, out TexturePayload? texturePayload))
         {
             texturePayload = new TexturePayload(
-                null,
-                null,
-                "sRGB",
-                TextureImportSourceFactory.CreateDatasetEncodedImage(
+                width: null,
+                height: null,
+                colorProfile: "sRGB",
+                source: TextureImportSourceFactory.CreateDatasetEncodedImage(
                     datasetSource,
                     resolvedTexturePath,
                     "sRGB",
-                    $"dataset:{resolvedTexturePath}"),
-                $"dataset:{resolvedTexturePath}");
+                    $"dataset:{resolvedTexturePath}"));
             texturePayloadsByResolvedPath[resolvedTexturePath] = texturePayload;
         }
 

--- a/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
@@ -18,7 +18,7 @@ internal static class MaterialGroupingPolicy
         {
             return new MaterialGroupingKey(
                 material.MaterialType,
-                TexturePayloadIdentity: null,
+                TextureSourceIdentity: null,
                 material.TextureSourceKind,
                 material.Projection,
                 depthOffset,
@@ -33,7 +33,7 @@ internal static class MaterialGroupingPolicy
 
         return new MaterialGroupingKey(
             material.MaterialType,
-            material.TexturePayload?.Identity,
+            material.TexturePayload?.Source.Identity,
             material.TextureSourceKind,
             material.Projection,
             depthOffset,
@@ -63,7 +63,7 @@ internal static class MaterialGroupingPolicy
 
 internal sealed record MaterialGroupingKey(
     MaterialType MaterialType,
-    string? TexturePayloadIdentity,
+    TextureImportSourceIdentity? TextureSourceIdentity,
     TextureSourceKind TextureSourceKind,
     MaterialProjection Projection,
     MaterialDepthOffset? DepthOffset,

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -129,6 +129,23 @@ public sealed record TexturePayload
             effectiveIdentity);
     }
 
+    internal TexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        IRawTexturePayloadSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        RawTexturePayload.EnsureValidDimensions(width, height);
+        Width = width;
+        Height = height;
+        ColorProfile = colorProfile;
+        BinaryPayload = [];
+        Identity = source.Identity;
+        Format = TexturePayloadFormat.RawRgba32;
+        Source = source;
+    }
+
     public TexturePayload(
         int? width,
         int? height,

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -111,12 +111,13 @@ public sealed record TexturePayload
         byte[] binaryPayload,
         string? identity = null)
     {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        RawTexturePayload.EnsureValidShape(width, height, binaryPayload.Length, RawTexturePayloadFormat.Rgba32);
+        ImmutableArray<byte> immutablePayload = ImmutableArray.CreateRange(binaryPayload);
+        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(binaryPayload);
-        ImmutableArray<byte> immutablePayload = ImmutableArray.CreateRange(binaryPayload);
-        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
         BinaryPayload = immutablePayload;
         Identity = effectiveIdentity;
         Format = TexturePayloadFormat.RawRgba32;
@@ -135,29 +136,37 @@ public sealed record TexturePayload
         ITextureImportSource source,
         string? identity = null)
     {
+        ArgumentNullException.ThrowIfNull(source);
+        string effectiveIdentity = identity ?? source.Identity;
+        if (!string.Equals(effectiveIdentity, source.Identity, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                "Texture payload identity must match the texture import source identity.",
+                nameof(identity));
+        }
+
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
-        Identity = identity ?? source.Identity;
+        Identity = effectiveIdentity;
         Format = TexturePayloadFormat.EncodedImage;
         Source = source;
     }
 
-    public int? Width { get; init; }
+    public int? Width { get; }
 
-    public int? Height { get; init; }
+    public int? Height { get; }
 
-    public string? ColorProfile { get; init; }
+    public string? ColorProfile { get; }
 
-    public ImmutableArray<byte> BinaryPayload { get; init; }
+    public ImmutableArray<byte> BinaryPayload { get; }
 
-    public string? Identity { get; init; }
+    public string Identity { get; }
 
-    public TexturePayloadFormat Format { get; init; }
+    public TexturePayloadFormat Format { get; }
 
-    public ITextureImportSource Source { get; init; }
+    public ITextureImportSource Source { get; }
 }
 
 public enum TextureSourceKind

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -116,15 +116,16 @@ public sealed record TexturePayload
         ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(binaryPayload);
         ImmutableArray<byte> immutablePayload = ImmutableArray.CreateRange(binaryPayload);
+        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
         BinaryPayload = immutablePayload;
-        Identity = identity;
+        Identity = effectiveIdentity;
         Format = TexturePayloadFormat.RawRgba32;
         Source = TextureImportSourceFactory.CreateRawRgba32InMemory(
             width,
             height,
             colorProfile,
             immutablePayload,
-            identity ?? Guid.NewGuid().ToString("N"));
+            effectiveIdentity);
     }
 
     public TexturePayload(

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -115,14 +115,15 @@ public sealed record TexturePayload
         Height = height;
         ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(binaryPayload);
-        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
+        ImmutableArray<byte> immutablePayload = ImmutableArray.CreateRange(binaryPayload);
+        BinaryPayload = immutablePayload;
         Identity = identity;
         Format = TexturePayloadFormat.RawRgba32;
         Source = TextureImportSourceFactory.CreateRawRgba32InMemory(
             width,
             height,
             colorProfile,
-            binaryPayload,
+            immutablePayload,
             identity ?? Guid.NewGuid().ToString("N"));
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -114,19 +114,18 @@ public sealed record TexturePayload
         ArgumentNullException.ThrowIfNull(binaryPayload);
         RawTexturePayload.EnsureValidShape(width, height, binaryPayload.Length, RawTexturePayloadFormat.Rgba32);
         ImmutableArray<byte> immutablePayload = ImmutableArray.CreateRange(binaryPayload);
-        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
+        TextureImportSourceIdentity effectiveIdentity = new(identity ?? Guid.NewGuid().ToString("N"));
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         BinaryPayload = immutablePayload;
-        Identity = effectiveIdentity;
         Format = TexturePayloadFormat.RawRgba32;
         Source = TextureImportSourceFactory.CreateRawRgba32InMemory(
             width,
             height,
             colorProfile,
             immutablePayload,
-            effectiveIdentity);
+            effectiveIdentity.Value);
     }
 
     internal TexturePayload(
@@ -136,12 +135,12 @@ public sealed record TexturePayload
         IRawTexturePayloadSource source)
     {
         ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(source.Identity.Value, nameof(source));
         RawTexturePayload.EnsureValidDimensions(width, height);
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         BinaryPayload = [];
-        Identity = source.Identity;
         Format = TexturePayloadFormat.RawRgba32;
         Source = source;
     }
@@ -150,23 +149,14 @@ public sealed record TexturePayload
         int? width,
         int? height,
         string? colorProfile,
-        ITextureImportSource source,
-        string? identity = null)
+        ITextureImportSource source)
     {
         ArgumentNullException.ThrowIfNull(source);
-        string effectiveIdentity = identity ?? source.Identity;
-        if (!string.Equals(effectiveIdentity, source.Identity, StringComparison.Ordinal))
-        {
-            throw new ArgumentException(
-                "Texture payload identity must match the texture import source identity.",
-                nameof(identity));
-        }
-
+        ArgumentException.ThrowIfNullOrWhiteSpace(source.Identity.Value, nameof(source));
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         BinaryPayload = [];
-        Identity = effectiveIdentity;
         Format = TexturePayloadFormat.EncodedImage;
         Source = source;
     }
@@ -178,8 +168,6 @@ public sealed record TexturePayload
     public string? ColorProfile { get; }
 
     public ImmutableArray<byte> BinaryPayload { get; }
-
-    public string Identity { get; }
 
     public TexturePayloadFormat Format { get; }
 

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -105,12 +105,11 @@ public enum TexturePayloadFormat
 public sealed record TexturePayload
 {
     public TexturePayload(
-        int? width,
-        int? height,
+        int width,
+        int height,
         string? colorProfile,
         byte[] binaryPayload,
-        string? identity = null,
-        TexturePayloadFormat format = TexturePayloadFormat.RawRgba32)
+        string? identity = null)
     {
         Width = width;
         Height = height;
@@ -118,14 +117,13 @@ public sealed record TexturePayload
         ArgumentNullException.ThrowIfNull(binaryPayload);
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
         Identity = identity;
-        Format = format;
-        Source = TextureImportSourceFactory.CreateInMemory(
+        Format = TexturePayloadFormat.RawRgba32;
+        Source = TextureImportSourceFactory.CreateRawRgba32InMemory(
             width,
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"),
-            format);
+            identity ?? Guid.NewGuid().ToString("N"));
     }
 
     public TexturePayload(
@@ -133,8 +131,7 @@ public sealed record TexturePayload
         int? height,
         string? colorProfile,
         ITextureImportSource source,
-        string? identity = null,
-        TexturePayloadFormat format = TexturePayloadFormat.EncodedImage)
+        string? identity = null)
     {
         Width = width;
         Height = height;
@@ -142,7 +139,7 @@ public sealed record TexturePayload
         ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
         Identity = identity ?? source.Identity;
-        Format = format;
+        Format = TexturePayloadFormat.EncodedImage;
         Source = source;
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -56,7 +57,7 @@ internal static class TextureImportSourceMaterializer
 
 internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
 {
-    private readonly byte[] bytes;
+    private readonly ImmutableArray<byte> bytes;
 
     public InMemoryRawTextureImportSource(
         int width,
@@ -70,7 +71,27 @@ internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
-        this.bytes = (byte[])bytes.Clone();
+        this.bytes = ImmutableArray.CreateRange(bytes);
+        Identity = identity;
+    }
+
+    public InMemoryRawTextureImportSource(
+        int width,
+        int height,
+        string? colorProfile,
+        ImmutableArray<byte> bytes,
+        string identity)
+    {
+        if (bytes.IsDefault)
+        {
+            throw new ArgumentException("Raw texture bytes must be initialized.", nameof(bytes));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        Width = width;
+        Height = height;
+        ColorProfile = colorProfile;
+        this.bytes = bytes;
         Identity = identity;
     }
 
@@ -93,7 +114,7 @@ internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
             Width,
             Height,
             ColorProfile,
-            (byte[])bytes.Clone()));
+            bytes.AsSpan().ToArray()));
     }
 }
 
@@ -220,6 +241,16 @@ internal static class TextureImportSourceFactory
         int height,
         string? colorProfile,
         byte[] bytes,
+        string identity)
+    {
+        return new InMemoryRawTextureImportSource(width, height, colorProfile, bytes, identity);
+    }
+
+    internal static ITextureImportSource CreateRawRgba32InMemory(
+        int width,
+        int height,
+        string? colorProfile,
+        ImmutableArray<byte> bytes,
         string identity)
     {
         return new InMemoryRawTextureImportSource(width, height, colorProfile, bytes, identity);

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -15,12 +15,70 @@ public enum RawTexturePayloadFormat
     RgbaFloat32 = 1,
 }
 
-public sealed record RawTexturePayload(
-    int Width,
-    int Height,
-    string? ColorProfile,
-    byte[] Bytes,
-    RawTexturePayloadFormat Format = RawTexturePayloadFormat.Rgba32);
+public sealed record RawTexturePayload
+{
+    public RawTexturePayload(
+        int Width,
+        int Height,
+        string? ColorProfile,
+        byte[] Bytes,
+        RawTexturePayloadFormat Format = RawTexturePayloadFormat.Rgba32)
+    {
+        ArgumentNullException.ThrowIfNull(Bytes);
+        EnsureValidShape(Width, Height, Bytes.Length, Format);
+        this.Width = Width;
+        this.Height = Height;
+        this.ColorProfile = ColorProfile;
+        this.Bytes = Bytes;
+        this.Format = Format;
+    }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public string? ColorProfile { get; }
+
+    public byte[] Bytes { get; }
+
+    public RawTexturePayloadFormat Format { get; }
+
+    internal static void EnsureValidShape(
+        int width,
+        int height,
+        int byteLength,
+        RawTexturePayloadFormat format)
+    {
+        EnsureValidDimensions(width, height);
+
+        int bytesPerPixel = format switch
+        {
+            RawTexturePayloadFormat.Rgba32 => 4,
+            RawTexturePayloadFormat.RgbaFloat32 => 4 * sizeof(float),
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported raw texture payload format."),
+        };
+        long expectedByteLength = checked((long)width * height * bytesPerPixel);
+        if (byteLength != expectedByteLength)
+        {
+            throw new ArgumentException(
+                $"Raw texture byte length must be width * height * {bytesPerPixel}.",
+                nameof(byteLength));
+        }
+    }
+
+    internal static void EnsureValidDimensions(int width, int height)
+    {
+        if (width <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), width, "Raw texture width must be positive.");
+        }
+
+        if (height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(height), height, "Raw texture height must be positive.");
+        }
+    }
+}
 
 public interface ITextureImportSource
 {
@@ -68,6 +126,7 @@ internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
     {
         ArgumentNullException.ThrowIfNull(bytes);
         ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        RawTexturePayload.EnsureValidShape(width, height, bytes.Length, RawTexturePayloadFormat.Rgba32);
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
@@ -88,6 +147,7 @@ internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
         }
 
         ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        RawTexturePayload.EnsureValidShape(width, height, bytes.Length, RawTexturePayloadFormat.Rgba32);
         Width = width;
         Height = height;
         ColorProfile = colorProfile;

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -113,7 +113,7 @@ public sealed record RawTexturePayload
 
 public interface ITextureImportSource
 {
-    string Identity { get; }
+    TextureImportSourceIdentity Identity { get; }
 
     string Description { get; }
 
@@ -156,13 +156,13 @@ internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
         string identity)
     {
         ArgumentNullException.ThrowIfNull(bytes);
-        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        TextureImportSourceIdentity resolvedIdentity = new(identity);
         RawTexturePayload.EnsureValidShape(width, height, bytes.Length, RawTexturePayloadFormat.Rgba32);
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         this.bytes = ImmutableArray.CreateRange(bytes);
-        Identity = identity;
+        Identity = resolvedIdentity;
     }
 
     public InMemoryRawTextureImportSource(
@@ -177,20 +177,20 @@ internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
             throw new ArgumentException("Raw texture bytes must be initialized.", nameof(bytes));
         }
 
-        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        TextureImportSourceIdentity resolvedIdentity = new(identity);
         RawTexturePayload.EnsureValidShape(width, height, bytes.Length, RawTexturePayloadFormat.Rgba32);
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         this.bytes = bytes;
-        Identity = identity;
+        Identity = resolvedIdentity;
     }
 
     public int Width { get; }
 
     public int Height { get; }
 
-    public string Identity { get; }
+    public TextureImportSourceIdentity Identity { get; }
 
     public string Description => $"memory:{Identity}";
 
@@ -219,13 +219,13 @@ internal sealed class InMemoryEncodedTextureImportSource : IRawTexturePayloadSou
         string identity)
     {
         ArgumentNullException.ThrowIfNull(bytes);
-        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        TextureImportSourceIdentity resolvedIdentity = new(identity);
         ColorProfile = colorProfile;
         this.bytes = ImmutableArray.CreateRange(bytes);
-        Identity = identity;
+        Identity = resolvedIdentity;
     }
 
-    public string Identity { get; }
+    public TextureImportSourceIdentity Identity { get; }
 
     public string Description => $"memory:{Identity}";
 
@@ -250,7 +250,7 @@ internal sealed class DatasetTextureImportSource(
     string? colorProfile,
     string identity) : IRawTexturePayloadSource
 {
-    public string Identity { get; } = identity;
+    public TextureImportSourceIdentity Identity { get; } = new(identity);
 
     public string Description => $"dataset:{relativePath}";
 
@@ -273,7 +273,7 @@ internal sealed class FileTextureImportSource(
     string colorProfile,
     string identity) : IRawTexturePayloadSource
 {
-    public string Identity { get; } = identity;
+    public TextureImportSourceIdentity Identity { get; } = new(identity);
 
     public string Description => $"file:{Path.GetFileName(absolutePath)}";
 
@@ -312,7 +312,7 @@ internal sealed class GeneratedTextureImportSource(
     string? colorProfile,
     long? estimatedByteLength = null) : IRawTexturePayloadSource
 {
-    public string Identity { get; } = identity;
+    public TextureImportSourceIdentity Identity { get; } = new(identity);
 
     public string Description { get; } = description;
 

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,6 +18,36 @@ public enum RawTexturePayloadFormat
 
 public sealed record RawTexturePayload
 {
+    private RawTexturePayload(
+        int Width,
+        int Height,
+        string? ColorProfile,
+        ImmutableArray<byte> Bytes,
+        RawTexturePayloadFormat Format = RawTexturePayloadFormat.Rgba32)
+    {
+        if (Bytes.IsDefault)
+        {
+            throw new ArgumentException("Raw texture bytes must be initialized.", nameof(Bytes));
+        }
+
+        EnsureValidShape(Width, Height, Bytes.Length, Format);
+        this.Width = Width;
+        this.Height = Height;
+        this.ColorProfile = ColorProfile;
+        this.Bytes = Bytes;
+        this.Format = Format;
+    }
+
+    internal static RawTexturePayload Create(
+        int width,
+        int height,
+        string? colorProfile,
+        ImmutableArray<byte> bytes,
+        RawTexturePayloadFormat format = RawTexturePayloadFormat.Rgba32)
+    {
+        return new RawTexturePayload(width, height, colorProfile, bytes, format);
+    }
+
     public RawTexturePayload(
         int Width,
         int Height,
@@ -29,7 +60,7 @@ public sealed record RawTexturePayload
         this.Width = Width;
         this.Height = Height;
         this.ColorProfile = ColorProfile;
-        this.Bytes = Bytes;
+        this.Bytes = ImmutableArray.CreateRange(Bytes);
         this.Format = Format;
     }
 
@@ -39,7 +70,7 @@ public sealed record RawTexturePayload
 
     public string? ColorProfile { get; }
 
-    public byte[] Bytes { get; }
+    public ImmutableArray<byte> Bytes { get; }
 
     public RawTexturePayloadFormat Format { get; }
 
@@ -170,17 +201,17 @@ internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
     public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return ValueTask.FromResult(new RawTexturePayload(
+        return ValueTask.FromResult(RawTexturePayload.Create(
             Width,
             Height,
             ColorProfile,
-            bytes.AsSpan().ToArray()));
+            bytes));
     }
 }
 
 internal sealed class InMemoryEncodedTextureImportSource : IRawTexturePayloadSource
 {
-    private readonly byte[] bytes;
+    private readonly ImmutableArray<byte> bytes;
 
     public InMemoryEncodedTextureImportSource(
         string? colorProfile,
@@ -190,7 +221,7 @@ internal sealed class InMemoryEncodedTextureImportSource : IRawTexturePayloadSou
         ArgumentNullException.ThrowIfNull(bytes);
         ArgumentException.ThrowIfNullOrWhiteSpace(identity);
         ColorProfile = colorProfile;
-        this.bytes = (byte[])bytes.Clone();
+        this.bytes = ImmutableArray.CreateRange(bytes);
         Identity = identity;
     }
 
@@ -204,7 +235,8 @@ internal sealed class InMemoryEncodedTextureImportSource : IRawTexturePayloadSou
 
     public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
     {
-        using MemoryStream stream = new(bytes, writable: false);
+        byte[] retainedBytes = ImmutableCollectionsMarshal.AsArray(bytes) ?? [];
+        using MemoryStream stream = new(retainedBytes, writable: false);
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream, cancellationToken);
         return TextureImportSourceFactory.CreateRawPayloadFromImage(
             image,

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -54,17 +54,16 @@ internal static class TextureImportSourceMaterializer
     }
 }
 
-internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
+internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
 {
     private readonly byte[] bytes;
 
-    public InMemoryTextureImportSource(
-        int? width,
-        int? height,
+    public InMemoryRawTextureImportSource(
+        int width,
+        int height,
         string? colorProfile,
         byte[] bytes,
-        string identity,
-        TexturePayloadFormat sourceFormat)
+        string identity)
     {
         ArgumentNullException.ThrowIfNull(bytes);
         ArgumentException.ThrowIfNullOrWhiteSpace(identity);
@@ -73,12 +72,11 @@ internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
         ColorProfile = colorProfile;
         this.bytes = (byte[])bytes.Clone();
         Identity = identity;
-        SourceFormat = sourceFormat;
     }
 
-    public int? Width { get; }
+    public int Width { get; }
 
-    public int? Height { get; }
+    public int Height { get; }
 
     public string Identity { get; }
 
@@ -88,34 +86,42 @@ internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
 
     public long? EstimatedByteLength => bytes.Length;
 
-    public TexturePayloadFormat SourceFormat { get; }
-
-    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return SourceFormat switch
-        {
-            TexturePayloadFormat.RawRgba32 => CreateRawPayload(),
-            TexturePayloadFormat.EncodedImage => await DecodeEncodedImageAsync(cancellationToken),
-            _ => throw new InvalidOperationException($"Unsupported texture payload format '{SourceFormat}'."),
-        };
-    }
-
-    private RawTexturePayload CreateRawPayload()
-    {
-        if (Width is null || Height is null)
-        {
-            throw new InvalidOperationException("Raw RGBA texture payload must include width and height.");
-        }
-
-        return new RawTexturePayload(
-            Width.Value,
-            Height.Value,
+        return ValueTask.FromResult(new RawTexturePayload(
+            Width,
+            Height,
             ColorProfile,
-            (byte[])bytes.Clone());
+            (byte[])bytes.Clone()));
+    }
+}
+
+internal sealed class InMemoryEncodedTextureImportSource : IRawTexturePayloadSource
+{
+    private readonly byte[] bytes;
+
+    public InMemoryEncodedTextureImportSource(
+        string? colorProfile,
+        byte[] bytes,
+        string identity)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        ColorProfile = colorProfile;
+        this.bytes = (byte[])bytes.Clone();
+        Identity = identity;
     }
 
-    private async ValueTask<RawTexturePayload> DecodeEncodedImageAsync(CancellationToken cancellationToken)
+    public string Identity { get; }
+
+    public string Description => $"memory:{Identity}";
+
+    public string? ColorProfile { get; }
+
+    public long? EstimatedByteLength => bytes.Length;
+
+    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
     {
         using MemoryStream stream = new(bytes, writable: false);
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream, cancellationToken);
@@ -209,15 +215,22 @@ internal sealed class GeneratedTextureImportSource(
 
 internal static class TextureImportSourceFactory
 {
-    public static ITextureImportSource CreateInMemory(
-        int? width,
-        int? height,
+    public static ITextureImportSource CreateRawRgba32InMemory(
+        int width,
+        int height,
         string? colorProfile,
         byte[] bytes,
-        string identity,
-        TexturePayloadFormat sourceFormat)
+        string identity)
     {
-        return new InMemoryTextureImportSource(width, height, colorProfile, bytes, identity, sourceFormat);
+        return new InMemoryRawTextureImportSource(width, height, colorProfile, bytes, identity);
+    }
+
+    public static ITextureImportSource CreateEncodedImageInMemory(
+        string? colorProfile,
+        byte[] bytes,
+        string identity)
+    {
+        return new InMemoryEncodedTextureImportSource(colorProfile, bytes, identity);
     }
 
     public static ITextureImportSource CreateDatasetEncodedImage(

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSourceIdentity.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSourceIdentity.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+public readonly record struct TextureImportSourceIdentity
+{
+    public TextureImportSourceIdentity(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    public string Value { get; }
+
+    public override string ToString() => Value;
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
@@ -153,13 +153,12 @@ internal sealed class DeterministicTerrainTextureAssetGenerator : ITerrainTextur
         cancellationToken.ThrowIfCancellationRequested();
         TerrainTextureSource? usedSource = terrainTextureOverlay.GetRequiredPrimaryTileSource();
         return Task.FromResult(new GeneratedTerrainTexture(
-            TextureImportSourceFactory.CreateInMemory(
+            TextureImportSourceFactory.CreateRawRgba32InMemory(
                 2,
                 2,
                 ResoniteTextureColorProfiles.Srgb,
                 RawTextureBytes,
-                "canonical-dump-terrain-texture",
-                TexturePayloadFormat.RawRgba32),
+                "canonical-dump-terrain-texture"),
             new ResoniteFloat2(1.0, 1.0),
             new ResoniteFloat2(0.0, 0.0),
             usedSource));

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClientCanonicalDump.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClientCanonicalDump.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -422,6 +423,13 @@ internal static class SceneSinkRecordingClientCanonicalDump
         }
 
         return Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+    }
+
+    private static string HashBytes(ImmutableArray<byte> bytes)
+    {
+        return bytes.IsDefaultOrEmpty
+            ? "empty"
+            : Convert.ToHexString(SHA256.HashData(bytes.AsSpan())).ToLowerInvariant();
     }
 
     private static string FormatNumber(double value)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImageLoader.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImageLoader.cs
@@ -35,7 +35,7 @@ internal sealed class ResoniteTextureImageLoader
         }
 
         return Image.LoadPixelData<Rgba32>(
-            rawPayload.Bytes,
+            rawPayload.Bytes.AsSpan().ToArray(),
             rawPayload.Width,
             rawPayload.Height);
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
@@ -39,7 +39,6 @@ internal static class ResoniteTextureImportFactory
             image.Height,
             colorProfile,
             rawPayload.Bytes,
-            identity ?? Guid.NewGuid().ToString("N"),
-            ResoniteTexturePayloadFormat.RawRgba32);
+            identity ?? Guid.NewGuid().ToString("N"));
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
@@ -34,7 +34,7 @@ internal static class ResoniteTextureImportFactory
         RawTexturePayload rawPayload = TextureImportSourceFactory.CreateRawPayloadFromImage(
             image,
             colorProfile);
-        return new ResoniteTexturePayload(
+        return ResoniteTexturePayload.CreateRaw(
             image.Width,
             image.Height,
             colorProfile,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -52,6 +52,23 @@ public sealed record ResoniteTexturePayload
         Source = source;
     }
 
+    internal ResoniteTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        IRawTexturePayloadSource source,
+        string? identity = null)
+    {
+        Width = width;
+        Height = height;
+        ColorProfile = colorProfile;
+        ArgumentNullException.ThrowIfNull(source);
+        BinaryPayload = [];
+        Identity = identity ?? source.Identity;
+        Format = ResoniteTexturePayloadFormat.RawRgba32;
+        Source = source;
+    }
+
     public int? Width { get; init; }
 
     public int? Height { get; init; }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -24,14 +24,15 @@ public sealed record ResoniteTexturePayload
         Height = height;
         ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(binaryPayload);
-        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
+        ImmutableArray<byte> immutablePayload = ImmutableArray.CreateRange(binaryPayload);
+        BinaryPayload = immutablePayload;
         Identity = identity;
         Format = ResoniteTexturePayloadFormat.RawRgba32;
         Source = TextureImportSourceFactory.CreateRawRgba32InMemory(
             width,
             height,
             colorProfile,
-            binaryPayload,
+            immutablePayload,
             identity ?? Guid.NewGuid().ToString("N"));
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -13,6 +13,44 @@ public enum ResoniteTexturePayloadFormat
 
 public sealed record ResoniteTexturePayload
 {
+    private ResoniteTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        ImmutableArray<byte> binaryPayload,
+        string? identity = null)
+    {
+        if (binaryPayload.IsDefault)
+        {
+            throw new ArgumentException("Raw texture bytes must be initialized.", nameof(binaryPayload));
+        }
+
+        RawTexturePayload.EnsureValidShape(width, height, binaryPayload.Length, RawTexturePayloadFormat.Rgba32);
+        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
+        Width = width;
+        Height = height;
+        ColorProfile = colorProfile;
+        BinaryPayload = binaryPayload;
+        Identity = effectiveIdentity;
+        Format = ResoniteTexturePayloadFormat.RawRgba32;
+        Source = TextureImportSourceFactory.CreateRawRgba32InMemory(
+            width,
+            height,
+            colorProfile,
+            binaryPayload,
+            effectiveIdentity);
+    }
+
+    internal static ResoniteTexturePayload CreateRaw(
+        int width,
+        int height,
+        string? colorProfile,
+        ImmutableArray<byte> binaryPayload,
+        string? identity = null)
+    {
+        return new ResoniteTexturePayload(width, height, colorProfile, binaryPayload, identity);
+    }
+
     public ResoniteTexturePayload(
         int width,
         int height,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -26,19 +26,18 @@ public sealed record ResoniteTexturePayload
         }
 
         RawTexturePayload.EnsureValidShape(width, height, binaryPayload.Length, RawTexturePayloadFormat.Rgba32);
-        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
+        TextureImportSourceIdentity effectiveIdentity = new(identity ?? Guid.NewGuid().ToString("N"));
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         BinaryPayload = binaryPayload;
-        Identity = effectiveIdentity;
         Format = ResoniteTexturePayloadFormat.RawRgba32;
         Source = TextureImportSourceFactory.CreateRawRgba32InMemory(
             width,
             height,
             colorProfile,
             binaryPayload,
-            effectiveIdentity);
+            effectiveIdentity.Value);
     }
 
     internal static ResoniteTexturePayload CreateRaw(
@@ -61,42 +60,32 @@ public sealed record ResoniteTexturePayload
         ArgumentNullException.ThrowIfNull(binaryPayload);
         RawTexturePayload.EnsureValidShape(width, height, binaryPayload.Length, RawTexturePayloadFormat.Rgba32);
         ImmutableArray<byte> immutablePayload = ImmutableArray.CreateRange(binaryPayload);
-        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
+        TextureImportSourceIdentity effectiveIdentity = new(identity ?? Guid.NewGuid().ToString("N"));
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         BinaryPayload = immutablePayload;
-        Identity = effectiveIdentity;
         Format = ResoniteTexturePayloadFormat.RawRgba32;
         Source = TextureImportSourceFactory.CreateRawRgba32InMemory(
             width,
             height,
             colorProfile,
             immutablePayload,
-            effectiveIdentity);
+            effectiveIdentity.Value);
     }
 
     public ResoniteTexturePayload(
         int? width,
         int? height,
         string? colorProfile,
-        ITextureImportSource source,
-        string? identity = null)
+        ITextureImportSource source)
     {
         ArgumentNullException.ThrowIfNull(source);
-        string effectiveIdentity = identity ?? source.Identity;
-        if (!string.Equals(effectiveIdentity, source.Identity, StringComparison.Ordinal))
-        {
-            throw new ArgumentException(
-                "Texture payload identity must match the texture import source identity.",
-                nameof(identity));
-        }
-
+        ArgumentException.ThrowIfNullOrWhiteSpace(source.Identity.Value, nameof(source));
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         BinaryPayload = [];
-        Identity = effectiveIdentity;
         Format = ResoniteTexturePayloadFormat.EncodedImage;
         Source = source;
     }
@@ -108,12 +97,12 @@ public sealed record ResoniteTexturePayload
         IRawTexturePayloadSource source)
     {
         ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(source.Identity.Value, nameof(source));
         RawTexturePayload.EnsureValidDimensions(width, height);
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         BinaryPayload = [];
-        Identity = source.Identity;
         Format = ResoniteTexturePayloadFormat.RawRgba32;
         Source = source;
     }
@@ -125,8 +114,6 @@ public sealed record ResoniteTexturePayload
     public string? ColorProfile { get; }
 
     public ImmutableArray<byte> BinaryPayload { get; }
-
-    public string Identity { get; }
 
     public ResoniteTexturePayloadFormat Format { get; }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -20,12 +20,13 @@ public sealed record ResoniteTexturePayload
         byte[] binaryPayload,
         string? identity = null)
     {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        RawTexturePayload.EnsureValidShape(width, height, binaryPayload.Length, RawTexturePayloadFormat.Rgba32);
+        ImmutableArray<byte> immutablePayload = ImmutableArray.CreateRange(binaryPayload);
+        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(binaryPayload);
-        ImmutableArray<byte> immutablePayload = ImmutableArray.CreateRange(binaryPayload);
-        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
         BinaryPayload = immutablePayload;
         Identity = effectiveIdentity;
         Format = ResoniteTexturePayloadFormat.RawRgba32;
@@ -44,12 +45,20 @@ public sealed record ResoniteTexturePayload
         ITextureImportSource source,
         string? identity = null)
     {
+        ArgumentNullException.ThrowIfNull(source);
+        string effectiveIdentity = identity ?? source.Identity;
+        if (!string.Equals(effectiveIdentity, source.Identity, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                "Texture payload identity must match the texture import source identity.",
+                nameof(identity));
+        }
+
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
-        Identity = identity ?? source.Identity;
+        Identity = effectiveIdentity;
         Format = ResoniteTexturePayloadFormat.EncodedImage;
         Source = source;
     }
@@ -60,27 +69,28 @@ public sealed record ResoniteTexturePayload
         string? colorProfile,
         IRawTexturePayloadSource source)
     {
+        ArgumentNullException.ThrowIfNull(source);
+        RawTexturePayload.EnsureValidDimensions(width, height);
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
         Identity = source.Identity;
         Format = ResoniteTexturePayloadFormat.RawRgba32;
         Source = source;
     }
 
-    public int? Width { get; init; }
+    public int? Width { get; }
 
-    public int? Height { get; init; }
+    public int? Height { get; }
 
-    public string? ColorProfile { get; init; }
+    public string? ColorProfile { get; }
 
-    public ImmutableArray<byte> BinaryPayload { get; init; }
+    public ImmutableArray<byte> BinaryPayload { get; }
 
-    public string? Identity { get; init; }
+    public string Identity { get; }
 
-    public ResoniteTexturePayloadFormat Format { get; init; }
+    public ResoniteTexturePayloadFormat Format { get; }
 
-    public ITextureImportSource Source { get; init; }
+    public ITextureImportSource Source { get; }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -25,15 +25,16 @@ public sealed record ResoniteTexturePayload
         ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(binaryPayload);
         ImmutableArray<byte> immutablePayload = ImmutableArray.CreateRange(binaryPayload);
+        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
         BinaryPayload = immutablePayload;
-        Identity = identity;
+        Identity = effectiveIdentity;
         Format = ResoniteTexturePayloadFormat.RawRgba32;
         Source = TextureImportSourceFactory.CreateRawRgba32InMemory(
             width,
             height,
             colorProfile,
             immutablePayload,
-            identity ?? Guid.NewGuid().ToString("N"));
+            effectiveIdentity);
     }
 
     public ResoniteTexturePayload(
@@ -57,15 +58,14 @@ public sealed record ResoniteTexturePayload
         int width,
         int height,
         string? colorProfile,
-        IRawTexturePayloadSource source,
-        string? identity = null)
+        IRawTexturePayloadSource source)
     {
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
-        Identity = identity ?? source.Identity;
+        Identity = source.Identity;
         Format = ResoniteTexturePayloadFormat.RawRgba32;
         Source = source;
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -14,12 +14,11 @@ public enum ResoniteTexturePayloadFormat
 public sealed record ResoniteTexturePayload
 {
     public ResoniteTexturePayload(
-        int? width,
-        int? height,
+        int width,
+        int height,
         string? colorProfile,
         byte[] binaryPayload,
-        string? identity = null,
-        ResoniteTexturePayloadFormat format = ResoniteTexturePayloadFormat.RawRgba32)
+        string? identity = null)
     {
         Width = width;
         Height = height;
@@ -27,14 +26,13 @@ public sealed record ResoniteTexturePayload
         ArgumentNullException.ThrowIfNull(binaryPayload);
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
         Identity = identity;
-        Format = format;
-        Source = TextureImportSourceFactory.CreateInMemory(
+        Format = ResoniteTexturePayloadFormat.RawRgba32;
+        Source = TextureImportSourceFactory.CreateRawRgba32InMemory(
             width,
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"),
-            (TexturePayloadFormat)format);
+            identity ?? Guid.NewGuid().ToString("N"));
     }
 
     public ResoniteTexturePayload(
@@ -42,8 +40,7 @@ public sealed record ResoniteTexturePayload
         int? height,
         string? colorProfile,
         ITextureImportSource source,
-        string? identity = null,
-        ResoniteTexturePayloadFormat format = ResoniteTexturePayloadFormat.EncodedImage)
+        string? identity = null)
     {
         Width = width;
         Height = height;
@@ -51,7 +48,7 @@ public sealed record ResoniteTexturePayload
         ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
         Identity = identity ?? source.Identity;
-        Format = format;
+        Format = ResoniteTexturePayloadFormat.EncodedImage;
         Source = source;
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -133,19 +133,27 @@ internal static class SceneImportContractMapper
 
     private static ResoniteTexturePayload ToInternal(TexturePayload payload)
     {
-        return payload.Format == TexturePayloadFormat.RawRgba32
-            ? new ResoniteTexturePayload(
-                payload.Width ?? throw new ArgumentException("Raw texture payload must include width.", nameof(payload)),
-                payload.Height ?? throw new ArgumentException("Raw texture payload must include height.", nameof(payload)),
-                payload.ColorProfile,
-                payload.BinaryPayload.AsSpan().ToArray(),
-                payload.Identity)
-            : new ResoniteTexturePayload(
+        if (payload.Format != TexturePayloadFormat.RawRgba32)
+        {
+            return new ResoniteTexturePayload(
                 payload.Width,
                 payload.Height,
                 payload.ColorProfile,
                 payload.Source,
                 payload.Identity);
+        }
+
+        if (payload.Source is not IRawTexturePayloadSource rawSource)
+        {
+            throw new ArgumentException("Raw texture payload must carry a raw texture import source.", nameof(payload));
+        }
+
+        return new ResoniteTexturePayload(
+            payload.Width ?? throw new ArgumentException("Raw texture payload must include width.", nameof(payload)),
+            payload.Height ?? throw new ArgumentException("Raw texture payload must include height.", nameof(payload)),
+            payload.ColorProfile,
+            rawSource,
+            payload.Identity);
     }
 
     private static ResoniteMaterialDepthOffset ToInternal(MaterialDepthOffset value) => new(value.Factor, value.Units);

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -133,16 +133,21 @@ internal static class SceneImportContractMapper
 
     private static ResoniteTexturePayload ToInternal(TexturePayload payload)
     {
-        if (payload.Format != TexturePayloadFormat.RawRgba32)
+        return payload.Format switch
         {
-            return new ResoniteTexturePayload(
+            TexturePayloadFormat.EncodedImage => new ResoniteTexturePayload(
                 payload.Width,
                 payload.Height,
                 payload.ColorProfile,
                 payload.Source,
-                payload.Identity);
-        }
+                payload.Identity),
+            TexturePayloadFormat.RawRgba32 => ToInternalRawTexturePayload(payload),
+            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.Format, "Unsupported texture payload format."),
+        };
+    }
 
+    private static ResoniteTexturePayload ToInternalRawTexturePayload(TexturePayload payload)
+    {
         if (payload.Source is not IRawTexturePayloadSource rawSource)
         {
             throw new ArgumentException("Raw texture payload must carry a raw texture import source.", nameof(payload));

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -139,8 +139,7 @@ internal static class SceneImportContractMapper
                 payload.Width,
                 payload.Height,
                 payload.ColorProfile,
-                payload.Source,
-                payload.Identity),
+                payload.Source),
             TexturePayloadFormat.RawRgba32 => ToInternalRawTexturePayload(payload),
             _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.Format, "Unsupported texture payload format."),
         };

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -133,13 +133,19 @@ internal static class SceneImportContractMapper
 
     private static ResoniteTexturePayload ToInternal(TexturePayload payload)
     {
-        return new ResoniteTexturePayload(
-            payload.Width,
-            payload.Height,
-            payload.ColorProfile,
-            payload.Source,
-            payload.Identity,
-            (ResoniteTexturePayloadFormat)payload.Format);
+        return payload.Format == TexturePayloadFormat.RawRgba32
+            ? new ResoniteTexturePayload(
+                payload.Width ?? throw new ArgumentException("Raw texture payload must include width.", nameof(payload)),
+                payload.Height ?? throw new ArgumentException("Raw texture payload must include height.", nameof(payload)),
+                payload.ColorProfile,
+                payload.BinaryPayload.AsSpan().ToArray(),
+                payload.Identity)
+            : new ResoniteTexturePayload(
+                payload.Width,
+                payload.Height,
+                payload.ColorProfile,
+                payload.Source,
+                payload.Identity);
     }
 
     private static ResoniteMaterialDepthOffset ToInternal(MaterialDepthOffset value) => new(value.Factor, value.Units);

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -157,8 +157,7 @@ internal static class SceneImportContractMapper
             payload.Width ?? throw new ArgumentException("Raw texture payload must include width.", nameof(payload)),
             payload.Height ?? throw new ArgumentException("Raw texture payload must include height.", nameof(payload)),
             payload.ColorProfile,
-            rawSource,
-            payload.Identity);
+            rawSource);
     }
 
     private static ResoniteMaterialType ToInternal(MaterialType materialType)

--- a/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkClient.cs
+++ b/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkClient.cs
@@ -263,7 +263,7 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
                     Width = rawPayload.Width,
                     Height = rawPayload.Height,
                     ColorProfile = rawPayload.ColorProfile ?? ResoniteTextureColorProfiles.Srgb,
-                    RawBinaryPayload = rawPayload.Bytes,
+                    RawBinaryPayload = rawPayload.Bytes.AsSpan().ToArray(),
                 }),
             cancellationToken);
     }
@@ -277,7 +277,7 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
                 {
                     Width = rawPayload.Width,
                     Height = rawPayload.Height,
-                    RawBinaryPayload = rawPayload.Bytes,
+                    RawBinaryPayload = rawPayload.Bytes.AsSpan().ToArray(),
                 }),
             cancellationToken);
     }

--- a/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
@@ -56,12 +56,11 @@ public sealed class TexturePayloadTests
     }
 
     [Fact]
-    public void RawConstructorKeepsGeneratedIdentityConsistentWithSource()
+    public void RawConstructorCreatesGeneratedSourceIdentity()
     {
         TexturePayload payload = new(1, 1, "sRGB", [1, 2, 3, 4]);
 
-        Assert.False(string.IsNullOrWhiteSpace(payload.Identity));
-        Assert.Equal(payload.Identity, payload.Source.Identity);
+        Assert.False(string.IsNullOrWhiteSpace(payload.Source.Identity.Value));
     }
 
     [Fact]
@@ -96,22 +95,31 @@ public sealed class TexturePayloadTests
     }
 
     [Fact]
-    public void EncodedConstructorRejectsPayloadIdentityThatDiffersFromSourceIdentity()
+    public void EncodedConstructorUsesSourceAsIdentityCarrier()
     {
         ITextureImportSource source = TextureImportSourceFactory.CreateEncodedImageInMemory(
             "sRGB",
             [1, 2, 3, 4],
             "source:texture");
 
-        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
-            new TexturePayload(
-                1,
-                1,
-                "sRGB",
-                source,
-                "payload:texture"));
+        TexturePayload payload = new(
+            1,
+            1,
+            "sRGB",
+            source);
 
-        Assert.Contains("identity must match", exception.Message, System.StringComparison.Ordinal);
+        Assert.Same(source, payload.Source);
+        Assert.Equal(new TextureImportSourceIdentity("source:texture"), payload.Source.Identity);
+    }
+
+    [Fact]
+    public void SourceBackedConstructorRejectsDefaultSourceIdentity()
+    {
+        Assert.ThrowsAny<ArgumentException>(() => new TexturePayload(
+            1,
+            1,
+            "sRGB",
+            new DefaultIdentityTextureImportSource()));
     }
 
     private static byte[] CreateEncodedPixelBytes(Rgba32 pixel)
@@ -121,5 +129,16 @@ public sealed class TexturePayloadTests
         using MemoryStream stream = new();
         image.SaveAsPng(stream);
         return stream.ToArray();
+    }
+
+    private sealed class DefaultIdentityTextureImportSource : ITextureImportSource
+    {
+        public TextureImportSourceIdentity Identity => default;
+
+        public string Description => "default identity";
+
+        public string? ColorProfile => "sRGB";
+
+        public long? EstimatedByteLength => null;
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 using PlateauResoniteLink.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.Application;
@@ -13,5 +16,19 @@ public sealed class TexturePayloadTests
         source[0] = 9;
 
         Assert.Equal<byte>([1, 2, 3, 4], payload.BinaryPayload);
+    }
+
+    [Fact]
+    public async Task ConstructorCreatesDimensionedRawTextureSource()
+    {
+        TexturePayload payload = new(1, 1, "sRGB", [1, 2, 3, 4], "dataset:texture");
+
+        RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            payload.Source,
+            CancellationToken.None);
+
+        Assert.Equal(1, rawPayload.Width);
+        Assert.Equal(1, rawPayload.Height);
+        Assert.Equal<byte>([1, 2, 3, 4], rawPayload.Bytes);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
@@ -1,8 +1,13 @@
 using System;
+using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Tests.Application;
 
@@ -34,12 +39,48 @@ public sealed class TexturePayloadTests
     }
 
     [Fact]
+    public async Task RawSourceMaterializationReusesImmutablePayloadBytes()
+    {
+        TexturePayload payload = new(1, 1, "sRGB", [1, 2, 3, 4], "dataset:texture");
+
+        RawTexturePayload first = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            payload.Source,
+            CancellationToken.None);
+        RawTexturePayload second = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            payload.Source,
+            CancellationToken.None);
+
+        Assert.Same(
+            ImmutableCollectionsMarshal.AsArray(first.Bytes),
+            ImmutableCollectionsMarshal.AsArray(second.Bytes));
+    }
+
+    [Fact]
     public void RawConstructorKeepsGeneratedIdentityConsistentWithSource()
     {
         TexturePayload payload = new(1, 1, "sRGB", [1, 2, 3, 4]);
 
         Assert.False(string.IsNullOrWhiteSpace(payload.Identity));
         Assert.Equal(payload.Identity, payload.Source.Identity);
+    }
+
+    [Fact]
+    public async Task EncodedSourceCopiesInputBeforeMaterialization()
+    {
+        byte[] sourceBytes = CreateEncodedPixelBytes(new Rgba32(10, 20, 30, 255));
+        ITextureImportSource source = TextureImportSourceFactory.CreateEncodedImageInMemory(
+            "sRGB",
+            sourceBytes,
+            "dataset:encoded-texture");
+        Array.Fill<byte>(sourceBytes, 0);
+
+        RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            source,
+            CancellationToken.None);
+
+        Assert.Equal(1, rawPayload.Width);
+        Assert.Equal(1, rawPayload.Height);
+        Assert.Equal<byte>([10, 20, 30, 255], rawPayload.Bytes);
     }
 
     [Theory]
@@ -71,5 +112,14 @@ public sealed class TexturePayloadTests
                 "payload:texture"));
 
         Assert.Contains("identity must match", exception.Message, System.StringComparison.Ordinal);
+    }
+
+    private static byte[] CreateEncodedPixelBytes(Rgba32 pixel)
+    {
+        using Image<Rgba32> image = new(1, 1);
+        image[0, 0] = pixel;
+        using MemoryStream stream = new();
+        image.SaveAsPng(stream);
+        return stream.ToArray();
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -39,5 +40,36 @@ public sealed class TexturePayloadTests
 
         Assert.False(string.IsNullOrWhiteSpace(payload.Identity));
         Assert.Equal(payload.Identity, payload.Source.Identity);
+    }
+
+    [Theory]
+    [InlineData(0, 1, 4)]
+    [InlineData(1, 0, 4)]
+    [InlineData(1, 1, 3)]
+    [InlineData(1, 1, 5)]
+    public void RawConstructorRejectsInvalidRawShape(int width, int height, int byteLength)
+    {
+        byte[] bytes = new byte[byteLength];
+
+        Assert.ThrowsAny<ArgumentException>(() => new TexturePayload(width, height, "sRGB", bytes, "dataset:texture"));
+    }
+
+    [Fact]
+    public void EncodedConstructorRejectsPayloadIdentityThatDiffersFromSourceIdentity()
+    {
+        ITextureImportSource source = TextureImportSourceFactory.CreateEncodedImageInMemory(
+            "sRGB",
+            [1, 2, 3, 4],
+            "source:texture");
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            new TexturePayload(
+                1,
+                1,
+                "sRGB",
+                source,
+                "payload:texture"));
+
+        Assert.Contains("identity must match", exception.Message, System.StringComparison.Ordinal);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
@@ -31,4 +31,13 @@ public sealed class TexturePayloadTests
         Assert.Equal(1, rawPayload.Height);
         Assert.Equal<byte>([1, 2, 3, 4], rawPayload.Bytes);
     }
+
+    [Fact]
+    public void RawConstructorKeepsGeneratedIdentityConsistentWithSource()
+    {
+        TexturePayload payload = new(1, 1, "sRGB", [1, 2, 3, 4]);
+
+        Assert.False(string.IsNullOrWhiteSpace(payload.Identity));
+        Assert.Equal(payload.Identity, payload.Source.Identity);
+    }
 }

--- a/tests/PlateauResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Formats/CityGmlAppearanceStoreTests.cs
@@ -277,7 +277,7 @@ public sealed class CityGmlAppearanceStoreTests
         Assert.Equal(1, datasetSource.OpenReadCallCount);
         Assert.Equal(1, rawPayload.Width);
         Assert.Equal(1, rawPayload.Height);
-        Assert.Equal([255, 0, 0, 255], rawPayload.Bytes);
+        Assert.Equal([255, 0, 0, 255], rawPayload.Bytes.AsSpan().ToArray());
     }
 
     private sealed class CountingDatasetContentSource(byte[] payload) : IPlateauDatasetContentSource

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -2072,10 +2072,10 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Equal(3, projected.Materials.Count);
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "ground");
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "ground-reversed");
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "outer-floor");
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Identity == "high-outer-floor");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "ground");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "ground-reversed");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "outer-floor");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "high-outer-floor");
     }
 
     [Fact]
@@ -2112,7 +2112,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Single(projected.Materials);
-        Assert.Equal("tran-ground", projected.Materials[0].TexturePayload?.Identity);
+        Assert.Equal("tran-ground", projected.Materials[0].TexturePayload?.Source.Identity.Value);
         Assert.NotEmpty(projected.Mesh.Vertices);
     }
 
@@ -2170,10 +2170,10 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Equal(2, projected.Materials.Count);
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "lod1-bottom");
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "lod1-bottom-reversed");
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Identity == "lod1-roof");
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Identity == "lod1-wall");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "lod1-bottom");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "lod1-bottom-reversed");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "lod1-roof");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "lod1-wall");
     }
 
     [Fact]
@@ -2245,7 +2245,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Single(projected.Materials);
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Identity == "only-surface");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity.Value == "only-surface");
     }
 
     [Fact]
@@ -2377,7 +2377,7 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.NotNull(explicitMaterial.TexturePayload);
         Assert.Contains(
             "udx/dem/53394525/appearance/mixed_surface.png",
-            explicitMaterial.TexturePayload!.Identity,
+            explicitMaterial.TexturePayload!.Source.Identity.Value,
             StringComparison.Ordinal);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -122,7 +122,7 @@ public sealed class NonDemCityObjectBakerTests
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
 
         string?[] identities = cityObject.Materials
-            .Select(static material => material.TexturePayload?.Identity)
+            .Select(static material => material.TexturePayload?.Source.Identity.Value)
             .ToArray();
         Assert.Collection(
             identities,
@@ -151,7 +151,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(CommonMaterialCatalog.Create().Generic.Uv, material.CommonMaterial);
         Assert.NotSame(payload, material.TexturePayload);
         Assert.NotNull(material.TexturePayload);
-        Assert.Contains("atlastex-", material.TexturePayload.Identity, StringComparison.Ordinal);
+        Assert.Contains("atlastex-", material.TexturePayload.Source.Identity.Value, StringComparison.Ordinal);
         Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, material.TexturePayload.Format);
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
@@ -193,7 +193,7 @@ public sealed class NonDemCityObjectBakerTests
             double averageX = submesh.TriangleVertexIndices
                 .Select(index => cityObject.Mesh.Vertices[index].Position.X)
                 .Average();
-            averageXByPayloadIdentity.Add(material.TexturePayload?.Identity ?? string.Empty, averageX);
+            averageXByPayloadIdentity.Add(material.TexturePayload?.Source.Identity.Value ?? string.Empty, averageX);
         }
 
         Assert.True(averageXByPayloadIdentity["textures/left.png"] < averageXByPayloadIdentity["textures/right.png"]);
@@ -590,7 +590,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(oversizedCandidate.DisplayName, cityObject.DisplayName);
         Assert.Equal(oversizedCandidate.Materials.Count, cityObject.Materials.Count);
         Assert.All(cityObject.Materials, static material => Assert.NotNull(material.TexturePayload));
-        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Source.Identity.Value?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -615,7 +615,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(new ResoniteFloat2(0.25, 0.75), cityObject.Mesh.Vertices[0].UV0);
         Assert.Equal(new ResoniteFloat2(2.25, 0.75), cityObject.Mesh.Vertices[1].UV0);
         Assert.Equal(new ResoniteFloat2(0.25, 1.25), cityObject.Mesh.Vertices[2].UV0);
-        Assert.DoesNotContain(cityObject.Materials, static candidate => candidate.TexturePayload?.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(cityObject.Materials, static candidate => candidate.TexturePayload?.Source.Identity.Value?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -791,7 +791,7 @@ public sealed class NonDemCityObjectBakerTests
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         Assert.Equal(oversizedCandidate.SlotKey, cityObject.SlotKey);
-        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Source.Identity.Value?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -1025,7 +1025,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal("atlasbake-unit-a-bldg-lod2-3", cityObject.SlotKey);
         Assert.Equal(
             "atlastex-unit-a.gml-3",
-            Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Identity);
+            Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Source.Identity.Value);
     }
 
     private static NonDemCityObjectBaker CreateBaker(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -541,13 +541,19 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         => Enumerable.Repeat(TerrainGridSampleCoverage.Measured, count).ToArray();
 
     private static TexturePayload ToContractTexturePayload(ResoniteTexturePayload payload)
-        => new(
-            payload.Width,
-            payload.Height,
-            payload.ColorProfile,
-            payload.BinaryPayload.AsSpan().ToArray(),
-            payload.Identity,
-            (TexturePayloadFormat)payload.Format);
+        => payload.Format == ResoniteTexturePayloadFormat.RawRgba32
+            ? new TexturePayload(
+                payload.Width ?? throw new ArgumentException("Raw texture payload must include width.", nameof(payload)),
+                payload.Height ?? throw new ArgumentException("Raw texture payload must include height.", nameof(payload)),
+                payload.ColorProfile,
+                payload.BinaryPayload.AsSpan().ToArray(),
+                payload.Identity)
+            : new TexturePayload(
+                payload.Width,
+                payload.Height,
+                payload.ColorProfile,
+                payload.Source,
+                payload.Identity);
 
 }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -547,8 +547,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 payload.Width,
                 payload.Height,
                 payload.ColorProfile,
-                payload.Source,
-                payload.Identity);
+                payload.Source);
 
     private static TexturePayload ToContractRawTexturePayload(ResoniteTexturePayload payload)
     {
@@ -561,7 +560,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 height,
                 payload.ColorProfile,
                 payload.BinaryPayload.AsSpan().ToArray(),
-                payload.Identity);
+                payload.Source.Identity.Value);
         }
 
         if (payload.Source is not IRawTexturePayloadSource rawSource)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -542,18 +542,35 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
 
     private static TexturePayload ToContractTexturePayload(ResoniteTexturePayload payload)
         => payload.Format == ResoniteTexturePayloadFormat.RawRgba32
-            ? new TexturePayload(
-                payload.Width ?? throw new ArgumentException("Raw texture payload must include width.", nameof(payload)),
-                payload.Height ?? throw new ArgumentException("Raw texture payload must include height.", nameof(payload)),
-                payload.ColorProfile,
-                payload.BinaryPayload.AsSpan().ToArray(),
-                payload.Identity)
+            ? ToContractRawTexturePayload(payload)
             : new TexturePayload(
                 payload.Width,
                 payload.Height,
                 payload.ColorProfile,
                 payload.Source,
                 payload.Identity);
+
+    private static TexturePayload ToContractRawTexturePayload(ResoniteTexturePayload payload)
+    {
+        int width = payload.Width ?? throw new ArgumentException("Raw texture payload must include width.", nameof(payload));
+        int height = payload.Height ?? throw new ArgumentException("Raw texture payload must include height.", nameof(payload));
+        if (!payload.BinaryPayload.IsDefaultOrEmpty)
+        {
+            return new TexturePayload(
+                width,
+                height,
+                payload.ColorProfile,
+                payload.BinaryPayload.AsSpan().ToArray(),
+                payload.Identity);
+        }
+
+        if (payload.Source is not IRawTexturePayloadSource rawSource)
+        {
+            throw new ArgumentException("Raw texture payload must carry a raw texture import source.", nameof(payload));
+        }
+
+        return new TexturePayload(width, height, payload.ColorProfile, rawSource);
+    }
 
 }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -528,7 +528,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.Equal(2, importedTexture.Width);
         Assert.Equal(2, importedTexture.Height);
         float[] pixels = new float[importedTexture.Bytes.Length / sizeof(float)];
-        Buffer.BlockCopy(importedTexture.Bytes, 0, pixels, 0, importedTexture.Bytes.Length);
+        Buffer.BlockCopy(importedTexture.Bytes.AsSpan().ToArray(), 0, pixels, 0, importedTexture.Bytes.Length);
         Assert.Equal(0.0f, pixels[0]);
         Assert.Equal(0.0f, pixels[1]);
         Assert.Equal(3.0f, pixels[2]);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
@@ -35,12 +35,11 @@ public sealed class ResoniteTexturePayloadTests
     }
 
     [Fact]
-    public void RawConstructorKeepsGeneratedIdentityConsistentWithSource()
+    public void RawConstructorCreatesGeneratedSourceIdentity()
     {
         ResoniteTexturePayload payload = new(1, 1, "sRGB", [4, 3, 2, 1]);
 
-        Assert.False(string.IsNullOrWhiteSpace(payload.Identity));
-        Assert.Equal(payload.Identity, payload.Source.Identity);
+        Assert.False(string.IsNullOrWhiteSpace(payload.Source.Identity.Value));
     }
 
     [Theory]
@@ -56,22 +55,31 @@ public sealed class ResoniteTexturePayloadTests
     }
 
     [Fact]
-    public void EncodedConstructorRejectsPayloadIdentityThatDiffersFromSourceIdentity()
+    public void EncodedConstructorUsesSourceAsIdentityCarrier()
     {
         ITextureImportSource source = TextureImportSourceFactory.CreateEncodedImageInMemory(
             "sRGB",
             [1, 2, 3, 4],
             "source:texture");
 
-        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
-            new ResoniteTexturePayload(
-                1,
-                1,
-                "sRGB",
-                source,
-                "payload:texture"));
+        ResoniteTexturePayload payload = new(
+            1,
+            1,
+            "sRGB",
+            source);
 
-        Assert.Contains("identity must match", exception.Message, System.StringComparison.Ordinal);
+        Assert.Same(source, payload.Source);
+        Assert.Equal(new TextureImportSourceIdentity("source:texture"), payload.Source.Identity);
+    }
+
+    [Fact]
+    public void SourceBackedConstructorRejectsDefaultSourceIdentity()
+    {
+        Assert.ThrowsAny<ArgumentException>(() => new ResoniteTexturePayload(
+            1,
+            1,
+            "sRGB",
+            new DefaultIdentityTextureImportSource()));
     }
 
     [Fact]
@@ -102,7 +110,18 @@ public sealed class ResoniteTexturePayloadTests
         TexturePayload contractPayload = Assert.IsType<TexturePayload>(contractBinding.TexturePayload);
         Assert.Equal(TexturePayloadFormat.RawRgba32, contractPayload.Format);
         Assert.Same(source, contractPayload.Source);
-        Assert.Equal(source.Identity, contractPayload.Identity);
+        Assert.Equal(source.Identity, contractPayload.Source.Identity);
         Assert.True(contractPayload.BinaryPayload.IsDefaultOrEmpty);
+    }
+
+    private sealed class DefaultIdentityTextureImportSource : ITextureImportSource
+    {
+        public TextureImportSourceIdentity Identity => default;
+
+        public string Description => "default identity";
+
+        public string? ColorProfile => "sRGB";
+
+        public long? EstimatedByteLength => null;
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -40,5 +41,36 @@ public sealed class ResoniteTexturePayloadTests
 
         Assert.False(string.IsNullOrWhiteSpace(payload.Identity));
         Assert.Equal(payload.Identity, payload.Source.Identity);
+    }
+
+    [Theory]
+    [InlineData(0, 1, 4)]
+    [InlineData(1, 0, 4)]
+    [InlineData(1, 1, 3)]
+    [InlineData(1, 1, 5)]
+    public void RawConstructorRejectsInvalidRawShape(int width, int height, int byteLength)
+    {
+        byte[] bytes = new byte[byteLength];
+
+        Assert.ThrowsAny<ArgumentException>(() => new ResoniteTexturePayload(width, height, "sRGB", bytes, "dataset:texture"));
+    }
+
+    [Fact]
+    public void EncodedConstructorRejectsPayloadIdentityThatDiffersFromSourceIdentity()
+    {
+        ITextureImportSource source = TextureImportSourceFactory.CreateEncodedImageInMemory(
+            "sRGB",
+            [1, 2, 3, 4],
+            "source:texture");
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            new ResoniteTexturePayload(
+                1,
+                1,
+                "sRGB",
+                source,
+                "payload:texture"));
+
+        Assert.Contains("identity must match", exception.Message, System.StringComparison.Ordinal);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
@@ -73,4 +73,36 @@ public sealed class ResoniteTexturePayloadTests
 
         Assert.Contains("identity must match", exception.Message, System.StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void ContractRoundTripPreservesSourceBackedRawPayload()
+    {
+        ITextureImportSource source = TextureImportSourceFactory.CreateRawRgba32InMemory(
+            1,
+            1,
+            "sRGB",
+            new byte[] { 4, 3, 2, 1 },
+            "source:texture");
+        ResoniteTexturePayload payload = new(
+            1,
+            1,
+            "sRGB",
+            Assert.IsAssignableFrom<IRawTexturePayloadSource>(source));
+        ResoniteMaterialBinding binding = new(
+            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+            MaterialType: ResoniteMaterialType.Standard,
+            TexturePayload: payload,
+            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+            Projection: ResoniteMaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0]);
+
+        MaterialBinding contractBinding = ResoniteLiveSceneImportTargetTestSupport.ToContractMaterial(binding);
+
+        TexturePayload contractPayload = Assert.IsType<TexturePayload>(contractBinding.TexturePayload);
+        Assert.Equal(TexturePayloadFormat.RawRgba32, contractPayload.Format);
+        Assert.Same(source, contractPayload.Source);
+        Assert.Equal(source.Identity, contractPayload.Identity);
+        Assert.True(contractPayload.BinaryPayload.IsDefaultOrEmpty);
+    }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
@@ -1,3 +1,7 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Targets;
@@ -13,5 +17,19 @@ public sealed class ResoniteTexturePayloadTests
         source[0] = 9;
 
         Assert.Equal<byte>([4, 3, 2, 1], payload.BinaryPayload);
+    }
+
+    [Fact]
+    public async Task ConstructorCreatesDimensionedRawTextureSource()
+    {
+        ResoniteTexturePayload payload = new(1, 1, "sRGB", [4, 3, 2, 1], "dataset:texture");
+
+        RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            payload.Source,
+            CancellationToken.None);
+
+        Assert.Equal(1, rawPayload.Width);
+        Assert.Equal(1, rawPayload.Height);
+        Assert.Equal<byte>([4, 3, 2, 1], rawPayload.Bytes);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
@@ -32,4 +32,13 @@ public sealed class ResoniteTexturePayloadTests
         Assert.Equal(1, rawPayload.Height);
         Assert.Equal<byte>([4, 3, 2, 1], rawPayload.Bytes);
     }
+
+    [Fact]
+    public void RawConstructorKeepsGeneratedIdentityConsistentWithSource()
+    {
+        ResoniteTexturePayload payload = new(1, 1, "sRGB", [4, 3, 2, 1]);
+
+        Assert.False(string.IsNullOrWhiteSpace(payload.Identity));
+        Assert.Equal(payload.Identity, payload.Source.Identity);
+    }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -14,7 +14,12 @@ public sealed class SceneImportContractMapperTests
             new(
                 BaseColor: new ColorRgba(0.1, 0.2, 0.3, 0.4),
                 MaterialType: MaterialType.Standard,
-                TexturePayload: new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
+                TexturePayload: new TexturePayload(
+                    2,
+                    2,
+                    "sRGB",
+                    TextureImportSourceFactory.CreateEncodedImageInMemory("sRGB", [1, 2, 3, 4], "dataset:texture"),
+                    "dataset:texture"),
                 TextureSourceKind: TextureSourceKind.Dataset,
                 Projection: MaterialProjection.Uv,
                 DepthOffset: new MaterialDepthOffset(-1.5, 2.5),

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -64,21 +64,6 @@ public sealed class SceneImportContractMapperTests
     }
 
     [Fact]
-    public void ToInternalMaterialBindingsRejectsUnsupportedTexturePayloadFormat()
-    {
-        MaterialBinding validBinding = CreateValidBinding();
-        MaterialBinding binding = validBinding with
-        {
-            TexturePayload = validBinding.TexturePayload! with
-            {
-                Format = (TexturePayloadFormat)999,
-            },
-        };
-
-        Assert.Throws<ArgumentOutOfRangeException>(() => SceneImportContractMapper.ToInternal(binding));
-    }
-
-    [Fact]
     public void ToInternalMaterialBindingsReusesRawTextureSource()
     {
         TexturePayload texturePayload = new(
@@ -110,31 +95,6 @@ public sealed class SceneImportContractMapperTests
         Assert.Same(texturePayload.Source, mapped.TexturePayload.Source);
         Assert.Equal(texturePayload.Source.Identity, mapped.TexturePayload.Identity);
         Assert.True(mapped.TexturePayload.BinaryPayload.IsDefaultOrEmpty);
-    }
-
-    [Fact]
-    public void ToInternalMaterialBindingsUsesRawSourceIdentityWhenContractIdentityDiverges()
-    {
-        TexturePayload texturePayload = new TexturePayload(
-            width: 1,
-            height: 1,
-            colorProfile: "linear",
-            binaryPayload: [0, 0, 0, 255]) with
-        {
-            Identity = "stale-contract-identity",
-        };
-        MaterialBinding[] bindings =
-        [
-            CreateValidBinding() with
-            {
-                TexturePayload = texturePayload,
-            },
-        ];
-
-        ResoniteMaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToInternal(bindings));
-
-        Assert.Same(texturePayload.Source, mapped.TexturePayload!.Source);
-        Assert.Equal(texturePayload.Source.Identity, mapped.TexturePayload.Identity);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -64,6 +64,21 @@ public sealed class SceneImportContractMapperTests
     }
 
     [Fact]
+    public void ToInternalMaterialBindingsRejectsUnsupportedTexturePayloadFormat()
+    {
+        MaterialBinding validBinding = CreateValidBinding();
+        MaterialBinding binding = validBinding with
+        {
+            TexturePayload = validBinding.TexturePayload! with
+            {
+                Format = (TexturePayloadFormat)999,
+            },
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => SceneImportContractMapper.ToInternal(binding));
+    }
+
+    [Fact]
     public void ToInternalMaterialBindingsReusesRawTextureSource()
     {
         TexturePayload texturePayload = new(

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -46,6 +46,40 @@ public sealed class SceneImportContractMapperTests
     }
 
     [Fact]
+    public void ToInternalMaterialBindingsReusesRawTextureSource()
+    {
+        TexturePayload texturePayload = new(
+            width: 2,
+            height: 2,
+            colorProfile: "linear",
+            binaryPayload:
+            [
+                0, 0, 0, 255,
+                255, 0, 0, 255,
+                0, 255, 0, 255,
+                0, 0, 255, 255,
+            ],
+            identity: "raw:texture");
+        MaterialBinding[] bindings =
+        [
+            new(
+                BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+                MaterialType: MaterialType.Standard,
+                TexturePayload: texturePayload,
+                TextureSourceKind: TextureSourceKind.Dataset,
+                Projection: MaterialProjection.Uv,
+                DepthOffset: null,
+                SubmeshIndices: [0]),
+        ];
+
+        ResoniteMaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToInternal(bindings));
+
+        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, mapped.TexturePayload!.Format);
+        Assert.Same(texturePayload.Source, mapped.TexturePayload.Source);
+        Assert.True(mapped.TexturePayload.BinaryPayload.IsDefaultOrEmpty);
+    }
+
+    [Fact]
     public void ToInternalMaterialBindingsKeepsTerrainOverlaySharedScopeIndependentFromProvider()
     {
         TerrainTextureOverlay overlay = new(

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -91,8 +91,7 @@ public sealed class SceneImportContractMapperTests
                 255, 0, 0, 255,
                 0, 255, 0, 255,
                 0, 0, 255, 255,
-            ],
-            identity: "raw:texture");
+            ]);
         MaterialBinding[] bindings =
         [
             new(
@@ -109,7 +108,33 @@ public sealed class SceneImportContractMapperTests
 
         Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, mapped.TexturePayload!.Format);
         Assert.Same(texturePayload.Source, mapped.TexturePayload.Source);
+        Assert.Equal(texturePayload.Source.Identity, mapped.TexturePayload.Identity);
         Assert.True(mapped.TexturePayload.BinaryPayload.IsDefaultOrEmpty);
+    }
+
+    [Fact]
+    public void ToInternalMaterialBindingsUsesRawSourceIdentityWhenContractIdentityDiverges()
+    {
+        TexturePayload texturePayload = new TexturePayload(
+            width: 1,
+            height: 1,
+            colorProfile: "linear",
+            binaryPayload: [0, 0, 0, 255]) with
+        {
+            Identity = "stale-contract-identity",
+        };
+        MaterialBinding[] bindings =
+        [
+            CreateValidBinding() with
+            {
+                TexturePayload = texturePayload,
+            },
+        ];
+
+        ResoniteMaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToInternal(bindings));
+
+        Assert.Same(texturePayload.Source, mapped.TexturePayload!.Source);
+        Assert.Equal(texturePayload.Source.Identity, mapped.TexturePayload.Identity);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -20,8 +20,7 @@ public sealed class SceneImportContractMapperTests
                     2,
                     2,
                     "sRGB",
-                    TextureImportSourceFactory.CreateEncodedImageInMemory("sRGB", [1, 2, 3, 4], "dataset:texture"),
-                    "dataset:texture"),
+                    TextureImportSourceFactory.CreateEncodedImageInMemory("sRGB", [1, 2, 3, 4], "dataset:texture")),
                 TextureSourceKind: TextureSourceKind.Dataset,
                 Projection: MaterialProjection.Uv,
                 DepthOffset: new MaterialDepthOffset(-1.5, 2.5),
@@ -37,7 +36,7 @@ public sealed class SceneImportContractMapperTests
 
         Assert.Equal(0.1, mapped.BaseColor.R, 9);
         Assert.Equal(0.2, mapped.BaseColor.G, 9);
-        Assert.Equal("dataset:texture", mapped.TexturePayload!.Identity);
+        Assert.Equal(new TextureImportSourceIdentity("dataset:texture"), mapped.TexturePayload!.Source.Identity);
         Assert.Equal(ResoniteTexturePayloadFormat.EncodedImage, mapped.TexturePayload.Format);
         Assert.Equal(-1.5, mapped.DepthOffset!.Factor, 9);
         Assert.Equal(2.5, mapped.DepthOffset.Units, 9);
@@ -93,7 +92,7 @@ public sealed class SceneImportContractMapperTests
 
         Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, mapped.TexturePayload!.Format);
         Assert.Same(texturePayload.Source, mapped.TexturePayload.Source);
-        Assert.Equal(texturePayload.Source.Identity, mapped.TexturePayload.Identity);
+        Assert.Equal(texturePayload.Source.Identity, mapped.TexturePayload.Source.Identity);
         Assert.True(mapped.TexturePayload.BinaryPayload.IsDefaultOrEmpty);
     }
 
@@ -176,8 +175,7 @@ public sealed class SceneImportContractMapperTests
                 2,
                 2,
                 "sRGB",
-                TextureImportSourceFactory.CreateEncodedImageInMemory("sRGB", [1, 2, 3, 4], "dataset:texture"),
-                "dataset:texture"),
+                TextureImportSourceFactory.CreateEncodedImageInMemory("sRGB", [1, 2, 3, 4], "dataset:texture")),
             TextureSourceKind: TextureSourceKind.Dataset,
             Projection: MaterialProjection.Uv,
             DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -225,7 +225,9 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         Assert.Equal(Materialize(texture.TextureSource).Width, Materialize(repeatedTexture.TextureSource).Width);
         Assert.Equal(Materialize(texture.TextureSource).Height, Materialize(repeatedTexture.TextureSource).Height);
-        Assert.Equal(Materialize(texture.TextureSource).Bytes, Materialize(repeatedTexture.TextureSource).Bytes);
+        Assert.Equal(
+            Materialize(texture.TextureSource).Bytes.AsSpan().ToArray(),
+            Materialize(repeatedTexture.TextureSource).Bytes.AsSpan().ToArray());
     }
 
     [Fact]
@@ -600,7 +602,7 @@ public sealed class TerrainTextureAssetGeneratorTests
     private static Image<Rgba32> LoadImage(ITextureImportSource texture)
     {
         RawTexturePayload rawPayload = Materialize(texture);
-        return Image.LoadPixelData<Rgba32>(rawPayload.Bytes, rawPayload.Width, rawPayload.Height);
+        return Image.LoadPixelData<Rgba32>(rawPayload.Bytes.AsSpan().ToArray(), rawPayload.Width, rawPayload.Height);
     }
 
     private static RawTexturePayload Materialize(ITextureImportSource texture)

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
@@ -275,7 +275,7 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
 
         Assert.Equal(0, handler.RequestCount);
         using Image<Rgba32> outputImage = Image.LoadPixelData<Rgba32>(
-            Materialize(texture.TextureSource).Bytes,
+            Materialize(texture.TextureSource).Bytes.AsSpan().ToArray(),
             Materialize(texture.TextureSource).Width,
             Materialize(texture.TextureSource).Height);
         Assert.Equal(new Rgba32(12, 34, 56, 255), outputImage[0, 0]);
@@ -391,7 +391,7 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
                 (double)layout.CropHeight / Materialize(texture.TextureSource).Height),
             texture.OccupiedUvRect.ScaleValue);
         using Image<Rgba32> outputImage = Image.LoadPixelData<Rgba32>(
-            Materialize(texture.TextureSource).Bytes,
+            Materialize(texture.TextureSource).Bytes.AsSpan().ToArray(),
             Materialize(texture.TextureSource).Width,
             Materialize(texture.TextureSource).Height);
         int occupiedLeft = (outputImage.Width - layout.CropWidth) / 2;
@@ -432,7 +432,7 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
         using Image<Rgba32> outputImage = Image.LoadPixelData<Rgba32>(
-            Materialize(texture.TextureSource).Bytes,
+            Materialize(texture.TextureSource).Bytes.AsSpan().ToArray(),
             Materialize(texture.TextureSource).Width,
             Materialize(texture.TextureSource).Height);
         Assert.Equal(TerrainTextureAssetGenerator.DefaultDemGroundFillColor, outputImage[0, 0]);
@@ -483,7 +483,7 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
         using Image<Rgba32> outputImage = Image.LoadPixelData<Rgba32>(
-            Materialize(texture.TextureSource).Bytes,
+            Materialize(texture.TextureSource).Bytes.AsSpan().ToArray(),
             Materialize(texture.TextureSource).Width,
             Materialize(texture.TextureSource).Height);
         int occupiedTop = outputImage.Height - layout.CropHeight;

--- a/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
@@ -16,13 +16,12 @@ internal static class TextureImportSourceTestFactory
         byte[] rawRgba32Bytes,
         string? identity = null)
     {
-        return TextureImportSourceFactory.CreateInMemory(
+        return TextureImportSourceFactory.CreateRawRgba32InMemory(
             width,
             height,
             colorProfile,
             rawRgba32Bytes,
-            identity ?? $"test-rgba32:{width}:{height}:{Guid.NewGuid():N}",
-            TexturePayloadFormat.RawRgba32);
+            identity ?? $"test-rgba32:{width}:{height}:{Guid.NewGuid():N}");
     }
 
     public static IReadOnlyList<RawTexturePayload> ImportedRgba32Textures(SceneSinkRecordingClient client)

--- a/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
@@ -151,7 +151,7 @@ public sealed class ResoniteLinkClientTests
         Assert.Equal(1, importedTexture.Width);
         Assert.Equal(1, importedTexture.Height);
         Assert.Equal(ResoniteTextureColorProfiles.Srgb, importedTexture.ColorProfile);
-        Assert.Equal([255, 0, 0, 255], importedTexture.Bytes);
+        Assert.Equal([255, 0, 0, 255], importedTexture.Bytes.AsSpan().ToArray());
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
@@ -382,7 +382,7 @@ public sealed class ResoniteLinkClientTests
     {
         public int MaterializeCallCount { get; private set; }
 
-        public string Identity => "instrumented";
+        public TextureImportSourceIdentity Identity { get; } = new("instrumented");
 
         public string Description => "instrumented";
 


### PR DESCRIPTION
## Summary
- split in-memory texture sources into raw RGBA and encoded-image variants
- make raw texture payload constructors require non-null width and height, and remove the raw/encoded format enum from those construction paths
- make source-backed texture payload constructors encoded-image only
- remove the runtime path where raw in-memory payloads could be created without dimensions and fail during materialization

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- Fake Live Sink canonical dump for plateau-13213-higashimurayama-shi-2020 mesh 53395325 dem,bldg grid geotiff
- git diff --no-index against type-dem-grid-projection-result baseline: no diff