### PR TITLE
Require validated local request factory

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -43,7 +44,7 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
             resourcePrefix: "source-archive",
             invalidateLocalFileCache: true,
             cancellationToken);
-        ValidatedDatasetLocation? resolvedDemTextureSource = await ResolveOptionalRemoteDatasetLocationAsync(
+        ValidatedLocalDatasetLocation? resolvedDemTextureSource = await ResolveOptionalRemoteDatasetLocationAsync(
             request.DemTextureSource,
             workRoot,
             resourcePrefix: "source-ortho",
@@ -63,30 +64,51 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
         bool invalidateLocalFileCache,
         CancellationToken cancellationToken)
     {
-        ValidatedDatasetLocation? resolvedSource = await ResolveOptionalRemoteDatasetLocationAsync(
-            source,
-            workRoot,
-            resourcePrefix,
-            invalidateLocalFileCache,
-            cancellationToken);
-        return resolvedSource is ValidatedLocalDatasetLocation localSource
-            ? localSource
-            : throw new InvalidOperationException("The normalized CityGML source must resolve to a local dataset location.");
+        return source switch
+        {
+            ValidatedLocalDatasetLocation localSource => localSource,
+            ValidatedRemoteDatasetLocation remoteSource => await ResolveRemoteDatasetLocationAsync(
+                remoteSource,
+                workRoot,
+                resourcePrefix,
+                invalidateLocalFileCache,
+                cancellationToken),
+            _ => throw new UnreachableException("Validated dataset locations are restricted to local and remote locations."),
+        };
     }
 
-    private async Task<ValidatedDatasetLocation?> ResolveOptionalRemoteDatasetLocationAsync(
+    private async Task<ValidatedLocalDatasetLocation?> ResolveOptionalRemoteDatasetLocationAsync(
         ValidatedDatasetLocation? source,
         string workRoot,
         string resourcePrefix,
         bool invalidateLocalFileCache,
         CancellationToken cancellationToken)
     {
-        if (source is null || source is ValidatedLocalDatasetLocation)
+        if (source is null)
         {
-            return source;
+            return null;
         }
 
-        ValidatedRemoteDatasetLocation remoteSource = (ValidatedRemoteDatasetLocation)source;
+        return source switch
+        {
+            ValidatedLocalDatasetLocation localSource => localSource,
+            ValidatedRemoteDatasetLocation remoteSource => await ResolveRemoteDatasetLocationAsync(
+                remoteSource,
+                workRoot,
+                resourcePrefix,
+                invalidateLocalFileCache,
+                cancellationToken),
+            _ => throw new UnreachableException("Validated dataset locations are restricted to local and remote locations."),
+        };
+    }
+
+    private async Task<ValidatedLocalDatasetLocation> ResolveRemoteDatasetLocationAsync(
+        ValidatedRemoteDatasetLocation remoteSource,
+        string workRoot,
+        string resourcePrefix,
+        bool invalidateLocalFileCache,
+        CancellationToken cancellationToken)
+    {
         string resourcePath = RemoteDatasetResourceLayout.GetRemoteResourcePath(
             workRoot,
             remoteSource.ServerUri,

--- a/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 using PlateauResoniteLink.Domain.Importing;
 
@@ -8,45 +7,12 @@ namespace PlateauResoniteLink.Application.Importing;
 
 public sealed record ResolvedLocalPlateauImportRequest
 {
-    private readonly ValidatedDatasetLocation? demTextureSource;
-
-    public ResolvedLocalPlateauImportRequest(
-        string Dataset,
-        string MeshCode,
-        string CityGmlLocalSourcePath,
-        DatasetLocation? DemTextureSource = null,
-        IReadOnlyList<string>? PackageNames = null,
-        IReadOnlySet<int>? GlobalExcludeLodLevels = null,
-        IReadOnlyDictionary<string, IReadOnlySet<int>>? ExcludeLodLevelsByPackage = null,
-        IReadOnlyDictionary<string, string>? PackagePatterns = null,
-        bool IncludeMarkingAlways = true,
-        TerrainMeshMode TerrainMeshMode = TerrainMeshMode.Static,
-        double TerrainGridMetersPerVertex = 2.0,
-        int TerrainGridMaxResolution = 1024)
-    {
-        ValidatedLocalDatasetLocation cityGmlSource = new(RequireNonEmpty(CityGmlLocalSourcePath, nameof(CityGmlLocalSourcePath)));
-        ValidatedLocalDatasetLocation? validatedDemTextureSource = ToResolvedDemTextureSource(DemTextureSource, nameof(DemTextureSource));
-        ValidatedRequest = CreateResolvedRequest(
-            Dataset,
-            MeshCode,
-            cityGmlSource,
-            validatedDemTextureSource,
-            PackageNames,
-            GlobalExcludeLodLevels,
-            ExcludeLodLevelsByPackage,
-            PackagePatterns,
-            IncludeMarkingAlways,
-            TerrainMeshMode,
-            TerrainGridMetersPerVertex,
-            TerrainGridMaxResolution);
-        CityGmlSource = cityGmlSource;
-        demTextureSource = validatedDemTextureSource;
-    }
+    private readonly ValidatedLocalDatasetLocation? demTextureSource;
 
     private ResolvedLocalPlateauImportRequest(
         ValidatedPlateauImportRequest request,
         ValidatedLocalDatasetLocation cityGmlSource,
-        ValidatedDatasetLocation? demTextureSource)
+        ValidatedLocalDatasetLocation? demTextureSource)
     {
         ValidatedRequest = request with
         {
@@ -104,156 +70,14 @@ public sealed record ResolvedLocalPlateauImportRequest
         }).ToImportRequest();
     }
 
-    internal static ResolvedLocalPlateauImportRequest Create(
+    public static ResolvedLocalPlateauImportRequest Create(
         ValidatedPlateauImportRequest request,
         ValidatedLocalDatasetLocation cityGmlSource,
-        ValidatedDatasetLocation? demTextureSource)
+        ValidatedLocalDatasetLocation? demTextureSource)
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(cityGmlSource);
-        if (demTextureSource is ValidatedRemoteDatasetLocation)
-        {
-            throw new ArgumentException("Resolved local import requests require DEM texture sources to be local when specified.", nameof(demTextureSource));
-        }
 
         return new ResolvedLocalPlateauImportRequest(request, cityGmlSource, demTextureSource);
-    }
-
-    private static ValidatedPlateauImportRequest CreateResolvedRequest(
-        string dataset,
-        string meshCode,
-        ValidatedLocalDatasetLocation cityGmlSource,
-        ValidatedDatasetLocation? demTextureSource,
-        IReadOnlyList<string>? packageNames,
-        IReadOnlySet<int>? globalExcludeLodLevels,
-        IReadOnlyDictionary<string, IReadOnlySet<int>>? excludeLodLevelsByPackage,
-        IReadOnlyDictionary<string, string>? packagePatterns,
-        bool includeMarkingAlways,
-        TerrainMeshMode terrainMeshMode,
-        double terrainGridMetersPerVertex,
-        int terrainGridMaxResolution)
-    {
-        string requiredDataset = RequireNonEmpty(dataset, nameof(dataset));
-        string requiredMeshCode = RequireNonEmpty(meshCode, nameof(meshCode));
-        string[]? normalizedPackageNames = NormalizePackageNames(packageNames);
-        Dictionary<string, IReadOnlySet<int>>? normalizedPackageExclusions = NormalizePackageExclusionMap(excludeLodLevelsByPackage);
-        Dictionary<string, string>? normalizedPackagePatterns = NormalizePackagePatternMap(packagePatterns);
-        if (!MeshCodeRequestSyntax.TryCreateSelectionRegex(requiredMeshCode, out Regex? meshCodePattern, out string? meshCodeError))
-        {
-            throw new ArgumentException(meshCodeError, nameof(meshCode));
-        }
-
-        meshCodePattern ??= new Regex(
-            $@"\A(?:{Regex.Escape(requiredMeshCode)})\z",
-            RegexOptions.Compiled | RegexOptions.CultureInvariant,
-            TimeSpan.FromSeconds(1));
-
-        return new ValidatedPlateauImportRequest(
-            requiredDataset,
-            requiredMeshCode,
-            meshCodePattern,
-            cityGmlSource,
-            demTextureSource,
-            normalizedPackageNames,
-            globalExcludeLodLevels,
-            normalizedPackageExclusions,
-            normalizedPackagePatterns,
-            includeMarkingAlways,
-            terrainMeshMode,
-            terrainGridMetersPerVertex,
-            terrainGridMaxResolution);
-    }
-
-    private static ValidatedLocalDatasetLocation? ToResolvedDemTextureSource(
-        DatasetLocation? source,
-        string parameterName)
-    {
-        return source switch
-        {
-            null => null,
-            LocalDatasetLocation localSource => new ValidatedLocalDatasetLocation(RequireNonEmpty(localSource.LocalSourcePath, parameterName)),
-            RemoteDatasetLocation => throw new ArgumentException("Resolved local import requests require DEM texture sources to be local when specified.", parameterName),
-            _ => throw new ArgumentException("Unsupported dataset source location.", parameterName),
-        };
-    }
-
-    private static string[]? NormalizePackageNames(IReadOnlyList<string>? packageNames)
-    {
-        if (packageNames is null)
-        {
-            return null;
-        }
-
-        if (packageNames.Count == 0)
-        {
-            throw new ArgumentException("At least one package name is required when packages are specified.", nameof(packageNames));
-        }
-
-        return PlateauPackageCatalog.NormalizeRequestedPackageNames(packageNames);
-    }
-
-    private static Dictionary<string, IReadOnlySet<int>>? NormalizePackageExclusionMap(
-        IReadOnlyDictionary<string, IReadOnlySet<int>>? exclusionsByPackage)
-    {
-        if (exclusionsByPackage is null)
-        {
-            return null;
-        }
-
-        Dictionary<string, IReadOnlySet<int>> normalized = new(StringComparer.OrdinalIgnoreCase);
-        foreach ((string packageName, IReadOnlySet<int> excludedLods) in exclusionsByPackage)
-        {
-            string normalizedPackageName = NormalizePackageMapKey(packageName, nameof(exclusionsByPackage));
-            if (!normalized.TryAdd(normalizedPackageName, excludedLods))
-            {
-                throw new ArgumentException(
-                    $"The {nameof(exclusionsByPackage)} value contains duplicate package keys after normalization: {normalizedPackageName}.",
-                    nameof(exclusionsByPackage));
-            }
-        }
-
-        return normalized;
-    }
-
-    private static Dictionary<string, string>? NormalizePackagePatternMap(
-        IReadOnlyDictionary<string, string>? patternsByPackage)
-    {
-        if (patternsByPackage is null)
-        {
-            return null;
-        }
-
-        Dictionary<string, string> normalized = new(StringComparer.OrdinalIgnoreCase);
-        foreach ((string packageName, string pattern) in patternsByPackage)
-        {
-            string normalizedPackageName = NormalizePackageMapKey(packageName, nameof(patternsByPackage));
-            if (!normalized.TryAdd(normalizedPackageName, pattern))
-            {
-                throw new ArgumentException(
-                    $"The {nameof(patternsByPackage)} value contains duplicate package keys after normalization: {normalizedPackageName}.",
-                    nameof(patternsByPackage));
-            }
-        }
-
-        return normalized;
-    }
-
-    private static string NormalizePackageMapKey(string packageName, string parameterName)
-    {
-        if (!PlateauPackageCatalog.TryNormalizePackageName(packageName, out string normalizedPackageName))
-        {
-            throw new ArgumentException(
-                $"Unsupported package '{packageName}'. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.",
-                parameterName);
-        }
-
-        return normalizedPackageName;
-    }
-
-    private static string RequireNonEmpty(string? value, string parameterName)
-    {
-        return string.IsNullOrWhiteSpace(value)
-            ? throw new ArgumentException("The value must not be empty.", parameterName)
-            : value;
     }
 }

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
@@ -4,8 +4,15 @@ using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Application.Importing;
 
-public abstract record ValidatedDatasetLocation(DatasetSourceKind SourceKind)
+public abstract record ValidatedDatasetLocation
 {
+    private protected ValidatedDatasetLocation(DatasetSourceKind sourceKind)
+    {
+        SourceKind = sourceKind;
+    }
+
+    public DatasetSourceKind SourceKind { get; }
+
     public abstract DatasetLocation ToDatasetLocation();
 }
 

--- a/tests/PlateauResoniteLink.Tests/Application/Importing/ResolvedLocalPlateauImportRequestTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/Importing/ResolvedLocalPlateauImportRequestTestFactory.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Application.Importing;
+
+internal static class ResolvedLocalPlateauImportRequestTestFactory
+{
+    public static ResolvedLocalPlateauImportRequest Create(
+        string cityGmlLocalSourcePath = "C:\\tmp\\plateau",
+        string dataset = "tokyo23ku",
+        string meshCode = "53394525",
+        IReadOnlyList<string>? packageNames = null,
+        string? demTextureLocalSourcePath = null)
+    {
+        ValidatedLocalDatasetLocation? demTextureSource = demTextureLocalSourcePath is null
+            ? null
+            : new ValidatedLocalDatasetLocation(demTextureLocalSourcePath);
+        ValidatedPlateauImportRequest request = new(
+            dataset,
+            meshCode,
+            new Regex($@"\A(?:{Regex.Escape(meshCode)})\z", RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1)),
+            new ValidatedLocalDatasetLocation(cityGmlLocalSourcePath),
+            demTextureSource,
+            packageNames);
+        return ResolvedLocalPlateauImportRequest.Create(
+            request,
+            new ValidatedLocalDatasetLocation(cityGmlLocalSourcePath),
+            demTextureSource);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Application/LocalCityGmlDocumentReaderTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/LocalCityGmlDocumentReaderTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Tests.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.Application;
 
@@ -24,12 +25,7 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: fixturePath,
-                PackageNames: ["bldg"]
-));
+            CreateResolvedRequest(fixturePath, ["bldg"]));
         ImportedSceneSourceDataset documentSet = readResult.DocumentSet;
 
         Assert.Equal(fixturePath, documentSet.DatasetSource.SourcePath);
