### PR TITLE
Type Non-DEM atlas bake classification

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
@@ -16,7 +16,7 @@ internal interface INonDemAtlasOrPreservedEntryFactory
     Task<NonDemAtlasOrPreservedEntry> CreateAsync(
         ResoniteConstructionCityObject cityObject,
         ResoniteMeshSubmesh submesh,
-        ResoniteMaterialBinding material,
+        NonDemAtlasBakeMaterial atlasMaterial,
         CancellationToken cancellationToken);
 }
 
@@ -30,17 +30,13 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
     public async Task<NonDemAtlasOrPreservedEntry> CreateAsync(
         ResoniteConstructionCityObject cityObject,
         ResoniteMeshSubmesh submesh,
-        ResoniteMaterialBinding material,
+        NonDemAtlasBakeMaterial atlasMaterial,
         CancellationToken cancellationToken)
     {
-        if (material.TexturePayload is null)
-        {
-            throw new InvalidOperationException("Non-DEM bake candidate material must have a texture payload.");
-        }
-
+        ResoniteMaterialBinding material = atlasMaterial.Material;
         TextureUvRect uvBounds = ComputeUvBounds(cityObject.Mesh.Vertices, submesh);
         using Image<Rgba32> sourceImage = await textureImageLoader.LoadAsync(
-            ResoniteTextureImportFactory.CreateSourceFromPayload(material.TexturePayload),
+            ResoniteTextureImportFactory.CreateSourceFromPayload(atlasMaterial.TexturePayload),
             cancellationToken);
         Rgba32 detectedBackgroundColor = NonDemTextureImageProcessing.DetectRepresentativeBackgroundColor(sourceImage);
         using Image<Rgba32> preparedSourceImage = sourceImage.Clone();
@@ -50,9 +46,8 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
             Rgba32 tintedUniformColor = NonDemTextureImageProcessing.MultiplyPixel(
                 uniformDatasetColor,
                 NonDemTextureImageProcessing.ToPixel(material.BaseColor));
-            return new NonDemAtlasOrPreservedEntry(
-                AtlasEntry: null,
-                PreservedEntry: new NonDemPreservedSubmeshEntry(
+            return new NonDemAtlasOrPreservedEntry.Preserved(
+                new NonDemPreservedSubmeshEntry(
                     cityObject,
                     submesh,
                     CreateVertexColorMaterial(material, submesh.Index),
@@ -68,8 +63,8 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
             targetHeight);
 
         NonDemTextureImageProcessing.ApplyBaseColor(bakedImage, material.BaseColor);
-        return new NonDemAtlasOrPreservedEntry(
-            AtlasEntry: new NonDemAtlasBatchEntry(
+        return new NonDemAtlasOrPreservedEntry.Atlas(
+            new NonDemAtlasBatchEntry(
                 cityObject,
                 submesh,
                 material,
@@ -78,8 +73,7 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
                     NonDemTextureImageProcessing.MultiplyPixel(
                         detectedBackgroundColor,
                         NonDemTextureImageProcessing.ToPixel(material.BaseColor))),
-                uvBounds),
-            PreservedEntry: null);
+                uvBounds));
     }
 
     private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -50,31 +50,31 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
                     $"Non-DEM bake city object '{cityObject.DisplayName}' left submesh index {submesh.Index} without a material assignment.");
             }
 
