### PR TITLE
Type CLI parse results

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 
@@ -331,7 +332,7 @@ public static class CliArgumentsParser
                             if (TryParsePackagePatternOption(token, args, ref index, out string? packageName, out string? patternValue))
                             {
                                 packagePatterns ??= new(StringComparer.OrdinalIgnoreCase);
-                                packagePatterns[packageName!] = patternValue!;
+                                packagePatterns[packageName] = patternValue;
                                 break;
                             }
 
@@ -351,6 +352,16 @@ public static class CliArgumentsParser
             {
                 ["tran"] = new HashSet<int> { 1 }
             };
+        }
+
+        if (string.IsNullOrWhiteSpace(dataset))
+        {
+            return CliParseResult.Failure("Specify --dataset.");
+        }
+
+        if (string.IsNullOrWhiteSpace(meshCode))
+        {
+            return CliParseResult.Failure("Specify --mesh-code.");
         }
 
         if (string.IsNullOrWhiteSpace(cityGmlSourceInput))
@@ -376,9 +387,9 @@ public static class CliArgumentsParser
         }
 
         PlateauImportRequest request = new(
-            Dataset: dataset ?? string.Empty,
-            MeshCode: meshCode ?? string.Empty,
-            CityGmlSource: cityGmlSource!,
+            Dataset: dataset,
+            MeshCode: meshCode,
+            CityGmlSource: cityGmlSource,
             DemTextureSource: demTextureSource,
             PackageNames: packageNames,
             GlobalExcludeLodLevels: globalExcludeLods,
@@ -716,7 +727,9 @@ public static class CliArgumentsParser
         string token,
         string[] args,
         ref int index,
+        [NotNullWhen(true)]
         out string? packageName,
+        [NotNullWhen(true)]
         out string? patternValue)
     {
         packageName = null;
@@ -737,7 +750,9 @@ public static class CliArgumentsParser
 
     private static bool TryParseDatasetLocationInput(
         string input,
+        [NotNullWhen(true)]
         out DatasetLocation? source,
+        [NotNullWhen(false)]
         out string? error)
     {
         string trimmedInput = input.Trim();

--- a/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
@@ -273,6 +273,7 @@ public static class CliArgumentsParser
                                     System.Globalization.NumberStyles.Float | System.Globalization.NumberStyles.AllowThousands,
                                     System.Globalization.CultureInfo.InvariantCulture,
                                     out terrainGridMetersPerVertex)
+                                || !double.IsFinite(terrainGridMetersPerVertex)
                                 || terrainGridMetersPerVertex <= 0.0)
                             {
                                 return CliParseResult.Failure(

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
@@ -349,7 +349,9 @@ public static class PlateauImportRequestValidator
             Dataset = TrimToEmpty(request.Dataset),
             MeshCode = TrimToEmpty(request.MeshCode),
             CityGmlSource = NormalizeDatasetLocation(request.CityGmlSource),
-            DemTextureSource = request.DemTextureSource is null ? null : NormalizeDatasetLocation(request.DemTextureSource),
+            DemTextureSource = request.DemTextureSource is null
+                ? null
+                : NormalizeDatasetLocation(request.DemTextureSource),
             PackageNames = request.PackageNames is null
                 ? null
                 : request.PackageNames.Select(static packageName => TrimToEmpty(packageName)).ToArray(),
@@ -360,8 +362,7 @@ public static class PlateauImportRequestValidator
     {
         return source switch
         {
-            LocalDatasetLocation localSource => new LocalDatasetLocation(localSource.LocalSourcePath.Trim()),
-            RemoteDatasetLocation remoteSource => remoteSource,
+            LocalDatasetLocation localSource => new LocalDatasetLocation(TrimToEmpty(localSource.LocalSourcePath)),
             _ => source,
         };
     }

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
@@ -215,9 +215,10 @@ public static class PlateauImportRequestValidator
             }
         }
 
