### PR TITLE
Split in-memory texture source variants

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -191,13 +191,11 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
             texturePayload = new EncodedImageTexturePayload(
                 null,
                 null,
-                "sRGB",
                 TextureImportSourceFactory.CreateDatasetEncodedImage(
                     datasetSource,
                     resolvedTexturePath,
                     "sRGB",
-                    $"dataset:{resolvedTexturePath}"),
-                $"dataset:{resolvedTexturePath}");
+                    $"dataset:{resolvedTexturePath}"));
             texturePayloadsByResolvedPath[resolvedTexturePath] = texturePayload;
         }
 

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -197,8 +197,7 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
                     resolvedTexturePath,
                     "sRGB",
                     $"dataset:{resolvedTexturePath}"),
-                $"dataset:{resolvedTexturePath}",
-                TexturePayloadFormat.EncodedImage);
+                $"dataset:{resolvedTexturePath}");
             texturePayloadsByResolvedPath[resolvedTexturePath] = texturePayload;
         }
 

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -188,7 +188,7 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
     {
         if (!texturePayloadsByResolvedPath.TryGetValue(resolvedTexturePath, out TexturePayload? texturePayload))
         {
-            texturePayload = new TexturePayload(
+            texturePayload = new EncodedImageTexturePayload(
                 null,
                 null,
                 "sRGB",

--- a/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/MaterialGroupingPolicy.cs
@@ -33,7 +33,7 @@ internal static class MaterialGroupingPolicy
 
         return new MaterialGroupingKey(
             material.MaterialType,
-            material.TexturePayload?.Identity,
+            material.TexturePayload?.Source.Identity,
             material.TextureSourceKind,
             material.Projection,
             depthOffset,

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -98,24 +98,13 @@ public sealed record MeshSubmesh(
 
 public abstract record TexturePayload
 {
-    private protected TexturePayload(
-        string? colorProfile,
-        string identity,
-        ITextureImportSource source)
+    private protected TexturePayload(ITextureImportSource source)
     {
-        if (string.IsNullOrWhiteSpace(identity))
-        {
-            throw new ArgumentException("Texture payload identity must be provided.", nameof(identity));
-        }
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(source.Identity);
 
-        ColorProfile = colorProfile;
-        Identity = identity;
-        Source = source ?? throw new ArgumentNullException(nameof(source));
+        Source = source;
     }
-
-    public string? ColorProfile { get; }
-
-    public string Identity { get; }
 
     public ITextureImportSource Source { get; }
 }
@@ -142,8 +131,8 @@ public sealed record RawRgba32TexturePayload : TexturePayload
         int height,
         string? colorProfile,
         byte[] binaryPayload,
-        (string Identity, ITextureImportSource Source) source)
-        : base(colorProfile, source.Identity, source.Source)
+        ITextureImportSource source)
+        : base(source)
     {
         ArgumentNullException.ThrowIfNull(binaryPayload);
         Width = width;
@@ -157,7 +146,7 @@ public sealed record RawRgba32TexturePayload : TexturePayload
 
     public ImmutableArray<byte> BinaryPayload { get; }
 
-    private static (string Identity, ITextureImportSource Source) CreateSource(
+    private static ITextureImportSource CreateSource(
         int width,
         int height,
         string? colorProfile,
@@ -166,14 +155,12 @@ public sealed record RawRgba32TexturePayload : TexturePayload
     {
         ArgumentNullException.ThrowIfNull(binaryPayload);
         string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
-        return (
-            effectiveIdentity,
-            TextureImportSourceFactory.CreateInMemoryRaw(
-                width,
-                height,
-                colorProfile,
-                binaryPayload,
-                effectiveIdentity));
+        return TextureImportSourceFactory.CreateInMemoryRaw(
+            width,
+            height,
+            colorProfile,
+            binaryPayload,
+            effectiveIdentity);
     }
 }
 
@@ -182,19 +169,8 @@ public sealed record EncodedImageTexturePayload : TexturePayload
     public EncodedImageTexturePayload(
         int? width,
         int? height,
-        string? colorProfile,
-        ITextureImportSource source,
-        string? identity = null)
-        : this(width, height, colorProfile, CreateSource(source, identity))
-    {
-    }
-
-    private EncodedImageTexturePayload(
-        int? width,
-        int? height,
-        string? colorProfile,
-        (string Identity, ITextureImportSource Source) source)
-        : base(colorProfile, source.Identity, source.Source)
+        ITextureImportSource source)
+        : base(source)
     {
         Width = width;
         Height = height;
@@ -203,14 +179,6 @@ public sealed record EncodedImageTexturePayload : TexturePayload
     public int? Width { get; }
 
     public int? Height { get; }
-
-    private static (string Identity, ITextureImportSource Source) CreateSource(
-        ITextureImportSource source,
-        string? identity)
-    {
-        ArgumentNullException.ThrowIfNull(source);
-        return (identity ?? source.Identity, source);
-    }
 }
 
 public enum TextureSourceKind

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -185,7 +185,16 @@ public sealed record EncodedImageTexturePayload : TexturePayload
         string? colorProfile,
         ITextureImportSource source,
         string? identity = null)
-        : base(colorProfile, identity ?? source?.Identity ?? throw new ArgumentNullException(nameof(source)), source!)
+        : this(width, height, colorProfile, CreateSource(source, identity))
+    {
+    }
+
+    private EncodedImageTexturePayload(
+        int? width,
+        int? height,
+        string? colorProfile,
+        (string Identity, ITextureImportSource Source) source)
+        : base(colorProfile, source.Identity, source.Source)
     {
         Width = width;
         Height = height;
@@ -194,6 +203,14 @@ public sealed record EncodedImageTexturePayload : TexturePayload
     public int? Width { get; }
 
     public int? Height { get; }
+
+    private static (string Identity, ITextureImportSource Source) CreateSource(
+        ITextureImportSource source,
+        string? identity)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        return (identity ?? source.Identity, source);
+    }
 }
 
 public enum TextureSourceKind

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -118,6 +118,7 @@ public sealed record TexturePayload
         ArgumentNullException.ThrowIfNull(binaryPayload);
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
         Identity = identity;
+        ValidateFormat(format);
         Format = format;
         Source = TextureImportSourceFactory.CreateInMemory(
             width,
@@ -142,6 +143,7 @@ public sealed record TexturePayload
         ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
         Identity = identity ?? source.Identity;
+        ValidateFormat(format);
         Format = format;
         Source = source;
     }
@@ -159,6 +161,14 @@ public sealed record TexturePayload
     public TexturePayloadFormat Format { get; init; }
 
     public ITextureImportSource Source { get; init; }
+
+    private static void ValidateFormat(TexturePayloadFormat format)
+    {
+        if (format is not (TexturePayloadFormat.RawRgba32 or TexturePayloadFormat.EncodedImage))
+        {
+            throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported texture payload format.");
+        }
+    }
 }
 
 public enum TextureSourceKind

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -143,19 +143,19 @@ public sealed record TexturePayload
         Source = source;
     }
 
-    public int? Width { get; init; }
+    public int? Width { get; }
 
-    public int? Height { get; init; }
+    public int? Height { get; }
 
-    public string? ColorProfile { get; init; }
+    public string? ColorProfile { get; }
 
-    public ImmutableArray<byte> BinaryPayload { get; init; }
+    public ImmutableArray<byte> BinaryPayload { get; }
 
-    public string? Identity { get; init; }
+    public string? Identity { get; }
 
-    public TexturePayloadFormat Format { get; init; }
+    public TexturePayloadFormat Format { get; }
 
-    public ITextureImportSource Source { get; init; }
+    public ITextureImportSource Source { get; }
 
 }
 

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -96,67 +96,104 @@ public sealed record MeshSubmesh(
     int Index,
     IReadOnlyList<int> TriangleVertexIndices);
 
-public enum TexturePayloadFormat
+public abstract record TexturePayload
 {
-    RawRgba32 = 0,
-    EncodedImage = 1,
+    private protected TexturePayload(
+        string? colorProfile,
+        string identity,
+        ITextureImportSource source)
+    {
+        if (string.IsNullOrWhiteSpace(identity))
+        {
+            throw new ArgumentException("Texture payload identity must be provided.", nameof(identity));
+        }
+
+        ColorProfile = colorProfile;
+        Identity = identity;
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+    }
+
+    public string? ColorProfile { get; }
+
+    public string Identity { get; }
+
+    public ITextureImportSource Source { get; }
 }
 
-public sealed record TexturePayload
+public sealed record RawRgba32TexturePayload : TexturePayload
 {
-    public TexturePayload(
+    public RawRgba32TexturePayload(
         int width,
         int height,
         string? colorProfile,
         byte[] binaryPayload,
         string? identity = null)
-    {
-        Width = width;
-        Height = height;
-        ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(binaryPayload);
-        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
-        Identity = identity;
-        Format = TexturePayloadFormat.RawRgba32;
-        Source = TextureImportSourceFactory.CreateInMemoryRaw(
+        : this(
             width,
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"));
+            CreateSource(width, height, colorProfile, binaryPayload, identity))
+    {
     }
 
-    public TexturePayload(
+    private RawRgba32TexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        (string Identity, ITextureImportSource Source) source)
+        : base(colorProfile, source.Identity, source.Source)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        Width = width;
+        Height = height;
+        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
+    }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public ImmutableArray<byte> BinaryPayload { get; }
+
+    private static (string Identity, ITextureImportSource Source) CreateSource(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        string? identity)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
+        return (
+            effectiveIdentity,
+            TextureImportSourceFactory.CreateInMemoryRaw(
+                width,
+                height,
+                colorProfile,
+                binaryPayload,
+                effectiveIdentity));
+    }
+}
+
+public sealed record EncodedImageTexturePayload : TexturePayload
+{
+    public EncodedImageTexturePayload(
         int? width,
         int? height,
         string? colorProfile,
         ITextureImportSource source,
         string? identity = null)
+        : base(colorProfile, identity ?? source?.Identity ?? throw new ArgumentNullException(nameof(source)), source!)
     {
         Width = width;
         Height = height;
-        ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(source);
-        BinaryPayload = [];
-        Identity = identity ?? source.Identity;
-        Format = TexturePayloadFormat.EncodedImage;
-        Source = source;
     }
 
     public int? Width { get; }
 
     public int? Height { get; }
-
-    public string? ColorProfile { get; }
-
-    public ImmutableArray<byte> BinaryPayload { get; }
-
-    public string? Identity { get; }
-
-    public TexturePayloadFormat Format { get; }
-
-    public ITextureImportSource Source { get; }
-
 }
 
 public enum TextureSourceKind

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -134,7 +134,7 @@ public sealed record RawRgba32TexturePayload : TexturePayload
         ITextureImportSource source)
         : base(source)
     {
-        ArgumentNullException.ThrowIfNull(binaryPayload);
+        Rgba32RawTexturePayload.ValidateByteLength(width, height, binaryPayload);
         Width = width;
         Height = height;
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -105,12 +105,11 @@ public enum TexturePayloadFormat
 public sealed record TexturePayload
 {
     public TexturePayload(
-        int? width,
-        int? height,
+        int width,
+        int height,
         string? colorProfile,
         byte[] binaryPayload,
-        string? identity = null,
-        TexturePayloadFormat format = TexturePayloadFormat.RawRgba32)
+        string? identity = null)
     {
         Width = width;
         Height = height;
@@ -118,15 +117,13 @@ public sealed record TexturePayload
         ArgumentNullException.ThrowIfNull(binaryPayload);
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
         Identity = identity;
-        ValidateFormat(format);
-        Format = format;
-        Source = TextureImportSourceFactory.CreateInMemory(
+        Format = TexturePayloadFormat.RawRgba32;
+        Source = TextureImportSourceFactory.CreateInMemoryRaw(
             width,
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"),
-            format);
+            identity ?? Guid.NewGuid().ToString("N"));
     }
 
     public TexturePayload(
@@ -134,8 +131,7 @@ public sealed record TexturePayload
         int? height,
         string? colorProfile,
         ITextureImportSource source,
-        string? identity = null,
-        TexturePayloadFormat format = TexturePayloadFormat.EncodedImage)
+        string? identity = null)
     {
         Width = width;
         Height = height;
@@ -143,8 +139,7 @@ public sealed record TexturePayload
         ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
         Identity = identity ?? source.Identity;
-        ValidateFormat(format);
-        Format = format;
+        Format = TexturePayloadFormat.EncodedImage;
         Source = source;
     }
 
