### PR TITLE
Enforce live send run contracts at construction

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -28,7 +28,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         IDefaultMaterialResolver materialResolver,
         Action<string>? progressReporter,
         CancellationToken cancellationToken,
-        out ImportedCityObject? heightMapCityObject)
+        out TerrainGridProjectedCityObject? heightMapCityObject)
     {
         cancellationToken.ThrowIfCancellationRequested();
         heightMapCityObject = null;
@@ -151,7 +151,17 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             Z = slotPosition.Z + centerZ,
         };
 
-        heightMapCityObject = new ImportedCityObject(
+        TerrainGridGeometry geometry = new(
+            Width: width,
+            Height: height,
+            Size: new Float2(extentX, extentZ),
+            MinHeight: minHeight,
+            MaxHeight: maxHeight,
+            HeightSamples: localHeights,
+            SampleCoverage: sampleCoverage,
+            UvScale: heightMapUvScale,
+            UvOffset: heightMapUvOffset);
+        ImportedCityObject projectedCityObject = new(
             ObjectKey: cityObject.SlotKey,
             DisplayName: cityObject.DisplayName,
             PackageName: cityObject.PackageName,
@@ -160,18 +170,10 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             Transform: new Transform3D(
                 ToContractFloat3(adjustedSlotPosition),
                 ToContractQuaternion(GridMeshTerrainRotation)),
-            Geometry: new TerrainGridGeometry(
-                Width: width,
-                Height: height,
-                Size: new Float2(extentX, extentZ),
-                MinHeight: minHeight,
-                MaxHeight: maxHeight,
-                HeightSamples: localHeights,
-                SampleCoverage: sampleCoverage,
-                UvScale: heightMapUvScale,
-                UvOffset: heightMapUvOffset),
+            Geometry: geometry,
             Materials: materials,
             SourceFileRelativePath: cityObject.SourceFileRelativePath);
+        heightMapCityObject = new TerrainGridProjectedCityObject(projectedCityObject, geometry);
         return true;
     }
 
@@ -375,3 +377,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         double MinZ,
         double MaxZ);
 }
+
+internal sealed record TerrainGridProjectedCityObject(
+    ImportedCityObject CityObject,
+    TerrainGridGeometry Geometry);

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -251,7 +251,7 @@ internal static class CityGmlParsedCityObjectProjection
             materialResolver,
             progressReporter,
             cancellationToken,
-            out ImportedCityObject? heightMapCityObject);
+            out TerrainGridProjectedCityObject? heightMapCityObject);
         if (!hasGrid)
         {
             return request.TerrainMeshMode == TerrainMeshMode.Dynamic
@@ -261,24 +261,23 @@ internal static class CityGmlParsedCityObjectProjection
 
         if (request.TerrainMeshMode == TerrainMeshMode.Grid)
         {
-            return heightMapCityObject!;
+            return heightMapCityObject!.CityObject;
         }
 
-        ImportedCityObject staticCityObject = CityGmlTriangleMeshCityObjectProjection.Project(
+        TriangleMeshProjectedCityObject staticCityObject = CityGmlTriangleMeshCityObjectProjection.ProjectTriangleMesh(
             cityObject,
             globalOriginPoint,
             globalCartesian,
             demTerrainTextureOverlay,
             materialResolver);
-        TriangleMeshGeometry staticMesh = AssertTriangleMeshGeometry(staticCityObject);
         TriangleMeshGeometry rebasedStaticMesh = TriangleMeshTransformRebaser.Rebase(
-            staticMesh,
-            staticCityObject.Transform,
-            heightMapCityObject!.Transform);
-        return heightMapCityObject with
+            staticCityObject.Geometry,
+            staticCityObject.CityObject.Transform,
+            heightMapCityObject!.CityObject.Transform);
+        return heightMapCityObject.CityObject with
         {
-            Geometry = new DynamicTerrainGeometry(rebasedStaticMesh, AssertTerrainGridGeometry(heightMapCityObject)),
-            Materials = staticCityObject.Materials,
+            Geometry = new DynamicTerrainGeometry(rebasedStaticMesh, heightMapCityObject.Geometry),
+            Materials = staticCityObject.CityObject.Materials,
         };
     }
 
@@ -450,18 +449,6 @@ internal static class CityGmlParsedCityObjectProjection
             origin.Longitude,
             origin.Altitude,
             cartesian);