-        if (normalizedRequest.TerrainGridMetersPerVertex <= 0)
+        if (!double.IsFinite(normalizedRequest.TerrainGridMetersPerVertex)
+            || normalizedRequest.TerrainGridMetersPerVertex <= 0)
         {
-            validationErrors.Add("The terrain grid meters-per-vertex value must be greater than zero.");
+            validationErrors.Add("The terrain grid meters-per-vertex value must be a finite value greater than zero.");
         }
 
         if (normalizedRequest.TerrainGridMaxResolution < 2)

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
@@ -16,14 +16,30 @@ public abstract record ValidatedDatasetLocation
     public abstract DatasetLocation ToDatasetLocation();
 }
 
-public sealed record ValidatedLocalDatasetLocation(string LocalSourcePath)
-    : ValidatedDatasetLocation(DatasetSourceKind.Local)
+public sealed record ValidatedLocalDatasetLocation : ValidatedDatasetLocation
 {
+    public ValidatedLocalDatasetLocation(string localSourcePath)
+        : base(DatasetSourceKind.Local)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localSourcePath);
+        LocalSourcePath = localSourcePath;
+    }
+
+    public string LocalSourcePath { get; }
+
     public override DatasetLocation ToDatasetLocation() => new LocalDatasetLocation(LocalSourcePath);
 }
 
-public sealed record ValidatedRemoteDatasetLocation(Uri ServerUri)
-    : ValidatedDatasetLocation(DatasetSourceKind.Remote)
+public sealed record ValidatedRemoteDatasetLocation : ValidatedDatasetLocation
 {
+    public ValidatedRemoteDatasetLocation(Uri serverUri)
+        : base(DatasetSourceKind.Remote)
+    {
+        ArgumentNullException.ThrowIfNull(serverUri);
+        ServerUri = serverUri;
+    }
+
+    public Uri ServerUri { get; }
+
     public override DatasetLocation ToDatasetLocation() => new RemoteDatasetLocation(ServerUri);
 }

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
@@ -16,24 +16,22 @@ public abstract record ValidatedDatasetLocation
     public abstract DatasetLocation ToDatasetLocation();
 }
 
-public sealed record ValidatedLocalDatasetLocation : ValidatedDatasetLocation
+public sealed record ValidatedLocalDatasetLocation(string LocalSourcePath) : ValidatedDatasetLocation(DatasetSourceKind.Local)
 {
-    public ValidatedLocalDatasetLocation(string localSourcePath)
-        : base(DatasetSourceKind.Local)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(localSourcePath);
-        LocalSourcePath = localSourcePath.Trim();
-    }
-
-    public string LocalSourcePath { get; }
+    public string LocalSourcePath { get; } = string.IsNullOrWhiteSpace(LocalSourcePath)
+        ? throw new ArgumentException("The local source path must not be empty.", nameof(LocalSourcePath))
+        : LocalSourcePath;
 
     public override DatasetLocation ToDatasetLocation() => new LocalDatasetLocation(LocalSourcePath);
 }
 
-public sealed record ValidatedRemoteDatasetLocation : ValidatedDatasetLocation
+public sealed record ValidatedRemoteDatasetLocation(Uri ServerUri) : ValidatedDatasetLocation(DatasetSourceKind.Remote)
 {
-    public ValidatedRemoteDatasetLocation(Uri serverUri)
-        : base(DatasetSourceKind.Remote)
+    public Uri ServerUri { get; } = ValidateServerUri(ServerUri);
+
+    public override DatasetLocation ToDatasetLocation() => new RemoteDatasetLocation(ServerUri);
+
+    private static Uri ValidateServerUri(Uri serverUri)
     {
         ArgumentNullException.ThrowIfNull(serverUri);
         if (!serverUri.IsAbsoluteUri)
@@ -47,10 +45,6 @@ public sealed record ValidatedRemoteDatasetLocation : ValidatedDatasetLocation
             throw new ArgumentException("The remote dataset location URI must use http or https.", nameof(serverUri));
         }
 
-        ServerUri = serverUri;
+        return serverUri;
     }
-
-    public Uri ServerUri { get; }
-
-    public override DatasetLocation ToDatasetLocation() => new RemoteDatasetLocation(ServerUri);
 }

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
@@ -22,7 +22,7 @@ public sealed record ValidatedLocalDatasetLocation : ValidatedDatasetLocation
         : base(DatasetSourceKind.Local)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(localSourcePath);
