### PR TITLE
Type georeferenced raster sources

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
@@ -154,19 +154,17 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
         GeographicRectangle overlayBounds,
         CancellationToken cancellationToken)
     {
-        foreach (TerrainTextureGeoReferencedRasterSource rasterSource in ResolveCandidateRasterSources(meshCode))
+        foreach (ITerrainTextureRasterContentSource rasterSource in ResolveCandidateRasterSources(meshCode))
         {
             GeoReferencedRasterMetadata? metadata = await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(
                 rasterSource,
                 cancellationToken);
-            if (metadata is null
-                || !metadata.IsUsable
-                || !Contains(metadata.GeographicBounds, overlayBounds))
+            if (metadata is null || !Contains(metadata.GeographicBounds, overlayBounds))
             {
                 continue;
             }
 
-            return rasterSource with { Metadata = metadata };
+            return new TerrainTextureGeoReferencedRasterSource(rasterSource, metadata);
         }
 
         return null;
@@ -191,11 +189,11 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
         }
     }
 
-    private TerrainTextureGeoReferencedRasterSource[] ResolveCandidateRasterSources(ThirdRegionalMeshCode meshCode)
+    private ITerrainTextureRasterContentSource[] ResolveCandidateRasterSources(ThirdRegionalMeshCode meshCode)
     {
         if (directRasterPath is not null)
         {
-            return [new TerrainTextureGeoReferencedRasterSource(directRasterPath)];
+            return [new LocalTerrainTextureRasterContentSource(directRasterPath)];
         }
 
         if (contentSource is null)
@@ -226,11 +224,11 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
         }
 
         return relativePaths
-            .Select(relativePath => new TerrainTextureGeoReferencedRasterSource(
-                new DatasetTerrainTextureRasterContentSource(
+            .Select(relativePath =>
+                (ITerrainTextureRasterContentSource)new DatasetTerrainTextureRasterContentSource(
                     $"dataset:{contentSource.SourcePath}:{relativePath}",
                     relativePath,
-                    EnsureLocalRasterFileAsync)))
+                    EnsureLocalRasterFileAsync))
             .ToArray();
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/DemTextureSourcePolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTextureSourcePolicy.cs
@@ -193,12 +193,12 @@ internal sealed class DefaultDemTextureSourcePolicy(
                 region.MeshCode,
                 region.GeographicBounds,
                 cancellationToken);
-            if (rasterSource?.Metadata is { IsUsable: true } metadata)
+            if (rasterSource is not null)
             {
                 candidates.Add(new DemTextureSourceCandidate(
                     DemTextureSourcePreference.GeoReferencedRaster,
                     rasterSource,
-                    EffectivePixelAreaSquareMeters: metadata.PixelWidthMeters * metadata.PixelHeightMeters));
+                    EffectivePixelAreaSquareMeters: rasterSource.Metadata.PixelWidthMeters * rasterSource.Metadata.PixelHeightMeters));
             }
         }
 

