### PR TITLE
Type resolved local import requests

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
@@ -43,7 +43,7 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
             resourcePrefix: "source-archive",
             invalidateLocalFileCache: true,
             cancellationToken);
-        ValidatedDatasetLocation? resolvedDemTextureSource = await ResolveOptionalRemoteDatasetLocationAsync(
+        ValidatedLocalDatasetLocation? resolvedDemTextureSource = await ResolveOptionalLocalDatasetLocationAsync(
             request.DemTextureSource,
             workRoot,
             resourcePrefix: "source-ortho",
@@ -63,18 +63,17 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
         bool invalidateLocalFileCache,
         CancellationToken cancellationToken)
     {
-        ValidatedDatasetLocation? resolvedSource = await ResolveOptionalRemoteDatasetLocationAsync(
+        ValidatedLocalDatasetLocation? resolvedSource = await ResolveOptionalLocalDatasetLocationAsync(
             source,
             workRoot,
             resourcePrefix,
             invalidateLocalFileCache,
             cancellationToken);
-        return resolvedSource is ValidatedLocalDatasetLocation localSource
-            ? localSource
-            : throw new InvalidOperationException("The normalized CityGML source must resolve to a local dataset location.");
+        return resolvedSource
+            ?? throw new InvalidOperationException("The normalized CityGML source must resolve to a local dataset location.");
     }
 
-    private async Task<ValidatedDatasetLocation?> ResolveOptionalRemoteDatasetLocationAsync(
+    private async Task<ValidatedLocalDatasetLocation?> ResolveOptionalLocalDatasetLocationAsync(
         ValidatedDatasetLocation? source,
         string workRoot,
         string resourcePrefix,
@@ -83,7 +82,7 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
     {
         if (source is null || source is ValidatedLocalDatasetLocation)
         {
-            return source;
+            return source as ValidatedLocalDatasetLocation;
         }
 
         ValidatedRemoteDatasetLocation remoteSource = (ValidatedRemoteDatasetLocation)source;

--- a/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
@@ -26,7 +26,7 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
         this.archiveFileLayoutPolicy = archiveFileLayoutPolicy ?? throw new ArgumentNullException(nameof(archiveFileLayoutPolicy));
     }
 
-    public async Task<ValidatedPlateauImportRequest> ResolveAsync(
+    public async Task<ResolvedLocalPlateauImportRequest> ResolveAsync(
         ValidatedPlateauImportRequest request,
         string workRoot,
         CancellationToken cancellationToken = default)
@@ -37,12 +37,12 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
         _ = archiveFileLayoutPolicy.CreateSafePathSegment(request.Dataset);
         _ = TryCreateSafePathSegment(request.MeshCode, out _);
 
-        ValidatedDatasetLocation resolvedSource = await ResolveOptionalRemoteDatasetLocationAsync(
+        ValidatedLocalDatasetLocation resolvedSource = await ResolveRequiredLocalDatasetLocationAsync(
             request.CityGmlSource,
             workRoot,
             resourcePrefix: "source-archive",
             invalidateLocalFileCache: true,
-            cancellationToken) ?? throw new InvalidOperationException("The normalized CityGML source must resolve to a local or remote location.");
+            cancellationToken);
         ValidatedDatasetLocation? resolvedDemTextureSource = await ResolveOptionalRemoteDatasetLocationAsync(
             request.DemTextureSource,
             workRoot,
@@ -50,11 +50,28 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
             invalidateLocalFileCache: false,
             cancellationToken);
 
-        return request with
-        {
-            CityGmlSource = resolvedSource,
-            DemTextureSource = resolvedDemTextureSource!,
-        };
+        return ResolvedLocalPlateauImportRequest.Create(
+            request,
+            resolvedSource,
+            resolvedDemTextureSource);
+    }
+
+    private async Task<ValidatedLocalDatasetLocation> ResolveRequiredLocalDatasetLocationAsync(
+        ValidatedDatasetLocation source,
+        string workRoot,
+        string resourcePrefix,
+        bool invalidateLocalFileCache,
+        CancellationToken cancellationToken)
+    {
+        ValidatedDatasetLocation? resolvedSource = await ResolveOptionalRemoteDatasetLocationAsync(
+            source,
+            workRoot,
+            resourcePrefix,
+            invalidateLocalFileCache,
+            cancellationToken);
+        return resolvedSource is ValidatedLocalDatasetLocation localSource
+            ? localSource
+            : throw new InvalidOperationException("The normalized CityGML source must resolve to a local dataset location.");
     }
 
     private async Task<ValidatedDatasetLocation?> ResolveOptionalRemoteDatasetLocationAsync(

--- a/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
@@ -52,6 +52,7 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
 
         return ResolvedLocalPlateauImportRequest.Create(
             request,
+            workRoot,
             resolvedSource,
             resolvedDemTextureSource);
     }

--- a/src/PlateauResoniteLink/Application/Importing/DefaultImportedSceneSourceComposer.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultImportedSceneSourceComposer.cs
@@ -15,7 +15,7 @@ internal sealed class DefaultImportedSceneSourceComposer(
     private const string PlateauLicenseUrl = "https://www.mlit.go.jp/plateau/site-policy/";
 
     public IImportedSceneSource Compose(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         ImportedSceneSourceSnapshot readResult,
         IImportedObjectUnitOptimizer objectUnitOptimizer,
         Action<string>? progressReporter = null)
@@ -25,16 +25,17 @@ internal sealed class DefaultImportedSceneSourceComposer(
         ArgumentNullException.ThrowIfNull(objectUnitOptimizer);
         ImportedSceneSourceDataset documentSet = readResult.DocumentSet;
         ImportedSceneSourceContext discoveryContext = readResult.DiscoveryContext;
+        PlateauImportRequest importRequest = request.ToImportRequest();
 
         ImportedSceneMetadata metadata = new(
             SchemaVersion: "3.0",
             SceneName: $"PLATEAU {request.Dataset} {request.MeshCode}",
-            Request: request,
+            Request: importRequest,
             SourceDataset: new PlateauSourceDataset(
                 PackageNames: documentSet.PackageNames.ToArray(),
                 SourceFiles: documentSet.RelativeSourceFiles.ToArray(),
                 SelectedMeshCodes: documentSet.SelectedMeshCodes),
-            Attribution: CreateAttribution(request),
+            Attribution: CreateAttribution(importRequest),
             GeodeticOrigin: new GeodeticOrigin(
                 Latitude: discoveryContext.GlobalOriginPoint.Latitude,
                 Longitude: discoveryContext.GlobalOriginPoint.Longitude,
@@ -42,7 +43,7 @@ internal sealed class DefaultImportedSceneSourceComposer(
 
         return new StreamingImportedSceneSource(
             metadata,
-            request,
+            importRequest,
             readResult,
             geometryProjector,
             demTextureSourcePolicy,

--- a/src/PlateauResoniteLink/Application/Importing/DefaultImportedSceneSourceFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultImportedSceneSourceFactory.cs
@@ -2,8 +2,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Application.Importing;
 
 internal sealed class DefaultImportedSceneSourceFactory : IImportedSceneSourceFactory
@@ -26,7 +24,7 @@ internal sealed class DefaultImportedSceneSourceFactory : IImportedSceneSourceFa
     }
 
     public Task<IImportedSceneSource> CreateAsync(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default)
     {
@@ -35,7 +33,7 @@ internal sealed class DefaultImportedSceneSourceFactory : IImportedSceneSourceFa
     }
 
     private async Task<IImportedSceneSource> CreateResolvedCoreAsync(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         Action<string>? progressReporter,
         CancellationToken cancellationToken)
     {

--- a/src/PlateauResoniteLink/Application/Importing/ICityGmlDocumentReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ICityGmlDocumentReader.cs
@@ -2,14 +2,12 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Application.Importing;
 
 internal interface ICityGmlDocumentReader
 {
     Task<ImportedSceneSourceSnapshot> ReadAsync(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/PlateauResoniteLink/Application/Importing/IImportedSceneSourceComposer.cs
+++ b/src/PlateauResoniteLink/Application/Importing/IImportedSceneSourceComposer.cs
@@ -1,13 +1,11 @@
 using System;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Application.Importing;
 
 internal interface IImportedSceneSourceComposer
 {
     IImportedSceneSource Compose(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         ImportedSceneSourceSnapshot readResult,
         IImportedObjectUnitOptimizer objectUnitOptimizer,
         Action<string>? progressReporter = null);

--- a/src/PlateauResoniteLink/Application/Importing/IImportedSceneSourceFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/IImportedSceneSourceFactory.cs
@@ -2,14 +2,12 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Application.Importing;
 
 public interface IImportedSceneSourceFactory
 {
     Task<IImportedSceneSource> CreateAsync(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/PlateauResoniteLink/Application/Importing/IPlateauDatasetSourceResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/IPlateauDatasetSourceResolver.cs
@@ -5,7 +5,7 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal interface IPlateauDatasetSourceResolver
 {
-    Task<ValidatedPlateauImportRequest> ResolveAsync(
+    Task<ResolvedLocalPlateauImportRequest> ResolveAsync(
         ValidatedPlateauImportRequest request,
         string workRoot,
         CancellationToken cancellationToken = default);

--- a/src/PlateauResoniteLink/Application/Importing/ImportedSceneSourceDiscoveryPipeline.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ImportedSceneSourceDiscoveryPipeline.cs
@@ -13,7 +13,7 @@ namespace PlateauResoniteLink.Application.Importing;
 internal static class ImportedSceneSourceDiscoveryPipeline
 {
     internal static async Task<ImportedSceneSourceSnapshot> ReadDocumentSetCoreAsync(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         IPlateauDatasetContentSourceFactory datasetContentSourceFactory,
         ICityGmlAppearanceStoreFactory appearanceStoreFactory,
         ICityGmlLodSelector lodSelector,
@@ -25,14 +25,8 @@ internal static class ImportedSceneSourceDiscoveryPipeline
         ArgumentNullException.ThrowIfNull(appearanceStoreFactory);
         ArgumentNullException.ThrowIfNull(lodSelector);
 
-        if (request.CityGmlSource is not LocalDatasetLocation localSource)
-        {
-            throw new PlateauImportValidationException(
-                [LocalCityGmlImportErrorMessages.MissingLocalSourcePath()]);
-        }
-
         IPlateauDatasetContentSource datasetSource = await datasetContentSourceFactory.CreateAsync(
-            localSource.LocalSourcePath,
+            request.CityGmlLocalSourcePath,
             cancellationToken);
         Stopwatch totalStopwatch = Stopwatch.StartNew();
         Stopwatch scanStopwatch = Stopwatch.StartNew();
@@ -59,7 +53,7 @@ internal static class ImportedSceneSourceDiscoveryPipeline
         if (sourceFiles.Length == 0)
         {
             throw new PlateauImportValidationException(
-                [LocalCityGmlImportErrorMessages.NoMatchingFiles(request, localSource.LocalSourcePath)]);
+                [LocalCityGmlImportErrorMessages.NoMatchingFiles(request.ToImportRequest(), request.CityGmlLocalSourcePath)]);
         }
 
         LodFilteringStrategy lodFilteringStrategy = new(

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlDocumentReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlDocumentReader.cs
@@ -2,8 +2,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Application.Importing;
 
 internal sealed class LocalCityGmlDocumentReader : ICityGmlDocumentReader
@@ -23,7 +21,7 @@ internal sealed class LocalCityGmlDocumentReader : ICityGmlDocumentReader
     }
 
     public async Task<ImportedSceneSourceSnapshot> ReadAsync(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default)
     {

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
@@ -45,11 +45,11 @@ internal sealed class PlateauImportService(
 
         try
         {
-            PlateauImportRequest resolvedRequest =
-                (await datasetSourceResolver.ResolveAsync(
-                    validatedRequest,
-                    datasetWorkRoot,
-                    cancellationToken)).ToImportRequest();
+            ResolvedLocalPlateauImportRequest resolvedRequest = await datasetSourceResolver.ResolveAsync(
+                validatedRequest,
+                datasetWorkRoot,
+                cancellationToken);
+            PlateauImportRequest resolvedImportRequest = resolvedRequest.ToImportRequest();
             ReportProgress(
                 PlateauLog.Debug("import", $"Resolved CityGML source for '{resolvedRequest.Dataset}' mesh-code '{resolvedRequest.MeshCode}'."));
 
@@ -68,12 +68,11 @@ internal sealed class PlateauImportService(
                     "import",
                     $"Setup will use {this.commonMaterials.Count} codebase-reachable common materials."));
 
-            LocalDatasetLocation resolvedCityGmlSource = (LocalDatasetLocation)resolvedRequest.CityGmlSource;
             SceneImportExecutionPlan executionPlan = SceneImportExecutionPlan.Create(
                 normalizedRequest,
-                resolvedRequest,
+                resolvedImportRequest,
                 metadata,
-                resolvedCityGmlSource.LocalSourcePath,
+                resolvedRequest.CityGmlLocalSourcePath,
                 datasetWorkRoot,
                 this.commonMaterials);
 

--- a/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+public sealed record ResolvedLocalPlateauImportRequest
+{
+    private readonly ValidatedDatasetLocation? demTextureSource;
+
+    public ResolvedLocalPlateauImportRequest(
+        string Dataset,
+        string MeshCode,
+        string CityGmlLocalSourcePath,
+        DatasetLocation? DemTextureSource = null,
+        IReadOnlyList<string>? PackageNames = null,
+        IReadOnlySet<int>? GlobalExcludeLodLevels = null,
+        IReadOnlyDictionary<string, IReadOnlySet<int>>? ExcludeLodLevelsByPackage = null,
+        IReadOnlyDictionary<string, string>? PackagePatterns = null,
+        bool IncludeMarkingAlways = true,
+        TerrainMeshMode TerrainMeshMode = TerrainMeshMode.Static,
+        double TerrainGridMetersPerVertex = 2.0,
+        int TerrainGridMaxResolution = 1024)
+    {
+        ValidatedLocalDatasetLocation cityGmlSource = new(RequireNonEmpty(CityGmlLocalSourcePath, nameof(CityGmlLocalSourcePath)));
+        ValidatedDatasetLocation? validatedDemTextureSource = ToValidatedDatasetLocation(DemTextureSource, nameof(DemTextureSource));
+        ValidatedRequest = CreateResolvedRequest(
+            Dataset,
+            MeshCode,
+            cityGmlSource,
+            validatedDemTextureSource,
+            PackageNames,
+            GlobalExcludeLodLevels,
+            ExcludeLodLevelsByPackage,
+            PackagePatterns,
+            IncludeMarkingAlways,
+            TerrainMeshMode,
+            TerrainGridMetersPerVertex,
+            TerrainGridMaxResolution);
+        CityGmlSource = cityGmlSource;
+        demTextureSource = validatedDemTextureSource;
+    }
+
+    private ResolvedLocalPlateauImportRequest(
+        ValidatedPlateauImportRequest request,
+        ValidatedLocalDatasetLocation cityGmlSource,
+        ValidatedDatasetLocation? demTextureSource)
+    {
+        ValidatedRequest = request with
+        {
+            CityGmlSource = cityGmlSource,
+            DemTextureSource = demTextureSource,
+        };
+        CityGmlSource = cityGmlSource;
+        this.demTextureSource = demTextureSource;
+    }
+
+    internal ValidatedPlateauImportRequest ValidatedRequest { get; }
+
+    internal ValidatedLocalDatasetLocation CityGmlSource { get; }
+
+    public string Dataset => ValidatedRequest.Dataset;
+
+    public string MeshCode => ValidatedRequest.MeshCode;
+
+    public string CityGmlLocalSourcePath => CityGmlSource.LocalSourcePath;
+
+    public DatasetLocation? DemTextureSource => demTextureSource?.ToDatasetLocation();
+
+    public DatasetSourceKind? DemTextureSourceKind => DemTextureSource?.SourceKind;
+
+    public string? DemTextureLocalSourcePath => DemTextureSource is LocalDatasetLocation localSource
+        ? localSource.LocalSourcePath
+        : null;
+
+    public Uri? DemTextureServerUri => DemTextureSource is RemoteDatasetLocation remoteSource
+        ? remoteSource.ServerUri
+        : null;
+
+    public IReadOnlyList<string>? PackageNames => ValidatedRequest.PackageNames;
+
+    public IReadOnlySet<int>? GlobalExcludeLodLevels => ValidatedRequest.GlobalExcludeLodLevels;
+
+    public IReadOnlyDictionary<string, IReadOnlySet<int>>? ExcludeLodLevelsByPackage => ValidatedRequest.ExcludeLodLevelsByPackage;
+
+    public IReadOnlyDictionary<string, string>? PackagePatterns => ValidatedRequest.PackagePatterns;
+
+    public bool IncludeMarkingAlways => ValidatedRequest.IncludeMarkingAlways;
+
+    public TerrainMeshMode TerrainMeshMode => ValidatedRequest.TerrainMeshMode;
+
+    public double TerrainGridMetersPerVertex => ValidatedRequest.TerrainGridMetersPerVertex;
+
+    public int TerrainGridMaxResolution => ValidatedRequest.TerrainGridMaxResolution;
+
+    public PlateauImportRequest ToImportRequest()
+    {
+        return (ValidatedRequest with
+        {
+            CityGmlSource = CityGmlSource,
+            DemTextureSource = demTextureSource,
+        }).ToImportRequest();
+    }
+
+    internal static ResolvedLocalPlateauImportRequest Create(
+        ValidatedPlateauImportRequest request,
+        ValidatedLocalDatasetLocation cityGmlSource,
+        ValidatedDatasetLocation? demTextureSource)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(cityGmlSource);
+
+        return new ResolvedLocalPlateauImportRequest(request, cityGmlSource, demTextureSource);
+    }
+
+    private static ValidatedPlateauImportRequest CreateResolvedRequest(
+        string dataset,
+        string meshCode,
+        ValidatedLocalDatasetLocation cityGmlSource,
+        ValidatedDatasetLocation? demTextureSource,
+        IReadOnlyList<string>? packageNames,
+        IReadOnlySet<int>? globalExcludeLodLevels,
+        IReadOnlyDictionary<string, IReadOnlySet<int>>? excludeLodLevelsByPackage,
+        IReadOnlyDictionary<string, string>? packagePatterns,
+        bool includeMarkingAlways,
+        TerrainMeshMode terrainMeshMode,
+        double terrainGridMetersPerVertex,
+        int terrainGridMaxResolution)
+    {
+        string requiredDataset = RequireNonEmpty(dataset, nameof(dataset));
+        string requiredMeshCode = RequireNonEmpty(meshCode, nameof(meshCode));
+        if (!MeshCodeRequestSyntax.TryCreateSelectionRegex(requiredMeshCode, out Regex? meshCodePattern, out string? meshCodeError))
+        {
+            throw new ArgumentException(meshCodeError, nameof(meshCode));
+        }
+
+        meshCodePattern ??= new Regex(
+            $@"\A(?:{Regex.Escape(requiredMeshCode)})\z",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant,
+            TimeSpan.FromSeconds(1));
+
+        return new ValidatedPlateauImportRequest(
+            requiredDataset,
+            requiredMeshCode,
+            meshCodePattern,
+            cityGmlSource,
+            demTextureSource,
+            packageNames,
+            globalExcludeLodLevels,
+            excludeLodLevelsByPackage,
+            packagePatterns,
+            includeMarkingAlways,
+            terrainMeshMode,
+            terrainGridMetersPerVertex,
+            terrainGridMaxResolution);
+    }
+
+    private static ValidatedDatasetLocation? ToValidatedDatasetLocation(
+        DatasetLocation? source,
+        string parameterName)
+    {
+        return source switch
+        {
+            null => null,
+            LocalDatasetLocation localSource => new ValidatedLocalDatasetLocation(RequireNonEmpty(localSource.LocalSourcePath, parameterName)),
+            RemoteDatasetLocation remoteSource => new ValidatedRemoteDatasetLocation(
+                remoteSource.ServerUri ?? throw new ArgumentException("The server URI must not be null.", parameterName)),
+            _ => throw new ArgumentException("Unsupported dataset source location.", parameterName),
+        };
+    }
+
+    private static string RequireNonEmpty(string? value, string parameterName)
+    {
+        string? trimmedValue = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmedValue)
+            ? throw new ArgumentException("The value must not be empty.", parameterName)
+            : trimmedValue;
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
@@ -136,6 +136,8 @@ public sealed record ResolvedLocalPlateauImportRequest
         string requiredDataset = RequireNonEmpty(dataset, nameof(dataset));
         string requiredMeshCode = RequireNonEmpty(meshCode, nameof(meshCode));
         string[]? normalizedPackageNames = NormalizePackageNames(packageNames);
+        Dictionary<string, IReadOnlySet<int>>? normalizedPackageExclusions = NormalizePackageExclusionMap(excludeLodLevelsByPackage);
+        Dictionary<string, string>? normalizedPackagePatterns = NormalizePackagePatternMap(packagePatterns);
         if (!MeshCodeRequestSyntax.TryCreateSelectionRegex(requiredMeshCode, out Regex? meshCodePattern, out string? meshCodeError))
         {
             throw new ArgumentException(meshCodeError, nameof(meshCode));
@@ -154,8 +156,8 @@ public sealed record ResolvedLocalPlateauImportRequest
             demTextureSource,
             normalizedPackageNames,
             globalExcludeLodLevels,
-            excludeLodLevelsByPackage,
-            packagePatterns,
+            normalizedPackageExclusions,
+            normalizedPackagePatterns,
             includeMarkingAlways,
             terrainMeshMode,
             terrainGridMetersPerVertex,
@@ -188,6 +190,64 @@ public sealed record ResolvedLocalPlateauImportRequest
         }
 
         return PlateauPackageCatalog.NormalizeRequestedPackageNames(packageNames);
+    }
+
+    private static Dictionary<string, IReadOnlySet<int>>? NormalizePackageExclusionMap(
+        IReadOnlyDictionary<string, IReadOnlySet<int>>? exclusionsByPackage)
+    {
+        if (exclusionsByPackage is null)
+        {
+            return null;
+        }
+
+        Dictionary<string, IReadOnlySet<int>> normalized = new(StringComparer.OrdinalIgnoreCase);
+        foreach ((string packageName, IReadOnlySet<int> excludedLods) in exclusionsByPackage)
+        {
+            string normalizedPackageName = NormalizePackageMapKey(packageName, nameof(exclusionsByPackage));
+            if (!normalized.TryAdd(normalizedPackageName, excludedLods))
+            {
+                throw new ArgumentException(
+                    $"The {nameof(exclusionsByPackage)} value contains duplicate package keys after normalization: {normalizedPackageName}.",
+                    nameof(exclusionsByPackage));
+            }
+        }
+
+        return normalized;
+    }
+
+    private static Dictionary<string, string>? NormalizePackagePatternMap(
+        IReadOnlyDictionary<string, string>? patternsByPackage)
+    {
+        if (patternsByPackage is null)
+        {
+            return null;
+        }
+
+        Dictionary<string, string> normalized = new(StringComparer.OrdinalIgnoreCase);
+        foreach ((string packageName, string pattern) in patternsByPackage)
+        {
+            string normalizedPackageName = NormalizePackageMapKey(packageName, nameof(patternsByPackage));
+            if (!normalized.TryAdd(normalizedPackageName, pattern))
+            {
+                throw new ArgumentException(
+                    $"The {nameof(patternsByPackage)} value contains duplicate package keys after normalization: {normalizedPackageName}.",
+                    nameof(patternsByPackage));
+            }
+        }
+
+        return normalized;
+    }
+
+    private static string NormalizePackageMapKey(string packageName, string parameterName)
+    {
+        if (!PlateauPackageCatalog.TryNormalizePackageName(packageName, out string normalizedPackageName))
+        {
+            throw new ArgumentException(
+                $"Unsupported package '{packageName}'. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.",
+                parameterName);
+        }
+
+        return normalizedPackageName;
     }
 
     private static string RequireNonEmpty(string? value, string parameterName)

--- a/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
@@ -8,13 +8,13 @@ namespace PlateauResoniteLink.Application.Importing;
 
 public sealed record ResolvedLocalPlateauImportRequest
 {
-    private readonly ValidatedDatasetLocation? demTextureSource;
+    private readonly ValidatedLocalDatasetLocation? demTextureSource;
 
     public ResolvedLocalPlateauImportRequest(
         string Dataset,
         string MeshCode,
         string CityGmlLocalSourcePath,
-        DatasetLocation? DemTextureSource = null,
+        LocalDatasetLocation? DemTextureSource = null,
         IReadOnlyList<string>? PackageNames = null,
         IReadOnlySet<int>? GlobalExcludeLodLevels = null,
         IReadOnlyDictionary<string, IReadOnlySet<int>>? ExcludeLodLevelsByPackage = null,
@@ -46,7 +46,7 @@ public sealed record ResolvedLocalPlateauImportRequest
     private ResolvedLocalPlateauImportRequest(
         ValidatedPlateauImportRequest request,
         ValidatedLocalDatasetLocation cityGmlSource,
-        ValidatedDatasetLocation? demTextureSource)
+        ValidatedLocalDatasetLocation? demTextureSource)
     {
         ValidatedRequest = request with
         {
@@ -67,17 +67,11 @@ public sealed record ResolvedLocalPlateauImportRequest
 
     public string CityGmlLocalSourcePath => CityGmlSource.LocalSourcePath;
 
-    public DatasetLocation? DemTextureSource => demTextureSource?.ToDatasetLocation();
+    public LocalDatasetLocation? DemTextureSource => demTextureSource is null
+        ? null
+        : new LocalDatasetLocation(demTextureSource.LocalSourcePath);
 
-    public DatasetSourceKind? DemTextureSourceKind => DemTextureSource?.SourceKind;
-
-    public string? DemTextureLocalSourcePath => DemTextureSource is LocalDatasetLocation localSource
-        ? localSource.LocalSourcePath
-        : null;
-
-    public Uri? DemTextureServerUri => DemTextureSource is RemoteDatasetLocation remoteSource
-        ? remoteSource.ServerUri
-        : null;
+    public string? DemTextureLocalSourcePath => demTextureSource?.LocalSourcePath;
 
     public IReadOnlyList<string>? PackageNames => ValidatedRequest.PackageNames;
 
@@ -107,14 +101,10 @@ public sealed record ResolvedLocalPlateauImportRequest
     internal static ResolvedLocalPlateauImportRequest Create(
         ValidatedPlateauImportRequest request,
         ValidatedLocalDatasetLocation cityGmlSource,
-        ValidatedDatasetLocation? demTextureSource)
+        ValidatedLocalDatasetLocation? demTextureSource)
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(cityGmlSource);
-        if (demTextureSource is ValidatedRemoteDatasetLocation)
-        {
-            throw new ArgumentException("Resolved local import requests require DEM texture sources to be local when specified.", nameof(demTextureSource));
-        }
 
         return new ResolvedLocalPlateauImportRequest(request, cityGmlSource, demTextureSource);
     }
@@ -123,7 +113,7 @@ public sealed record ResolvedLocalPlateauImportRequest
         string dataset,
         string meshCode,
         ValidatedLocalDatasetLocation cityGmlSource,
-        ValidatedDatasetLocation? demTextureSource,
+        ValidatedLocalDatasetLocation? demTextureSource,
         IReadOnlyList<string>? packageNames,
         IReadOnlySet<int>? globalExcludeLodLevels,
         IReadOnlyDictionary<string, IReadOnlySet<int>>? excludeLodLevelsByPackage,
@@ -165,16 +155,12 @@ public sealed record ResolvedLocalPlateauImportRequest
     }
 
     private static ValidatedLocalDatasetLocation? ToResolvedDemTextureSource(
-        DatasetLocation? source,
+        LocalDatasetLocation? source,
         string parameterName)
     {
-        return source switch
-        {
-            null => null,
-            LocalDatasetLocation localSource => new ValidatedLocalDatasetLocation(RequireNonEmpty(localSource.LocalSourcePath, parameterName)),
-            RemoteDatasetLocation => throw new ArgumentException("Resolved local import requests require DEM texture sources to be local when specified.", parameterName),
-            _ => throw new ArgumentException("Unsupported dataset source location.", parameterName),
-        };
+        return source is null
+            ? null
+            : new ValidatedLocalDatasetLocation(RequireNonEmpty(source.LocalSourcePath, parameterName));
     }
 
     private static string[]? NormalizePackageNames(IReadOnlyList<string>? packageNames)

--- a/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
@@ -100,13 +100,66 @@ public sealed record ResolvedLocalPlateauImportRequest
 
     internal static ResolvedLocalPlateauImportRequest Create(
         ValidatedPlateauImportRequest request,
+        string workRoot,
         ValidatedLocalDatasetLocation cityGmlSource,
         ValidatedLocalDatasetLocation? demTextureSource)
     {
         ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
         ArgumentNullException.ThrowIfNull(cityGmlSource);
 
+        ValidateResolvedSource(request.CityGmlSource, cityGmlSource, workRoot, "source-archive", nameof(cityGmlSource));
+        ValidateResolvedOptionalSource(request.DemTextureSource, demTextureSource, workRoot, "source-ortho", nameof(demTextureSource));
+
         return new ResolvedLocalPlateauImportRequest(request, cityGmlSource, demTextureSource);
+    }
+
+    private static void ValidateResolvedOptionalSource(
+        ValidatedDatasetLocation? requestedSource,
+        ValidatedLocalDatasetLocation? resolvedSource,
+        string workRoot,
+        string remotePathPrefix,
+        string parameterName)
+    {
+        if (requestedSource is null || resolvedSource is null)
+        {
+            if (requestedSource is not null || resolvedSource is not null)
+            {
+                throw new ArgumentException(
+                    "Resolved local source presence must match the requested source presence.",
+                    parameterName);
+            }
+
+            return;
+        }
+
+        ValidateResolvedSource(requestedSource, resolvedSource, workRoot, remotePathPrefix, parameterName);
+    }
+
+    private static void ValidateResolvedSource(
+        ValidatedDatasetLocation requestedSource,
+        ValidatedLocalDatasetLocation resolvedSource,
+        string workRoot,
+        string remotePathPrefix,
+        string parameterName)
+    {
+        switch (requestedSource)
+        {
+            case ValidatedLocalDatasetLocation requestedLocal
+                when string.Equals(requestedLocal.LocalSourcePath, resolvedSource.LocalSourcePath, StringComparison.Ordinal):
+                return;
+            case ValidatedRemoteDatasetLocation requestedRemote
+                when RemoteDatasetResourceLayout.MatchesRemoteResourcePath(
+                    workRoot,
+                    requestedRemote.ServerUri,
+                    remotePathPrefix,
+                    resolvedSource.LocalSourcePath):
+                return;
+            default:
+                throw new ArgumentException(
+                    "Resolved local source must match the requested local source or the expected remote materialization path.",
+                    parameterName);
+        }
     }
 
     private static ValidatedPlateauImportRequest CreateResolvedRequest(

--- a/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
@@ -25,7 +25,7 @@ public sealed record ResolvedLocalPlateauImportRequest
         int TerrainGridMaxResolution = 1024)
     {
         ValidatedLocalDatasetLocation cityGmlSource = new(RequireNonEmpty(CityGmlLocalSourcePath, nameof(CityGmlLocalSourcePath)));
-        ValidatedDatasetLocation? validatedDemTextureSource = ToValidatedDatasetLocation(DemTextureSource, nameof(DemTextureSource));
+        ValidatedLocalDatasetLocation? validatedDemTextureSource = ToResolvedDemTextureSource(DemTextureSource, nameof(DemTextureSource));
         ValidatedRequest = CreateResolvedRequest(
             Dataset,
             MeshCode,
@@ -111,6 +111,10 @@ public sealed record ResolvedLocalPlateauImportRequest
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(cityGmlSource);
+        if (demTextureSource is ValidatedRemoteDatasetLocation)
+        {
+            throw new ArgumentException("Resolved local import requests require DEM texture sources to be local when specified.", nameof(demTextureSource));
+        }
 
         return new ResolvedLocalPlateauImportRequest(request, cityGmlSource, demTextureSource);
     }
@@ -131,6 +135,7 @@ public sealed record ResolvedLocalPlateauImportRequest
     {
         string requiredDataset = RequireNonEmpty(dataset, nameof(dataset));
         string requiredMeshCode = RequireNonEmpty(meshCode, nameof(meshCode));
+        string[]? normalizedPackageNames = NormalizePackageNames(packageNames);
         if (!MeshCodeRequestSyntax.TryCreateSelectionRegex(requiredMeshCode, out Regex? meshCodePattern, out string? meshCodeError))
         {
             throw new ArgumentException(meshCodeError, nameof(meshCode));
@@ -147,7 +152,7 @@ public sealed record ResolvedLocalPlateauImportRequest
             meshCodePattern,
             cityGmlSource,
             demTextureSource,
-            packageNames,
+            normalizedPackageNames,
             globalExcludeLodLevels,
             excludeLodLevelsByPackage,
             packagePatterns,
@@ -157,7 +162,7 @@ public sealed record ResolvedLocalPlateauImportRequest
             terrainGridMaxResolution);
     }
 
-    private static ValidatedDatasetLocation? ToValidatedDatasetLocation(
+    private static ValidatedLocalDatasetLocation? ToResolvedDemTextureSource(
         DatasetLocation? source,
         string parameterName)
     {
@@ -165,10 +170,24 @@ public sealed record ResolvedLocalPlateauImportRequest
         {
             null => null,
             LocalDatasetLocation localSource => new ValidatedLocalDatasetLocation(RequireNonEmpty(localSource.LocalSourcePath, parameterName)),
-            RemoteDatasetLocation remoteSource => new ValidatedRemoteDatasetLocation(
-                remoteSource.ServerUri ?? throw new ArgumentException("The server URI must not be null.", parameterName)),
+            RemoteDatasetLocation => throw new ArgumentException("Resolved local import requests require DEM texture sources to be local when specified.", parameterName),
             _ => throw new ArgumentException("Unsupported dataset source location.", parameterName),
         };
+    }
+
+    private static string[]? NormalizePackageNames(IReadOnlyList<string>? packageNames)
+    {
+        if (packageNames is null)
+        {
+            return null;
+        }
+
+        if (packageNames.Count == 0)
+        {
+            throw new ArgumentException("At least one package name is required when packages are specified.", nameof(packageNames));
+        }
+
+        return PlateauPackageCatalog.NormalizeRequestedPackageNames(packageNames);
     }
 
     private static string RequireNonEmpty(string? value, string parameterName)

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedPlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedPlateauImportRequest.cs
@@ -22,6 +22,57 @@ public sealed record ValidatedPlateauImportRequest(
     double TerrainGridMetersPerVertex = 2.0,
     int TerrainGridMaxResolution = 1024)
 {
+#pragma warning disable IDE0032 // Backing fields keep with-expressions inside validated invariants.
+    private string dataset = RequireNonWhiteSpace(Dataset, nameof(Dataset));
+    private string meshCode = RequireNonWhiteSpace(MeshCode, nameof(MeshCode));
+    private Regex meshCodePattern = MeshCodePattern ?? throw new ArgumentNullException(nameof(MeshCodePattern));
+    private ValidatedDatasetLocation cityGmlSource =
+        CityGmlSource ?? throw new ArgumentNullException(nameof(CityGmlSource));
+    private double terrainGridMetersPerVertex = RequirePositive(
+        TerrainGridMetersPerVertex,
+        nameof(TerrainGridMetersPerVertex));
+    private int terrainGridMaxResolution = RequireMinimum(
+        TerrainGridMaxResolution,
+        2,
+        nameof(TerrainGridMaxResolution));
+#pragma warning restore IDE0032
+
+    public string Dataset
+    {
+        get => dataset;
+        init => dataset = RequireNonWhiteSpace(value, nameof(Dataset));
+    }
+
+    public string MeshCode
+    {
+        get => meshCode;
+        init => meshCode = RequireNonWhiteSpace(value, nameof(MeshCode));
+    }
+
+    public Regex MeshCodePattern
+    {
+        get => meshCodePattern;
+        init => meshCodePattern = value ?? throw new ArgumentNullException(nameof(MeshCodePattern));
+    }
+
+    public ValidatedDatasetLocation CityGmlSource
+    {
+        get => cityGmlSource;
+        init => cityGmlSource = value ?? throw new ArgumentNullException(nameof(CityGmlSource));
+    }
+
+    public double TerrainGridMetersPerVertex
+    {
+        get => terrainGridMetersPerVertex;
+        init => terrainGridMetersPerVertex = RequirePositive(value, nameof(TerrainGridMetersPerVertex));
+    }
+
+    public int TerrainGridMaxResolution
+    {
+        get => terrainGridMaxResolution;
+        init => terrainGridMaxResolution = RequireMinimum(value, 2, nameof(TerrainGridMaxResolution));
+    }
+
     public DatasetSourceKind CityGmlSourceKind => CityGmlSource.SourceKind;
 
     public string? CityGmlLocalSourcePath => CityGmlSource is ValidatedLocalDatasetLocation localSource ? localSource.LocalSourcePath : null;
@@ -52,5 +103,25 @@ public sealed record ValidatedPlateauImportRequest(
             TerrainMeshMode,
             TerrainGridMetersPerVertex,
             TerrainGridMaxResolution);
+    }
+
+    private static string RequireNonWhiteSpace(string value, string parameterName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value, parameterName);
+        return value;
+    }
+
+    private static double RequirePositive(double value, string parameterName)
+    {
+        return double.IsFinite(value) && value > 0
+            ? value
+            : throw new ArgumentOutOfRangeException(parameterName, value, "The value must be finite and greater than zero.");
+    }
+
+    private static int RequireMinimum(int value, int minimum, string parameterName)
+    {
+        return value >= minimum
+            ? value
+            : throw new ArgumentOutOfRangeException(parameterName, value, $"The value must be at least {minimum}.");
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Application/LocalCityGmlDocumentReaderTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/LocalCityGmlDocumentReaderTests.cs
@@ -24,10 +24,10 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new PlateauImportRequest(
+            new ResolvedLocalPlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "53394525",
-                CityGmlSource: DatasetLocation.Local(fixturePath),
+                CityGmlLocalSourcePath: fixturePath,
                 PackageNames: ["bldg"]
 ));
         ImportedSceneSourceDataset documentSet = readResult.DocumentSet;
@@ -53,10 +53,10 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new PlateauImportRequest(
+            new ResolvedLocalPlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "53394525",
-                CityGmlSource: DatasetLocation.Local(datasetSource.SourcePath),
+                CityGmlLocalSourcePath: datasetSource.SourcePath,
                 PackageNames: ["dem"]
 ));
         ImportedSceneSourceDataset documentSet = readResult.DocumentSet;
@@ -79,10 +79,10 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new PlateauImportRequest(
+            new ResolvedLocalPlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "53394525",
-                CityGmlSource: DatasetLocation.Local(fixturePath),
+                CityGmlLocalSourcePath: fixturePath,
                 PackageNames: ["dem", "tran"]
 ));
 

--- a/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 
@@ -107,29 +108,33 @@ public sealed class ResolvedLocalPlateauImportRequestTests
     }
 
     [Fact]
-    public void ConstructorRejectsRemoteDemTextureSource()
+    public void ConstructorKeepsLocalDemTextureSource()
     {
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                DemTextureSource: DatasetLocation.Remote(new Uri("https://example.test/ortho.tif"))));
+        ResolvedLocalPlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            CityGmlLocalSourcePath: "/tmp/plateau",
+            DemTextureSource: new LocalDatasetLocation("/tmp/ortho.tif"));
+
+        LocalDatasetLocation demTextureSource = Assert.IsType<LocalDatasetLocation>(request.DemTextureSource);
+        Assert.Equal("/tmp/ortho.tif", demTextureSource.LocalSourcePath);
     }
 
     [Fact]
-    public void CreateRejectsRemoteDemTextureSource()
+    public void CreateKeepsLocalDemTextureSource()
     {
         ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
             new PlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "53394525",
-                CityGmlSource: DatasetLocation.Remote(new Uri("https://example.test/tokyo.zip"))));
+                CityGmlSource: DatasetLocation.Remote(new Uri("https://example.test/tokyo.zip")),
+                DemTextureSource: DatasetLocation.Remote(new Uri("https://example.test/ortho.tif"))));
 
-        Assert.Throws<ArgumentException>(
-            () => ResolvedLocalPlateauImportRequest.Create(
-                request,
-                new ValidatedLocalDatasetLocation("/tmp/plateau"),
-                new ValidatedRemoteDatasetLocation(new Uri("https://example.test/ortho.tif"))));
+        ResolvedLocalPlateauImportRequest resolvedRequest = ResolvedLocalPlateauImportRequest.Create(
+            request,
+            new ValidatedLocalDatasetLocation("/tmp/plateau"),
+            new ValidatedLocalDatasetLocation("/tmp/ortho.tif"));
+
+        Assert.Equal("/tmp/ortho.tif", resolvedRequest.DemTextureLocalSourcePath);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
@@ -121,20 +122,116 @@ public sealed class ResolvedLocalPlateauImportRequestTests
     }
 
     [Fact]
-    public void CreateKeepsLocalDemTextureSource()
+    public void CreateKeepsResolvedRemoteDemTextureSource()
     {
+        string workRoot = "work";
+        Uri cityGmlUri = new("https://example.test/tokyo.zip");
+        Uri demTextureUri = new("https://example.test/ortho.tif");
         ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
             new PlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "53394525",
-                CityGmlSource: DatasetLocation.Remote(new Uri("https://example.test/tokyo.zip")),
-                DemTextureSource: DatasetLocation.Remote(new Uri("https://example.test/ortho.tif"))));
+                CityGmlSource: DatasetLocation.Remote(cityGmlUri),
+                DemTextureSource: DatasetLocation.Remote(demTextureUri)));
 
         ResolvedLocalPlateauImportRequest resolvedRequest = ResolvedLocalPlateauImportRequest.Create(
             request,
+            workRoot,
+            new ValidatedLocalDatasetLocation(
+                RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, cityGmlUri, "source-archive")),
+            new ValidatedLocalDatasetLocation(
+                RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, demTextureUri, "source-ortho")));
+
+        Assert.Equal(
+            RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, demTextureUri, "source-ortho"),
+            resolvedRequest.DemTextureLocalSourcePath);
+    }
+
+    [Fact]
+    public void CreateRejectsLocalCityGmlSourceMismatch()
+    {
+        ValidatedPlateauImportRequest request = CreateValidatedRequest(
+            new ValidatedLocalDatasetLocation("/tmp/plateau-a"));
+
+        Assert.Throws<ArgumentException>(
+            () => ResolvedLocalPlateauImportRequest.Create(
+                request,
+                "work",
+                new ValidatedLocalDatasetLocation("/tmp/plateau-b"),
+                demTextureSource: null));
+    }
+
+    [Fact]
+    public void CreateRejectsRemoteCityGmlSourceMismatch()
+    {
+        Uri cityGmlUri = new("https://example.test/tokyo.zip");
+        ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlSource: DatasetLocation.Remote(cityGmlUri)));
+
+        Assert.Throws<ArgumentException>(
+            () => ResolvedLocalPlateauImportRequest.Create(
+                request,
+                "work",
+                new ValidatedLocalDatasetLocation("/tmp/unexpected.zip"),
+                demTextureSource: null));
+    }
+
+    [Fact]
+    public void CreateRejectsDifferentResolvedLocalDemTextureSource()
+    {
+        ValidatedPlateauImportRequest request = CreateValidatedRequest(
+            new ValidatedLocalDatasetLocation("/tmp/plateau"),
+            new ValidatedLocalDatasetLocation("/tmp/ortho-a.tif"));
+
+        Assert.Throws<ArgumentException>(
+            () => ResolvedLocalPlateauImportRequest.Create(
+                request,
+                "work",
+                new ValidatedLocalDatasetLocation("/tmp/plateau"),
+                new ValidatedLocalDatasetLocation("/tmp/ortho-b.tif")));
+    }
+
+    [Fact]
+    public void CreateRejectsResolvedDemTextureSourceWhenNoneWasRequested()
+    {
+        ValidatedPlateauImportRequest request = CreateValidatedRequest(
+            new ValidatedLocalDatasetLocation("/tmp/plateau"));
+
+        Assert.Throws<ArgumentException>(
+            () => ResolvedLocalPlateauImportRequest.Create(
+                request,
+                "work",
+                new ValidatedLocalDatasetLocation("/tmp/plateau"),
+                new ValidatedLocalDatasetLocation("/tmp/ortho.tif")));
+    }
+
+    [Fact]
+    public void CreateRejectsUnresolvedDemTextureSourceWhenOneWasRequested()
+    {
+        ValidatedPlateauImportRequest request = CreateValidatedRequest(
             new ValidatedLocalDatasetLocation("/tmp/plateau"),
             new ValidatedLocalDatasetLocation("/tmp/ortho.tif"));
 
-        Assert.Equal("/tmp/ortho.tif", resolvedRequest.DemTextureLocalSourcePath);
+        Assert.Throws<ArgumentException>(
+            () => ResolvedLocalPlateauImportRequest.Create(
+                request,
+                "work",
+                new ValidatedLocalDatasetLocation("/tmp/plateau"),
+                demTextureSource: null));
+    }
+
+    private static ValidatedPlateauImportRequest CreateValidatedRequest(
+        ValidatedDatasetLocation cityGmlSource,
+        ValidatedDatasetLocation? demTextureSource = null)
+    {
+        return new ValidatedPlateauImportRequest(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            MeshCodePattern: new Regex("^53394525$", RegexOptions.CultureInvariant),
+            CityGmlSource: cityGmlSource,
+            DemTextureSource: demTextureSource);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 
@@ -53,6 +54,56 @@ public sealed class ResolvedLocalPlateauImportRequestTests
                 MeshCode: "53394525",
                 CityGmlLocalSourcePath: "/tmp/plateau",
                 PackageNames: ["unknown"]));