-        LocalSourcePath = localSourcePath;
+        LocalSourcePath = localSourcePath.Trim();
     }
 
     public string LocalSourcePath { get; }
@@ -36,6 +36,17 @@ public sealed record ValidatedRemoteDatasetLocation : ValidatedDatasetLocation
         : base(DatasetSourceKind.Remote)
     {
         ArgumentNullException.ThrowIfNull(serverUri);
+        if (!serverUri.IsAbsoluteUri)
+        {
+            throw new ArgumentException("The remote dataset location URI must be absolute.", nameof(serverUri));
+        }
+
+        if (!string.Equals(serverUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(serverUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("The remote dataset location URI must use http or https.", nameof(serverUri));
+        }
+
         ServerUri = serverUri;
     }
 

--- a/src/PlateauResoniteLink/Domain/Importing/PlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/PlateauImportRequest.cs
@@ -17,6 +17,17 @@ public sealed record PlateauImportRequest(
     double TerrainGridMetersPerVertex = 2.0,
     int TerrainGridMaxResolution = 1024)
 {
+#pragma warning disable IDE0032 // Backing field keeps with-expressions from assigning a null CityGmlSource.
+    private DatasetLocation cityGmlSource =
+        CityGmlSource ?? throw new ArgumentNullException(nameof(CityGmlSource));
+#pragma warning restore IDE0032
+
+    public DatasetLocation CityGmlSource
+    {
+        get => cityGmlSource;
+        init => cityGmlSource = value ?? throw new ArgumentNullException(nameof(CityGmlSource));
+    }
+
     public DatasetSourceKind CityGmlSourceKind => CityGmlSource.SourceKind;
 
     public string? CityGmlLocalSourcePath => CityGmlSource is LocalDatasetLocation localSource ? localSource.LocalSourcePath : null;

--- a/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -17,6 +17,9 @@ public sealed class PlateauImportRequestValidatorTests
         Assert.Throws<ArgumentNullException>(() => DatasetLocation.Remote(null!));
         Assert.Throws<ArgumentException>(() => new ValidatedLocalDatasetLocation(" "));
         Assert.Throws<ArgumentNullException>(() => new ValidatedRemoteDatasetLocation(null!));
+        Assert.Throws<ArgumentException>(() => new ValidatedRemoteDatasetLocation(new Uri("/dataset.zip", UriKind.Relative)));
+        Assert.Throws<ArgumentException>(() => new ValidatedRemoteDatasetLocation(new Uri("ftp://example.invalid/dataset.zip")));
+        Assert.Equal("C:/dataset", new ValidatedLocalDatasetLocation(" C:/dataset ").LocalSourcePath);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 using PlateauResoniteLink.Application.Importing;
@@ -19,7 +20,23 @@ public sealed class PlateauImportRequestValidatorTests
         Assert.Throws<ArgumentNullException>(() => new ValidatedRemoteDatasetLocation(null!));
         Assert.Throws<ArgumentException>(() => new ValidatedRemoteDatasetLocation(new Uri("/dataset.zip", UriKind.Relative)));
         Assert.Throws<ArgumentException>(() => new ValidatedRemoteDatasetLocation(new Uri("ftp://example.invalid/dataset.zip")));
-        Assert.Equal("C:/dataset", new ValidatedLocalDatasetLocation(" C:/dataset ").LocalSourcePath);
+        Assert.Equal(" C:/dataset ", new ValidatedLocalDatasetLocation(" C:/dataset ").LocalSourcePath);
+    }
+
+    [Fact]
+    public void ValidatedDatasetLocationEqualityIncludesSourcePayload()
+    {
+        ValidatedDatasetLocation[] locations =
+        [
+            new ValidatedLocalDatasetLocation("C:/dataset-a"),
+            new ValidatedLocalDatasetLocation("C:/dataset-b"),
+            new ValidatedRemoteDatasetLocation(new Uri("https://example.invalid/dataset-a.zip")),
+            new ValidatedRemoteDatasetLocation(new Uri("https://example.invalid/dataset-b.zip")),
+        ];
+
+        Assert.Equal(locations.Length, locations.Distinct().Count());
+        Assert.NotEqual(locations[0], locations[1]);
+        Assert.NotEqual(locations[2], locations[3]);
     }
 
     [Fact]
@@ -137,7 +154,7 @@ public sealed class PlateauImportRequestValidatorTests
     }
 
     [Fact]
-    public void TryNormalizeAndValidateTrimsAndNormalizesRequestData()
+    public void TryNormalizeAndValidateNormalizesRequestData()
     {
         using TemporaryDirectory sourceRoot = new();
         string geoTiffPath = Path.Combine(sourceRoot.Path, "53394525.tif");
@@ -146,8 +163,8 @@ public sealed class PlateauImportRequestValidatorTests
         PlateauImportRequest request = new(
             Dataset: " tokyo23ku ",
             MeshCode: " 53394525 ",
-            CityGmlSource: DatasetLocation.Local($"  {sourceRoot.Path}  "),
-            DemTextureSource: DatasetLocation.Local($"  {geoTiffPath}  "),
+            CityGmlSource: DatasetLocation.Local($" {sourceRoot.Path} "),
+            DemTextureSource: DatasetLocation.Local($" {geoTiffPath} "),
             PackageNames: [" waterbody ", " tran "]);
 
         bool success = PlateauImportRequestValidator.TryNormalizeAndValidate(

--- a/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -65,7 +65,7 @@ public sealed class PlateauImportRequestValidatorTests
                 MeshCode: "53394525",
                 MeshCodePattern: meshCodePattern,
                 CityGmlSource: source,
-                TerrainGridMetersPerVertex: 0));
+                TerrainGridMetersPerVertex: double.NaN));
         Assert.Throws<ArgumentOutOfRangeException>(
             () => new ValidatedPlateauImportRequest(
                 Dataset: "tokyo23ku",
@@ -230,7 +230,21 @@ public sealed class PlateauImportRequestValidatorTests
 
         IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
 
-        Assert.Contains("The terrain grid meters-per-vertex value must be greater than zero.", errors);
+        Assert.Contains("The terrain grid meters-per-vertex value must be a finite value greater than zero.", errors);
+    }
+
+    [Fact]
+    public void ValidateRejectsNonFiniteTerrainGridMetersPerVertex()
+    {
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            CityGmlSource: DatasetLocation.Local("C:/dataset"),
+            TerrainGridMetersPerVertex: double.PositiveInfinity);
+
+        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
+
+        Assert.Contains("The terrain grid meters-per-vertex value must be a finite value greater than zero.", errors);
     }
 
     [Theory]

