### PR TITLE
Type planned emission references

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -233,7 +233,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 ref nextFieldLocator);
         }
 
-        return new PlannedBatchEmission(
+        return PlannedBatchEmission.Create(
             slotEmissions,
             componentEmissions,
             slotResolutionTargets,

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -116,14 +116,11 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         PlannedSlotTargetReference target,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId)
     {
-        return target.Kind switch
+        return target switch
         {
-            PlannedSlotTargetReferenceKind.Canonical => target.CanonicalLocator.Value,
-            PlannedSlotTargetReferenceKind.Planned
-                when pendingSlotsByPlanId.TryGetValue(target.PlannedLocator, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
-                => pendingSlot.LocalId.Value,
-            PlannedSlotTargetReferenceKind.Planned => throw new InvalidOperationException("Batch slot target did not resolve to a planned slot."),
-            _ => throw new InvalidOperationException($"Unsupported planned slot target kind '{target.Kind}'."),
+            PlannedSlotTargetReference.CanonicalSlotTarget canonicalSlot => canonicalSlot.Locator.Value,
+            PlannedSlotTargetReference.PlannedSlotTarget plannedSlot => pendingSlotsByPlanId[plannedSlot.Locator].LocalId.Value,
+            _ => throw new InvalidOperationException("Batch slot target did not resolve to an executable target."),
         };
     }
 
@@ -134,21 +131,14 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
-        return target.Kind switch
+        return target switch
         {
-            PlannedWorldElementReferenceKind.CanonicalSlot => target.CanonicalSlot.Value,
-            PlannedWorldElementReferenceKind.CanonicalComponent => target.CanonicalComponent.Value,
-            PlannedWorldElementReferenceKind.PlannedSlot
-                when pendingSlotsByPlanId.TryGetValue(target.PlannedSlot, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
-                => pendingSlot.LocalId.Value,
-            PlannedWorldElementReferenceKind.PlannedComponent
-                when pendingComponentsByPlanId.TryGetValue(target.PlannedComponent, out ResoniteBatchOperations.PendingBatchComponent pendingComponent)
-                => pendingComponent.LocalId.Value,
-            PlannedWorldElementReferenceKind.PlannedField
-                => ResolveFieldId(target.PlannedField, pendingFieldsByPlanId, batchBuilder).Value,
-            PlannedWorldElementReferenceKind.PlannedSlot => throw new InvalidOperationException("Batch world element reference did not resolve to a planned slot."),
-            PlannedWorldElementReferenceKind.PlannedComponent => throw new InvalidOperationException("Batch world element reference did not resolve to a planned component."),
-            _ => throw new InvalidOperationException($"Unsupported planned world element reference kind '{target.Kind}'."),
+            PlannedWorldElementReference.CanonicalSlotElement canonicalSlot => canonicalSlot.Locator.Value,
+            PlannedWorldElementReference.CanonicalComponentElement canonicalComponent => canonicalComponent.Locator.Value,
+            PlannedWorldElementReference.PlannedSlotElement plannedSlot => pendingSlotsByPlanId[plannedSlot.Locator].LocalId.Value,
+            PlannedWorldElementReference.PlannedComponentElement plannedComponent => pendingComponentsByPlanId[plannedComponent.Locator].LocalId.Value,
+            PlannedWorldElementReference.PlannedFieldElement plannedField => ResolveFieldId(plannedField.Locator, pendingFieldsByPlanId, batchBuilder).Value,
+            _ => throw new InvalidOperationException("Batch world element reference did not resolve to an executable target."),
         };
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -116,18 +116,15 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         PlannedSlotTargetReference target,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId)
     {
-        if (target.Canonical is ResoniteSlotLocator canonical)
+        return target switch
         {
-            return canonical.Value;
-        }
-
-        if (target.Planned is BatchPlanSlotLocator planned
-            && pendingSlotsByPlanId.TryGetValue(planned, out ResoniteBatchOperations.PendingBatchSlot pendingSlot))
-        {
-            return pendingSlot.LocalId.Value;
-        }
-
-        throw new InvalidOperationException("Batch slot target did not resolve to a planned or canonical slot.");
+            PlannedSlotTargetReference.Canonical canonical => canonical.Locator.Value,
+            PlannedSlotTargetReference.Planned planned
+                when pendingSlotsByPlanId.TryGetValue(planned.Locator, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
+                => pendingSlot.LocalId.Value,
+            PlannedSlotTargetReference.Planned => throw new InvalidOperationException("Batch slot target did not resolve to a planned slot."),
+            _ => throw new InvalidOperationException($"Unsupported planned slot target type '{target.GetType().Name}'."),
+        };
     }
 
     private static string ResolveWorldElementId(
@@ -137,34 +134,22 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
-        if (target.CanonicalSlot is ResoniteSlotLocator canonicalSlot)
+        return target switch
         {
-            return canonicalSlot.Value;
-        }
-
-        if (target.CanonicalComponent is ResoniteComponentLocator canonicalComponent)
-        {
-            return canonicalComponent.Value;
-        }
-
-        if (target.PlannedSlot is BatchPlanSlotLocator plannedSlot
-            && pendingSlotsByPlanId.TryGetValue(plannedSlot, out ResoniteBatchOperations.PendingBatchSlot pendingSlot))
-        {
-            return pendingSlot.LocalId.Value;
-        }
-
-        if (target.PlannedComponent is BatchPlanComponentLocator plannedComponent
-            && pendingComponentsByPlanId.TryGetValue(plannedComponent, out ResoniteBatchOperations.PendingBatchComponent pendingComponent))
-        {
-            return pendingComponent.LocalId.Value;
-        }
-
-        if (target.PlannedField is BatchPlanFieldLocator plannedField)
-        {
-            return ResolveFieldId(plannedField, pendingFieldsByPlanId, batchBuilder).Value;
-        }
-
-        throw new InvalidOperationException("Batch world element reference did not resolve to a planned or canonical entity.");
+            PlannedWorldElementReference.CanonicalSlot canonicalSlot => canonicalSlot.Locator.Value,
+            PlannedWorldElementReference.CanonicalComponent canonicalComponent => canonicalComponent.Locator.Value,
+            PlannedWorldElementReference.PlannedSlot plannedSlot
+                when pendingSlotsByPlanId.TryGetValue(plannedSlot.Locator, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
+                => pendingSlot.LocalId.Value,
+            PlannedWorldElementReference.PlannedComponent plannedComponent
+                when pendingComponentsByPlanId.TryGetValue(plannedComponent.Locator, out ResoniteBatchOperations.PendingBatchComponent pendingComponent)
+                => pendingComponent.LocalId.Value,
+            PlannedWorldElementReference.PlannedField plannedField
+                => ResolveFieldId(plannedField.Locator, pendingFieldsByPlanId, batchBuilder).Value,
+            PlannedWorldElementReference.PlannedSlot => throw new InvalidOperationException("Batch world element reference did not resolve to a planned slot."),
+            PlannedWorldElementReference.PlannedComponent => throw new InvalidOperationException("Batch world element reference did not resolve to a planned component."),
+            _ => throw new InvalidOperationException($"Unsupported planned world element reference type '{target.GetType().Name}'."),
+        };
     }
 
     private static Dictionary<string, Member> TranslateMembers(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -116,14 +116,14 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         PlannedSlotTargetReference target,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId)
     {
-        return target switch
+        return target.Kind switch
         {
-            PlannedSlotTargetReference.Canonical canonical => canonical.Locator.Value,
-            PlannedSlotTargetReference.Planned planned
-                when pendingSlotsByPlanId.TryGetValue(planned.Locator, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
+            PlannedSlotTargetReferenceKind.Canonical => target.CanonicalLocator.Value,
+            PlannedSlotTargetReferenceKind.Planned
+                when pendingSlotsByPlanId.TryGetValue(target.PlannedLocator, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
                 => pendingSlot.LocalId.Value,
-            PlannedSlotTargetReference.Planned => throw new InvalidOperationException("Batch slot target did not resolve to a planned slot."),
-            _ => throw new InvalidOperationException($"Unsupported planned slot target type '{target.GetType().Name}'."),
+            PlannedSlotTargetReferenceKind.Planned => throw new InvalidOperationException("Batch slot target did not resolve to a planned slot."),
+            _ => throw new InvalidOperationException($"Unsupported planned slot target kind '{target.Kind}'."),
         };
     }
 
@@ -134,21 +134,21 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
-        return target switch
+        return target.Kind switch
         {
-            PlannedWorldElementReference.CanonicalSlot canonicalSlot => canonicalSlot.Locator.Value,
-            PlannedWorldElementReference.CanonicalComponent canonicalComponent => canonicalComponent.Locator.Value,
-            PlannedWorldElementReference.PlannedSlot plannedSlot
-                when pendingSlotsByPlanId.TryGetValue(plannedSlot.Locator, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
+            PlannedWorldElementReferenceKind.CanonicalSlot => target.CanonicalSlot.Value,
+            PlannedWorldElementReferenceKind.CanonicalComponent => target.CanonicalComponent.Value,
+            PlannedWorldElementReferenceKind.PlannedSlot
+                when pendingSlotsByPlanId.TryGetValue(target.PlannedSlot, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
                 => pendingSlot.LocalId.Value,
-            PlannedWorldElementReference.PlannedComponent plannedComponent
-                when pendingComponentsByPlanId.TryGetValue(plannedComponent.Locator, out ResoniteBatchOperations.PendingBatchComponent pendingComponent)
+            PlannedWorldElementReferenceKind.PlannedComponent
+                when pendingComponentsByPlanId.TryGetValue(target.PlannedComponent, out ResoniteBatchOperations.PendingBatchComponent pendingComponent)
                 => pendingComponent.LocalId.Value,
-            PlannedWorldElementReference.PlannedField plannedField
-                => ResolveFieldId(plannedField.Locator, pendingFieldsByPlanId, batchBuilder).Value,
-            PlannedWorldElementReference.PlannedSlot => throw new InvalidOperationException("Batch world element reference did not resolve to a planned slot."),
-            PlannedWorldElementReference.PlannedComponent => throw new InvalidOperationException("Batch world element reference did not resolve to a planned component."),
-            _ => throw new InvalidOperationException($"Unsupported planned world element reference type '{target.GetType().Name}'."),
+            PlannedWorldElementReferenceKind.PlannedField
+                => ResolveFieldId(target.PlannedField, pendingFieldsByPlanId, batchBuilder).Value,
+            PlannedWorldElementReferenceKind.PlannedSlot => throw new InvalidOperationException("Batch world element reference did not resolve to a planned slot."),
+            PlannedWorldElementReferenceKind.PlannedComponent => throw new InvalidOperationException("Batch world element reference did not resolve to a planned component."),
+            _ => throw new InvalidOperationException($"Unsupported planned world element reference kind '{target.Kind}'."),
         };
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -118,69 +118,108 @@ internal sealed record PlannedDynamicTerrainMeshBundle(
     public PlannedWorldElementReference InitialMeshTarget => GridMeshTarget;
 }
 
-internal abstract record PlannedSlotTargetReference
+internal enum PlannedSlotTargetReferenceKind
 {
-    private PlannedSlotTargetReference()
+    Unspecified = 0,
+    Canonical = 1,
+    Planned = 2,
+}
+
+internal readonly record struct PlannedSlotTargetReference
+{
+    private PlannedSlotTargetReference(
+        PlannedSlotTargetReferenceKind kind,
+        ResoniteSlotLocator canonicalSlot,
+        BatchPlanSlotLocator plannedSlot)
     {
+        Kind = kind;
+        CanonicalLocator = canonicalSlot;
+        PlannedLocator = plannedSlot;
     }
 
-    internal sealed record Canonical(ResoniteSlotLocator Locator) : PlannedSlotTargetReference;
+    public PlannedSlotTargetReferenceKind Kind { get; }
 
-    internal sealed record Planned(BatchPlanSlotLocator Locator) : PlannedSlotTargetReference;
+    public ResoniteSlotLocator CanonicalLocator { get; }
+
+    public BatchPlanSlotLocator PlannedLocator { get; }
 
     public static PlannedSlotTargetReference CanonicalSlot(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new Canonical(locator);
+        return new PlannedSlotTargetReference(PlannedSlotTargetReferenceKind.Canonical, locator, default);
     }
 
     public static PlannedSlotTargetReference PlannedSlot(BatchPlanSlotLocator locator)
     {
-        return new Planned(locator);
+        return new PlannedSlotTargetReference(PlannedSlotTargetReferenceKind.Planned, default, locator);
     }
 }
 
-internal abstract record PlannedWorldElementReference
+internal enum PlannedWorldElementReferenceKind
 {
-    private PlannedWorldElementReference()
+    Unspecified = 0,
+    CanonicalSlot = 1,
+    CanonicalComponent = 2,
+    PlannedSlot = 3,
+    PlannedComponent = 4,
+    PlannedField = 5,
+}
+
+internal readonly record struct PlannedWorldElementReference
+{
+    private PlannedWorldElementReference(
+        PlannedWorldElementReferenceKind kind,
+        ResoniteSlotLocator canonicalSlot,
+        ResoniteComponentLocator canonicalComponent,
+        BatchPlanSlotLocator plannedSlot,
+        BatchPlanComponentLocator plannedComponent,
+        BatchPlanFieldLocator plannedField)
     {
+        Kind = kind;
+        CanonicalSlot = canonicalSlot;
+        CanonicalComponent = canonicalComponent;
+        PlannedSlot = plannedSlot;
+        PlannedComponent = plannedComponent;
+        PlannedField = plannedField;
     }
 
-    internal sealed record CanonicalSlot(ResoniteSlotLocator Locator) : PlannedWorldElementReference;
+    public PlannedWorldElementReferenceKind Kind { get; }
 
-    internal sealed record CanonicalComponent(ResoniteComponentLocator Locator) : PlannedWorldElementReference;
+    public ResoniteSlotLocator CanonicalSlot { get; }
 
-    internal sealed record PlannedSlot(BatchPlanSlotLocator Locator) : PlannedWorldElementReference;
+    public ResoniteComponentLocator CanonicalComponent { get; }
 
-    internal sealed record PlannedComponent(BatchPlanComponentLocator Locator) : PlannedWorldElementReference;
+    public BatchPlanSlotLocator PlannedSlot { get; }
 
-    internal sealed record PlannedField(BatchPlanFieldLocator Locator) : PlannedWorldElementReference;
+    public BatchPlanComponentLocator PlannedComponent { get; }
+
+    public BatchPlanFieldLocator PlannedField { get; }
 
     public static PlannedWorldElementReference Canonical(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new CanonicalSlot(locator);
+        return new PlannedWorldElementReference(PlannedWorldElementReferenceKind.CanonicalSlot, locator, default, default, default, default);
     }
 
     public static PlannedWorldElementReference Canonical(ResoniteComponentLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new CanonicalComponent(locator);
+        return new PlannedWorldElementReference(PlannedWorldElementReferenceKind.CanonicalComponent, default, locator, default, default, default);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanSlotLocator locator)
     {
-        return new PlannedSlot(locator);
+        return new PlannedWorldElementReference(PlannedWorldElementReferenceKind.PlannedSlot, default, default, locator, default, default);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanComponentLocator locator)
     {
-        return new PlannedComponent(locator);
+        return new PlannedWorldElementReference(PlannedWorldElementReferenceKind.PlannedComponent, default, default, default, locator, default);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanFieldLocator locator)
     {
-        return new PlannedField(locator);
+        return new PlannedWorldElementReference(PlannedWorldElementReferenceKind.PlannedField, default, default, default, default, locator);
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -118,109 +118,70 @@ internal sealed record PlannedDynamicTerrainMeshBundle(
     public PlannedWorldElementReference InitialMeshTarget => GridMeshTarget;
 }
 
-internal enum PlannedSlotTargetReferenceKind
+internal abstract record PlannedSlotTargetReference
 {
-    Unspecified = 0,
-    Canonical = 1,
-    Planned = 2,
-}
-
-internal readonly record struct PlannedSlotTargetReference
-{
-    private PlannedSlotTargetReference(
-        PlannedSlotTargetReferenceKind kind,
-        ResoniteSlotLocator canonicalSlot,
-        BatchPlanSlotLocator plannedSlot)
+    private PlannedSlotTargetReference()
     {
-        Kind = kind;
-        CanonicalLocator = canonicalSlot;
-        PlannedLocator = plannedSlot;
     }
-
-    public PlannedSlotTargetReferenceKind Kind { get; }
-
-    public ResoniteSlotLocator CanonicalLocator { get; }
-
-    public BatchPlanSlotLocator PlannedLocator { get; }
 
     public static PlannedSlotTargetReference CanonicalSlot(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedSlotTargetReference(PlannedSlotTargetReferenceKind.Canonical, locator, default);
+        return new CanonicalSlotTarget(locator);
     }
 
     public static PlannedSlotTargetReference PlannedSlot(BatchPlanSlotLocator locator)
     {
-        return new PlannedSlotTargetReference(PlannedSlotTargetReferenceKind.Planned, default, locator);
+        return new PlannedSlotTarget(locator);
     }
+
+    internal sealed record CanonicalSlotTarget(ResoniteSlotLocator Locator) : PlannedSlotTargetReference;
+
+    internal sealed record PlannedSlotTarget(BatchPlanSlotLocator Locator) : PlannedSlotTargetReference;
 }
 
-internal enum PlannedWorldElementReferenceKind
+internal abstract record PlannedWorldElementReference
 {
-    Unspecified = 0,
-    CanonicalSlot = 1,
-    CanonicalComponent = 2,
-    PlannedSlot = 3,
-    PlannedComponent = 4,
-    PlannedField = 5,
-}
-
-internal readonly record struct PlannedWorldElementReference
-{
-    private PlannedWorldElementReference(
-        PlannedWorldElementReferenceKind kind,
-        ResoniteSlotLocator canonicalSlot,
-        ResoniteComponentLocator canonicalComponent,
-        BatchPlanSlotLocator plannedSlot,
-        BatchPlanComponentLocator plannedComponent,
-        BatchPlanFieldLocator plannedField)
+    private PlannedWorldElementReference()
     {
-        Kind = kind;
-        CanonicalSlot = canonicalSlot;
-        CanonicalComponent = canonicalComponent;
-        PlannedSlot = plannedSlot;
-        PlannedComponent = plannedComponent;
-        PlannedField = plannedField;
     }
-
-    public PlannedWorldElementReferenceKind Kind { get; }
-
-    public ResoniteSlotLocator CanonicalSlot { get; }
-
-    public ResoniteComponentLocator CanonicalComponent { get; }
-
-    public BatchPlanSlotLocator PlannedSlot { get; }
-
-    public BatchPlanComponentLocator PlannedComponent { get; }
-
-    public BatchPlanFieldLocator PlannedField { get; }
 
     public static PlannedWorldElementReference Canonical(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedWorldElementReference(PlannedWorldElementReferenceKind.CanonicalSlot, locator, default, default, default, default);
+        return new CanonicalSlotElement(locator);
     }
 
     public static PlannedWorldElementReference Canonical(ResoniteComponentLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedWorldElementReference(PlannedWorldElementReferenceKind.CanonicalComponent, default, locator, default, default, default);
+        return new CanonicalComponentElement(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanSlotLocator locator)
     {
-        return new PlannedWorldElementReference(PlannedWorldElementReferenceKind.PlannedSlot, default, default, locator, default, default);
+        return new PlannedSlotElement(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanComponentLocator locator)
     {
-        return new PlannedWorldElementReference(PlannedWorldElementReferenceKind.PlannedComponent, default, default, default, locator, default);
+        return new PlannedComponentElement(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanFieldLocator locator)
     {
-        return new PlannedWorldElementReference(PlannedWorldElementReferenceKind.PlannedField, default, default, default, default, locator);
+        return new PlannedFieldElement(locator);
     }
+
+    internal sealed record CanonicalSlotElement(ResoniteSlotLocator Locator) : PlannedWorldElementReference;
+
+    internal sealed record CanonicalComponentElement(ResoniteComponentLocator Locator) : PlannedWorldElementReference;
+
+    internal sealed record PlannedSlotElement(BatchPlanSlotLocator Locator) : PlannedWorldElementReference;
+
+    internal sealed record PlannedComponentElement(BatchPlanComponentLocator Locator) : PlannedWorldElementReference;
+
+    internal sealed record PlannedFieldElement(BatchPlanFieldLocator Locator) : PlannedWorldElementReference;
 }
 
 internal abstract record PlannedMember;
@@ -319,8 +280,126 @@ internal sealed record PlannedBatchComponentEmission(
     string ComponentType,
     IReadOnlyDictionary<string, PlannedMember> Members);
 
-internal sealed record PlannedBatchEmission(
-    IReadOnlyList<PlannedBatchSlotEmission> SlotEmissions,
-    IReadOnlyList<PlannedBatchComponentEmission> ComponentEmissions,
-    IReadOnlyList<BatchPlanSlotLocator> SlotResolutionTargets,
-    IReadOnlyList<BatchPlanComponentLocator> ComponentResolutionTargets);
+internal sealed record PlannedBatchEmission
+{
+    private PlannedBatchEmission(
+        IReadOnlyList<PlannedBatchSlotEmission> slotEmissions,
+        IReadOnlyList<PlannedBatchComponentEmission> componentEmissions,
+        IReadOnlyList<BatchPlanSlotLocator> slotResolutionTargets,
+        IReadOnlyList<BatchPlanComponentLocator> componentResolutionTargets)
+    {
+        SlotEmissions = slotEmissions;
+        ComponentEmissions = componentEmissions;
+        SlotResolutionTargets = slotResolutionTargets;
+        ComponentResolutionTargets = componentResolutionTargets;
+    }
+
+    public IReadOnlyList<PlannedBatchSlotEmission> SlotEmissions { get; }
+
+    public IReadOnlyList<PlannedBatchComponentEmission> ComponentEmissions { get; }
+
+    public IReadOnlyList<BatchPlanSlotLocator> SlotResolutionTargets { get; }
+
+    public IReadOnlyList<BatchPlanComponentLocator> ComponentResolutionTargets { get; }
+
+    public static PlannedBatchEmission Create(
+        IReadOnlyList<PlannedBatchSlotEmission> slotEmissions,
+        IReadOnlyList<PlannedBatchComponentEmission> componentEmissions,
+        IReadOnlyList<BatchPlanSlotLocator> slotResolutionTargets,
+        IReadOnlyList<BatchPlanComponentLocator> componentResolutionTargets)
+    {
+        ValidatePlannedReferences(slotEmissions, componentEmissions, slotResolutionTargets, componentResolutionTargets);
+        return new PlannedBatchEmission(slotEmissions, componentEmissions, slotResolutionTargets, componentResolutionTargets);
+    }
+
+    private static void ValidatePlannedReferences(
+        IReadOnlyList<PlannedBatchSlotEmission> slotEmissions,
+        IReadOnlyList<PlannedBatchComponentEmission> componentEmissions,
+        IReadOnlyList<BatchPlanSlotLocator> slotResolutionTargets,
+        IReadOnlyList<BatchPlanComponentLocator> componentResolutionTargets)
+    {
+        HashSet<BatchPlanSlotLocator> emittedSlots = [];
+        foreach (PlannedBatchSlotEmission slotEmission in slotEmissions)
+        {
+            if (slotEmission.ParentTarget is PlannedSlotTargetReference.PlannedSlotTarget plannedParent
+                && !emittedSlots.Contains(plannedParent.Locator))
+            {
+                throw new InvalidOperationException("Planned slot parent target must reference an earlier planned slot.");
+            }
+
+            emittedSlots.Add(slotEmission.Identity);
+        }
+
+        foreach (BatchPlanSlotLocator slotResolutionTarget in slotResolutionTargets)
+        {
+            if (!emittedSlots.Contains(slotResolutionTarget))
+            {
+                throw new InvalidOperationException("Planned slot resolution target must reference an emitted planned slot.");
+            }
+        }
+
+        HashSet<BatchPlanComponentLocator> emittedComponents = [];
+        foreach (PlannedBatchComponentEmission componentEmission in componentEmissions)
+        {
+            if (componentEmission.ContainerTarget is PlannedSlotTargetReference.PlannedSlotTarget plannedContainer
+                && !emittedSlots.Contains(plannedContainer.Locator))
+            {
+                throw new InvalidOperationException("Planned component container target must reference an emitted planned slot.");
+            }
+
+            foreach (PlannedWorldElementReference target in EnumerateMemberTargets(componentEmission.Members.Values))
+            {
+                ValidateWorldElementReference(target, emittedSlots, emittedComponents);
+            }
+
+            emittedComponents.Add(componentEmission.Identity);
+        }
+
+        foreach (BatchPlanComponentLocator componentResolutionTarget in componentResolutionTargets)
+        {
+            if (!emittedComponents.Contains(componentResolutionTarget))
+            {
+                throw new InvalidOperationException("Planned component resolution target must reference an emitted planned component.");
+            }
+        }
+    }
+
+    private static void ValidateWorldElementReference(
+        PlannedWorldElementReference target,
+        HashSet<BatchPlanSlotLocator> emittedSlots,
+        HashSet<BatchPlanComponentLocator> emittedComponents)
+    {
+        switch (target)
+        {
+            case PlannedWorldElementReference.PlannedSlotElement plannedSlot
+                when !emittedSlots.Contains(plannedSlot.Locator):
+                throw new InvalidOperationException("Planned world element target must reference an emitted planned slot.");
+            case PlannedWorldElementReference.PlannedComponentElement plannedComponent
+                when !emittedComponents.Contains(plannedComponent.Locator):
+                throw new InvalidOperationException("Planned world element target must reference an earlier planned component.");
+        }
+    }
+
+    private static IEnumerable<PlannedWorldElementReference> EnumerateMemberTargets(IEnumerable<PlannedMember> members)
+    {
+        foreach (PlannedMember member in members)
+        {
+            switch (member)
+            {
+                case PlannedElementReferenceMember reference:
+                    yield return reference.Target;
+                    break;
+                case PlannedAddressableReferenceMember reference:
+                    yield return reference.Target;
+                    break;
+                case PlannedSyncListMember syncList:
+                    foreach (PlannedWorldElementReference nestedTarget in EnumerateMemberTargets(syncList.Elements))
+                    {
+                        yield return nestedTarget;
+                    }
+
+                    break;
+            }
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -118,85 +118,69 @@ internal sealed record PlannedDynamicTerrainMeshBundle(
     public PlannedWorldElementReference InitialMeshTarget => GridMeshTarget;
 }
 
-internal readonly record struct PlannedSlotTargetReference
+internal abstract record PlannedSlotTargetReference
 {
-    private PlannedSlotTargetReference(ResoniteSlotLocator? canonical, BatchPlanSlotLocator? planned)
+    private PlannedSlotTargetReference()
     {
-        Canonical = canonical;
-        Planned = planned;
     }
 
-    public ResoniteSlotLocator? Canonical { get; }
+    internal sealed record Canonical(ResoniteSlotLocator Locator) : PlannedSlotTargetReference;
 
-    public BatchPlanSlotLocator? Planned { get; }
-
-    public bool IsCanonical => Canonical is not null;
-
-    public bool IsPlanned => Planned is not null;
+    internal sealed record Planned(BatchPlanSlotLocator Locator) : PlannedSlotTargetReference;
 
     public static PlannedSlotTargetReference CanonicalSlot(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedSlotTargetReference(locator, null);
+        return new Canonical(locator);
     }
 
     public static PlannedSlotTargetReference PlannedSlot(BatchPlanSlotLocator locator)
     {
-        return new PlannedSlotTargetReference(null, locator);
+        return new Planned(locator);
     }
 }
 
-internal readonly record struct PlannedWorldElementReference
+internal abstract record PlannedWorldElementReference
 {
-    private PlannedWorldElementReference(
-        ResoniteSlotLocator? canonicalSlot,
-        ResoniteComponentLocator? canonicalComponent,
-        BatchPlanSlotLocator? plannedSlot,
-        BatchPlanComponentLocator? plannedComponent,
-        BatchPlanFieldLocator? plannedField)
+    private PlannedWorldElementReference()
     {
-        CanonicalSlot = canonicalSlot;
-        CanonicalComponent = canonicalComponent;
-        PlannedSlot = plannedSlot;
-        PlannedComponent = plannedComponent;
-        PlannedField = plannedField;
     }
 
-    public ResoniteSlotLocator? CanonicalSlot { get; }
+    internal sealed record CanonicalSlot(ResoniteSlotLocator Locator) : PlannedWorldElementReference;
 
-    public ResoniteComponentLocator? CanonicalComponent { get; }
+    internal sealed record CanonicalComponent(ResoniteComponentLocator Locator) : PlannedWorldElementReference;
 
-    public BatchPlanSlotLocator? PlannedSlot { get; }
+    internal sealed record PlannedSlot(BatchPlanSlotLocator Locator) : PlannedWorldElementReference;
 
-    public BatchPlanComponentLocator? PlannedComponent { get; }
+    internal sealed record PlannedComponent(BatchPlanComponentLocator Locator) : PlannedWorldElementReference;
 
-    public BatchPlanFieldLocator? PlannedField { get; }
+    internal sealed record PlannedField(BatchPlanFieldLocator Locator) : PlannedWorldElementReference;
 
     public static PlannedWorldElementReference Canonical(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedWorldElementReference(locator, null, null, null, null);
+        return new CanonicalSlot(locator);
     }
 
     public static PlannedWorldElementReference Canonical(ResoniteComponentLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedWorldElementReference(null, locator, null, null, null);
+        return new CanonicalComponent(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanSlotLocator locator)
     {
-        return new PlannedWorldElementReference(null, null, locator, null, null);
+        return new PlannedSlot(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanComponentLocator locator)
     {
-        return new PlannedWorldElementReference(null, null, null, locator, null);
+        return new PlannedComponent(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanFieldLocator locator)
     {
-        return new PlannedWorldElementReference(null, null, null, null, locator);
+        return new PlannedField(locator);
     }
 }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -35,6 +35,73 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     }
 
     [Fact]
+    public void PlannedBatchEmissionCreateRejectsForwardPlannedSlotParentReference()
+    {
+        BatchPlanSlotLocator child = new(1);
+        BatchPlanSlotLocator parent = new(2);
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => PlannedBatchEmission.Create(
+                [
+                    new PlannedBatchSlotEmission(
+                        child,
+                        PlannedSlotTargetReference.PlannedSlot(parent),
+                        "child",
+                        null,
+                        null),
+                    new PlannedBatchSlotEmission(
+                        parent,
+                        PlannedSlotTargetReference.CanonicalSlot(new ResoniteSlotLocator("root")),
+                        "parent",
+                        null,
+                        null),
+                ],
+                [],
+                [child, parent],
+                []));
+
+        Assert.Equal("Planned slot parent target must reference an earlier planned slot.", error.Message);
+    }
+
+    [Fact]
+    public void PlannedBatchEmissionCreateRejectsForwardPlannedComponentMemberReference()
+    {
+        BatchPlanSlotLocator container = new(1);
+        BatchPlanComponentLocator source = new(1);
+        BatchPlanComponentLocator target = new(2);
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => PlannedBatchEmission.Create(
+                [
+                    new PlannedBatchSlotEmission(
+                        container,
+                        PlannedSlotTargetReference.CanonicalSlot(new ResoniteSlotLocator("root")),
+                        "container",
+                        null,
+                        null),
+                ],
+                [
+                    new PlannedBatchComponentEmission(
+                        source,
+                        PlannedSlotTargetReference.PlannedSlot(container),
+                        "[FrooxEngine]FrooxEngine.Source",
+                        new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
+                        {
+                            ["Target"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(target)),
+                        }),
+                    new PlannedBatchComponentEmission(
+                        target,
+                        PlannedSlotTargetReference.PlannedSlot(container),
+                        "[FrooxEngine]FrooxEngine.Target",
+                        new Dictionary<string, PlannedMember>(StringComparer.Ordinal)),
+                ],
+                [container],
+                [source, target]));
+
+        Assert.Equal("Planned world element target must reference an earlier planned component.", error.Message);
+    }
+
+    [Fact]
     public void CreatePlannedBatchEmission_CreatesTerrainGridPlanWithPlannedTextureReference()
     {
         ResoniteObjectSlotHierarchy objectSlots = new(
@@ -196,8 +263,8 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             PlannedAddressableFieldMember state = Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]);
             PlannedElementReferenceMember target = Assert.IsType<PlannedElementReferenceMember>(meshSwitch.Members["Target"]);
             Assert.True(
-                target.Target.Kind == PlannedWorldElementReferenceKind.PlannedField
-                && new[] { rendererMesh.Identity, colliderMesh.Identity }.Contains(target.Target.PlannedField));
+                AssertPlannedField(target.Target) is BatchPlanFieldLocator plannedTarget
+                && new[] { rendererMesh.Identity, colliderMesh.Identity }.Contains(plannedTarget));
             Assert.False(Assert.IsType<Field_bool>(state.Value).Value);
             Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(meshSwitch.Members["FalseTarget"])).TargetID);
             Assert.Equal(ToPlannedTargetId(staticMesh.Identity), Assert.IsType<Reference>(ToMember(meshSwitch.Members["TrueTarget"])).TargetID);
@@ -207,10 +274,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         {
             PlannedElementReferenceMember target = Assert.IsType<PlannedElementReferenceMember>(boolDriver.Members["Target"]);
             Assert.True(
-                target.Target.Kind == PlannedWorldElementReferenceKind.PlannedField
+                AssertPlannedField(target.Target) is BatchPlanFieldLocator plannedStateTarget
                 && meshSwitches
                     .Select(meshSwitch => Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]).Identity)
-                    .Contains(target.Target.PlannedField));
+                    .Contains(plannedStateTarget));
             Assert.Equal("PLATEAU.Terrain.Static.Enabled", Assert.IsType<Field_string>(ToMember(boolDriver.Members["VariableName"])).Value);
             Assert.False(Assert.IsType<Field_bool>(ToMember(boolDriver.Members["DefaultValue"])).Value);
         }
@@ -612,37 +679,34 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
     private static ResoniteSlotLocator AssertCanonical(PlannedSlotTargetReference target)
     {
-        Assert.Equal(PlannedSlotTargetReferenceKind.Canonical, target.Kind);
-        return target.CanonicalLocator;
+        return Assert.IsType<PlannedSlotTargetReference.CanonicalSlotTarget>(target).Locator;
     }
 
     private static BatchPlanSlotLocator AssertPlanned(PlannedSlotTargetReference target)
     {
-        Assert.Equal(PlannedSlotTargetReferenceKind.Planned, target.Kind);
-        return target.PlannedLocator;
+        return Assert.IsType<PlannedSlotTargetReference.PlannedSlotTarget>(target).Locator;
     }
 
     private static BatchPlanFieldLocator AssertPlannedField(PlannedWorldElementReference target)
     {
-        Assert.Equal(PlannedWorldElementReferenceKind.PlannedField, target.Kind);
-        return target.PlannedField;
+        return Assert.IsType<PlannedWorldElementReference.PlannedFieldElement>(target).Locator;
     }
 
     private static bool IsCanonical(PlannedSlotTargetReference target, ResoniteSlotLocator locator)
     {
-        return target.Kind == PlannedSlotTargetReferenceKind.Canonical
-            && target.CanonicalLocator == locator;
+        return target is PlannedSlotTargetReference.CanonicalSlotTarget canonicalSlot
+            && canonicalSlot.Locator == locator;
     }
 
     private static bool IsPlanned(PlannedSlotTargetReference target)
     {
-        return target.Kind == PlannedSlotTargetReferenceKind.Planned;
+        return target is PlannedSlotTargetReference.PlannedSlotTarget;
     }
 
     private static bool IsPlanned(PlannedSlotTargetReference target, BatchPlanSlotLocator locator)
     {
-        return target.Kind == PlannedSlotTargetReferenceKind.Planned
-            && target.PlannedLocator == locator;
+        return target is PlannedSlotTargetReference.PlannedSlotTarget plannedSlot
+            && plannedSlot.Locator == locator;
     }
 
     private static void AssertGradientPoint(Member member, float expectedPosition, int expectedX, int expectedY)
@@ -689,12 +753,12 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     {
         return target switch
         {
-            { Kind: PlannedWorldElementReferenceKind.CanonicalSlot } => target.CanonicalSlot.Value,
-            { Kind: PlannedWorldElementReferenceKind.CanonicalComponent } => target.CanonicalComponent.Value,
-            { Kind: PlannedWorldElementReferenceKind.PlannedSlot } => ToPlannedTargetId(target.PlannedSlot),
-            { Kind: PlannedWorldElementReferenceKind.PlannedComponent } => ToPlannedTargetId(target.PlannedComponent),
-            { Kind: PlannedWorldElementReferenceKind.PlannedField } => ToPlannedTargetId(target.PlannedField),
-            _ => null,
+            PlannedWorldElementReference.CanonicalSlotElement canonicalSlot => canonicalSlot.Locator.Value,
+            PlannedWorldElementReference.CanonicalComponentElement canonicalComponent => canonicalComponent.Locator.Value,
+            PlannedWorldElementReference.PlannedSlotElement plannedSlot => ToPlannedTargetId(plannedSlot.Locator),
+            PlannedWorldElementReference.PlannedComponentElement plannedComponent => ToPlannedTargetId(plannedComponent.Locator),
+            PlannedWorldElementReference.PlannedFieldElement plannedField => ToPlannedTargetId(plannedField.Locator),
+            _ => throw new InvalidOperationException("Unsupported planned world element reference."),
         };
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -196,8 +196,8 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             PlannedAddressableFieldMember state = Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]);
             PlannedElementReferenceMember target = Assert.IsType<PlannedElementReferenceMember>(meshSwitch.Members["Target"]);
             Assert.True(
-                target.Target is PlannedWorldElementReference.PlannedField { Locator: BatchPlanFieldLocator plannedTarget }
-                && new[] { rendererMesh.Identity, colliderMesh.Identity }.Contains(plannedTarget));
+                target.Target.Kind == PlannedWorldElementReferenceKind.PlannedField
+                && new[] { rendererMesh.Identity, colliderMesh.Identity }.Contains(target.Target.PlannedField));
             Assert.False(Assert.IsType<Field_bool>(state.Value).Value);
             Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(meshSwitch.Members["FalseTarget"])).TargetID);
             Assert.Equal(ToPlannedTargetId(staticMesh.Identity), Assert.IsType<Reference>(ToMember(meshSwitch.Members["TrueTarget"])).TargetID);
@@ -207,10 +207,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         {
             PlannedElementReferenceMember target = Assert.IsType<PlannedElementReferenceMember>(boolDriver.Members["Target"]);
             Assert.True(
-                target.Target is PlannedWorldElementReference.PlannedField { Locator: BatchPlanFieldLocator plannedStateTarget }
+                target.Target.Kind == PlannedWorldElementReferenceKind.PlannedField
                 && meshSwitches
                     .Select(meshSwitch => Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]).Identity)
-                    .Contains(plannedStateTarget));
+                    .Contains(target.Target.PlannedField));
             Assert.Equal("PLATEAU.Terrain.Static.Enabled", Assert.IsType<Field_string>(ToMember(boolDriver.Members["VariableName"])).Value);
             Assert.False(Assert.IsType<Field_bool>(ToMember(boolDriver.Members["DefaultValue"])).Value);
         }
@@ -612,37 +612,37 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
     private static ResoniteSlotLocator AssertCanonical(PlannedSlotTargetReference target)
     {
-        PlannedSlotTargetReference.Canonical canonical = Assert.IsType<PlannedSlotTargetReference.Canonical>(target);
-        return canonical.Locator;
+        Assert.Equal(PlannedSlotTargetReferenceKind.Canonical, target.Kind);
+        return target.CanonicalLocator;
     }
 
     private static BatchPlanSlotLocator AssertPlanned(PlannedSlotTargetReference target)
     {
-        PlannedSlotTargetReference.Planned planned = Assert.IsType<PlannedSlotTargetReference.Planned>(target);
-        return planned.Locator;
+        Assert.Equal(PlannedSlotTargetReferenceKind.Planned, target.Kind);
+        return target.PlannedLocator;
     }
 
     private static BatchPlanFieldLocator AssertPlannedField(PlannedWorldElementReference target)
     {
-        PlannedWorldElementReference.PlannedField planned = Assert.IsType<PlannedWorldElementReference.PlannedField>(target);
-        return planned.Locator;
+        Assert.Equal(PlannedWorldElementReferenceKind.PlannedField, target.Kind);
+        return target.PlannedField;
     }
 
     private static bool IsCanonical(PlannedSlotTargetReference target, ResoniteSlotLocator locator)
     {
-        return target is PlannedSlotTargetReference.Canonical canonical
-            && canonical.Locator == locator;
+        return target.Kind == PlannedSlotTargetReferenceKind.Canonical
+            && target.CanonicalLocator == locator;
     }
 
     private static bool IsPlanned(PlannedSlotTargetReference target)
     {
-        return target is PlannedSlotTargetReference.Planned;
+        return target.Kind == PlannedSlotTargetReferenceKind.Planned;
     }
 
     private static bool IsPlanned(PlannedSlotTargetReference target, BatchPlanSlotLocator locator)
     {
-        return target is PlannedSlotTargetReference.Planned planned
-            && planned.Locator == locator;
+        return target.Kind == PlannedSlotTargetReferenceKind.Planned
+            && target.PlannedLocator == locator;
     }
 
     private static void AssertGradientPoint(Member member, float expectedPosition, int expectedX, int expectedY)
@@ -689,11 +689,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     {
         return target switch
         {
-            PlannedWorldElementReference.CanonicalSlot canonicalSlot => canonicalSlot.Locator.Value,
-            PlannedWorldElementReference.CanonicalComponent canonicalComponent => canonicalComponent.Locator.Value,
-            PlannedWorldElementReference.PlannedSlot plannedSlot => ToPlannedTargetId(plannedSlot.Locator),
-            PlannedWorldElementReference.PlannedComponent plannedComponent => ToPlannedTargetId(plannedComponent.Locator),
-            PlannedWorldElementReference.PlannedField plannedField => ToPlannedTargetId(plannedField.Locator),
+            { Kind: PlannedWorldElementReferenceKind.CanonicalSlot } => target.CanonicalSlot.Value,
+            { Kind: PlannedWorldElementReferenceKind.CanonicalComponent } => target.CanonicalComponent.Value,
+            { Kind: PlannedWorldElementReferenceKind.PlannedSlot } => ToPlannedTargetId(target.PlannedSlot),
+            { Kind: PlannedWorldElementReferenceKind.PlannedComponent } => ToPlannedTargetId(target.PlannedComponent),
+            { Kind: PlannedWorldElementReferenceKind.PlannedField } => ToPlannedTargetId(target.PlannedField),
             _ => null,
         };
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -28,7 +28,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             });
 
         Assert.Equal(fieldIdentity, bundle.Field.Identity);
