### PR TITLE
Type scene import plan source resolution

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
@@ -41,21 +41,21 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
         ValidatedLocalDatasetLocation resolvedSource = await ResolveRequiredLocalDatasetLocationAsync(
             request.CityGmlSource,
             workRoot,
-            resourcePrefix: "source-archive",
+            resourcePrefix: ResolvedLocalPlateauImportRequest.RemoteCityGmlResourcePrefix,
             invalidateLocalFileCache: true,
             cancellationToken);
         ValidatedLocalDatasetLocation? resolvedDemTextureSource = await ResolveOptionalLocalDatasetLocationAsync(
             request.DemTextureSource,
             workRoot,
-            resourcePrefix: "source-ortho",
+            resourcePrefix: ResolvedLocalPlateauImportRequest.RemoteDemTextureResourcePrefix,
             invalidateLocalFileCache: false,
             cancellationToken);
 
         return ResolvedLocalPlateauImportRequest.Create(
             request,
-            workRoot,
             resolvedSource,
-            resolvedDemTextureSource);
+            resolvedDemTextureSource,
+            workRoot);
     }
 
     private async Task<ValidatedLocalDatasetLocation> ResolveRequiredLocalDatasetLocationAsync(

--- a/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -64,14 +65,17 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
         bool invalidateLocalFileCache,
         CancellationToken cancellationToken)
     {
-        ValidatedLocalDatasetLocation? resolvedSource = await ResolveOptionalLocalDatasetLocationAsync(
-            source,
-            workRoot,
-            resourcePrefix,
-            invalidateLocalFileCache,
-            cancellationToken);
-        return resolvedSource
-            ?? throw new InvalidOperationException("The normalized CityGML source must resolve to a local dataset location.");
+        return source switch
+        {
+            ValidatedLocalDatasetLocation localSource => localSource,
+            ValidatedRemoteDatasetLocation remoteSource => await ResolveRemoteDatasetLocationAsync(
+                remoteSource,
+                workRoot,
+                resourcePrefix,
+                invalidateLocalFileCache,
+                cancellationToken),
+            _ => throw new UnreachableException("Validated dataset locations are restricted to local and remote locations."),
+        };
     }
 
     private async Task<ValidatedLocalDatasetLocation?> ResolveOptionalLocalDatasetLocationAsync(
@@ -81,12 +85,31 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
         bool invalidateLocalFileCache,
         CancellationToken cancellationToken)
     {
-        if (source is null || source is ValidatedLocalDatasetLocation)
+        if (source is null)
         {
-            return source as ValidatedLocalDatasetLocation;
+            return null;
         }
 
-        ValidatedRemoteDatasetLocation remoteSource = (ValidatedRemoteDatasetLocation)source;
+        return source switch
+        {
+            ValidatedLocalDatasetLocation localSource => localSource,
+            ValidatedRemoteDatasetLocation remoteSource => await ResolveRemoteDatasetLocationAsync(
+                remoteSource,
+                workRoot,
+                resourcePrefix,
+                invalidateLocalFileCache,
+                cancellationToken),
+            _ => throw new UnreachableException("Validated dataset locations are restricted to local and remote locations."),
+        };
+    }
+
+    private async Task<ValidatedLocalDatasetLocation> ResolveRemoteDatasetLocationAsync(
+        ValidatedRemoteDatasetLocation remoteSource,
+        string workRoot,
+        string resourcePrefix,
+        bool invalidateLocalFileCache,
+        CancellationToken cancellationToken)
+    {
         string resourcePath = RemoteDatasetResourceLayout.GetRemoteResourcePath(
             workRoot,
             remoteSource.ServerUri,

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
@@ -39,7 +39,6 @@ internal sealed class PlateauImportService(
         ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
 
         ValidatedPlateauImportRequest validatedRequest = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(request);
-        PlateauImportRequest normalizedRequest = validatedRequest.ToImportRequest();
         string datasetWorkRoot = archiveFileLayoutPolicy.ResolveDatasetRoot(workRoot, validatedRequest.Dataset);
         ExceptionDispatchInfo? failure = null;
 
@@ -49,7 +48,6 @@ internal sealed class PlateauImportService(
                 validatedRequest,
                 datasetWorkRoot,
                 cancellationToken);
-            PlateauImportRequest resolvedImportRequest = resolvedRequest.ToImportRequest();
             ReportProgress(
                 PlateauLog.Debug("import", $"Resolved CityGML source for '{resolvedRequest.Dataset}' mesh-code '{resolvedRequest.MeshCode}'."));
 
@@ -69,10 +67,8 @@ internal sealed class PlateauImportService(
                     $"Setup will use {this.commonMaterials.Count} codebase-reachable common materials."));
 
             SceneImportExecutionPlan executionPlan = SceneImportExecutionPlan.Create(
-                normalizedRequest,
-                resolvedImportRequest,
+                resolvedRequest,
                 metadata,
-                resolvedRequest.CityGmlLocalSourcePath,
                 datasetWorkRoot,
                 this.commonMaterials);
 

--- a/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 using PlateauResoniteLink.Domain.Importing;
 
@@ -8,40 +7,10 @@ namespace PlateauResoniteLink.Application.Importing;
 
 public sealed record ResolvedLocalPlateauImportRequest
 {
-    private readonly ValidatedLocalDatasetLocation? demTextureSource;
+    internal const string RemoteCityGmlResourcePrefix = "source-archive";
+    internal const string RemoteDemTextureResourcePrefix = "source-ortho";
 
-    public ResolvedLocalPlateauImportRequest(
-        string Dataset,
-        string MeshCode,
-        string CityGmlLocalSourcePath,
-        LocalDatasetLocation? DemTextureSource = null,
-        IReadOnlyList<string>? PackageNames = null,
-        IReadOnlySet<int>? GlobalExcludeLodLevels = null,
-        IReadOnlyDictionary<string, IReadOnlySet<int>>? ExcludeLodLevelsByPackage = null,
-        IReadOnlyDictionary<string, string>? PackagePatterns = null,
-        bool IncludeMarkingAlways = true,
-        TerrainMeshMode TerrainMeshMode = TerrainMeshMode.Static,
-        double TerrainGridMetersPerVertex = 2.0,
-        int TerrainGridMaxResolution = 1024)
-    {
-        ValidatedLocalDatasetLocation cityGmlSource = new(RequireNonEmpty(CityGmlLocalSourcePath, nameof(CityGmlLocalSourcePath)));
-        ValidatedLocalDatasetLocation? validatedDemTextureSource = ToResolvedDemTextureSource(DemTextureSource, nameof(DemTextureSource));
-        ValidatedRequest = CreateResolvedRequest(
-            Dataset,
-            MeshCode,
-            cityGmlSource,
-            validatedDemTextureSource,
-            PackageNames,
-            GlobalExcludeLodLevels,
-            ExcludeLodLevelsByPackage,
-            PackagePatterns,
-            IncludeMarkingAlways,
-            TerrainMeshMode,
-            TerrainGridMetersPerVertex,
-            TerrainGridMaxResolution);
-        CityGmlSource = cityGmlSource;
-        demTextureSource = validatedDemTextureSource;
-    }
+    private readonly ValidatedLocalDatasetLocation? demTextureSource;
 
     private ResolvedLocalPlateauImportRequest(
         ValidatedPlateauImportRequest request,
@@ -98,202 +67,88 @@ public sealed record ResolvedLocalPlateauImportRequest
         }).ToImportRequest();
     }
 
-    internal static ResolvedLocalPlateauImportRequest Create(
+    public static ResolvedLocalPlateauImportRequest Create(
         ValidatedPlateauImportRequest request,
-        string workRoot,
         ValidatedLocalDatasetLocation cityGmlSource,
-        ValidatedLocalDatasetLocation? demTextureSource)
+        ValidatedLocalDatasetLocation? demTextureSource,
+        string? workRoot = null)
     {
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
         ArgumentNullException.ThrowIfNull(cityGmlSource);
-
-        ValidateResolvedSource(request.CityGmlSource, cityGmlSource, workRoot, "source-archive", nameof(cityGmlSource));
-        ValidateResolvedOptionalSource(request.DemTextureSource, demTextureSource, workRoot, "source-ortho", nameof(demTextureSource));
+        ValidateResolvedLocalSource(
+            request.CityGmlSource,
+            cityGmlSource,
+            workRoot,
+            RemoteCityGmlResourcePrefix,
+            nameof(cityGmlSource));
+        ValidateResolvedOptionalLocalSource(
+            request.DemTextureSource,
+            demTextureSource,
+            workRoot,
+            RemoteDemTextureResourcePrefix,
+            nameof(demTextureSource));
 
         return new ResolvedLocalPlateauImportRequest(request, cityGmlSource, demTextureSource);
     }
 
-    private static void ValidateResolvedOptionalSource(
-        ValidatedDatasetLocation? requestedSource,
-        ValidatedLocalDatasetLocation? resolvedSource,
-        string workRoot,
-        string remotePathPrefix,
+    private static void ValidateResolvedLocalSource(
+        ValidatedDatasetLocation requestedSource,
+        ValidatedLocalDatasetLocation resolvedSource,
+        string? workRoot,
+        string remoteResourcePrefix,
         string parameterName)
     {
-        if (requestedSource is null || resolvedSource is null)
+        if (requestedSource is ValidatedLocalDatasetLocation requestedLocalSource
+            && !string.Equals(
+                requestedLocalSource.LocalSourcePath,
+                resolvedSource.LocalSourcePath,
+                StringComparison.Ordinal))
         {
-            if (requestedSource is not null || resolvedSource is not null)
+            throw new ArgumentException(
+                "Resolved local dataset source must match the requested local dataset source.",
+                parameterName);
+        }
+
+        if (requestedSource is ValidatedRemoteDatasetLocation requestedRemoteSource)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
+            if (!RemoteDatasetResourceLayout.MatchesRemoteResourcePath(
+                    workRoot,
+                    requestedRemoteSource.ServerUri,
+                    remoteResourcePrefix,
+                    resolvedSource.LocalSourcePath))
             {
                 throw new ArgumentException(
-                    "Resolved local source presence must match the requested source presence.",
+                    "Resolved local dataset source must match the requested remote dataset source cache path.",
+                    parameterName);
+            }
+        }
+    }
+
+    private static void ValidateResolvedOptionalLocalSource(
+        ValidatedDatasetLocation? requestedSource,
+        ValidatedLocalDatasetLocation? resolvedSource,
+        string? workRoot,
+        string remoteResourcePrefix,
+        string parameterName)
+    {
+        if (requestedSource is null)
+        {
+            if (resolvedSource is not null)
+            {
+                throw new ArgumentException(
+                    "Resolved local dataset source must be omitted when no source was requested.",
                     parameterName);
             }
 
             return;
         }
 
-        ValidateResolvedSource(requestedSource, resolvedSource, workRoot, remotePathPrefix, parameterName);
-    }
-
-    private static void ValidateResolvedSource(
-        ValidatedDatasetLocation requestedSource,
-        ValidatedLocalDatasetLocation resolvedSource,
-        string workRoot,
-        string remotePathPrefix,
-        string parameterName)
-    {
-        switch (requestedSource)
+        if (resolvedSource is null)
         {
-            case ValidatedLocalDatasetLocation requestedLocal
-                when string.Equals(requestedLocal.LocalSourcePath, resolvedSource.LocalSourcePath, StringComparison.Ordinal):
-                return;
-            case ValidatedRemoteDatasetLocation requestedRemote
-                when RemoteDatasetResourceLayout.MatchesRemoteResourcePath(
-                    workRoot,
-                    requestedRemote.ServerUri,
-                    remotePathPrefix,
-                    resolvedSource.LocalSourcePath):
-                return;
-            default:
-                throw new ArgumentException(
-                    "Resolved local source must match the requested local source or the expected remote materialization path.",
-                    parameterName);
-        }
-    }
-
-    private static ValidatedPlateauImportRequest CreateResolvedRequest(
-        string dataset,
-        string meshCode,
-        ValidatedLocalDatasetLocation cityGmlSource,
-        ValidatedLocalDatasetLocation? demTextureSource,
-        IReadOnlyList<string>? packageNames,
-        IReadOnlySet<int>? globalExcludeLodLevels,
-        IReadOnlyDictionary<string, IReadOnlySet<int>>? excludeLodLevelsByPackage,
-        IReadOnlyDictionary<string, string>? packagePatterns,
-        bool includeMarkingAlways,
-        TerrainMeshMode terrainMeshMode,
-        double terrainGridMetersPerVertex,
-        int terrainGridMaxResolution)
-    {
-        string requiredDataset = RequireNonEmpty(dataset, nameof(dataset));
-        string requiredMeshCode = RequireNonEmpty(meshCode, nameof(meshCode));
-        string[]? normalizedPackageNames = NormalizePackageNames(packageNames);
-        Dictionary<string, IReadOnlySet<int>>? normalizedPackageExclusions = NormalizePackageExclusionMap(excludeLodLevelsByPackage);
-        Dictionary<string, string>? normalizedPackagePatterns = NormalizePackagePatternMap(packagePatterns);
-        if (!MeshCodeRequestSyntax.TryCreateSelectionRegex(requiredMeshCode, out Regex? meshCodePattern, out string? meshCodeError))
-        {
-            throw new ArgumentException(meshCodeError, nameof(meshCode));
+            throw new ArgumentNullException(parameterName);
         }
 
-        meshCodePattern ??= new Regex(
-            $@"\A(?:{Regex.Escape(requiredMeshCode)})\z",
-            RegexOptions.Compiled | RegexOptions.CultureInvariant,
-            TimeSpan.FromSeconds(1));
-
-        return new ValidatedPlateauImportRequest(
-            requiredDataset,
-            requiredMeshCode,
-            meshCodePattern,
-            cityGmlSource,
-            demTextureSource,
-            normalizedPackageNames,
-            globalExcludeLodLevels,
-            normalizedPackageExclusions,
-            normalizedPackagePatterns,
-            includeMarkingAlways,
-            terrainMeshMode,
-            terrainGridMetersPerVertex,
-            terrainGridMaxResolution);
-    }
-
-    private static ValidatedLocalDatasetLocation? ToResolvedDemTextureSource(
-        LocalDatasetLocation? source,
-        string parameterName)
-    {
-        return source is null
-            ? null
-            : new ValidatedLocalDatasetLocation(RequireNonEmpty(source.LocalSourcePath, parameterName));
-    }
-
-    private static string[]? NormalizePackageNames(IReadOnlyList<string>? packageNames)
-    {
-        if (packageNames is null)
-        {
-            return null;
-        }
-
-        if (packageNames.Count == 0)
-        {
-            throw new ArgumentException("At least one package name is required when packages are specified.", nameof(packageNames));
-        }
-
-        return PlateauPackageCatalog.NormalizeRequestedPackageNames(packageNames);
-    }
-
-    private static Dictionary<string, IReadOnlySet<int>>? NormalizePackageExclusionMap(
-        IReadOnlyDictionary<string, IReadOnlySet<int>>? exclusionsByPackage)
-    {
-        if (exclusionsByPackage is null)
-        {
-            return null;
-        }
-
-        Dictionary<string, IReadOnlySet<int>> normalized = new(StringComparer.OrdinalIgnoreCase);
-        foreach ((string packageName, IReadOnlySet<int> excludedLods) in exclusionsByPackage)
-        {
-            string normalizedPackageName = NormalizePackageMapKey(packageName, nameof(exclusionsByPackage));
-            if (!normalized.TryAdd(normalizedPackageName, excludedLods))
-            {
-                throw new ArgumentException(
-                    $"The {nameof(exclusionsByPackage)} value contains duplicate package keys after normalization: {normalizedPackageName}.",
-                    nameof(exclusionsByPackage));
-            }
-        }
-
-        return normalized;
-    }
-
-    private static Dictionary<string, string>? NormalizePackagePatternMap(
-        IReadOnlyDictionary<string, string>? patternsByPackage)
-    {
-        if (patternsByPackage is null)
-        {
-            return null;
-        }
-
-        Dictionary<string, string> normalized = new(StringComparer.OrdinalIgnoreCase);
-        foreach ((string packageName, string pattern) in patternsByPackage)
-        {
-            string normalizedPackageName = NormalizePackageMapKey(packageName, nameof(patternsByPackage));
-            if (!normalized.TryAdd(normalizedPackageName, pattern))
-            {
-                throw new ArgumentException(
-                    $"The {nameof(patternsByPackage)} value contains duplicate package keys after normalization: {normalizedPackageName}.",
-                    nameof(patternsByPackage));
-            }
-        }
-
-        return normalized;
-    }
-
-    private static string NormalizePackageMapKey(string packageName, string parameterName)
-    {
-        if (!PlateauPackageCatalog.TryNormalizePackageName(packageName, out string normalizedPackageName))
-        {
-            throw new ArgumentException(
-                $"Unsupported package '{packageName}'. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.",
-                parameterName);
-        }
-
-        return normalizedPackageName;
-    }
-
-    private static string RequireNonEmpty(string? value, string parameterName)
-    {
-        string? trimmedValue = value?.Trim();
-        return string.IsNullOrWhiteSpace(trimmedValue)
-            ? throw new ArgumentException("The value must not be empty.", parameterName)
-            : trimmedValue;
+        ValidateResolvedLocalSource(requestedSource, resolvedSource, workRoot, remoteResourcePrefix, parameterName);
     }
 }

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionPlan.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionPlan.cs
@@ -2,111 +2,62 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Application.Importing;
 
 public sealed record SceneImportExecutionPlan
 {
-    public SceneImportExecutionPlan(
-        PlateauImportRequest normalizedRequest,
-        PlateauImportRequest resolvedRequest,
+    private SceneImportExecutionPlan(
         SceneImportRequest sceneImportRequest)
     {
-        ArgumentNullException.ThrowIfNull(normalizedRequest);
-        ArgumentNullException.ThrowIfNull(resolvedRequest);
         ArgumentNullException.ThrowIfNull(sceneImportRequest);
 
-        ValidateRequestConsistency(normalizedRequest, resolvedRequest, sceneImportRequest.Metadata.Request, sceneImportRequest.WorkRoot);
-
-        NormalizedRequest = normalizedRequest;
-        ResolvedRequest = resolvedRequest;
         SceneImportRequest = sceneImportRequest;
     }
-
-    public PlateauImportRequest NormalizedRequest { get; }
-
-    public PlateauImportRequest ResolvedRequest { get; }
 
     public SceneImportRequest SceneImportRequest { get; }
 
     public static SceneImportExecutionPlan Create(
-        PlateauImportRequest normalizedRequest,
-        PlateauImportRequest resolvedRequest,
+        ResolvedLocalPlateauImportRequest resolvedRequest,
         ImportedSceneMetadata metadata,
-        string resolvedSourcePath,
         string workRoot,
         CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials)
     {
         ArgumentNullException.ThrowIfNull(metadata);
-        ArgumentException.ThrowIfNullOrWhiteSpace(resolvedSourcePath);
+        ArgumentNullException.ThrowIfNull(resolvedRequest);
         ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
         ArgumentNullException.ThrowIfNull(commonMaterials);
 
+        PlateauImportRequest resolvedImportRequest = resolvedRequest.ToImportRequest();
+        ValidateMetadataRequestConsistency(resolvedImportRequest, metadata.Request);
+
         return new SceneImportExecutionPlan(
-            normalizedRequest,
-            resolvedRequest,
             new SceneImportRequest(
                 metadata,
-                resolvedSourcePath,
                 workRoot,
                 commonMaterials));
     }
 
-    private static void ValidateRequestConsistency(
-        PlateauImportRequest normalizedRequest,
-        PlateauImportRequest resolvedRequest,
-        PlateauImportRequest importRequest,
-        string workRoot)
+    private static void ValidateMetadataRequestConsistency(
+        PlateauImportRequest expectedRequest,
+        PlateauImportRequest metadataRequest)
     {
-        if (!string.Equals(normalizedRequest.Dataset, importRequest.Dataset, StringComparison.Ordinal)
-            || !string.Equals(normalizedRequest.MeshCode, importRequest.MeshCode, StringComparison.Ordinal)
-            || !HasCompatibleSourceResolution(normalizedRequest.CityGmlSource, resolvedRequest.CityGmlSource, workRoot, "source-archive")
-            || !HasCompatibleSourceResolution(normalizedRequest.DemTextureSource, resolvedRequest.DemTextureSource, workRoot, "source-ortho")
-            || !SourcesEqual(resolvedRequest.CityGmlSource, importRequest.CityGmlSource)
-            || !SourcesEqual(resolvedRequest.DemTextureSource, importRequest.DemTextureSource)
-            || normalizedRequest.IncludeMarkingAlways != importRequest.IncludeMarkingAlways
-            || normalizedRequest.TerrainMeshMode != importRequest.TerrainMeshMode
-            || normalizedRequest.TerrainGridMetersPerVertex != importRequest.TerrainGridMetersPerVertex
-            || normalizedRequest.TerrainGridMaxResolution != importRequest.TerrainGridMaxResolution
-            || !SequenceEqual(normalizedRequest.PackageNames, importRequest.PackageNames)
-            || !SetEqual(normalizedRequest.GlobalExcludeLodLevels, importRequest.GlobalExcludeLodLevels)
-            || !DictionaryOfSetsEqual(normalizedRequest.ExcludeLodLevelsByPackage, importRequest.ExcludeLodLevelsByPackage)
-            || !DictionaryEqual(normalizedRequest.PackagePatterns, importRequest.PackagePatterns))
+        if (!string.Equals(expectedRequest.Dataset, metadataRequest.Dataset, StringComparison.Ordinal)
+            || !string.Equals(expectedRequest.MeshCode, metadataRequest.MeshCode, StringComparison.Ordinal)
+            || !SourcesEqual(expectedRequest.CityGmlSource, metadataRequest.CityGmlSource)
+            || !SourcesEqual(expectedRequest.DemTextureSource, metadataRequest.DemTextureSource)
+            || expectedRequest.IncludeMarkingAlways != metadataRequest.IncludeMarkingAlways
+            || expectedRequest.TerrainMeshMode != metadataRequest.TerrainMeshMode
+            || expectedRequest.TerrainGridMetersPerVertex != metadataRequest.TerrainGridMetersPerVertex
+            || expectedRequest.TerrainGridMaxResolution != metadataRequest.TerrainGridMaxResolution
+            || !SequenceEqual(expectedRequest.PackageNames, metadataRequest.PackageNames)
+            || !SetEqual(expectedRequest.GlobalExcludeLodLevels, metadataRequest.GlobalExcludeLodLevels)
+            || !DictionaryOfSetsEqual(expectedRequest.ExcludeLodLevelsByPackage, metadataRequest.ExcludeLodLevelsByPackage)
+            || !DictionaryEqual(expectedRequest.PackagePatterns, metadataRequest.PackagePatterns))
         {
             throw new ArgumentException(
-                "Scene import execution plan requires normalized and import requests to match for execution identity and import options. Only source-resolved location values may differ.",
-                nameof(importRequest));
+                "Scene import execution plan requires imported scene metadata to carry the resolved local import request.",
+                nameof(metadataRequest));
         }
-    }
-
-    private static bool HasCompatibleSourceResolution(
-        DatasetLocation? normalizedSource,
-        DatasetLocation? resolvedSource,
-        string workRoot,
-        string remotePathPrefix)
-    {
-        if (normalizedSource is null || resolvedSource is null)
-        {
-            return normalizedSource is null && resolvedSource is null;
-        }
-
-        if (normalizedSource.SourceKind == resolvedSource.SourceKind)
-        {
-            return SourcesEqual(normalizedSource, resolvedSource);
-        }
-
-        if (normalizedSource is RemoteDatasetLocation remoteSource
-            && resolvedSource is LocalDatasetLocation localSource)
-        {
-            return RemoteDatasetResourceLayout.MatchesRemoteResourcePath(
-                workRoot,
-                remoteSource.ServerUri,
-                remotePathPrefix,
-                localSource.LocalSourcePath);
-        }
-
-        return false;
     }
 
     private static bool SourcesEqual(DatasetLocation? left, DatasetLocation? right)

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionPlan.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionPlan.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using PlateauResoniteLink.Domain.Importing;
+
 namespace PlateauResoniteLink.Application.Importing;
 
 public sealed record SceneImportExecutionPlan

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportRequest.cs
@@ -2,6 +2,5 @@ namespace PlateauResoniteLink.Application.Importing;
 
 public sealed record SceneImportRequest(
     ImportedSceneMetadata Metadata,
-    string ResolvedSourcePath,
     string WorkRoot,
     CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials);

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
@@ -4,8 +4,15 @@ using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Application.Importing;
 
-public abstract record ValidatedDatasetLocation(DatasetSourceKind SourceKind)
+public abstract record ValidatedDatasetLocation
 {
+    private protected ValidatedDatasetLocation(DatasetSourceKind sourceKind)
+    {
+        SourceKind = sourceKind;
+    }
+
+    public DatasetSourceKind SourceKind { get; }
+
     public abstract DatasetLocation ToDatasetLocation();
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -116,12 +116,9 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         PlannedSlotTargetReference target,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId)
     {
-        return target switch
-        {
-            PlannedSlotTargetReference.CanonicalSlotTarget canonicalSlot => canonicalSlot.Locator.Value,
-            PlannedSlotTargetReference.PlannedSlotTarget plannedSlot => pendingSlotsByPlanId[plannedSlot.Locator].LocalId.Value,
-            _ => throw new InvalidOperationException("Batch slot target did not resolve to an executable target."),
-        };
+        return target.Match(
+            static canonicalSlot => canonicalSlot.Value,
+            plannedSlot => pendingSlotsByPlanId[plannedSlot].LocalId.Value);
     }
 
     private static string ResolveWorldElementId(
@@ -131,15 +128,12 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
-        return target switch
-        {
-            PlannedWorldElementReference.CanonicalSlotElement canonicalSlot => canonicalSlot.Locator.Value,
-            PlannedWorldElementReference.CanonicalComponentElement canonicalComponent => canonicalComponent.Locator.Value,
-            PlannedWorldElementReference.PlannedSlotElement plannedSlot => pendingSlotsByPlanId[plannedSlot.Locator].LocalId.Value,
-            PlannedWorldElementReference.PlannedComponentElement plannedComponent => pendingComponentsByPlanId[plannedComponent.Locator].LocalId.Value,
-            PlannedWorldElementReference.PlannedFieldElement plannedField => ResolveFieldId(plannedField.Locator, pendingFieldsByPlanId, batchBuilder).Value,
-            _ => throw new InvalidOperationException("Batch world element reference did not resolve to an executable target."),
-        };
+        return target.Match(
+            static canonicalSlot => canonicalSlot.Value,
+            static canonicalComponent => canonicalComponent.Value,
+            plannedSlot => pendingSlotsByPlanId[plannedSlot].LocalId.Value,
+            plannedComponent => pendingComponentsByPlanId[plannedComponent].LocalId.Value,
+            plannedField => ResolveFieldId(plannedField, pendingFieldsByPlanId, batchBuilder).Value);
     }
 
     private static Dictionary<string, Member> TranslateMembers(
@@ -162,31 +156,31 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
-        return member switch
-        {
-            PlannedLiteralMember literal => literal.Value,
-            PlannedElementReferenceMember reference => new Reference
+        return member.Match(
+            literal: static literal => literal,
+            reference: reference => new Reference
             {
                 TargetID = ResolveWorldElementId(
-                    reference.Target,
+                    reference,
                     pendingSlotsByPlanId,
                     pendingComponentsByPlanId,
                     pendingFieldsByPlanId,
                     batchBuilder),
             },
-            PlannedAddressableFieldMember addressableField => TranslateAddressableField(
+            addressableField: addressableField => TranslateAddressableField(
                 addressableField,
                 pendingFieldsByPlanId,
                 batchBuilder),
-            PlannedAddressableReferenceMember addressableReference => TranslateAddressableReference(
-                addressableReference,
+            addressableReference: (identity, target) => TranslateAddressableReference(
+                identity,
+                target,
                 pendingSlotsByPlanId,
                 pendingComponentsByPlanId,
                 pendingFieldsByPlanId,
                 batchBuilder),
-            PlannedSyncListMember syncList => new SyncList
+            list: elements => new SyncList
             {
-                Elements = syncList.Elements
+                Elements = elements
                     .Select(element => TranslateMember(
                         element,
                         pendingSlotsByPlanId,
@@ -194,24 +188,23 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
                         pendingFieldsByPlanId,
                         batchBuilder))
                     .ToList(),
-            },
-            _ => throw new InvalidOperationException($"Unsupported planned member type '{member.GetType().Name}'."),
-        };
+            });
     }
 
     private static Reference TranslateAddressableReference(
-        PlannedAddressableReferenceMember addressableReference,
+        BatchPlanFieldLocator identity,
+        PlannedWorldElementReference target,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId,
         Dictionary<BatchPlanComponentLocator, ResoniteBatchOperations.PendingBatchComponent> pendingComponentsByPlanId,
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
-        string fieldId = ResolveFieldId(addressableReference.Identity, pendingFieldsByPlanId, batchBuilder).Value;
+        string fieldId = ResolveFieldId(identity, pendingFieldsByPlanId, batchBuilder).Value;
         return new Reference
         {
             ID = fieldId,
             TargetID = ResolveWorldElementId(
-                addressableReference.Target,
+                target,
                 pendingSlotsByPlanId,
                 pendingComponentsByPlanId,
                 pendingFieldsByPlanId,
@@ -225,32 +218,7 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
         string fieldId = ResolveFieldId(addressableField.Identity, pendingFieldsByPlanId, batchBuilder).Value;
-        return addressableField.Value switch
-        {
-            Field_int2 value => new Field_int2
-            {
-                ID = fieldId,
-                Value = value.Value,
-            },
-            Field_bool value => new Field_bool
-            {
-                ID = fieldId,
-                Value = value.Value,
-            },
-            Field_float value => new Field_float
-            {
-                ID = fieldId,
-                Value = value.Value,
-            },
-            Reference value => new Reference
-            {
-                ID = fieldId,
-                TargetID = value.TargetID,
-                TargetType = value.TargetType,
-            },
-            _ => throw new InvalidOperationException(
-                $"Unsupported planned addressable field member type '{addressableField.Value.GetType().Name}'."),
-        };
+        return addressableField.Bind(fieldId);
     }
 
     private static ResoniteBatchOperations.BatchTemporaryFieldId ResolveFieldId(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -116,13 +116,11 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         PlannedSlotTargetReference target,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId)
     {
-        return target.Kind switch
+        return target switch
         {
-            PlannedSlotTargetReferenceKind.CanonicalSlot => target.CanonicalSlotLocator.Value,
-            PlannedSlotTargetReferenceKind.PlannedSlot => pendingSlotsByPlanId.TryGetValue(target.PlannedSlotLocator, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
-                ? pendingSlot.LocalId.Value
-                : throw new InvalidOperationException("Batch slot target did not resolve to a planned slot."),
-            _ => throw new InvalidOperationException("Batch slot target did not resolve to a known target kind."),
+            PlannedSlotTargetReference.CanonicalSlotTarget canonicalSlot => canonicalSlot.Locator.Value,
+            PlannedSlotTargetReference.PlannedSlotTarget plannedSlot => pendingSlotsByPlanId[plannedSlot.Locator].LocalId.Value,
+            _ => throw new InvalidOperationException("Batch slot target did not resolve to an executable target."),
         };
     }
 
@@ -133,18 +131,14 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
-        return target.Kind switch
+        return target switch
         {
-            PlannedWorldElementReferenceKind.CanonicalSlot => target.CanonicalSlotLocator.Value,
-            PlannedWorldElementReferenceKind.CanonicalComponent => target.CanonicalComponentLocator.Value,
-            PlannedWorldElementReferenceKind.PlannedSlot => pendingSlotsByPlanId.TryGetValue(target.PlannedSlotLocator, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
-                ? pendingSlot.LocalId.Value
-                : throw new InvalidOperationException("Batch world element reference did not resolve to a planned slot."),
-            PlannedWorldElementReferenceKind.PlannedComponent => pendingComponentsByPlanId.TryGetValue(target.PlannedComponentLocator, out ResoniteBatchOperations.PendingBatchComponent pendingComponent)
-                ? pendingComponent.LocalId.Value
-                : throw new InvalidOperationException("Batch world element reference did not resolve to a planned component."),
-            PlannedWorldElementReferenceKind.PlannedField => ResolveFieldId(target.PlannedFieldLocator, pendingFieldsByPlanId, batchBuilder).Value,
-            _ => throw new InvalidOperationException("Batch world element reference did not resolve to a known target kind."),
+            PlannedWorldElementReference.CanonicalSlotElement canonicalSlot => canonicalSlot.Locator.Value,
+            PlannedWorldElementReference.CanonicalComponentElement canonicalComponent => canonicalComponent.Locator.Value,
+            PlannedWorldElementReference.PlannedSlotElement plannedSlot => pendingSlotsByPlanId[plannedSlot.Locator].LocalId.Value,
+            PlannedWorldElementReference.PlannedComponentElement plannedComponent => pendingComponentsByPlanId[plannedComponent.Locator].LocalId.Value,
+            PlannedWorldElementReference.PlannedFieldElement plannedField => ResolveFieldId(plannedField.Locator, pendingFieldsByPlanId, batchBuilder).Value,
+            _ => throw new InvalidOperationException("Batch world element reference did not resolve to an executable target."),
         };
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -116,11 +116,14 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         PlannedSlotTargetReference target,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId)
     {
-        return target.Match(
-            static canonical => canonical.Value,
-            planned => pendingSlotsByPlanId.TryGetValue(planned, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
+        return target.Kind switch
+        {
+            PlannedSlotTargetReferenceKind.CanonicalSlot => target.CanonicalSlotLocator.Value,
+            PlannedSlotTargetReferenceKind.PlannedSlot => pendingSlotsByPlanId.TryGetValue(target.PlannedSlotLocator, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
                 ? pendingSlot.LocalId.Value
-                : throw new InvalidOperationException("Batch slot target did not resolve to a planned slot."));
+                : throw new InvalidOperationException("Batch slot target did not resolve to a planned slot."),
+            _ => throw new InvalidOperationException("Batch slot target did not resolve to a known target kind."),
+        };
     }
 
     private static string ResolveWorldElementId(
@@ -130,16 +133,19 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
-        return target.Match(
-            static canonicalSlot => canonicalSlot.Value,
-            static canonicalComponent => canonicalComponent.Value,
-            plannedSlot => pendingSlotsByPlanId.TryGetValue(plannedSlot, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
+        return target.Kind switch
+        {
+            PlannedWorldElementReferenceKind.CanonicalSlot => target.CanonicalSlotLocator.Value,
+            PlannedWorldElementReferenceKind.CanonicalComponent => target.CanonicalComponentLocator.Value,
+            PlannedWorldElementReferenceKind.PlannedSlot => pendingSlotsByPlanId.TryGetValue(target.PlannedSlotLocator, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
                 ? pendingSlot.LocalId.Value
                 : throw new InvalidOperationException("Batch world element reference did not resolve to a planned slot."),
-            plannedComponent => pendingComponentsByPlanId.TryGetValue(plannedComponent, out ResoniteBatchOperations.PendingBatchComponent pendingComponent)
+            PlannedWorldElementReferenceKind.PlannedComponent => pendingComponentsByPlanId.TryGetValue(target.PlannedComponentLocator, out ResoniteBatchOperations.PendingBatchComponent pendingComponent)
                 ? pendingComponent.LocalId.Value
                 : throw new InvalidOperationException("Batch world element reference did not resolve to a planned component."),
-            plannedField => ResolveFieldId(plannedField, pendingFieldsByPlanId, batchBuilder).Value);
+            PlannedWorldElementReferenceKind.PlannedField => ResolveFieldId(target.PlannedFieldLocator, pendingFieldsByPlanId, batchBuilder).Value,
+            _ => throw new InvalidOperationException("Batch world element reference did not resolve to a known target kind."),
+        };
     }
 
     private static Dictionary<string, Member> TranslateMembers(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -116,12 +116,11 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         PlannedSlotTargetReference target,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId)
     {
-        return target switch
-        {
-            PlannedSlotTargetReference.CanonicalSlotTarget canonicalSlot => canonicalSlot.Locator.Value,
-            PlannedSlotTargetReference.PlannedSlotTarget plannedSlot => pendingSlotsByPlanId[plannedSlot.Locator].LocalId.Value,
-            _ => throw new InvalidOperationException("Batch slot target did not resolve to an executable target."),
-        };
+        return target.Match(
+            static canonical => canonical.Value,
+            planned => pendingSlotsByPlanId.TryGetValue(planned, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
+                ? pendingSlot.LocalId.Value
+                : throw new InvalidOperationException("Batch slot target did not resolve to a planned slot."));
     }
 
     private static string ResolveWorldElementId(
@@ -131,15 +130,16 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
-        return target switch
-        {
-            PlannedWorldElementReference.CanonicalSlotElement canonicalSlot => canonicalSlot.Locator.Value,
-            PlannedWorldElementReference.CanonicalComponentElement canonicalComponent => canonicalComponent.Locator.Value,
-            PlannedWorldElementReference.PlannedSlotElement plannedSlot => pendingSlotsByPlanId[plannedSlot.Locator].LocalId.Value,
-            PlannedWorldElementReference.PlannedComponentElement plannedComponent => pendingComponentsByPlanId[plannedComponent.Locator].LocalId.Value,
-            PlannedWorldElementReference.PlannedFieldElement plannedField => ResolveFieldId(plannedField.Locator, pendingFieldsByPlanId, batchBuilder).Value,
-            _ => throw new InvalidOperationException("Batch world element reference did not resolve to an executable target."),
-        };
+        return target.Match(
+            static canonicalSlot => canonicalSlot.Value,
+            static canonicalComponent => canonicalComponent.Value,
+            plannedSlot => pendingSlotsByPlanId.TryGetValue(plannedSlot, out ResoniteBatchOperations.PendingBatchSlot pendingSlot)
+                ? pendingSlot.LocalId.Value
+                : throw new InvalidOperationException("Batch world element reference did not resolve to a planned slot."),
+            plannedComponent => pendingComponentsByPlanId.TryGetValue(plannedComponent, out ResoniteBatchOperations.PendingBatchComponent pendingComponent)
+                ? pendingComponent.LocalId.Value
+                : throw new InvalidOperationException("Batch world element reference did not resolve to a planned component."),
+            plannedField => ResolveFieldId(plannedField, pendingFieldsByPlanId, batchBuilder).Value);
     }
 
     private static Dictionary<string, Member> TranslateMembers(

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
@@ -59,19 +59,69 @@ internal sealed record SharedTerrainTextureAsset(
     CreatedComponent TextureComponent,
     CreatedComponent MainTexturePropertyBlockComponent);
 
-internal sealed record LiveSendRunPlan(
-    ResoniteSceneSetupInfo SetupInfo,
-    string ResolvedWorkRoot,
-    ResoniteLocalOrigin RequestLocalOrigin,
-    IReadOnlyDictionary<string, string> SourceFileSlotNamesByRelativePath,
-    ResoniteImportBudgetProfile ResourceBudget,
-    LiveSendQueuePlan Queue,
-    bool MeshBakeEnabled);
+internal sealed record LiveSendRunPlan
+{
+    public LiveSendRunPlan(
+        ResoniteSceneSetupInfo SetupInfo,
+        string ResolvedWorkRoot,
+        ResoniteLocalOrigin RequestLocalOrigin,
+        IReadOnlyDictionary<string, string> SourceFileSlotNamesByRelativePath,
+        ResoniteImportBudgetProfile ResourceBudget,
+        LiveSendQueuePlan Queue,
+        bool MeshBakeEnabled)
+    {
+        ArgumentNullException.ThrowIfNull(SetupInfo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(ResolvedWorkRoot);
+        ArgumentNullException.ThrowIfNull(SourceFileSlotNamesByRelativePath);
+        ArgumentNullException.ThrowIfNull(ResourceBudget);
+        ArgumentNullException.ThrowIfNull(Queue);
 
-internal sealed record LiveSendQueuePlan(
-    int ConnectionCount,
-    int QueueCapacity,
-    long MemoryBudgetBytes);
+        this.SetupInfo = SetupInfo;
+        this.ResolvedWorkRoot = ResolvedWorkRoot;
+        this.RequestLocalOrigin = RequestLocalOrigin;
+        this.SourceFileSlotNamesByRelativePath = SourceFileSlotNamesByRelativePath;
+        this.ResourceBudget = ResourceBudget;
+        this.Queue = Queue;
+        this.MeshBakeEnabled = MeshBakeEnabled;
+    }
+
+    public ResoniteSceneSetupInfo SetupInfo { get; }
+
+    public string ResolvedWorkRoot { get; }
+
+    public ResoniteLocalOrigin RequestLocalOrigin { get; }
+
+    public IReadOnlyDictionary<string, string> SourceFileSlotNamesByRelativePath { get; }
+
+    public ResoniteImportBudgetProfile ResourceBudget { get; }
+
+    public LiveSendQueuePlan Queue { get; }
+
+    public bool MeshBakeEnabled { get; }
+}
+
+internal sealed record LiveSendQueuePlan
+{
+    public LiveSendQueuePlan(
+        int ConnectionCount,
+        int QueueCapacity,
+        long MemoryBudgetBytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(QueueCapacity, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(MemoryBudgetBytes, 1);
+
+        this.ConnectionCount = ConnectionCount;
+        this.QueueCapacity = QueueCapacity;
+        this.MemoryBudgetBytes = MemoryBudgetBytes;
+    }
+
+    public int ConnectionCount { get; }
+
+    public int QueueCapacity { get; }
+
+    public long MemoryBudgetBytes { get; }
+}
 
 internal sealed record LiveSendRunContext(
     LiveSendRunPlan Plan,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
@@ -25,12 +25,8 @@ internal sealed class ResoniteLiveSendConnectionInitializer : IResoniteLiveSendC
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(request.SetupInfo);
-        ArgumentNullException.ThrowIfNull(request.ConnectionRequest);
         ArgumentNullException.ThrowIfNull(runPlan);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
 
         ReportProgress(
             context,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Logging;
-using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
@@ -27,7 +26,7 @@ internal sealed class ResoniteLiveSendConnectionInitializer : IResoniteLiveSendC
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(request.SetupInfo);
-        ArgumentNullException.ThrowIfNull(request.NormalizedRequest);
+        ArgumentNullException.ThrowIfNull(request.ConnectionRequest);
         ArgumentNullException.ThrowIfNull(runPlan);
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(context.Endpoint);
@@ -47,9 +46,7 @@ internal sealed class ResoniteLiveSendConnectionInitializer : IResoniteLiveSendC
                 $"Connecting ResoniteLink connection pool to {context.Endpoint} "
                 + $"with {request.ConnectionCount} available routed connection(s)."));
         await context.ClientSession.EnsureConnectedAsync(
-            new LiveSendConnectionRequest(
-                request.NormalizedRequest.Dataset,
-                request.NormalizedRequest.MeshCode),
+            request.ConnectionRequest,
             cancellationToken);
         connectionStopwatch.Stop();
         ReportProgress(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendFinalizer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendFinalizer.cs
@@ -141,8 +141,29 @@ internal sealed class ResoniteLiveSendFinalizer(
     }
 }
 
-internal sealed record LiveSendFinalizationContext(
-    Uri Endpoint,
-    LiveSendEnqueueContext EnqueueContext,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
+internal sealed record LiveSendFinalizationContext
+{
+    public LiveSendFinalizationContext(
+        Uri Endpoint,
+        LiveSendEnqueueContext EnqueueContext,
+        ResoniteLinkSendDiagnostics Diagnostics,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(Endpoint);
+        ArgumentNullException.ThrowIfNull(EnqueueContext);
+        ArgumentNullException.ThrowIfNull(Diagnostics);
+
+        this.Endpoint = Endpoint;
+        this.EnqueueContext = EnqueueContext;
+        this.Diagnostics = Diagnostics;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public Uri Endpoint { get; }
+
+    public LiveSendEnqueueContext EnqueueContext { get; }
+
+    public ResoniteLinkSendDiagnostics Diagnostics { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendPhaseContextFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendPhaseContextFactory.cs
@@ -18,9 +18,6 @@ internal sealed class ResoniteLiveSendPhaseContextFactory : IResoniteLiveSendPha
     public LiveSendRunStartContext CreateRunStartContext(LiveSendRunExecutionContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
 
         return new LiveSendRunStartContext(
             context.Endpoint,
@@ -32,8 +29,6 @@ internal sealed class ResoniteLiveSendPhaseContextFactory : IResoniteLiveSendPha
     public LiveSendEnqueueContext CreateEnqueueContext(LiveSendRunExecutionContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentOutOfRangeException.ThrowIfLessThan(context.ConnectionCount, 1);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
 
         return new LiveSendEnqueueContext(
             context.ConnectionCount,
@@ -46,8 +41,6 @@ internal sealed class ResoniteLiveSendPhaseContextFactory : IResoniteLiveSendPha
         LiveSendEnqueueContext enqueueContext)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
         ArgumentNullException.ThrowIfNull(enqueueContext);
 
         return new LiveSendFinalizationContext(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunExecutor.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunExecutor.cs
@@ -8,12 +8,37 @@ using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed record LiveSendRunExecutionContext(
-    Uri Endpoint,
-    int ConnectionCount,
-    ILiveSendClientSession ClientSession,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
+internal sealed record LiveSendRunExecutionContext
+{
+    public LiveSendRunExecutionContext(
+        Uri Endpoint,
+        int ConnectionCount,
+        ILiveSendClientSession ClientSession,
+        ResoniteLinkSendDiagnostics Diagnostics,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(Endpoint);
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
+        ArgumentNullException.ThrowIfNull(ClientSession);
+        ArgumentNullException.ThrowIfNull(Diagnostics);
+
+        this.Endpoint = Endpoint;
+        this.ConnectionCount = ConnectionCount;
+        this.ClientSession = ClientSession;
+        this.Diagnostics = Diagnostics;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public Uri Endpoint { get; }
+
+    public int ConnectionCount { get; }
+
+    public ILiveSendClientSession ClientSession { get; }
+
+    public ResoniteLinkSendDiagnostics Diagnostics { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}
 
 internal interface IResoniteLiveSendRunExecutor
 {
@@ -70,10 +95,6 @@ internal sealed class ResoniteLiveSendRunExecutor(
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(objectUnits);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentOutOfRangeException.ThrowIfLessThan(context.ConnectionCount, 1);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
 
         bool completedSuccessfully = false;
         LiveSendRunState? state = null;

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
@@ -38,9 +38,7 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
     {
         ArgumentNullException.ThrowIfNull(runPlan);
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
 
         ReportProgress(
             context,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -7,21 +7,77 @@ using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed record LiveSendRunStartRequest(
-    ResoniteSceneSetupInfo SetupInfo,
-    string WorkRoot,
-    CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials,
-    LiveSendConnectionRequest ConnectionRequest,
-    ResoniteLocalOrigin RequestLocalOrigin,
-    ResoniteImportMemoryProfile MemoryProfile,
-    int ConnectionCount,
-    bool MeshBakeEnabled);
+internal sealed record LiveSendRunStartRequest
+{
+    public LiveSendRunStartRequest(
+        ResoniteSceneSetupInfo SetupInfo,
+        string WorkRoot,
+        CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials,
+        LiveSendConnectionRequest ConnectionRequest,
+        ResoniteLocalOrigin RequestLocalOrigin,
+        ResoniteImportMemoryProfile MemoryProfile,
+        int ConnectionCount,
+        bool MeshBakeEnabled)
+    {
+        ArgumentNullException.ThrowIfNull(SetupInfo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(WorkRoot);
+        ArgumentNullException.ThrowIfNull(CommonMaterials);
+        ArgumentNullException.ThrowIfNull(ConnectionRequest);
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
 
-internal sealed record LiveSendRunStartContext(
-    Uri Endpoint,
-    ILiveSendClientSession ClientSession,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
+        this.SetupInfo = SetupInfo;
+        this.WorkRoot = WorkRoot;
+        this.CommonMaterials = CommonMaterials;
+        this.ConnectionRequest = ConnectionRequest;
+        this.RequestLocalOrigin = RequestLocalOrigin;
+        this.MemoryProfile = MemoryProfile;
+        this.ConnectionCount = ConnectionCount;
+        this.MeshBakeEnabled = MeshBakeEnabled;
+    }
+
+    public ResoniteSceneSetupInfo SetupInfo { get; }
+
+    public string WorkRoot { get; }
+
+    public CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials { get; }
+
+    public LiveSendConnectionRequest ConnectionRequest { get; }
+
+    public ResoniteLocalOrigin RequestLocalOrigin { get; }
+
+    public ResoniteImportMemoryProfile MemoryProfile { get; }
+
+    public int ConnectionCount { get; }
+
+    public bool MeshBakeEnabled { get; }
+}
+
+internal sealed record LiveSendRunStartContext
+{
+    public LiveSendRunStartContext(
+        Uri Endpoint,
+        ILiveSendClientSession ClientSession,
+        ResoniteLinkSendDiagnostics Diagnostics,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(Endpoint);
+        ArgumentNullException.ThrowIfNull(ClientSession);
+        ArgumentNullException.ThrowIfNull(Diagnostics);
+
+        this.Endpoint = Endpoint;
+        this.ClientSession = ClientSession;
+        this.Diagnostics = Diagnostics;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public Uri Endpoint { get; }
+
+    public ILiveSendClientSession ClientSession { get; }
+
+    public ResoniteLinkSendDiagnostics Diagnostics { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}
 
 internal interface IResoniteLiveSendRunStarter
 {
@@ -45,13 +101,6 @@ internal sealed class ResoniteLiveSendRunStarter(
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(request.SetupInfo);
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkRoot);
-        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
-        ArgumentNullException.ThrowIfNull(request.ConnectionRequest);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
 
         LiveSendRunPlan runPlan = runPlanFactory.Create(
             request.SetupInfo,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -12,7 +11,7 @@ internal sealed record LiveSendRunStartRequest(
     ResoniteSceneSetupInfo SetupInfo,
     string WorkRoot,
     CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials,
-    PlateauImportRequest NormalizedRequest,
+    LiveSendConnectionRequest ConnectionRequest,
     ResoniteLocalOrigin RequestLocalOrigin,
     ResoniteImportMemoryProfile MemoryProfile,
     int ConnectionCount,
@@ -49,7 +48,7 @@ internal sealed class ResoniteLiveSendRunStarter(
         ArgumentNullException.ThrowIfNull(request.SetupInfo);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkRoot);
         ArgumentNullException.ThrowIfNull(request.CommonMaterials);
-        ArgumentNullException.ThrowIfNull(request.NormalizedRequest);
+        ArgumentNullException.ThrowIfNull(request.ConnectionRequest);
         ArgumentNullException.ThrowIfNull(context.Endpoint);
         ArgumentNullException.ThrowIfNull(context.ClientSession);
         ArgumentNullException.ThrowIfNull(context.Diagnostics);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendStartRequestFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendStartRequestFactory.cs
@@ -1,6 +1,7 @@
 using System;
 
 using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
@@ -29,7 +30,7 @@ internal sealed class ResoniteLiveSendStartRequestFactory : IResoniteLiveSendSta
             CreateSceneSetupInfo(request),
             request.WorkRoot,
             request.CommonMaterials,
-            plan.NormalizedRequest,
+            new LiveSendConnectionRequest(request.Metadata.Request.Dataset, request.Metadata.Request.MeshCode),
             CreateLocalOrigin(request.Metadata.GeodeticOrigin),
             memoryProfile,
             connectionCount,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
@@ -6,10 +6,28 @@ using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed record LiveSendWorkerLaunchRequest(
-    LiveSendRunState State,
-    LiveSendQueuePlan QueuePlan,
-    ResoniteImportBudgetProfile ResourceBudget);
+internal sealed record LiveSendWorkerLaunchRequest
+{
+    public LiveSendWorkerLaunchRequest(
+        LiveSendRunState State,
+        LiveSendQueuePlan QueuePlan,
+        ResoniteImportBudgetProfile ResourceBudget)
+    {
+        ArgumentNullException.ThrowIfNull(State);
+        ArgumentNullException.ThrowIfNull(QueuePlan);
+        ArgumentNullException.ThrowIfNull(ResourceBudget);
+
+        this.State = State;
+        this.QueuePlan = QueuePlan;
+        this.ResourceBudget = ResourceBudget;
+    }
+
+    public LiveSendRunState State { get; }
+
+    public LiveSendQueuePlan QueuePlan { get; }
+
+    public ResoniteImportBudgetProfile ResourceBudget { get; }
+}
 
 internal interface IResoniteLiveSendWorkerLauncher
 {
@@ -29,15 +47,8 @@ internal sealed class ResoniteLiveSendWorkerLauncher(
         LiveSendRunStartContext context)
     {
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(request.State);
-        ArgumentNullException.ThrowIfNull(request.QueuePlan);
-        ArgumentNullException.ThrowIfNull(request.ResourceBudget);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
         int connectionCount = request.QueuePlan.ConnectionCount;
-        ArgumentOutOfRangeException.ThrowIfLessThan(connectionCount, 1);
 
         ReportProgress(
             context,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectEnqueuer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectEnqueuer.cs
@@ -218,7 +218,24 @@ internal sealed class ResoniteQueuedCityObjectEnqueuer : IResoniteQueuedCityObje
     }
 }
 
-internal sealed record LiveSendEnqueueContext(
-    int ConnectionCount,
-    Func<IResoniteLinkClient> GetRoutedClient,
-    Action<string>? ProgressReporter);
+internal sealed record LiveSendEnqueueContext
+{
+    public LiveSendEnqueueContext(
+        int ConnectionCount,
+        Func<IResoniteLinkClient> GetRoutedClient,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
+        ArgumentNullException.ThrowIfNull(GetRoutedClient);
+
+        this.ConnectionCount = ConnectionCount;
+        this.GetRoutedClient = GetRoutedClient;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public int ConnectionCount { get; }
+
+    public Func<IResoniteLinkClient> GetRoutedClient { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectWorker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectWorker.cs
@@ -167,9 +167,34 @@ internal sealed class ResoniteQueuedCityObjectWorker(
     }
 }
 
-internal sealed record LiveSendWorkerContext(
-    Uri Endpoint,
-    int ConnectionCount,
-    Func<IResoniteLinkClient> GetRoutedClient,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
+internal sealed record LiveSendWorkerContext
+{
+    public LiveSendWorkerContext(
+        Uri Endpoint,
+        int ConnectionCount,
+        Func<IResoniteLinkClient> GetRoutedClient,
+        ResoniteLinkSendDiagnostics Diagnostics,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(Endpoint);
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
+        ArgumentNullException.ThrowIfNull(GetRoutedClient);
+        ArgumentNullException.ThrowIfNull(Diagnostics);
+
+        this.Endpoint = Endpoint;
+        this.ConnectionCount = ConnectionCount;
+        this.GetRoutedClient = GetRoutedClient;
+        this.Diagnostics = Diagnostics;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public Uri Endpoint { get; }
+
+    public int ConnectionCount { get; }
+
+    public Func<IResoniteLinkClient> GetRoutedClient { get; }
+
+    public ResoniteLinkSendDiagnostics Diagnostics { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -124,9 +124,9 @@ internal abstract record PlannedSlotTargetReference
     {
     }
 
-    public abstract TResult Match<TResult>(
-        Func<ResoniteSlotLocator, TResult> canonicalSlot,
-        Func<BatchPlanSlotLocator, TResult> batchSlot);
+    public abstract T Match<T>(
+        Func<ResoniteSlotLocator, T> canonicalSlot,
+        Func<BatchPlanSlotLocator, T> plannedSlot);
 
     public static PlannedSlotTargetReference CanonicalSlot(ResoniteSlotLocator locator)
     {
@@ -141,9 +141,9 @@ internal abstract record PlannedSlotTargetReference
 
     internal sealed record CanonicalSlotTarget(ResoniteSlotLocator Locator) : PlannedSlotTargetReference
     {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<BatchPlanSlotLocator, TResult> batchSlot)
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<BatchPlanSlotLocator, T> plannedSlot)
         {
             return canonicalSlot(Locator);
         }
@@ -151,11 +151,11 @@ internal abstract record PlannedSlotTargetReference
 
     internal sealed record BatchSlotTarget(BatchPlanSlotLocator Locator) : PlannedSlotTargetReference
     {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<BatchPlanSlotLocator, TResult> batchSlot)
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<BatchPlanSlotLocator, T> plannedSlot)
         {
-            return batchSlot(Locator);
+            return plannedSlot(Locator);
         }
     }
 }
@@ -166,12 +166,12 @@ internal abstract record PlannedWorldElementReference
     {
     }
 
-    public abstract TResult Match<TResult>(
-        Func<ResoniteSlotLocator, TResult> canonicalSlot,
-        Func<ResoniteComponentLocator, TResult> canonicalComponent,
-        Func<BatchPlanSlotLocator, TResult> batchSlot,
-        Func<BatchPlanComponentLocator, TResult> batchComponent,
-        Func<BatchPlanFieldLocator, TResult> batchField);
+    public abstract T Match<T>(
+        Func<ResoniteSlotLocator, T> canonicalSlot,
+        Func<ResoniteComponentLocator, T> canonicalComponent,
+        Func<BatchPlanSlotLocator, T> plannedSlot,
+        Func<BatchPlanComponentLocator, T> plannedComponent,
+        Func<BatchPlanFieldLocator, T> plannedField);
 
     public static PlannedWorldElementReference Canonical(ResoniteSlotLocator locator)
     {
@@ -202,12 +202,12 @@ internal abstract record PlannedWorldElementReference
 
     internal sealed record CanonicalSlotElement(ResoniteSlotLocator Locator) : PlannedWorldElementReference
     {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<ResoniteComponentLocator, TResult> canonicalComponent,
-            Func<BatchPlanSlotLocator, TResult> batchSlot,
-            Func<BatchPlanComponentLocator, TResult> batchComponent,
-            Func<BatchPlanFieldLocator, TResult> batchField)
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<ResoniteComponentLocator, T> canonicalComponent,
+            Func<BatchPlanSlotLocator, T> plannedSlot,
+            Func<BatchPlanComponentLocator, T> plannedComponent,
+            Func<BatchPlanFieldLocator, T> plannedField)
         {
             return canonicalSlot(Locator);
         }
@@ -215,12 +215,12 @@ internal abstract record PlannedWorldElementReference
 
     internal sealed record CanonicalComponentElement(ResoniteComponentLocator Locator) : PlannedWorldElementReference
     {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<ResoniteComponentLocator, TResult> canonicalComponent,
-            Func<BatchPlanSlotLocator, TResult> batchSlot,
-            Func<BatchPlanComponentLocator, TResult> batchComponent,
-            Func<BatchPlanFieldLocator, TResult> batchField)
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<ResoniteComponentLocator, T> canonicalComponent,
+            Func<BatchPlanSlotLocator, T> plannedSlot,
+            Func<BatchPlanComponentLocator, T> plannedComponent,
+            Func<BatchPlanFieldLocator, T> plannedField)
         {
             return canonicalComponent(Locator);
         }
@@ -228,88 +228,202 @@ internal abstract record PlannedWorldElementReference
 
     internal sealed record BatchSlotElement(BatchPlanSlotLocator Locator) : PlannedWorldElementReference
     {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<ResoniteComponentLocator, TResult> canonicalComponent,
-            Func<BatchPlanSlotLocator, TResult> batchSlot,
-            Func<BatchPlanComponentLocator, TResult> batchComponent,
-            Func<BatchPlanFieldLocator, TResult> batchField)
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<ResoniteComponentLocator, T> canonicalComponent,
+            Func<BatchPlanSlotLocator, T> plannedSlot,
+            Func<BatchPlanComponentLocator, T> plannedComponent,
+            Func<BatchPlanFieldLocator, T> plannedField)
         {
-            return batchSlot(Locator);
+            return plannedSlot(Locator);
         }
     }
 
     internal sealed record BatchComponentElement(BatchPlanComponentLocator Locator) : PlannedWorldElementReference
     {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<ResoniteComponentLocator, TResult> canonicalComponent,
-            Func<BatchPlanSlotLocator, TResult> batchSlot,
-            Func<BatchPlanComponentLocator, TResult> batchComponent,
-            Func<BatchPlanFieldLocator, TResult> batchField)
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<ResoniteComponentLocator, T> canonicalComponent,
+            Func<BatchPlanSlotLocator, T> plannedSlot,
+            Func<BatchPlanComponentLocator, T> plannedComponent,
+            Func<BatchPlanFieldLocator, T> plannedField)
         {
-            return batchComponent(Locator);
+            return plannedComponent(Locator);
         }
     }
 
     internal sealed record BatchFieldElement(BatchPlanFieldLocator Locator) : PlannedWorldElementReference
     {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<ResoniteComponentLocator, TResult> canonicalComponent,
-            Func<BatchPlanSlotLocator, TResult> batchSlot,
-            Func<BatchPlanComponentLocator, TResult> batchComponent,
-            Func<BatchPlanFieldLocator, TResult> batchField)
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<ResoniteComponentLocator, T> canonicalComponent,
+            Func<BatchPlanSlotLocator, T> plannedSlot,
+            Func<BatchPlanComponentLocator, T> plannedComponent,
+            Func<BatchPlanFieldLocator, T> plannedField)
         {
-            return batchField(Locator);
+            return plannedField(Locator);
         }
     }
 }
 
-internal abstract record PlannedMember;
+internal abstract record PlannedMember
+{
+    private protected PlannedMember()
+    {
+    }
 
-internal sealed record PlannedLiteralMember(Member Value) : PlannedMember;
+    public abstract T Match<T>(
+        Func<Member, T> literal,
+        Func<PlannedWorldElementReference, T> reference,
+        Func<PlannedAddressableFieldMember, T> addressableField,
+        Func<BatchPlanFieldLocator, PlannedWorldElementReference, T> addressableReference,
+        Func<IReadOnlyList<PlannedMember>, T> list);
+}
 
-internal sealed record PlannedElementReferenceMember(PlannedWorldElementReference Target) : PlannedMember;
+internal sealed record PlannedLiteralMember(Member Value) : PlannedMember
+{
+    public override T Match<T>(
+        Func<Member, T> literal,
+        Func<PlannedWorldElementReference, T> reference,
+        Func<PlannedAddressableFieldMember, T> addressableField,
+        Func<BatchPlanFieldLocator, PlannedWorldElementReference, T> addressableReference,
+        Func<IReadOnlyList<PlannedMember>, T> list)
+    {
+        return literal(Value);
+    }
+}
 
-internal sealed record PlannedAddressableFieldMember(BatchPlanFieldLocator Identity, Member Value) : PlannedMember;
+internal sealed record PlannedElementReferenceMember(PlannedWorldElementReference Target) : PlannedMember
+{
+    public override T Match<T>(
+        Func<Member, T> literal,
+        Func<PlannedWorldElementReference, T> reference,
+        Func<PlannedAddressableFieldMember, T> addressableField,
+        Func<BatchPlanFieldLocator, PlannedWorldElementReference, T> addressableReference,
+        Func<IReadOnlyList<PlannedMember>, T> list)
+    {
+        return reference(Target);
+    }
+}
+
+internal abstract record PlannedAddressableFieldMember(BatchPlanFieldLocator Identity) : PlannedMember
+{
+    public abstract Member Value { get; }
+
+    public abstract Member Bind(string fieldId);
+
+    public override T Match<T>(
+        Func<Member, T> literal,
+        Func<PlannedWorldElementReference, T> reference,
+        Func<PlannedAddressableFieldMember, T> addressableField,
+        Func<BatchPlanFieldLocator, PlannedWorldElementReference, T> addressableReference,
+        Func<IReadOnlyList<PlannedMember>, T> list)
+    {
+        return addressableField(this);
+    }
+
+    internal sealed record Int2(BatchPlanFieldLocator Identity, Field_int2 FieldValue)
+        : PlannedAddressableFieldMember(Identity)
+    {
+        public override Member Value => FieldValue;
+
+        public override Member Bind(string fieldId)
+        {
+            return new Field_int2
+            {
+                ID = fieldId,
+                Value = FieldValue.Value,
+            };
+        }
+    }
+
+    internal sealed record Bool(BatchPlanFieldLocator Identity, Field_bool FieldValue)
+        : PlannedAddressableFieldMember(Identity)
+    {
+        public override Member Value => FieldValue;
+
+        public override Member Bind(string fieldId)
+        {
+            return new Field_bool
+            {
+                ID = fieldId,
+                Value = FieldValue.Value,
+            };
+        }
+    }
+
+    internal sealed record Float(BatchPlanFieldLocator Identity, Field_float FieldValue)
+        : PlannedAddressableFieldMember(Identity)
+    {
+        public override Member Value => FieldValue;
+
+        public override Member Bind(string fieldId)
+        {
+            return new Field_float
+            {
+                ID = fieldId,
+                Value = FieldValue.Value,
+            };
+        }
+    }
+}
 
 internal sealed record PlannedAddressableReferenceMember(
     BatchPlanFieldLocator Identity,
     PlannedWorldElementReference Target)
-    : PlannedMember;
+    : PlannedMember
+{
+    public override T Match<T>(
+        Func<Member, T> literal,
+        Func<PlannedWorldElementReference, T> reference,
+        Func<PlannedAddressableFieldMember, T> addressableField,
+        Func<BatchPlanFieldLocator, PlannedWorldElementReference, T> addressableReference,
+        Func<IReadOnlyList<PlannedMember>, T> list)
+    {
+        return addressableReference(Identity, Target);
+    }
+}
 
-internal sealed record PlannedSyncListMember(IReadOnlyList<PlannedMember> Elements) : PlannedMember;
+internal sealed record PlannedSyncListMember(IReadOnlyList<PlannedMember> Elements) : PlannedMember
+{
+    public override T Match<T>(
+        Func<Member, T> literal,
+        Func<PlannedWorldElementReference, T> reference,
+        Func<PlannedAddressableFieldMember, T> addressableField,
+        Func<BatchPlanFieldLocator, PlannedWorldElementReference, T> addressableReference,
+        Func<IReadOnlyList<PlannedMember>, T> list)
+    {
+        return list(Elements);
+    }
+}
 
 internal sealed record PlannedDriverTargetBundle(
     PlannedAddressableFieldMember Field,
     PlannedElementReferenceMember Target,
     PlannedLiteralMember DefaultValue)
 {
-    public static PlannedDriverTargetBundle Create(BatchPlanFieldLocator fieldIdentity, Member defaultValue)
+    public static PlannedDriverTargetBundle Create(BatchPlanFieldLocator fieldIdentity, Field_bool defaultValue)
     {
         ArgumentNullException.ThrowIfNull(defaultValue);
         return new PlannedDriverTargetBundle(
-            new PlannedAddressableFieldMember(fieldIdentity, defaultValue),
+            new PlannedAddressableFieldMember.Bool(fieldIdentity, defaultValue),
             new PlannedElementReferenceMember(PlannedWorldElementReference.Planned(fieldIdentity)),
-            new PlannedLiteralMember(CloneDriverDefaultValue(defaultValue)));
+            new PlannedLiteralMember(new Field_bool
+            {
+                Value = defaultValue.Value,
+            }));
     }
 
-    private static Member CloneDriverDefaultValue(Member value)
+    public static PlannedDriverTargetBundle Create(BatchPlanFieldLocator fieldIdentity, Field_float defaultValue)
     {
-        return value switch
-        {
-            Field_bool field => new Field_bool
+        ArgumentNullException.ThrowIfNull(defaultValue);
+        return new PlannedDriverTargetBundle(
+            new PlannedAddressableFieldMember.Float(fieldIdentity, defaultValue),
+            new PlannedElementReferenceMember(PlannedWorldElementReference.Planned(fieldIdentity)),
+            new PlannedLiteralMember(new Field_float
             {
-                Value = field.Value,
-            },
-            Field_float field => new Field_float
-            {
-                Value = field.Value,
-            },
-            _ => throw new InvalidOperationException(
-                $"Unsupported planned driver default value type '{value.GetType().Name}'."),
-        };
+                Value = defaultValue.Value,
+            }));
     }
 }
 
@@ -326,10 +440,22 @@ internal static class PlannedMembers
         return new PlannedElementReferenceMember(target);
     }
 
-    public static PlannedMember AddressableField(BatchPlanFieldLocator identity, Member value)
+    public static PlannedMember AddressableField(BatchPlanFieldLocator identity, Field_int2 value)
     {
         ArgumentNullException.ThrowIfNull(value);
-        return new PlannedAddressableFieldMember(identity, value);
+        return new PlannedAddressableFieldMember.Int2(identity, value);
+    }
+
+    public static PlannedMember AddressableField(BatchPlanFieldLocator identity, Field_bool value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return new PlannedAddressableFieldMember.Bool(identity, value);
+    }
+
+    public static PlannedMember AddressableField(BatchPlanFieldLocator identity, Field_float value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return new PlannedAddressableFieldMember.Float(identity, value);
     }
 
     public static PlannedMember AddressableReference(BatchPlanFieldLocator identity, PlannedWorldElementReference target)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -118,175 +118,152 @@ internal sealed record PlannedDynamicTerrainMeshBundle(
     public PlannedWorldElementReference InitialMeshTarget => GridMeshTarget;
 }
 
-internal readonly record struct PlannedSlotTargetReference
+internal abstract record PlannedSlotTargetReference
 {
-    private PlannedSlotTargetReference(
-        PlannedSlotTargetReferenceKind kind,
-        ResoniteSlotLocator canonicalSlotLocator,
-        BatchPlanSlotLocator plannedSlotLocator)
+    private PlannedSlotTargetReference()
     {
-        Kind = kind;
-        CanonicalSlotLocator = canonicalSlotLocator;
-        PlannedSlotLocator = plannedSlotLocator;
     }
 
-    public PlannedSlotTargetReferenceKind Kind { get; }
-
-    public ResoniteSlotLocator CanonicalSlotLocator { get; }
-
-    public BatchPlanSlotLocator PlannedSlotLocator { get; }
-
-    public TResult Match<TResult>(
+    public abstract TResult Match<TResult>(
         Func<ResoniteSlotLocator, TResult> canonicalSlot,
-        Func<BatchPlanSlotLocator, TResult> plannedSlot)
-    {
-        return Kind switch
-        {
-            PlannedSlotTargetReferenceKind.CanonicalSlot => canonicalSlot(CanonicalSlotLocator),
-            PlannedSlotTargetReferenceKind.PlannedSlot => plannedSlot(PlannedSlotLocator),
-            _ => throw new InvalidOperationException("Planned slot target reference has no assigned target."),
-        };
-    }
+        Func<BatchPlanSlotLocator, TResult> batchSlot);
 
     public static PlannedSlotTargetReference CanonicalSlot(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedSlotTargetReference(
-            PlannedSlotTargetReferenceKind.CanonicalSlot,
-            locator,
-            default);
+        return new CanonicalSlotTarget(locator);
     }
 
     public static PlannedSlotTargetReference PlannedSlot(BatchPlanSlotLocator locator)
     {
-        return new PlannedSlotTargetReference(
-            PlannedSlotTargetReferenceKind.PlannedSlot,
-            default,
-            locator);
+        return new BatchSlotTarget(locator);
     }
-}
 
-internal enum PlannedSlotTargetReferenceKind
-{
-    Unspecified = 0,
-    CanonicalSlot = 1,
-    PlannedSlot = 2,
-}
-
-internal readonly record struct PlannedWorldElementReference
-{
-    private PlannedWorldElementReference(
-        PlannedWorldElementReferenceKind kind,
-        ResoniteSlotLocator canonicalSlotLocator,
-        ResoniteComponentLocator canonicalComponentLocator,
-        BatchPlanSlotLocator plannedSlotLocator,
-        BatchPlanComponentLocator plannedComponentLocator,
-        BatchPlanFieldLocator plannedFieldLocator)
+    internal sealed record CanonicalSlotTarget(ResoniteSlotLocator Locator) : PlannedSlotTargetReference
     {
-        Kind = kind;
-        CanonicalSlotLocator = canonicalSlotLocator;
-        CanonicalComponentLocator = canonicalComponentLocator;
-        PlannedSlotLocator = plannedSlotLocator;
-        PlannedComponentLocator = plannedComponentLocator;
-        PlannedFieldLocator = plannedFieldLocator;
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<BatchPlanSlotLocator, TResult> batchSlot)
+        {
+            return canonicalSlot(Locator);
+        }
     }
 
-    public PlannedWorldElementReferenceKind Kind { get; }
+    internal sealed record BatchSlotTarget(BatchPlanSlotLocator Locator) : PlannedSlotTargetReference
+    {
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<BatchPlanSlotLocator, TResult> batchSlot)
+        {
+            return batchSlot(Locator);
+        }
+    }
+}
 
-    public ResoniteSlotLocator CanonicalSlotLocator { get; }
+internal abstract record PlannedWorldElementReference
+{
+    private PlannedWorldElementReference()
+    {
+    }
 
-    public ResoniteComponentLocator CanonicalComponentLocator { get; }
-
-    public BatchPlanSlotLocator PlannedSlotLocator { get; }
-
-    public BatchPlanComponentLocator PlannedComponentLocator { get; }
-
-    public BatchPlanFieldLocator PlannedFieldLocator { get; }
-
-    public TResult Match<TResult>(
+    public abstract TResult Match<TResult>(
         Func<ResoniteSlotLocator, TResult> canonicalSlot,
         Func<ResoniteComponentLocator, TResult> canonicalComponent,
-        Func<BatchPlanSlotLocator, TResult> plannedSlot,
-        Func<BatchPlanComponentLocator, TResult> plannedComponent,
-        Func<BatchPlanFieldLocator, TResult> plannedField)
-    {
-        return Kind switch
-        {
-            PlannedWorldElementReferenceKind.CanonicalSlot => canonicalSlot(CanonicalSlotLocator),
-            PlannedWorldElementReferenceKind.CanonicalComponent => canonicalComponent(CanonicalComponentLocator),
-            PlannedWorldElementReferenceKind.PlannedSlot => plannedSlot(PlannedSlotLocator),
-            PlannedWorldElementReferenceKind.PlannedComponent => plannedComponent(PlannedComponentLocator),
-            PlannedWorldElementReferenceKind.PlannedField => plannedField(PlannedFieldLocator),
-            _ => throw new InvalidOperationException("Planned world element reference has no assigned target."),
-        };
-    }
+        Func<BatchPlanSlotLocator, TResult> batchSlot,
+        Func<BatchPlanComponentLocator, TResult> batchComponent,
+        Func<BatchPlanFieldLocator, TResult> batchField);
 
     public static PlannedWorldElementReference Canonical(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedWorldElementReference(
-            PlannedWorldElementReferenceKind.CanonicalSlot,
-            locator,
-            default,
-            default,
-            default,
-            default);
+        return new CanonicalSlotElement(locator);
     }
 
     public static PlannedWorldElementReference Canonical(ResoniteComponentLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedWorldElementReference(
-            PlannedWorldElementReferenceKind.CanonicalComponent,
-            default,
-            locator,
-            default,
-            default,
-            default);
+        return new CanonicalComponentElement(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanSlotLocator locator)
     {
-        return new PlannedWorldElementReference(
-            PlannedWorldElementReferenceKind.PlannedSlot,
-            default,
-            default,
-            locator,
-            default,
-            default);
+        return new BatchSlotElement(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanComponentLocator locator)
     {
-        return new PlannedWorldElementReference(
-            PlannedWorldElementReferenceKind.PlannedComponent,
-            default,
-            default,
-            default,
-            locator,
-            default);
+        return new BatchComponentElement(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanFieldLocator locator)
     {
-        return new PlannedWorldElementReference(
-            PlannedWorldElementReferenceKind.PlannedField,
-            default,
-            default,
-            default,
-            default,
-            locator);
+        return new BatchFieldElement(locator);
     }
-}
 
-internal enum PlannedWorldElementReferenceKind
-{
-    Unspecified = 0,
-    CanonicalSlot = 1,
-    CanonicalComponent = 2,
-    PlannedSlot = 3,
-    PlannedComponent = 4,
-    PlannedField = 5,
+    internal sealed record CanonicalSlotElement(ResoniteSlotLocator Locator) : PlannedWorldElementReference
+    {
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<ResoniteComponentLocator, TResult> canonicalComponent,
+            Func<BatchPlanSlotLocator, TResult> batchSlot,
+            Func<BatchPlanComponentLocator, TResult> batchComponent,
+            Func<BatchPlanFieldLocator, TResult> batchField)
+        {
+            return canonicalSlot(Locator);
+        }
+    }
+
+    internal sealed record CanonicalComponentElement(ResoniteComponentLocator Locator) : PlannedWorldElementReference
+    {
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<ResoniteComponentLocator, TResult> canonicalComponent,
+            Func<BatchPlanSlotLocator, TResult> batchSlot,
+            Func<BatchPlanComponentLocator, TResult> batchComponent,
+            Func<BatchPlanFieldLocator, TResult> batchField)
+        {
+            return canonicalComponent(Locator);
+        }
+    }
+
+    internal sealed record BatchSlotElement(BatchPlanSlotLocator Locator) : PlannedWorldElementReference
+    {
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<ResoniteComponentLocator, TResult> canonicalComponent,
+            Func<BatchPlanSlotLocator, TResult> batchSlot,
+            Func<BatchPlanComponentLocator, TResult> batchComponent,
+            Func<BatchPlanFieldLocator, TResult> batchField)
+        {
+            return batchSlot(Locator);
+        }
+    }
+
+    internal sealed record BatchComponentElement(BatchPlanComponentLocator Locator) : PlannedWorldElementReference
+    {
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<ResoniteComponentLocator, TResult> canonicalComponent,
+            Func<BatchPlanSlotLocator, TResult> batchSlot,
+            Func<BatchPlanComponentLocator, TResult> batchComponent,
+            Func<BatchPlanFieldLocator, TResult> batchField)
+        {
+            return batchComponent(Locator);
+        }
+    }
+
+    internal sealed record BatchFieldElement(BatchPlanFieldLocator Locator) : PlannedWorldElementReference
+    {
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<ResoniteComponentLocator, TResult> canonicalComponent,
+            Func<BatchPlanSlotLocator, TResult> batchSlot,
+            Func<BatchPlanComponentLocator, TResult> batchComponent,
+            Func<BatchPlanFieldLocator, TResult> batchField)
+        {
+            return batchField(Locator);
+        }
+    }
 }
 
 internal abstract record PlannedMember;

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -118,152 +118,175 @@ internal sealed record PlannedDynamicTerrainMeshBundle(
     public PlannedWorldElementReference InitialMeshTarget => GridMeshTarget;
 }
 
-internal abstract record PlannedSlotTargetReference
+internal readonly record struct PlannedSlotTargetReference
 {
-    private PlannedSlotTargetReference()
+    private PlannedSlotTargetReference(
+        PlannedSlotTargetReferenceKind kind,
+        ResoniteSlotLocator canonicalSlotLocator,
+        BatchPlanSlotLocator plannedSlotLocator)
     {
+        Kind = kind;
+        CanonicalSlotLocator = canonicalSlotLocator;
+        PlannedSlotLocator = plannedSlotLocator;
     }
 
-    public abstract TResult Match<TResult>(
+    public PlannedSlotTargetReferenceKind Kind { get; }
+
+    public ResoniteSlotLocator CanonicalSlotLocator { get; }
+
+    public BatchPlanSlotLocator PlannedSlotLocator { get; }
+
+    public TResult Match<TResult>(
         Func<ResoniteSlotLocator, TResult> canonicalSlot,
-        Func<BatchPlanSlotLocator, TResult> batchSlot);
+        Func<BatchPlanSlotLocator, TResult> plannedSlot)
+    {
+        return Kind switch
+        {
+            PlannedSlotTargetReferenceKind.CanonicalSlot => canonicalSlot(CanonicalSlotLocator),
+            PlannedSlotTargetReferenceKind.PlannedSlot => plannedSlot(PlannedSlotLocator),
+            _ => throw new InvalidOperationException("Planned slot target reference has no assigned target."),
+        };
+    }
 
     public static PlannedSlotTargetReference CanonicalSlot(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new CanonicalSlotTarget(locator);
+        return new PlannedSlotTargetReference(
+            PlannedSlotTargetReferenceKind.CanonicalSlot,
+            locator,
+            default);
     }
 
     public static PlannedSlotTargetReference PlannedSlot(BatchPlanSlotLocator locator)
     {
-        return new BatchSlotTarget(locator);
-    }
-
-    internal sealed record CanonicalSlotTarget(ResoniteSlotLocator Locator) : PlannedSlotTargetReference
-    {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<BatchPlanSlotLocator, TResult> batchSlot)
-        {
-            return canonicalSlot(Locator);
-        }
-    }
-
-    internal sealed record BatchSlotTarget(BatchPlanSlotLocator Locator) : PlannedSlotTargetReference
-    {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<BatchPlanSlotLocator, TResult> batchSlot)
-        {
-            return batchSlot(Locator);
-        }
+        return new PlannedSlotTargetReference(
+            PlannedSlotTargetReferenceKind.PlannedSlot,
+            default,
+            locator);
     }
 }
 
-internal abstract record PlannedWorldElementReference
+internal enum PlannedSlotTargetReferenceKind
 {
-    private PlannedWorldElementReference()
+    Unspecified = 0,
+    CanonicalSlot = 1,
+    PlannedSlot = 2,
+}
+
+internal readonly record struct PlannedWorldElementReference
+{
+    private PlannedWorldElementReference(
+        PlannedWorldElementReferenceKind kind,
+        ResoniteSlotLocator canonicalSlotLocator,
+        ResoniteComponentLocator canonicalComponentLocator,
+        BatchPlanSlotLocator plannedSlotLocator,
+        BatchPlanComponentLocator plannedComponentLocator,
+        BatchPlanFieldLocator plannedFieldLocator)
     {
+        Kind = kind;
+        CanonicalSlotLocator = canonicalSlotLocator;
+        CanonicalComponentLocator = canonicalComponentLocator;
+        PlannedSlotLocator = plannedSlotLocator;
+        PlannedComponentLocator = plannedComponentLocator;
+        PlannedFieldLocator = plannedFieldLocator;
     }
 
-    public abstract TResult Match<TResult>(
+    public PlannedWorldElementReferenceKind Kind { get; }
+
+    public ResoniteSlotLocator CanonicalSlotLocator { get; }
+
+    public ResoniteComponentLocator CanonicalComponentLocator { get; }
+
+    public BatchPlanSlotLocator PlannedSlotLocator { get; }
+
+    public BatchPlanComponentLocator PlannedComponentLocator { get; }
+
+    public BatchPlanFieldLocator PlannedFieldLocator { get; }
+
+    public TResult Match<TResult>(
         Func<ResoniteSlotLocator, TResult> canonicalSlot,
         Func<ResoniteComponentLocator, TResult> canonicalComponent,
-        Func<BatchPlanSlotLocator, TResult> batchSlot,
-        Func<BatchPlanComponentLocator, TResult> batchComponent,
-        Func<BatchPlanFieldLocator, TResult> batchField);
+        Func<BatchPlanSlotLocator, TResult> plannedSlot,
+        Func<BatchPlanComponentLocator, TResult> plannedComponent,
+        Func<BatchPlanFieldLocator, TResult> plannedField)
+    {
+        return Kind switch
+        {
+            PlannedWorldElementReferenceKind.CanonicalSlot => canonicalSlot(CanonicalSlotLocator),
+            PlannedWorldElementReferenceKind.CanonicalComponent => canonicalComponent(CanonicalComponentLocator),
+            PlannedWorldElementReferenceKind.PlannedSlot => plannedSlot(PlannedSlotLocator),
+            PlannedWorldElementReferenceKind.PlannedComponent => plannedComponent(PlannedComponentLocator),
+            PlannedWorldElementReferenceKind.PlannedField => plannedField(PlannedFieldLocator),
+            _ => throw new InvalidOperationException("Planned world element reference has no assigned target."),
+        };
+    }
 
     public static PlannedWorldElementReference Canonical(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new CanonicalSlotElement(locator);
+        return new PlannedWorldElementReference(
+            PlannedWorldElementReferenceKind.CanonicalSlot,
+            locator,
+            default,
+            default,
+            default,
+            default);
     }
 
     public static PlannedWorldElementReference Canonical(ResoniteComponentLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new CanonicalComponentElement(locator);
+        return new PlannedWorldElementReference(
+            PlannedWorldElementReferenceKind.CanonicalComponent,
+            default,
+            locator,
+            default,
+            default,
+            default);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanSlotLocator locator)
     {
-        return new BatchSlotElement(locator);
+        return new PlannedWorldElementReference(
+            PlannedWorldElementReferenceKind.PlannedSlot,
+            default,
+            default,
+            locator,
+            default,
+            default);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanComponentLocator locator)
     {
-        return new BatchComponentElement(locator);
+        return new PlannedWorldElementReference(
+            PlannedWorldElementReferenceKind.PlannedComponent,
+            default,
+            default,
+            default,
+            locator,
+            default);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanFieldLocator locator)
     {
-        return new BatchFieldElement(locator);
+        return new PlannedWorldElementReference(
+            PlannedWorldElementReferenceKind.PlannedField,
+            default,
+            default,
+            default,
+            default,
+            locator);
     }
+}
 
-    internal sealed record CanonicalSlotElement(ResoniteSlotLocator Locator) : PlannedWorldElementReference
-    {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<ResoniteComponentLocator, TResult> canonicalComponent,
-            Func<BatchPlanSlotLocator, TResult> batchSlot,
-            Func<BatchPlanComponentLocator, TResult> batchComponent,
-            Func<BatchPlanFieldLocator, TResult> batchField)
-        {
-            return canonicalSlot(Locator);
-        }
-    }
-
-    internal sealed record CanonicalComponentElement(ResoniteComponentLocator Locator) : PlannedWorldElementReference
-    {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<ResoniteComponentLocator, TResult> canonicalComponent,
-            Func<BatchPlanSlotLocator, TResult> batchSlot,
-            Func<BatchPlanComponentLocator, TResult> batchComponent,
-            Func<BatchPlanFieldLocator, TResult> batchField)
-        {
-            return canonicalComponent(Locator);
-        }
-    }
-
-    internal sealed record BatchSlotElement(BatchPlanSlotLocator Locator) : PlannedWorldElementReference
-    {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<ResoniteComponentLocator, TResult> canonicalComponent,
-            Func<BatchPlanSlotLocator, TResult> batchSlot,
-            Func<BatchPlanComponentLocator, TResult> batchComponent,
-            Func<BatchPlanFieldLocator, TResult> batchField)
-        {
-            return batchSlot(Locator);
-        }
-    }
-
-    internal sealed record BatchComponentElement(BatchPlanComponentLocator Locator) : PlannedWorldElementReference
-    {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<ResoniteComponentLocator, TResult> canonicalComponent,
-            Func<BatchPlanSlotLocator, TResult> batchSlot,
-            Func<BatchPlanComponentLocator, TResult> batchComponent,
-            Func<BatchPlanFieldLocator, TResult> batchField)
-        {
-            return batchComponent(Locator);
-        }
-    }
-
-    internal sealed record BatchFieldElement(BatchPlanFieldLocator Locator) : PlannedWorldElementReference
-    {
-        public override TResult Match<TResult>(
-            Func<ResoniteSlotLocator, TResult> canonicalSlot,
-            Func<ResoniteComponentLocator, TResult> canonicalComponent,
-            Func<BatchPlanSlotLocator, TResult> batchSlot,
-            Func<BatchPlanComponentLocator, TResult> batchComponent,
-            Func<BatchPlanFieldLocator, TResult> batchField)
-        {
-            return batchField(Locator);
-        }
-    }
+internal enum PlannedWorldElementReferenceKind
+{
+    Unspecified = 0,
+    CanonicalSlot = 1,
+    CanonicalComponent = 2,
+    PlannedSlot = 3,
+    PlannedComponent = 4,
+    PlannedField = 5,
 }
 
 internal abstract record PlannedMember;

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -124,6 +124,10 @@ internal abstract record PlannedSlotTargetReference
     {
     }
 
+    public abstract TResult Match<TResult>(
+        Func<ResoniteSlotLocator, TResult> canonicalSlot,
+        Func<BatchPlanSlotLocator, TResult> batchSlot);
+
     public static PlannedSlotTargetReference CanonicalSlot(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
@@ -132,12 +136,28 @@ internal abstract record PlannedSlotTargetReference
 
     public static PlannedSlotTargetReference PlannedSlot(BatchPlanSlotLocator locator)
     {
-        return new PlannedSlotTarget(locator);
+        return new BatchSlotTarget(locator);
     }
 
-    internal sealed record CanonicalSlotTarget(ResoniteSlotLocator Locator) : PlannedSlotTargetReference;
+    internal sealed record CanonicalSlotTarget(ResoniteSlotLocator Locator) : PlannedSlotTargetReference
+    {
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<BatchPlanSlotLocator, TResult> batchSlot)
+        {
+            return canonicalSlot(Locator);
+        }
+    }
 
-    internal sealed record PlannedSlotTarget(BatchPlanSlotLocator Locator) : PlannedSlotTargetReference;
+    internal sealed record BatchSlotTarget(BatchPlanSlotLocator Locator) : PlannedSlotTargetReference
+    {
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<BatchPlanSlotLocator, TResult> batchSlot)
+        {
+            return batchSlot(Locator);
+        }
+    }
 }
 
 internal abstract record PlannedWorldElementReference
@@ -145,6 +165,13 @@ internal abstract record PlannedWorldElementReference
     private PlannedWorldElementReference()
     {
     }
+
+    public abstract TResult Match<TResult>(
+        Func<ResoniteSlotLocator, TResult> canonicalSlot,
+        Func<ResoniteComponentLocator, TResult> canonicalComponent,
+        Func<BatchPlanSlotLocator, TResult> batchSlot,
+        Func<BatchPlanComponentLocator, TResult> batchComponent,
+        Func<BatchPlanFieldLocator, TResult> batchField);
 
     public static PlannedWorldElementReference Canonical(ResoniteSlotLocator locator)
     {
@@ -160,28 +187,83 @@ internal abstract record PlannedWorldElementReference
 
     public static PlannedWorldElementReference Planned(BatchPlanSlotLocator locator)
     {
-        return new PlannedSlotElement(locator);
+        return new BatchSlotElement(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanComponentLocator locator)
     {
-        return new PlannedComponentElement(locator);
+        return new BatchComponentElement(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanFieldLocator locator)
     {
-        return new PlannedFieldElement(locator);
+        return new BatchFieldElement(locator);
     }
 
-    internal sealed record CanonicalSlotElement(ResoniteSlotLocator Locator) : PlannedWorldElementReference;
+    internal sealed record CanonicalSlotElement(ResoniteSlotLocator Locator) : PlannedWorldElementReference
+    {
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<ResoniteComponentLocator, TResult> canonicalComponent,
+            Func<BatchPlanSlotLocator, TResult> batchSlot,
+            Func<BatchPlanComponentLocator, TResult> batchComponent,
+            Func<BatchPlanFieldLocator, TResult> batchField)
+        {
+            return canonicalSlot(Locator);
+        }
+    }
 
-    internal sealed record CanonicalComponentElement(ResoniteComponentLocator Locator) : PlannedWorldElementReference;
+    internal sealed record CanonicalComponentElement(ResoniteComponentLocator Locator) : PlannedWorldElementReference
+    {
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<ResoniteComponentLocator, TResult> canonicalComponent,
+            Func<BatchPlanSlotLocator, TResult> batchSlot,
+            Func<BatchPlanComponentLocator, TResult> batchComponent,
+            Func<BatchPlanFieldLocator, TResult> batchField)
+        {
+            return canonicalComponent(Locator);
+        }
+    }
 
-    internal sealed record PlannedSlotElement(BatchPlanSlotLocator Locator) : PlannedWorldElementReference;
+    internal sealed record BatchSlotElement(BatchPlanSlotLocator Locator) : PlannedWorldElementReference
+    {
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<ResoniteComponentLocator, TResult> canonicalComponent,
+            Func<BatchPlanSlotLocator, TResult> batchSlot,
+            Func<BatchPlanComponentLocator, TResult> batchComponent,
+            Func<BatchPlanFieldLocator, TResult> batchField)
+        {
+            return batchSlot(Locator);
+        }
+    }
 
-    internal sealed record PlannedComponentElement(BatchPlanComponentLocator Locator) : PlannedWorldElementReference;
+    internal sealed record BatchComponentElement(BatchPlanComponentLocator Locator) : PlannedWorldElementReference
+    {
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<ResoniteComponentLocator, TResult> canonicalComponent,
+            Func<BatchPlanSlotLocator, TResult> batchSlot,
+            Func<BatchPlanComponentLocator, TResult> batchComponent,
+            Func<BatchPlanFieldLocator, TResult> batchField)
+        {
+            return batchComponent(Locator);
+        }
+    }
 
-    internal sealed record PlannedFieldElement(BatchPlanFieldLocator Locator) : PlannedWorldElementReference;
+    internal sealed record BatchFieldElement(BatchPlanFieldLocator Locator) : PlannedWorldElementReference
+    {
+        public override TResult Match<TResult>(
+            Func<ResoniteSlotLocator, TResult> canonicalSlot,
+            Func<ResoniteComponentLocator, TResult> canonicalComponent,
+            Func<BatchPlanSlotLocator, TResult> batchSlot,
+            Func<BatchPlanComponentLocator, TResult> batchComponent,
+            Func<BatchPlanFieldLocator, TResult> batchField)
+        {
+            return batchField(Locator);
+        }
+    }
 }
 
 internal abstract record PlannedMember;
@@ -321,7 +403,7 @@ internal sealed record PlannedBatchEmission
         HashSet<BatchPlanSlotLocator> emittedSlots = [];
         foreach (PlannedBatchSlotEmission slotEmission in slotEmissions)
         {
-            if (slotEmission.ParentTarget is PlannedSlotTargetReference.PlannedSlotTarget plannedParent
+            if (slotEmission.ParentTarget is PlannedSlotTargetReference.BatchSlotTarget plannedParent
                 && !emittedSlots.Contains(plannedParent.Locator))
             {
                 throw new InvalidOperationException("Planned slot parent target must reference an earlier planned slot.");
@@ -341,7 +423,7 @@ internal sealed record PlannedBatchEmission
         HashSet<BatchPlanComponentLocator> emittedComponents = [];
         foreach (PlannedBatchComponentEmission componentEmission in componentEmissions)
         {
-            if (componentEmission.ContainerTarget is PlannedSlotTargetReference.PlannedSlotTarget plannedContainer
+            if (componentEmission.ContainerTarget is PlannedSlotTargetReference.BatchSlotTarget plannedContainer
                 && !emittedSlots.Contains(plannedContainer.Locator))
             {
                 throw new InvalidOperationException("Planned component container target must reference an emitted planned slot.");
@@ -371,10 +453,10 @@ internal sealed record PlannedBatchEmission
     {
         switch (target)
         {
-            case PlannedWorldElementReference.PlannedSlotElement plannedSlot
+            case PlannedWorldElementReference.BatchSlotElement plannedSlot
                 when !emittedSlots.Contains(plannedSlot.Locator):
                 throw new InvalidOperationException("Planned world element target must reference an emitted planned slot.");
-            case PlannedWorldElementReference.PlannedComponentElement plannedComponent
+            case PlannedWorldElementReference.BatchComponentElement plannedComponent
                 when !emittedComponents.Contains(plannedComponent.Locator):
                 throw new InvalidOperationException("Planned world element target must reference an earlier planned component.");
         }

--- a/tests/PlateauResoniteLink.Tests/Application/Importing/ResolvedLocalPlateauImportRequestTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/Importing/ResolvedLocalPlateauImportRequestTestFactory.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Application.Importing;
+
+internal static class ResolvedLocalPlateauImportRequestTestFactory
+{
+    public static ResolvedLocalPlateauImportRequest Create(
+        string cityGmlLocalSourcePath = "C:\\tmp\\plateau",
+        string dataset = "tokyo23ku",
+        string meshCode = "53394525",
+        IReadOnlyList<string>? packageNames = null,
+        string? demTextureLocalSourcePath = null)
+    {
+        ValidatedLocalDatasetLocation? demTextureSource = demTextureLocalSourcePath is null
+            ? null
+            : new ValidatedLocalDatasetLocation(demTextureLocalSourcePath);
+        ValidatedPlateauImportRequest request = new(
+            dataset,
+            meshCode,
+            new Regex($@"\A(?:{Regex.Escape(meshCode)})\z", RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1)),
+            new ValidatedLocalDatasetLocation(cityGmlLocalSourcePath),
+            demTextureSource,
+            packageNames);
+        return ResolvedLocalPlateauImportRequest.Create(
+            request,
+            new ValidatedLocalDatasetLocation(cityGmlLocalSourcePath),
+            demTextureSource);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Application/Importing/ResolvedLocalPlateauImportRequestTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/Importing/ResolvedLocalPlateauImportRequestTestFactory.cs
@@ -18,16 +18,34 @@ internal static class ResolvedLocalPlateauImportRequestTestFactory
         ValidatedLocalDatasetLocation? demTextureSource = demTextureLocalSourcePath is null
             ? null
             : new ValidatedLocalDatasetLocation(demTextureLocalSourcePath);
-        ValidatedPlateauImportRequest request = new(
+        ValidatedPlateauImportRequest request = CreateValidatedRequest(
+            cityGmlLocalSourcePath,
+            dataset,
+            meshCode,
+            packageNames,
+            demTextureLocalSourcePath);
+        return ResolvedLocalPlateauImportRequest.Create(
+            request,
+            new ValidatedLocalDatasetLocation(cityGmlLocalSourcePath),
+            demTextureSource);
+    }
+
+    public static ValidatedPlateauImportRequest CreateValidatedRequest(
+        string cityGmlLocalSourcePath = "C:\\tmp\\plateau",
+        string dataset = "tokyo23ku",
+        string meshCode = "53394525",
+        IReadOnlyList<string>? packageNames = null,
+        string? demTextureLocalSourcePath = null)
+    {
+        ValidatedLocalDatasetLocation? demTextureSource = demTextureLocalSourcePath is null
+            ? null
+            : new ValidatedLocalDatasetLocation(demTextureLocalSourcePath);
+        return new ValidatedPlateauImportRequest(
             dataset,
             meshCode,
             new Regex($@"\A(?:{Regex.Escape(meshCode)})\z", RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1)),
             new ValidatedLocalDatasetLocation(cityGmlLocalSourcePath),
             demTextureSource,
             packageNames);
-        return ResolvedLocalPlateauImportRequest.Create(
-            request,
-            new ValidatedLocalDatasetLocation(cityGmlLocalSourcePath),
-            demTextureSource);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Application/LocalCityGmlDocumentReaderTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/LocalCityGmlDocumentReaderTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Tests.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.Application;
 
@@ -24,12 +25,7 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: fixturePath,
-                PackageNames: ["bldg"]
-));
+            CreateResolvedRequest(fixturePath, ["bldg"]));
         ImportedSceneSourceDataset documentSet = readResult.DocumentSet;
 
         Assert.Equal(fixturePath, documentSet.DatasetSource.SourcePath);
@@ -53,12 +49,7 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: datasetSource.SourcePath,
-                PackageNames: ["dem"]
-));
+            CreateResolvedRequest(datasetSource.SourcePath, ["dem"]));
         ImportedSceneSourceDataset documentSet = readResult.DocumentSet;
 
         Assert.Equal(["udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml"], documentSet.RelativeSourceFiles);
@@ -79,12 +70,7 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: fixturePath,
-                PackageNames: ["dem", "tran"]
-));
+            CreateResolvedRequest(fixturePath, ["dem", "tran"]));
 
         GeodeticCoordinate expectedOrigin = MeshCodeBounds.TryParse("53394525")!.GetGeodeticCenter();
         Assert.Equal(["53394525"], readResult.DocumentSet.SelectedMeshCodes);
@@ -102,6 +88,15 @@ public sealed class LocalCityGmlDocumentReaderTests
             Assert.Equal(datasetSource.SourcePath, sourcePath);
             return Task.FromResult(datasetSource);
         }
+    }
+
+    private static ResolvedLocalPlateauImportRequest CreateResolvedRequest(
+        string cityGmlLocalSourcePath,
+        IReadOnlyList<string> packageNames)
+    {
+        return ResolvedLocalPlateauImportRequestTestFactory.Create(
+            cityGmlLocalSourcePath: cityGmlLocalSourcePath,
+            packageNames: packageNames);
     }
 
     private sealed class CountingDatasetContentSource(

--- a/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
@@ -1,265 +1,135 @@
 using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Tests.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.Application;
 
 public sealed class ResolvedLocalPlateauImportRequestTests
 {
     [Fact]
-    public void ConstructorTrimsResolvedBoundaryStrings()
+    public void CreateCarriesPackageNamesFromValidatedRequest()
     {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: " plateau-13213 ",
-            MeshCode: " 53395325 ",
-            CityGmlLocalSourcePath: " C:/data/source.zip ",
-            DemTextureSource: new LocalDatasetLocation(" C:/data/ortho.7z "));
-
-        Assert.Equal("plateau-13213", request.Dataset);
-        Assert.Equal("53395325", request.MeshCode);
-        Assert.Equal("C:/data/source.zip", request.CityGmlLocalSourcePath);
-        Assert.Equal("C:/data/ortho.7z", request.DemTextureLocalSourcePath);
-    }
-
-    [Fact]
-    public void ConstructorNormalizesPackageNamesAtResolvedBoundary()
-    {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            PackageNames: [" BLDG ", "waterbody", "bldg"]);
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            packageNames: ["bldg", "wtr"]);
 
         Assert.Equal(["bldg", "wtr"], request.PackageNames);
     }
 
     [Fact]
-    public void ConstructorRejectsEmptyPackageNames()
+    public void CreateCarriesLocalDemTextureSource()
     {
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                PackageNames: []));
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            demTextureLocalSourcePath: "C:\\tmp\\ortho.tif");
+
+        Assert.Equal("C:\\tmp\\ortho.tif", request.DemTextureLocalSourcePath);
     }
 
     [Fact]
-    public void ConstructorRejectsUnsupportedPackageNames()
+    public void CreateRejectsDifferentResolvedLocalCityGmlSource()
     {
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                PackageNames: ["unknown"]));
-    }
+        ValidatedPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.CreateValidatedRequest(
+            cityGmlLocalSourcePath: "C:\\tmp\\plateau-a");
 
-    [Theory]
-    [InlineData(0.0)]
-    [InlineData(-0.01)]
-    [InlineData(double.PositiveInfinity)]
-    public void ConstructorRejectsInvalidTerrainGridMetersPerVertex(double metersPerVertex)
-    {
-        Assert.Throws<ArgumentOutOfRangeException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                TerrainGridMetersPerVertex: metersPerVertex));
-    }
-
-    [Theory]
-    [InlineData(1)]
-    [InlineData(0)]
-    [InlineData(-4)]
-    public void ConstructorRejectsInvalidTerrainGridMaxResolution(int maxResolution)
-    {
-        Assert.Throws<ArgumentOutOfRangeException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                TerrainGridMaxResolution: maxResolution));
-    }
-
-    [Fact]
-    public void ConstructorNormalizesPackageOptionMapKeysAtResolvedBoundary()
-    {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
-            {
-                [" BLDG "] = new HashSet<int> { 1 },
-                ["waterbody"] = new HashSet<int> { 2 },
-            },
-            PackagePatterns: new Dictionary<string, string>
-            {
-                [" BLDG "] = "_bldg_",
-                ["waterbody"] = "_wtr_",
-            });
-
-        Assert.Equal([1], request.ExcludeLodLevelsByPackage!["bldg"]);
-        Assert.Equal([2], request.ExcludeLodLevelsByPackage!["wtr"]);
-        Assert.Equal("_bldg_", request.PackagePatterns!["bldg"]);
-        Assert.Equal("_wtr_", request.PackagePatterns!["wtr"]);
-    }
-
-    [Fact]
-    public void ConstructorRejectsDuplicatePackageOptionMapKeysAfterNormalization()
-    {
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
-                {
-                    [" BLDG "] = new HashSet<int> { 1 },
-                    ["bldg"] = new HashSet<int> { 2 },
-                }));
-
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                PackagePatterns: new Dictionary<string, string>
-                {
-                    ["waterbody"] = "_wtr_",
-                    ["wtr"] = "_wtr_",
-                }));
-    }
-
-    [Fact]
-    public void ConstructorKeepsLocalDemTextureSource()
-    {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            DemTextureSource: new LocalDatasetLocation("/tmp/ortho.tif"));
-
-        LocalDatasetLocation demTextureSource = Assert.IsType<LocalDatasetLocation>(request.DemTextureSource);
-        Assert.Equal("/tmp/ortho.tif", demTextureSource.LocalSourcePath);
-    }
-
-    [Fact]
-    public void CreateKeepsResolvedRemoteDemTextureSource()
-    {
-        string workRoot = "work";
-        Uri cityGmlUri = new("https://example.test/tokyo.zip");
-        Uri demTextureUri = new("https://example.test/ortho.tif");
-        ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
-            new PlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlSource: DatasetLocation.Remote(cityGmlUri),
-                DemTextureSource: DatasetLocation.Remote(demTextureUri)));
-
-        ResolvedLocalPlateauImportRequest resolvedRequest = ResolvedLocalPlateauImportRequest.Create(
-            request,
-            workRoot,
-            new ValidatedLocalDatasetLocation(
-                RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, cityGmlUri, "source-archive")),
-            new ValidatedLocalDatasetLocation(
-                RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, demTextureUri, "source-ortho")));
-
-        Assert.Equal(
-            RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, demTextureUri, "source-ortho"),
-            resolvedRequest.DemTextureLocalSourcePath);
-    }
-
-    [Fact]
-    public void CreateRejectsLocalCityGmlSourceMismatch()
-    {
-        ValidatedPlateauImportRequest request = CreateValidatedRequest(
-            new ValidatedLocalDatasetLocation("/tmp/plateau-a"));
-
-        Assert.Throws<ArgumentException>(
+        ArgumentException exception = Assert.Throws<ArgumentException>(
             () => ResolvedLocalPlateauImportRequest.Create(
                 request,
-                "work",
-                new ValidatedLocalDatasetLocation("/tmp/plateau-b"),
-                demTextureSource: null));
-    }
+                new ValidatedLocalDatasetLocation("C:\\tmp\\plateau-b"),
+                null));
 
