### PR TITLE
Type rendered non-DEM atlases

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -475,15 +475,13 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
     {
         ResoniteMaterialBinding material = plannedMaterial.Material;
         PlannedSlotTargetReference materialContainerTarget = meshAssetSlotTarget;
-        if (plannedMaterial.PreserveDedicatedMaterialSlot)
+        if (plannedMaterial is PlannedPreservedSlotDedicatedMaterialAsset preservedSlotMaterial)
         {
             BatchPlanSlotLocator materialSlotId = CreateBatchPlanSlotLocator(ref nextSlotLocator);
-            string materialSlotName = plannedMaterial.DedicatedMaterialSlotName
-                ?? throw new InvalidOperationException("Dedicated material slot preservation requires a planned material-index slot name.");
             slotEmissions.Add(new PlannedBatchSlotEmission(
                 materialSlotId,
                 meshAssetSlotTarget,
-                materialSlotName,
+                preservedSlotMaterial.DedicatedMaterialSlotName,
                 null,
                 null));
             materialContainerTarget = PlannedSlotTargetReference.PlannedSlot(materialSlotId);

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteSlotCreator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteSlotCreator.cs
@@ -35,6 +35,6 @@ internal sealed class ResoniteSlotCreator : IResoniteSlotCreator
             position,
             rotation);
         BatchResponse response = await client.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
-        return CanonicalBatchEntityMap.Create(response).ResolveSlot(pendingSlot);
+        return CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions).ResolveSlot(pendingSlot);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteBatchOperations.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteBatchOperations.cs
@@ -334,26 +334,21 @@ internal static class ResoniteBatchOperations
 internal sealed class CanonicalBatchEntityMap
 {
     private readonly Dictionary<string, Response> responsesByMessageId;
-    private readonly Queue<Response> responsesWithoutMessageId;
 
-    private CanonicalBatchEntityMap(
-        Dictionary<string, Response> responsesByMessageId,
-        Queue<Response> responsesWithoutMessageId)
+    private CanonicalBatchEntityMap(Dictionary<string, Response> responsesByMessageId)
     {
         this.responsesByMessageId = responsesByMessageId;
-        this.responsesWithoutMessageId = responsesWithoutMessageId;
     }
 
-    public static CanonicalBatchEntityMap Create(BatchResponse batchResponse)
+    public static CanonicalBatchEntityMap Create(
+        BatchResponse batchResponse,
+        IReadOnlyList<ResoniteBatchOperations.PendingBatchOperation> pendingOperations)
     {
         ArgumentNullException.ThrowIfNull(batchResponse);
-        return new CanonicalBatchEntityMap(
-            (batchResponse.Responses ?? [])
-                .Where(static response => !string.IsNullOrWhiteSpace(response.SourceMessageID))
-                .ToDictionary(response => response.SourceMessageID!, StringComparer.Ordinal),
-            new Queue<Response>(
-                (batchResponse.Responses ?? [])
-                    .Where(static response => string.IsNullOrWhiteSpace(response.SourceMessageID))));
+        ArgumentNullException.ThrowIfNull(pendingOperations);
+
+        IReadOnlyList<Response> responses = batchResponse.Responses ?? [];
+        return new CanonicalBatchEntityMap(CorrelateResponses(responses, pendingOperations));
     }
 
     public CreatedSlot ResolveSlot(ResoniteBatchOperations.PendingBatchSlot pendingSlot)
@@ -400,15 +395,78 @@ internal sealed class CanonicalBatchEntityMap
     {
         if (!responsesByMessageId.TryGetValue(messageId.Value, out Response? response))
         {
-            if (responsesWithoutMessageId.Count == 0)
-            {
-                throw new InvalidOperationException($"Batch response did not include message '{messageId.Value}'.");
-            }
-
-            response = responsesWithoutMessageId.Dequeue();
+            throw new InvalidOperationException($"Batch response did not include message '{messageId.Value}'.");
         }
 
         ResoniteLinkClient.EnsureSuccess(response, operationName);
         return response;
+    }
+
+    private static Dictionary<string, Response> CorrelateResponses(
+        IReadOnlyList<Response> responses,
+        IReadOnlyList<ResoniteBatchOperations.PendingBatchOperation> pendingOperations)
+    {
+        if (responses.Count == 0 && pendingOperations.Count == 0)
+        {
+            return new Dictionary<string, Response>(StringComparer.Ordinal);
+        }
+
+        bool anyMessageId = responses.Any(static response => !string.IsNullOrWhiteSpace(response.SourceMessageID));
+        bool anyMissingMessageId = responses.Any(static response => string.IsNullOrWhiteSpace(response.SourceMessageID));
+        if (anyMessageId && anyMissingMessageId)
+        {
+            throw new InvalidOperationException("Batch response mixed message-correlated and ordered-only responses.");
+        }
+
+        if (!anyMessageId)
+        {
+            return CorrelateOrderedResponses(responses, pendingOperations);
+        }
+
+        Dictionary<string, Response> correlated = new(StringComparer.Ordinal);
+        foreach (Response response in responses)
+        {
+            string messageId = response.SourceMessageID!;
+            if (!correlated.TryAdd(messageId, response))
+            {
+                throw new InvalidOperationException($"Batch response included duplicate message '{messageId}'.");
+            }
+        }
+
+        foreach (ResoniteBatchOperations.PendingBatchOperation pendingOperation in pendingOperations)
+        {
+            if (!correlated.ContainsKey(pendingOperation.MessageId.Value))
+            {
+                throw new InvalidOperationException($"Batch response did not include message '{pendingOperation.MessageId.Value}'.");
+            }
+        }
+
+        if (correlated.Count != pendingOperations.Count)
+        {
+            throw new InvalidOperationException(
+                $"Batch response included {correlated.Count} message-correlated response(s) for {pendingOperations.Count} pending operation(s).");
+        }
+
+        return correlated;
+    }
+
+    private static Dictionary<string, Response> CorrelateOrderedResponses(
+        IReadOnlyList<Response> responses,
+        IReadOnlyList<ResoniteBatchOperations.PendingBatchOperation> pendingOperations)
+    {
+        if (responses.Count != pendingOperations.Count)
+        {
+            throw new InvalidOperationException(
+                $"Batch response included {responses.Count} ordered response(s) for {pendingOperations.Count} pending operation(s).");
+        }
+
+        Dictionary<string, Response> correlated = new(StringComparer.Ordinal);
+        for (int i = 0; i < responses.Count; i++)
+        {
+            ResoniteBatchOperations.PendingBatchOperation pendingOperation = pendingOperations[i];
+            correlated[pendingOperation.MessageId.Value] = responses[i];
+        }
+
+        return correlated;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -298,7 +298,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             componentType,
             members);
         BatchResponse response = await client.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
-        return CanonicalBatchEntityMap.Create(response).ResolveComponent(pendingComponent);
+        return CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions).ResolveComponent(pendingComponent);
     }
 
     public static ResoniteMaterialBinding ResolveTerrainTextureCanvasMaterial(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -69,10 +69,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             albedoTextureTask,
             bundledTextureImportTasks,
             cancellationToken);