-            NonDemMaterialBakeCategory category = NonDemCityObjectBakeMaterialClassifier.Classify(material);
-            switch (category)
+            NonDemMaterialBakeClassification classification = NonDemCityObjectBakeMaterialClassifier.Classify(material);
+            switch (classification)
             {
-                case NonDemMaterialBakeCategory.AtlasCandidate:
+                case NonDemMaterialBakeClassification.AtlasCandidate atlasCandidate:
                     hadAtlasCandidateMaterial = true;
                     NonDemAtlasOrPreservedEntry bakeEntry = await entryFactory.CreateAsync(
                         normalizedCityObject,
                         submesh,
-                        material,
+                        atlasCandidate.Candidate,
                         cancellationToken);
-                    if (bakeEntry.AtlasEntry is not null)
+                    switch (bakeEntry)
                     {
-                        atlasEntries.Add(bakeEntry.AtlasEntry);
-                    }
-
-                    if (bakeEntry.PreservedEntry is not null)
-                    {
-                        preservedEntries.Add(bakeEntry.PreservedEntry);
+                        case NonDemAtlasOrPreservedEntry.Atlas atlasEntry:
+                            atlasEntries.Add(atlasEntry.Entry);
+                            break;
+                        case NonDemAtlasOrPreservedEntry.Preserved preservedEntry:
+                            preservedEntries.Add(preservedEntry.Entry);
+                            break;
                     }
 
                     break;
-                case NonDemMaterialBakeCategory.PreservedCommonMaterial when policy.PreserveCommonMaterials:
-                case NonDemMaterialBakeCategory.PreservedTextureless when policy.PreserveTexturelessMaterials:
-                case NonDemMaterialBakeCategory.PreservedVertexColor when policy.PreserveVertexColorMaterials:
-                case NonDemMaterialBakeCategory.PreservedOther:
+                case NonDemMaterialBakeClassification.Preserved { Kind: NonDemPreservedMaterialKind.CommonMaterial } when policy.PreserveCommonMaterials:
+                case NonDemMaterialBakeClassification.Preserved { Kind: NonDemPreservedMaterialKind.Textureless } when policy.PreserveTexturelessMaterials:
+                case NonDemMaterialBakeClassification.Preserved { Kind: NonDemPreservedMaterialKind.VertexColor } when policy.PreserveVertexColorMaterials:
+                case NonDemMaterialBakeClassification.Preserved { Kind: NonDemPreservedMaterialKind.Other }:
                     ResoniteMeshSubmesh normalizedSubmesh = normalizedCityObject.Mesh.Submeshes.Single(candidate => candidate.Index == submesh.Index);
                     ResoniteMaterialBinding normalizedMaterial = normalizedCityObject.Materials.Single(candidate => candidate.SubmeshIndices.Contains(submesh.Index));
                     preservedEntries.Add(new NonDemPreservedSubmeshEntry(normalizedCityObject, normalizedSubmesh, normalizedMaterial));

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeMaterialClassifier.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeMaterialClassifier.cs
@@ -21,19 +21,22 @@ internal static class NonDemCityObjectBakeMaterialClassifier
                 return false;
             }
 
-            NonDemMaterialBakeCategory category = Classify(material);
-            hasAtlasCandidateSubmesh |= category == NonDemMaterialBakeCategory.AtlasCandidate;
-            if (category == NonDemMaterialBakeCategory.PreservedCommonMaterial && !policy.PreserveCommonMaterials)
+            NonDemMaterialBakeClassification classification = Classify(material);
+            hasAtlasCandidateSubmesh |= classification is NonDemMaterialBakeClassification.AtlasCandidate;
+            if (classification is NonDemMaterialBakeClassification.Preserved { Kind: NonDemPreservedMaterialKind.CommonMaterial }
+                && !policy.PreserveCommonMaterials)
             {
                 return false;
             }
 
-            if (category == NonDemMaterialBakeCategory.PreservedVertexColor && !policy.PreserveVertexColorMaterials)
+            if (classification is NonDemMaterialBakeClassification.Preserved { Kind: NonDemPreservedMaterialKind.VertexColor }
+                && !policy.PreserveVertexColorMaterials)
             {
                 return false;
             }
 
-            if (category == NonDemMaterialBakeCategory.PreservedTextureless && !policy.PreserveTexturelessMaterials)
+            if (classification is NonDemMaterialBakeClassification.Preserved { Kind: NonDemPreservedMaterialKind.Textureless }
+                && !policy.PreserveTexturelessMaterials)
             {
                 return false;
             }
@@ -61,57 +64,32 @@ internal static class NonDemCityObjectBakeMaterialClassifier
         return true;
     }
 