-    [Fact]
-    public void CreateRejectsRemoteCityGmlSourceMismatch()
-    {
-        Uri cityGmlUri = new("https://example.test/tokyo.zip");
-        ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
-            new PlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlSource: DatasetLocation.Remote(cityGmlUri)));
-
-        Assert.Throws<ArgumentException>(
-            () => ResolvedLocalPlateauImportRequest.Create(
-                request,
-                "work",
-                new ValidatedLocalDatasetLocation("/tmp/unexpected.zip"),
-                demTextureSource: null));
+        Assert.Equal("cityGmlSource", exception.ParamName);
     }
 
     [Fact]
     public void CreateRejectsDifferentResolvedLocalDemTextureSource()
     {
-        ValidatedPlateauImportRequest request = CreateValidatedRequest(
-            new ValidatedLocalDatasetLocation("/tmp/plateau"),
-            new ValidatedLocalDatasetLocation("/tmp/ortho-a.tif"));
+        ValidatedPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.CreateValidatedRequest(
+            demTextureLocalSourcePath: "C:\\tmp\\ortho-a.tif");
 
-        Assert.Throws<ArgumentException>(
+        ArgumentException exception = Assert.Throws<ArgumentException>(
             () => ResolvedLocalPlateauImportRequest.Create(
                 request,
-                "work",
-                new ValidatedLocalDatasetLocation("/tmp/plateau"),
-                new ValidatedLocalDatasetLocation("/tmp/ortho-b.tif")));
+                new ValidatedLocalDatasetLocation("C:\\tmp\\plateau"),
+                new ValidatedLocalDatasetLocation("C:\\tmp\\ortho-b.tif")));
+
+        Assert.Equal("demTextureSource", exception.ParamName);
     }
 
     [Fact]
     public void CreateRejectsResolvedDemTextureSourceWhenNoneWasRequested()
     {
-        ValidatedPlateauImportRequest request = CreateValidatedRequest(
-            new ValidatedLocalDatasetLocation("/tmp/plateau"));
+        ValidatedPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.CreateValidatedRequest();
 
-        Assert.Throws<ArgumentException>(
+        ArgumentException exception = Assert.Throws<ArgumentException>(
             () => ResolvedLocalPlateauImportRequest.Create(
                 request,
-                "work",
-                new ValidatedLocalDatasetLocation("/tmp/plateau"),
-                new ValidatedLocalDatasetLocation("/tmp/ortho.tif")));
+                new ValidatedLocalDatasetLocation("C:\\tmp\\plateau"),
+                new ValidatedLocalDatasetLocation("C:\\tmp\\ortho.tif")));
+
+        Assert.Equal("demTextureSource", exception.ParamName);
     }
 
     [Fact]