--- a/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
@@ -14,6 +15,72 @@ public sealed class PlateauImportRequestValidatorTests
     {
         Assert.Throws<ArgumentException>(() => DatasetLocation.Local(" "));
         Assert.Throws<ArgumentNullException>(() => DatasetLocation.Remote(null!));
+        Assert.Throws<ArgumentException>(() => new ValidatedLocalDatasetLocation(" "));
+        Assert.Throws<ArgumentNullException>(() => new ValidatedRemoteDatasetLocation(null!));
+    }
+
+    [Fact]
+    public void PlateauImportRequestRequiresCityGmlSource()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new PlateauImportRequest("tokyo23ku", "53394525", null!));
+
+        PlateauImportRequest request = new("tokyo23ku", "53394525", DatasetLocation.Local("C:/dataset"));
+        Assert.Throws<ArgumentNullException>(() => request with { CityGmlSource = null! });
+    }
+
+    [Fact]
+    public void ValidatedPlateauImportRequestRequiresValidatedPayload()
+    {
+        ValidatedLocalDatasetLocation source = new("C:/dataset");
+        Regex meshCodePattern = new(@"\A53394525\z");
+
+        Assert.Throws<ArgumentException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: " ",
+                MeshCode: "53394525",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: source));
+        Assert.Throws<ArgumentException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: " ",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: source));
+        Assert.Throws<ArgumentNullException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                MeshCodePattern: null!,
+                CityGmlSource: source));
+        Assert.Throws<ArgumentNullException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: null!));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: source,
+                TerrainGridMetersPerVertex: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: source,
+                TerrainGridMaxResolution: 1));
+
+        ValidatedPlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            MeshCodePattern: meshCodePattern,
+            CityGmlSource: source);
+
+        Assert.Throws<ArgumentNullException>(() => request with { CityGmlSource = null! });
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -82,6 +82,56 @@ public sealed class CliArgumentsParserTests
         Assert.Equal("Specify --citygml-source.", result.Error);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData(" ")]