-        return new PlannedDedicatedMaterialAsset(
+        return new PlannedInlineDedicatedMaterialAsset(
             material,
-            textures,
-            PreserveDedicatedMaterialSlot: false);
+            textures);
     }
 
     public async Task<PlannedDedicatedMaterialAsset> PlanDedicatedMaterialAssetAsync(
@@ -107,13 +106,14 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             albedoTextureTask,
             bundledTextureImportTasks: null,
             cancellationToken);
-        return new PlannedDedicatedMaterialAsset(
-            material,
-            textures,
-            preserveDedicatedMaterialSlot,
-            DedicatedMaterialSlotName: preserveDedicatedMaterialSlot
-                ? ResoniteSceneMaterialConventions.CreateDedicatedMaterialSlotName(material, materialIndex)
-                : null);
+        return preserveDedicatedMaterialSlot
+            ? new PlannedPreservedSlotDedicatedMaterialAsset(
+                material,
+                textures,
+                ResoniteSceneMaterialConventions.CreateDedicatedMaterialSlotName(material, materialIndex))
+            : new PlannedInlineDedicatedMaterialAsset(
+                material,
+                textures);
     }
 
     public static Uri? TryGetPlannedTextureUri(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -94,7 +94,7 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
                 $"City object '{cityObject.DisplayName}' batch completed in {batchStopwatch.Elapsed.TotalSeconds:F3}s "
                 + $"(operations={operationCount}, est_payload_bytes={EstimateBatchPayloadBytes(operationCount)})."));
 
-        CanonicalBatchEntityMap canonicalBatchEntityMap = CanonicalBatchEntityMap.Create(batchResponse);
+        CanonicalBatchEntityMap canonicalBatchEntityMap = CanonicalBatchEntityMap.Create(batchResponse, batchBuilder.PendingActions);
         canonicalBatchEntityMap.ValidateAll(batchBuilder.PendingActions);
         foreach (BatchPlanSlotLocator slotResolutionTarget in batchEmission.SlotResolutionTargets)
         {

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneSetupInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneSetupInterpreter.cs
@@ -171,7 +171,7 @@ internal sealed class ResoniteSceneSetupInterpreter : IResoniteSceneSetupInterpr
         if (batchBuilder.Actions.Count > 0)
         {
             BatchResponse response = await setupClient.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
-            CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response);
+            CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions);
             if (pendingAssets is not null)
             {
                 assetsSlot = CreateSlot(entityMap.ResolveSlot(pendingAssets.Value));
@@ -338,7 +338,7 @@ internal sealed class ResoniteSceneSetupInterpreter : IResoniteSceneSetupInterpr
 
         BatchResponse response = await setupClient.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
 
-        CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response);
+        CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions);
         CreatedSlot datasetRootSlot = entityMap.ResolveSlot(pendingDatasetRootSlot);
         CreatedSlot datasetAssetsRootSlot = entityMap.ResolveSlot(pendingDatasetAssetsRootSlot);
         CreatedSlot commonAssetsRootSlot = existingSharedCommonMaterialsSlot is null

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
@@ -14,7 +14,7 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal interface INonDemAtlasOrPreservedEntryFactory
 {
     Task<NonDemAtlasOrPreservedEntry> CreateAsync(
-        ResoniteConstructionCityObject cityObject,
+        NonDemSourceScopedTriangleCityObject cityObject,
         ResoniteMeshSubmesh submesh,
         ResoniteMaterialBinding material,
         CancellationToken cancellationToken);
@@ -28,7 +28,7 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
         ?? throw new ArgumentNullException(nameof(textureImageLoader));
 
     public async Task<NonDemAtlasOrPreservedEntry> CreateAsync(
-        ResoniteConstructionCityObject cityObject,
+        NonDemSourceScopedTriangleCityObject cityObject,
         ResoniteMeshSubmesh submesh,
         ResoniteMaterialBinding material,
         CancellationToken cancellationToken)

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
@@ -6,9 +6,6 @@ using System.Threading;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed record NonDemBakedGeometry(
@@ -22,8 +19,7 @@ internal interface INonDemBakedGeometryComposer
         NonDemSourceFileBatchKey sourceFileKey,
         IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
         int batchIndex,
-        NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout,
-        Image<Rgba32>? atlasImage,
+        NonDemRenderedAtlas? atlas,
         CancellationToken cancellationToken);
 }
 
@@ -33,8 +29,7 @@ internal sealed class NonDemBakedGeometryComposer : INonDemBakedGeometryComposer
         NonDemSourceFileBatchKey sourceFileKey,
         IReadOnlyList<NonDemCityObjectBakeCandidate> candidates,
         int batchIndex,