-    public void CreateRejectsUnresolvedDemTextureSourceWhenOneWasRequested()
+    public void CreateRejectsRemoteCityGmlSourceResolvedOutsideExpectedCachePath()
     {
-        ValidatedPlateauImportRequest request = CreateValidatedRequest(
-            new ValidatedLocalDatasetLocation("/tmp/plateau"),
-            new ValidatedLocalDatasetLocation("/tmp/ortho.tif"));
+        using TemporaryDirectory workRoot = new();
+        ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlSource: DatasetLocation.Remote(new Uri("https://example.test/source.zip"))));
 
-        Assert.Throws<ArgumentException>(
+        ArgumentException exception = Assert.Throws<ArgumentException>(
             () => ResolvedLocalPlateauImportRequest.Create(
                 request,
-                "work",
-                new ValidatedLocalDatasetLocation("/tmp/plateau"),
-                demTextureSource: null));
+                new ValidatedLocalDatasetLocation("C:\\tmp\\other.zip"),
+                null,
+                workRoot.Path));
+
+        Assert.Equal("cityGmlSource", exception.ParamName);
     }
 
-    private static ValidatedPlateauImportRequest CreateValidatedRequest(
-        ValidatedDatasetLocation cityGmlSource,
-        ValidatedDatasetLocation? demTextureSource = null)
+    [Fact]
+    public void CreateAcceptsRemoteCityGmlSourceResolvedToExpectedCachePath()
     {
-        return new ValidatedPlateauImportRequest(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            MeshCodePattern: new Regex("^53394525$", RegexOptions.CultureInvariant),
-            CityGmlSource: cityGmlSource,
-            DemTextureSource: demTextureSource);
+        using TemporaryDirectory workRoot = new();
+        Uri sourceUri = new("https://example.test/source.zip");
+        ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlSource: DatasetLocation.Remote(sourceUri)));
+        string expectedSourcePath = RemoteDatasetResourceLayout.GetRemoteResourcePath(
+            workRoot.Path,
+            sourceUri,
+            ResolvedLocalPlateauImportRequest.RemoteCityGmlResourcePrefix);
+
+        ResolvedLocalPlateauImportRequest resolvedRequest = ResolvedLocalPlateauImportRequest.Create(
+            request,
+            new ValidatedLocalDatasetLocation(expectedSourcePath),
+            null,
+            workRoot.Path);
+
+        Assert.Equal(expectedSourcePath, resolvedRequest.CityGmlLocalSourcePath);
+    }
+
+    [Fact]
+    public void CreateRejectsRemoteDemTextureSourceResolvedOutsideExpectedCachePath()
+    {
+        using TemporaryDirectory workRoot = new();
+        ValidatedPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.CreateValidatedRequest() with
+        {
+            DemTextureSource = new ValidatedRemoteDatasetLocation(new Uri("https://example.test/ortho.tif")),
+        };
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(
+            () => ResolvedLocalPlateauImportRequest.Create(
+                request,
+                new ValidatedLocalDatasetLocation("C:\\tmp\\plateau"),
+                new ValidatedLocalDatasetLocation("C:\\tmp\\other.tif"),
+                workRoot.Path));
+
+        Assert.Equal("demTextureSource", exception.ParamName);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
@@ -90,7 +90,7 @@ public sealed class ImportServiceFactoryTests
             ValidatedLocalDatasetLocation? localDemTextureSource = request.DemTextureSource is null
                 ? null
                 : Assert.IsType<ValidatedLocalDatasetLocation>(request.DemTextureSource);
-            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(request, workRoot, localSource, localDemTextureSource));
+            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(request, localSource, localDemTextureSource, workRoot));
         }
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
@@ -17,10 +17,7 @@ public sealed class DefaultImportedSceneSourceComposerTests
     [Fact]
     public void ComposeMapsDocumentSetBoundaryIntoImportedSceneMetadata()
     {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau");
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create();
         PlateauImportRequest importRequest = request.ToImportRequest();
 
         TerrainTextureOverlay overlay = new(
@@ -71,12 +68,9 @@ public sealed class DefaultImportedSceneSourceComposerTests
     [Fact]
     public async Task ComposedStreamingSourcePreflightValidatesExplicitDemTextureSource()
     {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            PackageNames: ["dem"],
-            DemTextureSource: new LocalDatasetLocation("/tmp/plateau/ortho.tif"));
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            packageNames: ["dem"],
+            demTextureLocalSourcePath: "C:\\tmp\\plateau\\ortho.tif");
         PlateauImportRequest importRequest = request.ToImportRequest();
         ImportedSceneSourceSnapshot readResult = new(
             new ImportedSceneSourceDataset(

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceFactoryTests.cs
@@ -42,10 +42,7 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             new PassthroughImportedObjectUnitOptimizer());
         Action<string> progressReporter = _ => { };
 
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau");
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create();
 
         IImportedSceneSource result = await factory.CreateAsync(request, progressReporter);
 
@@ -76,12 +73,8 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             reader,
             composer,
             new PassthroughImportedObjectUnitOptimizer());
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            PackageNames: ["dem"]
-);
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            packageNames: ["dem"]);
 
         _ = await factory.CreateAsync(request);
 
