### PR TITLE
Type Non-DEM bake entries as a closed union

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemBakeEntryFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemBakeEntryFactory.cs
@@ -11,23 +11,23 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal interface INonDemAtlasOrPreservedEntryFactory
+internal interface INonDemBakeEntryFactory
 {
-    Task<NonDemAtlasOrPreservedEntry> CreateAsync(
+    Task<NonDemBakeEntry> CreateAsync(
         ResoniteConstructionCityObject cityObject,
         ResoniteMeshSubmesh submesh,
         ResoniteMaterialBinding material,
         CancellationToken cancellationToken);
 }
 
-internal sealed class NonDemAtlasOrPreservedEntryFactory(
+internal sealed class NonDemBakeEntryFactory(
     ResoniteTextureImageLoader textureImageLoader,
-    int maxAtlasTextureEdge) : INonDemAtlasOrPreservedEntryFactory
+    int maxAtlasTextureEdge) : INonDemBakeEntryFactory
 {
     private readonly ResoniteTextureImageLoader textureImageLoader = textureImageLoader
         ?? throw new ArgumentNullException(nameof(textureImageLoader));
 
-    public async Task<NonDemAtlasOrPreservedEntry> CreateAsync(
+    public async Task<NonDemBakeEntry> CreateAsync(
         ResoniteConstructionCityObject cityObject,
         ResoniteMeshSubmesh submesh,
         ResoniteMaterialBinding material,
@@ -50,9 +50,8 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
             Rgba32 tintedUniformColor = NonDemTextureImageProcessing.MultiplyPixel(
                 uniformDatasetColor,
                 NonDemTextureImageProcessing.ToPixel(material.BaseColor));
-            return new NonDemAtlasOrPreservedEntry(
-                AtlasEntry: null,
-                PreservedEntry: new NonDemPreservedSubmeshEntry(
+            return new NonDemBakeEntry.Preserved(
+                new NonDemPreservedSubmeshEntry(
                     cityObject,
                     submesh,
                     CreateVertexColorMaterial(material, submesh.Index),
@@ -68,8 +67,8 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
             targetHeight);
 
         NonDemTextureImageProcessing.ApplyBaseColor(bakedImage, material.BaseColor);
-        return new NonDemAtlasOrPreservedEntry(
-            AtlasEntry: new NonDemAtlasBatchEntry(
+        return new NonDemBakeEntry.Atlas(
+            new NonDemAtlasBatchEntry(
                 cityObject,
                 submesh,
                 material,
@@ -78,8 +77,7 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
                     NonDemTextureImageProcessing.MultiplyPixel(
                         detectedBackgroundColor,
                         NonDemTextureImageProcessing.ToPixel(material.BaseColor))),
-                uvBounds),
-            PreservedEntry: null);
+                uvBounds));
     }
 
     private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -59,7 +59,9 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
                         normalizedCityObject,
                         submesh,
                         material,
-                        cancellationToken);
+                        cancellationToken)
+                        ?? throw new InvalidOperationException(
+                            $"Non-DEM bake entry factory returned no entry for city object '{cityObject.DisplayName}' submesh index {submesh.Index}.");
                     switch (bakeEntry)
                     {
                         case NonDemBakeEntry.Atlas atlas:
@@ -68,6 +70,9 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
                         case NonDemBakeEntry.Preserved preserved:
                             preservedEntries.Add(preserved.Entry);
                             break;
+                        default:
+                            throw new InvalidOperationException(
+                                $"Unsupported Non-DEM bake entry type '{bakeEntry.GetType().FullName}'.");
                     }
 
                     break;

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -14,9 +14,9 @@ internal interface INonDemCityObjectBakeCandidateFactory
 }
 
 internal sealed class NonDemCityObjectBakeCandidateFactory(
-    INonDemAtlasOrPreservedEntryFactory entryFactory) : INonDemCityObjectBakeCandidateFactory
+    INonDemBakeEntryFactory entryFactory) : INonDemCityObjectBakeCandidateFactory
 {
-    private readonly INonDemAtlasOrPreservedEntryFactory entryFactory = entryFactory
+    private readonly INonDemBakeEntryFactory entryFactory = entryFactory
         ?? throw new ArgumentNullException(nameof(entryFactory));
 
     public async Task<NonDemCityObjectBakeCandidate?> CreateAsync(
@@ -55,19 +55,19 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
             {
                 case NonDemMaterialBakeCategory.AtlasCandidate:
                     hadAtlasCandidateMaterial = true;
-                    NonDemAtlasOrPreservedEntry bakeEntry = await entryFactory.CreateAsync(
+                    NonDemBakeEntry bakeEntry = await entryFactory.CreateAsync(
                         normalizedCityObject,
                         submesh,
                         material,
                         cancellationToken);
-                    if (bakeEntry.AtlasEntry is not null)
+                    switch (bakeEntry)
                     {
-                        atlasEntries.Add(bakeEntry.AtlasEntry);
-                    }
-
-                    if (bakeEntry.PreservedEntry is not null)
-                    {
-                        preservedEntries.Add(bakeEntry.PreservedEntry);
+                        case NonDemBakeEntry.Atlas atlas:
+                            atlasEntries.Add(atlas.Entry);
+                            break;
+                        case NonDemBakeEntry.Preserved preserved:
+                            preservedEntries.Add(preserved.Entry);
+                            break;
                     }
 
                     break;

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -8,7 +8,7 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal interface INonDemCityObjectBakeCandidateFactory
 {
-    Task<NonDemCityObjectBakeCandidate?> CreateAsync(
+    Task<NonDemCityObjectBakeCandidate> CreateAsync(
         NonDemBufferedCityObject bufferedCityObject,
         CancellationToken cancellationToken);
 }
@@ -19,7 +19,7 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
     private readonly INonDemBakeEntryFactory entryFactory = entryFactory
         ?? throw new ArgumentNullException(nameof(entryFactory));
 
-    public async Task<NonDemCityObjectBakeCandidate?> CreateAsync(
+    public async Task<NonDemCityObjectBakeCandidate> CreateAsync(
         NonDemBufferedCityObject bufferedCityObject,
         CancellationToken cancellationToken)
     {
@@ -40,7 +40,6 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
 
         List<NonDemAtlasBatchEntry> atlasEntries = [];
         List<NonDemPreservedSubmeshEntry> preservedEntries = [];
-        bool hadAtlasCandidateMaterial = false;
         foreach (ResoniteMeshSubmesh submesh in normalizedCityObject.Mesh.Submeshes.OrderBy(static candidate => candidate.Index))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -54,26 +53,12 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
             switch (category)
             {
                 case NonDemMaterialBakeCategory.AtlasCandidate:
-                    hadAtlasCandidateMaterial = true;
                     NonDemBakeEntry bakeEntry = await entryFactory.CreateAsync(
                         normalizedCityObject,
                         submesh,
                         material,
-                        cancellationToken)
-                        ?? throw new InvalidOperationException(
-                            $"Non-DEM bake entry factory returned no entry for city object '{cityObject.DisplayName}' submesh index {submesh.Index}.");
-                    switch (bakeEntry)
-                    {
-                        case NonDemBakeEntry.Atlas atlas:
-                            atlasEntries.Add(atlas.Entry);
-                            break;
-                        case NonDemBakeEntry.Preserved preserved:
-                            preservedEntries.Add(preserved.Entry);
-                            break;
-                        default:
-                            throw new InvalidOperationException(
-                                $"Unsupported Non-DEM bake entry type '{bakeEntry.GetType().FullName}'.");
-                    }
+                        cancellationToken);
+                    bakeEntry.AddTo(atlasEntries, preservedEntries);
 
                     break;
                 case NonDemMaterialBakeCategory.PreservedCommonMaterial when policy.PreserveCommonMaterials:
@@ -85,11 +70,6 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
                     preservedEntries.Add(new NonDemPreservedSubmeshEntry(normalizedCityObject, normalizedSubmesh, normalizedMaterial));
                     break;
             }
-        }
-
-        if (policy.RequireAtlasCandidateMaterial && !hadAtlasCandidateMaterial)
-        {
-            return null;
         }
 
         if (atlasEntries.Count == 0 && preservedEntries.Count == 0)

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
@@ -16,6 +16,10 @@ internal abstract record NonDemBakeEntry
     {
     }
 
+    internal abstract void AddTo(
+        List<NonDemAtlasBatchEntry> atlasEntries,
+        List<NonDemPreservedSubmeshEntry> preservedEntries);
+
     internal sealed record Atlas : NonDemBakeEntry
     {
         public Atlas(NonDemAtlasBatchEntry entry)
@@ -25,6 +29,15 @@ internal abstract record NonDemBakeEntry
         }
 
         public NonDemAtlasBatchEntry Entry { get; }
+
+        internal override void AddTo(
+            List<NonDemAtlasBatchEntry> atlasEntries,
+            List<NonDemPreservedSubmeshEntry> preservedEntries)
+        {
+            ArgumentNullException.ThrowIfNull(atlasEntries);
+            ArgumentNullException.ThrowIfNull(preservedEntries);
+            atlasEntries.Add(Entry);
+        }
     }
 
     internal sealed record Preserved : NonDemBakeEntry
@@ -36,6 +49,15 @@ internal abstract record NonDemBakeEntry
         }
 
         public NonDemPreservedSubmeshEntry Entry { get; }
+
+        internal override void AddTo(
+            List<NonDemAtlasBatchEntry> atlasEntries,
+            List<NonDemPreservedSubmeshEntry> preservedEntries)
+        {
+            ArgumentNullException.ThrowIfNull(atlasEntries);
+            ArgumentNullException.ThrowIfNull(preservedEntries);
+            preservedEntries.Add(Entry);
+        }
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using PlateauResoniteLink.Domain.Importing;
@@ -15,9 +16,27 @@ internal abstract record NonDemBakeEntry
     {
     }
 
-    internal sealed record Atlas(NonDemAtlasBatchEntry Entry) : NonDemBakeEntry;
+    internal sealed record Atlas : NonDemBakeEntry
+    {
+        public Atlas(NonDemAtlasBatchEntry entry)
+        {
+            ArgumentNullException.ThrowIfNull(entry);
+            Entry = entry;
+        }
 
-    internal sealed record Preserved(NonDemPreservedSubmeshEntry Entry) : NonDemBakeEntry;
+        public NonDemAtlasBatchEntry Entry { get; }
+    }
+
+    internal sealed record Preserved : NonDemBakeEntry
+    {
+        public Preserved(NonDemPreservedSubmeshEntry entry)
+        {
+            ArgumentNullException.ThrowIfNull(entry);
+            Entry = entry;
+        }
+
+        public NonDemPreservedSubmeshEntry Entry { get; }
+    }
 }
 
 internal readonly record struct NonDemBufferedCityObject(

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
@@ -9,9 +9,16 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed record NonDemMaterialAtlasTile(Image<Rgba32> Image, Rgba32 BackgroundColor);
 
-internal sealed record NonDemAtlasOrPreservedEntry(
-    NonDemAtlasBatchEntry? AtlasEntry,
-    NonDemPreservedSubmeshEntry? PreservedEntry);
+internal abstract record NonDemBakeEntry
+{
+    private NonDemBakeEntry()
+    {
+    }
+
+    internal sealed record Atlas(NonDemAtlasBatchEntry Entry) : NonDemBakeEntry;
+
+    internal sealed record Preserved(NonDemPreservedSubmeshEntry Entry) : NonDemBakeEntry;
+}
 
 internal readonly record struct NonDemBufferedCityObject(
     ResoniteConstructionCityObject CityObject,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -34,10 +34,10 @@ internal sealed class NonDemCityObjectBaker(
             return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: false, []));
         }
 
-        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
-        NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(cityObject, policy);
+        ResoniteConstructionCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
+        NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(normalizedCityObject, policy);
         List<ResoniteConstructionCityObject> readyCityObjects = [];
-        sourceFileBuffer.Add(sourceFileKey, new NonDemBufferedCityObject(cityObject, policy));
+        sourceFileBuffer.Add(sourceFileKey, new NonDemBufferedCityObject(normalizedCityObject, policy));
         BakedInputCityObjectCount++;
         return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: true, readyCityObjects));
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -39,11 +39,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
                      StringComparer.Ordinal))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            NonDemCityObjectBakeCandidate? candidate = await candidateFactory.CreateAsync(bufferedCityObject, cancellationToken);