@@ -162,13 +157,6 @@ public sealed record TexturePayload
 
     public ITextureImportSource Source { get; init; }
 
-    private static void ValidateFormat(TexturePayloadFormat format)
-    {
-        if (format is not (TexturePayloadFormat.RawRgba32 or TexturePayloadFormat.EncodedImage))
-        {
-            throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported texture payload format.");
-        }
-    }
 }
 
 public enum TextureSourceKind

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -83,6 +83,8 @@ public sealed class Rgba32RawTexturePayload : RawTexturePayload
 
 public sealed class RgbaFloat32RawTexturePayload : RawTexturePayload
 {
+    private const int BytesPerPixel = 16;
+
     public RgbaFloat32RawTexturePayload(
         int width,
         int height,
@@ -90,6 +92,25 @@ public sealed class RgbaFloat32RawTexturePayload : RawTexturePayload
         byte[] bytes)
         : base(width, height, colorProfile, bytes)
     {
+        ValidateByteLength(width, height, bytes);
+    }
+
+    internal static void ValidateByteLength(
+        int width,
+        int height,
+        byte[] bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        int expectedByteLength = checked(width * height * BytesPerPixel);
+        if (bytes.Length != expectedByteLength)
+        {
+            throw new ArgumentException(
+                $"RGBA float32 texture payload length must be width * height * {BytesPerPixel} bytes ({expectedByteLength}), but was {bytes.Length}.",
+                nameof(bytes));
+        }
     }
 
     public override TResult Match<TResult>(

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -54,18 +54,19 @@ internal static class TextureImportSourceMaterializer
     }
 }
 
-internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
+internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
 {
     private readonly byte[] bytes;
 
-    public InMemoryTextureImportSource(
-        int? width,
-        int? height,
+    public InMemoryRawTextureImportSource(
+        int width,
+        int height,
         string? colorProfile,
         byte[] bytes,
-        string identity,
-        TexturePayloadFormat sourceFormat)
+        string identity)
     {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
         ArgumentNullException.ThrowIfNull(bytes);
         ArgumentException.ThrowIfNullOrWhiteSpace(identity);
         Width = width;
@@ -73,12 +74,11 @@ internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
         ColorProfile = colorProfile;
         this.bytes = (byte[])bytes.Clone();
         Identity = identity;
-        SourceFormat = sourceFormat;
     }
 
-    public int? Width { get; }
+    public int Width { get; }
 
-    public int? Height { get; }
+    public int Height { get; }
 
     public string Identity { get; }
 
@@ -88,35 +88,44 @@ internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
 
     public long? EstimatedByteLength => bytes.Length;
 
-    public TexturePayloadFormat SourceFormat { get; }
+    public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(new RawTexturePayload(
+            Width,
+            Height,
+            ColorProfile,
+            (byte[])bytes.Clone()));
+    }
+}
+
+internal sealed class InMemoryEncodedTextureImportSource : IRawTexturePayloadSource
+{
+    private readonly byte[] bytes;
+
+    public InMemoryEncodedTextureImportSource(
+        string? colorProfile,
+        byte[] bytes,
+        string identity)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        ColorProfile = colorProfile;
+        this.bytes = (byte[])bytes.Clone();
+        Identity = identity;
+    }
+
+    public string Identity { get; }
+
+    public string Description => $"memory:{Identity}";
+
+    public string? ColorProfile { get; }
+
+    public long? EstimatedByteLength => bytes.Length;
 
     public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return SourceFormat switch
-        {
-            TexturePayloadFormat.RawRgba32 => CreateRawPayload(),
-            TexturePayloadFormat.EncodedImage => await DecodeEncodedImageAsync(cancellationToken),
-            _ => throw new InvalidOperationException($"Unsupported texture payload format '{SourceFormat}'."),
-        };
-    }
-
-    private RawTexturePayload CreateRawPayload()
-    {
-        if (Width is null || Height is null)
-        {
-            throw new InvalidOperationException("Raw RGBA texture payload must include width and height.");
-        }
-
-        return new RawTexturePayload(
-            Width.Value,
-            Height.Value,
-            ColorProfile,
-            (byte[])bytes.Clone());
-    }
-
-    private async ValueTask<RawTexturePayload> DecodeEncodedImageAsync(CancellationToken cancellationToken)
-    {
         using MemoryStream stream = new(bytes, writable: false);
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream, cancellationToken);
         return TextureImportSourceFactory.CreateRawPayloadFromImage(
@@ -217,7 +226,20 @@ internal static class TextureImportSourceFactory
         string identity,
         TexturePayloadFormat sourceFormat)
     {
-        return new InMemoryTextureImportSource(width, height, colorProfile, bytes, identity, sourceFormat);
+        return sourceFormat switch
+        {
+            TexturePayloadFormat.RawRgba32 => new InMemoryRawTextureImportSource(
+                width ?? throw new ArgumentException("Raw RGBA texture import source requires width.", nameof(width)),
+                height ?? throw new ArgumentException("Raw RGBA texture import source requires height.", nameof(height)),
+                colorProfile,
+                bytes,
+                identity),
+            TexturePayloadFormat.EncodedImage => new InMemoryEncodedTextureImportSource(
+                colorProfile,
+                bytes,
+                identity),
+            _ => throw new ArgumentOutOfRangeException(nameof(sourceFormat), sourceFormat, "Unsupported texture payload format."),
+        };
     }
 
     public static ITextureImportSource CreateDatasetEncodedImage(

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -8,18 +8,99 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Application.Importing;
 
-public enum RawTexturePayloadFormat
+public abstract class RawTexturePayload
 {
-    Rgba32 = 0,
-    RgbaFloat32 = 1,
+    private protected RawTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        Width = width;
+        Height = height;
+        ColorProfile = colorProfile;
+        Bytes = bytes;
+    }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public string? ColorProfile { get; }
+
+    public byte[] Bytes { get; }
+
+    public abstract TResult Match<TResult>(
+        Func<Rgba32RawTexturePayload, TResult> rgba32,
+        Func<RgbaFloat32RawTexturePayload, TResult> rgbaFloat32);
 }
 
-public sealed record RawTexturePayload(
-    int Width,
-    int Height,
-    string? ColorProfile,
-    byte[] Bytes,
-    RawTexturePayloadFormat Format = RawTexturePayloadFormat.Rgba32);
+public sealed class Rgba32RawTexturePayload : RawTexturePayload
+{
+    private const int BytesPerPixel = 4;
+
+    public Rgba32RawTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] bytes)
+        : base(width, height, colorProfile, bytes)
+    {
+        ValidateByteLength(width, height, bytes);
+    }
+
+    internal static void ValidateByteLength(
+        int width,
+        int height,
+        byte[] bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        int expectedByteLength = checked(width * height * BytesPerPixel);
+        if (bytes.Length != expectedByteLength)
+        {
+            throw new ArgumentException(
+                $"RGBA32 texture payload length must be width * height * {BytesPerPixel} bytes ({expectedByteLength}), but was {bytes.Length}.",
+                nameof(bytes));
+        }
+    }
+
+    public override TResult Match<TResult>(
+        Func<Rgba32RawTexturePayload, TResult> rgba32,
+        Func<RgbaFloat32RawTexturePayload, TResult> rgbaFloat32)
+    {
+        ArgumentNullException.ThrowIfNull(rgba32);
+        ArgumentNullException.ThrowIfNull(rgbaFloat32);
+        return rgba32(this);
+    }
+}
+
+public sealed class RgbaFloat32RawTexturePayload : RawTexturePayload
+{
+    public RgbaFloat32RawTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] bytes)
+        : base(width, height, colorProfile, bytes)
+    {
+    }
+
+    public override TResult Match<TResult>(
+        Func<Rgba32RawTexturePayload, TResult> rgba32,
+        Func<RgbaFloat32RawTexturePayload, TResult> rgbaFloat32)
+    {
+        ArgumentNullException.ThrowIfNull(rgba32);
+        ArgumentNullException.ThrowIfNull(rgbaFloat32);
+        return rgbaFloat32(this);
+    }
+}
 
 public interface ITextureImportSource
 {
@@ -32,9 +113,14 @@ public interface ITextureImportSource
     long? EstimatedByteLength { get; }
 }
 
-internal interface IRawTexturePayloadSource : ITextureImportSource
+internal interface IRgba32RawTexturePayloadSource : ITextureImportSource
 {
-    ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken);
+    ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken);
+}
+
+internal interface IRgbaFloat32RawTexturePayloadSource : ITextureImportSource
+{
+    ValueTask<RgbaFloat32RawTexturePayload> MaterializeRgbaFloat32Async(CancellationToken cancellationToken);
 }
 
 internal static class TextureImportSourceMaterializer
@@ -44,17 +130,50 @@ internal static class TextureImportSourceMaterializer
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(source);
-        if (source is not IRawTexturePayloadSource rawSource)
+        if (source is IRgba32RawTexturePayloadSource rgba32Source)
         {
-            throw new InvalidOperationException(
-                $"Texture import source '{source.GetType().Name}' cannot materialize a raw texture payload.");
+            return new ValueTask<RawTexturePayload>(MaterializeRgba32AsRawAsync(rgba32Source, cancellationToken));
         }
 
-        return rawSource.MaterializeRawAsync(cancellationToken);
+        if (source is IRgbaFloat32RawTexturePayloadSource rgbaFloat32Source)
+        {
+            return new ValueTask<RawTexturePayload>(MaterializeRgbaFloat32AsRawAsync(rgbaFloat32Source, cancellationToken));
+        }
+
+        throw new InvalidOperationException(
+            $"Texture import source '{source.GetType().Name}' cannot materialize a raw texture payload.");
+
+        static async Task<RawTexturePayload> MaterializeRgba32AsRawAsync(
+            IRgba32RawTexturePayloadSource source,
+            CancellationToken cancellationToken)
+        {
+            return await source.MaterializeRgba32Async(cancellationToken);
+        }
+
+        static async Task<RawTexturePayload> MaterializeRgbaFloat32AsRawAsync(
+            IRgbaFloat32RawTexturePayloadSource source,
+            CancellationToken cancellationToken)
+        {
+            return await source.MaterializeRgbaFloat32Async(cancellationToken);
+        }
+    }
+
+    public static ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(
+        ITextureImportSource source,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (source is not IRgba32RawTexturePayloadSource rgba32Source)
+        {
+            throw new InvalidOperationException(
+                $"Texture import source '{source.GetType().Name}' cannot materialize an RGBA32 texture payload.");
+        }
+
+        return rgba32Source.MaterializeRgba32Async(cancellationToken);
     }
 }
 
-internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
+internal sealed class InMemoryRawTextureImportSource : IRgba32RawTexturePayloadSource
 {
     private readonly byte[] bytes;
 
@@ -69,6 +188,7 @@ internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
         ArgumentNullException.ThrowIfNull(bytes);
         ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        Rgba32RawTexturePayload.ValidateByteLength(width, height, bytes);
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
@@ -88,10 +208,10 @@ internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
 
     public long? EstimatedByteLength => bytes.Length;
 
-    public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return ValueTask.FromResult(new RawTexturePayload(
+        return ValueTask.FromResult(new Rgba32RawTexturePayload(
             Width,
             Height,
             ColorProfile,
@@ -99,7 +219,7 @@ internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
     }
 }
 
-internal sealed class InMemoryEncodedTextureImportSource : IRawTexturePayloadSource
+internal sealed class InMemoryEncodedTextureImportSource : IRgba32RawTexturePayloadSource
 {
     private readonly byte[] bytes;
 
@@ -123,7 +243,7 @@ internal sealed class InMemoryEncodedTextureImportSource : IRawTexturePayloadSou
 
     public long? EstimatedByteLength => bytes.Length;
 
-    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public async ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         using MemoryStream stream = new(bytes, writable: false);
@@ -138,7 +258,7 @@ internal sealed class DatasetTextureImportSource(
     IPlateauDatasetContentSource datasetSource,
     string relativePath,
     string? colorProfile,
-    string identity) : IRawTexturePayloadSource
+    string identity) : IRgba32RawTexturePayloadSource
 {
     public string Identity { get; } = identity;
 
@@ -150,7 +270,7 @@ internal sealed class DatasetTextureImportSource(
         ? lengthSource.TryGetFileLength(relativePath)
         : null;
 
-    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public async ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
         await using Stream stream = await datasetSource.OpenReadAsync(relativePath, cancellationToken);
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream, cancellationToken);
@@ -161,7 +281,7 @@ internal sealed class DatasetTextureImportSource(
 internal sealed class FileTextureImportSource(
     string absolutePath,
     string colorProfile,
-    string identity) : IRawTexturePayloadSource
+    string identity) : IRgba32RawTexturePayloadSource
 {
     public string Identity { get; } = identity;
 
@@ -188,19 +308,19 @@ internal sealed class FileTextureImportSource(
         }
     }
 
-    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public async ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(absolutePath, cancellationToken);
         return TextureImportSourceFactory.CreateRawPayloadFromImage(image, ColorProfile);
     }
 }
 
-internal sealed class GeneratedTextureImportSource(
-    Func<CancellationToken, ValueTask<RawTexturePayload>> materializeRawAsync,
+internal sealed class GeneratedRgba32TextureImportSource(
+    Func<CancellationToken, ValueTask<Rgba32RawTexturePayload>> materializeRgba32Async,
     string identity,
     string description,
     string? colorProfile,
-    long? estimatedByteLength = null) : IRawTexturePayloadSource
+    long? estimatedByteLength = null) : IRgba32RawTexturePayloadSource
 {
     public string Identity { get; } = identity;
 
@@ -210,9 +330,30 @@ internal sealed class GeneratedTextureImportSource(
 
     public long? EstimatedByteLength { get; } = estimatedByteLength;
 
-    public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
-        return materializeRawAsync(cancellationToken);
+        return materializeRgba32Async(cancellationToken);
+    }
+}
+
+internal sealed class GeneratedRgbaFloat32TextureImportSource(
+    Func<CancellationToken, ValueTask<RgbaFloat32RawTexturePayload>> materializeRgbaFloat32Async,
+    string identity,
+    string description,
+    string? colorProfile,
+    long? estimatedByteLength = null) : IRgbaFloat32RawTexturePayloadSource
+{
+    public string Identity { get; } = identity;
+
+    public string Description { get; } = description;
+
+    public string? ColorProfile { get; } = colorProfile;
+
+    public long? EstimatedByteLength { get; } = estimatedByteLength;
+
+    public ValueTask<RgbaFloat32RawTexturePayload> MaterializeRgbaFloat32Async(CancellationToken cancellationToken)
+    {
+        return materializeRgbaFloat32Async(cancellationToken);
     }
 }
 
@@ -266,15 +407,30 @@ internal static class TextureImportSourceFactory
             identity ?? $"file:{Path.GetFullPath(absolutePath)}:{colorProfile}");
     }
 