@@ -122,12 +115,9 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             reader,
             composer,
             new PassthroughImportedObjectUnitOptimizer());
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            PackageNames: ["dem"],
-            DemTextureSource: new LocalDatasetLocation("C:\\ortho\\53394525.tif"));
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            packageNames: ["dem"],
+            demTextureLocalSourcePath: "C:\\ortho\\53394525.tif");
 
         _ = await factory.CreateAsync(request);
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -68,10 +68,8 @@ public sealed class LocalCityGmlObjectProjectionTests
     {
         string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
         LocalCityGmlDocumentReader documentReader = CreateDocumentReader();
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: fixturePath);
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            cityGmlLocalSourcePath: fixturePath);
         PlateauImportRequest importRequest = request.ToImportRequest();
 
         DefaultImportedSceneSourceFactory factory = new(

--- a/tests/PlateauResoniteLink.Tests/Targets/LiveSendRunContractTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/LiveSendRunContractTests.cs
@@ -1,0 +1,100 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test names describe contract cases.")]
+public sealed class LiveSendRunContractTests
+{
+    [Fact]
+    public void StartRequest_RejectsIncompleteRunInputsAtConstruction()
+    {
+        ResoniteSceneSetupInfo setupInfo = CreateSetupInfo();
+
+        Assert.Throws<ArgumentNullException>(() => new LiveSendRunStartRequest(
+            null!,
+            "work",
+            CommonMaterialCatalog.Create(),
+            new LiveSendConnectionRequest("dataset", "53394525"),
+            new ResoniteLocalOrigin(0, 0, 0),
+            ResoniteImportMemoryProfile.Large,
+            1,
+            MeshBakeEnabled: true));
+        Assert.Throws<ArgumentException>(() => new LiveSendRunStartRequest(
+            setupInfo,
+            " ",
+            CommonMaterialCatalog.Create(),
+            new LiveSendConnectionRequest("dataset", "53394525"),
+            new ResoniteLocalOrigin(0, 0, 0),
+            ResoniteImportMemoryProfile.Large,
+            1,
+            MeshBakeEnabled: true));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LiveSendRunStartRequest(
+            setupInfo,
+            "work",
+            CommonMaterialCatalog.Create(),
+            new LiveSendConnectionRequest("dataset", "53394525"),
+            new ResoniteLocalOrigin(0, 0, 0),
+            ResoniteImportMemoryProfile.Large,
+            0,
+            MeshBakeEnabled: true));
+    }
+
+    [Fact]
+    public void RunContexts_RejectMissingSessionStateAtConstruction()
+    {
+        Assert.Throws<ArgumentNullException>(() => new LiveSendRunStartContext(
+            null!,
+            new DelegatingClientSession(),
+            ResoniteLinkSendDiagnostics.Disabled,
+            ProgressReporter: null));
+        Assert.Throws<ArgumentNullException>(() => new LiveSendRunExecutionContext(
+            new Uri("ws://localhost:12345/"),
+            1,
+            null!,
+            ResoniteLinkSendDiagnostics.Disabled,
+            ProgressReporter: null));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LiveSendRunExecutionContext(
+            new Uri("ws://localhost:12345/"),
+            0,
+            new DelegatingClientSession(),
+            ResoniteLinkSendDiagnostics.Disabled,
+            ProgressReporter: null));
+    }
+
+    [Fact]
+    public void QueueAndWorkerContracts_RejectNonExecutableInputsAtConstruction()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LiveSendQueuePlan(
+            ConnectionCount: 0,
+            QueueCapacity: 1,
+            MemoryBudgetBytes: 1));
+        Assert.Throws<ArgumentNullException>(() => new LiveSendEnqueueContext(
+            ConnectionCount: 1,
+            GetRoutedClient: null!,
+            ProgressReporter: null));
+        Assert.Throws<ArgumentNullException>(() => new LiveSendWorkerContext(
+            new Uri("ws://localhost:12345/"),
+            ConnectionCount: 1,
+            GetRoutedClient: null!,
+            ResoniteLinkSendDiagnostics.Disabled,
+            ProgressReporter: null));
+    }
+
+    private static ResoniteSceneSetupInfo CreateSetupInfo()
+    {
+        return new ResoniteSceneSetupInfo(
+            "dataset",
+            "53394525",
+            Array.Empty<string>(),
+            Array.Empty<string>(),
+            new ResoniteLicenseAttributionMetadata(
+                RequireCredit: false,
+                CreditText: null,
+                LicenseName: null,
+                LicenseUrl: null));
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -920,12 +920,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         using SceneSinkRecordingClient routedClient = new();
         DelegatingClientSession session = new(routedClient);
         await using ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(routedClient, session: session);
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDatasetParentMeshPackages"),
-            PackageNames: ["dem"]
-);
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            cityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDatasetParentMeshPackages"),
+            packageNames: ["dem"]);
         ImportedSceneSourceSnapshot readResult = await new LocalCityGmlDocumentReader(
             new DefaultPlateauDatasetContentSourceFactory(new RemoteArchiveDistributionPolicy(), new ArchiveFileLayoutPolicy()),
             new CityGmlAppearanceStoreFactory(),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -281,13 +281,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             request,
             ["udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml"]);
         CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials = CommonMaterialCatalog.Create();