--- a/src/PlateauResoniteLink/Application/Importing/TerrainTextureGeoReferencedRasterCropper.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainTextureGeoReferencedRasterCropper.cs
@@ -15,11 +15,6 @@ internal static class TerrainTextureGeoReferencedRasterCropper
         GeoReferencedRasterMetadata metadata,
         GeographicRectangle requestedBounds)
     {
-        if (!metadata.IsUsable)
-        {
-            return null;
-        }
-
         GeographicRectangle rasterBounds = metadata.GeographicBounds;
         GeographicRectangle intersection = new(
             Math.Max(requestedBounds.MinLatitude, rasterBounds.MinLatitude),

--- a/src/PlateauResoniteLink/Application/Importing/TerrainTextureGeoReferencedRasterMetadataReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainTextureGeoReferencedRasterMetadataReader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Security;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,8 +26,15 @@ internal static class TerrainTextureGeoReferencedRasterMetadataReader
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(source);
-        await using Stream stream = await source.OpenReadAsync(cancellationToken);
-        return await TryReadMetadataAsync(stream, cancellationToken);
+        try
+        {
+            await using Stream stream = await source.OpenReadAsync(cancellationToken);
+            return await TryReadMetadataAsync(stream, cancellationToken);
+        }
+        catch (Exception exception) when (IsCandidateRasterReadFailure(exception))
+        {
+            return null;
+        }
     }
 
     public static async Task<GeoReferencedRasterMetadata?> TryReadMetadataAsync(
@@ -38,42 +46,45 @@ internal static class TerrainTextureGeoReferencedRasterMetadataReader
             return null;
         }
 
-        ImageInfo imageInfo;
         try
         {
-            imageInfo = await Image.IdentifyAsync(sourcePath, cancellationToken)
-                ?? throw new InvalidOperationException($"Failed to identify raster '{sourcePath}'.");
+            ImageInfo? identifiedImage = await Image.IdentifyAsync(sourcePath, cancellationToken);
+            if (identifiedImage is null)
+            {
+                return null;
+            }
+
+            ImageInfo imageInfo = identifiedImage;
+            ExifProfile? exifProfile = imageInfo.Metadata.ExifProfile;
+            GeoTiffTagSnapshot? tiffTags = await GeoTiffTagReader.TryReadAsync(sourcePath, cancellationToken);
+
+            double[]? tiePoints = TryGetDoubleArray(exifProfile, ExifTag.ModelTiePoint)
+                ?? tiffTags?.ModelTiePoint;
+            double[]? pixelScale = TryGetDoubleArray(exifProfile, ExifTag.PixelScale)
+                ?? tiffTags?.PixelScale;
+            double[]? modelTransform = TryGetDoubleArray(exifProfile, ExifTag.ModelTransform)
+                ?? tiffTags?.ModelTransform;
+            ushort[]? geoKeyDirectory = TryGetUnsignedShortArray(exifProfile, "GeoKeyDirectoryTag")
+                ?? tiffTags?.GeoKeyDirectory;
+            double[]? geoDoubleParams = TryGetNamedDoubleArray(exifProfile, "GeoDoubleParamsTag")
+                ?? tiffTags?.GeoDoubleParams;
+            string? geoAsciiParams = TryGetNamedString(exifProfile, "GeoAsciiParamsTag")
+                ?? tiffTags?.GeoAsciiParams;
+
+            return TryCreateMetadata(
+                imageInfo.Width,
+                imageInfo.Height,
+                tiePoints,
+                pixelScale,
+                modelTransform,
+                geoKeyDirectory,
+                geoDoubleParams,
+                geoAsciiParams);
         }
-        catch (UnknownImageFormatException)
+        catch (Exception exception) when (IsCandidateRasterReadFailure(exception))
         {
             return null;
         }
-
-        ExifProfile? exifProfile = imageInfo.Metadata.ExifProfile;
-        GeoTiffTagSnapshot? tiffTags = await GeoTiffTagReader.TryReadAsync(sourcePath, cancellationToken);
-
-        double[]? tiePoints = TryGetDoubleArray(exifProfile, ExifTag.ModelTiePoint)
-            ?? tiffTags?.ModelTiePoint;
-        double[]? pixelScale = TryGetDoubleArray(exifProfile, ExifTag.PixelScale)
-            ?? tiffTags?.PixelScale;
-        double[]? modelTransform = TryGetDoubleArray(exifProfile, ExifTag.ModelTransform)
-            ?? tiffTags?.ModelTransform;
-        ushort[]? geoKeyDirectory = TryGetUnsignedShortArray(exifProfile, "GeoKeyDirectoryTag")
-            ?? tiffTags?.GeoKeyDirectory;
-        double[]? geoDoubleParams = TryGetNamedDoubleArray(exifProfile, "GeoDoubleParamsTag")
-            ?? tiffTags?.GeoDoubleParams;
-        string? geoAsciiParams = TryGetNamedString(exifProfile, "GeoAsciiParamsTag")
-            ?? tiffTags?.GeoAsciiParams;
-
-        return TryCreateMetadata(
-            imageInfo.Width,
-            imageInfo.Height,
-            tiePoints,
-            pixelScale,
-            modelTransform,
-            geoKeyDirectory,
-            geoDoubleParams,
-            geoAsciiParams);
     }
 
     public static async Task<GeoReferencedRasterMetadata?> TryReadMetadataAsync(
@@ -90,41 +101,54 @@ internal static class TerrainTextureGeoReferencedRasterMetadataReader
         try
         {
             stream.Seek(0, SeekOrigin.Begin);
-            imageInfo = await Image.IdentifyAsync(stream, cancellationToken)
-                ?? throw new InvalidOperationException("Failed to identify raster stream.");
+            ImageInfo? identifiedImage = await Image.IdentifyAsync(stream, cancellationToken);
+            if (identifiedImage is null)
+            {
+                return null;
+            }
+
+            imageInfo = identifiedImage;
+            ExifProfile? exifProfile = imageInfo.Metadata.ExifProfile;
+            stream.Seek(0, SeekOrigin.Begin);
+            GeoTiffTagSnapshot? tiffTags = await GeoTiffTagReader.TryReadAsync(stream, cancellationToken);
+
+            double[]? tiePoints = TryGetDoubleArray(exifProfile, ExifTag.ModelTiePoint)
+                ?? tiffTags?.ModelTiePoint;
+            double[]? pixelScale = TryGetDoubleArray(exifProfile, ExifTag.PixelScale)
+                ?? tiffTags?.PixelScale;
+            double[]? modelTransform = TryGetDoubleArray(exifProfile, ExifTag.ModelTransform)
+                ?? tiffTags?.ModelTransform;
+            ushort[]? geoKeyDirectory = TryGetUnsignedShortArray(exifProfile, "GeoKeyDirectoryTag")
+                ?? tiffTags?.GeoKeyDirectory;
+            double[]? geoDoubleParams = TryGetNamedDoubleArray(exifProfile, "GeoDoubleParamsTag")
+                ?? tiffTags?.GeoDoubleParams;
+            string? geoAsciiParams = TryGetNamedString(exifProfile, "GeoAsciiParamsTag")
+                ?? tiffTags?.GeoAsciiParams;
+
+            return TryCreateMetadata(
+                imageInfo.Width,
+                imageInfo.Height,
+                tiePoints,
+                pixelScale,
+                modelTransform,
+                geoKeyDirectory,
+                geoDoubleParams,
+                geoAsciiParams);
         }
-        catch (UnknownImageFormatException)
+        catch (Exception exception) when (IsCandidateRasterReadFailure(exception))
         {
             return null;
         }
-
-        ExifProfile? exifProfile = imageInfo.Metadata.ExifProfile;
-        stream.Seek(0, SeekOrigin.Begin);
-        GeoTiffTagSnapshot? tiffTags = await GeoTiffTagReader.TryReadAsync(stream, cancellationToken);
-
-        double[]? tiePoints = TryGetDoubleArray(exifProfile, ExifTag.ModelTiePoint)
-            ?? tiffTags?.ModelTiePoint;
-        double[]? pixelScale = TryGetDoubleArray(exifProfile, ExifTag.PixelScale)
-            ?? tiffTags?.PixelScale;
-        double[]? modelTransform = TryGetDoubleArray(exifProfile, ExifTag.ModelTransform)
-            ?? tiffTags?.ModelTransform;
-        ushort[]? geoKeyDirectory = TryGetUnsignedShortArray(exifProfile, "GeoKeyDirectoryTag")
-            ?? tiffTags?.GeoKeyDirectory;
-        double[]? geoDoubleParams = TryGetNamedDoubleArray(exifProfile, "GeoDoubleParamsTag")
-            ?? tiffTags?.GeoDoubleParams;
-        string? geoAsciiParams = TryGetNamedString(exifProfile, "GeoAsciiParamsTag")
-            ?? tiffTags?.GeoAsciiParams;
-
-        return TryCreateMetadata(
-            imageInfo.Width,
-            imageInfo.Height,
-            tiePoints,
-            pixelScale,
-            modelTransform,
-            geoKeyDirectory,
-            geoDoubleParams,
-            geoAsciiParams);
     }