+    }
+
+    [Fact]
+    public void ConstructorNormalizesPackageOptionMapKeysAtResolvedBoundary()
+    {
+        ResolvedLocalPlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            CityGmlLocalSourcePath: "/tmp/plateau",
+            ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
+            {
+                [" BLDG "] = new HashSet<int> { 1 },
+                ["waterbody"] = new HashSet<int> { 2 },
+            },
+            PackagePatterns: new Dictionary<string, string>
+            {
+                [" BLDG "] = "_bldg_",
+                ["waterbody"] = "_wtr_",
+            });
+
+        Assert.Equal([1], request.ExcludeLodLevelsByPackage!["bldg"]);
+        Assert.Equal([2], request.ExcludeLodLevelsByPackage!["wtr"]);
+        Assert.Equal("_bldg_", request.PackagePatterns!["bldg"]);
+        Assert.Equal("_wtr_", request.PackagePatterns!["wtr"]);
+    }
+
+    [Fact]
+    public void ConstructorRejectsDuplicatePackageOptionMapKeysAfterNormalization()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new ResolvedLocalPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlLocalSourcePath: "/tmp/plateau",
+                ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
+                {
+                    [" BLDG "] = new HashSet<int> { 1 },
+                    ["bldg"] = new HashSet<int> { 2 },
+                }));
+
+        Assert.Throws<ArgumentException>(
+            () => new ResolvedLocalPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlLocalSourcePath: "/tmp/plateau",
+                PackagePatterns: new Dictionary<string, string>
+                {
+                    ["waterbody"] = "_wtr_",
+                    ["wtr"] = "_wtr_",
+                }));
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
@@ -1,3 +1,4 @@
+using System;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 
@@ -18,5 +19,66 @@ public sealed class ResolvedLocalPlateauImportRequestTests
         Assert.Equal("53395325", request.MeshCode);
         Assert.Equal("C:/data/source.zip", request.CityGmlLocalSourcePath);
         Assert.Equal("C:/data/ortho.7z", request.DemTextureLocalSourcePath);