-        NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout,
-        Image<Rgba32>? atlasImage,
+        NonDemRenderedAtlas? atlas,
         CancellationToken cancellationToken)
     {
         ResoniteFloat3 bakeOrigin = ComputeBakeOrigin(candidates);
@@ -42,8 +37,9 @@ internal sealed class NonDemBakedGeometryComposer : INonDemBakedGeometryComposer
         List<ResoniteMeshSubmesh> submeshes = [];
         List<ResoniteMaterialBinding> materials = [];
 
-        if (layout is not null)
+        if (atlas is not null)
         {
+            NonDemAtlasLayout<NonDemAtlasBatchEntry> layout = atlas.Layout;
             string textureIdentity = NonDemSourceFileBatching.CreateAtlasTextureIdentity(sourceFileKey, batchIndex);
             List<int> atlasTriangleIndices = [];
             foreach (NonDemAtlasPlacement<NonDemAtlasBatchEntry> placement in layout.Placements
@@ -64,7 +60,7 @@ internal sealed class NonDemBakedGeometryComposer : INonDemBakedGeometryComposer
                     DepthOffset: null,
                     SubmeshIndices: [0],
                     TexturePayload: ResoniteTextureImportFactory.CreatePayloadFromImage(
-                        atlasImage ?? throw new InvalidOperationException("Non-DEM atlas image is required when an atlas layout exists."),
+                        atlas.Image,
                         identity: textureIdentity),
                     CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv));
         }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
@@ -180,7 +180,7 @@ internal sealed class NonDemBakedGeometryComposer : INonDemBakedGeometryComposer
         double minY = double.PositiveInfinity;
         double minZ = double.PositiveInfinity;
 
-        foreach (ResoniteConstructionCityObject cityObject in candidates.Select(static candidate => candidate.CityObject))
+        foreach (NonDemSourceScopedTriangleCityObject cityObject in candidates.Select(static candidate => candidate.CityObject))
         {
             foreach (ResoniteMeshVertex vertex in cityObject.Mesh.Vertices)
             {

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
@@ -42,16 +42,13 @@ internal sealed class NonDemCityObjectBakeAssembler(
         List<NonDemAtlasBatchEntry> entries = candidates.SelectMany(static candidate => candidate.AtlasEntries).ToList();
         using NonDemRenderedAtlas? atlas = RenderAtlas(entries, cancellationToken);
 
-        ResoniteConstructionCityObject firstCityObject = candidates[0].CityObject;
+        NonDemSourceScopedTriangleCityObject firstCityObject = candidates[0].CityObject;
         string slotKey = preservePrimaryIdentity
             ? firstCityObject.SlotKey
             : NonDemSourceFileBatching.CreateBatchSlotKey(sourceFileKey, batchIndex);
         string displayName = preservePrimaryIdentity
             ? firstCityObject.DisplayName
             : NonDemSourceFileBatching.CreateBatchDisplayName(sourceFileKey, batchIndex, slotKey);
-        string? sourceFileRelativePath = string.IsNullOrWhiteSpace(firstCityObject.SourceFileRelativePath)
-            ? null
-            : sourceFileKey.SourceFileRelativePath;
 
         NonDemBakedGeometry geometry = geometryComposer.Compose(
             sourceFileKey,
@@ -70,7 +67,7 @@ internal sealed class NonDemCityObjectBakeAssembler(
             Mesh: geometry.Mesh,
             Materials: geometry.Materials,
             CollisionEnabled: candidates.Any(static candidate => candidate.CityObject.CollisionEnabled),
-            SourceFileRelativePath: sourceFileRelativePath);
+            SourceFileRelativePath: sourceFileKey.SourceFileRelativePath);
         return Task.FromResult(bakedCityObject);
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,21 +40,7 @@ internal sealed class NonDemCityObjectBakeAssembler(
         CancellationToken cancellationToken)
     {
         List<NonDemAtlasBatchEntry> entries = candidates.SelectMany(static candidate => candidate.AtlasEntries).ToList();
-        NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout = null;
-        if (entries.Count > 0
-            && (!atlasLayoutFactory.TryCreate(entries, out layout) || layout is null))
-        {
-            throw new InvalidOperationException("Failed to create non-DEM atlas layout.");
-        }
-
-        using Image<Rgba32>? atlasImage = layout is null
-            ? null
-            : new Image<Rgba32>(layout.Width, layout.Height, new Rgba32(0, 0, 0, 0));
-        if (layout is not null)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            atlasImageRenderer.Draw(atlasImage!, layout.Placements);
-        }
+        using NonDemRenderedAtlas? atlas = RenderAtlas(entries, cancellationToken);
 
         ResoniteConstructionCityObject firstCityObject = candidates[0].CityObject;
         string slotKey = preservePrimaryIdentity
@@ -70,8 +57,7 @@ internal sealed class NonDemCityObjectBakeAssembler(
             sourceFileKey,
             candidates,
             batchIndex,
-            layout,
-            atlasImage,
+            atlas,
             cancellationToken);
 
         ResoniteConstructionCityObject bakedCityObject = new(
@@ -86,5 +72,29 @@ internal sealed class NonDemCityObjectBakeAssembler(
             CollisionEnabled: candidates.Any(static candidate => candidate.CityObject.CollisionEnabled),
             SourceFileRelativePath: sourceFileRelativePath);
         return Task.FromResult(bakedCityObject);
+    }
+
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "NonDemRenderedAtlas takes ownership of the rendered image and disposes it after geometry composition.")]
+    private NonDemRenderedAtlas? RenderAtlas(
+        List<NonDemAtlasBatchEntry> entries,
+        CancellationToken cancellationToken)
+    {
+        if (entries.Count == 0)
+        {
+            return null;
+        }
+
+        if (!atlasLayoutFactory.TryCreate(entries, out NonDemAtlasLayout<NonDemAtlasBatchEntry>? layout) || layout is null)
+        {
+            throw new InvalidOperationException("Failed to create non-DEM atlas layout.");
+        }
+
+        Image<Rgba32> atlasImage = new(layout.Width, layout.Height, new Rgba32(0, 0, 0, 0));
+        cancellationToken.ThrowIfCancellationRequested();
+        atlasImageRenderer.Draw(atlasImage, layout.Placements);
+        return new NonDemRenderedAtlas(layout, atlasImage);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
@@ -93,8 +93,21 @@ internal sealed class NonDemCityObjectBakeAssembler(
         }
 
         Image<Rgba32> atlasImage = new(layout.Width, layout.Height, new Rgba32(0, 0, 0, 0));
-        cancellationToken.ThrowIfCancellationRequested();
-        atlasImageRenderer.Draw(atlasImage, layout.Placements);
-        return new NonDemRenderedAtlas(layout, atlasImage);
+        bool ownershipTransferred = false;
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            atlasImageRenderer.Draw(atlasImage, layout.Placements);
+            NonDemRenderedAtlas renderedAtlas = new(layout, atlasImage);
+            ownershipTransferred = true;
+            return renderedAtlas;
+        }
+        finally
+        {
+            if (!ownershipTransferred)
+            {
+                atlasImage.Dispose();
+            }
+        }
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -23,7 +23,7 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
         NonDemBufferedCityObject bufferedCityObject,
         CancellationToken cancellationToken)
     {
-        ResoniteConstructionCityObject cityObject = bufferedCityObject.CityObject;
+        NonDemSourceScopedTriangleCityObject cityObject = bufferedCityObject.CityObject;
         NonDemCityObjectBakePolicy policy = bufferedCityObject.Policy;
         if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(cityObject, out _))
         {
@@ -31,7 +31,7 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
                 $"Non-DEM bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
         }
 