+
+    private static bool IsCandidateRasterReadFailure(Exception exception) =>
+        exception is UnknownImageFormatException
+            or IOException
+            or UnauthorizedAccessException
+            or SecurityException
+            or InvalidDataException
+            or OverflowException
+            or ArgumentOutOfRangeException;
 
     internal static GeoReferencedRasterMetadata? TryCreateMetadata(
         int pixelWidth,

--- a/src/PlateauResoniteLink/Application/Importing/TerrainTextureGeoReferencedRasterMetadataReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainTextureGeoReferencedRasterMetadataReader.cs
@@ -21,7 +21,7 @@ internal static class TerrainTextureGeoReferencedRasterMetadataReader
     private const int ProjectedCSTypeGeoKey = 3072;
 
     public static async Task<GeoReferencedRasterMetadata?> TryReadMetadataAsync(
-        TerrainTextureGeoReferencedRasterSource source,
+        ITerrainTextureRasterContentSource source,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(source);
@@ -161,13 +161,9 @@ internal static class TerrainTextureGeoReferencedRasterMetadataReader
         GeographicRectangle? geographicBounds = TryConvertToGeographicBounds(
             coordinateSystemIdentifier,
             modelBounds);
-        if (geographicBounds is null)
+        if (geographicBounds is null || string.IsNullOrWhiteSpace(coordinateSystemIdentifier))
         {
-            return new GeoReferencedRasterMetadata(
-                modelBounds.ToFallbackGeographicRectangle(),
-                coordinateSystemIdentifier,
-                PixelWidthMeters: 0.0,
-                PixelHeightMeters: 0.0);
+            return null;
         }
 
         return new GeoReferencedRasterMetadata(
@@ -635,11 +631,5 @@ internal static class TerrainTextureGeoReferencedRasterMetadataReader
         double MinX,
         double MinY,
         double MaxX,
-        double MaxY)
-    {
-        public GeographicRectangle ToFallbackGeographicRectangle()
-        {
-            return new GeographicRectangle(MinY, MaxY, MinX, MaxX);
-        }
-    }
+        double MaxY);
 }

--- a/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
@@ -30,18 +30,26 @@ public sealed record TerrainTextureTileSource(string UrlTemplate, int ZoomLevel)
 
 public sealed record GeoReferencedRasterMetadata(
     GeographicRectangle GeographicBounds,
-    string? CoordinateSystemIdentifier,
+    string CoordinateSystemIdentifier,
     double PixelWidthMeters,
     double PixelHeightMeters)
 {
-    public bool IsUsable => !string.IsNullOrWhiteSpace(CoordinateSystemIdentifier)
-        && PixelWidthMeters > 0.0
-        && PixelHeightMeters > 0.0;
+    public string CoordinateSystemIdentifier { get; init; } = string.IsNullOrWhiteSpace(CoordinateSystemIdentifier)
+        ? throw new ArgumentException("Geo-referenced raster coordinate system identifier must be provided.", nameof(CoordinateSystemIdentifier))
+        : CoordinateSystemIdentifier;
+
+    public double PixelWidthMeters { get; init; } = PixelWidthMeters > 0.0
+        ? PixelWidthMeters
+        : throw new ArgumentOutOfRangeException(nameof(PixelWidthMeters));
+
+    public double PixelHeightMeters { get; init; } = PixelHeightMeters > 0.0
+        ? PixelHeightMeters
+        : throw new ArgumentOutOfRangeException(nameof(PixelHeightMeters));
 
     public string IdentityKey =>
         string.Create(
             CultureInfo.InvariantCulture,
-            $"georaster-meta-crs-{CoordinateSystemIdentifier ?? "none"}-pixel-{TerrainTextureDescriptorFormatting.FormatRounded(PixelWidthMeters)}x{TerrainTextureDescriptorFormatting.FormatRounded(PixelHeightMeters)}-bounds-{TerrainTextureDescriptorFormatting.FormatBounds(GeographicBounds)}");
+            $"georaster-meta-crs-{CoordinateSystemIdentifier}-pixel-{TerrainTextureDescriptorFormatting.FormatRounded(PixelWidthMeters)}x{TerrainTextureDescriptorFormatting.FormatRounded(PixelHeightMeters)}-bounds-{TerrainTextureDescriptorFormatting.FormatBounds(GeographicBounds)}");
 }
 
 public interface ITerrainTextureRasterContentSource