+    public void ParseImportRequiresDatasetAtCliBoundary(string? dataset)
+    {
+        string[] args = dataset is null
+            ? [
+                "import",
+                "--mesh-code", "53394525",
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+            ]
+            : [
+                "import",
+                "--dataset", dataset,
+                "--mesh-code", "53394525",
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+            ];
+
+        CliParseResult result = CliArgumentsParser.Parse(args);
+
+        Assert.Equal("Specify --dataset.", AssertFailure(result).Error);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(" ")]
+    public void ParseImportRequiresMeshCodeAtCliBoundary(string? meshCode)
+    {
+        string[] args = meshCode is null
+            ? [
+                "import",
+                "--dataset", "tokyo23ku",
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+            ]
+            : [
+                "import",
+                "--dataset", "tokyo23ku",
+                "--mesh-code", meshCode,
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+            ];
+
+        CliParseResult result = CliArgumentsParser.Parse(args);
+
+        Assert.Equal("Specify --mesh-code.", AssertFailure(result).Error);
+    }
+
     [Fact]
     public void ParseParsesCanonicalSceneDumpImportWithoutResoniteLinkEndpoint()
     {

--- a/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -104,7 +104,7 @@ public sealed class CliArgumentsParserTests
 
         CliParseResult result = CliArgumentsParser.Parse(args);
 
-        Assert.Equal("Specify --dataset.", AssertFailure(result).Error);
+        Assert.Equal("Specify --dataset.", result.Error);
     }
 
     [Theory]
@@ -129,7 +129,7 @@ public sealed class CliArgumentsParserTests
 
         CliParseResult result = CliArgumentsParser.Parse(args);
 
-        Assert.Equal("Specify --mesh-code.", AssertFailure(result).Error);
+        Assert.Equal("Specify --mesh-code.", result.Error);
     }
 
     [Fact]
@@ -306,7 +306,7 @@ public sealed class CliArgumentsParserTests
 
         Assert.Equal(
             $"The value '{metersPerVertex}' is not a valid positive terrain grid meters-per-vertex value.",
-            AssertFailure(result).Error);
+            result.Error);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -238,6 +238,27 @@ public sealed class CliArgumentsParserTests
         Assert.Equal(512, result.Options.Request.TerrainGridMaxResolution);
     }
 
+    [Theory]
+    [InlineData("NaN")]
+    [InlineData("Infinity")]
+    [InlineData("-Infinity")]
+    public void ParseRejectsNonFiniteTerrainGridMetersPerVertex(string metersPerVertex)
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "import",
+                "--dataset", "tokyo23ku",
+                "--mesh-code", "53394525",
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+                "--terrain-grid-meters-per-vertex", metersPerVertex,
+            ]);
+
+        Assert.Equal(
+            $"The value '{metersPerVertex}' is not a valid positive terrain grid meters-per-vertex value.",
+            AssertFailure(result).Error);
+    }
+
     [Fact]
     public void ParseParsesTerrainDynamicMode()
     {


### PR DESCRIPTION
## Summary
- replace nullable/tagged CLI parse result state with closed result variants for help, failure, and each supported success command
- close CliCommandOptions inheritance to this assembly so parser success cannot carry an unknown command payload from outside the CLI boundary
- update CLI parse tests to assert typed variants instead of nullable Error / Options / Command combinations

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- Fake Live Sink canonical scene dump compared with baseline via git diff --no-index; no diff