### PR TITLE
Type dedicated material slot plans

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -475,15 +475,13 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
     {
         ResoniteMaterialBinding material = plannedMaterial.Material;
         PlannedSlotTargetReference materialContainerTarget = meshAssetSlotTarget;
-        if (plannedMaterial.PreserveDedicatedMaterialSlot)
+        if (plannedMaterial is PlannedPreservedSlotDedicatedMaterialAsset preservedSlotMaterial)
         {
             BatchPlanSlotLocator materialSlotId = CreateBatchPlanSlotLocator(ref nextSlotLocator);
-            string materialSlotName = plannedMaterial.DedicatedMaterialSlotName
-                ?? throw new InvalidOperationException("Dedicated material slot preservation requires a planned material-index slot name.");
             slotEmissions.Add(new PlannedBatchSlotEmission(
                 materialSlotId,
                 meshAssetSlotTarget,
-                materialSlotName,
+                preservedSlotMaterial.DedicatedMaterialSlotName,
                 null,
                 null));
             materialContainerTarget = PlannedSlotTargetReference.PlannedSlot(materialSlotId);

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteSlotCreator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteSlotCreator.cs
@@ -35,6 +35,6 @@ internal sealed class ResoniteSlotCreator : IResoniteSlotCreator
             position,
             rotation);
         BatchResponse response = await client.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
-        return CanonicalBatchEntityMap.Create(response).ResolveSlot(pendingSlot);
+        return CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions).ResolveSlot(pendingSlot);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteBatchOperations.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteBatchOperations.cs
@@ -334,26 +334,21 @@ internal static class ResoniteBatchOperations
 internal sealed class CanonicalBatchEntityMap
 {
     private readonly Dictionary<string, Response> responsesByMessageId;
-    private readonly Queue<Response> responsesWithoutMessageId;
 
-    private CanonicalBatchEntityMap(
-        Dictionary<string, Response> responsesByMessageId,
-        Queue<Response> responsesWithoutMessageId)
+    private CanonicalBatchEntityMap(Dictionary<string, Response> responsesByMessageId)
     {
         this.responsesByMessageId = responsesByMessageId;
-        this.responsesWithoutMessageId = responsesWithoutMessageId;
     }
 
-    public static CanonicalBatchEntityMap Create(BatchResponse batchResponse)
+    public static CanonicalBatchEntityMap Create(
+        BatchResponse batchResponse,
+        IReadOnlyList<ResoniteBatchOperations.PendingBatchOperation> pendingOperations)
     {
         ArgumentNullException.ThrowIfNull(batchResponse);
-        return new CanonicalBatchEntityMap(
-            (batchResponse.Responses ?? [])
-                .Where(static response => !string.IsNullOrWhiteSpace(response.SourceMessageID))
-                .ToDictionary(response => response.SourceMessageID!, StringComparer.Ordinal),
-            new Queue<Response>(
-                (batchResponse.Responses ?? [])
-                    .Where(static response => string.IsNullOrWhiteSpace(response.SourceMessageID))));
+        ArgumentNullException.ThrowIfNull(pendingOperations);
+
+        IReadOnlyList<Response> responses = batchResponse.Responses ?? [];
+        return new CanonicalBatchEntityMap(CorrelateResponses(responses, pendingOperations));
     }
 
     public CreatedSlot ResolveSlot(ResoniteBatchOperations.PendingBatchSlot pendingSlot)
@@ -400,15 +395,78 @@ internal sealed class CanonicalBatchEntityMap
     {
         if (!responsesByMessageId.TryGetValue(messageId.Value, out Response? response))
         {
-            if (responsesWithoutMessageId.Count == 0)
-            {
-                throw new InvalidOperationException($"Batch response did not include message '{messageId.Value}'.");
-            }
-
-            response = responsesWithoutMessageId.Dequeue();
+            throw new InvalidOperationException($"Batch response did not include message '{messageId.Value}'.");
         }
 
         ResoniteLinkClient.EnsureSuccess(response, operationName);
         return response;
+    }
+
+    private static Dictionary<string, Response> CorrelateResponses(
+        IReadOnlyList<Response> responses,
+        IReadOnlyList<ResoniteBatchOperations.PendingBatchOperation> pendingOperations)
+    {
+        if (responses.Count == 0 && pendingOperations.Count == 0)
+        {
+            return new Dictionary<string, Response>(StringComparer.Ordinal);
+        }
+
+        bool anyMessageId = responses.Any(static response => !string.IsNullOrWhiteSpace(response.SourceMessageID));
+        bool anyMissingMessageId = responses.Any(static response => string.IsNullOrWhiteSpace(response.SourceMessageID));
+        if (anyMessageId && anyMissingMessageId)
+        {
+            throw new InvalidOperationException("Batch response mixed message-correlated and ordered-only responses.");
+        }
+
+        if (!anyMessageId)
+        {
+            return CorrelateOrderedResponses(responses, pendingOperations);
+        }
+
+        Dictionary<string, Response> correlated = new(StringComparer.Ordinal);
+        foreach (Response response in responses)
+        {
+            string messageId = response.SourceMessageID!;
+            if (!correlated.TryAdd(messageId, response))
+            {
+                throw new InvalidOperationException($"Batch response included duplicate message '{messageId}'.");
+            }
+        }
+
+        foreach (ResoniteBatchOperations.PendingBatchOperation pendingOperation in pendingOperations)
+        {
+            if (!correlated.ContainsKey(pendingOperation.MessageId.Value))
+            {
+                throw new InvalidOperationException($"Batch response did not include message '{pendingOperation.MessageId.Value}'.");
+            }
+        }
+
+        if (correlated.Count != pendingOperations.Count)
+        {
+            throw new InvalidOperationException(
+                $"Batch response included {correlated.Count} message-correlated response(s) for {pendingOperations.Count} pending operation(s).");
+        }
+
+        return correlated;
+    }
+
+    private static Dictionary<string, Response> CorrelateOrderedResponses(
+        IReadOnlyList<Response> responses,
+        IReadOnlyList<ResoniteBatchOperations.PendingBatchOperation> pendingOperations)
+    {
+        if (responses.Count != pendingOperations.Count)
+        {
+            throw new InvalidOperationException(
+                $"Batch response included {responses.Count} ordered response(s) for {pendingOperations.Count} pending operation(s).");
+        }
+
+        Dictionary<string, Response> correlated = new(StringComparer.Ordinal);
+        for (int i = 0; i < responses.Count; i++)
+        {
+            ResoniteBatchOperations.PendingBatchOperation pendingOperation = pendingOperations[i];
+            correlated[pendingOperation.MessageId.Value] = responses[i];
+        }
+
+        return correlated;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -298,7 +298,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             componentType,
             members);
         BatchResponse response = await client.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
-        return CanonicalBatchEntityMap.Create(response).ResolveComponent(pendingComponent);
+        return CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions).ResolveComponent(pendingComponent);
     }
 
     public static ResoniteMaterialBinding ResolveTerrainTextureCanvasMaterial(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -69,10 +69,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             albedoTextureTask,
             bundledTextureImportTasks,
             cancellationToken);