@@ -76,11 +84,11 @@ public sealed record LocalTerrainTextureRasterContentSource(string SourcePath) :
 
 public sealed record TerrainTextureGeoReferencedRasterSource(
     ITerrainTextureRasterContentSource ContentSource,
-    GeoReferencedRasterMetadata? Metadata = null) : TerrainTextureSource
+    GeoReferencedRasterMetadata Metadata) : TerrainTextureSource
 {
     public TerrainTextureGeoReferencedRasterSource(
         string sourcePath,
-        GeoReferencedRasterMetadata? metadata = null)
+        GeoReferencedRasterMetadata metadata)
         : this(new LocalTerrainTextureRasterContentSource(sourcePath), metadata)
     {
     }
@@ -88,10 +96,11 @@ public sealed record TerrainTextureGeoReferencedRasterSource(
     public ITerrainTextureRasterContentSource ContentSource { get; init; } =
         ContentSource ?? throw new ArgumentNullException(nameof(ContentSource));
 
-    public GeoReferencedRasterMetadata? Metadata { get; init; } = Metadata;
+    public GeoReferencedRasterMetadata Metadata { get; init; } =
+        Metadata ?? throw new ArgumentNullException(nameof(Metadata));
 
     public override string IdentityKey =>
-        string.Create(CultureInfo.InvariantCulture, $"georaster-{ContentSource.IdentityKey}-meta-{Metadata?.IdentityKey ?? "none"}");
+        string.Create(CultureInfo.InvariantCulture, $"georaster-{ContentSource.IdentityKey}-meta-{Metadata.IdentityKey}");
 
     public ValueTask<Stream> OpenReadAsync(CancellationToken cancellationToken) =>
         ContentSource.OpenReadAsync(cancellationToken);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
@@ -167,7 +167,7 @@ internal sealed class ResoniteQueuedTexturePreparer(
         {
             TerrainTextureGeoReferencedRasterSource rasterSource => string.Create(
                 CultureInfo.InvariantCulture,
-                $"GeoTIFF(source='{rasterSource.ContentSource.Description}', crs='{rasterSource.Metadata?.CoordinateSystemIdentifier ?? "unknown"}')"),
+                $"GeoTIFF(source='{rasterSource.ContentSource.Description}', crs='{rasterSource.Metadata.CoordinateSystemIdentifier}')"),
             TerrainTextureTileSource tileSource when IsGsiFallbackSource(tileSource) => string.Create(
                 CultureInfo.InvariantCulture,
                 $"GSI seamless photo tile(z={tileSource.ZoomLevel})"),

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
@@ -167,7 +167,7 @@ internal sealed class ResoniteQueuedTexturePreparer(
         {
             TerrainTextureGeoReferencedRasterSource rasterSource => string.Create(
                 CultureInfo.InvariantCulture,
-                $"GeoTIFF(source='{rasterSource.ContentSource.Description}', crs='{rasterSource.Metadata.CoordinateSystemIdentifier}')"),
+                $"Geo-referenced raster(source='{rasterSource.ContentSource.Description}', crs='{rasterSource.Metadata.CoordinateSystemIdentifier}')"),
             TerrainTextureTileSource tileSource when IsGsiFallbackSource(tileSource) => string.Create(
                 CultureInfo.InvariantCulture,
                 $"GSI seamless photo tile(z={tileSource.ZoomLevel})"),

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -126,6 +127,10 @@ internal sealed class TerrainTextureAssetGenerator(
         return cachedTexture.GeneratedTexture;
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Each non-null TerrainTextureSourceImage is disposed by the using block before the next source is evaluated.")]
     private async Task<CachedTerrainTexture> CreateTextureAsync(
         TerrainTextureOverlay terrainTextureOverlay,
         CancellationToken cancellationToken)
@@ -144,7 +149,7 @@ internal sealed class TerrainTextureAssetGenerator(
                     terrainTextureOverlay,
                     tileSource,
                     cancellationToken),
-                TerrainTextureGeoReferencedRasterSource rasterSource => await TryCreateTextureFromGeoReferencedRasterSourceAsync(
+                TerrainTextureGeoReferencedRasterSource rasterSource => await CreateTextureFromGeoReferencedRasterSourceAsync(
                     terrainTextureOverlay,
                     rasterSource,
                     cancellationToken),
@@ -210,46 +215,26 @@ internal sealed class TerrainTextureAssetGenerator(
         "Reliability",
         "CA2000:Dispose objects before losing scope",
         Justification = "The returned source image owns and disposes the cropped raster image.")]
-    private static async Task<TerrainTextureSourceImage?> TryCreateTextureFromGeoReferencedRasterSourceAsync(
+    private static async Task<TerrainTextureSourceImage> CreateTextureFromGeoReferencedRasterSourceAsync(
         TerrainTextureOverlay terrainTextureOverlay,
         TerrainTextureGeoReferencedRasterSource rasterSource,
         CancellationToken cancellationToken)
     {
-        try
+        await using Stream sourceStream = await rasterSource.OpenReadAsync(cancellationToken);
+        using Image<Rgba32> sourceImage = await Image.LoadAsync<Rgba32>(sourceStream, cancellationToken);
+        Image<Rgba32>? cropped = TerrainTextureGeoReferencedRasterCropper.TryCrop(
+            sourceImage,
+            rasterSource.Metadata,
+            terrainTextureOverlay.GeographicBounds);
+        if (cropped is null)
         {
-            GeoReferencedRasterMetadata? metadata = rasterSource.Metadata
-                ?? await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(rasterSource, cancellationToken);
-            if (metadata is null || !metadata.IsUsable)
-            {
-                return null;
-            }
+            throw new InvalidOperationException(
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"Geo-referenced raster source '{rasterSource.ContentSource.Description}' does not overlap terrain overlay bounds '{TerrainTextureDescriptorFormatting.FormatBounds(terrainTextureOverlay.GeographicBounds)}'."));
+        }
 
-            await using Stream sourceStream = await rasterSource.OpenReadAsync(cancellationToken);
-            using Image<Rgba32> sourceImage = await Image.LoadAsync<Rgba32>(sourceStream, cancellationToken);
-            Image<Rgba32>? cropped = TerrainTextureGeoReferencedRasterCropper.TryCrop(
-                sourceImage,
-                metadata,
-                terrainTextureOverlay.GeographicBounds);
-            return cropped is null
-                ? null
-                : new TerrainTextureSourceImage(cropped, null);
-        }
-        catch (UnknownImageFormatException)
-        {
-            return null;
-        }
-        catch (InvalidImageContentException)
-        {
-            return null;
-        }
-        catch (IOException)
-        {
-            return null;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return null;
-        }
+        return new TerrainTextureSourceImage(cropped, null);
     }
 
     private static GeneratedTerrainTexture CreateGeneratedTexture(

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -150,7 +149,7 @@ internal sealed class TerrainTextureAssetGenerator(
                     tileSource,
                     cancellationToken),
                 TerrainTextureGeoReferencedRasterSource rasterSource => await CreateTextureFromGeoReferencedRasterSourceAsync(
-                    terrainTextureOverlay,
+                    terrainTextureOverlay.GeographicBounds,
                     rasterSource,
                     cancellationToken),
                 _ => null,
@@ -215,8 +214,8 @@ internal sealed class TerrainTextureAssetGenerator(
         "Reliability",
         "CA2000:Dispose objects before losing scope",
         Justification = "The returned source image owns and disposes the cropped raster image.")]
-    private static async Task<TerrainTextureSourceImage> CreateTextureFromGeoReferencedRasterSourceAsync(
-        TerrainTextureOverlay terrainTextureOverlay,
+    private static async Task<TerrainTextureSourceImage?> CreateTextureFromGeoReferencedRasterSourceAsync(
+        GeographicRectangle geographicBounds,
         TerrainTextureGeoReferencedRasterSource rasterSource,
         CancellationToken cancellationToken)
     {
@@ -228,11 +227,7 @@ internal sealed class TerrainTextureAssetGenerator(
         }
         catch (Exception exception) when (exception is not OperationCanceledException)
         {
-            throw new InvalidOperationException(
-                string.Create(
-                    CultureInfo.InvariantCulture,
-                    $"Failed to open or decode geo-referenced raster source '{rasterSource.ContentSource.Description}' for terrain overlay bounds '{TerrainTextureDescriptorFormatting.FormatBounds(terrainTextureOverlay.GeographicBounds)}'."),
-                exception);
+            return null;
         }
 
         using (sourceImage)
@@ -240,13 +235,10 @@ internal sealed class TerrainTextureAssetGenerator(
             Image<Rgba32>? cropped = TerrainTextureGeoReferencedRasterCropper.TryCrop(
                 sourceImage,
                 rasterSource.Metadata,
-                terrainTextureOverlay.GeographicBounds);
+                geographicBounds);
             if (cropped is null)
             {
-                throw new InvalidOperationException(
-                    string.Create(
-                        CultureInfo.InvariantCulture,
-                        $"Geo-referenced raster source '{rasterSource.ContentSource.Description}' does not overlap terrain overlay bounds '{TerrainTextureDescriptorFormatting.FormatBounds(terrainTextureOverlay.GeographicBounds)}'."));
+                return null;
             }
 
             return new TerrainTextureSourceImage(cropped, null);

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -220,21 +220,37 @@ internal sealed class TerrainTextureAssetGenerator(
         TerrainTextureGeoReferencedRasterSource rasterSource,
         CancellationToken cancellationToken)
     {
-        await using Stream sourceStream = await rasterSource.OpenReadAsync(cancellationToken);
-        using Image<Rgba32> sourceImage = await Image.LoadAsync<Rgba32>(sourceStream, cancellationToken);
-        Image<Rgba32>? cropped = TerrainTextureGeoReferencedRasterCropper.TryCrop(
-            sourceImage,
-            rasterSource.Metadata,
-            terrainTextureOverlay.GeographicBounds);
-        if (cropped is null)
+        Image<Rgba32> sourceImage;
+        try
+        {
+            await using Stream sourceStream = await rasterSource.OpenReadAsync(cancellationToken);
+            sourceImage = await Image.LoadAsync<Rgba32>(sourceStream, cancellationToken);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
         {
             throw new InvalidOperationException(
                 string.Create(
                     CultureInfo.InvariantCulture,
-                    $"Geo-referenced raster source '{rasterSource.ContentSource.Description}' does not overlap terrain overlay bounds '{TerrainTextureDescriptorFormatting.FormatBounds(terrainTextureOverlay.GeographicBounds)}'."));
+                    $"Failed to open or decode geo-referenced raster source '{rasterSource.ContentSource.Description}' for terrain overlay bounds '{TerrainTextureDescriptorFormatting.FormatBounds(terrainTextureOverlay.GeographicBounds)}'."),
+                exception);
         }
 
-        return new TerrainTextureSourceImage(cropped, null);
+        using (sourceImage)
+        {
+            Image<Rgba32>? cropped = TerrainTextureGeoReferencedRasterCropper.TryCrop(
+                sourceImage,
+                rasterSource.Metadata,
+                terrainTextureOverlay.GeographicBounds);
+            if (cropped is null)
+            {
+                throw new InvalidOperationException(
+                    string.Create(
+                        CultureInfo.InvariantCulture,
+                        $"Geo-referenced raster source '{rasterSource.ContentSource.Description}' does not overlap terrain overlay bounds '{TerrainTextureDescriptorFormatting.FormatBounds(terrainTextureOverlay.GeographicBounds)}'."));
+            }
+
+            return new TerrainTextureSourceImage(cropped, null);
+        }
     }
 
     private static GeneratedTerrainTexture CreateGeneratedTexture(

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
@@ -183,7 +183,7 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
     }
 
     [Fact]
-    public async Task TryResolveRasterSourceAsyncEvictsFaultedBackgroundTaskAfterCanceledWaiter()
+    public async Task TryResolveRasterSourceAsyncTreatsFaultedCandidateMaterializationAsUnavailableAfterCanceledWaiter()
     {
         using TemporaryDirectory datasetRoot = new();
         FaultingGateableDatasetContentSource datasetSource = CreateFaultingGateableDatasetSource(datasetRoot.Path);
@@ -203,35 +203,15 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         datasetSource.ReleaseOpenRead.TrySetResult();
         await datasetSource.BackgroundCompletion.Task.WaitAsync(CancellationToken.None);
 
-        await AssertEventuallyRetriesFaultedBackgroundTaskAsync(catalog, datasetSource, bounds);
-        Assert.Equal(2, datasetSource.EnsureLocalFileCallCount);
+        TerrainTextureGeoReferencedRasterSource? retryResult = await catalog.TryResolveRasterSourceAsync(
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, ThirdRegionalMeshCode.Parse("53394525"), bounds),
+            ThirdRegionalMeshCode.Parse("53394525"),
+            bounds,
+            CancellationToken.None);
+
+        Assert.Null(retryResult);
+        Assert.Equal(1, datasetSource.EnsureLocalFileCallCount);
         Assert.Equal(0, datasetSource.OpenReadCallCount);
-    }
-
-    private static async Task AssertEventuallyRetriesFaultedBackgroundTaskAsync(
-        DemTerrainGeoReferencedRasterCatalog catalog,
-        FaultingGateableDatasetContentSource datasetSource,
-        GeographicRectangle bounds)
-    {
-        for (int attempt = 0; attempt < 50; attempt++)
-        {
-            await Assert.ThrowsAnyAsync<IOException>(async () => await catalog.TryResolveRasterSourceAsync(
-                    new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, ThirdRegionalMeshCode.Parse("53394525"), bounds),
-                    ThirdRegionalMeshCode.Parse("53394525"),
-                    bounds,
-                    CancellationToken.None));
-
-            if (datasetSource.EnsureLocalFileCallCount == 2)
-            {
-                return;
-            }
-
-            await Task.Delay(20);
-        }
-
-        Assert.Fail(
-            $"Faulted background task was not evicted after 50 retry attempts. "
-            + $"Observed EnsureLocalFileCallCount={datasetSource.EnsureLocalFileCallCount}.");
     }
 
     private static RecordingDatasetContentSource CreateDatasetSource(string datasetRoot)

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
@@ -101,7 +101,7 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
             CancellationToken.None);
 
         TerrainTextureGeoReferencedRasterSource resolvedResult = Assert.IsType<TerrainTextureGeoReferencedRasterSource>(result);
-        Assert.Equal("EPSG:4326", resolvedResult.Metadata?.CoordinateSystemIdentifier);
+        Assert.Equal("EPSG:4326", resolvedResult.Metadata.CoordinateSystemIdentifier);
         Assert.Equal(1, datasetSource.EnsureLocalFileCallCount);
         Assert.Equal(0, datasetSource.OpenReadCallCount);
 
@@ -170,7 +170,7 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await firstCall);
         TerrainTextureGeoReferencedRasterSource? secondResult = await secondCall;
         TerrainTextureGeoReferencedRasterSource resolvedSecondResult = Assert.IsType<TerrainTextureGeoReferencedRasterSource>(secondResult);