+    }
+
+    [Fact]
+    public void ConstructorNormalizesPackageNamesAtResolvedBoundary()
+    {
+        ResolvedLocalPlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            CityGmlLocalSourcePath: "/tmp/plateau",
+            PackageNames: [" BLDG ", "waterbody", "bldg"]);
+
+        Assert.Equal(["bldg", "wtr"], request.PackageNames);
+    }
+
+    [Fact]
+    public void ConstructorRejectsEmptyPackageNames()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new ResolvedLocalPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlLocalSourcePath: "/tmp/plateau",
+                PackageNames: []));
+    }
+
+    [Fact]
+    public void ConstructorRejectsUnsupportedPackageNames()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new ResolvedLocalPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlLocalSourcePath: "/tmp/plateau",
+                PackageNames: ["unknown"]));
+    }
+
+    [Fact]
+    public void ConstructorRejectsRemoteDemTextureSource()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new ResolvedLocalPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlLocalSourcePath: "/tmp/plateau",
+                DemTextureSource: DatasetLocation.Remote(new Uri("https://example.test/ortho.tif"))));
+    }
+
+    [Fact]
+    public void CreateRejectsRemoteDemTextureSource()
+    {
+        ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlSource: DatasetLocation.Remote(new Uri("https://example.test/tokyo.zip"))));
+
+        Assert.Throws<ArgumentException>(
+            () => ResolvedLocalPlateauImportRequest.Create(
+                request,
+                new ValidatedLocalDatasetLocation("/tmp/plateau"),
+                new ValidatedRemoteDatasetLocation(new Uri("https://example.test/ortho.tif"))));
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
@@ -58,6 +58,34 @@ public sealed class ResolvedLocalPlateauImportRequestTests
                 PackageNames: ["unknown"]));
     }
 
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-0.01)]
+    [InlineData(double.PositiveInfinity)]
+    public void ConstructorRejectsInvalidTerrainGridMetersPerVertex(double metersPerVertex)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ResolvedLocalPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlLocalSourcePath: "/tmp/plateau",
+                TerrainGridMetersPerVertex: metersPerVertex));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(0)]
+    [InlineData(-4)]
+    public void ConstructorRejectsInvalidTerrainGridMaxResolution(int maxResolution)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ResolvedLocalPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlLocalSourcePath: "/tmp/plateau",
+                TerrainGridMaxResolution: maxResolution));
+    }
+
     [Fact]
     public void ConstructorNormalizesPackageOptionMapKeysAtResolvedBoundary()
     {

--- a/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
@@ -1,0 +1,22 @@
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Tests.Application;
+
+public sealed class ResolvedLocalPlateauImportRequestTests
+{
+    [Fact]
+    public void ConstructorTrimsResolvedBoundaryStrings()
+    {
+        ResolvedLocalPlateauImportRequest request = new(
+            Dataset: " plateau-13213 ",
+            MeshCode: " 53395325 ",
+            CityGmlLocalSourcePath: " C:/data/source.zip ",
+            DemTextureSource: new LocalDatasetLocation(" C:/data/ortho.7z "));
+
+        Assert.Equal("plateau-13213", request.Dataset);
+        Assert.Equal("53395325", request.MeshCode);
+        Assert.Equal("C:/data/source.zip", request.CityGmlLocalSourcePath);
+        Assert.Equal("C:/data/ortho.7z", request.DemTextureLocalSourcePath);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
@@ -90,7 +90,7 @@ public sealed class ImportServiceFactoryTests
             ValidatedLocalDatasetLocation? localDemTextureSource = request.DemTextureSource is null
                 ? null
                 : Assert.IsType<ValidatedLocalDatasetLocation>(request.DemTextureSource);
-            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(request, localSource, localDemTextureSource));
+            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(request, workRoot, localSource, localDemTextureSource));
         }
     }
 

