### PR TITLE
Correlate batch responses at the boundary

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteSlotCreator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteSlotCreator.cs
@@ -35,6 +35,6 @@ internal sealed class ResoniteSlotCreator : IResoniteSlotCreator
             position,
             rotation);
         BatchResponse response = await client.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
-        return CanonicalBatchEntityMap.Create(response).ResolveSlot(pendingSlot);
+        return CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions).ResolveSlot(pendingSlot);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteBatchOperations.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteBatchOperations.cs
@@ -334,26 +334,21 @@ internal static class ResoniteBatchOperations
 internal sealed class CanonicalBatchEntityMap
 {
     private readonly Dictionary<string, Response> responsesByMessageId;
-    private readonly Queue<Response> responsesWithoutMessageId;
 
-    private CanonicalBatchEntityMap(
-        Dictionary<string, Response> responsesByMessageId,
-        Queue<Response> responsesWithoutMessageId)
+    private CanonicalBatchEntityMap(Dictionary<string, Response> responsesByMessageId)
     {
         this.responsesByMessageId = responsesByMessageId;
-        this.responsesWithoutMessageId = responsesWithoutMessageId;
     }
 
-    public static CanonicalBatchEntityMap Create(BatchResponse batchResponse)
+    public static CanonicalBatchEntityMap Create(
+        BatchResponse batchResponse,
+        IReadOnlyList<ResoniteBatchOperations.PendingBatchOperation> pendingOperations)
     {
         ArgumentNullException.ThrowIfNull(batchResponse);
-        return new CanonicalBatchEntityMap(
-            (batchResponse.Responses ?? [])
-                .Where(static response => !string.IsNullOrWhiteSpace(response.SourceMessageID))
-                .ToDictionary(response => response.SourceMessageID!, StringComparer.Ordinal),
-            new Queue<Response>(
-                (batchResponse.Responses ?? [])
-                    .Where(static response => string.IsNullOrWhiteSpace(response.SourceMessageID))));
+        ArgumentNullException.ThrowIfNull(pendingOperations);
+
+        IReadOnlyList<Response> responses = batchResponse.Responses ?? [];
+        return new CanonicalBatchEntityMap(CorrelateResponses(responses, pendingOperations));
     }
 
     public CreatedSlot ResolveSlot(ResoniteBatchOperations.PendingBatchSlot pendingSlot)
@@ -400,15 +395,78 @@ internal sealed class CanonicalBatchEntityMap
     {
         if (!responsesByMessageId.TryGetValue(messageId.Value, out Response? response))
         {
-            if (responsesWithoutMessageId.Count == 0)
-            {
-                throw new InvalidOperationException($"Batch response did not include message '{messageId.Value}'.");
-            }
-
-            response = responsesWithoutMessageId.Dequeue();
+            throw new InvalidOperationException($"Batch response did not include message '{messageId.Value}'.");
         }
 
         ResoniteLinkClient.EnsureSuccess(response, operationName);
         return response;
+    }
+
+    private static Dictionary<string, Response> CorrelateResponses(
+        IReadOnlyList<Response> responses,
+        IReadOnlyList<ResoniteBatchOperations.PendingBatchOperation> pendingOperations)
+    {
+        if (responses.Count == 0 && pendingOperations.Count == 0)
+        {
+            return new Dictionary<string, Response>(StringComparer.Ordinal);
+        }
+
+        bool anyMessageId = responses.Any(static response => !string.IsNullOrWhiteSpace(response.SourceMessageID));
+        bool anyMissingMessageId = responses.Any(static response => string.IsNullOrWhiteSpace(response.SourceMessageID));
+        if (anyMessageId && anyMissingMessageId)
+        {
+            throw new InvalidOperationException("Batch response mixed message-correlated and ordered-only responses.");
+        }
+
+        if (!anyMessageId)
+        {
+            return CorrelateOrderedResponses(responses, pendingOperations);
+        }
+
+        Dictionary<string, Response> correlated = new(StringComparer.Ordinal);
+        foreach (Response response in responses)
+        {
+            string messageId = response.SourceMessageID!;
+            if (!correlated.TryAdd(messageId, response))
+            {
+                throw new InvalidOperationException($"Batch response included duplicate message '{messageId}'.");
+            }
+        }
+
+        foreach (ResoniteBatchOperations.PendingBatchOperation pendingOperation in pendingOperations)
+        {
+            if (!correlated.ContainsKey(pendingOperation.MessageId.Value))
+            {
+                throw new InvalidOperationException($"Batch response did not include message '{pendingOperation.MessageId.Value}'.");
+            }
+        }
+
+        if (correlated.Count != pendingOperations.Count)
+        {
+            throw new InvalidOperationException(
+                $"Batch response included {correlated.Count} message-correlated response(s) for {pendingOperations.Count} pending operation(s).");
+        }
+
+        return correlated;
+    }
+
+    private static Dictionary<string, Response> CorrelateOrderedResponses(
+        IReadOnlyList<Response> responses,
+        IReadOnlyList<ResoniteBatchOperations.PendingBatchOperation> pendingOperations)
+    {
+        if (responses.Count != pendingOperations.Count)
+        {
+            throw new InvalidOperationException(
+                $"Batch response included {responses.Count} ordered response(s) for {pendingOperations.Count} pending operation(s).");
+        }
+
+        Dictionary<string, Response> correlated = new(StringComparer.Ordinal);
+        for (int i = 0; i < responses.Count; i++)
+        {
+            ResoniteBatchOperations.PendingBatchOperation pendingOperation = pendingOperations[i];
+            correlated[pendingOperation.MessageId.Value] = responses[i];
+        }
+
+        return correlated;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -298,7 +298,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             componentType,
             members);
         BatchResponse response = await client.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
-        return CanonicalBatchEntityMap.Create(response).ResolveComponent(pendingComponent);
+        return CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions).ResolveComponent(pendingComponent);
     }
 
     public static ResoniteMaterialBinding ResolveTerrainTextureCanvasMaterial(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -94,7 +94,7 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
                 $"City object '{cityObject.DisplayName}' batch completed in {batchStopwatch.Elapsed.TotalSeconds:F3}s "
                 + $"(operations={operationCount}, est_payload_bytes={EstimateBatchPayloadBytes(operationCount)})."));
 