-        Assert.Equal("EPSG:4326", resolvedSecondResult.Metadata?.CoordinateSystemIdentifier);
+        Assert.Equal("EPSG:4326", resolvedSecondResult.Metadata.CoordinateSystemIdentifier);
 
         TerrainTextureGeoReferencedRasterSource? thirdResult = await catalog.TryResolveRasterSourceAsync(
             new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, ThirdRegionalMeshCode.Parse("53394525"), bounds),

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
@@ -516,9 +516,12 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         using HttpClient httpClient = new(handler);
         TerrainTextureAssetGenerator generator = new(httpClient, disablePersistentCache: true);
 
-        await Assert.ThrowsAsync<FileNotFoundException>(
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
             async () => await generator.EnsureTextureAsync(overlay, CancellationToken.None));
 
+        Assert.Contains("missing.tif", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(TerrainTextureDescriptorFormatting.FormatBounds(bounds), exception.Message, StringComparison.Ordinal);
+        Assert.IsType<FileNotFoundException>(exception.InnerException);
         Assert.Equal(0, handler.RequestCount);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
@@ -64,6 +64,25 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
     }
 
     [Fact]
+    public async Task TryReadMetadataAsyncReturnsNullWhenRasterContentSourceCannotOpen()
+    {
+        GeoReferencedRasterMetadata? metadata = await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(
+            new ThrowingRasterContentSource(new IOException("candidate raster unavailable")),
+            CancellationToken.None);
+
+        Assert.Null(metadata);
+    }
+
+    [Fact]
+    public async Task TryReadMetadataAsyncPropagatesCancellationFromRasterContentSource()
+    {
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            async () => await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(
+                new ThrowingRasterContentSource(new OperationCanceledException("cancelled")),
+                CancellationToken.None));
+    }
+
+    [Fact]
     public void TryCreateMetadataResolvesWebMercatorBoundsFromRealPlateauGeoTiffTags()
     {
         ushort[] geoKeyDirectory =
@@ -496,7 +515,7 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
     }
 
     [Fact]