--- a/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
@@ -81,12 +81,13 @@ public sealed class ImportServiceFactoryTests
 
     private sealed class StubPlateauDatasetSourceResolver : IPlateauDatasetSourceResolver
     {
-        public Task<ValidatedPlateauImportRequest> ResolveAsync(
+        public Task<ResolvedLocalPlateauImportRequest> ResolveAsync(
             ValidatedPlateauImportRequest request,
             string workRoot,
             CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(request);
+            ValidatedLocalDatasetLocation localSource = Assert.IsType<ValidatedLocalDatasetLocation>(request.CityGmlSource);
+            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(request, localSource, request.DemTextureSource));
         }
     }
 
@@ -134,7 +135,7 @@ public sealed class ImportServiceFactoryTests
         public int CreateCallCount { get; private set; }
 
         public Task<IImportedSceneSource> CreateAsync(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             Action<string>? progressReporter = null,
             CancellationToken cancellationToken = default)
         {
@@ -143,7 +144,7 @@ public sealed class ImportServiceFactoryTests
             ImportedSceneMetadata metadata = new(
                 "3.0",
                 $"PLATEAU {request.Dataset} {request.MeshCode}",
-                request,
+                request.ToImportRequest(),
                 new PlateauSourceDataset(["bldg"], [], []),
                 new Attribution(
                     new LicenseMetadata(true, "credit", "license", "https://example.invalid")),

--- a/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
@@ -87,7 +87,10 @@ public sealed class ImportServiceFactoryTests
             CancellationToken cancellationToken = default)
         {
             ValidatedLocalDatasetLocation localSource = Assert.IsType<ValidatedLocalDatasetLocation>(request.CityGmlSource);
-            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(request, localSource, request.DemTextureSource));
+            ValidatedLocalDatasetLocation? localDemTextureSource = request.DemTextureSource is null
+                ? null
+                : Assert.IsType<ValidatedLocalDatasetLocation>(request.DemTextureSource);
+            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(request, localSource, localDemTextureSource));
         }
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
@@ -17,10 +17,11 @@ public sealed class DefaultImportedSceneSourceComposerTests
     [Fact]
     public void ComposeMapsDocumentSetBoundaryIntoImportedSceneMetadata()
     {
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("/tmp/plateau"));
+            CityGmlLocalSourcePath: "/tmp/plateau");
+        PlateauImportRequest importRequest = request.ToImportRequest();
 
         TerrainTextureOverlay overlay = new(
             PackageName: "bldg",
@@ -51,7 +52,7 @@ public sealed class DefaultImportedSceneSourceComposerTests
 
         Assert.Equal("3.0", source.Metadata.SchemaVersion);
         Assert.Equal("PLATEAU tokyo23ku 53394525", source.Metadata.SceneName);
-        Assert.Same(request, source.Metadata.Request);
+        Assert.Equal(importRequest, source.Metadata.Request);
         Assert.Equal(documentSet.PackageNames, source.Metadata.SourceDataset.PackageNames);
         Assert.Equal(documentSet.RelativeSourceFiles, source.Metadata.SourceDataset.SourceFiles);
         Assert.Equal(documentSet.SelectedMeshCodes, source.Metadata.SourceDataset.SelectedMeshCodes);
@@ -70,12 +71,13 @@ public sealed class DefaultImportedSceneSourceComposerTests
     [Fact]
     public async Task ComposedStreamingSourcePreflightValidatesExplicitDemTextureSource()
     {
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("/tmp/plateau"),
+            CityGmlLocalSourcePath: "/tmp/plateau",
             PackageNames: ["dem"],
             DemTextureSource: DatasetLocation.Local("/tmp/plateau/ortho.tif"));
+        PlateauImportRequest importRequest = request.ToImportRequest();
         ImportedSceneSourceSnapshot readResult = new(
             new ImportedSceneSourceDataset(
                 new EmptyDatasetContentSource(),
@@ -106,7 +108,7 @@ public sealed class DefaultImportedSceneSourceComposerTests
         await preflight.ValidateBeforeSinkSetupAsync();
 
         Assert.Equal(1, demTextureSourcePolicy.ResolveCallCount);
-        Assert.Same(request, demTextureSourcePolicy.LastRequest);
+        Assert.Equal(importRequest, demTextureSourcePolicy.LastRequest);
         Assert.NotEmpty(demTextureSourcePolicy.LastOverlayRegions!);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
@@ -76,7 +76,7 @@ public sealed class DefaultImportedSceneSourceComposerTests
             MeshCode: "53394525",
             CityGmlLocalSourcePath: "/tmp/plateau",
             PackageNames: ["dem"],
-            DemTextureSource: DatasetLocation.Local("/tmp/plateau/ortho.tif"));
+            DemTextureSource: new LocalDatasetLocation("/tmp/plateau/ortho.tif"));
         PlateauImportRequest importRequest = request.ToImportRequest();
         ImportedSceneSourceSnapshot readResult = new(
             new ImportedSceneSourceDataset(

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceFactoryTests.cs
@@ -42,10 +42,10 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             new PassthroughImportedObjectUnitOptimizer());
         Action<string> progressReporter = _ => { };
 
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("/tmp/plateau"));
+            CityGmlLocalSourcePath: "/tmp/plateau");
 
         IImportedSceneSource result = await factory.CreateAsync(request, progressReporter);
 
