### PR TITLE
Type non-DEM bake inputs

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemAtlasOrPreservedEntryFactory.cs
@@ -14,7 +14,7 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal interface INonDemAtlasOrPreservedEntryFactory
 {
     Task<NonDemAtlasOrPreservedEntry> CreateAsync(
-        ResoniteConstructionCityObject cityObject,
+        NonDemSourceScopedTriangleCityObject cityObject,
         ResoniteMeshSubmesh submesh,
         ResoniteMaterialBinding material,
         CancellationToken cancellationToken);
@@ -28,7 +28,7 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
         ?? throw new ArgumentNullException(nameof(textureImageLoader));
 
     public async Task<NonDemAtlasOrPreservedEntry> CreateAsync(
-        ResoniteConstructionCityObject cityObject,
+        NonDemSourceScopedTriangleCityObject cityObject,
         ResoniteMeshSubmesh submesh,
         ResoniteMaterialBinding material,
         CancellationToken cancellationToken)

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
@@ -180,7 +180,7 @@ internal sealed class NonDemBakedGeometryComposer : INonDemBakedGeometryComposer
         double minY = double.PositiveInfinity;
         double minZ = double.PositiveInfinity;
 
-        foreach (ResoniteConstructionCityObject cityObject in candidates.Select(static candidate => candidate.CityObject))
+        foreach (NonDemSourceScopedTriangleCityObject cityObject in candidates.Select(static candidate => candidate.CityObject))
         {
             foreach (ResoniteMeshVertex vertex in cityObject.Mesh.Vertices)
             {

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeAssembler.cs
@@ -42,16 +42,13 @@ internal sealed class NonDemCityObjectBakeAssembler(
         List<NonDemAtlasBatchEntry> entries = candidates.SelectMany(static candidate => candidate.AtlasEntries).ToList();
         using NonDemRenderedAtlas? atlas = RenderAtlas(entries, cancellationToken);
 
-        ResoniteConstructionCityObject firstCityObject = candidates[0].CityObject;
+        NonDemSourceScopedTriangleCityObject firstCityObject = candidates[0].CityObject;
         string slotKey = preservePrimaryIdentity
             ? firstCityObject.SlotKey
             : NonDemSourceFileBatching.CreateBatchSlotKey(sourceFileKey, batchIndex);
         string displayName = preservePrimaryIdentity
             ? firstCityObject.DisplayName
             : NonDemSourceFileBatching.CreateBatchDisplayName(sourceFileKey, batchIndex, slotKey);
-        string? sourceFileRelativePath = string.IsNullOrWhiteSpace(firstCityObject.SourceFileRelativePath)
-            ? null
-            : sourceFileKey.SourceFileRelativePath;
 
         NonDemBakedGeometry geometry = geometryComposer.Compose(
             sourceFileKey,
@@ -70,7 +67,7 @@ internal sealed class NonDemCityObjectBakeAssembler(
             Mesh: geometry.Mesh,
             Materials: geometry.Materials,
             CollisionEnabled: candidates.Any(static candidate => candidate.CityObject.CollisionEnabled),
-            SourceFileRelativePath: sourceFileRelativePath);
+            SourceFileRelativePath: sourceFileKey.SourceFileRelativePath);
         return Task.FromResult(bakedCityObject);
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -23,7 +23,7 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
         NonDemBufferedCityObject bufferedCityObject,
         CancellationToken cancellationToken)
     {
-        ResoniteConstructionCityObject cityObject = bufferedCityObject.CityObject;
+        NonDemSourceScopedTriangleCityObject cityObject = bufferedCityObject.CityObject;
         NonDemCityObjectBakePolicy policy = bufferedCityObject.Policy;
         if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(cityObject, out _))
         {
@@ -31,7 +31,7 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
                 $"Non-DEM bake city object '{cityObject.DisplayName}' contained duplicate material assignments for a submesh.");
         }
 
-        ResoniteConstructionCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
+        NonDemSourceScopedTriangleCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
         if (!NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(normalizedCityObject, out Dictionary<int, ResoniteMaterialBinding>? materialBySubmeshIndex))
         {
             throw new InvalidOperationException(

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeMaterialClassifier.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeMaterialClassifier.cs
@@ -5,7 +5,7 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal static class NonDemCityObjectBakeMaterialClassifier
 {
     public static bool CanBufferCityObjectMaterials(
-        ResoniteConstructionCityObject cityObject,
+        NonDemSourceScopedTriangleCityObject cityObject,
         NonDemCityObjectBakePolicy policy)
     {
         if (!TryCreateMaterialBySubmeshIndex(cityObject, out Dictionary<int, ResoniteMaterialBinding> materialBySubmeshIndex))
@@ -43,7 +43,7 @@ internal static class NonDemCityObjectBakeMaterialClassifier
     }
 
     public static bool TryCreateMaterialBySubmeshIndex(
-        ResoniteConstructionCityObject cityObject,
+        NonDemSourceScopedTriangleCityObject cityObject,
         out Dictionary<int, ResoniteMaterialBinding> materialBySubmeshIndex)
     {
         materialBySubmeshIndex = [];

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using PlateauResoniteLink.Domain.Importing;
 
@@ -24,19 +25,75 @@ internal sealed record NonDemAtlasOrPreservedEntry(
     NonDemAtlasBatchEntry? AtlasEntry,
     NonDemPreservedSubmeshEntry? PreservedEntry);
 
-internal readonly record struct NonDemBufferedCityObject(
+internal sealed record NonDemSourceScopedTriangleCityObject(
     ResoniteConstructionCityObject CityObject,
+    ResoniteImportedMesh Mesh,
+    string SourceFileRelativePath)
+{
+    public string SlotKey => CityObject.SlotKey;
+
+    public string DisplayName => CityObject.DisplayName;
+
+    public string PackageName => CityObject.PackageName;
+
+    public string ActualMeshCode => CityObject.ActualMeshCode;
+
+    public int? LodLevel => CityObject.LodLevel;
+
+    public ResoniteTransform Transform => CityObject.Transform;
+
+    public IReadOnlyList<ResoniteMaterialBinding> Materials => CityObject.Materials;
+
+    public bool CollisionEnabled => CityObject.CollisionEnabled;
+
+    public static bool TryCreate(
+        ResoniteConstructionCityObject cityObject,
+        [NotNullWhen(true)] out NonDemSourceScopedTriangleCityObject? scopedCityObject)
+    {
+        ArgumentNullException.ThrowIfNull(cityObject);
+
+        if (cityObject.Geometry is not ResoniteTriangleMeshGeometry triangleMesh
+            || string.IsNullOrWhiteSpace(cityObject.SourceFileRelativePath))
+        {
+            scopedCityObject = null;
+            return false;
+        }
+
+        scopedCityObject = new NonDemSourceScopedTriangleCityObject(
+            cityObject,
+            triangleMesh.Mesh,
+            cityObject.SourceFileRelativePath);
+        return true;
+    }
+
+    public NonDemSourceScopedTriangleCityObject WithMeshAndMaterials(
+        ResoniteImportedMesh mesh,
+        IReadOnlyList<ResoniteMaterialBinding> materials)
+    {
+        return new NonDemSourceScopedTriangleCityObject(
+            CityObject with
+            {
+                Geometry = new ResoniteTriangleMeshGeometry(mesh),
+                Materials = materials,
+            },
+            mesh,
+            SourceFileRelativePath);
+    }
+}
+
+internal readonly record struct NonDemBufferedCityObject(
+    NonDemSourceScopedTriangleCityObject CityObject,
     NonDemCityObjectBakePolicy Policy);
 
 internal sealed record NonDemAtlasBatchEntry(
-    ResoniteConstructionCityObject CityObject,
+    NonDemSourceScopedTriangleCityObject CityObject,
     ResoniteMeshSubmesh Submesh,
     ResoniteMaterialBinding Material,
     NonDemMaterialAtlasTile Tile,
     TextureUvRect UvBounds);
 
 internal sealed record NonDemPreservedSubmeshEntry(
-    ResoniteConstructionCityObject CityObject,
+    NonDemSourceScopedTriangleCityObject CityObject,
     ResoniteMeshSubmesh Submesh,
     ResoniteMaterialBinding Material,
     ResoniteColor? VertexColorOverride = null);
@@ -46,6 +103,6 @@ internal sealed record NonDemOrderedPreservedSubmeshEntry(
     int Order);
 
 internal sealed record NonDemCityObjectBakeCandidate(
-    ResoniteConstructionCityObject CityObject,
+    NonDemSourceScopedTriangleCityObject CityObject,
     IReadOnlyList<NonDemAtlasBatchEntry> AtlasEntries,
     IReadOnlyList<NonDemPreservedSubmeshEntry> PreservedEntries);

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicy.cs
@@ -14,13 +14,13 @@ internal enum NonDemMaterialBakeCategory
 
 internal sealed record NonDemCityObjectBakePolicy(
     string Name,
-    Func<ResoniteConstructionCityObject, bool> CanBufferCityObject,
+    Func<NonDemSourceScopedTriangleCityObject, bool> CanBufferCityObject,
     bool RequireAtlasCandidateMaterial,
     bool PreserveVertexColorMaterials,
     bool PreserveTexturelessMaterials,
     bool PreserveCommonMaterials)
 {
-    public bool CanBuffer(ResoniteConstructionCityObject cityObject)
+    public bool CanBuffer(NonDemSourceScopedTriangleCityObject cityObject)
     {
         return CanBufferCityObject(cityObject);
     }
@@ -31,8 +31,7 @@ internal static class NonDemCityObjectBakePolicies
     internal static readonly NonDemCityObjectBakePolicy Default = new(
         Name: "non-dem",
         CanBufferCityObject: static cityObject =>
-            cityObject.Geometry is ResoniteTriangleMeshGeometry
-            && cityObject.Transform.Rotation is null
+            cityObject.Transform.Rotation is null
             && !string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase),
         RequireAtlasCandidateMaterial: false,
         PreserveVertexColorMaterials: true,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicyResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakePolicyResolver.cs
@@ -5,7 +5,7 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal interface INonDemCityObjectBakePolicyResolver
 {
-    NonDemCityObjectBakePolicy? Resolve(ResoniteConstructionCityObject cityObject);
+    NonDemCityObjectBakePolicy? Resolve(NonDemSourceScopedTriangleCityObject cityObject);
 }
 
 internal sealed class NonDemCityObjectBakePolicyResolver(
@@ -14,7 +14,7 @@ internal sealed class NonDemCityObjectBakePolicyResolver(
     private readonly IReadOnlyList<NonDemCityObjectBakePolicy> bakePolicies = bakePolicies
         ?? throw new ArgumentNullException(nameof(bakePolicies));
 
-    public NonDemCityObjectBakePolicy? Resolve(ResoniteConstructionCityObject cityObject)
+    public NonDemCityObjectBakePolicy? Resolve(NonDemSourceScopedTriangleCityObject cityObject)
     {
         foreach (NonDemCityObjectBakePolicy policy in bakePolicies)
         {

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -28,16 +28,21 @@ internal sealed class NonDemCityObjectBaker(
         ArgumentNullException.ThrowIfNull(cityObject);
         cancellationToken.ThrowIfCancellationRequested();
 
-        NonDemCityObjectBakePolicy? policy = bakePolicyResolver.Resolve(cityObject);
+        if (!NonDemSourceScopedTriangleCityObject.TryCreate(cityObject, out NonDemSourceScopedTriangleCityObject? scopedCityObject))
+        {
+            return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: false, []));
+        }
+
+        NonDemCityObjectBakePolicy? policy = bakePolicyResolver.Resolve(scopedCityObject);
         if (policy is null)
         {
             return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: false, []));
         }
 
-        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
-        NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(cityObject, policy);
+        scopedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(scopedCityObject);
+        NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(scopedCityObject, policy);
         List<ResoniteConstructionCityObject> readyCityObjects = [];
-        sourceFileBuffer.Add(sourceFileKey, new NonDemBufferedCityObject(cityObject, policy));
+        sourceFileBuffer.Add(sourceFileKey, new NonDemBufferedCityObject(scopedCityObject, policy));
         BakedInputCityObjectCount++;
         return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: true, readyCityObjects));
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -105,7 +105,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
         if (passThroughCandidates.Count == 1)
         {
             NonDemCityObjectBakeCandidate passThroughCandidate = passThroughCandidates[0];
-            await onBakedCityObject(passThroughCandidate.CityObject, cancellationToken);
+            await onBakedCityObject(passThroughCandidate.CityObject.CityObject, cancellationToken);
             candidateImageDisposer.Dispose(passThroughCandidate);
             emittedCount++;
         }
@@ -163,7 +163,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
     {
         try
         {
-            await onBakedCityObject(fallbackCandidate.CityObject, cancellationToken);
+            await onBakedCityObject(fallbackCandidate.CityObject.CityObject, cancellationToken);
             return 1;
         }
         finally

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBatching.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBatching.cs
@@ -10,24 +10,16 @@ internal static class NonDemSourceFileBatching
     public static IComparer<NonDemSourceFileBatchKey> KeyComparer { get; } = new SourceFileBatchKeyComparer();
 
     public static NonDemSourceFileBatchKey CreateKey(
-        ResoniteConstructionCityObject cityObject,
+        NonDemSourceScopedTriangleCityObject cityObject,
         NonDemCityObjectBakePolicy policy)
     {
         string context = policy.Name;
-        string? sourceFileRelativePath = string.IsNullOrWhiteSpace(cityObject.SourceFileRelativePath) ? null : cityObject.SourceFileRelativePath;
-        if (sourceFileRelativePath is null)
-        {
-            throw new InvalidOperationException(
-                $"Non-DEM batch candidate '{cityObject.DisplayName}' did not provide source scope. "
-                + "source-file-owned batching requires SourceFileRelativePath.");
-        }
-
         return new NonDemSourceFileBatchKey(
             cityObject.ActualMeshCode,
             cityObject.PackageName.ToLowerInvariant(),
             cityObject.LodLevel,
             context,
-            SourceFileRelativePath: sourceFileRelativePath);
+            SourceFileRelativePath: cityObject.SourceFileRelativePath);
     }
 
     public static string CreateBatchSlotKey(NonDemSourceFileBatchKey sourceFileKey, int batchIndex)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteDynamicMaterialUvNormalizer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteDynamicMaterialUvNormalizer.cs
@@ -60,6 +60,45 @@ public static class ResoniteDynamicMaterialUvNormalizer
         };
     }
 
+    internal static NonDemSourceScopedTriangleCityObject Normalize(NonDemSourceScopedTriangleCityObject cityObject)
+    {
+        ArgumentNullException.ThrowIfNull(cityObject);
+
+        if (!cityObject.Materials.Any(ShouldNormalizeTextureTransform))
+        {
+            return cityObject;
+        }
+
+        Dictionary<int, ResoniteMaterialBinding> materialBySubmeshIndex = cityObject.Materials
+            .SelectMany(material => material.SubmeshIndices.Select(submeshIndex => (submeshIndex, material)))
+            .ToDictionary(static pair => pair.submeshIndex, static pair => pair.material);
+
+        List<ResoniteMeshVertex> normalizedVertices = [];
+        List<ResoniteMeshSubmesh> normalizedSubmeshes = [];
+        foreach (ResoniteMeshSubmesh submesh in cityObject.Mesh.Submeshes)
+        {
+            materialBySubmeshIndex.TryGetValue(submesh.Index, out ResoniteMaterialBinding? material);
+            List<int> normalizedTriangleVertexIndices = new(submesh.TriangleVertexIndices.Count);
+            foreach (int sourceIndex in submesh.TriangleVertexIndices)
+            {
+                ResoniteMeshVertex sourceVertex = cityObject.Mesh.Vertices[sourceIndex];
+                ResoniteFloat2 normalizedUv = material is not null && ShouldNormalizeTextureTransform(material)
+                    ? ApplyTextureTransform(sourceVertex.UV0, material)
+                    : sourceVertex.UV0;
+                normalizedVertices.Add(sourceVertex with { UV0 = normalizedUv });
+                normalizedTriangleVertexIndices.Add(normalizedVertices.Count - 1);
+            }
+
+            normalizedSubmeshes.Add(submesh with { TriangleVertexIndices = normalizedTriangleVertexIndices });
+        }
+
+        return cityObject.WithMeshAndMaterials(
+            new ResoniteImportedMesh(normalizedVertices, normalizedSubmeshes),
+            cityObject.Materials
+                .Select(NormalizeMaterialBinding)
+                .ToArray());
+    }
+
     public static ResoniteMaterialBinding NormalizeMaterialBinding(ResoniteMaterialBinding material)
     {
         ArgumentNullException.ThrowIfNull(material);

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
@@ -44,13 +44,13 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
         };
 
         Assert.False(NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(
-            CreateCityObject([CreateTexturelessMaterial()]),
+            CreateScopedCityObject([CreateTexturelessMaterial()]),
             requireAtlasCandidate));
         Assert.True(NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(
-            CreateCityObject([CreateDatasetTextureMaterial()]),
+            CreateScopedCityObject([CreateDatasetTextureMaterial()]),
             requireAtlasCandidate));
         Assert.False(NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(
-            CreateCityObject([CreateTexturelessMaterial()]),
+            CreateScopedCityObject([CreateTexturelessMaterial()]),
             requireAtlasCandidate with
             {
                 RequireAtlasCandidateMaterial = false,
@@ -68,8 +68,19 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
             ]);
 
         Assert.False(NonDemCityObjectBakeMaterialClassifier.TryCreateMaterialBySubmeshIndex(
-            cityObject,
+            CreateScopedCityObject(cityObject),
             out _));
+    }
+
+    private static NonDemSourceScopedTriangleCityObject CreateScopedCityObject(IReadOnlyList<ResoniteMaterialBinding> materials)
+    {
+        return CreateScopedCityObject(CreateCityObject(materials));
+    }
+
+    private static NonDemSourceScopedTriangleCityObject CreateScopedCityObject(ResoniteConstructionCityObject cityObject)
+    {
+        Assert.True(NonDemSourceScopedTriangleCityObject.TryCreate(cityObject, out NonDemSourceScopedTriangleCityObject? scopedCityObject));
+        return scopedCityObject;
     }
 
     private static ResoniteConstructionCityObject CreateCityObject(IReadOnlyList<ResoniteMaterialBinding> materials)
@@ -97,7 +108,8 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
                         new ResoniteFloat2(0.0, 1.0)),
                 ],
                 [new ResoniteMeshSubmesh(0, [0, 1, 2])]),
-            materials);
+            materials,
+            SourceFileRelativePath: "udx/bldg/53394525_bldg_6697_op.gml");
     }
 
     private static ResoniteMaterialBinding CreateDatasetTextureMaterial()

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -893,6 +893,29 @@ public sealed class NonDemCityObjectBakerTests
     }
 
     [Fact]