-    public static NonDemMaterialBakeCategory Classify(ResoniteMaterialBinding material)
+    public static NonDemMaterialBakeClassification Classify(ResoniteMaterialBinding material)
     {
-        if (IsAtlasBakeCandidate(material))
+        if (NonDemAtlasBakeMaterial.TryCreate(material) is NonDemAtlasBakeMaterial atlasCandidate)
         {
-            return NonDemMaterialBakeCategory.AtlasCandidate;
+            return new NonDemMaterialBakeClassification.AtlasCandidate(atlasCandidate);
         }
 
         if (material.MaterialType == ResoniteMaterialType.VertexColor)
         {
-            return NonDemMaterialBakeCategory.PreservedVertexColor;
+            return new NonDemMaterialBakeClassification.Preserved(NonDemPreservedMaterialKind.VertexColor);
         }
 
         if (material.AssetScope == ResoniteMaterialAssetScope.Common
             || !string.IsNullOrWhiteSpace(material.Family))
         {
             return CanPreserveAsCommonMaterial(material)
-                ? NonDemMaterialBakeCategory.PreservedCommonMaterial
-                : NonDemMaterialBakeCategory.PreservedOther;
+                ? new NonDemMaterialBakeClassification.Preserved(NonDemPreservedMaterialKind.CommonMaterial)
+                : new NonDemMaterialBakeClassification.Preserved(NonDemPreservedMaterialKind.Other);
         }
 
         if (material.TexturePayload is null)
         {
-            return NonDemMaterialBakeCategory.PreservedTextureless;
+            return new NonDemMaterialBakeClassification.Preserved(NonDemPreservedMaterialKind.Textureless);
         }
 
-        return NonDemMaterialBakeCategory.PreservedOther;
-    }
-
-    private static bool IsAtlasBakeCandidate(ResoniteMaterialBinding material)
-    {
-        if (material.DepthOffset is not null
-            || material.Projection != ResoniteMaterialProjection.Uv
-            || material.AssetScope == ResoniteMaterialAssetScope.Common)
-        {
-            return false;
-        }
-
-        if (material.MaterialType != ResoniteMaterialType.Standard
-            || material.TexturePayload is null
-            || material.TextureSourceKind != ResoniteTextureSourceKind.Dataset)
-        {
-            return false;
-        }
-
-        if (string.IsNullOrWhiteSpace(material.Family))
-        {
-            return true;
-        }
-
-        return material.TerrainOverlay is null
-            && ResoniteMaterialSharing.CanUseSharedAlbedoOnlyMaterial(material);
+        return new NonDemMaterialBakeClassification.Preserved(NonDemPreservedMaterialKind.Other);
     }
 
     private static bool CanPreserveAsCommonMaterial(ResoniteMaterialBinding material)

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
@@ -9,9 +9,66 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed record NonDemMaterialAtlasTile(Image<Rgba32> Image, Rgba32 BackgroundColor);
 