-        Assert.Equal(fieldIdentity, bundle.Target.Target.PlannedField);
+        Assert.Equal(fieldIdentity, AssertPlannedField(bundle.Target.Target));
         Assert.False(Assert.IsType<Field_bool>(bundle.Field.Value).Value);
         Assert.False(Assert.IsType<Field_bool>(bundle.DefaultValue.Value).Value);
         Assert.NotSame(bundle.Field.Value, bundle.DefaultValue.Value);
@@ -69,11 +69,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchSlotEmission meshAssetSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object", StringComparison.Ordinal)
-                && slot.ParentTarget.Canonical == new ResoniteSlotLocator("asset-lod-slot"));
+                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         PlannedBatchSlotEmission presentationSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object", StringComparison.Ordinal)
-                && slot.ParentTarget.Canonical == new ResoniteSlotLocator("lod-slot"));
+                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("lod-slot")));
         PlannedBatchSlotEmission heightMapSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object_terrain-grid", StringComparison.Ordinal));
@@ -97,14 +97,14 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshCollider", StringComparison.Ordinal));
 
         Assert.Equal(new ResoniteSlotLocator("asset-lod-slot"), AssertCanonical(meshAssetSlot.ParentTarget));
-        Assert.False(meshAssetSlot.ParentTarget.IsPlanned);
+        Assert.False(IsPlanned(meshAssetSlot.ParentTarget));
         Assert.Equal(new ResoniteSlotLocator("asset-lod-slot"), AssertCanonical(heightMapSlot.ParentTarget));