+    public async Task TryBufferAsyncSkipsNonDemCityObjectsWithoutSourceFileScope()
+    {
+        NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);
+        ResoniteConstructionCityObject cityObject = CreateUvScaledLod2Building(
+            "source-scope-missing",
+            CreatePayload("textures/source-scope-missing.png", new Rgba32(255, 0, 0, 255), 4, 4),
+            "unit-a",
+            new ResoniteFloat2(2.0, 0.5),
+            new ResoniteFloat2(0.25, 0.75)) with
+        {
+            SourceFileRelativePath = null,
+        };
+
+        BufferedCityObjectBufferResult result = await baker.TryBufferAsync(cityObject);
+
+        Assert.False(result.Buffered);
+        Assert.Empty(result.ReadyCityObjects);
+        Assert.Equal(new ResoniteFloat2(2.0, 0.5), Assert.Single(cityObject.Materials).TextureScale);
+        Assert.Equal(new ResoniteFloat2(0.25, 0.75), Assert.Single(cityObject.Materials).TextureOffset);
+        Assert.Empty(await baker.FlushAllAsync());
+    }
+
+    [Fact]
     public async Task TryBufferAsyncBuffersLodlessNonDemCityObjects()
     {
         NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemSourceFileBatchingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemSourceFileBatchingTests.cs
@@ -1,5 +1,3 @@
-using System;
-
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Targets;
@@ -7,13 +5,13 @@ namespace PlateauResoniteLink.Tests.Targets;
 public sealed class NonDemSourceFileBatchingTests
 {
     [Fact]
-    public void CreateKeyNormalizesPackageNameAndRequiresSourceFileScope()
+    public void CreateKeyUsesRequiredSourceFileScopeFromScopedTriangleCityObject()
     {
-        ResoniteConstructionCityObject cityObject = CreateCityObject() with
+        NonDemSourceScopedTriangleCityObject cityObject = CreateScopedCityObject(CreateCityObject() with
         {
             PackageName = "BLDG",
             SourceFileRelativePath = "udx/bldg/53394525_bldg_6697_op.gml",
-        };
+        });
 
         NonDemSourceFileBatchKey key = NonDemSourceFileBatching.CreateKey(
             cityObject,
@@ -21,9 +19,6 @@ public sealed class NonDemSourceFileBatchingTests
 
         Assert.Equal("bldg", key.PackageName);
         Assert.Equal("udx/bldg/53394525_bldg_6697_op.gml", key.SourceFileRelativePath);
-        Assert.Throws<InvalidOperationException>(() => NonDemSourceFileBatching.CreateKey(
-            cityObject with { SourceFileRelativePath = null },
-            NonDemCityObjectBakePolicies.Default));
     }
 
     [Fact]
@@ -83,5 +78,11 @@ public sealed class NonDemSourceFileBatchingTests
                 ],
                 [new ResoniteMeshSubmesh(0, [0, 1, 2])]),
             []);
+    }
+
+    private static NonDemSourceScopedTriangleCityObject CreateScopedCityObject(ResoniteConstructionCityObject cityObject)
+    {
+        Assert.True(NonDemSourceScopedTriangleCityObject.TryCreate(cityObject, out NonDemSourceScopedTriangleCityObject? scopedCityObject));
+        return scopedCityObject;
     }
 }


### PR DESCRIPTION
## Summary
- narrow non-DEM bake buffering to source-file-scoped triangle mesh city objects
- pass the narrowed mesh/source scope through candidate, atlas, preserved-entry, and geometry composition paths
- remove source-file scope validation from source-file batching by making it require the narrowed input type

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- canonical scene dump for plateau-13213-higashimurayama-shi-2020 mesh 53395325 dem,bldg grid GeoTIFF
- git diff --no-index against semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json