-        CanonicalBatchEntityMap canonicalBatchEntityMap = CanonicalBatchEntityMap.Create(batchResponse);
+        CanonicalBatchEntityMap canonicalBatchEntityMap = CanonicalBatchEntityMap.Create(batchResponse, batchBuilder.PendingActions);
         canonicalBatchEntityMap.ValidateAll(batchBuilder.PendingActions);
         foreach (BatchPlanSlotLocator slotResolutionTarget in batchEmission.SlotResolutionTargets)
         {

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneSetupInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneSetupInterpreter.cs
@@ -171,7 +171,7 @@ internal sealed class ResoniteSceneSetupInterpreter : IResoniteSceneSetupInterpr
         if (batchBuilder.Actions.Count > 0)
         {
             BatchResponse response = await setupClient.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
-            CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response);
+            CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions);
             if (pendingAssets is not null)
             {
                 assetsSlot = CreateSlot(entityMap.ResolveSlot(pendingAssets.Value));
@@ -338,7 +338,7 @@ internal sealed class ResoniteSceneSetupInterpreter : IResoniteSceneSetupInterpr
 
         BatchResponse response = await setupClient.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
 
-        CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response);
+        CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions);
         CreatedSlot datasetRootSlot = entityMap.ResolveSlot(pendingDatasetRootSlot);
         CreatedSlot datasetAssetsRootSlot = entityMap.ResolveSlot(pendingDatasetAssetsRootSlot);
         CreatedSlot commonAssetsRootSlot = existingSharedCommonMaterialsSlot is null

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupPreparer.cs
@@ -151,7 +151,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
         if (batchBuilder.Actions.Count > 0)
         {
             BatchResponse response = await client.RunDataModelOperationBatchAsync(batchBuilder.Actions, cancellationToken);
-            CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response);
+            CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response, batchBuilder.PendingActions);
             foreach (PreparedCommonMaterialBatchEntry preparedMaterial in preparedMaterials)
             {
                 if (preparedMaterial.PendingMaterialSlot is not null)

--- a/tests/PlateauResoniteLink.Tests/Targets/CanonicalBatchEntityMapTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/CanonicalBatchEntityMapTests.cs
@@ -1,0 +1,120 @@
+using System;
+
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Targets.Resonite.Execution;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class CanonicalBatchEntityMapTests
+{
+    [Fact]
+    public void CreateRejectsMixedMessageIdAndOrderedOnlyResponses()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot first = builder.AddSlot("parent", "First", null, null);
+        _ = builder.AddSlot("parent", "Second", null, null);
+        BatchResponse response = new()
+        {
+            Responses =
+            [
+                NewEntity("slot-1", first.MessageId.Value),
+                NewEntity("slot-2", sourceMessageId: null),
+            ],
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CanonicalBatchEntityMap.Create(response, builder.PendingActions));
+
+        Assert.Contains("mixed message-correlated and ordered-only responses", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateRejectsDuplicateMessageIds()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot pending = builder.AddSlot("parent", "First", null, null);
+        BatchResponse response = new()
+        {
+            Responses =
+            [
+                NewEntity("slot-1", pending.MessageId.Value),
+                NewEntity("slot-2", pending.MessageId.Value),
+            ],
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CanonicalBatchEntityMap.Create(response, builder.PendingActions));
+
+        Assert.Contains($"duplicate message '{pending.MessageId.Value}'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateRejectsMissingMessageIdResponse()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot pending = builder.AddSlot("parent", "First", null, null);
+        BatchResponse response = new()
+        {
+            Responses = [],
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CanonicalBatchEntityMap.Create(response, builder.PendingActions));
+
+        Assert.Contains($"0 ordered response(s) for {builder.PendingActions.Count} pending operation(s)", exception.Message, StringComparison.Ordinal);
+        Assert.Equal("First", pending.SlotName);
+    }
+
+    [Fact]
+    public void CreateRejectsExtraMessageIdResponse()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot pending = builder.AddSlot("parent", "First", null, null);
+        BatchResponse response = new()
+        {
+            Responses =
+            [
+                NewEntity("slot-1", pending.MessageId.Value),
+                NewEntity("slot-extra", "unexpected-message"),
+            ],
+        };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CanonicalBatchEntityMap.Create(response, builder.PendingActions));
+
+        Assert.Contains("2 message-correlated response(s) for 1 pending operation(s)", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateCorrelatesOrderedOnlyResponsesWhenCountsMatch()
+    {
+        ResoniteBatchOperations.BatchActionBuilder builder = new();
+        ResoniteBatchOperations.PendingBatchSlot first = builder.AddSlot("parent", "First", null, null);
+        ResoniteBatchOperations.PendingBatchSlot second = builder.AddSlot("parent", "Second", null, null);
+        BatchResponse response = new()
+        {
+            Responses =
+            [
+                NewEntity("slot-1", sourceMessageId: null),
+                NewEntity("slot-2", sourceMessageId: null),
+            ],
+        };
+
+        CanonicalBatchEntityMap entityMap = CanonicalBatchEntityMap.Create(response, builder.PendingActions);
+
+        Assert.Equal(new ResoniteSlotLocator("slot-1"), entityMap.ResolveSlot(first).Locator);
+        Assert.Equal(new ResoniteSlotLocator("slot-2"), entityMap.ResolveSlot(second).Locator);
+    }
+
+    private static NewEntityId NewEntity(string entityId, string? sourceMessageId)
+    {
+        return new NewEntityId
+        {
+            EntityId = entityId,
+            Success = true,
+            SourceMessageID = sourceMessageId,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- make `CanonicalBatchEntityMap` correlate `BatchResponse` entries with pending batch operations at creation time
- reject mixed message-id / ordered-only responses, duplicate message ids, and response count mismatches before slot/component resolution
- update batch execution call sites to pass `BatchActionBuilder.PendingActions`

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020` mesh `53395325` packages `dem,bldg` terrain grid, no diff from baseline