-        return new PlannedDedicatedMaterialAsset(
+        return new PlannedInlineDedicatedMaterialAsset(
             material,
-            textures,
-            PreserveDedicatedMaterialSlot: false);
+            textures);
     }
 
     public async Task<PlannedDedicatedMaterialAsset> PlanDedicatedMaterialAssetAsync(
@@ -107,13 +106,14 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             albedoTextureTask,
             bundledTextureImportTasks: null,
             cancellationToken);
-        return new PlannedDedicatedMaterialAsset(
-            material,
-            textures,
-            preserveDedicatedMaterialSlot,
-            DedicatedMaterialSlotName: preserveDedicatedMaterialSlot
-                ? ResoniteSceneMaterialConventions.CreateDedicatedMaterialSlotName(material, materialIndex)
-                : null);
+        return preserveDedicatedMaterialSlot
+            ? new PlannedPreservedSlotDedicatedMaterialAsset(
+                material,
+                textures,
+                ResoniteSceneMaterialConventions.CreateDedicatedMaterialSlotName(material, materialIndex))
+            : new PlannedInlineDedicatedMaterialAsset(
+                material,
+                textures);
     }
 
     public static Uri? TryGetPlannedTextureUri(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -94,7 +94,7 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
                 $"City object '{cityObject.DisplayName}' batch completed in {batchStopwatch.Elapsed.TotalSeconds:F3}s "
                 + $"(operations={operationCount}, est_payload_bytes={EstimateBatchPayloadBytes(operationCount)})."));
 