-    public static ITextureImportSource CreateGeneratedImage(
-        Func<CancellationToken, ValueTask<RawTexturePayload>> materializeRawAsync,
+    public static ITextureImportSource CreateGeneratedRgba32Image(
+        Func<CancellationToken, ValueTask<Rgba32RawTexturePayload>> materializeRgba32Async,
         string identity,
         string description,
         string? colorProfile,
         long? estimatedByteLength = null)
     {
-        return new GeneratedTextureImportSource(
-            materializeRawAsync,
+        return new GeneratedRgba32TextureImportSource(
+            materializeRgba32Async,
+            identity,
+            description,
+            colorProfile,
+            estimatedByteLength);
+    }
+
+    public static ITextureImportSource CreateGeneratedRgbaFloat32Image(
+        Func<CancellationToken, ValueTask<RgbaFloat32RawTexturePayload>> materializeRgbaFloat32Async,
+        string identity,
+        string description,
+        string? colorProfile,
+        long? estimatedByteLength = null)
+    {
+        return new GeneratedRgbaFloat32TextureImportSource(
+            materializeRgbaFloat32Async,
             identity,
             description,
             colorProfile,
@@ -290,7 +446,7 @@ internal static class TextureImportSourceFactory
         ArgumentNullException.ThrowIfNull(image);
         Image<Rgba32> retainedImage = image.Clone();
         object gate = new();
-        return CreateGeneratedImage(
+        return CreateGeneratedRgba32Image(
             cancellationToken =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -305,14 +461,14 @@ internal static class TextureImportSourceFactory
             (long)image.Width * image.Height * 4);
     }
 
-    public static RawTexturePayload CreateRawPayloadFromImage(
+    public static Rgba32RawTexturePayload CreateRawPayloadFromImage(
         Image<Rgba32> image,
         string? colorProfile)
     {
         ArgumentNullException.ThrowIfNull(image);
         byte[] rawBytes = new byte[image.Width * image.Height * 4];
         image.CopyPixelDataTo(rawBytes);
-        return new RawTexturePayload(
+        return new Rgba32RawTexturePayload(
             image.Width,
             image.Height,
             colorProfile,

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -218,28 +218,30 @@ internal sealed class GeneratedTextureImportSource(
 
 internal static class TextureImportSourceFactory
 {
-    public static ITextureImportSource CreateInMemory(
-        int? width,
-        int? height,
+    public static ITextureImportSource CreateInMemoryRaw(
+        int width,
+        int height,
         string? colorProfile,
         byte[] bytes,
-        string identity,
-        TexturePayloadFormat sourceFormat)
+        string identity)
     {
-        return sourceFormat switch
-        {
-            TexturePayloadFormat.RawRgba32 => new InMemoryRawTextureImportSource(
-                width ?? throw new ArgumentException("Raw RGBA texture import source requires width.", nameof(width)),
-                height ?? throw new ArgumentException("Raw RGBA texture import source requires height.", nameof(height)),
-                colorProfile,
-                bytes,
-                identity),
-            TexturePayloadFormat.EncodedImage => new InMemoryEncodedTextureImportSource(
-                colorProfile,
-                bytes,
-                identity),
-            _ => throw new ArgumentOutOfRangeException(nameof(sourceFormat), sourceFormat, "Unsupported texture payload format."),
-        };
+        return new InMemoryRawTextureImportSource(
+            width,
+            height,
+            colorProfile,
+            bytes,
+            identity);
+    }
+
+    public static ITextureImportSource CreateInMemoryEncodedImage(
+        string? colorProfile,
+        byte[] bytes,
+        string identity)
+    {
+        return new InMemoryEncodedTextureImportSource(
+            colorProfile,
+            bytes,
+            identity);
     }
 
     public static ITextureImportSource CreateDatasetEncodedImage(

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
@@ -153,13 +153,12 @@ internal sealed class DeterministicTerrainTextureAssetGenerator : ITerrainTextur
         cancellationToken.ThrowIfCancellationRequested();
         TerrainTextureSource usedSource = terrainTextureOverlay.GetRequiredPrimaryTileSource();
         return Task.FromResult(new GeneratedTerrainTexture(
-            TextureImportSourceFactory.CreateInMemory(
+            TextureImportSourceFactory.CreateInMemoryRaw(
                 2,
                 2,
                 ResoniteTextureColorProfiles.Srgb,
                 RawTextureBytes,
-                "canonical-dump-terrain-texture",
-                TexturePayloadFormat.RawRgba32),
+                "canonical-dump-terrain-texture"),
             new ResoniteFloat2(1.0, 1.0),
             new ResoniteFloat2(0.0, 0.0),
             usedSource));

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClientCanonicalDump.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClientCanonicalDump.cs
@@ -139,8 +139,7 @@ internal static class SceneSinkRecordingClientCanonicalDump
         List<JsonObject> textureNodes = [];
         for (int index = 0; index < client.ImportedTexturePayloads.Count; index++)
         {
-            RawTexturePayload texture = client.ImportedTexturePayloads[index];
-            if (texture.Format != RawTexturePayloadFormat.Rgba32)
+            if (client.ImportedTexturePayloads[index] is not Rgba32RawTexturePayload texture)
             {
                 continue;
             }
@@ -164,8 +163,7 @@ internal static class SceneSinkRecordingClientCanonicalDump
         List<JsonObject> hdrTextureNodes = [];
         for (int index = 0; index < client.ImportedTexturePayloads.Count; index++)
         {
-            RawTexturePayload texture = client.ImportedTexturePayloads[index];
-            if (texture.Format != RawTexturePayloadFormat.RgbaFloat32)
+            if (client.ImportedTexturePayloads[index] is not RgbaFloat32RawTexturePayload texture)
             {
                 continue;
             }
@@ -398,16 +396,16 @@ internal static class SceneSinkRecordingClientCanonicalDump
 
     private static string CreateTextureToken(RawTexturePayload texture)
     {
-        return texture.Format == RawTexturePayloadFormat.RgbaFloat32
-            ? string.Create(
+        return texture.Match(
+            rgba32 => string.Create(
                 CultureInfo.InvariantCulture,
-                $"hdr-texture:{texture.Width}x{texture.Height}:{HashBytes(texture.Bytes)}")
-            : string.Create(
+                $"texture:{rgba32.Width}x{rgba32.Height}:{rgba32.ColorProfile}:{HashBytes(rgba32.Bytes)}"),
+            rgbaFloat32 => string.Create(
                 CultureInfo.InvariantCulture,
-                $"texture:{texture.Width}x{texture.Height}:{texture.ColorProfile}:{HashBytes(texture.Bytes)}");
+                $"hdr-texture:{rgbaFloat32.Width}x{rgbaFloat32.Height}:{HashBytes(rgbaFloat32.Bytes)}"));
     }
 
-    private static string CreateHdrTextureToken(RawTexturePayload texture)
+    private static string CreateHdrTextureToken(RgbaFloat32RawTexturePayload texture)
     {
         return string.Create(
             CultureInfo.InvariantCulture,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
@@ -211,7 +211,7 @@ internal static class ResoniteCityObjectPreparation
 
     public static ITextureImportSource PrepareTerrainGridDisplacementTexture(ResoniteTerrainGridGeometry geometry)
     {
-        return TextureImportSourceFactory.CreateGeneratedImage(
+        return TextureImportSourceFactory.CreateGeneratedRgbaFloat32Image(
             cancellationToken =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -223,7 +223,7 @@ internal static class ResoniteCityObjectPreparation
             estimatedByteLength: checked((long)geometry.Width * geometry.Height * 4L * sizeof(float)));
     }
 
-    private static RawTexturePayload CreateTerrainGridDisplacementPayload(ResoniteTerrainGridGeometry geometry)
+    private static RgbaFloat32RawTexturePayload CreateTerrainGridDisplacementPayload(ResoniteTerrainGridGeometry geometry)
     {
         float[] rawPixels = new float[geometry.Width * geometry.Height * 4];
         double heightRange = Math.Max(geometry.MaxHeight - geometry.MinHeight, 0.0);
@@ -249,12 +249,11 @@ internal static class ResoniteCityObjectPreparation
 
         byte[] rawBytes = new byte[rawPixels.Length * sizeof(float)];
         Buffer.BlockCopy(rawPixels, 0, rawBytes, 0, rawBytes.Length);
-        return new RawTexturePayload(
+        return new RgbaFloat32RawTexturePayload(
             geometry.Width,
             geometry.Height,
-            ColorProfile: null,
-            rawBytes,
-            RawTexturePayloadFormat.RgbaFloat32);
+            colorProfile: null,
+            rawBytes);
     }
 
     public static string CreateTriangleMeshDiagnosticSummary(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImageLoader.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImageLoader.cs
@@ -25,14 +25,9 @@ internal sealed class ResoniteTextureImageLoader
         ITextureImportSource textureSource,
         CancellationToken cancellationToken)
     {
-        RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+        Rgba32RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRgba32Async(
             textureSource,
             cancellationToken);
-        if (rawPayload.Format != RawTexturePayloadFormat.Rgba32)
-        {
-            throw new InvalidOperationException(
-                $"Unsupported texture payload format '{rawPayload.Format}' for image loading.");
-        }
 
         return Image.LoadPixelData<Rgba32>(
             rawPayload.Bytes,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
@@ -39,7 +39,6 @@ internal static class ResoniteTextureImportFactory
             image.Height,
             colorProfile,
             rawPayload.Bytes,
-            identity ?? Guid.NewGuid().ToString("N"),
-            ResoniteTexturePayloadFormat.RawRgba32);
+            identity ?? Guid.NewGuid().ToString("N"));
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
@@ -34,7 +34,7 @@ internal static class ResoniteTextureImportFactory
         RawTexturePayload rawPayload = TextureImportSourceFactory.CreateRawPayloadFromImage(
             image,
             colorProfile);
-        return new ResoniteTexturePayload(
+        return new RawRgba32ResoniteTexturePayload(
             image.Width,
             image.Height,
             colorProfile,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -5,64 +5,119 @@ using PlateauResoniteLink.Application.Importing;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-public enum ResoniteTexturePayloadFormat
+public abstract class ResoniteTexturePayload
 {
-    RawRgba32,
-    EncodedImage,
+    private protected ResoniteTexturePayload(
+        string? colorProfile,
+        string identity,
+        ITextureImportSource source)
+    {
+        if (string.IsNullOrWhiteSpace(identity))
+        {
+            throw new ArgumentException("Resonite texture payload identity must be provided.", nameof(identity));
+        }
+
+        ColorProfile = colorProfile;
+        Identity = identity;
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+    }
+
+    public string? ColorProfile { get; }
+
+    public string Identity { get; }
+
+    public ITextureImportSource Source { get; }
 }
 
-public sealed record ResoniteTexturePayload
+public sealed class RawRgba32ResoniteTexturePayload : ResoniteTexturePayload
 {
-    public ResoniteTexturePayload(
+    public RawRgba32ResoniteTexturePayload(
         int width,
         int height,
         string? colorProfile,
         byte[] binaryPayload,
         string? identity = null)
-    {
-        Width = width;
-        Height = height;
-        ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(binaryPayload);
-        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
-        Identity = identity;
-        Format = ResoniteTexturePayloadFormat.RawRgba32;
-        Source = TextureImportSourceFactory.CreateInMemoryRaw(
+        : this(
             width,
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"));
+            CreateSource(width, height, colorProfile, binaryPayload, identity))
+    {
     }
 
-    public ResoniteTexturePayload(
+    private RawRgba32ResoniteTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        (string Identity, ITextureImportSource Source) source)
+        : base(colorProfile, source.Identity, source.Source)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        Width = width;
+        Height = height;
+        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
+    }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public ImmutableArray<byte> BinaryPayload { get; }
+
+    private static (string Identity, ITextureImportSource Source) CreateSource(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        string? identity)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
+        return (
+            effectiveIdentity,
+            TextureImportSourceFactory.CreateInMemoryRaw(
+                width,
+                height,
+                colorProfile,
+                binaryPayload,
+                effectiveIdentity));
+    }
+}
+
+public sealed class EncodedImageResoniteTexturePayload : ResoniteTexturePayload
+{
+    public EncodedImageResoniteTexturePayload(
         int? width,
         int? height,
         string? colorProfile,
         ITextureImportSource source,
         string? identity = null)
+        : this(width, height, colorProfile, CreateSource(source, identity))
+    {
+    }
+
+    private EncodedImageResoniteTexturePayload(
+        int? width,
+        int? height,
+        string? colorProfile,
+        (string Identity, ITextureImportSource Source) source)
+        : base(colorProfile, source.Identity, source.Source)
     {
         Width = width;
         Height = height;
-        ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(source);
-        BinaryPayload = [];
-        Identity = identity ?? source.Identity;
-        Format = ResoniteTexturePayloadFormat.EncodedImage;
-        Source = source;
     }
 
     public int? Width { get; }
 
     public int? Height { get; }
 
-    public string? ColorProfile { get; }
-
-    public ImmutableArray<byte> BinaryPayload { get; }
-
-    public string? Identity { get; }
-
-    public ResoniteTexturePayloadFormat Format { get; }
-
-    public ITextureImportSource Source { get; }
+    private static (string Identity, ITextureImportSource Source) CreateSource(
+        ITextureImportSource source,
+        string? identity)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        return (identity ?? source.Identity, source);
+    }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -14,12 +14,11 @@ public enum ResoniteTexturePayloadFormat
 public sealed record ResoniteTexturePayload
 {
     public ResoniteTexturePayload(
-        int? width,
-        int? height,
+        int width,
+        int height,
         string? colorProfile,
         byte[] binaryPayload,
-        string? identity = null,
-        ResoniteTexturePayloadFormat format = ResoniteTexturePayloadFormat.RawRgba32)
+        string? identity = null)
     {
         Width = width;
         Height = height;
@@ -27,14 +26,13 @@ public sealed record ResoniteTexturePayload
         ArgumentNullException.ThrowIfNull(binaryPayload);
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
         Identity = identity;
-        Format = format;
-        Source = TextureImportSourceFactory.CreateInMemory(
+        Format = ResoniteTexturePayloadFormat.RawRgba32;
+        Source = TextureImportSourceFactory.CreateInMemoryRaw(
             width,
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"),
-            (TexturePayloadFormat)format);
+            identity ?? Guid.NewGuid().ToString("N"));
     }
 
     public ResoniteTexturePayload(
@@ -42,8 +40,7 @@ public sealed record ResoniteTexturePayload
         int? height,
         string? colorProfile,
         ITextureImportSource source,
-        string? identity = null,
-        ResoniteTexturePayloadFormat format = ResoniteTexturePayloadFormat.EncodedImage)
+        string? identity = null)
     {
         Width = width;
         Height = height;
@@ -51,7 +48,7 @@ public sealed record ResoniteTexturePayload
         ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
         Identity = identity ?? source.Identity;
-        Format = format;
+        Format = ResoniteTexturePayloadFormat.EncodedImage;
         Source = source;
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -7,24 +7,14 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 public abstract class ResoniteTexturePayload
 {
-    private protected ResoniteTexturePayload(
-        string? colorProfile,
-        string identity,
-        ITextureImportSource source)
+    private protected ResoniteTexturePayload(ITextureImportSource source)
     {
-        if (string.IsNullOrWhiteSpace(identity))
-        {
-            throw new ArgumentException("Resonite texture payload identity must be provided.", nameof(identity));
-        }
-
-        ColorProfile = colorProfile;
-        Identity = identity;
         Source = source ?? throw new ArgumentNullException(nameof(source));
+        if (string.IsNullOrWhiteSpace(Source.Identity))
+        {
+            throw new ArgumentException("Texture source identity must be non-empty.", nameof(source));
+        }
     }
-
-    public string? ColorProfile { get; }
-
-    public string Identity { get; }
 
     public ITextureImportSource Source { get; }
 }
@@ -51,8 +41,8 @@ public sealed class RawRgba32ResoniteTexturePayload : ResoniteTexturePayload
         int height,
         string? colorProfile,
         byte[] binaryPayload,
-        (string Identity, ITextureImportSource Source) source)
-        : base(colorProfile, source.Identity, source.Source)
+        ITextureImportSource source)
+        : base(source)
     {
         ArgumentNullException.ThrowIfNull(binaryPayload);
         Width = width;
@@ -66,7 +56,7 @@ public sealed class RawRgba32ResoniteTexturePayload : ResoniteTexturePayload
 
     public ImmutableArray<byte> BinaryPayload { get; }
 
-    private static (string Identity, ITextureImportSource Source) CreateSource(
+    private static ITextureImportSource CreateSource(
         int width,
         int height,
         string? colorProfile,
@@ -75,14 +65,12 @@ public sealed class RawRgba32ResoniteTexturePayload : ResoniteTexturePayload
     {
         ArgumentNullException.ThrowIfNull(binaryPayload);
         string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
-        return (
-            effectiveIdentity,
-            TextureImportSourceFactory.CreateInMemoryRaw(
-                width,
-                height,
-                colorProfile,
-                binaryPayload,
-                effectiveIdentity));
+        return TextureImportSourceFactory.CreateInMemoryRaw(
+            width,
+            height,
+            colorProfile,
+            binaryPayload,
+            effectiveIdentity);
     }
 }
 
@@ -91,19 +79,8 @@ public sealed class EncodedImageResoniteTexturePayload : ResoniteTexturePayload
     public EncodedImageResoniteTexturePayload(
         int? width,
         int? height,
-        string? colorProfile,
-        ITextureImportSource source,
-        string? identity = null)
-        : this(width, height, colorProfile, CreateSource(source, identity))
-    {
-    }
-
-    private EncodedImageResoniteTexturePayload(
-        int? width,
-        int? height,
-        string? colorProfile,
-        (string Identity, ITextureImportSource Source) source)
-        : base(colorProfile, source.Identity, source.Source)
+        ITextureImportSource source)
+        : base(source)
     {
         Width = width;
         Height = height;
@@ -112,12 +89,4 @@ public sealed class EncodedImageResoniteTexturePayload : ResoniteTexturePayload
     public int? Width { get; }
 
     public int? Height { get; }
-
-    private static (string Identity, ITextureImportSource Source) CreateSource(
-        ITextureImportSource source,
-        string? identity)
-    {
-        ArgumentNullException.ThrowIfNull(source);
-        return (identity ?? source.Identity, source);
-    }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -52,17 +52,17 @@ public sealed record ResoniteTexturePayload
         Source = source;
     }
 
-    public int? Width { get; init; }
+    public int? Width { get; }
 
-    public int? Height { get; init; }
+    public int? Height { get; }
 
-    public string? ColorProfile { get; init; }
+    public string? ColorProfile { get; }
 
-    public ImmutableArray<byte> BinaryPayload { get; init; }
+    public ImmutableArray<byte> BinaryPayload { get; }
 
-    public string? Identity { get; init; }
+    public string? Identity { get; }
 
-    public ResoniteTexturePayloadFormat Format { get; init; }
+    public ResoniteTexturePayloadFormat Format { get; }
 
-    public ITextureImportSource Source { get; init; }
+    public ITextureImportSource Source { get; }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -139,13 +139,22 @@ internal static class SceneImportContractMapper
 
     private static ResoniteTexturePayload ToInternal(TexturePayload payload)
     {
-        return new ResoniteTexturePayload(
-            payload.Width,
-            payload.Height,
-            payload.ColorProfile,
-            payload.Source,
-            payload.Identity,
-            ToInternal(payload.Format));
+        return payload.Format switch
+        {
+            TexturePayloadFormat.RawRgba32 => new ResoniteTexturePayload(
+                payload.Width ?? throw new InvalidOperationException("Raw texture payload requires width."),
+                payload.Height ?? throw new InvalidOperationException("Raw texture payload requires height."),
+                payload.ColorProfile,
+                payload.BinaryPayload.AsSpan().ToArray(),
+                payload.Identity),
+            TexturePayloadFormat.EncodedImage => new ResoniteTexturePayload(
+                payload.Width,
+                payload.Height,
+                payload.ColorProfile,
+                payload.Source,
+                payload.Identity),
+            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.Format, "Unsupported texture payload format."),
+        };
     }
 
     private static ResoniteMaterialType ToInternal(MaterialType materialType)
@@ -176,16 +185,6 @@ internal static class SceneImportContractMapper
             MaterialProjection.Uv => ResoniteMaterialProjection.Uv,
             MaterialProjection.Triplanar => ResoniteMaterialProjection.Triplanar,
             _ => throw new ArgumentOutOfRangeException(nameof(projection), projection, "Unsupported material projection."),
-        };
-    }
-
-    private static ResoniteTexturePayloadFormat ToInternal(TexturePayloadFormat format)
-    {
-        return format switch
-        {
-            TexturePayloadFormat.RawRgba32 => ResoniteTexturePayloadFormat.RawRgba32,
-            TexturePayloadFormat.EncodedImage => ResoniteTexturePayloadFormat.EncodedImage,
-            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported texture payload format."),
         };
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -139,21 +139,21 @@ internal static class SceneImportContractMapper
 
     private static ResoniteTexturePayload ToInternal(TexturePayload payload)
     {
-        return payload.Format switch
+        return payload switch
         {
-            TexturePayloadFormat.RawRgba32 => new ResoniteTexturePayload(
-                payload.Width.GetValueOrDefault(),
-                payload.Height.GetValueOrDefault(),
-                payload.ColorProfile,
-                payload.BinaryPayload.AsSpan().ToArray(),
-                payload.Identity),
-            TexturePayloadFormat.EncodedImage => new ResoniteTexturePayload(
-                payload.Width,
-                payload.Height,
-                payload.ColorProfile,
-                payload.Source,
-                payload.Identity),
-            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.Format, "Unsupported texture payload format."),
+            RawRgba32TexturePayload raw => new ResoniteTexturePayload(
+                raw.Width,
+                raw.Height,
+                raw.ColorProfile,
+                raw.BinaryPayload.AsSpan().ToArray(),
+                raw.Identity),
+            EncodedImageTexturePayload encoded => new ResoniteTexturePayload(
+                encoded.Width,
+                encoded.Height,
+                encoded.ColorProfile,
+                encoded.Source,
+                encoded.Identity),
+            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.GetType(), "Unsupported texture payload type."),
         };
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -142,8 +142,8 @@ internal static class SceneImportContractMapper
         return payload.Format switch
         {
             TexturePayloadFormat.RawRgba32 => new ResoniteTexturePayload(
-                payload.Width ?? throw new InvalidOperationException("Raw texture payload requires width."),
-                payload.Height ?? throw new InvalidOperationException("Raw texture payload requires height."),
+                payload.Width.GetValueOrDefault(),
+                payload.Height.GetValueOrDefault(),
                 payload.ColorProfile,
                 payload.BinaryPayload.AsSpan().ToArray(),
                 payload.Identity),

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -141,13 +141,13 @@ internal static class SceneImportContractMapper
     {
         return payload switch
         {
-            RawRgba32TexturePayload raw => new ResoniteTexturePayload(
+            RawRgba32TexturePayload raw => new RawRgba32ResoniteTexturePayload(
                 raw.Width,
                 raw.Height,
                 raw.ColorProfile,
                 raw.BinaryPayload.AsSpan().ToArray(),
                 raw.Identity),
-            EncodedImageTexturePayload encoded => new ResoniteTexturePayload(
+            EncodedImageTexturePayload encoded => new EncodedImageResoniteTexturePayload(
                 encoded.Width,
                 encoded.Height,
                 encoded.ColorProfile,

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -144,15 +144,13 @@ internal static class SceneImportContractMapper
             RawRgba32TexturePayload raw => new RawRgba32ResoniteTexturePayload(
                 raw.Width,
                 raw.Height,
-                raw.ColorProfile,
+                raw.Source.ColorProfile,
                 raw.BinaryPayload.AsSpan().ToArray(),
-                raw.Identity),
+                raw.Source.Identity),
             EncodedImageTexturePayload encoded => new EncodedImageResoniteTexturePayload(
                 encoded.Width,
                 encoded.Height,
-                encoded.ColorProfile,
-                encoded.Source,
-                encoded.Identity),
+                encoded.Source),
             _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.GetType(), "Unsupported texture payload type."),
         };
     }

--- a/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkClient.cs
+++ b/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkClient.cs
@@ -164,12 +164,9 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
         RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
             textureSource,
             cancellationToken);
-        AssetData result = rawPayload.Format switch
-        {
-            RawTexturePayloadFormat.Rgba32 => await ImportRawTextureAsync(rawPayload, cancellationToken),
-            RawTexturePayloadFormat.RgbaFloat32 => await ImportRawHdrTextureAsync(rawPayload, cancellationToken),
-            _ => throw new InvalidOperationException($"Unsupported texture payload format '{rawPayload.Format}'."),
-        };
+        AssetData result = await rawPayload.Match(
+            rgba32 => ImportRawTextureAsync(rgba32, cancellationToken),
+            rgbaFloat32 => ImportRawHdrTextureAsync(rgbaFloat32, cancellationToken));
 
         EnsureSuccess(result, "import texture");
         return result.AssetURL ?? throw new InvalidOperationException("ResoniteLink returned a null texture asset URL.");
@@ -253,7 +250,7 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
             "component");
     }
 
-    private Task<AssetData> ImportRawTextureAsync(RawTexturePayload rawPayload, CancellationToken cancellationToken)
+    private Task<AssetData> ImportRawTextureAsync(Rgba32RawTexturePayload rawPayload, CancellationToken cancellationToken)
     {
         return ExecuteSerializedAsync(
             "import_texture",
@@ -268,7 +265,7 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
             cancellationToken);
     }
 
-    private Task<AssetData> ImportRawHdrTextureAsync(RawTexturePayload rawPayload, CancellationToken cancellationToken)
+    private Task<AssetData> ImportRawHdrTextureAsync(RgbaFloat32RawTexturePayload rawPayload, CancellationToken cancellationToken)
     {
         return ExecuteSerializedAsync(
             "import_texture",

--- a/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,9 +26,34 @@ public sealed class TextureImportSourceFactoryTests
             source,
             CancellationToken.None);
 
+        Assert.IsType<Rgba32RawTexturePayload>(payload);
         Assert.Equal(1, payload.Width);
         Assert.Equal(1, payload.Height);
         Assert.Equal([255, 255, 255, 255], payload.Bytes);
+    }
+
+    [Fact]
+    public void CreateInMemoryRawRgbaRejectsByteLengthMismatch()
+    {
+        Assert.Throws<ArgumentException>(
+            () => TextureImportSourceFactory.CreateInMemoryRaw(
+                width: 2,
+                height: 2,
+                colorProfile: "sRGB",
+                bytes: [255, 255, 255, 255],
+                identity: "raw-with-invalid-byte-length"));
+    }
+
+    [Fact]
+    public void CreateInMemoryRawRgbaRejectsByteLengthOverflow()
+    {
+        Assert.Throws<OverflowException>(
+            () => TextureImportSourceFactory.CreateInMemoryRaw(
+                width: int.MaxValue,
+                height: int.MaxValue,
+                colorProfile: "sRGB",
+                bytes: [255, 255, 255, 255],
+                identity: "raw-with-overflow-byte-length"));
     }
 
     [Fact]
@@ -48,9 +74,36 @@ public sealed class TextureImportSourceFactoryTests
             source,
             CancellationToken.None);
 
+        Assert.IsType<Rgba32RawTexturePayload>(payload);
         Assert.Equal(1, payload.Width);
         Assert.Equal(1, payload.Height);
         Assert.Equal([1, 2, 3, 255], payload.Bytes);
+    }
+
+    [Fact]
+    public async Task CreateGeneratedRgbaFloat32ImageDoesNotMaterializeAsRgba32()
+    {
+        ITextureImportSource source = TextureImportSourceFactory.CreateGeneratedRgbaFloat32Image(
+            _ => ValueTask.FromResult(new RgbaFloat32RawTexturePayload(
+                width: 1,
+                height: 1,
+                colorProfile: null,
+                bytes: new byte[16])),
+            identity: "hdr",
+            description: "hdr",
+            colorProfile: null,
+            estimatedByteLength: 16);
+
+        RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            source,
+            CancellationToken.None);
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await TextureImportSourceMaterializer.MaterializeRgba32Async(
+                source,
+                CancellationToken.None));
+
+        Assert.IsType<RgbaFloat32RawTexturePayload>(rawPayload);
+        Assert.Contains("cannot materialize an RGBA32 texture payload", exception.Message, System.StringComparison.Ordinal);
     }
 
 }

--- a/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Tests.Application;
+
+public sealed class TextureImportSourceFactoryTests
+{
+    [Fact]
+    public void CreateInMemoryRawRgbaRequiresDimensionsBeforeMaterialization()
+    {
+        ArgumentException widthError = Assert.Throws<ArgumentException>(
+            () => TextureImportSourceFactory.CreateInMemory(
+                width: null,
+                height: 1,
+                colorProfile: "sRGB",
+                bytes: [255, 255, 255, 255],
+                identity: "raw-without-width",
+                sourceFormat: TexturePayloadFormat.RawRgba32));
+        ArgumentException heightError = Assert.Throws<ArgumentException>(
+            () => TextureImportSourceFactory.CreateInMemory(
+                width: 1,
+                height: null,
+                colorProfile: "sRGB",
+                bytes: [255, 255, 255, 255],
+                identity: "raw-without-height",
+                sourceFormat: TexturePayloadFormat.RawRgba32));
+
+        Assert.Equal("width", widthError.ParamName);
+        Assert.Equal("height", heightError.ParamName);
+    }
+
+    [Fact]
+    public async Task CreateInMemoryEncodedImageOwnsDimensionsAfterDecode()
+    {
+        await using MemoryStream stream = new();
+        using (Image<Rgba32> image = new(1, 1, new Rgba32(1, 2, 3, 255)))
+        {
+            await image.SaveAsPngAsync(stream);
+        }
+
+        ITextureImportSource source = TextureImportSourceFactory.CreateInMemory(
+            width: null,
+            height: null,
+            colorProfile: "sRGB",
+            bytes: stream.ToArray(),
+            identity: "encoded-without-dimensions",
+            sourceFormat: TexturePayloadFormat.EncodedImage);
+
+        RawTexturePayload payload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            source,
+            CancellationToken.None);
+
+        Assert.Equal(1, payload.Width);
+        Assert.Equal(1, payload.Height);
+        Assert.Equal([1, 2, 3, 255], payload.Bytes);
+    }
+
+    [Fact]
+    public void TexturePayloadRejectsUnsupportedFormatAtConstructionBoundary()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new TexturePayload(
+                width: 1,
+                height: 1,
+                colorProfile: "sRGB",
+                binaryPayload: [255, 255, 255, 255],
+                identity: "invalid-format",
+                format: (TexturePayloadFormat)999));
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
@@ -106,4 +106,26 @@ public sealed class TextureImportSourceFactoryTests
         Assert.Contains("cannot materialize an RGBA32 texture payload", exception.Message, System.StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void RgbaFloat32RawTexturePayloadRejectsByteLengthMismatch()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new RgbaFloat32RawTexturePayload(
+                width: 2,
+                height: 2,
+                colorProfile: null,
+                bytes: new byte[16]));
+    }
+
+    [Fact]
+    public void RgbaFloat32RawTexturePayloadRejectsByteLengthOverflow()
+    {
+        Assert.Throws<OverflowException>(
+            () => new RgbaFloat32RawTexturePayload(
+                width: int.MaxValue,
+                height: int.MaxValue,
+                colorProfile: null,
+                bytes: new byte[16]));
+    }
+
 }

--- a/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,27 +12,22 @@ namespace PlateauResoniteLink.Tests.Application;
 public sealed class TextureImportSourceFactoryTests
 {
     [Fact]
-    public void CreateInMemoryRawRgbaRequiresDimensionsBeforeMaterialization()
+    public async Task CreateInMemoryRawRgbaRequiresDimensionsAtConstruction()
     {
-        ArgumentException widthError = Assert.Throws<ArgumentException>(
-            () => TextureImportSourceFactory.CreateInMemory(
-                width: null,
-                height: 1,
-                colorProfile: "sRGB",
-                bytes: [255, 255, 255, 255],
-                identity: "raw-without-width",
-                sourceFormat: TexturePayloadFormat.RawRgba32));
-        ArgumentException heightError = Assert.Throws<ArgumentException>(
-            () => TextureImportSourceFactory.CreateInMemory(
-                width: 1,
-                height: null,
-                colorProfile: "sRGB",
-                bytes: [255, 255, 255, 255],
-                identity: "raw-without-height",
-                sourceFormat: TexturePayloadFormat.RawRgba32));
+        ITextureImportSource source = TextureImportSourceFactory.CreateInMemoryRaw(
+            width: 1,
+            height: 1,
+            colorProfile: "sRGB",
+            bytes: [255, 255, 255, 255],
+            identity: "raw-with-dimensions");
 
-        Assert.Equal("width", widthError.ParamName);
-        Assert.Equal("height", heightError.ParamName);
+        RawTexturePayload payload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            source,
+            CancellationToken.None);
+
+        Assert.Equal(1, payload.Width);
+        Assert.Equal(1, payload.Height);
+        Assert.Equal([255, 255, 255, 255], payload.Bytes);
     }
 
     [Fact]
@@ -45,13 +39,10 @@ public sealed class TextureImportSourceFactoryTests
             await image.SaveAsPngAsync(stream);
         }
 
-        ITextureImportSource source = TextureImportSourceFactory.CreateInMemory(
-            width: null,
-            height: null,
+        ITextureImportSource source = TextureImportSourceFactory.CreateInMemoryEncodedImage(
             colorProfile: "sRGB",
             bytes: stream.ToArray(),
-            identity: "encoded-without-dimensions",
-            sourceFormat: TexturePayloadFormat.EncodedImage);
+            identity: "encoded-without-dimensions");
 
         RawTexturePayload payload = await TextureImportSourceMaterializer.MaterializeRawAsync(
             source,
@@ -62,16 +53,4 @@ public sealed class TextureImportSourceFactoryTests
         Assert.Equal([1, 2, 3, 255], payload.Bytes);
     }
 
-    [Fact]
-    public void TexturePayloadRejectsUnsupportedFormatAtConstructionBoundary()
-    {
-        Assert.Throws<ArgumentOutOfRangeException>(
-            () => new TexturePayload(
-                width: 1,
-                height: 1,
-                colorProfile: "sRGB",
-                binaryPayload: [255, 255, 255, 255],
-                identity: "invalid-format",
-                format: (TexturePayloadFormat)999));
-    }
 }

--- a/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
@@ -18,6 +18,25 @@ public sealed class TexturePayloadTests
     }
 
     [Fact]
+    public void ConstructorRejectsRawRgbaByteLengthMismatch()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new RawRgba32TexturePayload(2, 2, "sRGB", [255, 255, 255, 255], "dataset:texture"));
+    }
+
+    [Fact]
+    public void ConstructorRejectsRawRgbaByteLengthOverflow()
+    {
+        Assert.Throws<OverflowException>(
+            () => new RawRgba32TexturePayload(
+                int.MaxValue,
+                int.MaxValue,
+                "sRGB",
+                [255, 255, 255, 255],
+                "dataset:texture"));
+    }
+
+    [Fact]
     public void ConstructorCarriesIdentityAndColorProfileOnSourceOnly()
     {
         RawRgba32TexturePayload payload = new(1, 1, "sRGB", [1, 2, 3, 4], "dataset:texture");

--- a/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
@@ -9,7 +9,7 @@ public sealed class TexturePayloadTests
     {
         byte[] source = [1, 2, 3, 4];
 
-        TexturePayload payload = new(1, 1, "sRGB", source, "dataset:texture");
+        RawRgba32TexturePayload payload = new(1, 1, "sRGB", source, "dataset:texture");
         source[0] = 9;
 
         Assert.Equal<byte>([1, 2, 3, 4], payload.BinaryPayload);

--- a/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using PlateauResoniteLink.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.Application;
@@ -13,5 +15,32 @@ public sealed class TexturePayloadTests
         source[0] = 9;
 
         Assert.Equal<byte>([1, 2, 3, 4], payload.BinaryPayload);
+    }
+
+    [Fact]
+    public void ConstructorCarriesIdentityAndColorProfileOnSourceOnly()
+    {
+        RawRgba32TexturePayload payload = new(1, 1, "sRGB", [1, 2, 3, 4], "dataset:texture");
+
+        Assert.Equal("dataset:texture", payload.Source.Identity);
+        Assert.Equal("sRGB", payload.Source.ColorProfile);
+    }
+
+    [Fact]
+    public void ConstructorRejectsTextureSourceWithoutIdentity()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new EncodedImageTexturePayload(null, null, new BlankIdentityTextureImportSource()));
+    }
+
+    private sealed class BlankIdentityTextureImportSource : ITextureImportSource
+    {
+        public string Identity => " ";
+
+        public string Description => "blank";
+
+        public string? ColorProfile => null;
+
+        public long? EstimatedByteLength => null;
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
@@ -13,7 +13,7 @@ public sealed class DefaultMaterialResolverTests
     [Fact]
     public void ResolveMaterialUsesDatasetTextureWhenPresent()
     {
-        TexturePayload payload = new(4, 4, "srgb", new byte[4 * 4 * 4], "udx/bldg/53394525/appearance/roof.png");
+        TexturePayload payload = new RawRgba32TexturePayload(4, 4, "srgb", new byte[4 * 4 * 4], "udx/bldg/53394525/appearance/roof.png");
 
         ResolvedMaterial material = resolver.ResolveMaterial(new DefaultMaterialRequest(
             "bldg",
@@ -41,7 +41,7 @@ public sealed class DefaultMaterialResolverTests
     public void ResolveMaterialUsesDatasetTextureBeforeBuildingFallback(int surfaceRoleValue)
     {
         DefaultMaterialSurfaceRole surfaceRole = (DefaultMaterialSurfaceRole)surfaceRoleValue;
-        TexturePayload payload = new(4, 4, "srgb", new byte[4 * 4 * 4], $"udx/bldg/53394525/appearance/{surfaceRole}.png");
+        TexturePayload payload = new RawRgba32TexturePayload(4, 4, "srgb", new byte[4 * 4 * 4], $"udx/bldg/53394525/appearance/{surfaceRole}.png");
 
         ResolvedMaterial material = resolver.ResolveMaterial(new DefaultMaterialRequest(
             "bldg",

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -720,7 +720,7 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
 
     private static TexturePayload CreateTexturePayload(string identity)
     {
-        return new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], identity);
+        return new RawRgba32TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], identity);
     }
 
     private static double ComputeParsedNormalY(ParsedSurface surface)

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
@@ -65,7 +65,7 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
                 "textured-road",
                 width: 4.0,
                 length: 12.0,
-                texturePayload: new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")));
+                texturePayload: new RawRgba32TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")));
 
         ParsedCityObject? marking = GeneratedRoadMarkingCityObjectFactory.Create(road, new GeodeticPoint(0.0, 0.0, 0.0), cityObjectCartesian: null);
 
@@ -83,7 +83,7 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
                     "textured-road",
                     width: 4.0,
                     length: 12.0,
-                    texturePayload: new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")),
+                    texturePayload: new RawRgba32TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")),
                 CreateRoadSurface(
                     "plain-road",
                     width: 4.0,

--- a/tests/PlateauResoniteLink.Tests/Profiles/ImportedDynamicMaterialUvNormalizerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/ImportedDynamicMaterialUvNormalizerTests.cs
@@ -270,7 +270,7 @@ public sealed class ImportedDynamicMaterialUvNormalizerTests
         return new PresentationMaterialBinding(
             BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
             MaterialType: MaterialType.Standard,
-            TexturePayload: new TexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),
+            TexturePayload: new RawRgba32TexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),
             TextureSourceKind: TextureSourceKind.Dataset,
             Projection: MaterialProjection.Uv,
             DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -3857,7 +3857,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
     private static TexturePayload CreateTexturePayload(string identity)
     {
-        return new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], identity);
+        return new RawRgba32TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], identity);
     }
 
     private static HashSet<string> GetCulledSurfaceIdsBeforeProjectionForTest(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -2071,10 +2071,10 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Equal(3, projected.Materials.Count);
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "ground");
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "ground-reversed");
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "outer-floor");
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Identity == "high-outer-floor");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "ground");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "ground-reversed");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "outer-floor");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity == "high-outer-floor");
     }
 
     [Fact]