@@ -76,10 +76,10 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             reader,
             composer,
             new PassthroughImportedObjectUnitOptimizer());
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("/tmp/plateau"),
+            CityGmlLocalSourcePath: "/tmp/plateau",
             PackageNames: ["dem"]
 );
 
@@ -122,10 +122,10 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             reader,
             composer,
             new PassthroughImportedObjectUnitOptimizer());
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("/tmp/plateau"),
+            CityGmlLocalSourcePath: "/tmp/plateau",
             PackageNames: ["dem"],
             DemTextureSource: DatasetLocation.Local("C:\\ortho\\53394525.tif"));
 
@@ -151,14 +151,14 @@ public sealed class DefaultImportedSceneSourceFactoryTests
                     new GeodeticPoint(35.0, 139.0, 0.0)));
         }
 
-        public PlateauImportRequest? LastRequest { get; private set; }
+        public ResolvedLocalPlateauImportRequest? LastRequest { get; private set; }
 
         public Action<string>? LastProgressReporter { get; private set; }
 
         public ImportedSceneSourceSnapshot ReadResult { get; }
 
         public Task<ImportedSceneSourceSnapshot> ReadAsync(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             Action<string>? progressReporter = null,
             CancellationToken cancellationToken = default)
         {
@@ -172,14 +172,14 @@ public sealed class DefaultImportedSceneSourceFactoryTests
     {
         internal IImportedSceneSource ImportedSceneSource { get; } = importedSceneSource;
 
-        public PlateauImportRequest? LastRequest { get; private set; }
+        public ResolvedLocalPlateauImportRequest? LastRequest { get; private set; }
 
         public ImportedSceneSourceSnapshot? LastReadResult { get; private set; }
 
         public Action<string>? LastProgressReporter { get; private set; }
 
         public IImportedSceneSource Compose(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             ImportedSceneSourceSnapshot readResult,
             IImportedObjectUnitOptimizer objectUnitOptimizer,
             Action<string>? progressReporter = null)

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceFactoryTests.cs
@@ -127,7 +127,7 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             MeshCode: "53394525",
             CityGmlLocalSourcePath: "/tmp/plateau",
             PackageNames: ["dem"],
-            DemTextureSource: DatasetLocation.Local("C:\\ortho\\53394525.tif"));
+            DemTextureSource: new LocalDatasetLocation("C:\\ortho\\53394525.tif"));
 
         _ = await factory.CreateAsync(request);
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -68,10 +68,11 @@ public sealed class LocalCityGmlObjectProjectionTests
     {
         string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
         LocalCityGmlDocumentReader documentReader = CreateDocumentReader();
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local(fixturePath));
+            CityGmlLocalSourcePath: fixturePath);
+        PlateauImportRequest importRequest = request.ToImportRequest();
 
         DefaultImportedSceneSourceFactory factory = new(
             documentReader,
@@ -87,7 +88,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         Assert.Equal("3.0", source.Metadata.SchemaVersion);
         Assert.Equal("PLATEAU tokyo23ku 53394525", source.Metadata.SceneName);
-        Assert.Same(request, source.Metadata.Request);
+        Assert.Equal(importRequest, source.Metadata.Request);
         Assert.Contains("bldg", source.Metadata.SourceDataset.PackageNames);
         Assert.Contains("53394525", source.Metadata.SourceDataset.SelectedMeshCodes!);
         Assert.NotEmpty(source.Metadata.SourceDataset.SourceFiles);

--- a/tests/PlateauResoniteLink.Tests/Sources/CkanPlateauDatasetSourceResolverCacheTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Sources/CkanPlateauDatasetSourceResolverCacheTests.cs
@@ -84,7 +84,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolved = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolved = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", @"^533944\d$", "https://example.test/direct.zip"),
             workRoot.Path);
 