-            if (candidate is null)
-            {
-                continue;
-            }
+            NonDemCityObjectBakeCandidate candidate = await candidateFactory.CreateAsync(bufferedCityObject, cancellationToken);
 
             if (candidate.AtlasEntries.Count == 0 && !batchFitPolicy.RequiresBakeEmission(candidate))
             {

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -15,7 +15,7 @@ internal sealed class NonDemSourceFileBakeEmitterFactory(
             atlasBudget.TilePaddingPixels);
         return new NonDemSourceFileBakeEmitter(
             new NonDemCityObjectBakeCandidateFactory(
-                new NonDemAtlasOrPreservedEntryFactory(textureImageLoader, atlasBudget.EffectiveMaxAtlasTextureEdge)),
+                new NonDemBakeEntryFactory(textureImageLoader, atlasBudget.EffectiveMaxAtlasTextureEdge)),
             new NonDemCityObjectBakeAssembler(
                 layoutFactory,
                 new NonDemAtlasImageRenderer(atlasBudget.TilePaddingPixels),

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeCandidateFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeCandidateFactoryTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class NonDemCityObjectBakeCandidateFactoryTests
+{
+    [Fact]
+    public void BakeEntryVariantsRejectNullPayload()
+    {
+        Assert.Throws<ArgumentNullException>(() => new NonDemBakeEntry.Atlas(null!));
+        Assert.Throws<ArgumentNullException>(() => new NonDemBakeEntry.Preserved(null!));
+    }
+
+    [Fact]
+    public async Task CreateAsyncRejectsNullBakeEntryFromFactoryBoundary()
+    {
+        NonDemCityObjectBakeCandidateFactory candidateFactory = new(new NullBakeEntryFactory());
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => candidateFactory.CreateAsync(
+                new NonDemBufferedCityObject(
+                    CreateAtlasCandidateCityObject(),
+                    NonDemCityObjectBakePolicies.Default),
+                CancellationToken.None));
+
+        Assert.Contains("returned no entry", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static ResoniteConstructionCityObject CreateAtlasCandidateCityObject()
+    {
+        return new ResoniteConstructionCityObject(
+            SlotKey: "object",
+            DisplayName: "object",
+            PackageName: "bldg",
+            ActualMeshCode: "53394525",
+            LodLevel: 2,
+            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            Mesh: new ResoniteImportedMesh(
+                [
+                    new ResoniteMeshVertex(
+                        new ResoniteFloat3(0.0, 0.0, 0.0),
+                        new ResoniteFloat3(0.0, 1.0, 0.0),
+                        new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(
+                        new ResoniteFloat3(1.0, 0.0, 0.0),
+                        new ResoniteFloat3(0.0, 1.0, 0.0),
+                        new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(
+                        new ResoniteFloat3(0.0, 0.0, 1.0),
+                        new ResoniteFloat3(0.0, 1.0, 0.0),
+                        new ResoniteFloat2(0.0, 1.0)),
+                ],
+                [new ResoniteMeshSubmesh(0, [0, 1, 2])]),
+            Materials:
+            [
+                new ResoniteMaterialBinding(
+                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
+                    MaterialType: ResoniteMaterialType.Standard,
+                    TexturePayload: new ResoniteTexturePayload(
+                        width: 1,
+                        height: 1,
+                        colorProfile: null,
+                        binaryPayload: [255, 255, 255, 255],
+                        identity: "dataset.png"),
+                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
+                    Projection: ResoniteMaterialProjection.Uv,
+                    DepthOffset: null,
+                    SubmeshIndices: [0]),
+            ]);
+    }
+
+    private sealed class NullBakeEntryFactory : INonDemBakeEntryFactory
+    {
+        public Task<NonDemBakeEntry> CreateAsync(
+            ResoniteConstructionCityObject cityObject,
+            ResoniteMeshSubmesh submesh,
+            ResoniteMaterialBinding material,
+            CancellationToken cancellationToken)
+        {
+            _ = cityObject;
+            _ = submesh;
+            _ = material;
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<NonDemBakeEntry>(null!);
+        }
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeCandidateFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeCandidateFactoryTests.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 using PlateauResoniteLink.Targets.Resonite;
 
@@ -13,79 +11,5 @@ public sealed class NonDemCityObjectBakeCandidateFactoryTests
     {
         Assert.Throws<ArgumentNullException>(() => new NonDemBakeEntry.Atlas(null!));
         Assert.Throws<ArgumentNullException>(() => new NonDemBakeEntry.Preserved(null!));
-    }
-
-    [Fact]
-    public async Task CreateAsyncRejectsNullBakeEntryFromFactoryBoundary()
-    {
-        NonDemCityObjectBakeCandidateFactory candidateFactory = new(new NullBakeEntryFactory());
-
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => candidateFactory.CreateAsync(
-                new NonDemBufferedCityObject(
-                    CreateAtlasCandidateCityObject(),
-                    NonDemCityObjectBakePolicies.Default),
-                CancellationToken.None));
-
-        Assert.Contains("returned no entry", exception.Message, StringComparison.Ordinal);
-    }
-
-    private static ResoniteConstructionCityObject CreateAtlasCandidateCityObject()
-    {
-        return new ResoniteConstructionCityObject(
-            SlotKey: "object",
-            DisplayName: "object",
-            PackageName: "bldg",
-            ActualMeshCode: "53394525",
-            LodLevel: 2,
-            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
-            Mesh: new ResoniteImportedMesh(
-                [
-                    new ResoniteMeshVertex(
-                        new ResoniteFloat3(0.0, 0.0, 0.0),
-                        new ResoniteFloat3(0.0, 1.0, 0.0),
-                        new ResoniteFloat2(0.0, 0.0)),
-                    new ResoniteMeshVertex(
-                        new ResoniteFloat3(1.0, 0.0, 0.0),
-                        new ResoniteFloat3(0.0, 1.0, 0.0),
-                        new ResoniteFloat2(1.0, 0.0)),
-                    new ResoniteMeshVertex(
-                        new ResoniteFloat3(0.0, 0.0, 1.0),
-                        new ResoniteFloat3(0.0, 1.0, 0.0),
-                        new ResoniteFloat2(0.0, 1.0)),
-                ],
-                [new ResoniteMeshSubmesh(0, [0, 1, 2])]),
-            Materials:
-            [
-                new ResoniteMaterialBinding(
-                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-                    MaterialType: ResoniteMaterialType.Standard,
-                    TexturePayload: new ResoniteTexturePayload(
-                        width: 1,
-                        height: 1,
-                        colorProfile: null,
-                        binaryPayload: [255, 255, 255, 255],
-                        identity: "dataset.png"),
-                    TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-                    Projection: ResoniteMaterialProjection.Uv,
-                    DepthOffset: null,
-                    SubmeshIndices: [0]),
-            ]);
-    }
-
-    private sealed class NullBakeEntryFactory : INonDemBakeEntryFactory
-    {
-        public Task<NonDemBakeEntry> CreateAsync(
-            ResoniteConstructionCityObject cityObject,
-            ResoniteMeshSubmesh submesh,
-            ResoniteMaterialBinding material,
-            CancellationToken cancellationToken)
-        {
-            _ = cityObject;
-            _ = submesh;
-            _ = material;
-            cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult<NonDemBakeEntry>(null!);
-        }
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -893,6 +893,36 @@ public sealed class NonDemCityObjectBakerTests
     }
 
     [Fact]
+    public async Task TryBufferAsyncRejectsDuplicateMaterialBindingsBeforeDynamicUvNormalization()
+    {
+        NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);
+        ResoniteConstructionCityObject cityObject = CreateUvScaledLod2Building(
+            "duplicate-dynamic",
+            CreatePayload("textures/duplicate-dynamic.png", new Rgba32(255, 0, 0, 255), 4, 4),
+            "unit-a",
+            new ResoniteFloat2(2.0, 0.5),
+            new ResoniteFloat2(0.25, 0.75));
+        ResoniteMaterialBinding material = Assert.Single(cityObject.Materials);
+        cityObject = cityObject with
+        {
+            Materials =
+            [
+                material,
+                material with
+                {
+                    BaseColor = new ResoniteColor(0.5, 1.0, 1.0, 1.0),
+                },
+            ],
+        };
+
+        BufferedCityObjectBufferResult result = await baker.TryBufferAsync(cityObject);
+
+        Assert.False(result.Buffered);
+        Assert.Empty(result.ReadyCityObjects);
+        Assert.Empty(await baker.FlushAllAsync());
+    }
+
+    [Fact]
     public async Task TryBufferAsyncBuffersLodlessNonDemCityObjects()
     {
         NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);


### PR DESCRIPTION
## Summary
- Replace the nullable `NonDemAtlasOrPreservedEntry` pair with a closed `NonDemBakeEntry` union.
- Make the bake-entry factory return exactly one of atlas or preserved at the producer boundary.
- Consume bake entries with pattern matching instead of independent null checks.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink dump: `runtime/windows/resonite/semantic-baselines/type-nondem-bake-entry-union/current/higashi-53395325-dem-bldg-grid-geotiff.json`
- `git diff --no-index` against `type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json` produced no diff.