@@ -2111,7 +2111,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Single(projected.Materials);
-        Assert.Equal("tran-ground", projected.Materials[0].TexturePayload?.Identity);
+        Assert.Equal("tran-ground", projected.Materials[0].TexturePayload?.Source.Identity);
         Assert.NotEmpty(projected.Mesh.Vertices);
     }
 
@@ -2169,10 +2169,10 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Equal(2, projected.Materials.Count);
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "lod1-bottom");
-        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Identity == "lod1-bottom-reversed");
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Identity == "lod1-roof");
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Identity == "lod1-wall");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "lod1-bottom");
+        Assert.DoesNotContain(projected.Materials, static material => material.TexturePayload?.Source.Identity == "lod1-bottom-reversed");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity == "lod1-roof");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity == "lod1-wall");
     }
 
     [Fact]
@@ -2244,7 +2244,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             materialResolver: new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
 
         Assert.Single(projected.Materials);
-        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Identity == "only-surface");
+        Assert.Contains(projected.Materials, static material => material.TexturePayload?.Source.Identity == "only-surface");
     }
 
     [Fact]
@@ -2379,7 +2379,7 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.NotNull(explicitMaterial.TexturePayload);
         Assert.Contains(
             "udx/dem/53394525/appearance/mixed_surface.png",
-            explicitMaterial.TexturePayload!.Identity,
+            explicitMaterial.TexturePayload!.Source.Identity,
             StringComparison.Ordinal);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