-        SceneImportExecutionPlan plan = SceneImportExecutionPlan.Create(
-            request,
-            request,
+        SceneImportExecutionPlan plan = ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(
             metadata,
-            request.CityGmlLocalSourcePath!,
             workDirectory.Path,
-            commonMaterials);
+            commonMaterials: commonMaterials);
 
         InvalidOperationException error = await Assert.ThrowsAsync<InvalidOperationException>(() => importTarget.ExecuteAsync(
             plan,
@@ -323,11 +320,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             request,
             ["udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml"]);
 
-        SceneImportExecutionPlan plan = SceneImportExecutionPlan.Create(
-            request,
-            request,
+        SceneImportExecutionPlan plan = ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(
             metadata,
-            request.CityGmlLocalSourcePath!,
             workDirectory.Path,
             commonMaterials: CommonMaterialCatalog.Create());
 
@@ -389,13 +383,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         ResoniteConstructionCityObject cityObject = CreateMixedSharedMaterialAndPayloadCityObject(
             "runtime-shared-texture",
             terrainAlignedDepthOffset);
-        SceneImportExecutionPlan plan = SceneImportExecutionPlan.Create(
-            request,
-            request,
+        SceneImportExecutionPlan plan = ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(
             metadata,
-            request.CityGmlLocalSourcePath!,
             workDirectory.Path,
-            ResoniteLiveSceneImportTargetTestSupport.CreateReferencedCommonMaterials([cityObject], enableMeshBake: false));
+            commonMaterials: ResoniteLiveSceneImportTargetTestSupport.CreateReferencedCommonMaterials([cityObject], enableMeshBake: false));
 
         _ = await importTarget.ExecuteAsync(
             plan,
@@ -453,13 +444,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         ResoniteConstructionCityObject cityObject = CreateVertexColorTriangleCityObject(
             "terrain-aligned-vertex-common",
             new ResoniteMaterialDepthOffset(-10.0, -10.0));
-        SceneImportExecutionPlan plan = SceneImportExecutionPlan.Create(
-            request,
-            request,
+        SceneImportExecutionPlan plan = ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(
             metadata,
-            request.CityGmlLocalSourcePath!,
             workDirectory.Path,
-            ResoniteLiveSceneImportTargetTestSupport.CreateReferencedCommonMaterials([cityObject], enableMeshBake: true));
+            commonMaterials: ResoniteLiveSceneImportTargetTestSupport.CreateReferencedCommonMaterials([cityObject], enableMeshBake: true));
 
         _ = await importTarget.ExecuteAsync(
             plan,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -160,22 +160,20 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         PlateauImportRequest? normalizedRequest = null,
         CommonMaterialCatalog<DefaultCommonMaterialMember>? commonMaterials = null)
     {
-        PlateauImportRequest effectiveNormalizedRequest = normalizedRequest ?? metadata.Request;
-        PlateauImportRequest resolvedRequest = CreateResolvedRequest(
+        ValidatedPlateauImportRequest effectiveNormalizedRequest = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+            normalizedRequest ?? metadata.Request);
+        ResolvedLocalPlateauImportRequest resolvedRequest = CreateResolvedRequest(
             effectiveNormalizedRequest,
             metadata.Request,
             workDirectory);
-        PlateauImportRequest importRequest = CreateImportRequest(effectiveNormalizedRequest, resolvedRequest);
         ImportedSceneMetadata effectiveMetadata = metadata with
         {
-            Request = importRequest,
+            Request = resolvedRequest.ToImportRequest(),
         };
 
         return SceneImportExecutionPlan.Create(
-            effectiveNormalizedRequest,
             resolvedRequest,
             effectiveMetadata,
-            GetRequiredResolvedLocalSourcePath(resolvedRequest),
             workDirectory,
             commonMaterials ?? CreateReferencedCommonMaterials([], enableMeshBake: false));
     }
@@ -204,23 +202,12 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         return catalog.FilterToDefinitions(definitions);
     }
 
-    private static PlateauImportRequest CreateImportRequest(
-        PlateauImportRequest normalizedRequest,
-        PlateauImportRequest resolvedRequest)
-    {
-        return normalizedRequest with
-        {
-            CityGmlSource = resolvedRequest.CityGmlSource,
-            DemTextureSource = resolvedRequest.DemTextureSource,
-        };
-    }
-
-    private static PlateauImportRequest CreateResolvedRequest(
-        PlateauImportRequest normalizedRequest,
+    private static ResolvedLocalPlateauImportRequest CreateResolvedRequest(
+        ValidatedPlateauImportRequest normalizedRequest,
         PlateauImportRequest metadataRequest,
         string workDirectory)
     {
-        string? resolvedSourcePath = ResolveLocalPath(normalizedRequest.CityGmlSource, workDirectory, "source-archive")
+        string? resolvedSourcePath = ResolveLocalPath(normalizedRequest.CityGmlSource.ToDatasetLocation(), workDirectory, "source-archive")
             ?? metadataRequest.CityGmlLocalSourcePath;
         if (string.IsNullOrWhiteSpace(resolvedSourcePath))
         {
@@ -230,23 +217,25 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         DatasetLocation? resolvedDemTextureSource = metadataRequest.DemTextureSource;
         if (normalizedRequest.DemTextureSource is not null)
         {
-            string? resolvedDemTexturePath = ResolveLocalPath(normalizedRequest.DemTextureSource, workDirectory, "source-ortho");
+            string? resolvedDemTexturePath = ResolveLocalPath(normalizedRequest.DemTextureSource.ToDatasetLocation(), workDirectory, "source-ortho");
             resolvedDemTextureSource = resolvedDemTexturePath is null
                 ? metadataRequest.DemTextureSource
                 : DatasetLocation.Local(resolvedDemTexturePath);
         }
 
-        return normalizedRequest with
-        {
-            CityGmlSource = DatasetLocation.Local(resolvedSourcePath),
-            DemTextureSource = resolvedDemTextureSource,
-        };
-    }
-
-    private static string GetRequiredResolvedLocalSourcePath(PlateauImportRequest resolvedRequest)
-    {
-        return resolvedRequest.CityGmlLocalSourcePath
-            ?? throw new ArgumentException("Resolved request must include a local CityGML source path.", nameof(resolvedRequest));
+        return new ResolvedLocalPlateauImportRequest(
+            normalizedRequest.Dataset,
+            normalizedRequest.MeshCode,
+            resolvedSourcePath,
+            resolvedDemTextureSource,
+            normalizedRequest.PackageNames,
+            normalizedRequest.GlobalExcludeLodLevels,
+            normalizedRequest.ExcludeLodLevelsByPackage,
+            normalizedRequest.PackagePatterns,
+            normalizedRequest.IncludeMarkingAlways,
+            normalizedRequest.TerrainMeshMode,
+            normalizedRequest.TerrainGridMetersPerVertex,
+            normalizedRequest.TerrainGridMaxResolution);
     }
 
     private static string? ResolveLocalPath(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -214,28 +214,22 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             throw new ArgumentException("Metadata request must include a local CityGML source path.", nameof(metadataRequest));
         }
 
-        DatasetLocation? resolvedDemTextureSource = metadataRequest.DemTextureSource;
+        ValidatedLocalDatasetLocation? resolvedDemTextureSource = metadataRequest.DemTextureLocalSourcePath is { } metadataDemTexturePath
+            ? new ValidatedLocalDatasetLocation(metadataDemTexturePath)
+            : null;
         if (normalizedRequest.DemTextureSource is not null)
         {
             string? resolvedDemTexturePath = ResolveLocalPath(normalizedRequest.DemTextureSource.ToDatasetLocation(), workDirectory, "source-ortho");
-            resolvedDemTextureSource = resolvedDemTexturePath is null
-                ? metadataRequest.DemTextureSource
-                : DatasetLocation.Local(resolvedDemTexturePath);
+            if (resolvedDemTexturePath is not null)
+            {
+                resolvedDemTextureSource = new ValidatedLocalDatasetLocation(resolvedDemTexturePath);
+            }
         }
 
-        return new ResolvedLocalPlateauImportRequest(
-            normalizedRequest.Dataset,
-            normalizedRequest.MeshCode,
-            resolvedSourcePath,
-            resolvedDemTextureSource,
-            normalizedRequest.PackageNames,
-            normalizedRequest.GlobalExcludeLodLevels,
-            normalizedRequest.ExcludeLodLevelsByPackage,
-            normalizedRequest.PackagePatterns,
-            normalizedRequest.IncludeMarkingAlways,
-            normalizedRequest.TerrainMeshMode,
-            normalizedRequest.TerrainGridMetersPerVertex,
-            normalizedRequest.TerrainGridMaxResolution);
+        return ResolvedLocalPlateauImportRequest.Create(
+            normalizedRequest,
+            new ValidatedLocalDatasetLocation(resolvedSourcePath),
+            resolvedDemTextureSource);
     }
 
     private static string? ResolveLocalPath(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -229,7 +229,8 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         return ResolvedLocalPlateauImportRequest.Create(
             normalizedRequest,
             new ValidatedLocalDatasetLocation(resolvedSourcePath),
-            resolvedDemTextureSource);
+            resolvedDemTextureSource,
+            workDirectory);
     }
 
     private static string? ResolveLocalPath(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -175,12 +175,12 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.False(Assert.IsType<Field_bool>(ToMember(heightTexture.Members["MipMaps"])).Value);
         Reference displacementTexture = Assert.IsType<Reference>(ToMember(gridMesh.Members["DisplacementTexture"]));
         Assert.Equal(ToPlannedTargetId(heightTexture.Identity), displacementTexture.TargetID);
-        PlannedAddressableFieldMember gridPointsMember = Assert.IsType<PlannedAddressableFieldMember>(gridMesh.Members["Points"]);
+        PlannedAddressableFieldMember gridPointsMember = Assert.IsType<PlannedAddressableFieldMember.Int2>(gridMesh.Members["Points"]);
         Field_int2 gridPoints = Assert.IsType<Field_int2>(gridPointsMember.Value);
         Assert.Equal(2, gridPoints.Value.x);
         Assert.Equal(3, gridPoints.Value.y);
         Assert.True(string.IsNullOrWhiteSpace(gridPoints.ID));
-        PlannedAddressableFieldMember progress = Assert.IsType<PlannedAddressableFieldMember>(pointsGradientDriver.Members["Progress"]);
+        PlannedAddressableFieldMember progress = Assert.IsType<PlannedAddressableFieldMember.Float>(pointsGradientDriver.Members["Progress"]);
         Assert.Equal(1.0f, Assert.IsType<Field_float>(progress.Value).Value);
         PlannedElementReferenceMember pointsTarget = Assert.IsType<PlannedElementReferenceMember>(pointsGradientDriver.Members["Target"]);
         Assert.Equal(gridPointsMember.Identity, AssertPlannedField(pointsTarget.Target));
@@ -257,7 +257,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(colliderMesh)).TargetID);
         foreach (PlannedBatchComponentEmission meshSwitch in meshSwitches)
         {
-            PlannedAddressableFieldMember state = Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]);
+            PlannedAddressableFieldMember state = Assert.IsType<PlannedAddressableFieldMember.Bool>(meshSwitch.Members["State"]);
             PlannedElementReferenceMember target = Assert.IsType<PlannedElementReferenceMember>(meshSwitch.Members["Target"]);
             Assert.True(
                 AssertPlannedField(target.Target) is BatchPlanFieldLocator plannedTarget
@@ -273,7 +273,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             Assert.True(
                 AssertPlannedField(target.Target) is BatchPlanFieldLocator plannedStateTarget
                 && meshSwitches
-                    .Select(meshSwitch => Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]).Identity)
+                    .Select(meshSwitch => Assert.IsType<PlannedAddressableFieldMember.Bool>(meshSwitch.Members["State"]).Identity)
                     .Contains(plannedStateTarget));
             Assert.Equal("PLATEAU.Terrain.Static.Enabled", Assert.IsType<Field_string>(ToMember(boolDriver.Members["VariableName"])).Value);
             Assert.False(Assert.IsType<Field_bool>(ToMember(boolDriver.Members["DefaultValue"])).Value);