-        Assert.False(heightMapSlot.ParentTarget.IsPlanned);
+        Assert.False(IsPlanned(heightMapSlot.ParentTarget));
         Assert.Equal(presentationSlot.Identity, AssertPlanned(gridMesh.ContainerTarget));
         Assert.Equal(presentationSlot.Identity, AssertPlanned(pointsGradientDriver.ContainerTarget));
         Assert.Equal(presentationSlot.Identity, AssertPlanned(pointsProgressDriver.ContainerTarget));
         Assert.Equal(heightMapSlot.Identity, AssertPlanned(heightTexture.ContainerTarget));
-        Assert.True(heightTexture.ContainerTarget.IsPlanned);
+        Assert.True(IsPlanned(heightTexture.ContainerTarget));
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(heightTexture.Members["WrapModeU"])).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(heightTexture.Members["WrapModeV"])).Value);
         Assert.Equal("Point", Assert.IsType<Field_Nullable_Enum>(ToMember(heightTexture.Members["FilterMode"])).Value);
@@ -119,14 +119,14 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedAddressableFieldMember progress = Assert.IsType<PlannedAddressableFieldMember>(pointsGradientDriver.Members["Progress"]);
         Assert.Equal(1.0f, Assert.IsType<Field_float>(progress.Value).Value);
         PlannedElementReferenceMember pointsTarget = Assert.IsType<PlannedElementReferenceMember>(pointsGradientDriver.Members["Target"]);