@@ -123,7 +123,7 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
     {
         return CreateTexturelessMaterial() with
         {
-            TexturePayload = new ResoniteTexturePayload(
+            TexturePayload = new RawRgba32ResoniteTexturePayload(
                 width: 1,
                 height: 1,
                 colorProfile: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -118,7 +118,7 @@ public sealed class NonDemCityObjectBakerTests
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
 
         string?[] identities = cityObject.Materials
-            .Select(static material => material.TexturePayload?.Identity)
+            .Select(static material => material.TexturePayload?.Source.Identity)
             .ToArray();
         Assert.Collection(
             identities,
@@ -147,7 +147,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(CommonMaterialCatalog.Create().Generic.Uv, material.CommonMaterial);
         Assert.NotSame(payload, material.TexturePayload);
         Assert.NotNull(material.TexturePayload);
-        Assert.Contains("atlastex-", material.TexturePayload.Identity, StringComparison.Ordinal);
+        Assert.Contains("atlastex-", material.TexturePayload.Source.Identity, StringComparison.Ordinal);
         Assert.IsType<RawRgba32ResoniteTexturePayload>(material.TexturePayload);
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
@@ -189,7 +189,7 @@ public sealed class NonDemCityObjectBakerTests
             double averageX = submesh.TriangleVertexIndices
                 .Select(index => cityObject.Mesh.Vertices[index].Position.X)
                 .Average();
-            averageXByPayloadIdentity.Add(material.TexturePayload?.Identity ?? string.Empty, averageX);
+            averageXByPayloadIdentity.Add(material.TexturePayload?.Source.Identity ?? string.Empty, averageX);
         }
 
         Assert.True(averageXByPayloadIdentity["textures/left.png"] < averageXByPayloadIdentity["textures/right.png"]);
@@ -594,7 +594,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(oversizedCandidate.DisplayName, cityObject.DisplayName);
         Assert.Equal(oversizedCandidate.Materials.Count, cityObject.Materials.Count);
         Assert.All(cityObject.Materials, static material => Assert.NotNull(material.TexturePayload));
-        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Source.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -619,7 +619,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(new ResoniteFloat2(0.25, 0.75), cityObject.Mesh.Vertices[0].UV0);
         Assert.Equal(new ResoniteFloat2(2.25, 0.75), cityObject.Mesh.Vertices[1].UV0);
         Assert.Equal(new ResoniteFloat2(0.25, 1.25), cityObject.Mesh.Vertices[2].UV0);
-        Assert.DoesNotContain(cityObject.Materials, static candidate => candidate.TexturePayload?.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(cityObject.Materials, static candidate => candidate.TexturePayload?.Source.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -798,7 +798,7 @@ public sealed class NonDemCityObjectBakerTests
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         Assert.Equal(oversizedCandidate.SlotKey, cityObject.SlotKey);
-        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(cityObject.Materials, static material => material.TexturePayload?.Source.Identity?.Contains("generated/lod2-atlas/", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -1061,7 +1061,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal("atlasbake-unit-a-bldg-lod2-3", cityObject.SlotKey);
         Assert.Equal(
             "atlastex-unit-a.gml-3",
-            Assert.IsType<RawRgba32ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Identity);
+            Assert.IsType<RawRgba32ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Source.Identity);
     }
 
     private static NonDemCityObjectBaker CreateBaker(

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -29,12 +29,9 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Single(cityObject.Mesh.Submeshes);
         Assert.Equal(6, cityObject.Mesh.Vertices.Count);
         Assert.Equal("unit-a.gml", cityObject.SourceFileRelativePath);
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, atlasPayload.Format);
-        Assert.NotNull(atlasPayload.Width);
-        Assert.NotNull(atlasPayload.Height);
-        Assert.InRange(atlasPayload.Width!.Value, 1, 32);
-        Assert.InRange(atlasPayload.Height!.Value, 1, 32);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        Assert.InRange(atlasPayload.Width, 1, 32);
+        Assert.InRange(atlasPayload.Height, 1, 32);
         Assert.Equal(CommonMaterialCatalog.Create().Generic.Uv, cityObject.Materials[0].CommonMaterial);
     }
 
@@ -63,8 +60,7 @@ public sealed class NonDemCityObjectBakerTests
             new ResoniteFloat2(0.5, 0.0)));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, atlasPayload.Format);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
         Assert.Equal(1, atlasPayload.Width);
         Assert.Equal(1, atlasPayload.Height);
         Assert.Null(cityObject.Materials[0].TextureScale);
@@ -152,7 +148,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.NotSame(payload, material.TexturePayload);
         Assert.NotNull(material.TexturePayload);
         Assert.Contains("atlastex-", material.TexturePayload.Identity, StringComparison.Ordinal);
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, material.TexturePayload.Format);
+        Assert.IsType<RawRgba32ResoniteTexturePayload>(material.TexturePayload);
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
     }