@@ -377,14 +377,14 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Reference dedicatedMaterialReference = Assert.IsType<Reference>(materials.Elements[1]);
         PlannedBatchSlotEmission dedicatedMaterialSlot = Assert.Single(
             batchPlan.SlotEmissions,
-            slot => IsPlannedSlotTarget(slot.ParentTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object"))
+            slot => IsBatchSlotTarget(slot.ParentTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object"))
                 && string.Equals(slot.SlotName, "material-000-pbs-uv-uv", StringComparison.Ordinal));
         PlannedBatchComponentEmission dedicatedMaterialComponent = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal));
         PlannedBatchComponentEmission albedoTexture = Assert.Single(
             batchPlan.ComponentEmissions,
-            component => IsPlannedSlotTarget(component.ContainerTarget, dedicatedMaterialSlot.Identity)
+            component => IsBatchSlotTarget(component.ContainerTarget, dedicatedMaterialSlot.Identity)
                 && string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
 
         Assert.Equal("existing-material-id", reusableMaterialReference.TargetID);
@@ -441,7 +441,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         Assert.DoesNotContain(
             batchPlan.SlotEmissions,
-            slot => IsPlannedSlotTarget(slot.ParentTarget, meshAssetSlot.Identity)
+            slot => IsBatchSlotTarget(slot.ParentTarget, meshAssetSlot.Identity)
                 && !string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal));
 
         PlannedBatchComponentEmission materialComponent = Assert.Single(
@@ -527,7 +527,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchComponentEmission overrideTexture = Assert.Single(
             batchPlan.ComponentEmissions,
             component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && IsPlannedSlotTarget(component.ContainerTarget, assetSlot.Identity));
+                && IsBatchSlotTarget(component.ContainerTarget, assetSlot.Identity));
 
         Assert.Equal("shared-material-id", materialReference.TargetID);
         Assert.Equal(ToPlannedTargetId(propertyBlockComponent.Identity), propertyBlockReference.TargetID);
