### PR TITLE
Require dataset location payloads

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
@@ -51,8 +51,7 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
     {
         ArgumentNullException.ThrowIfNull(datasetContentSourceFactory);
 
-        if (source is not LocalDatasetLocation localSource
-            || string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
+        if (source is not LocalDatasetLocation localSource)
         {
             return null;
         }

--- a/src/PlateauResoniteLink/Application/Importing/ImportedSceneSourceDiscoveryPipeline.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ImportedSceneSourceDiscoveryPipeline.cs
@@ -25,14 +25,14 @@ internal static class ImportedSceneSourceDiscoveryPipeline
         ArgumentNullException.ThrowIfNull(appearanceStoreFactory);
         ArgumentNullException.ThrowIfNull(lodSelector);
 
-        if (request.CityGmlSource is not LocalDatasetLocation localSource || string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
+        if (request.CityGmlSource is not LocalDatasetLocation localSource)
         {
             throw new PlateauImportValidationException(
                 [LocalCityGmlImportErrorMessages.MissingLocalSourcePath()]);
         }
 
         IPlateauDatasetContentSource datasetSource = await datasetContentSourceFactory.CreateAsync(
-            localSource.LocalSourcePath!,
+            localSource.LocalSourcePath,
             cancellationToken);
         Stopwatch totalStopwatch = Stopwatch.StartNew();
         Stopwatch scanStopwatch = Stopwatch.StartNew();
@@ -59,7 +59,7 @@ internal static class ImportedSceneSourceDiscoveryPipeline
         if (sourceFiles.Length == 0)
         {
             throw new PlateauImportValidationException(
-                [LocalCityGmlImportErrorMessages.NoMatchingFiles(request, localSource.LocalSourcePath!)]);
+                [LocalCityGmlImportErrorMessages.NoMatchingFiles(request, localSource.LocalSourcePath)]);
         }
 
         LodFilteringStrategy lodFilteringStrategy = new(

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
@@ -137,12 +137,6 @@ public static class PlateauImportRequestValidator
         switch (normalizedRequest.CityGmlSource)
         {
             case LocalDatasetLocation localSource:
-                if (string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
-                {
-                    validationErrors.Add("The --citygml-source value is required.");
-                    break;
-                }
-
                 if (!Directory.Exists(localSource.LocalSourcePath)
                     && !File.Exists(localSource.LocalSourcePath))
                 {
@@ -167,12 +161,6 @@ public static class PlateauImportRequestValidator
                 validatedCityGmlSource = new ValidatedLocalDatasetLocation(localSource.LocalSourcePath);
                 break;
             case RemoteDatasetLocation remoteSource:
-                if (remoteSource.ServerUri is null)
-                {
-                    validationErrors.Add("The --citygml-source value is required.");
-                    break;
-                }
-
                 if (!remoteSource.ServerUri.IsAbsoluteUri)
                 {
                     validationErrors.Add("The --citygml-source value must be an absolute URI.");
@@ -194,12 +182,6 @@ public static class PlateauImportRequestValidator
             switch (normalizedRequest.DemTextureSource)
             {
                 case LocalDatasetLocation localSource:
-                    if (string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
-                    {
-                        validationErrors.Add("The --geotiff-source value must not be empty.");
-                        break;
-                    }
-
                     if (!File.Exists(localSource.LocalSourcePath))
                     {
                         validationErrors.Add($"The GeoTIFF source path '{localSource.LocalSourcePath}' must point to an existing file.");
@@ -216,12 +198,6 @@ public static class PlateauImportRequestValidator
                     validatedDemTextureSource = new ValidatedLocalDatasetLocation(localSource.LocalSourcePath);
                     break;
                 case RemoteDatasetLocation remoteSource:
-                    if (remoteSource.ServerUri is null)
-                    {
-                        validationErrors.Add("The --geotiff-source value must not be empty.");
-                        break;
-                    }
-
                     if (!remoteSource.ServerUri.IsAbsoluteUri)
                     {
                         validationErrors.Add("The --geotiff-source value must be an absolute URI.");
@@ -383,13 +359,8 @@ public static class PlateauImportRequestValidator
     {
         return source switch
         {
-            LocalDatasetLocation localSource => new LocalDatasetLocation(
-                string.IsNullOrWhiteSpace(localSource.LocalSourcePath)
-                    ? null
-                    : localSource.LocalSourcePath.Trim()),
-            RemoteDatasetLocation remoteSource => remoteSource.ServerUri is null
-                ? new RemoteDatasetLocation(null)
-                : remoteSource,
+            LocalDatasetLocation localSource => new LocalDatasetLocation(localSource.LocalSourcePath.Trim()),
+            RemoteDatasetLocation remoteSource => remoteSource,
             _ => source,
         };
     }

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
@@ -68,11 +68,12 @@ internal sealed class PlateauImportService(
                     "import",
                     $"Setup will use {this.commonMaterials.Count} codebase-reachable common materials."));
 
+            LocalDatasetLocation resolvedCityGmlSource = (LocalDatasetLocation)resolvedRequest.CityGmlSource;
             SceneImportExecutionPlan executionPlan = SceneImportExecutionPlan.Create(
                 normalizedRequest,
                 resolvedRequest,
                 metadata,
-                resolvedRequest.CityGmlLocalSourcePath!,
+                resolvedCityGmlSource.LocalSourcePath,
                 datasetWorkRoot,
                 this.commonMaterials);
 

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionPlan.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionPlan.cs
@@ -101,7 +101,7 @@ public sealed record SceneImportExecutionPlan
         {
             return RemoteDatasetResourceLayout.MatchesRemoteResourcePath(
                 workRoot,
-                remoteSource.ServerUri!,
+                remoteSource.ServerUri,
                 remotePathPrefix,
                 localSource.LocalSourcePath);
         }

--- a/src/PlateauResoniteLink/Domain/Importing/DatasetLocation.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/DatasetLocation.cs
@@ -4,20 +4,38 @@ namespace PlateauResoniteLink.Domain.Importing;
 
 public abstract record DatasetLocation(DatasetSourceKind SourceKind)
 {
-    public static DatasetLocation Local(string? localSourcePath)
+    public static DatasetLocation Local(string localSourcePath)
     {
         return new LocalDatasetLocation(localSourcePath);
     }
 
-    public static DatasetLocation Remote(Uri? serverUri)
+    public static DatasetLocation Remote(Uri serverUri)
     {
         return new RemoteDatasetLocation(serverUri);
     }
 
 }
 
-public sealed record LocalDatasetLocation(string? LocalSourcePath)
-    : DatasetLocation(DatasetSourceKind.Local);
+public sealed record LocalDatasetLocation : DatasetLocation
+{
+    public LocalDatasetLocation(string localSourcePath)
+        : base(DatasetSourceKind.Local)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localSourcePath);
+        LocalSourcePath = localSourcePath;
+    }
 
-public sealed record RemoteDatasetLocation(Uri? ServerUri)
-    : DatasetLocation(DatasetSourceKind.Remote);
+    public string LocalSourcePath { get; }
+}
+
+public sealed record RemoteDatasetLocation : DatasetLocation
+{
+    public RemoteDatasetLocation(Uri serverUri)
+        : base(DatasetSourceKind.Remote)
+    {
+        ArgumentNullException.ThrowIfNull(serverUri);
+        ServerUri = serverUri;
+    }
+
+    public Uri ServerUri { get; }
+}

--- a/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -10,16 +10,10 @@ namespace PlateauResoniteLink.Tests.Application;
 public sealed class PlateauImportRequestValidatorTests
 {
     [Fact]
-    public void ValidateRequiresCityGmlSource()
+    public void DatasetLocationFactoriesRequireSourcePayload()
     {
-        PlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Remote(null));
-
-        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
-
-        Assert.Contains("The --citygml-source value is required.", errors);
+        Assert.Throws<ArgumentException>(() => DatasetLocation.Local(" "));
+        Assert.Throws<ArgumentNullException>(() => DatasetLocation.Remote(null!));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Require `DatasetLocation` local/remote payloads at construction time instead of allowing null/blank values through the raw request model.
- Remove downstream null/blank payload checks from import validation, discovery, and DEM raster catalog paths now that the domain type carries the invariant.
- Keep absence localized to optional request slots such as `DemTextureSource`, rather than hiding it inside local/remote payloads.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (987 passed)
- Fake Live Sink canonical dump: `runtime/windows/resonite/semantic-baselines/type-required-source-file/current/higashi-53395325-dem-bldg-grid-geotiff.json`
- `git diff --no-index` against `runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json` produced no diff.