-        Assert.Equal(gridPointsMember.Identity, pointsTarget.Target.PlannedField);
+        Assert.Equal(gridPointsMember.Identity, AssertPlannedField(pointsTarget.Target));
         SyncList gradientPoints = Assert.IsType<SyncList>(ToMember(pointsGradientDriver.Members["Points"]));
         Assert.Equal(2, gradientPoints.Elements.Count);
         AssertGradientPoint(gradientPoints.Elements[0], 0.0f, 2, 2);
         AssertGradientPoint(gradientPoints.Elements[1], 1.0f, 2, 3);
         Assert.Equal("PLATEAU.Terrain.Grid.Detail", Assert.IsType<Field_string>(ToMember(pointsProgressDriver.Members["VariableName"])).Value);
         PlannedElementReferenceMember progressTarget = Assert.IsType<PlannedElementReferenceMember>(pointsProgressDriver.Members["Target"]);
-        Assert.Equal(progress.Identity, progressTarget.Target.PlannedField);
+        Assert.Equal(progress.Identity, AssertPlannedField(progressTarget.Target));
         Assert.Equal(1.0f, Assert.IsType<Field_float>(ToMember(pointsProgressDriver.Members["DefaultValue"])).Value);
         Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(meshRenderer.Members["Mesh"])).TargetID);
         Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(meshCollider.Members["Mesh"])).TargetID);