@@ -570,7 +570,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchComponentEmission overrideTexture = Assert.Single(
             batchPlan.ComponentEmissions,
             component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && IsPlannedSlotTarget(component.ContainerTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object")));
+                && IsBatchSlotTarget(component.ContainerTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object")));
 
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(overrideTexture.Members["WrapModeU"])).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(overrideTexture.Members["WrapModeV"])).Value);
@@ -690,7 +690,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             && canonicalSlot.Locator == expected;
     }
 
-    private static bool IsPlannedSlotTarget(PlannedSlotTargetReference target, BatchPlanSlotLocator expected)
+    private static bool IsBatchSlotTarget(PlannedSlotTargetReference target, BatchPlanSlotLocator expected)
     {
         return target is PlannedSlotTargetReference.BatchSlotTarget plannedSlot
             && plannedSlot.Locator == expected;
@@ -712,25 +712,22 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
     private static Member ToMember(PlannedMember member)
     {
-        return member switch
-        {
-            PlannedLiteralMember literal => literal.Value,
-            PlannedElementReferenceMember reference => new Reference
+        return member.Match(
+            literal: static literal => literal,
+            reference: reference => new Reference
             {
-                TargetID = ResolveTargetId(reference.Target),
+                TargetID = ResolveTargetId(reference),
             },
-            PlannedAddressableFieldMember field => field.Value,
-            PlannedAddressableReferenceMember reference => new Reference
+            addressableField: static field => field.Value,
+            addressableReference: (identity, target) => new Reference
             {
-                ID = ToPlannedTargetId(reference.Identity),
-                TargetID = ResolveTargetId(reference.Target),
+                ID = ToPlannedTargetId(identity),
+                TargetID = ResolveTargetId(target),
             },
-            PlannedSyncListMember syncList => new SyncList
+            list: elements => new SyncList
             {
-                Elements = syncList.Elements.Select(ToMember).ToList(),
-            },
-            _ => throw new InvalidOperationException($"Unsupported planned member type '{member.GetType().Name}'."),
-        };
+                Elements = elements.Select(ToMember).ToList(),
+            });
     }
 
     private static BatchPlanSlotLocator FindAssetSlotIdentity(PlannedBatchEmission batchPlan, string slotName)
@@ -746,9 +743,9 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         return target.Match(
             static canonicalSlot => canonicalSlot.Value,
             static canonicalComponent => canonicalComponent.Value,
-            ToPlannedTargetId,
-            ToPlannedTargetId,
-            ToPlannedTargetId);
+            static plannedSlot => ToPlannedTargetId(plannedSlot),
+            static plannedComponent => ToPlannedTargetId(plannedComponent),
+            static plannedField => ToPlannedTargetId(plannedField));
     }
 
     private static string ToPlannedTargetId(BatchPlanSlotLocator locator)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -136,11 +136,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchSlotEmission meshAssetSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object", StringComparison.Ordinal)
-                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
+                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         PlannedBatchSlotEmission presentationSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object", StringComparison.Ordinal)
-                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("lod-slot")));
+                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("lod-slot")));
         PlannedBatchSlotEmission heightMapSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object_terrain-grid", StringComparison.Ordinal));
@@ -164,14 +164,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshCollider", StringComparison.Ordinal));
 
         Assert.Equal(new ResoniteSlotLocator("asset-lod-slot"), AssertCanonical(meshAssetSlot.ParentTarget));
-        Assert.False(IsPlanned(meshAssetSlot.ParentTarget));
         Assert.Equal(new ResoniteSlotLocator("asset-lod-slot"), AssertCanonical(heightMapSlot.ParentTarget));
-        Assert.False(IsPlanned(heightMapSlot.ParentTarget));
         Assert.Equal(presentationSlot.Identity, AssertPlanned(gridMesh.ContainerTarget));
         Assert.Equal(presentationSlot.Identity, AssertPlanned(pointsGradientDriver.ContainerTarget));
         Assert.Equal(presentationSlot.Identity, AssertPlanned(pointsProgressDriver.ContainerTarget));
         Assert.Equal(heightMapSlot.Identity, AssertPlanned(heightTexture.ContainerTarget));
-        Assert.True(IsPlanned(heightTexture.ContainerTarget));
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(heightTexture.Members["WrapModeU"])).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(heightTexture.Members["WrapModeV"])).Value);
         Assert.Equal("Point", Assert.IsType<Field_Nullable_Enum>(ToMember(heightTexture.Members["FilterMode"])).Value);
@@ -380,14 +377,14 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Reference dedicatedMaterialReference = Assert.IsType<Reference>(materials.Elements[1]);
         PlannedBatchSlotEmission dedicatedMaterialSlot = Assert.Single(
             batchPlan.SlotEmissions,
-            slot => IsPlanned(slot.ParentTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object"))
+            slot => IsPlannedSlotTarget(slot.ParentTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object"))
                 && string.Equals(slot.SlotName, "material-000-pbs-uv-uv", StringComparison.Ordinal));
         PlannedBatchComponentEmission dedicatedMaterialComponent = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal));
         PlannedBatchComponentEmission albedoTexture = Assert.Single(
             batchPlan.ComponentEmissions,
-            component => IsPlanned(component.ContainerTarget, dedicatedMaterialSlot.Identity)
+            component => IsPlannedSlotTarget(component.ContainerTarget, dedicatedMaterialSlot.Identity)
                 && string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
 
         Assert.Equal("existing-material-id", reusableMaterialReference.TargetID);
@@ -441,10 +438,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchSlotEmission meshAssetSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal)
-                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
+                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         Assert.DoesNotContain(
             batchPlan.SlotEmissions,
-            slot => IsPlanned(slot.ParentTarget, meshAssetSlot.Identity)
+            slot => IsPlannedSlotTarget(slot.ParentTarget, meshAssetSlot.Identity)
                 && !string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal));
 
         PlannedBatchComponentEmission materialComponent = Assert.Single(
@@ -526,11 +523,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchSlotEmission assetSlot = Assert.Single(
             batchPlan.SlotEmissions,
             slot => string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal)
-                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
+                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         PlannedBatchComponentEmission overrideTexture = Assert.Single(
             batchPlan.ComponentEmissions,
             component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && IsPlanned(component.ContainerTarget, assetSlot.Identity));
+                && IsPlannedSlotTarget(component.ContainerTarget, assetSlot.Identity));
 
         Assert.Equal("shared-material-id", materialReference.TargetID);
         Assert.Equal(ToPlannedTargetId(propertyBlockComponent.Identity), propertyBlockReference.TargetID);
@@ -573,7 +570,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchComponentEmission overrideTexture = Assert.Single(
             batchPlan.ComponentEmissions,
             component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && IsPlanned(component.ContainerTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object")));
+                && IsPlannedSlotTarget(component.ContainerTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object")));
 
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(overrideTexture.Members["WrapModeU"])).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(overrideTexture.Members["WrapModeV"])).Value);
@@ -684,29 +681,24 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
     private static BatchPlanSlotLocator AssertPlanned(PlannedSlotTargetReference target)
     {
-        return Assert.IsType<PlannedSlotTargetReference.PlannedSlotTarget>(target).Locator;
+        return Assert.IsType<PlannedSlotTargetReference.BatchSlotTarget>(target).Locator;
+    }
+
+    private static bool IsCanonicalSlotTarget(PlannedSlotTargetReference target, ResoniteSlotLocator expected)
+    {
+        return target is PlannedSlotTargetReference.CanonicalSlotTarget canonical
+            && canonical.Locator == expected;
+    }
+
+    private static bool IsPlannedSlotTarget(PlannedSlotTargetReference target, BatchPlanSlotLocator expected)
+    {
+        return target is PlannedSlotTargetReference.BatchSlotTarget planned
+            && planned.Locator == expected;
     }
 
     private static BatchPlanFieldLocator AssertPlannedField(PlannedWorldElementReference target)
     {
-        return Assert.IsType<PlannedWorldElementReference.PlannedFieldElement>(target).Locator;
-    }
-
-    private static bool IsCanonical(PlannedSlotTargetReference target, ResoniteSlotLocator locator)
-    {
-        return target is PlannedSlotTargetReference.CanonicalSlotTarget canonicalSlot
-            && canonicalSlot.Locator == locator;
-    }
-
-    private static bool IsPlanned(PlannedSlotTargetReference target)
-    {
-        return target is PlannedSlotTargetReference.PlannedSlotTarget;
-    }
-
-    private static bool IsPlanned(PlannedSlotTargetReference target, BatchPlanSlotLocator locator)
-    {
-        return target is PlannedSlotTargetReference.PlannedSlotTarget plannedSlot
-            && plannedSlot.Locator == locator;
+        return Assert.IsType<PlannedWorldElementReference.BatchFieldElement>(target).Locator;
     }
 
     private static void AssertGradientPoint(Member member, float expectedPosition, int expectedX, int expectedY)