@@ -104,7 +104,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolved = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolved = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944|533945/branch", "https://example.test/direct.zip"),
             workRoot.Path);
 
@@ -143,11 +143,11 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest firstRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest firstRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example-a.test/533944.zip"),
             workRoot.Path);
 
-        ValidatedPlateauImportRequest secondRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest secondRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example-b.test/533944.zip"),
             workRoot.Path);
 
@@ -187,11 +187,11 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
         Uri archiveUri = new("https://example.test/533944.zip", UriKind.Absolute);
 
-        ValidatedPlateauImportRequest firstRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest firstRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", archiveUri),
             workRoot.Path);
 
-        ValidatedPlateauImportRequest secondRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest secondRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "53394525", archiveUri),
             workRoot.Path);
 
@@ -214,7 +214,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", archiveUri),
             workRoot.Path);
 
@@ -244,7 +244,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = new(httpClient, archivePolicy, new ArchiveFileLayoutPolicy());
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", archiveUri),
             workRoot.Path);
 
@@ -297,7 +297,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         Assert.Empty(Directory.EnumerateFiles(workRoot.Path, "533944.zip", SearchOption.AllDirectories));
         Assert.Empty(Directory.EnumerateFiles(workRoot.Path, "*.tmp", SearchOption.AllDirectories));
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", archiveUri),
             workRoot.Path);
 
