### PR TITLE
Type dynamic terrain projection results

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -28,7 +28,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         IDefaultMaterialResolver materialResolver,
         Action<string>? progressReporter,
         CancellationToken cancellationToken,
-        out ImportedCityObject? heightMapCityObject)
+        out TerrainGridProjectedCityObject? heightMapCityObject)
     {
         cancellationToken.ThrowIfCancellationRequested();
         heightMapCityObject = null;
@@ -151,7 +151,17 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             Z = slotPosition.Z + centerZ,
         };
 
-        heightMapCityObject = new ImportedCityObject(
+        TerrainGridGeometry geometry = new(
+            Width: width,
+            Height: height,
+            Size: new Float2(extentX, extentZ),
+            MinHeight: minHeight,
+            MaxHeight: maxHeight,
+            HeightSamples: localHeights,
+            SampleCoverage: sampleCoverage,
+            UvScale: heightMapUvScale,
+            UvOffset: heightMapUvOffset);
+        ImportedCityObject projectedCityObject = new(
             ObjectKey: cityObject.SlotKey,
             DisplayName: cityObject.DisplayName,
             PackageName: cityObject.PackageName,
@@ -160,18 +170,10 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             Transform: new Transform3D(
                 ToContractFloat3(adjustedSlotPosition),
                 ToContractQuaternion(GridMeshTerrainRotation)),
-            Geometry: new TerrainGridGeometry(
-                Width: width,
-                Height: height,
-                Size: new Float2(extentX, extentZ),
-                MinHeight: minHeight,
-                MaxHeight: maxHeight,
-                HeightSamples: localHeights,
-                SampleCoverage: sampleCoverage,
-                UvScale: heightMapUvScale,
-                UvOffset: heightMapUvOffset),
+            Geometry: geometry,
             Materials: materials,
             SourceFileRelativePath: cityObject.SourceFileRelativePath);
+        heightMapCityObject = new TerrainGridProjectedCityObject(projectedCityObject, geometry);
         return true;
     }
 
@@ -375,3 +377,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         double MinZ,
         double MaxZ);
 }
+
+internal sealed record TerrainGridProjectedCityObject(
+    ImportedCityObject CityObject,
+    TerrainGridGeometry Geometry);

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -251,7 +251,7 @@ internal static class CityGmlParsedCityObjectProjection
             materialResolver,
             progressReporter,
             cancellationToken,
-            out ImportedCityObject? heightMapCityObject);
+            out TerrainGridProjectedCityObject? heightMapCityObject);
         if (!hasGrid)
         {
             return request.TerrainMeshMode == TerrainMeshMode.Dynamic
@@ -261,24 +261,23 @@ internal static class CityGmlParsedCityObjectProjection
 
         if (request.TerrainMeshMode == TerrainMeshMode.Grid)
         {
-            return heightMapCityObject!;
+            return heightMapCityObject!.CityObject;
         }
 
-        ImportedCityObject staticCityObject = CityGmlTriangleMeshCityObjectProjection.Project(
+        TriangleMeshProjectedCityObject staticCityObject = CityGmlTriangleMeshCityObjectProjection.ProjectTriangleMesh(
             cityObject,
             globalOriginPoint,
             globalCartesian,
             demTerrainTextureOverlay,
             materialResolver);
-        TriangleMeshGeometry staticMesh = AssertTriangleMeshGeometry(staticCityObject);
         TriangleMeshGeometry rebasedStaticMesh = TriangleMeshTransformRebaser.Rebase(
-            staticMesh,
-            staticCityObject.Transform,
-            heightMapCityObject!.Transform);
-        return heightMapCityObject with
+            staticCityObject.Geometry,
+            staticCityObject.CityObject.Transform,
+            heightMapCityObject!.CityObject.Transform);
+        return heightMapCityObject.CityObject with
         {
-            Geometry = new DynamicTerrainGeometry(rebasedStaticMesh, AssertTerrainGridGeometry(heightMapCityObject)),
-            Materials = staticCityObject.Materials,
+            Geometry = new DynamicTerrainGeometry(rebasedStaticMesh, heightMapCityObject.Geometry),
+            Materials = staticCityObject.CityObject.Materials,
         };
     }
 