@@ -212,7 +208,7 @@ public sealed class NonDemCityObjectBakerTests
             new ResoniteFloat2(0.0, 0.0)));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload);
 
         Assert.Equal(2, atlasPayload.Width);
         Assert.Equal(1, atlasPayload.Height);
@@ -261,8 +257,7 @@ public sealed class NonDemCityObjectBakerTests
             null));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, atlasPayload.Format);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
         Assert.Equal(4, atlasPayload.Width);
         Assert.Equal(1, atlasPayload.Height);
         Assert.Equal(new Rgba32(255, 0, 0, 255), ReadPixel(atlasPayload, 0, 0));
@@ -285,7 +280,7 @@ public sealed class NonDemCityObjectBakerTests
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         ResoniteMaterialBinding material = Assert.Single(cityObject.Materials);
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(material.TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(material.TexturePayload);
 
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
@@ -325,7 +320,7 @@ public sealed class NonDemCityObjectBakerTests
                 "unit-a"));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
 
         Assert.Equal(2, atlasPayload.Width);
         Assert.Equal(1, atlasPayload.Height);
@@ -783,7 +778,7 @@ public sealed class NonDemCityObjectBakerTests
         await AssertBufferedAsync(baker, CreateLod2Building("building-c", CreateCheckerPayload("textures/c.png", new Rgba32(0, 0, 255, 255), new Rgba32(255, 0, 255, 255), 3, 3), 4, "unit-a"));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
         Assert.Equal(16, atlasPayload.Width);
         Assert.Equal(8, atlasPayload.Height);
     }
@@ -973,7 +968,7 @@ public sealed class NonDemCityObjectBakerTests
                 "unit-a"));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
         Assert.Equal(512, atlasPayload.Width);
         Assert.Equal(512, atlasPayload.Height);
     }
@@ -1066,7 +1061,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal("atlasbake-unit-a-bldg-lod2-3", cityObject.SlotKey);
         Assert.Equal(
             "atlastex-unit-a.gml-3",
-            Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Identity);
+            Assert.IsType<RawRgba32ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Identity);
     }
 
     private static NonDemCityObjectBaker CreateBaker(
@@ -1151,11 +1146,9 @@ public sealed class NonDemCityObjectBakerTests
         return ResoniteTextureImportFactory.CreatePayloadFromImage(image, identity: identity);
     }
 
-    private static Rgba32 ReadPixel(ResoniteTexturePayload payload, int x, int y)
+    private static Rgba32 ReadPixel(RawRgba32ResoniteTexturePayload payload, int x, int y)
     {
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, payload.Format);
-        Assert.NotNull(payload.Width);
-        int width = payload.Width.Value;
+        int width = payload.Width;
         int offset = ((y * width) + x) * 4;
         ReadOnlySpan<byte> bytes = payload.BinaryPayload.AsSpan();
         return new Rgba32(

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
@@ -12,7 +12,7 @@ public sealed class NonDemPreservedMaterialGroupingTests
         {
             AssetBinding = ResoniteMaterialAssetBindingTestFactory.SharedGenericUv(),
         };
-        ResoniteTexturePayload texture = new(
+        ResoniteTexturePayload texture = new RawRgba32ResoniteTexturePayload(
             width: 1,
             height: 1,
             colorProfile: null,
@@ -31,7 +31,7 @@ public sealed class NonDemPreservedMaterialGroupingTests
         });
         NonDemPreservedMaterialGroupingKey differentTexture = NonDemPreservedMaterialGrouping.CreateKey(commonMaterial with
         {
-            TexturePayload = new ResoniteTexturePayload(
+            TexturePayload = new RawRgba32ResoniteTexturePayload(
                 width: 1,
                 height: 1,
                 colorProfile: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
@@ -289,7 +289,7 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
         return new ResoniteMaterialBinding(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -570,13 +570,13 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
     private static TexturePayload ToContractTexturePayload(ResoniteTexturePayload payload)
         => payload.Format switch
         {
-            ResoniteTexturePayloadFormat.RawRgba32 => new TexturePayload(
-                payload.Width.GetValueOrDefault(),
-                payload.Height.GetValueOrDefault(),
+            ResoniteTexturePayloadFormat.RawRgba32 => new RawRgba32TexturePayload(
+                payload.Width ?? throw new InvalidOperationException("Raw texture payload requires width."),
+                payload.Height ?? throw new InvalidOperationException("Raw texture payload requires height."),
                 payload.ColorProfile,
                 payload.BinaryPayload.AsSpan().ToArray(),
                 payload.Identity),
-            ResoniteTexturePayloadFormat.EncodedImage => new TexturePayload(
+            ResoniteTexturePayloadFormat.EncodedImage => new EncodedImageTexturePayload(
                 payload.Width,
                 payload.Height,
                 payload.ColorProfile,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -573,15 +573,13 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             RawRgba32ResoniteTexturePayload raw => new RawRgba32TexturePayload(
                 raw.Width,
                 raw.Height,
-                raw.ColorProfile,
+                raw.Source.ColorProfile,
                 raw.BinaryPayload.AsSpan().ToArray(),
-                raw.Identity),
+                raw.Source.Identity),
             EncodedImageResoniteTexturePayload encoded => new EncodedImageTexturePayload(
                 encoded.Width,
                 encoded.Height,
-                encoded.ColorProfile,
-                encoded.Source,
-                encoded.Identity),
+                encoded.Source),
             _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.GetType(), "Unsupported texture payload type."),
         };
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -568,13 +568,22 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         => Enumerable.Repeat(TerrainGridSampleCoverage.Measured, count).ToArray();
 
     private static TexturePayload ToContractTexturePayload(ResoniteTexturePayload payload)
-        => new(
-            payload.Width,
-            payload.Height,
-            payload.ColorProfile,
-            payload.BinaryPayload.AsSpan().ToArray(),
-            payload.Identity,
-            (TexturePayloadFormat)payload.Format);
+        => payload.Format switch
+        {
+            ResoniteTexturePayloadFormat.RawRgba32 => new TexturePayload(
+                payload.Width ?? throw new InvalidOperationException("Raw texture payload requires width."),
+                payload.Height ?? throw new InvalidOperationException("Raw texture payload requires height."),
+                payload.ColorProfile,
+                payload.BinaryPayload.AsSpan().ToArray(),
+                payload.Identity),
+            ResoniteTexturePayloadFormat.EncodedImage => new TexturePayload(
+                payload.Width,
+                payload.Height,
+                payload.ColorProfile,
+                payload.Source,
+                payload.Identity),
+            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.Format, "Unsupported texture payload format."),
+        };
 
 }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -71,7 +71,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             r, g, b, 255,
             r, g, b, 255,
         ];
-        return new ResoniteTexturePayload(2, 2, ResoniteTextureColorProfiles.Srgb, rawBytes, identity);
+        return new RawRgba32ResoniteTexturePayload(2, 2, ResoniteTextureColorProfiles.Srgb, rawBytes, identity);
     }
 
     public static ImportedSceneMetadata CreateMetadata(
@@ -568,21 +568,21 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         => Enumerable.Repeat(TerrainGridSampleCoverage.Measured, count).ToArray();
 
     private static TexturePayload ToContractTexturePayload(ResoniteTexturePayload payload)
-        => payload.Format switch
+        => payload switch
         {
-            ResoniteTexturePayloadFormat.RawRgba32 => new RawRgba32TexturePayload(
-                payload.Width ?? throw new InvalidOperationException("Raw texture payload requires width."),
-                payload.Height ?? throw new InvalidOperationException("Raw texture payload requires height."),
-                payload.ColorProfile,
-                payload.BinaryPayload.AsSpan().ToArray(),
-                payload.Identity),
-            ResoniteTexturePayloadFormat.EncodedImage => new EncodedImageTexturePayload(
-                payload.Width,
-                payload.Height,
-                payload.ColorProfile,
-                payload.Source,
-                payload.Identity),
-            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.Format, "Unsupported texture payload format."),
+            RawRgba32ResoniteTexturePayload raw => new RawRgba32TexturePayload(
+                raw.Width,
+                raw.Height,
+                raw.ColorProfile,
+                raw.BinaryPayload.AsSpan().ToArray(),
+                raw.Identity),
+            EncodedImageResoniteTexturePayload encoded => new EncodedImageTexturePayload(
+                encoded.Width,
+                encoded.Height,
+                encoded.ColorProfile,
+                encoded.Source,
+                encoded.Identity),
+            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.GetType(), "Unsupported texture payload type."),
         };
 
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -571,8 +571,8 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         => payload.Format switch
         {
             ResoniteTexturePayloadFormat.RawRgba32 => new TexturePayload(
-                payload.Width ?? throw new InvalidOperationException("Raw texture payload requires width."),
-                payload.Height ?? throw new InvalidOperationException("Raw texture payload requires height."),
+                payload.Width.GetValueOrDefault(),
+                payload.Height.GetValueOrDefault(),
                 payload.ColorProfile,
                 payload.BinaryPayload.AsSpan().ToArray(),
                 payload.Identity),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -1000,7 +1000,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
-                    TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/uv-bake-budget.png"),
+                    TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/uv-bake-budget.png"),
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
@@ -104,7 +104,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
         ResoniteMaterialBinding material = new(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic.png"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic.png"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
@@ -172,7 +172,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
         ResoniteMaterialBinding material = new(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/direct-terrain-grid-style.png"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/direct-terrain-grid-style.png"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -357,7 +357,7 @@ public sealed class ResoniteMaterialPlanningTests
         ResoniteMaterialBinding firstMaterial = new(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], identity: "payload-a"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], identity: "payload-a"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -151,7 +151,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
         ResoniteMaterialBinding material = new(
             BaseColor: new ResoniteColor(0.1, 0.2, 0.3, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/payload-a.png"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/payload-a.png"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: new ResoniteMaterialDepthOffset(2.0, 3.0),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
@@ -1,3 +1,6 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Targets;
@@ -13,5 +16,32 @@ public sealed class ResoniteTexturePayloadTests
         source[0] = 9;
 
         Assert.Equal<byte>([4, 3, 2, 1], payload.BinaryPayload);
+    }
+
+    [Fact]
+    public void ConstructorCarriesIdentityAndColorProfileOnSourceOnly()
+    {
+        RawRgba32ResoniteTexturePayload payload = new(1, 1, "sRGB", [4, 3, 2, 1], "dataset:texture");
+
+        Assert.Equal("dataset:texture", payload.Source.Identity);
+        Assert.Equal("sRGB", payload.Source.ColorProfile);
+    }
+
+    [Fact]
+    public void ConstructorRejectsTextureSourceWithoutIdentity()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new EncodedImageResoniteTexturePayload(null, null, new BlankIdentityTextureImportSource()));
+    }
+
+    private sealed class BlankIdentityTextureImportSource : ITextureImportSource
+    {
+        public string Identity => " ";
+
+        public string Description => "blank";
+
+        public string? ColorProfile => null;
+
+        public long? EstimatedByteLength => null;
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
@@ -9,7 +9,7 @@ public sealed class ResoniteTexturePayloadTests
     {
         byte[] source = [4, 3, 2, 1];
 
-        ResoniteTexturePayload payload = new(1, 1, "sRGB", source, "dataset:texture");
+        RawRgba32ResoniteTexturePayload payload = new(1, 1, "sRGB", source, "dataset:texture");
         source[0] = 9;
 
         Assert.Equal<byte>([4, 3, 2, 1], payload.BinaryPayload);

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -60,7 +60,6 @@ public sealed class SceneImportContractMapperTests
     [InlineData(nameof(MaterialBinding.MaterialType))]
     [InlineData(nameof(MaterialBinding.TextureSourceKind))]
     [InlineData(nameof(MaterialBinding.Projection))]
-    [InlineData(nameof(TexturePayload.Format))]
     public void ToInternalMaterialBindingsRejectsUnsupportedContractEnumValues(string invalidField)
     {
         MaterialBinding binding = CreateValidBinding() with
@@ -68,9 +67,6 @@ public sealed class SceneImportContractMapperTests
             MaterialType = invalidField == nameof(MaterialBinding.MaterialType) ? (MaterialType)999 : MaterialType.Standard,
             TextureSourceKind = invalidField == nameof(MaterialBinding.TextureSourceKind) ? (TextureSourceKind)999 : TextureSourceKind.Dataset,
             Projection = invalidField == nameof(MaterialBinding.Projection) ? (MaterialProjection)999 : MaterialProjection.Uv,
-            TexturePayload = invalidField == nameof(TexturePayload.Format)
-                ? new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", (TexturePayloadFormat)999)
-                : new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
         };
 
         Assert.Throws<ArgumentOutOfRangeException>(() => SceneImportContractMapper.ToInternal(binding));

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -31,8 +31,8 @@ public sealed class SceneImportContractMapperTests
 
         Assert.Equal(0.1, mapped.BaseColor.R, 9);
         Assert.Equal(0.2, mapped.BaseColor.G, 9);
-        Assert.Equal("dataset:texture", mapped.TexturePayload!.Identity);
-        Assert.Equal(ResoniteTexturePayloadFormat.EncodedImage, mapped.TexturePayload.Format);
+        EncodedImageResoniteTexturePayload encodedPayload = Assert.IsType<EncodedImageResoniteTexturePayload>(mapped.TexturePayload);
+        Assert.Equal("dataset:texture", encodedPayload.Identity);
         Assert.Equal(-1.5, mapped.DepthOffset!.Factor, 9);
         Assert.Equal(2.5, mapped.DepthOffset.Units, 9);
         Assert.Equal(0.25, mapped.TextureScale!.X, 9);
@@ -78,11 +78,11 @@ public sealed class SceneImportContractMapperTests
 
         ResoniteMaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToInternal(bindings));
 
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, mapped.TexturePayload!.Format);
-        Assert.Equal(2, mapped.TexturePayload.Width);
-        Assert.Equal(1, mapped.TexturePayload.Height);
-        Assert.Equal("raw:texture", mapped.TexturePayload.Identity);
-        Assert.Equal<byte>([1, 2, 3, 4, 5, 6, 7, 8], mapped.TexturePayload.BinaryPayload);
+        RawRgba32ResoniteTexturePayload rawPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(mapped.TexturePayload);
+        Assert.Equal(2, rawPayload.Width);
+        Assert.Equal(1, rawPayload.Height);
+        Assert.Equal("raw:texture", rawPayload.Identity);
+        Assert.Equal<byte>([1, 2, 3, 4, 5, 6, 7, 8], rawPayload.BinaryPayload);
     }
 
     [Theory]

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -16,7 +16,7 @@ public sealed class SceneImportContractMapperTests
             new PresentationMaterialBinding(
                 BaseColor: new ColorRgba(0.1, 0.2, 0.3, 0.4),
                 MaterialType: MaterialType.Standard,
-                TexturePayload: new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
+                TexturePayload: CreateEncodedTexturePayload(),
                 TextureSourceKind: TextureSourceKind.Dataset,
                 Projection: MaterialProjection.Uv,
                 DepthOffset: new MaterialDepthOffset(-1.5, 2.5),
@@ -145,10 +145,22 @@ public sealed class SceneImportContractMapperTests
         return new PresentationMaterialBinding(
             BaseColor: new ColorRgba(0.1, 0.2, 0.3, 0.4),
             MaterialType: MaterialType.Standard,
-            TexturePayload: new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
+            TexturePayload: CreateEncodedTexturePayload(),
             TextureSourceKind: TextureSourceKind.Dataset,
             Projection: MaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0]);
+    }
+
+    private static TexturePayload CreateEncodedTexturePayload()
+    {
+        return new TexturePayload(
+            width: 2,
+            height: 2,
+            colorProfile: "sRGB",
+            source: TextureImportSourceFactory.CreateInMemoryEncodedImage(
+                colorProfile: "sRGB",
+                bytes: [1, 2, 3, 4],
+                identity: "dataset:texture"));
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -32,7 +32,7 @@ public sealed class SceneImportContractMapperTests
         Assert.Equal(0.1, mapped.BaseColor.R, 9);
         Assert.Equal(0.2, mapped.BaseColor.G, 9);
         EncodedImageResoniteTexturePayload encodedPayload = Assert.IsType<EncodedImageResoniteTexturePayload>(mapped.TexturePayload);
-        Assert.Equal("dataset:texture", encodedPayload.Identity);
+        Assert.Equal("dataset:texture", encodedPayload.Source.Identity);
         Assert.Equal(-1.5, mapped.DepthOffset!.Factor, 9);
         Assert.Equal(2.5, mapped.DepthOffset.Units, 9);
         Assert.Equal(0.25, mapped.TextureScale!.X, 9);
@@ -81,7 +81,7 @@ public sealed class SceneImportContractMapperTests
         RawRgba32ResoniteTexturePayload rawPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(mapped.TexturePayload);
         Assert.Equal(2, rawPayload.Width);
         Assert.Equal(1, rawPayload.Height);
-        Assert.Equal("raw:texture", rawPayload.Identity);
+        Assert.Equal("raw:texture", rawPayload.Source.Identity);
         Assert.Equal<byte>([1, 2, 3, 4, 5, 6, 7, 8], rawPayload.BinaryPayload);
     }
 