@@ -53,12 +49,7 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: datasetSource.SourcePath,
-                PackageNames: ["dem"]
-));
+            CreateResolvedRequest(datasetSource.SourcePath, ["dem"]));
         ImportedSceneSourceDataset documentSet = readResult.DocumentSet;
 
         Assert.Equal(["udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml"], documentSet.RelativeSourceFiles);
@@ -79,12 +70,7 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: fixturePath,
-                PackageNames: ["dem", "tran"]
-));
+            CreateResolvedRequest(fixturePath, ["dem", "tran"]));
 
         GeodeticCoordinate expectedOrigin = MeshCodeBounds.TryParse("53394525")!.GetGeodeticCenter();
         Assert.Equal(["53394525"], readResult.DocumentSet.SelectedMeshCodes);
@@ -102,6 +88,15 @@ public sealed class LocalCityGmlDocumentReaderTests
             Assert.Equal(datasetSource.SourcePath, sourcePath);
             return Task.FromResult(datasetSource);
         }
+    }
+
+    private static ResolvedLocalPlateauImportRequest CreateResolvedRequest(
+        string cityGmlLocalSourcePath,
+        IReadOnlyList<string> packageNames)
+    {
+        return ResolvedLocalPlateauImportRequestTestFactory.Create(
+            cityGmlLocalSourcePath: cityGmlLocalSourcePath,
+            packageNames: packageNames);
     }
 
     private sealed class CountingDatasetContentSource(

--- a/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
@@ -1,121 +1,25 @@
-using System;
-using System.Collections.Generic;
-
 using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Tests.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.Application;
 
 public sealed class ResolvedLocalPlateauImportRequestTests
 {
     [Fact]
-    public void ConstructorNormalizesPackageNamesAtResolvedBoundary()
+    public void CreateCarriesPackageNamesFromValidatedRequest()
     {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            PackageNames: [" BLDG ", "waterbody", "bldg"]);
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            packageNames: ["bldg", "wtr"]);
 
         Assert.Equal(["bldg", "wtr"], request.PackageNames);
     }
 
     [Fact]