-    public async Task EnsureTextureAsyncRejectsUnavailableGeoReferencedRasterSourceWithoutTileFallback()
+    public async Task EnsureTextureAsyncSkipsUnavailableGeoReferencedRasterSourceBeforeTileFallback()
     {
         GeographicRectangle bounds = new(0.0, WebMercatorTileMath.MaxLatitude, -180.0, 180.0);
         TerrainTextureOverlay overlay = new(
@@ -516,17 +535,15 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         using HttpClient httpClient = new(handler);
         TerrainTextureAssetGenerator generator = new(httpClient, disablePersistentCache: true);
 
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await generator.EnsureTextureAsync(overlay, CancellationToken.None));
+        GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        Assert.Contains("missing.tif", exception.Message, StringComparison.Ordinal);
-        Assert.Contains(TerrainTextureDescriptorFormatting.FormatBounds(bounds), exception.Message, StringComparison.Ordinal);
-        Assert.IsType<FileNotFoundException>(exception.InnerException);
-        Assert.Equal(0, handler.RequestCount);
+        Assert.IsType<TerrainTextureTileSource>(texture.UsedSource);
+        Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
+        Assert.True(handler.RequestCount > 0);
     }
 
     [Fact]
-    public async Task EnsureTextureAsyncRejectsNonOverlappingGeoReferencedRasterSourceWithoutTileFallback()
+    public async Task EnsureTextureAsyncSkipsNonOverlappingGeoReferencedRasterSourceBeforeTileFallback()
     {
         using TemporaryDirectory workDirectory = new();
         string rasterPath = Path.Combine(workDirectory.Path, "terrain.png");
@@ -557,10 +574,24 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         using HttpClient httpClient = new(handler);
         TerrainTextureAssetGenerator generator = new(httpClient, disablePersistentCache: true);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await generator.EnsureTextureAsync(overlay, CancellationToken.None));