-        ResoniteConstructionCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
+        NonDemSourceScopedTriangleCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(normalizedCityObject, out Dictionary<int, ResoniteMaterialBinding>? materialBySubmeshIndex))
         {
             throw new InvalidOperationException(

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeMaterialClassifier.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeMaterialClassifier.cs
@@ -5,7 +5,7 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal static class NonDemCityObjectBakeMaterialClassifier
 {
     public static bool CanBufferCityObjectMaterials(
-        ResoniteConstructionCityObject cityObject,
+        NonDemSourceScopedTriangleCityObject cityObject,
         NonDemCityObjectBakePolicy policy)
     {
         if (!TryCreateMaterialBySubmeshIndex(cityObject, out Dictionary<int, ResoniteMaterialBinding> materialBySubmeshIndex))
@@ -43,7 +43,7 @@ internal static class NonDemCityObjectBakeMaterialClassifier
     }
 
     public static bool TryCreateMaterialBySubmeshIndex(
-        ResoniteConstructionCityObject cityObject,
+        NonDemSourceScopedTriangleCityObject cityObject,
         out Dictionary<int, ResoniteMaterialBinding> materialBySubmeshIndex)
     {
         materialBySubmeshIndex = [];

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using PlateauResoniteLink.Domain.Importing;
 
@@ -24,19 +25,75 @@ internal sealed record NonDemAtlasOrPreservedEntry(
     NonDemAtlasBatchEntry? AtlasEntry,
     NonDemPreservedSubmeshEntry? PreservedEntry);
 
-internal readonly record struct NonDemBufferedCityObject(
+internal sealed record NonDemSourceScopedTriangleCityObject(
     ResoniteConstructionCityObject CityObject,
+    ResoniteImportedMesh Mesh,
+    string SourceFileRelativePath)
+{
+    public string SlotKey => CityObject.SlotKey;
+
+    public string DisplayName => CityObject.DisplayName;
+
+    public string PackageName => CityObject.PackageName;
+
+    public string ActualMeshCode => CityObject.ActualMeshCode;
+
+    public int? LodLevel => CityObject.LodLevel;
+
+    public ResoniteTransform Transform => CityObject.Transform;
+
+    public IReadOnlyList<ResoniteMaterialBinding> Materials => CityObject.Materials;
+
+    public bool CollisionEnabled => CityObject.CollisionEnabled;
+
+    public static bool TryCreate(
+        ResoniteConstructionCityObject cityObject,
+        [NotNullWhen(true)] out NonDemSourceScopedTriangleCityObject? scopedCityObject)
+    {
+        ArgumentNullException.ThrowIfNull(cityObject);
+
+        if (cityObject.Geometry is not ResoniteTriangleMeshGeometry triangleMesh
+            || string.IsNullOrWhiteSpace(cityObject.SourceFileRelativePath))
+        {
+            scopedCityObject = null;
+            return false;
+        }
+
+        scopedCityObject = new NonDemSourceScopedTriangleCityObject(
+            cityObject,
+            triangleMesh.Mesh,
+            cityObject.SourceFileRelativePath);
+        return true;
+    }
+
+    public NonDemSourceScopedTriangleCityObject WithMeshAndMaterials(
+        ResoniteImportedMesh mesh,
+        IReadOnlyList<ResoniteMaterialBinding> materials)
+    {
+        return new NonDemSourceScopedTriangleCityObject(
+            CityObject with
+            {
+                Geometry = new ResoniteTriangleMeshGeometry(mesh),
+                Materials = materials,
+            },
+            mesh,
+            SourceFileRelativePath);
+    }
+}
+
+internal readonly record struct NonDemBufferedCityObject(
+    NonDemSourceScopedTriangleCityObject CityObject,
     NonDemCityObjectBakePolicy Policy);
 
 internal sealed record NonDemAtlasBatchEntry(
-    ResoniteConstructionCityObject CityObject,
+    NonDemSourceScopedTriangleCityObject CityObject,
     ResoniteMeshSubmesh Submesh,
     ResoniteMaterialBinding Material,
     NonDemMaterialAtlasTile Tile,
     TextureUvRect UvBounds);
 
 internal sealed record NonDemPreservedSubmeshEntry(
-    ResoniteConstructionCityObject CityObject,
+    NonDemSourceScopedTriangleCityObject CityObject,
     ResoniteMeshSubmesh Submesh,
     ResoniteMaterialBinding Material,
     ResoniteColor? VertexColorOverride = null);
@@ -46,6 +103,6 @@ internal sealed record NonDemOrderedPreservedSubmeshEntry(
     int Order);
 
 internal sealed record NonDemCityObjectBakeCandidate(
-    ResoniteConstructionCityObject CityObject,
+    NonDemSourceScopedTriangleCityObject CityObject,
     IReadOnlyList<NonDemAtlasBatchEntry> AtlasEntries,
     IReadOnlyList<NonDemPreservedSubmeshEntry> PreservedEntries);

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using PlateauResoniteLink.Domain.Importing;
@@ -8,6 +9,16 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed record NonDemMaterialAtlasTile(Image<Rgba32> Image, Rgba32 BackgroundColor);
+
+internal sealed record NonDemRenderedAtlas(
+    NonDemAtlasLayout<NonDemAtlasBatchEntry> Layout,
+    Image<Rgba32> Image) : IDisposable
+{
+    public void Dispose()
+    {
+        Image.Dispose();
+    }
+}
 
 internal sealed record NonDemAtlasOrPreservedEntry(
     NonDemAtlasBatchEntry? AtlasEntry,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicy.cs
@@ -14,13 +14,13 @@ internal enum NonDemMaterialBakeCategory
 
 internal sealed record NonDemCityObjectBakePolicy(
     string Name,
-    Func<ResoniteConstructionCityObject, bool> CanBufferCityObject,
+    Func<NonDemSourceScopedTriangleCityObject, bool> CanBufferCityObject,
     bool RequireAtlasCandidateMaterial,
     bool PreserveVertexColorMaterials,
     bool PreserveTexturelessMaterials,
     bool PreserveCommonMaterials)
 {
-    public bool CanBuffer(ResoniteConstructionCityObject cityObject)
+    public bool CanBuffer(NonDemSourceScopedTriangleCityObject cityObject)
     {
         return CanBufferCityObject(cityObject);
     }
@@ -31,8 +31,7 @@ internal static class NonDemCityObjectBakePolicies
     internal static readonly NonDemCityObjectBakePolicy Default = new(
         Name: "non-dem",
         CanBufferCityObject: static cityObject =>
-            cityObject.Geometry is ResoniteTriangleMeshGeometry
-            && cityObject.Transform.Rotation is null
+            cityObject.Transform.Rotation is null
             && !string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase),
         RequireAtlasCandidateMaterial: false,
         PreserveVertexColorMaterials: true,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicyResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicyResolver.cs
@@ -5,7 +5,7 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal interface INonDemCityObjectBakePolicyResolver
 {
-    NonDemCityObjectBakePolicy? Resolve(ResoniteConstructionCityObject cityObject);
+    NonDemCityObjectBakePolicy? Resolve(NonDemSourceScopedTriangleCityObject cityObject);
 }
 
 internal sealed class NonDemCityObjectBakePolicyResolver(
@@ -14,7 +14,7 @@ internal sealed class NonDemCityObjectBakePolicyResolver(
     private readonly IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies = bakePolicies
         ?? throw new ArgumentNullException(nameof(bakePolicies));
 
-    public NonDemCityObjectBakePolicy? Resolve(ResoniteConstructionCityObject cityObject)
+    public NonDemCityObjectBakePolicy? Resolve(NonDemSourceScopedTriangleCityObject cityObject)
     {
         foreach (NonDemCityObjectBakePolicy policy in bakePolicies)
         {

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -28,16 +28,21 @@ internal sealed class NonDemCityObjectBaker(
         ArgumentNullException.ThrowIfNull(cityObject);
         cancellationToken.ThrowIfCancellationRequested();
 
-        NonDemCityObjectBakePolicy? policy = bakePolicyResolver.Resolve(cityObject);
+        if (!NonDemSourceScopedTriangleCityObject.TryCreate(cityObject, out NonDemSourceScopedTriangleCityObject? scopedCityObject))
+        {
+            return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: false, []));
+        }
+
+        NonDemCityObjectBakePolicy? policy = bakePolicyResolver.Resolve(scopedCityObject);
         if (policy is null)
         {
             return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: false, []));
         }
 
-        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
-        NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(cityObject, policy);
+        scopedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(scopedCityObject);
+        NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(scopedCityObject, policy);
         List<ResoniteConstructionCityObject> readyCityObjects = [];
-        sourceFileBuffer.Add(sourceFileKey, new NonDemBufferedCityObject(cityObject, policy));
+        sourceFileBuffer.Add(sourceFileKey, new NonDemBufferedCityObject(scopedCityObject, policy));
         BakedInputCityObjectCount++;
         return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: true, readyCityObjects));
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -105,7 +105,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
         if (passThroughCandidates.Count == 1)
         {
             NonDemCityObjectBakeCandidate passThroughCandidate = passThroughCandidates[0];
-            await onBakedCityObject(passThroughCandidate.CityObject, cancellationToken);
+            await onBakedCityObject(passThroughCandidate.CityObject.CityObject, cancellationToken);
             candidateImageDisposer.Dispose(passThroughCandidate);
             emittedCount++;
         }
@@ -163,7 +163,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
     {
         try
         {
-            await onBakedCityObject(fallbackCandidate.CityObject, cancellationToken);
+            await onBakedCityObject(fallbackCandidate.CityObject.CityObject, cancellationToken);
             return 1;
         }
         finally

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBatching.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBatching.cs
@@ -10,24 +10,16 @@ internal static class NonDemSourceFileBatching
     public static IComparer<NonDemSourceFileBatchKey> KeyComparer { get; } = new SourceFileBatchKeyComparer();
 
     public static NonDemSourceFileBatchKey CreateKey(
-        ResoniteConstructionCityObject cityObject,
+        NonDemSourceScopedTriangleCityObject cityObject,
         NonDemCityObjectBakePolicy policy)
     {
         string context = policy.Name;
-        string? sourceFileRelativePath = string.IsNullOrWhiteSpace(cityObject.SourceFileRelativePath) ? null : cityObject.SourceFileRelativePath;
-        if (sourceFileRelativePath is null)
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM batch candidate '{cityObject.DisplayName}' did not provide source scope. "
-                + "source-file-owned batching requires SourceFileRelativePath.");
-        }
-
         return new NonDemSourceFileBatchKey(
             cityObject.ActualMeshCode,
             cityObject.PackageName.ToLowerInvariant(),
             cityObject.LodLevel,
             context,
-            SourceFileRelativePath: sourceFileRelativePath);
+            SourceFileRelativePath: cityObject.SourceFileRelativePath);
     }
 
     public static string CreateBatchSlotKey(NonDemSourceFileBatchKey sourceFileKey, int batchIndex)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupPreparer.cs
@@ -151,7 +151,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
         if (batchBuilder.Actions.Count > 0)
         {
             BatchResponse response = await client.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
-            CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response);
+            CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions);
             foreach (PreparedCommonMaterialBatchEntry preparedMaterial in preparedMaterials)
             {
                 if (preparedMaterial.PendingMaterialSlot is not null)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteDynamicMaterialUvNormalizer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteDynamicMaterialUvNormalizer.cs
@@ -60,6 +60,45 @@ public static class ResoniteDynamicMaterialUvNormalizer
         };
     }
 
+    internal static NonDemSourceScopedTriangleCityObject Normalize(NonDemSourceScopedTriangleCityObject cityObject)
+    {
+        ArgumentNullException.ThrowIfNull(cityObject);
+
+        if (!cityObject.Materials.Any(ShouldNormalizeTextureTransform))
+        {
+            return cityObject;
+        }
+
+        Dictionary<int, ResoniteMaterialBinding> materialBySubmeshIndex = cityObject.Materials
+            .SelectMany(material => material.SubmeshIndices.Select(submeshIndex => (submeshIndex, material)))
+            .ToDictionary(static pair => pair.submeshIndex, static pair => pair.material);
+
+        List<ResoniteMeshVertex> normalizedVertices = [];
+        List<ResoniteMeshSubmesh> normalizedSubmeshes = [];
+        foreach (ResoniteMeshSubmesh submesh in cityObject.Mesh.Submeshes)
+        {
+            materialBySubmeshIndex.TryGetValue(submesh.Index, out ResoniteMaterialBinding? material);
+            List<int> normalizedTriangleVertexIndices = new(submesh.TriangleVertexIndices.Count);
+            foreach (int sourceIndex in submesh.TriangleVertexIndices)
+            {
+                ResoniteMeshVertex sourceVertex = cityObject.Mesh.Vertices[sourceIndex];
+                ResoniteFloat2 normalizedUv = material is not null && ShouldNormalizeTextureTransform(material)
+                    ? ApplyTextureTransform(sourceVertex.UV0, material)
+                    : sourceVertex.UV0;
+                normalizedVertices.Add(sourceVertex with { UV0 = normalizedUv });
+                normalizedTriangleVertexIndices.Add(normalizedVertices.Count - 1);
+            }
+
+            normalizedSubmeshes.Add(submesh with { TriangleVertexIndices = normalizedTriangleVertexIndices });
+        }
+
+        return cityObject.WithMeshAndMaterials(
+            new ResoniteImportedMesh(normalizedVertices, normalizedSubmeshes),
+            cityObject.Materials
+                .Select(NormalizeMaterialBinding)
+                .ToArray());
+    }
+
     public static ResoniteMaterialBinding NormalizeMaterialBinding(ResoniteMaterialBinding material)
     {
         ArgumentNullException.ThrowIfNull(material);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -48,12 +48,21 @@ internal sealed record PlannedReusableMaterialAsset(
     ResoniteComponentLocator Target)
     : PlannedMaterialAsset;
 
-internal sealed record PlannedDedicatedMaterialAsset(
+internal abstract record PlannedDedicatedMaterialAsset(
+    ResoniteMaterialBinding Material,
+    IReadOnlyList<PlannedTextureAsset> Textures)
+    : PlannedMaterialAsset;
+
+internal sealed record PlannedInlineDedicatedMaterialAsset(
+    ResoniteMaterialBinding Material,
+    IReadOnlyList<PlannedTextureAsset> Textures)
+    : PlannedDedicatedMaterialAsset(Material, Textures);
+
+internal sealed record PlannedPreservedSlotDedicatedMaterialAsset(
     ResoniteMaterialBinding Material,
     IReadOnlyList<PlannedTextureAsset> Textures,
-    bool PreserveDedicatedMaterialSlot,
-    string? DedicatedMaterialSlotName = null)
-    : PlannedMaterialAsset;
+    string DedicatedMaterialSlotName)
+    : PlannedDedicatedMaterialAsset(Material, Textures);
 
 internal abstract record PlannedRendererMaterialBinding(PlannedMaterialAsset MaterialAsset);
 

--- a/tests/PlateauResoniteLink.Tests/Targets/CanonicalBatchEntityMapTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/CanonicalBatchEntityMapTests.cs
@@ -1,0 +1,120 @@
+using System;
+
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class CanonicalBatchEntityMapTests
+{
+    [Fact]
+    public void CreateRejectsMixedMessageIdAndOrderedOnlyResponses()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot first = builder.AddSlot("parent", "First", null, null);
+        _ = builder.AddSlot("parent", "Second", null, null);
+        BatchResponse response = new()
+        {
+            Responses =
+            [
+                NewEntity("slot-1", first.MessageId.Value),
+                NewEntity("slot-2", sourceMessageId: null),
+            ],
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CanonicalBatchEntityMap.Create(response, builder.PendingActions));
+
+        Assert.Contains("mixed message-correlated and ordered-only responses", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateRejectsDuplicateMessageIds()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot pending = builder.AddSlot("parent", "First", null, null);
+        BatchResponse response = new()
+        {
+            Responses =
+            [
+                NewEntity("slot-1", pending.MessageId.Value),
+                NewEntity("slot-2", pending.MessageId.Value),
+            ],
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CanonicalBatchEntityMap.Create(response, builder.PendingActions));
+
+        Assert.Contains($"duplicate message '{pending.MessageId.Value}'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateRejectsMissingMessageIdResponse()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot pending = builder.AddSlot("parent", "First", null, null);
+        BatchResponse response = new()
+        {
+            Responses = [],
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CanonicalBatchEntityMap.Create(response, builder.PendingActions));
+
+        Assert.Contains($"0 ordered response(s) for {builder.PendingActions.Count} pending operation(s)", exception.Message, StringComparison.Ordinal);
+        Assert.Equal("First", pending.SlotName);
+    }
+
+    [Fact]
+    public void CreateRejectsExtraMessageIdResponse()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot pending = builder.AddSlot("parent", "First", null, null);
+        BatchResponse response = new()
+        {
+            Responses =
+            [
+                NewEntity("slot-1", pending.MessageId.Value),
+                NewEntity("slot-extra", "unexpected-message"),
+            ],
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CanonicalBatchEntityMap.Create(response, builder.PendingActions));
+
+        Assert.Contains("2 message-correlated response(s) for 1 pending operation(s)", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateCorrelatesOrderedOnlyResponsesWhenCountsMatch()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot first = builder.AddSlot("parent", "First", null, null);
+        ResoniteBatchOperations.PendingBatchSlot second = builder.AddSlot("parent", "Second", null, null);
+        BatchResponse response = new()
+        {
+            Responses =
+            [
+                NewEntity("slot-1", sourceMessageId: null),
+                NewEntity("slot-2", sourceMessageId: null),
+            ],
+        };
+
+        CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response, builder.PendingActions);
+
+        Assert.Equal(new ResoniteSlotLocator("slot-1"), entityMap.ResolveSlot(first).Locator);
+        Assert.Equal(new ResoniteSlotLocator("slot-2"), entityMap.ResolveSlot(second).Locator);
+    }
+
+    private static NewEntityId NewEntity(string entityId, string? sourceMessageId)
+    {
+        return new NewEntityId
+        {
+            EntityId = entityId,
+            Success = true,
+            SourceMessageID = sourceMessageId,
+        };
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
@@ -44,13 +44,13 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
         };
 
         Assert.False(NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(
-            CreateCityObject([CreateTexturelessMaterial()]),
+            CreateScopedCityObject([CreateTexturelessMaterial()]),
             requireAtlasCandidate));
         Assert.True(NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(
-            CreateCityObject([CreateDatasetTextureMaterial()]),
+            CreateScopedCityObject([CreateDatasetTextureMaterial()]),
             requireAtlasCandidate));
         Assert.False(NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(
-            CreateCityObject([CreateTexturelessMaterial()]),
+            CreateScopedCityObject([CreateTexturelessMaterial()]),
             requireAtlasCandidate with
             {
                 RequireAtlasCandidateMaterial = false,
@@ -68,8 +68,19 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
             ]);
 
         Assert.False(NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(
-            cityObject,
+            CreateScopedCityObject(cityObject),
             out _));
+    }
+
+    private static NonDemSourceScopedTriangleCityObject CreateScopedCityObject(IReadOnlyList<ResoniteMaterialBinding> materials)
+    {
+        return CreateScopedCityObject(CreateCityObject(materials));
+    }
+
+    private static NonDemSourceScopedTriangleCityObject CreateScopedCityObject(ResoniteConstructionCityObject cityObject)
+    {
+        Assert.True(NonDemSourceScopedTriangleCityObject.TryCreate(cityObject, out NonDemSourceScopedTriangleCityObject? scopedCityObject));
+        return scopedCityObject;
     }
 
     private static ResoniteConstructionCityObject CreateCityObject(IReadOnlyList<ResoniteMaterialBinding> materials)
@@ -97,7 +108,8 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
                         new ResoniteFloat2(0.0, 1.0)),
                 ],
                 [new ResoniteMeshSubmesh(0, [0, 1, 2])]),
-            materials);
+            materials,
+            SourceFileRelativePath: "udx/bldg/53394525_bldg_6697_op.gml");
     }
 
     private static ResoniteMaterialBinding CreateDatasetTextureMaterial()

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -893,6 +893,29 @@ public sealed class NonDemCityObjectBakerTests
     }
 
     [Fact]