-    public void ConstructorRejectsEmptyPackageNames()
+    public void CreateCarriesLocalDemTextureSource()
     {
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                PackageNames: []));
-    }
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            demTextureLocalSourcePath: "C:\\tmp\\ortho.tif");
 
-    [Fact]
-    public void ConstructorRejectsUnsupportedPackageNames()
-    {
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                PackageNames: ["unknown"]));
-    }
-
-    [Fact]
-    public void ConstructorNormalizesPackageOptionMapKeysAtResolvedBoundary()
-    {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
-            {
-                [" BLDG "] = new HashSet<int> { 1 },
-                ["waterbody"] = new HashSet<int> { 2 },
-            },
-            PackagePatterns: new Dictionary<string, string>
-            {
-                [" BLDG "] = "_bldg_",
-                ["waterbody"] = "_wtr_",
-            });
-
-        Assert.Equal([1], request.ExcludeLodLevelsByPackage!["bldg"]);
-        Assert.Equal([2], request.ExcludeLodLevelsByPackage!["wtr"]);
-        Assert.Equal("_bldg_", request.PackagePatterns!["bldg"]);
-        Assert.Equal("_wtr_", request.PackagePatterns!["wtr"]);
-    }
-
-    [Fact]
-    public void ConstructorRejectsDuplicatePackageOptionMapKeysAfterNormalization()
-    {
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
-                {
-                    [" BLDG "] = new HashSet<int> { 1 },
-                    ["bldg"] = new HashSet<int> { 2 },
-                }));
-
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                PackagePatterns: new Dictionary<string, string>
-                {
-                    ["waterbody"] = "_wtr_",
-                    ["wtr"] = "_wtr_",
-                }));
-    }
-
-    [Fact]
-    public void ConstructorRejectsRemoteDemTextureSource()
-    {
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                DemTextureSource: DatasetLocation.Remote(new Uri("https://example.test/ortho.tif"))));
-    }
-
-    [Fact]
-    public void CreateRejectsRemoteDemTextureSource()
-    {
-        ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
-            new PlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlSource: DatasetLocation.Remote(new Uri("https://example.test/tokyo.zip"))));
-
-        Assert.Throws<ArgumentException>(
-            () => ResolvedLocalPlateauImportRequest.Create(
-                request,
-                new ValidatedLocalDatasetLocation("/tmp/plateau"),
-                new ValidatedRemoteDatasetLocation(new Uri("https://example.test/ortho.tif"))));
+        Assert.Equal("C:\\tmp\\ortho.tif", request.DemTextureLocalSourcePath);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
@@ -87,7 +87,10 @@ public sealed class ImportServiceFactoryTests
             CancellationToken cancellationToken = default)
         {
             ValidatedLocalDatasetLocation localSource = Assert.IsType<ValidatedLocalDatasetLocation>(request.CityGmlSource);
-            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(request, localSource, request.DemTextureSource));
+            ValidatedLocalDatasetLocation? localDemTextureSource = request.DemTextureSource is null
+                ? null
+                : Assert.IsType<ValidatedLocalDatasetLocation>(request.DemTextureSource);
+            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(request, localSource, localDemTextureSource));
         }
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
@@ -17,10 +17,7 @@ public sealed class DefaultImportedSceneSourceComposerTests
     [Fact]
     public void ComposeMapsDocumentSetBoundaryIntoImportedSceneMetadata()
     {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau");
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create();
         PlateauImportRequest importRequest = request.ToImportRequest();
 
         TerrainTextureOverlay overlay = new(
@@ -71,12 +68,9 @@ public sealed class DefaultImportedSceneSourceComposerTests
     [Fact]
     public async Task ComposedStreamingSourcePreflightValidatesExplicitDemTextureSource()
     {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            PackageNames: ["dem"],
-            DemTextureSource: DatasetLocation.Local("/tmp/plateau/ortho.tif"));
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            packageNames: ["dem"],
+            demTextureLocalSourcePath: "C:\\tmp\\plateau\\ortho.tif");
         PlateauImportRequest importRequest = request.ToImportRequest();
         ImportedSceneSourceSnapshot readResult = new(
             new ImportedSceneSourceDataset(

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceFactoryTests.cs
@@ -42,10 +42,7 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             new PassthroughImportedObjectUnitOptimizer());
         Action<string> progressReporter = _ => { };
 
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau");
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create();
 
         IImportedSceneSource result = await factory.CreateAsync(request, progressReporter);
 
@@ -76,12 +73,8 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             reader,
             composer,
             new PassthroughImportedObjectUnitOptimizer());
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            PackageNames: ["dem"]
-);
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            packageNames: ["dem"]);
 
         _ = await factory.CreateAsync(request);
 