@@ -746,20 +738,21 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         return Assert.Single(
             batchPlan.SlotEmissions,
             slot => string.Equals(slot.SlotName, slotName, StringComparison.Ordinal)
-                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot"))).Identity;
+                && slot.ParentTarget is PlannedSlotTargetReference.CanonicalSlotTarget
+                {
+                    Locator: { } locator,
+                }
+                && locator == new ResoniteSlotLocator("asset-lod-slot")).Identity;
     }
 
     private static string? ResolveTargetId(PlannedWorldElementReference target)
     {
-        return target switch
-        {
-            PlannedWorldElementReference.CanonicalSlotElement canonicalSlot => canonicalSlot.Locator.Value,
-            PlannedWorldElementReference.CanonicalComponentElement canonicalComponent => canonicalComponent.Locator.Value,
-            PlannedWorldElementReference.PlannedSlotElement plannedSlot => ToPlannedTargetId(plannedSlot.Locator),
-            PlannedWorldElementReference.PlannedComponentElement plannedComponent => ToPlannedTargetId(plannedComponent.Locator),
-            PlannedWorldElementReference.PlannedFieldElement plannedField => ToPlannedTargetId(plannedField.Locator),
-            _ => throw new InvalidOperationException("Unsupported planned world element reference."),
-        };
+        return target.Match(
+            static canonicalSlot => canonicalSlot.Value,
+            static canonicalComponent => canonicalComponent.Value,
+            ToPlannedTargetId,
+            ToPlannedTargetId,
+            ToPlannedTargetId);
     }
 
     private static string ToPlannedTargetId(BatchPlanSlotLocator locator)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -676,32 +676,29 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
     private static ResoniteSlotLocator AssertCanonical(PlannedSlotTargetReference target)
     {
-        Assert.Equal(PlannedSlotTargetReferenceKind.CanonicalSlot, target.Kind);
-        return target.CanonicalSlotLocator;
+        return Assert.IsType<PlannedSlotTargetReference.CanonicalSlotTarget>(target).Locator;
     }
 
     private static BatchPlanSlotLocator AssertPlanned(PlannedSlotTargetReference target)
     {
-        Assert.Equal(PlannedSlotTargetReferenceKind.PlannedSlot, target.Kind);
-        return target.PlannedSlotLocator;
+        return Assert.IsType<PlannedSlotTargetReference.BatchSlotTarget>(target).Locator;
     }
 
     private static bool IsCanonicalSlotTarget(PlannedSlotTargetReference target, ResoniteSlotLocator expected)
     {
-        return target.Kind == PlannedSlotTargetReferenceKind.CanonicalSlot
-            && target.CanonicalSlotLocator == expected;
+        return target is PlannedSlotTargetReference.CanonicalSlotTarget canonicalSlot
+            && canonicalSlot.Locator == expected;
     }
 
     private static bool IsPlannedSlotTarget(PlannedSlotTargetReference target, BatchPlanSlotLocator expected)
     {
-        return target.Kind == PlannedSlotTargetReferenceKind.PlannedSlot
-            && target.PlannedSlotLocator == expected;
+        return target is PlannedSlotTargetReference.BatchSlotTarget plannedSlot
+            && plannedSlot.Locator == expected;
     }
 
     private static BatchPlanFieldLocator AssertPlannedField(PlannedWorldElementReference target)
     {
-        Assert.Equal(PlannedWorldElementReferenceKind.PlannedField, target.Kind);
-        return target.PlannedFieldLocator;
+        return Assert.IsType<PlannedWorldElementReference.BatchFieldElement>(target).Locator;
     }
 
     private static void AssertGradientPoint(Member member, float expectedPosition, int expectedX, int expectedY)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -676,29 +676,32 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
     private static ResoniteSlotLocator AssertCanonical(PlannedSlotTargetReference target)
     {
-        return Assert.IsType<PlannedSlotTargetReference.CanonicalSlotTarget>(target).Locator;
+        Assert.Equal(PlannedSlotTargetReferenceKind.CanonicalSlot, target.Kind);
+        return target.CanonicalSlotLocator;
     }
 
     private static BatchPlanSlotLocator AssertPlanned(PlannedSlotTargetReference target)
     {
-        return Assert.IsType<PlannedSlotTargetReference.BatchSlotTarget>(target).Locator;
+        Assert.Equal(PlannedSlotTargetReferenceKind.PlannedSlot, target.Kind);
+        return target.PlannedSlotLocator;
     }
 
     private static bool IsCanonicalSlotTarget(PlannedSlotTargetReference target, ResoniteSlotLocator expected)
     {
-        return target is PlannedSlotTargetReference.CanonicalSlotTarget canonical
-            && canonical.Locator == expected;
+        return target.Kind == PlannedSlotTargetReferenceKind.CanonicalSlot
+            && target.CanonicalSlotLocator == expected;
     }
 
     private static bool IsPlannedSlotTarget(PlannedSlotTargetReference target, BatchPlanSlotLocator expected)
     {
-        return target is PlannedSlotTargetReference.BatchSlotTarget planned
-            && planned.Locator == expected;
+        return target.Kind == PlannedSlotTargetReferenceKind.PlannedSlot
+            && target.PlannedSlotLocator == expected;
     }
 
     private static BatchPlanFieldLocator AssertPlannedField(PlannedWorldElementReference target)
     {
-        return Assert.IsType<PlannedWorldElementReference.BatchFieldElement>(target).Locator;
+        Assert.Equal(PlannedWorldElementReferenceKind.PlannedField, target.Kind);
+        return target.PlannedFieldLocator;
     }
 
     private static void AssertGradientPoint(Member member, float expectedPosition, int expectedX, int expectedY)
@@ -738,11 +741,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         return Assert.Single(
             batchPlan.SlotEmissions,
             slot => string.Equals(slot.SlotName, slotName, StringComparison.Ordinal)
-                && slot.ParentTarget is PlannedSlotTargetReference.CanonicalSlotTarget
-                {
-                    Locator: { } locator,
-                }
-                && locator == new ResoniteSlotLocator("asset-lod-slot")).Identity;
+                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot"))).Identity;
     }
 
     private static string? ResolveTargetId(PlannedWorldElementReference target)

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceCollectionExtensionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceCollectionExtensionsTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Tests.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.UseCases;
 
@@ -16,10 +17,8 @@ public sealed class PlateauImportServiceCollectionExtensionsTests
     [Fact]
     public async Task AddImportedSceneSourceServicesUsesCustomComposerWhenFactoryCreatesSourceFromReader()
     {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDataset"));
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            cityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDataset"));
         ImportedSceneSourceSnapshot expectedReadResult = new(
             new ImportedSceneSourceDataset(
                 new StubDatasetContentSource(request.CityGmlLocalSourcePath),

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
@@ -613,9 +613,9 @@ public sealed class PlateauImportServiceTests
                 : Assert.IsType<ValidatedLocalDatasetLocation>(resolvedRequest.DemTextureSource);
             return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(
                 request,
-                workRoot,
                 localSource,
-                localDemTextureSource));
+                localDemTextureSource,
+                workRoot));
         }
     }
 

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
@@ -61,11 +61,8 @@ public sealed class PlateauImportServiceTests
         ImportExecutionResult result = await service.ExecuteAsync(rawRequest, workRoot.Path);
 
         Assert.Equal(Path.Combine(workRoot.Path, "tokyo23ku"), datasetSourceResolver.LastWorkRoot);
-        Assert.NotNull(sceneSink.ConnectedRequest);
-        Assert.Equal("tokyo23ku", sceneSink.ConnectedRequest!.Dataset);
-        Assert.Equal("53394525", sceneSink.ConnectedRequest.MeshCode);
-        Assert.Equal(rawSourceUri, sceneSink.ConnectedRequest.CityGmlServerUri);
-        Assert.Equal(["bldg"], sceneSink.ConnectedRequest.PackageNames);
+        Assert.Equal("tokyo23ku", sceneSink.ConnectedDataset);
+        Assert.Equal("53394525", sceneSink.ConnectedMeshCode);
         Assert.NotNull(importedSceneSourceFactory.LastRequest);
         Assert.Equal("tokyo23ku", importedSceneSourceFactory.LastRequest!.Dataset);
         Assert.Equal("53394525", importedSceneSourceFactory.LastRequest.MeshCode);
@@ -73,7 +70,6 @@ public sealed class PlateauImportServiceTests
         Assert.Equal(["bldg"], importedSceneSourceFactory.LastRequest.PackageNames);
         Assert.NotNull(sceneSink.BeginRequest);
         Assert.Equal(resolvedSourcePath, sceneSink.BeginRequest!.Metadata.Request.CityGmlLocalSourcePath);
-        Assert.Equal(resolvedSourcePath, sceneSink.BeginRequest.ResolvedSourcePath);
         Assert.Equal(Path.Combine(workRoot.Path, "tokyo23ku"), sceneSink.BeginRequest.WorkRoot);
         Assert.Equal(["bldg"], sceneSink.BeginRequest.Metadata.SourceDataset.PackageNames);
         Assert.Equal(readResult.DocumentSet.RelativeSourceFiles, sceneSink.BeginRequest.Metadata.SourceDataset.SourceFiles);
@@ -541,7 +537,9 @@ public sealed class PlateauImportServiceTests
     {
         public int ExecuteCallCount { get; private set; }
 
-        public PlateauImportRequest? ConnectedRequest { get; private set; }
+        public string? ConnectedDataset { get; private set; }
+
+        public string? ConnectedMeshCode { get; private set; }
 
         public SceneImportRequest? BeginRequest { get; private set; }
 
@@ -561,7 +559,8 @@ public sealed class PlateauImportServiceTests
             CancellationToken cancellationToken = default)
         {
             ExecuteCallCount++;
-            ConnectedRequest = plan.NormalizedRequest;
+            ConnectedDataset = plan.SceneImportRequest.Metadata.Request.Dataset;
+            ConnectedMeshCode = plan.SceneImportRequest.Metadata.Request.MeshCode;
             BeginRequest = plan.SceneImportRequest;
             OnExecuteBeforeRead?.Invoke(plan);
             await foreach (ImportedObjectUnit objectUnit in objectUnits.WithCancellation(cancellationToken))

--- a/tests/PlateauResoniteLink.Tests/UseCases/SceneImportExecutionPlanTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/SceneImportExecutionPlanTests.cs
@@ -25,11 +25,12 @@ public sealed class SceneImportExecutionPlanTests
         string resolvedSourcePath = RemoteDatasetResourceLayout.GetRemoteResourcePath(
             workRoot,
             remoteCityGmlUri,
-            "source-archive");
+            ResolvedLocalPlateauImportRequest.RemoteCityGmlResourcePrefix);
         ResolvedLocalPlateauImportRequest resolvedRequest = ResolvedLocalPlateauImportRequest.Create(
             validatedRequest,
             new ValidatedLocalDatasetLocation(resolvedSourcePath),
-            demTextureSource: null);
+            demTextureSource: null,
+            workRoot);
         ImportedSceneMetadata metadata = CreateMetadata(resolvedRequest.ToImportRequest());
 
         SceneImportExecutionPlan plan = SceneImportExecutionPlan.Create(

--- a/tests/PlateauResoniteLink.Tests/UseCases/SceneImportExecutionPlanTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/SceneImportExecutionPlanTests.cs
@@ -11,141 +11,58 @@ namespace PlateauResoniteLink.Tests.UseCases;
 public sealed class SceneImportExecutionPlanTests
 {
     [Fact]
-    public void Constructor_AllowsResolvedLocalCityGmlSourceForRemoteInput()
+    public void CreateCarriesResolvedLocalRequest()
     {
         string workRoot = "work";
         Uri remoteCityGmlUri = new("https://example.test/tokyo23ku.zip");
-        PlateauImportRequest normalizedRequest = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Remote(remoteCityGmlUri),
-            PackageNames: ["bldg"]);
-        PlateauImportRequest resolvedRequest = normalizedRequest with
-        {
-            CityGmlSource = DatasetLocation.Local(
-                RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, remoteCityGmlUri, "source-archive")),
-        };
+        ValidatedPlateauImportRequest validatedRequest = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlSource: DatasetLocation.Remote(remoteCityGmlUri),
+                PackageNames: ["bldg"]));
+        string resolvedSourcePath = RemoteDatasetResourceLayout.GetRemoteResourcePath(
+            workRoot,
+            remoteCityGmlUri,
+            "source-archive");
+        ResolvedLocalPlateauImportRequest resolvedRequest = ResolvedLocalPlateauImportRequest.Create(
+            validatedRequest,
+            new ValidatedLocalDatasetLocation(resolvedSourcePath),
+            demTextureSource: null);
+        ImportedSceneMetadata metadata = CreateMetadata(resolvedRequest.ToImportRequest());
 
-        SceneImportExecutionPlan plan = new(
-            normalizedRequest,
+        SceneImportExecutionPlan plan = SceneImportExecutionPlan.Create(
             resolvedRequest,
-            new SceneImportRequest(CreateMetadata(resolvedRequest), "resolved-source", workRoot, CommonMaterialCatalog.Create()));
+            metadata,
+            workRoot,
+            CommonMaterialCatalog.Create());
 
-        Assert.Equal(normalizedRequest, plan.NormalizedRequest);
-        Assert.Equal(resolvedRequest, plan.ResolvedRequest);
-        Assert.Equal(resolvedRequest.CityGmlLocalSourcePath, plan.SceneImportRequest.Metadata.Request.CityGmlLocalSourcePath);
+        Assert.Equal(metadata.SourceDataset, plan.SceneImportRequest.Metadata.SourceDataset);
+        Assert.Equal(resolvedSourcePath, plan.SceneImportRequest.Metadata.Request.CityGmlLocalSourcePath);
     }
 
     [Fact]
-    public void Constructor_RejectsDifferentRemoteCityGmlSource()
-    {
-        PlateauImportRequest normalizedRequest = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Remote(new Uri("https://example.test/tokyo23ku.zip")),
-            PackageNames: ["bldg"]);
-        PlateauImportRequest mismatchedRequest = normalizedRequest with
-        {
-            CityGmlSource = DatasetLocation.Remote(new Uri("https://example.test/other.zip")),
-        };
-
-        Assert.Throws<ArgumentException>(
-            () => new SceneImportExecutionPlan(
-                normalizedRequest,
-                mismatchedRequest,
-                new SceneImportRequest(CreateMetadata(mismatchedRequest), "resolved-source", "work", CommonMaterialCatalog.Create())));
-    }
-
-    [Fact]
-    public void Constructor_RejectsDifferentLocalDemTextureSource()
-    {
-        PlateauImportRequest normalizedRequest = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("raw-source"),
-            DemTextureSource: DatasetLocation.Local("ortho-a.tif"),
-            PackageNames: ["bldg"]);
-        PlateauImportRequest mismatchedRequest = normalizedRequest with
-        {
-            DemTextureSource = DatasetLocation.Local("ortho-b.tif"),
-        };
-
-        Assert.Throws<ArgumentException>(
-            () => new SceneImportExecutionPlan(
-                normalizedRequest,
-                mismatchedRequest,
-                new SceneImportRequest(CreateMetadata(mismatchedRequest), "resolved-source", "work", CommonMaterialCatalog.Create())));
-    }
-
-    [Fact]
-    public void Constructor_RejectsDifferentTerrainMeshMode()
-    {
-        PlateauImportRequest normalizedRequest = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("raw-source"),
-            TerrainMeshMode: TerrainMeshMode.Static,
-            PackageNames: ["bldg"]);
-        PlateauImportRequest mismatchedRequest = normalizedRequest with
-        {
-            TerrainMeshMode = TerrainMeshMode.Dynamic,
-        };
-
-        Assert.Throws<ArgumentException>(
-            () => new SceneImportExecutionPlan(
-                normalizedRequest,
-                mismatchedRequest,
-                new SceneImportRequest(CreateMetadata(mismatchedRequest), "resolved-source", "work", CommonMaterialCatalog.Create())));
-    }
-
-    [Fact]
-    public void Constructor_AllowsResolvedLocalDemTextureSourceForRemoteInput()
+    public void CreateRejectsMetadataRequestThatDoesNotMatchResolvedLocalRequest()
     {
         string workRoot = "work";
-        Uri remoteDemTextureUri = new("https://example.test/ortho-a.tif");
-        PlateauImportRequest normalizedRequest = new(
+        ResolvedLocalPlateauImportRequest resolvedRequest = ResolvedLocalPlateauImportRequestTestFactory.Create(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("raw-source"),
-            DemTextureSource: DatasetLocation.Remote(remoteDemTextureUri),
-            PackageNames: ["bldg"]);
-        PlateauImportRequest resolvedRequest = normalizedRequest with
-        {
-            DemTextureSource = DatasetLocation.Local(
-                RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, remoteDemTextureUri, "source-ortho")),
-        };
+            CityGmlLocalSourcePath: "/tmp/plateau");
+        ImportedSceneMetadata metadata = CreateMetadata(
+            resolvedRequest.ToImportRequest() with
+            {
+                MeshCode = "53394526",
+            });
 
-        SceneImportExecutionPlan plan = new(
-            normalizedRequest,
-            resolvedRequest,
-            new SceneImportRequest(CreateMetadata(resolvedRequest), "resolved-source", workRoot, CommonMaterialCatalog.Create()));
-
-        Assert.Equal(
-            RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, remoteDemTextureUri, "source-ortho"),
-            plan.SceneImportRequest.Metadata.Request.DemTextureLocalSourcePath);
-    }
-
-    [Fact]
-    public void Constructor_RejectsResolvedLocalDemTextureSourceThatDoesNotMatchExpectedRemoteMaterializationPath()
-    {
-        string workRoot = "work";
-        Uri remoteDemTextureUri = new("https://example.test/ortho-a.tif");
-        PlateauImportRequest normalizedRequest = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("raw-source"),
-            DemTextureSource: DatasetLocation.Remote(remoteDemTextureUri),
-            PackageNames: ["bldg"]);
-        PlateauImportRequest resolvedRequest = normalizedRequest with
-        {
-            DemTextureSource = DatasetLocation.Local("unexpected-local-ortho.tif"),
-        };
-
-        Assert.Throws<ArgumentException>(
-            () => new SceneImportExecutionPlan(
-                normalizedRequest,
+        ArgumentException exception = Assert.Throws<ArgumentException>(
+            () => SceneImportExecutionPlan.Create(
                 resolvedRequest,
-                new SceneImportRequest(CreateMetadata(resolvedRequest), "resolved-source", workRoot, CommonMaterialCatalog.Create())));
+                metadata,
+                workRoot,
+                CommonMaterialCatalog.Create()));
+
+        Assert.Equal("metadataRequest", exception.ParamName);
     }
 
     private static ImportedSceneMetadata CreateMetadata(PlateauImportRequest request)

--- a/tests/PlateauResoniteLink.Tests/UseCases/SceneImportExecutionPlanTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/SceneImportExecutionPlanTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Tests.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.UseCases;
 
@@ -46,9 +47,9 @@ public sealed class SceneImportExecutionPlanTests
     {
         string workRoot = "work";
         ResolvedLocalPlateauImportRequest resolvedRequest = ResolvedLocalPlateauImportRequestTestFactory.Create(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau");
+            dataset: "tokyo23ku",
+            meshCode: "53394525",
+            cityGmlLocalSourcePath: "/tmp/plateau");
         ImportedSceneMetadata metadata = CreateMetadata(
             resolvedRequest.ToImportRequest() with
             {


### PR DESCRIPTION
## Summary
- make scene import plans accept only resolved local import requests instead of parallel normalized/resolved raw requests
- remove scene-plan runtime request consistency checks and the duplicate resolved source path field
- pass a concrete live-send connection request instead of retaining the whole normalized import request downstream

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- canonical scene dump for plateau-13213-higashimurayama-shi-2020 mesh 53395325 dem,bldg grid geotiff; no diff from baseline