-internal sealed record NonDemAtlasOrPreservedEntry(
-    NonDemAtlasBatchEntry? AtlasEntry,
-    NonDemPreservedSubmeshEntry? PreservedEntry);
+internal sealed record NonDemAtlasBakeMaterial
+{
+    private NonDemAtlasBakeMaterial(ResoniteMaterialBinding material, ResoniteTexturePayload texturePayload)
+    {
+        Material = material;
+        TexturePayload = texturePayload;
+    }
+
+    public ResoniteMaterialBinding Material { get; }
+
+    public ResoniteTexturePayload TexturePayload { get; }
+
+    public static NonDemAtlasBakeMaterial? TryCreate(ResoniteMaterialBinding material)
+    {
+        if (material.DepthOffset is not null
+            || material.Projection != ResoniteMaterialProjection.Uv
+            || material.AssetScope == ResoniteMaterialAssetScope.Common)
+        {
+            return null;
+        }
+
+        if (material.MaterialType != ResoniteMaterialType.Standard
+            || material.TexturePayload is null
+            || material.TextureSourceKind != ResoniteTextureSourceKind.Dataset)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(material.Family)
+            && (material.TerrainOverlay is not null
+                || !ResoniteMaterialSharing.CanUseSharedAlbedoOnlyMaterial(material)))
+        {
+            return null;
+        }
+
+        return new NonDemAtlasBakeMaterial(material, material.TexturePayload);
+    }
+}
+
+internal abstract record NonDemMaterialBakeClassification
+{
+    private NonDemMaterialBakeClassification()
+    {
+    }
+
+    public sealed record AtlasCandidate(NonDemAtlasBakeMaterial Candidate) : NonDemMaterialBakeClassification;
+
+    public sealed record Preserved(NonDemPreservedMaterialKind Kind) : NonDemMaterialBakeClassification;
+}
+
+internal abstract record NonDemAtlasOrPreservedEntry
+{
+    private NonDemAtlasOrPreservedEntry()
+    {
+    }
+
+    public sealed record Atlas(NonDemAtlasBatchEntry Entry) : NonDemAtlasOrPreservedEntry;
+
+    public sealed record Preserved(NonDemPreservedSubmeshEntry Entry) : NonDemAtlasOrPreservedEntry;
+}
 
 internal readonly record struct NonDemBufferedCityObject(
     ResoniteConstructionCityObject CityObject,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicy.cs
@@ -3,13 +3,12 @@ using System.Collections.Generic;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal enum NonDemMaterialBakeCategory
+internal enum NonDemPreservedMaterialKind
 {
-    AtlasCandidate,
-    PreservedCommonMaterial,
-    PreservedVertexColor,
-    PreservedTextureless,
-    PreservedOther,
+    CommonMaterial,
+    VertexColor,
+    Textureless,
+    Other,
 }
 
 internal sealed record NonDemCityObjectBakePolicy(

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
@@ -10,24 +10,24 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
     [Fact]
     public void ClassifySeparatesAtlasCandidateFromPreservedMaterialKinds()
     {
-        Assert.Equal(
-            NonDemMaterialBakeCategory.AtlasCandidate,
+        NonDemMaterialBakeClassification.AtlasCandidate atlasCandidate = Assert.IsType<NonDemMaterialBakeClassification.AtlasCandidate>(
             NonDemCityObjectBakeMaterialClassifier.Classify(CreateDatasetTextureMaterial()));
-        Assert.Equal(
-            NonDemMaterialBakeCategory.PreservedVertexColor,
+        Assert.Equal("dataset.png", atlasCandidate.Candidate.TexturePayload.Identity);
+        AssertPreservedKind(
+            NonDemPreservedMaterialKind.VertexColor,
             NonDemCityObjectBakeMaterialClassifier.Classify(CreateTexturelessMaterial() with { MaterialType = ResoniteMaterialType.VertexColor }));
-        Assert.Equal(
-            NonDemMaterialBakeCategory.PreservedCommonMaterial,
+        AssertPreservedKind(
+            NonDemPreservedMaterialKind.CommonMaterial,
             NonDemCityObjectBakeMaterialClassifier.Classify(CreateTexturelessMaterial() with
             {
                 AssetScope = ResoniteMaterialAssetScope.Common,
                 CommonMaterial = CommonMaterialCatalog.Create().Generic.Uv,
             }));
-        Assert.Equal(
-            NonDemMaterialBakeCategory.PreservedTextureless,
+        AssertPreservedKind(
+            NonDemPreservedMaterialKind.Textureless,
             NonDemCityObjectBakeMaterialClassifier.Classify(CreateTexturelessMaterial()));
-        Assert.Equal(
-            NonDemMaterialBakeCategory.PreservedOther,
+        AssertPreservedKind(
+            NonDemPreservedMaterialKind.Other,
             NonDemCityObjectBakeMaterialClassifier.Classify(CreateDatasetTextureMaterial() with
             {
                 Projection = ResoniteMaterialProjection.Triplanar,
@@ -70,6 +70,14 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
         Assert.False(NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(
             cityObject,
             out _));
+    }
+
+    private static void AssertPreservedKind(
+        NonDemPreservedMaterialKind expectedKind,
+        NonDemMaterialBakeClassification classification)
+    {
+        NonDemMaterialBakeClassification.Preserved preserved = Assert.IsType<NonDemMaterialBakeClassification.Preserved>(classification);
+        Assert.Equal(expectedKind, preserved.Kind);
     }
 
     private static ResoniteConstructionCityObject CreateCityObject(IReadOnlyList<ResoniteMaterialBinding> materials)


### PR DESCRIPTION
## Summary
- replace the Non-DEM material bake enum with a typed classification that carries an atlas candidate payload
- make the atlas/preserved entry result a discriminated shape instead of a pair of nullable entries
- remove the runtime guard where the atlas entry factory rechecked for a missing texture payload

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- Fake Live Sink canonical dump for plateau-13213-higashimurayama-shi-2020 mesh 53395325 dem,bldg grid geotiff
- git diff --no-index against type-dem-grid-projection-result baseline: no diff