@@ -186,7 +186,6 @@ public sealed class SceneImportContractMapperTests
         return new EncodedImageTexturePayload(
             width: 2,
             height: 2,
-            colorProfile: "sRGB",
             source: TextureImportSourceFactory.CreateInMemoryEncodedImage(
                 colorProfile: "sRGB",
                 bytes: [1, 2, 3, 4],

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -56,6 +56,35 @@ public sealed class SceneImportContractMapperTests
         Assert.Equal(commonMaterial, mapped.CommonMaterial);
     }
 
+    [Fact]
+    public void ToInternalMaterialBindingsMapsRawTextureDimensionsWithoutNullableGuards()
+    {
+        MaterialBinding[] bindings =
+        [
+            new PresentationMaterialBinding(
+                BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+                MaterialType: MaterialType.Standard,
+                TexturePayload: new RawRgba32TexturePayload(
+                    width: 2,
+                    height: 1,
+                    colorProfile: "sRGB",
+                    binaryPayload: [1, 2, 3, 4, 5, 6, 7, 8],
+                    identity: "raw:texture"),
+                TextureSourceKind: TextureSourceKind.Dataset,
+                Projection: MaterialProjection.Uv,
+                DepthOffset: null,
+                SubmeshIndices: [0]),
+        ];
+
+        ResoniteMaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToInternal(bindings));
+
+        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, mapped.TexturePayload!.Format);
+        Assert.Equal(2, mapped.TexturePayload.Width);
+        Assert.Equal(1, mapped.TexturePayload.Height);
+        Assert.Equal("raw:texture", mapped.TexturePayload.Identity);
+        Assert.Equal<byte>([1, 2, 3, 4, 5, 6, 7, 8], mapped.TexturePayload.BinaryPayload);
+    }
+
     [Theory]
     [InlineData(nameof(MaterialBinding.MaterialType))]
     [InlineData(nameof(MaterialBinding.TextureSourceKind))]
@@ -154,7 +183,7 @@ public sealed class SceneImportContractMapperTests
 
     private static TexturePayload CreateEncodedTexturePayload()
     {
-        return new TexturePayload(
+        return new EncodedImageTexturePayload(
             width: 2,
             height: 2,
             colorProfile: "sRGB",

--- a/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
@@ -16,13 +16,12 @@ internal static class TextureImportSourceTestFactory
         byte[] rawRgba32Bytes,
         string? identity = null)
     {
-        return TextureImportSourceFactory.CreateInMemory(
+        return TextureImportSourceFactory.CreateInMemoryRaw(
             width,
             height,
             colorProfile,
             rawRgba32Bytes,
-            identity ?? $"test-rgba32:{width}:{height}:{Guid.NewGuid():N}",
-            TexturePayloadFormat.RawRgba32);
+            identity ?? $"test-rgba32:{width}:{height}:{Guid.NewGuid():N}");
     }
 
     public static IReadOnlyList<RawTexturePayload> ImportedRgba32Textures(SceneSinkRecordingClient client)

--- a/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
@@ -24,25 +24,24 @@ internal static class TextureImportSourceTestFactory
             identity ?? $"test-rgba32:{width}:{height}:{Guid.NewGuid():N}");
     }
 
-    public static IReadOnlyList<RawTexturePayload> ImportedRgba32Textures(SceneSinkRecordingClient client)
+    public static IReadOnlyList<Rgba32RawTexturePayload> ImportedRgba32Textures(SceneSinkRecordingClient client)
     {
         return client.ImportedTexturePayloads
-            .Where(static payload => payload.Format == RawTexturePayloadFormat.Rgba32)
+            .OfType<Rgba32RawTexturePayload>()
             .ToArray();
     }
 
-    public static IReadOnlyList<RawTexturePayload> ImportedHdrTextures(SceneSinkRecordingClient client)
+    public static IReadOnlyList<RgbaFloat32RawTexturePayload> ImportedHdrTextures(SceneSinkRecordingClient client)
     {
         return client.ImportedTexturePayloads
-            .Where(static payload => payload.Format == RawTexturePayloadFormat.RgbaFloat32)
+            .OfType<RgbaFloat32RawTexturePayload>()
             .ToArray();
     }
 
-    public static bool IsSolidColorTexture(RawTexturePayload texture, byte r, byte g, byte b)
+    public static bool IsSolidColorTexture(Rgba32RawTexturePayload texture, byte r, byte g, byte b)
     {
         byte[] expectedPixel = [r, g, b, 255];
-        return texture.Format == RawTexturePayloadFormat.Rgba32
-            && texture.Width == 2
+        return texture.Width == 2
             && texture.Height == 2
             && texture.Bytes.Chunk(4).All(pixel => pixel.SequenceEqual(expectedPixel));
     }

--- a/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
@@ -378,7 +378,7 @@ public sealed class ResoniteLinkClientTests
         }
     }
 
-    private sealed class InstrumentedTextureImportSource : IRawTexturePayloadSource
+    private sealed class InstrumentedTextureImportSource : IRgba32RawTexturePayloadSource
     {
         public int MaterializeCallCount { get; private set; }
 
@@ -390,11 +390,11 @@ public sealed class ResoniteLinkClientTests
 
         public long? EstimatedByteLength => 4;
 
-        public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+        public ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             MaterializeCallCount++;
-            return ValueTask.FromResult(new RawTexturePayload(
+            return ValueTask.FromResult(new Rgba32RawTexturePayload(
                 1,
                 1,
                 ResoniteTextureColorProfiles.Srgb,


### PR DESCRIPTION
## Summary
- split in-memory texture sources into raw RGBA and encoded image variants
- require raw RGBA width/height at the construction boundary instead of materialization time
- reject unsupported `TexturePayloadFormat` when `TexturePayload` is constructed

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020` mesh `53395325`, compared with `git diff --no-index` against the semantic baseline: no diff