@@ -450,18 +449,6 @@ internal static class CityGmlParsedCityObjectProjection
             origin.Longitude,
             origin.Altitude,
             cartesian);
-    }
-
-    private static TriangleMeshGeometry AssertTriangleMeshGeometry(ImportedCityObject cityObject)
-    {
-        return cityObject.Geometry as TriangleMeshGeometry
-            ?? throw new InvalidOperationException("Dynamic terrain static variant must be projected as a triangle mesh.");
-    }
-
-    private static TerrainGridGeometry AssertTerrainGridGeometry(ImportedCityObject cityObject)
-    {
-        return cityObject.Geometry as TerrainGridGeometry
-            ?? throw new InvalidOperationException("Dynamic terrain grid variant must be projected as a terrain grid.");
     }
 
     private static bool HasRenderableGeometry(ImportedCityObject cityObject)

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
@@ -17,6 +17,21 @@ internal static class CityGmlTriangleMeshCityObjectProjection
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
+        return ProjectTriangleMesh(
+            cityObject,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlay,
+            materialResolver).CityObject;
+    }
+
+    internal static TriangleMeshProjectedCityObject ProjectTriangleMesh(
+        ParsedCityObject cityObject,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IDefaultMaterialResolver materialResolver)
+    {
         double? geometryHeightMeters = cityObject.GeometryHeightMeters
             ?? ResolveGeometryHeightMeters(cityObject.Surfaces);
         cityObject = GeneratedLod1RoofCityObjectFactory.Create(cityObject) with
@@ -104,16 +119,18 @@ internal static class CityGmlTriangleMeshCityObjectProjection
             materials.Add(CityGmlSurfaceMaterialResolver.CreateMaterialBinding(cityObject.ActualMeshCode, representativeSurface, materialIndex));
         }
 
-        return new ImportedCityObject(
+        TriangleMeshGeometry geometry = new(new ImportedMesh(vertices.ToArray(), submeshes.ToArray()));
+        ImportedCityObject projectedCityObject = new(
             ObjectKey: cityObject.SlotKey,
             DisplayName: cityObject.DisplayName,
             PackageName: cityObject.PackageName,
             ActualMeshCode: cityObject.ActualMeshCode,
             LodLevel: cityObject.LodLevel,
             Transform: new Transform3D(ToContractFloat3(slotPosition)),
-            Mesh: new ImportedMesh(vertices.ToArray(), submeshes.ToArray()),
+            Geometry: geometry,
             Materials: materials,
             SourceFileRelativePath: cityObject.SourceFileRelativePath);
+        return new TriangleMeshProjectedCityObject(projectedCityObject, geometry);
     }
 
     private static GeodeticPoint ResolveCityObjectOrigin(ParsedCityObject cityObject)
@@ -177,3 +194,7 @@ internal static class CityGmlTriangleMeshCityObjectProjection
 
     private static Float3 ToContractFloat3(Float3 value) => new(value.X, value.Y, value.Z);
 }
+
+internal sealed record TriangleMeshProjectedCityObject(
+    ImportedCityObject CityObject,
+    TriangleMeshGeometry Geometry);


### PR DESCRIPTION
## Summary
- Return typed triangle-mesh and terrain-grid projection results from the projection functions that create them.
- Build dynamic terrain from those typed projection results instead of downcasting ImportedCityObject.Geometry and throwing on impossible geometry variants.
- Keep the public ImportedCityObject contract unchanged; this narrows only the internal projection boundary.

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- canonical scene dump for plateau-13213-higashimurayama-shi-2020 mesh 53395325 packages dem,bldg terrain grid, no diff vs baseline