+    public async Task TryBufferAsyncSkipsNonDemCityObjectsWithoutSourceFileScope()
+    {
+        NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);
+        ResoniteConstructionCityObject cityObject = CreateUvScaledLod2Building(
+            "source-scope-missing",
+            CreatePayload("textures/source-scope-missing.png", new Rgba32(255, 0, 0, 255), 4, 4),
+            "unit-a",
+            new ResoniteFloat2(2.0, 0.5),
+            new ResoniteFloat2(0.25, 0.75)) with
+        {
+            SourceFileRelativePath = null,
+        };
+
+        BufferedCityObjectBufferResult result = await baker.TryBufferAsync(cityObject);
+
+        Assert.False(result.Buffered);
+        Assert.Empty(result.ReadyCityObjects);
+        Assert.Equal(new ResoniteFloat2(2.0, 0.5), Assert.Single(cityObject.Materials).TextureScale);
+        Assert.Equal(new ResoniteFloat2(0.25, 0.75), Assert.Single(cityObject.Materials).TextureOffset);
+        Assert.Empty(await baker.FlushAllAsync());
+    }
+
+    [Fact]
     public async Task TryBufferAsyncBuffersLodlessNonDemCityObjects()
     {
         NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemSourceFileBatchingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemSourceFileBatchingTests.cs
@@ -1,5 +1,3 @@
-using System;
-
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Targets;
@@ -7,13 +5,13 @@ namespace PlateauResoniteLink.Tests.Targets;
 public sealed class NonDemSourceFileBatchingTests
 {
     [Fact]
-    public void CreateKeyNormalizesPackageNameAndRequiresSourceFileScope()
+    public void CreateKeyUsesRequiredSourceFileScopeFromScopedTriangleCityObject()
     {
-        ResoniteConstructionCityObject cityObject = CreateCityObject() with
+        NonDemSourceScopedTriangleCityObject cityObject = CreateScopedCityObject(CreateCityObject() with
         {
             PackageName = "BLDG",
             SourceFileRelativePath = "udx/bldg/53394525_bldg_6697_op.gml",
-        };
+        });
 
         NonDemSourceFileBatchKey key = NonDemSourceFileBatching.CreateKey(
             cityObject,
@@ -21,9 +19,6 @@ public sealed class NonDemSourceFileBatchingTests
 
         Assert.Equal("bldg", key.PackageName);
         Assert.Equal("udx/bldg/53394525_bldg_6697_op.gml", key.SourceFileRelativePath);
-        Assert.Throws<InvalidOperationException>(() => NonDemSourceFileBatching.CreateKey(
-            cityObject with { SourceFileRelativePath = null },
-            NonDemCityObjectBakePolicies.Default));
     }
 
     [Fact]
@@ -83,5 +78,11 @@ public sealed class NonDemSourceFileBatchingTests
                 ],
                 [new ResoniteMeshSubmesh(0, [0, 1, 2])]),
             []);