@@ -365,7 +365,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
         using TemporaryDirectory workRoot = new();
 
-        ValidatedPlateauImportRequest firstRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest firstRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/533944.zip"),
             workRoot.Path);
 
@@ -374,7 +374,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
             workRoot.Path,
             firstRequest.CityGmlLocalSourcePath);
 
-        ValidatedPlateauImportRequest secondRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest secondRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/533944.zip"),
             workRoot.Path);
 
@@ -421,7 +421,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
         using TemporaryDirectory workRoot = new();
 
-        ValidatedPlateauImportRequest firstRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest firstRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/533944.zip"),
             workRoot.Path);
 
@@ -433,7 +433,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
             workRoot.Path,
             firstArchivePath);
 
-        ValidatedPlateauImportRequest secondRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest secondRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/533944.zip"),
             workRoot.Path);
 
@@ -466,7 +466,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", archiveUri),
             workRoot.Path);
 

--- a/tests/PlateauResoniteLink.Tests/Sources/CkanPlateauDatasetSourceResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Sources/CkanPlateauDatasetSourceResolverTests.cs
@@ -62,11 +62,11 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/direct.zip"),
             workRoot.Path);
 
-        Assert.Equal(DatasetSourceKind.Local, resolvedRequest.CityGmlSourceKind);
+        Assert.False(string.IsNullOrWhiteSpace(resolvedRequest.CityGmlLocalSourcePath));
         await AssertResolvedArchiveContainsAsync(
             resolvedRequest,
             "direct.zip",
@@ -97,11 +97,11 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/direct.7z"),
             workRoot.Path);
 