-    }
-
-    private static TriangleMeshGeometry AssertTriangleMeshGeometry(ImportedCityObject cityObject)
-    {
-        return cityObject.Geometry as TriangleMeshGeometry
-            ?? throw new InvalidOperationException("Dynamic terrain static variant must be projected as a triangle mesh.");
-    }
-
-    private static TerrainGridGeometry AssertTerrainGridGeometry(ImportedCityObject cityObject)
-    {
-        return cityObject.Geometry as TerrainGridGeometry
-            ?? throw new InvalidOperationException("Dynamic terrain grid variant must be projected as a terrain grid.");
     }
 
     private static bool HasRenderableGeometry(ImportedCityObject cityObject)

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
@@ -17,6 +17,21 @@ internal static class CityGmlTriangleMeshCityObjectProjection
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
+        return ProjectTriangleMesh(
+            cityObject,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlay,
+            materialResolver).CityObject;
+    }
+
+    internal static TriangleMeshProjectedCityObject ProjectTriangleMesh(
+        ParsedCityObject cityObject,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IDefaultMaterialResolver materialResolver)
+    {
         double? geometryHeightMeters = cityObject.GeometryHeightMeters
             ?? ResolveGeometryHeightMeters(cityObject.Surfaces);
         cityObject = GeneratedLod1RoofCityObjectFactory.Create(cityObject) with
@@ -104,16 +119,18 @@ internal static class CityGmlTriangleMeshCityObjectProjection
             materials.Add(CityGmlSurfaceMaterialResolver.CreateMaterialBinding(cityObject.ActualMeshCode, representativeSurface, materialIndex));
         }
 
-        return new ImportedCityObject(
+        TriangleMeshGeometry geometry = new(new ImportedMesh(vertices.ToArray(), submeshes.ToArray()));
+        ImportedCityObject projectedCityObject = new(
             ObjectKey: cityObject.SlotKey,
             DisplayName: cityObject.DisplayName,
             PackageName: cityObject.PackageName,
             ActualMeshCode: cityObject.ActualMeshCode,
             LodLevel: cityObject.LodLevel,
             Transform: new Transform3D(ToContractFloat3(slotPosition)),
-            Mesh: new ImportedMesh(vertices.ToArray(), submeshes.ToArray()),
+            Geometry: geometry,
             Materials: materials,
             SourceFileRelativePath: cityObject.SourceFileRelativePath);
+        return new TriangleMeshProjectedCityObject(projectedCityObject, geometry);
     }
 
     private static GeodeticPoint ResolveCityObjectOrigin(ParsedCityObject cityObject)
@@ -177,3 +194,7 @@ internal static class CityGmlTriangleMeshCityObjectProjection
 
     private static Float3 ToContractFloat3(Float3 value) => new(value.X, value.Y, value.Z);
 }
+
+internal sealed record TriangleMeshProjectedCityObject(
+    ImportedCityObject CityObject,
+    TriangleMeshGeometry Geometry);

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
@@ -59,19 +59,69 @@ internal sealed record SharedTerrainTextureAsset(
     CreatedComponent TextureComponent,
     CreatedComponent MainTexturePropertyBlockComponent);
 