@@ -196,7 +196,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             PlannedAddressableFieldMember state = Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]);
             PlannedElementReferenceMember target = Assert.IsType<PlannedElementReferenceMember>(meshSwitch.Members["Target"]);
             Assert.True(
-                target.Target.PlannedField is BatchPlanFieldLocator plannedTarget
+                target.Target is PlannedWorldElementReference.PlannedField { Locator: BatchPlanFieldLocator plannedTarget }
                 && new[] { rendererMesh.Identity, colliderMesh.Identity }.Contains(plannedTarget));
             Assert.False(Assert.IsType<Field_bool>(state.Value).Value);
             Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(meshSwitch.Members["FalseTarget"])).TargetID);
@@ -207,7 +207,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         {
             PlannedElementReferenceMember target = Assert.IsType<PlannedElementReferenceMember>(boolDriver.Members["Target"]);
             Assert.True(
-                target.Target.PlannedField is BatchPlanFieldLocator plannedStateTarget
+                target.Target is PlannedWorldElementReference.PlannedField { Locator: BatchPlanFieldLocator plannedStateTarget }
                 && meshSwitches
                     .Select(meshSwitch => Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]).Identity)
                     .Contains(plannedStateTarget));
@@ -313,14 +313,14 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Reference dedicatedMaterialReference = Assert.IsType<Reference>(materials.Elements[1]);
         PlannedBatchSlotEmission dedicatedMaterialSlot = Assert.Single(
             batchPlan.SlotEmissions,
-            slot => slot.ParentTarget.Planned == FindAssetSlotIdentity(batchPlan, "Triangle Object")
+            slot => IsPlanned(slot.ParentTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object"))
                 && string.Equals(slot.SlotName, "material-000-pbs-uv-uv", StringComparison.Ordinal));
         PlannedBatchComponentEmission dedicatedMaterialComponent = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal));
         PlannedBatchComponentEmission albedoTexture = Assert.Single(
             batchPlan.ComponentEmissions,
-            component => component.ContainerTarget.Planned == dedicatedMaterialSlot.Identity
+            component => IsPlanned(component.ContainerTarget, dedicatedMaterialSlot.Identity)
                 && string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
 
         Assert.Equal("existing-material-id", reusableMaterialReference.TargetID);
@@ -374,10 +374,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchSlotEmission meshAssetSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal)
-                && slot.ParentTarget.Canonical == new ResoniteSlotLocator("asset-lod-slot"));
+                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         Assert.DoesNotContain(
             batchPlan.SlotEmissions,
-            slot => slot.ParentTarget.Planned == meshAssetSlot.Identity
+            slot => IsPlanned(slot.ParentTarget, meshAssetSlot.Identity)
                 && !string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal));
 
         PlannedBatchComponentEmission materialComponent = Assert.Single(
@@ -459,11 +459,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchSlotEmission assetSlot = Assert.Single(
             batchPlan.SlotEmissions,
             slot => string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal)
-                && slot.ParentTarget.Canonical == new ResoniteSlotLocator("asset-lod-slot"));
+                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         PlannedBatchComponentEmission overrideTexture = Assert.Single(
             batchPlan.ComponentEmissions,
             component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && component.ContainerTarget.Planned == assetSlot.Identity);