@@ -122,12 +115,9 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             reader,
             composer,
             new PassthroughImportedObjectUnitOptimizer());
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            PackageNames: ["dem"],
-            DemTextureSource: DatasetLocation.Local("C:\\ortho\\53394525.tif"));
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            packageNames: ["dem"],
+            demTextureLocalSourcePath: "C:\\ortho\\53394525.tif");
 
         _ = await factory.CreateAsync(request);
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -68,10 +68,8 @@ public sealed class LocalCityGmlObjectProjectionTests
     {
         string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
         LocalCityGmlDocumentReader documentReader = CreateDocumentReader();
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: fixturePath);
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            cityGmlLocalSourcePath: fixturePath);
         PlateauImportRequest importRequest = request.ToImportRequest();
 
         DefaultImportedSceneSourceFactory factory = new(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -921,12 +921,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         using SceneSinkRecordingClient routedClient = new();
         DelegatingClientSession session = new(routedClient);
         await using ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(routedClient, session: session);
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDatasetParentMeshPackages"),
-            PackageNames: ["dem"]
-);
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            cityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDatasetParentMeshPackages"),
+            packageNames: ["dem"]);
         ImportedSceneSourceSnapshot readResult = await new LocalCityGmlDocumentReader(
             new DefaultPlateauDatasetContentSourceFactory(new RemoteArchiveDistributionPolicy(), new ArchiveFileLayoutPolicy()),
             new CityGmlAppearanceStoreFactory(),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -214,28 +214,22 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             throw new ArgumentException("Metadata request must include a local CityGML source path.", nameof(metadataRequest));
         }
 