-        CanonicalBatchEntityMap canonicalBatchEntityMap = CanonicalBatchEntityMap.Create(batchResponse);
+        CanonicalBatchEntityMap canonicalBatchEntityMap = CanonicalBatchEntityMap.Create(batchResponse, batchBuilder.PendingActions);
         canonicalBatchEntityMap.ValidateAll(batchBuilder.PendingActions);
         foreach (BatchPlanSlotLocator slotResolutionTarget in batchEmission.SlotResolutionTargets)
         {

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneSetupInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneSetupInterpreter.cs
@@ -171,7 +171,7 @@ internal sealed class ResoniteSceneSetupInterpreter : IResoniteSceneSetupInterpr
         if (batchBuilder.Actions.Count > 0)
         {
             BatchResponse response = await setupClient.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
-            CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response);
+            CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions);
             if (pendingAssets is not null)
             {
                 assetsSlot = CreateSlot(entityMap.ResolveSlot(pendingAssets.Value));
@@ -338,7 +338,7 @@ internal sealed class ResoniteSceneSetupInterpreter : IResoniteSceneSetupInterpr
 
         BatchResponse response = await setupClient.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
 
-        CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response);
+        CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions);
         CreatedSlot datasetRootSlot = entityMap.ResolveSlot(pendingDatasetRootSlot);
         CreatedSlot datasetAssetsRootSlot = entityMap.ResolveSlot(pendingDatasetAssetsRootSlot);
         CreatedSlot commonAssetsRootSlot = existingSharedCommonMaterialsSlot is null

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupPreparer.cs
@@ -151,7 +151,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
         if (batchBuilder.Actions.Count > 0)
         {
             BatchResponse response = await client.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
-            CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response);
+            CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions);
             foreach (PreparedCommonMaterialBatchEntry preparedMaterial in preparedMaterials)
             {
                 if (preparedMaterial.PendingMaterialSlot is not null)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -48,12 +48,21 @@ internal sealed record PlannedReusableMaterialAsset(
     ResoniteComponentLocator Target)
     : PlannedMaterialAsset;
 
-internal sealed record PlannedDedicatedMaterialAsset(
+internal abstract record PlannedDedicatedMaterialAsset(
+    ResoniteMaterialBinding Material,
+    IReadOnlyList<PlannedTextureAsset> Textures)
+    : PlannedMaterialAsset;
+
+internal sealed record PlannedInlineDedicatedMaterialAsset(
+    ResoniteMaterialBinding Material,
+    IReadOnlyList<PlannedTextureAsset> Textures)
+    : PlannedDedicatedMaterialAsset(Material, Textures);
+
+internal sealed record PlannedPreservedSlotDedicatedMaterialAsset(
     ResoniteMaterialBinding Material,
     IReadOnlyList<PlannedTextureAsset> Textures,
-    bool PreserveDedicatedMaterialSlot,
-    string? DedicatedMaterialSlotName = null)
-    : PlannedMaterialAsset;
+    string DedicatedMaterialSlotName)
+    : PlannedDedicatedMaterialAsset(Material, Textures);
 
 internal abstract record PlannedRendererMaterialBinding(PlannedMaterialAsset MaterialAsset);
 

--- a/tests/PlateauResoniteLink.Tests/Targets/CanonicalBatchEntityMapTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/CanonicalBatchEntityMapTests.cs
@@ -1,0 +1,120 @@
+using System;
+
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class CanonicalBatchEntityMapTests
+{
+    [Fact]
+    public void CreateRejectsMixedMessageIdAndOrderedOnlyResponses()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot first = builder.AddSlot("parent", "First", null, null);
+        _ = builder.AddSlot("parent", "Second", null, null);
+        BatchResponse response = new()
+        {
+            Responses =
+            [
+                NewEntity("slot-1", first.MessageId.Value),
+                NewEntity("slot-2", sourceMessageId: null),
+            ],
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CanonicalBatchEntityMap.Create(response, builder.PendingActions));
+
+        Assert.Contains("mixed message-correlated and ordered-only responses", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateRejectsDuplicateMessageIds()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot pending = builder.AddSlot("parent", "First", null, null);
+        BatchResponse response = new()
+        {
+            Responses =
+            [
+                NewEntity("slot-1", pending.MessageId.Value),
+                NewEntity("slot-2", pending.MessageId.Value),
+            ],
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CanonicalBatchEntityMap.Create(response, builder.PendingActions));
+
+        Assert.Contains($"duplicate message '{pending.MessageId.Value}'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateRejectsMissingMessageIdResponse()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot pending = builder.AddSlot("parent", "First", null, null);
+        BatchResponse response = new()
+        {
+            Responses = [],
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CanonicalBatchEntityMap.Create(response, builder.PendingActions));
+
+        Assert.Contains($"0 ordered response(s) for {builder.PendingActions.Count} pending operation(s)", exception.Message, StringComparison.Ordinal);
+        Assert.Equal("First", pending.SlotName);
+    }
+
+    [Fact]
+    public void CreateRejectsExtraMessageIdResponse()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot pending = builder.AddSlot("parent", "First", null, null);
+        BatchResponse response = new()
+        {
+            Responses =
+            [
+                NewEntity("slot-1", pending.MessageId.Value),
+                NewEntity("slot-extra", "unexpected-message"),
+            ],
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CanonicalBatchEntityMap.Create(response, builder.PendingActions));
+
+        Assert.Contains("2 message-correlated response(s) for 1 pending operation(s)", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateCorrelatesOrderedOnlyResponsesWhenCountsMatch()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot first = builder.AddSlot("parent", "First", null, null);
+        ResoniteBatchOperations.PendingBatchSlot second = builder.AddSlot("parent", "Second", null, null);
+        BatchResponse response = new()
+        {
+            Responses =
+            [
+                NewEntity("slot-1", sourceMessageId: null),
+                NewEntity("slot-2", sourceMessageId: null),
+            ],
+        };
+
+        CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response, builder.PendingActions);
+
+        Assert.Equal(new ResoniteSlotLocator("slot-1"), entityMap.ResolveSlot(first).Locator);
+        Assert.Equal(new ResoniteSlotLocator("slot-2"), entityMap.ResolveSlot(second).Locator);
+    }
+
+    private static NewEntityId NewEntity(string entityId, string? sourceMessageId)
+    {
+        return new NewEntityId
+        {
+            EntityId = entityId,
+            Success = true,
+            SourceMessageID = sourceMessageId,
+        };
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -216,10 +216,10 @@ public sealed class ResoniteMaterialPlanningTests
             material,
             materialIndex: 2);
 
-        Assert.True(preserved.PreserveDedicatedMaterialSlot);
-        Assert.Equal(expectedDedicatedSlotName, preserved.DedicatedMaterialSlotName);
-        Assert.False(notPreserved.PreserveDedicatedMaterialSlot);
-        Assert.Null(notPreserved.DedicatedMaterialSlotName);
+        PlannedPreservedSlotDedicatedMaterialAsset preservedSlotMaterial =
+            Assert.IsType<PlannedPreservedSlotDedicatedMaterialAsset>(preserved);
+        Assert.Equal(expectedDedicatedSlotName, preservedSlotMaterial.DedicatedMaterialSlotName);
+        Assert.IsType<PlannedInlineDedicatedMaterialAsset>(notPreserved);
     }
 
     [Fact]
@@ -264,14 +264,13 @@ public sealed class ResoniteMaterialPlanningTests
     {
         ResoniteBatchOperations.BatchActionBuilder batchBuilder = new();
         ResoniteMaterialBinding material = CreateBundledMaterial(BundledDefaultMaterialFamilies.Facade, 0);
-        PlannedDedicatedMaterialAsset plannedMaterial = new(
+        PlannedDedicatedMaterialAsset plannedMaterial = new PlannedInlineDedicatedMaterialAsset(
             material,
             [
                 new PlannedTextureAsset(
                     ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
                     new Uri("resdb:///texture/albedo", UriKind.Absolute)),
-            ],
-            PreserveDedicatedMaterialSlot: false);
+            ]);
 
         ResoniteMaterialPlanning.AddCommonMaterialComponents(batchBuilder, plannedMaterial, "slot");
 
@@ -287,7 +286,7 @@ public sealed class ResoniteMaterialPlanningTests
     {
         ResoniteBatchOperations.BatchActionBuilder batchBuilder = new();
         ResoniteMaterialBinding material = CreateBundledMaterial(BundledDefaultMaterialFamilies.WallResidentialPlasterLow, 0);
-        PlannedDedicatedMaterialAsset plannedMaterial = new(
+        PlannedDedicatedMaterialAsset plannedMaterial = new PlannedInlineDedicatedMaterialAsset(
             material,
             [
                 new PlannedTextureAsset(
@@ -296,8 +295,7 @@ public sealed class ResoniteMaterialPlanningTests
                 new PlannedTextureAsset(
                     ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.TextureMemberRole.Emission),
                     new Uri("resdb:///texture/emission", UriKind.Absolute)),
-            ],
-            PreserveDedicatedMaterialSlot: false);
+            ]);
 
         ResoniteMaterialPlanning.AddCommonMaterialComponents(batchBuilder, plannedMaterial, "slot");
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -271,7 +271,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             "Triangle Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(0.0, 0.0, 0.0),
             null);