-        Assert.Equal(DatasetSourceKind.Local, resolvedRequest.CityGmlSourceKind);
+        Assert.False(string.IsNullOrWhiteSpace(resolvedRequest.CityGmlLocalSourcePath));
         await AssertResolvedArchiveContainsAsync(
             resolvedRequest,
             "direct.7z",
@@ -132,11 +132,11 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "53394611", "https://example.test/wrapped.zip"),
             workRoot.Path);
 
-        Assert.Equal(DatasetSourceKind.Local, resolvedRequest.CityGmlSourceKind);
+        Assert.False(string.IsNullOrWhiteSpace(resolvedRequest.CityGmlLocalSourcePath));
         await AssertResolvedArchiveContainsAsync(
             resolvedRequest,
             "wrapped.zip",
@@ -167,11 +167,11 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "53394611", "https://example.test/wrapped.7z"),
             workRoot.Path);
 
-        Assert.Equal(DatasetSourceKind.Local, resolvedRequest.CityGmlSourceKind);
+        Assert.False(string.IsNullOrWhiteSpace(resolvedRequest.CityGmlLocalSourcePath));
         await AssertResolvedArchiveContainsAsync(
             resolvedRequest,
             "wrapped.7z",
@@ -214,11 +214,11 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/official-packages.zip"),
             workRoot.Path);
 
-        Assert.Equal(DatasetSourceKind.Local, resolvedRequest.CityGmlSourceKind);
+        Assert.False(string.IsNullOrWhiteSpace(resolvedRequest.CityGmlLocalSourcePath));
         await AssertResolvedArchiveContainsAsync(resolvedRequest, "official-packages.zip", "udx/area/plateau_tokyo23ku_area_533944.gml");
         await AssertResolvedArchiveContainsAsync(resolvedRequest, "official-packages.zip", "udx/cons/plateau_tokyo23ku_cons_533944.gml");
         await AssertResolvedArchiveContainsAsync(resolvedRequest, "official-packages.zip", "udx/ifld/plateau_tokyo23ku_ifld_533944.gml");
@@ -270,11 +270,11 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/official-packages.7z"),
             workRoot.Path);
 
-        Assert.Equal(DatasetSourceKind.Local, resolvedRequest.CityGmlSourceKind);
+        Assert.False(string.IsNullOrWhiteSpace(resolvedRequest.CityGmlLocalSourcePath));
         await AssertResolvedArchiveContainsAsync(resolvedRequest, "official-packages.7z", "udx/area/plateau_tokyo23ku_area_533944.gml");
         await AssertResolvedArchiveContainsAsync(resolvedRequest, "official-packages.7z", "udx/cons/plateau_tokyo23ku_cons_533944.gml");
         await AssertResolvedArchiveContainsAsync(resolvedRequest, "official-packages.7z", "udx/ifld/plateau_tokyo23ku_ifld_533944.gml");
@@ -435,7 +435,7 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", archiveUri),
             workRoot);
 
@@ -446,7 +446,7 @@ public sealed class CkanPlateauDatasetSourceResolverTests
     }
 
     private static async Task AssertResolvedArchiveContainsAsync(
-        ValidatedPlateauImportRequest resolvedRequest,
+        ResolvedLocalPlateauImportRequest resolvedRequest,
         string expectedArchiveFileName,
         string expectedRelativePath)
     {

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -933,10 +933,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         using SceneSinkRecordingClient routedClient = new();
         DelegatingClientSession session = new(routedClient);
         await using ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(routedClient, session: session);
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local(TestData.GetFixturePath("LocalPlateauDatasetParentMeshPackages")),
+            CityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDatasetParentMeshPackages"),
             PackageNames: ["dem"]
 );
         ImportedSceneSourceSnapshot readResult = await new LocalCityGmlDocumentReader(

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceCollectionExtensionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceCollectionExtensionsTests.cs
@@ -16,13 +16,13 @@ public sealed class PlateauImportServiceCollectionExtensionsTests
     [Fact]
     public async Task AddImportedSceneSourceServicesUsesCustomComposerWhenFactoryCreatesSourceFromReader()
     {
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local(TestData.GetFixturePath("LocalPlateauDataset")));
+            CityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDataset"));
         ImportedSceneSourceSnapshot expectedReadResult = new(
             new ImportedSceneSourceDataset(
-                new StubDatasetContentSource(request.CityGmlLocalSourcePath!),
+                new StubDatasetContentSource(request.CityGmlLocalSourcePath),
                 [],
                 ["bldg"],
                 [],
@@ -108,10 +108,10 @@ public sealed class PlateauImportServiceCollectionExtensionsTests
 
     private sealed class CustomCityGmlDocumentReader(ImportedSceneSourceSnapshot? readResult = null) : ICityGmlDocumentReader
     {
-        public PlateauImportRequest? LastRequest { get; private set; }
+        public ResolvedLocalPlateauImportRequest? LastRequest { get; private set; }
 
         public Task<ImportedSceneSourceSnapshot> ReadAsync(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             Action<string>? progressReporter = null,
             CancellationToken cancellationToken = default)
         {
@@ -123,7 +123,7 @@ public sealed class PlateauImportServiceCollectionExtensionsTests
     private sealed class CustomImportedSceneSourceFactory : IImportedSceneSourceFactory
     {
         public Task<IImportedSceneSource> CreateAsync(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             Action<string>? progressReporter = null,
             CancellationToken cancellationToken = default)
         {
@@ -151,12 +151,12 @@ public sealed class PlateauImportServiceCollectionExtensionsTests
 
     private sealed class RecordingConstructionComposer(IImportedSceneSource source) : IImportedSceneSourceComposer
     {
-        public PlateauImportRequest? LastRequest { get; private set; }
+        public ResolvedLocalPlateauImportRequest? LastRequest { get; private set; }
 
         public ImportedSceneSourceSnapshot? LastReadResult { get; private set; }
 
         public IImportedSceneSource Compose(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             ImportedSceneSourceSnapshot readResult,
             IImportedObjectUnitOptimizer objectUnitOptimizer,
             Action<string>? progressReporter = null)

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
@@ -601,14 +601,18 @@ public sealed class PlateauImportServiceTests
 
         public string? LastWorkRoot { get; private set; }
 
-        public Task<ValidatedPlateauImportRequest> ResolveAsync(
+        public Task<ResolvedLocalPlateauImportRequest> ResolveAsync(
             ValidatedPlateauImportRequest request,
             string workRoot,
             CancellationToken cancellationToken = default)
         {
             ResolveCallCount++;
             LastWorkRoot = workRoot;
-            return Task.FromResult(resolvedRequest);
+            ValidatedLocalDatasetLocation localSource = Assert.IsType<ValidatedLocalDatasetLocation>(resolvedRequest.CityGmlSource);
+            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(
+                resolvedRequest,
+                localSource,
+                resolvedRequest.DemTextureSource));
         }
     }
 
@@ -616,7 +620,7 @@ public sealed class PlateauImportServiceTests
     {
         public int ResolveCallCount { get; private set; }
 
-        public Task<ValidatedPlateauImportRequest> ResolveAsync(
+        public Task<ResolvedLocalPlateauImportRequest> ResolveAsync(
             ValidatedPlateauImportRequest request,
             string workRoot,
             CancellationToken cancellationToken = default)
@@ -632,10 +636,10 @@ public sealed class PlateauImportServiceTests
     {
         public int CreateCallCount { get; private set; }
 
-        public PlateauImportRequest? LastRequest { get; private set; }
+        public ResolvedLocalPlateauImportRequest? LastRequest { get; private set; }
 
         public Task<IImportedSceneSource> CreateAsync(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             Action<string>? progressReporter = null,
             CancellationToken cancellationToken = default)
         {

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
@@ -613,7 +613,8 @@ public sealed class PlateauImportServiceTests
                 ? null
                 : Assert.IsType<ValidatedLocalDatasetLocation>(resolvedRequest.DemTextureSource);
             return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(
-                resolvedRequest,
+                request,
+                workRoot,
                 localSource,
                 localDemTextureSource));
         }

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
@@ -609,10 +609,13 @@ public sealed class PlateauImportServiceTests
             ResolveCallCount++;
             LastWorkRoot = workRoot;
             ValidatedLocalDatasetLocation localSource = Assert.IsType<ValidatedLocalDatasetLocation>(resolvedRequest.CityGmlSource);
+            ValidatedLocalDatasetLocation? localDemTextureSource = resolvedRequest.DemTextureSource is null
+                ? null
+                : Assert.IsType<ValidatedLocalDatasetLocation>(resolvedRequest.DemTextureSource);
             return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(
                 resolvedRequest,
                 localSource,
-                resolvedRequest.DemTextureSource));
+                localDemTextureSource));
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `ResolvedLocalPlateauImportRequest` to represent the boundary after CityGML source resolution has produced a local source path.
- Change dataset resolution, document reading, scene source factory, and composition to accept the resolved-local request instead of rechecking `PlateauImportRequest.CityGmlSource` at discovery time.
- Remove the local-source runtime guard from discovery; the resolver now produces the required local-source proof before the source-read pipeline can be called.

## Validation
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink dump: `type-resolved-local-import-request/current/higashi-53395325-dem-bldg-grid-geotiff.json`
- `git diff --no-index` against `type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json` returned no diff