+    }
+
+    private static NonDemSourceScopedTriangleCityObject CreateScopedCityObject(ResoniteConstructionCityObject cityObject)
+    {
+        Assert.True(NonDemSourceScopedTriangleCityObject.TryCreate(cityObject, out NonDemSourceScopedTriangleCityObject? scopedCityObject));
+        return scopedCityObject;
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -216,10 +216,10 @@ public sealed class ResoniteMaterialPlanningTests
             material,
             materialIndex: 2);
 
-        Assert.True(preserved.PreserveDedicatedMaterialSlot);
-        Assert.Equal(expectedDedicatedSlotName, preserved.DedicatedMaterialSlotName);
-        Assert.False(notPreserved.PreserveDedicatedMaterialSlot);
-        Assert.Null(notPreserved.DedicatedMaterialSlotName);
+        PlannedPreservedSlotDedicatedMaterialAsset preservedSlotMaterial =
+            Assert.IsType<PlannedPreservedSlotDedicatedMaterialAsset>(preserved);
+        Assert.Equal(expectedDedicatedSlotName, preservedSlotMaterial.DedicatedMaterialSlotName);
+        Assert.IsType<PlannedInlineDedicatedMaterialAsset>(notPreserved);
     }
 
     [Fact]
@@ -264,14 +264,13 @@ public sealed class ResoniteMaterialPlanningTests
     {
         ResoniteBatchOperations.BatchActionBuilder batchBuilder = new();
         ResoniteMaterialBinding material = CreateBundledMaterial(BundledDefaultMaterialFamilies.Facade, 0);
-        PlannedDedicatedMaterialAsset plannedMaterial = new(
+        PlannedDedicatedMaterialAsset plannedMaterial = new PlannedInlineDedicatedMaterialAsset(
             material,
             [
                 new PlannedTextureAsset(
                     ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
                     new Uri("resdb:///texture/albedo", UriKind.Absolute)),
-            ],
-            PreserveDedicatedMaterialSlot: false);
+            ]);
 
         ResoniteMaterialPlanning.AddCommonMaterialComponents(batchBuilder, plannedMaterial, "slot");
 