+                && IsPlanned(component.ContainerTarget, assetSlot.Identity));
 
         Assert.Equal("shared-material-id", materialReference.TargetID);
         Assert.Equal(ToPlannedTargetId(propertyBlockComponent.Identity), propertyBlockReference.TargetID);
@@ -506,7 +506,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchComponentEmission overrideTexture = Assert.Single(
             batchPlan.ComponentEmissions,
             component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && component.ContainerTarget.Planned == FindAssetSlotIdentity(batchPlan, "Triangle Object"));
+                && IsPlanned(component.ContainerTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object")));
 
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(overrideTexture.Members["WrapModeU"])).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(overrideTexture.Members["WrapModeV"])).Value);
@@ -612,16 +612,37 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
     private static ResoniteSlotLocator AssertCanonical(PlannedSlotTargetReference target)
     {
-        Assert.NotNull(target.Canonical);
-        Assert.Null(target.Planned);
-        return target.Canonical.Value;
+        PlannedSlotTargetReference.Canonical canonical = Assert.IsType<PlannedSlotTargetReference.Canonical>(target);
+        return canonical.Locator;
     }
 
     private static BatchPlanSlotLocator AssertPlanned(PlannedSlotTargetReference target)
     {
-        Assert.NotNull(target.Planned);
-        Assert.Null(target.Canonical);
-        return target.Planned.Value;
+        PlannedSlotTargetReference.Planned planned = Assert.IsType<PlannedSlotTargetReference.Planned>(target);
+        return planned.Locator;
+    }
+
+    private static BatchPlanFieldLocator AssertPlannedField(PlannedWorldElementReference target)
+    {
+        PlannedWorldElementReference.PlannedField planned = Assert.IsType<PlannedWorldElementReference.PlannedField>(target);
+        return planned.Locator;
+    }
+
+    private static bool IsCanonical(PlannedSlotTargetReference target, ResoniteSlotLocator locator)
+    {
+        return target is PlannedSlotTargetReference.Canonical canonical
+            && canonical.Locator == locator;
+    }
+
+    private static bool IsPlanned(PlannedSlotTargetReference target)
+    {
+        return target is PlannedSlotTargetReference.Planned;
+    }
+
+    private static bool IsPlanned(PlannedSlotTargetReference target, BatchPlanSlotLocator locator)
+    {
+        return target is PlannedSlotTargetReference.Planned planned
+            && planned.Locator == locator;
     }
 
     private static void AssertGradientPoint(Member member, float expectedPosition, int expectedX, int expectedY)