-        PlannedDedicatedMaterialAsset dedicatedMaterial = new(
+        PlannedDedicatedMaterialAsset dedicatedMaterial = new PlannedPreservedSlotDedicatedMaterialAsset(
             new ResoniteMaterialBinding(
                 BaseColor: new PlateauResoniteLink.Targets.Resonite.ResoniteColor(1.0, 1.0, 1.0, 1.0),
                 MaterialType: ResoniteMaterialType.Standard,
@@ -281,7 +281,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 DepthOffset: null,
                 SubmeshIndices: [0]),
             [new PlannedTextureAsset(new TextureIdentity("albedo"), new Uri("resdb:///texture/albedo"))],
-            PreserveDedicatedMaterialSlot: true,
             DedicatedMaterialSlotName: "material-000-pbs-uv-uv");
         PlannedReusableMaterialAsset reusableMaterial = new(new ResoniteComponentLocator("existing-material-id"));
         PlannedSceneObjectEmission emissionPlan = new(
@@ -339,7 +338,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             "Triangle Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(0.0, 0.0, 0.0),
             null);
-        PlannedDedicatedMaterialAsset dedicatedMaterial = new(
+        PlannedDedicatedMaterialAsset dedicatedMaterial = new PlannedInlineDedicatedMaterialAsset(
             new ResoniteMaterialBinding(
                 BaseColor: new PlateauResoniteLink.Targets.Resonite.ResoniteColor(1.0, 1.0, 1.0, 1.0),
                 MaterialType: ResoniteMaterialType.Standard,
@@ -354,8 +353,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 new PlannedTextureAsset(new TextureIdentity("height"), new Uri("resdb:///texture/height")),
                 new PlannedTextureAsset(new TextureIdentity("metallic"), new Uri("resdb:///texture/metallic")),
                 new PlannedTextureAsset(new TextureIdentity("emission"), new Uri("resdb:///texture/emission")),
-            ],
-            PreserveDedicatedMaterialSlot: false);
+            ]);
         PlannedSceneObjectEmission emissionPlan = new(
             new PlannedTriangleMeshGeometryAsset(
                 new GeometryIdentity("geom"),


### PR DESCRIPTION
## Summary
- split dedicated material plans into inline and preserved-slot variants
- remove the bool + nullable slot-name contract from `PlannedDedicatedMaterialAsset`
- make batch emission use the preserved-slot variant directly instead of throwing when a slot name is missing

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020` mesh `53395325` packages `dem,bldg` terrain grid, no diff from baseline