-        DatasetLocation? resolvedDemTextureSource = metadataRequest.DemTextureSource;
+        ValidatedLocalDatasetLocation? resolvedDemTextureSource = metadataRequest.DemTextureLocalSourcePath is { } metadataDemTexturePath
+            ? new ValidatedLocalDatasetLocation(metadataDemTexturePath)
+            : null;
         if (normalizedRequest.DemTextureSource is not null)
         {
             string? resolvedDemTexturePath = ResolveLocalPath(normalizedRequest.DemTextureSource.ToDatasetLocation(), workDirectory, "source-ortho");
-            resolvedDemTextureSource = resolvedDemTexturePath is null
-                ? metadataRequest.DemTextureSource
-                : DatasetLocation.Local(resolvedDemTexturePath);
+            if (resolvedDemTexturePath is not null)
+            {
+                resolvedDemTextureSource = new ValidatedLocalDatasetLocation(resolvedDemTexturePath);
+            }
         }
 
-        return new ResolvedLocalPlateauImportRequest(
-            normalizedRequest.Dataset,
-            normalizedRequest.MeshCode,
-            resolvedSourcePath,
-            resolvedDemTextureSource,
-            normalizedRequest.PackageNames,
-            normalizedRequest.GlobalExcludeLodLevels,
-            normalizedRequest.ExcludeLodLevelsByPackage,
-            normalizedRequest.PackagePatterns,
-            normalizedRequest.IncludeMarkingAlways,
-            normalizedRequest.TerrainMeshMode,
-            normalizedRequest.TerrainGridMetersPerVertex,
-            normalizedRequest.TerrainGridMaxResolution);
+        return ResolvedLocalPlateauImportRequest.Create(
+            normalizedRequest,
+            new ValidatedLocalDatasetLocation(resolvedSourcePath),
+            resolvedDemTextureSource);
     }
 
     private static string? ResolveLocalPath(

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceCollectionExtensionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceCollectionExtensionsTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Tests.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.UseCases;
 
@@ -16,10 +17,8 @@ public sealed class PlateauImportServiceCollectionExtensionsTests
     [Fact]
     public async Task AddImportedSceneSourceServicesUsesCustomComposerWhenFactoryCreatesSourceFromReader()
     {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDataset"));
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            cityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDataset"));
         ImportedSceneSourceSnapshot expectedReadResult = new(
             new ImportedSceneSourceDataset(
                 new StubDatasetContentSource(request.CityGmlLocalSourcePath),

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
@@ -608,10 +608,13 @@ public sealed class PlateauImportServiceTests
             ResolveCallCount++;
             LastWorkRoot = workRoot;
             ValidatedLocalDatasetLocation localSource = Assert.IsType<ValidatedLocalDatasetLocation>(resolvedRequest.CityGmlSource);
+            ValidatedLocalDatasetLocation? localDemTextureSource = resolvedRequest.DemTextureSource is null
+                ? null
+                : Assert.IsType<ValidatedLocalDatasetLocation>(resolvedRequest.DemTextureSource);
             return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(
                 resolvedRequest,
                 localSource,
-                resolvedRequest.DemTextureSource));
+                localDemTextureSource));
         }
     }
 


### PR DESCRIPTION
## Summary
- remove the raw public `ResolvedLocalPlateauImportRequest` constructor so resolved local requests can only be created from `ValidatedPlateauImportRequest` plus validated local dataset locations
- narrow resolver output for materialized DEM texture sources to `ValidatedLocalDatasetLocation?`
- restrict `ValidatedDatasetLocation` derivation to this assembly and update tests/helpers to use validated inputs instead of revalidating raw strings at the resolved boundary

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (984 passed)
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020` mesh `53395325`, packages `dem,bldg`, grid terrain
- `git diff --no-index -- runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json runtime/windows/resonite/semantic-baselines/type-resolved-local-request-factory/current/higashi-53395325-dem-bldg-grid-geotiff.json` (no diff)