@@ -661,34 +682,20 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         return Assert.Single(
             batchPlan.SlotEmissions,
             slot => string.Equals(slot.SlotName, slotName, StringComparison.Ordinal)
-                && slot.ParentTarget.Canonical == new ResoniteSlotLocator("asset-lod-slot")).Identity;
+                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot"))).Identity;
     }
 
     private static string? ResolveTargetId(PlannedWorldElementReference target)
     {
-        if (target.CanonicalSlot is ResoniteSlotLocator canonicalSlot)
+        return target switch
         {
-            return canonicalSlot.Value;
-        }
-
-        if (target.CanonicalComponent is ResoniteComponentLocator canonicalComponent)
-        {
-            return canonicalComponent.Value;
-        }
-
-        if (target.PlannedSlot is BatchPlanSlotLocator plannedSlot)
-        {
-            return ToPlannedTargetId(plannedSlot);
-        }
-
-        if (target.PlannedComponent is BatchPlanComponentLocator plannedComponent)
-        {
-            return ToPlannedTargetId(plannedComponent);
-        }
-
-        return target.PlannedField is BatchPlanFieldLocator plannedField
-            ? ToPlannedTargetId(plannedField)
-            : null;
+            PlannedWorldElementReference.CanonicalSlot canonicalSlot => canonicalSlot.Locator.Value,
+            PlannedWorldElementReference.CanonicalComponent canonicalComponent => canonicalComponent.Locator.Value,
+            PlannedWorldElementReference.PlannedSlot plannedSlot => ToPlannedTargetId(plannedSlot.Locator),
+            PlannedWorldElementReference.PlannedComponent plannedComponent => ToPlannedTargetId(plannedComponent.Locator),
+            PlannedWorldElementReference.PlannedField plannedField => ToPlannedTargetId(plannedField.Locator),
+            _ => null,
+        };
     }
 
     private static string ToPlannedTargetId(BatchPlanSlotLocator locator)


### PR DESCRIPTION
## Summary
- Replace nullable planned slot/world reference structs with closed reference unions.
- Resolve batch targets with pattern matching over the reference kind instead of probing nullable fields.
- Update batch emission planning tests to assert the closed reference shape.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink dump: `runtime/windows/resonite/semantic-baselines/type-planned-emission-references/current/higashi-53395325-dem-bldg-grid-geotiff.json`
- `git diff --no-index` against `type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json` produced no diff.