@@ -287,7 +286,7 @@ public sealed class ResoniteMaterialPlanningTests
     {
         ResoniteBatchOperations.BatchActionBuilder batchBuilder = new();
         ResoniteMaterialBinding material = CreateBundledMaterial(BundledDefaultMaterialFamilies.WallResidentialPlasterLow, 0);
-        PlannedDedicatedMaterialAsset plannedMaterial = new(
+        PlannedDedicatedMaterialAsset plannedMaterial = new PlannedInlineDedicatedMaterialAsset(
             material,
             [
                 new PlannedTextureAsset(
@@ -296,8 +295,7 @@ public sealed class ResoniteMaterialPlanningTests
                 new PlannedTextureAsset(
                     ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.TextureMemberRole.Emission),
                     new Uri("resdb:///texture/emission", UriKind.Absolute)),
-            ],
-            PreserveDedicatedMaterialSlot: false);
+            ]);
 
         ResoniteMaterialPlanning.AddCommonMaterialComponents(batchBuilder, plannedMaterial, "slot");
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -271,7 +271,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             "Triangle Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(0.0, 0.0, 0.0),
             null);
-        PlannedDedicatedMaterialAsset dedicatedMaterial = new(
+        PlannedDedicatedMaterialAsset dedicatedMaterial = new PlannedPreservedSlotDedicatedMaterialAsset(
             new ResoniteMaterialBinding(
                 BaseColor: new PlateauResoniteLink.Targets.Resonite.ResoniteColor(1.0, 1.0, 1.0, 1.0),
                 MaterialType: ResoniteMaterialType.Standard,
@@ -281,7 +281,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 DepthOffset: null,
                 SubmeshIndices: [0]),
             [new PlannedTextureAsset(new TextureIdentity("albedo"), new Uri("resdb:///texture/albedo"))],
-            PreserveDedicatedMaterialSlot: true,
             DedicatedMaterialSlotName: "material-000-pbs-uv-uv");
         PlannedReusableMaterialAsset reusableMaterial = new(new ResoniteComponentLocator("existing-material-id"));
         PlannedSceneObjectEmission emissionPlan = new(
@@ -339,7 +338,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             "Triangle Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(0.0, 0.0, 0.0),
             null);
-        PlannedDedicatedMaterialAsset dedicatedMaterial = new(
+        PlannedDedicatedMaterialAsset dedicatedMaterial = new PlannedInlineDedicatedMaterialAsset(
             new ResoniteMaterialBinding(
                 BaseColor: new PlateauResoniteLink.Targets.Resonite.ResoniteColor(1.0, 1.0, 1.0, 1.0),
                 MaterialType: ResoniteMaterialType.Standard,
@@ -354,8 +353,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 new PlannedTextureAsset(new TextureIdentity("height"), new Uri("resdb:///texture/height")),
                 new PlannedTextureAsset(new TextureIdentity("metallic"), new Uri("resdb:///texture/metallic")),
                 new PlannedTextureAsset(new TextureIdentity("emission"), new Uri("resdb:///texture/emission")),
-            ],
-            PreserveDedicatedMaterialSlot: false);
+            ]);
         PlannedSceneObjectEmission emissionPlan = new(
             new PlannedTriangleMeshGeometryAsset(
                 new GeometryIdentity("geom"),


### PR DESCRIPTION
## Summary
- represent rendered non-DEM atlases as a single `NonDemRenderedAtlas` carrying both layout and image
- pass the rendered atlas into geometry composition instead of nullable correlated `layout`/`atlasImage` parameters
- keep image disposal owned by the rendered atlas value used during bake composition

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020` mesh `53395325` packages `dem,bldg` terrain grid, no diff from baseline