+        GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        Assert.Equal(0, handler.RequestCount);
+        Assert.IsType<TerrainTextureTileSource>(texture.UsedSource);
+        Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
+        Assert.True(handler.RequestCount > 0);
+    }
+
+    private sealed class ThrowingRasterContentSource(Exception exception) : ITerrainTextureRasterContentSource
+    {
+        public string IdentityKey => "throwing-raster";
+
+        public string Description => "throwing-raster";
+
+        public ValueTask<Stream> OpenReadAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            throw exception;
+        }
     }
 
     private sealed class NeverCalledMapTileHandler : HttpMessageHandler

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
@@ -38,7 +38,6 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             geoAsciiParams: null);
 
         Assert.NotNull(metadata);
-        Assert.True(metadata.IsUsable);
         Assert.Equal("EPSG:6676", metadata.CoordinateSystemIdentifier);
         Assert.Equal(1.0, metadata.PixelWidthMeters);
         Assert.Equal(1.0, metadata.PixelHeightMeters);
@@ -49,7 +48,7 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
     }
 
     [Fact]
-    public void TryCreateMetadataReturnsUnusableMetadataWhenCoordinateSystemIsMissing()
+    public void TryCreateMetadataReturnsNullWhenCoordinateSystemIsMissing()
     {
         GeoReferencedRasterMetadata? metadata = TerrainTextureGeoReferencedRasterMetadataReader.TryCreateMetadata(
             pixelWidth: 10,
@@ -61,9 +60,7 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             geoDoubleParams: null,
             geoAsciiParams: null);
 
-        Assert.NotNull(metadata);
-        Assert.False(metadata.IsUsable);
-        Assert.Null(metadata.CoordinateSystemIdentifier);
+        Assert.Null(metadata);
     }
 
     [Fact]