-internal sealed record LiveSendRunPlan(
-    ResoniteSceneSetupInfo SetupInfo,
-    string ResolvedWorkRoot,
-    ResoniteLocalOrigin RequestLocalOrigin,
-    IReadOnlyDictionary<string, string> SourceFileSlotNamesByRelativePath,
-    ResoniteImportBudgetProfile ResourceBudget,
-    LiveSendQueuePlan Queue,
-    bool MeshBakeEnabled);
+internal sealed record LiveSendRunPlan
+{
+    public LiveSendRunPlan(
+        ResoniteSceneSetupInfo SetupInfo,
+        string ResolvedWorkRoot,
+        ResoniteLocalOrigin RequestLocalOrigin,
+        IReadOnlyDictionary<string, string> SourceFileSlotNamesByRelativePath,
+        ResoniteImportBudgetProfile ResourceBudget,
+        LiveSendQueuePlan Queue,
+        bool MeshBakeEnabled)
+    {
+        ArgumentNullException.ThrowIfNull(SetupInfo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(ResolvedWorkRoot);
+        ArgumentNullException.ThrowIfNull(SourceFileSlotNamesByRelativePath);
+        ArgumentNullException.ThrowIfNull(ResourceBudget);
+        ArgumentNullException.ThrowIfNull(Queue);
 
-internal sealed record LiveSendQueuePlan(
-    int ConnectionCount,
-    int QueueCapacity,
-    long MemoryBudgetBytes);
+        this.SetupInfo = SetupInfo;
+        this.ResolvedWorkRoot = ResolvedWorkRoot;
+        this.RequestLocalOrigin = RequestLocalOrigin;
+        this.SourceFileSlotNamesByRelativePath = SourceFileSlotNamesByRelativePath;
+        this.ResourceBudget = ResourceBudget;
+        this.Queue = Queue;
+        this.MeshBakeEnabled = MeshBakeEnabled;
+    }
+
+    public ResoniteSceneSetupInfo SetupInfo { get; }
+
+    public string ResolvedWorkRoot { get; }
+
+    public ResoniteLocalOrigin RequestLocalOrigin { get; }
+
+    public IReadOnlyDictionary<string, string> SourceFileSlotNamesByRelativePath { get; }
+
+    public ResoniteImportBudgetProfile ResourceBudget { get; }
+
+    public LiveSendQueuePlan Queue { get; }
+
+    public bool MeshBakeEnabled { get; }
+}
+
+internal sealed record LiveSendQueuePlan
+{
+    public LiveSendQueuePlan(
+        int ConnectionCount,
+        int QueueCapacity,
+        long MemoryBudgetBytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(QueueCapacity, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(MemoryBudgetBytes, 1);
+
+        this.ConnectionCount = ConnectionCount;
+        this.QueueCapacity = QueueCapacity;
+        this.MemoryBudgetBytes = MemoryBudgetBytes;
+    }
+
+    public int ConnectionCount { get; }
+
+    public int QueueCapacity { get; }
+
+    public long MemoryBudgetBytes { get; }
+}
 
 internal sealed record LiveSendRunContext(
     LiveSendRunPlan Plan,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
@@ -25,12 +25,8 @@ internal sealed class ResoniteLiveSendConnectionInitializer : IResoniteLiveSendC
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(request.SetupInfo);
-        ArgumentNullException.ThrowIfNull(request.ConnectionRequest);
         ArgumentNullException.ThrowIfNull(runPlan);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
 
         ReportProgress(
             context,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendFinalizer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendFinalizer.cs
@@ -141,8 +141,29 @@ internal sealed class ResoniteLiveSendFinalizer(
     }
 }
 
-internal sealed record LiveSendFinalizationContext(
-    Uri Endpoint,
-    LiveSendEnqueueContext EnqueueContext,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
+internal sealed record LiveSendFinalizationContext
+{
+    public LiveSendFinalizationContext(
+        Uri Endpoint,
+        LiveSendEnqueueContext EnqueueContext,
+        ResoniteLinkSendDiagnostics Diagnostics,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(Endpoint);
+        ArgumentNullException.ThrowIfNull(EnqueueContext);
+        ArgumentNullException.ThrowIfNull(Diagnostics);
+
+        this.Endpoint = Endpoint;
+        this.EnqueueContext = EnqueueContext;
+        this.Diagnostics = Diagnostics;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public Uri Endpoint { get; }
+
+    public LiveSendEnqueueContext EnqueueContext { get; }
+
+    public ResoniteLinkSendDiagnostics Diagnostics { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendPhaseContextFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendPhaseContextFactory.cs
@@ -18,9 +18,6 @@ internal sealed class ResoniteLiveSendPhaseContextFactory : IResoniteLiveSendPha
     public LiveSendRunStartContext CreateRunStartContext(LiveSendRunExecutionContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
 
         return new LiveSendRunStartContext(
             context.Endpoint,
@@ -32,8 +29,6 @@ internal sealed class ResoniteLiveSendPhaseContextFactory : IResoniteLiveSendPha
     public LiveSendEnqueueContext CreateEnqueueContext(LiveSendRunExecutionContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentOutOfRangeException.ThrowIfLessThan(context.ConnectionCount, 1);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
 
         return new LiveSendEnqueueContext(
             context.ConnectionCount,
@@ -46,8 +41,6 @@ internal sealed class ResoniteLiveSendPhaseContextFactory : IResoniteLiveSendPha
         LiveSendEnqueueContext enqueueContext)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
         ArgumentNullException.ThrowIfNull(enqueueContext);
 
         return new LiveSendFinalizationContext(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunExecutor.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunExecutor.cs
@@ -8,12 +8,37 @@ using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed record LiveSendRunExecutionContext(
-    Uri Endpoint,
-    int ConnectionCount,
-    ILiveSendClientSession ClientSession,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
+internal sealed record LiveSendRunExecutionContext
+{
+    public LiveSendRunExecutionContext(
+        Uri Endpoint,
+        int ConnectionCount,
+        ILiveSendClientSession ClientSession,
+        ResoniteLinkSendDiagnostics Diagnostics,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(Endpoint);
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
+        ArgumentNullException.ThrowIfNull(ClientSession);
+        ArgumentNullException.ThrowIfNull(Diagnostics);
+
+        this.Endpoint = Endpoint;
+        this.ConnectionCount = ConnectionCount;
+        this.ClientSession = ClientSession;
+        this.Diagnostics = Diagnostics;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public Uri Endpoint { get; }
+
+    public int ConnectionCount { get; }
+
+    public ILiveSendClientSession ClientSession { get; }
+
+    public ResoniteLinkSendDiagnostics Diagnostics { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}
 
 internal interface IResoniteLiveSendRunExecutor
 {
@@ -70,10 +95,6 @@ internal sealed class ResoniteLiveSendRunExecutor(
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(objectUnits);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentOutOfRangeException.ThrowIfLessThan(context.ConnectionCount, 1);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
 
         bool completedSuccessfully = false;
         LiveSendRunState? state = null;

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
@@ -38,9 +38,7 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
     {
         ArgumentNullException.ThrowIfNull(runPlan);
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
 
         ReportProgress(
             context,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -7,21 +7,77 @@ using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed record LiveSendRunStartRequest(
-    ResoniteSceneSetupInfo SetupInfo,
-    string WorkRoot,
-    CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials,
-    LiveSendConnectionRequest ConnectionRequest,
-    ResoniteLocalOrigin RequestLocalOrigin,
-    ResoniteImportMemoryProfile MemoryProfile,
-    int ConnectionCount,
-    bool MeshBakeEnabled);
+internal sealed record LiveSendRunStartRequest
+{
+    public LiveSendRunStartRequest(
+        ResoniteSceneSetupInfo SetupInfo,
+        string WorkRoot,
+        CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials,
+        LiveSendConnectionRequest ConnectionRequest,
+        ResoniteLocalOrigin RequestLocalOrigin,
+        ResoniteImportMemoryProfile MemoryProfile,
+        int ConnectionCount,
+        bool MeshBakeEnabled)
+    {
+        ArgumentNullException.ThrowIfNull(SetupInfo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(WorkRoot);
+        ArgumentNullException.ThrowIfNull(CommonMaterials);
+        ArgumentNullException.ThrowIfNull(ConnectionRequest);
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
 
-internal sealed record LiveSendRunStartContext(
-    Uri Endpoint,
-    ILiveSendClientSession ClientSession,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
+        this.SetupInfo = SetupInfo;
+        this.WorkRoot = WorkRoot;
+        this.CommonMaterials = CommonMaterials;
+        this.ConnectionRequest = ConnectionRequest;
+        this.RequestLocalOrigin = RequestLocalOrigin;
+        this.MemoryProfile = MemoryProfile;
+        this.ConnectionCount = ConnectionCount;
+        this.MeshBakeEnabled = MeshBakeEnabled;
+    }
+
+    public ResoniteSceneSetupInfo SetupInfo { get; }
+
+    public string WorkRoot { get; }
+
+    public CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials { get; }
+
+    public LiveSendConnectionRequest ConnectionRequest { get; }
+
+    public ResoniteLocalOrigin RequestLocalOrigin { get; }
+
+    public ResoniteImportMemoryProfile MemoryProfile { get; }
+
+    public int ConnectionCount { get; }
+
+    public bool MeshBakeEnabled { get; }
+}
+
+internal sealed record LiveSendRunStartContext
+{
+    public LiveSendRunStartContext(
+        Uri Endpoint,
+        ILiveSendClientSession ClientSession,
+        ResoniteLinkSendDiagnostics Diagnostics,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(Endpoint);
+        ArgumentNullException.ThrowIfNull(ClientSession);
+        ArgumentNullException.ThrowIfNull(Diagnostics);
+
+        this.Endpoint = Endpoint;
+        this.ClientSession = ClientSession;
+        this.Diagnostics = Diagnostics;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public Uri Endpoint { get; }
+
+    public ILiveSendClientSession ClientSession { get; }
+
+    public ResoniteLinkSendDiagnostics Diagnostics { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}
 
 internal interface IResoniteLiveSendRunStarter
 {
@@ -45,13 +101,6 @@ internal sealed class ResoniteLiveSendRunStarter(
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(request.SetupInfo);
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkRoot);
-        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
-        ArgumentNullException.ThrowIfNull(request.ConnectionRequest);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
 
         LiveSendRunPlan runPlan = runPlanFactory.Create(
             request.SetupInfo,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
@@ -6,10 +6,28 @@ using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed record LiveSendWorkerLaunchRequest(
-    LiveSendRunState State,
-    LiveSendQueuePlan QueuePlan,
-    ResoniteImportBudgetProfile ResourceBudget);
+internal sealed record LiveSendWorkerLaunchRequest
+{
+    public LiveSendWorkerLaunchRequest(
+        LiveSendRunState State,
+        LiveSendQueuePlan QueuePlan,
+        ResoniteImportBudgetProfile ResourceBudget)
+    {
+        ArgumentNullException.ThrowIfNull(State);
+        ArgumentNullException.ThrowIfNull(QueuePlan);
+        ArgumentNullException.ThrowIfNull(ResourceBudget);
+
+        this.State = State;
+        this.QueuePlan = QueuePlan;
+        this.ResourceBudget = ResourceBudget;
+    }
+
+    public LiveSendRunState State { get; }
+
+    public LiveSendQueuePlan QueuePlan { get; }
+
+    public ResoniteImportBudgetProfile ResourceBudget { get; }
+}
 
 internal interface IResoniteLiveSendWorkerLauncher
 {
@@ -29,15 +47,8 @@ internal sealed class ResoniteLiveSendWorkerLauncher(
         LiveSendRunStartContext context)
     {
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(request.State);
-        ArgumentNullException.ThrowIfNull(request.QueuePlan);
-        ArgumentNullException.ThrowIfNull(request.ResourceBudget);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
         int connectionCount = request.QueuePlan.ConnectionCount;
-        ArgumentOutOfRangeException.ThrowIfLessThan(connectionCount, 1);
 
         ReportProgress(
             context,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectEnqueuer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectEnqueuer.cs
@@ -218,7 +218,24 @@ internal sealed class ResoniteQueuedCityObjectEnqueuer : IResoniteQueuedCityObje
     }
 }
 
-internal sealed record LiveSendEnqueueContext(
-    int ConnectionCount,
-    Func<IResoniteLinkClient> GetRoutedClient,
-    Action<string>? ProgressReporter);
+internal sealed record LiveSendEnqueueContext
+{
+    public LiveSendEnqueueContext(
+        int ConnectionCount,
+        Func<IResoniteLinkClient> GetRoutedClient,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
+        ArgumentNullException.ThrowIfNull(GetRoutedClient);
+
+        this.ConnectionCount = ConnectionCount;
+        this.GetRoutedClient = GetRoutedClient;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public int ConnectionCount { get; }
+
+    public Func<IResoniteLinkClient> GetRoutedClient { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectWorker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectWorker.cs
@@ -167,9 +167,34 @@ internal sealed class ResoniteQueuedCityObjectWorker(
     }
 }
 
-internal sealed record LiveSendWorkerContext(
-    Uri Endpoint,
-    int ConnectionCount,
-    Func<IResoniteLinkClient> GetRoutedClient,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
+internal sealed record LiveSendWorkerContext
+{
+    public LiveSendWorkerContext(
+        Uri Endpoint,
+        int ConnectionCount,
+        Func<IResoniteLinkClient> GetRoutedClient,
+        ResoniteLinkSendDiagnostics Diagnostics,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(Endpoint);
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
+        ArgumentNullException.ThrowIfNull(GetRoutedClient);
+        ArgumentNullException.ThrowIfNull(Diagnostics);
+
+        this.Endpoint = Endpoint;
+        this.ConnectionCount = ConnectionCount;
+        this.GetRoutedClient = GetRoutedClient;
+        this.Diagnostics = Diagnostics;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public Uri Endpoint { get; }
+
+    public int ConnectionCount { get; }
+
+    public Func<IResoniteLinkClient> GetRoutedClient { get; }
+
+    public ResoniteLinkSendDiagnostics Diagnostics { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/LiveSendRunContractTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/LiveSendRunContractTests.cs
@@ -1,0 +1,100 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test names describe contract cases.")]
+public sealed class LiveSendRunContractTests
+{
+    [Fact]
+    public void StartRequest_RejectsIncompleteRunInputsAtConstruction()
+    {
+        ResoniteSceneSetupInfo setupInfo = CreateSetupInfo();
+
+        Assert.Throws<ArgumentNullException>(() => new LiveSendRunStartRequest(
+            null!,
+            "work",
+            CommonMaterialCatalog.Create(),
+            new LiveSendConnectionRequest("dataset", "53394525"),
+            new ResoniteLocalOrigin(0, 0, 0),
+            ResoniteImportMemoryProfile.Large,
+            1,
+            MeshBakeEnabled: true));
+        Assert.Throws<ArgumentException>(() => new LiveSendRunStartRequest(
+            setupInfo,
+            " ",
+            CommonMaterialCatalog.Create(),
+            new LiveSendConnectionRequest("dataset", "53394525"),
+            new ResoniteLocalOrigin(0, 0, 0),
+            ResoniteImportMemoryProfile.Large,
+            1,
+            MeshBakeEnabled: true));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LiveSendRunStartRequest(
+            setupInfo,
+            "work",
+            CommonMaterialCatalog.Create(),
+            new LiveSendConnectionRequest("dataset", "53394525"),
+            new ResoniteLocalOrigin(0, 0, 0),
+            ResoniteImportMemoryProfile.Large,
+            0,
+            MeshBakeEnabled: true));
+    }
+
+    [Fact]
+    public void RunContexts_RejectMissingSessionStateAtConstruction()
+    {
+        Assert.Throws<ArgumentNullException>(() => new LiveSendRunStartContext(
+            null!,
+            new DelegatingClientSession(),
+            ResoniteLinkSendDiagnostics.Disabled,
+            ProgressReporter: null));
+        Assert.Throws<ArgumentNullException>(() => new LiveSendRunExecutionContext(
+            new Uri("ws://localhost:12345/"),
+            1,
+            null!,
+            ResoniteLinkSendDiagnostics.Disabled,
+            ProgressReporter: null));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LiveSendRunExecutionContext(
+            new Uri("ws://localhost:12345/"),
+            0,
+            new DelegatingClientSession(),
+            ResoniteLinkSendDiagnostics.Disabled,
+            ProgressReporter: null));
+    }
+
+    [Fact]
+    public void QueueAndWorkerContracts_RejectNonExecutableInputsAtConstruction()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LiveSendQueuePlan(
+            ConnectionCount: 0,
+            QueueCapacity: 1,
+            MemoryBudgetBytes: 1));
+        Assert.Throws<ArgumentNullException>(() => new LiveSendEnqueueContext(
+            ConnectionCount: 1,
+            GetRoutedClient: null!,
+            ProgressReporter: null));
+        Assert.Throws<ArgumentNullException>(() => new LiveSendWorkerContext(
+            new Uri("ws://localhost:12345/"),
+            ConnectionCount: 1,
+            GetRoutedClient: null!,
+            ResoniteLinkSendDiagnostics.Disabled,
+            ProgressReporter: null));
+    }
+
+    private static ResoniteSceneSetupInfo CreateSetupInfo()
+    {
+        return new ResoniteSceneSetupInfo(
+            "dataset",
+            "53394525",
+            Array.Empty<string>(),
+            Array.Empty<string>(),
+            new ResoniteLicenseAttributionMetadata(
+                RequireCredit: false,
+                CreditText: null,
+                LicenseName: null,
+                LicenseUrl: null));
+    }
+}


### PR DESCRIPTION
## Summary
- Move live-send run request/context invariants into the run contract constructors.
- Remove repeated downstream null and connection-count checks from starter, connection initialization, setup preparation, worker launch, and phase context creation.
- Add focused contract tests for non-executable live-send inputs.

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- canonical scene dump for plateau-13213-higashimurayama-shi-2020 mesh 53395325 packages dem,bldg terrain grid, no diff vs baseline