@@ -92,7 +89,6 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             geoAsciiParams: "WGS 84 / Pseudo-Mercator|WGS 84|");
 
         Assert.NotNull(metadata);
-        Assert.True(metadata.IsUsable);
         Assert.Equal("EPSG:3857", metadata.CoordinateSystemIdentifier);
         Assert.InRange(metadata.GeographicBounds.MinLatitude, 35.76, 35.77);
         Assert.InRange(metadata.GeographicBounds.MaxLatitude, 35.77, 35.78);
@@ -126,7 +122,6 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
                 geoDoubleParams: snapshot.GeoDoubleParams,
                 geoAsciiParams: snapshot.GeoAsciiParams));
 
-        Assert.True(metadata.IsUsable);
         Assert.Equal("EPSG:4326", metadata.CoordinateSystemIdentifier);
         Assert.InRange(metadata.GeographicBounds.MinLatitude, 34.9989, 34.9991);
         Assert.InRange(metadata.GeographicBounds.MaxLongitude, 139.0009, 139.0011);
@@ -152,7 +147,6 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             geoAsciiParams: "WGS 84 / Pseudo-Mercator|WGS 84|");
 
         Assert.NotNull(metadata);
-        Assert.True(metadata.IsUsable);
         Assert.Equal("EPSG:3857", metadata.CoordinateSystemIdentifier);
     }
 
@@ -170,7 +164,6 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             geoAsciiParams: "WGS 84 / Pseudo-Mercator|WGS 84|");
 
         Assert.NotNull(metadata);
-        Assert.True(metadata.IsUsable);
         Assert.Equal("EPSG:3857", metadata.CoordinateSystemIdentifier);
     }
 
@@ -503,7 +496,7 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
     }
 
     [Fact]
-    public async Task EnsureTextureAsyncSkipsUnsupportedGeoReferencedRasterSource()
+    public async Task EnsureTextureAsyncRejectsUnavailableGeoReferencedRasterSourceWithoutTileFallback()
     {
         GeographicRectangle bounds = new(0.0, WebMercatorTileMath.MaxLatitude, -180.0, 180.0);
         TerrainTextureOverlay overlay = new(
@@ -513,7 +506,9 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             MaxTextureSize: 1024,
             Sources:
             [
-                new TerrainTextureGeoReferencedRasterSource("missing.tif"),
+                new TerrainTextureGeoReferencedRasterSource(
+                    "missing.tif",
+                    new GeoReferencedRasterMetadata(bounds, "EPSG:4326", 1.0, 1.0)),
                 new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", 1),
             ]);
 
@@ -521,11 +516,48 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         using HttpClient httpClient = new(handler);
         TerrainTextureAssetGenerator generator = new(httpClient, disablePersistentCache: true);
 
-        GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
+        await Assert.ThrowsAsync<FileNotFoundException>(
+            async () => await generator.EnsureTextureAsync(overlay, CancellationToken.None));
 
-        Assert.Equal(4, handler.RequestCount);
-        Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
-        Assert.IsType<TerrainTextureTileSource>(texture.UsedSource);
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task EnsureTextureAsyncRejectsNonOverlappingGeoReferencedRasterSourceWithoutTileFallback()
+    {
+        using TemporaryDirectory workDirectory = new();
+        string rasterPath = Path.Combine(workDirectory.Path, "terrain.png");
+        using (Image<Rgba32> rasterImage = new(2, 2, new Rgba32(12, 34, 56, 255)))
+        {
+            await rasterImage.SaveAsPngAsync(rasterPath);
+        }
+
+        GeographicRectangle requestedBounds = new(35.0, 35.001, 139.0, 139.001);
+        TerrainTextureOverlay overlay = new(
+            PackageName: "dem",
+            MeshCode: ThirdRegionalMeshCode.Parse("53394525"),
+            GeographicBounds: requestedBounds,
+            MaxTextureSize: 1024,
+            Sources:
+            [
+                new TerrainTextureGeoReferencedRasterSource(
+                    rasterPath,
+                    new GeoReferencedRasterMetadata(
+                        new GeographicRectangle(36.0, 36.001, 140.0, 140.001),
+                        "EPSG:4326",
+                        1.0,
+                        1.0)),
+                new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", 1),
+            ]);
+
+        using TerrainTextureAssetGeneratorTestsProxyMapTileHandler handler = new();
+        using HttpClient httpClient = new(handler);
+        TerrainTextureAssetGenerator generator = new(httpClient, disablePersistentCache: true);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await generator.EnsureTextureAsync(overlay, CancellationToken.None));
+
+        Assert.Equal(0, handler.RequestCount);
     }
 
     private sealed class NeverCalledMapTileHandler : HttpMessageHandler


### PR DESCRIPTION
## Summary
- Make `TerrainTextureGeoReferencedRasterSource` require confirmed `GeoReferencedRasterMetadata` instead of carrying optional metadata.
- Keep raw raster candidates as `ITerrainTextureRasterContentSource` until metadata is read and coverage is confirmed.
- Remove `IsUsable`, `none`/`unknown` metadata identity sentinels, and post-selection GeoTIFF fallback to tile sources when the confirmed raster cannot be read or does not overlap.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020` mesh `53395325`, packages `dem,bldg`, grid terrain, with GeoTIFF source
- `git diff --no-index` against `semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json` produced no diff