### PR TITLE
Enforce validated import request payloads

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliApplication.cs
+++ b/src/PlateauResoniteLink.Cli/CliApplication.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
@@ -45,25 +46,19 @@ public sealed class CliApplication
     {
         CliParseResult parseResult = CliArgumentsParser.Parse(args);
 
-        if (parseResult.ShowHelp)
-        {
-            await standardOutput.WriteLineAsync(CliArgumentsParser.HelpText);
-            return 0;
-        }
-
-        if (parseResult.Error is not null)
-        {
-            await standardError.WriteLineAsync(parseResult.Error);
-            await standardError.WriteLineAsync();
-            await standardError.WriteLineAsync(CliArgumentsParser.HelpText);
-            return 1;
-        }
-
         try
         {
-            switch (parseResult.Command)
+            switch (parseResult)
             {
-                case ImportCommandOptions options:
+                case CliParseResult.HelpResult:
+                    await standardOutput.WriteLineAsync(CliArgumentsParser.HelpText);
+                    return 0;
+                case CliParseResult.FailureResult failure:
+                    await standardError.WriteLineAsync(failure.Error);
+                    await standardError.WriteLineAsync();
+                    await standardError.WriteLineAsync(CliArgumentsParser.HelpText);
+                    return 1;
+                case CliParseResult.ImportSuccessResult { Command: ImportCommandOptions options }:
                     {
                         Action<string> reporter = CreateReporter(options.VerboseLogging);
                         PlateauImportService effectiveImportService = importServiceFactory.Create(options, reporter);
@@ -97,7 +92,7 @@ public sealed class CliApplication
 
                         return 0;
                     }
-                case SearchCommandOptions options:
+                case CliParseResult.SearchSuccessResult { Command: SearchCommandOptions options }:
                     {
                         DatasetSearchResult result = await datasetInspectionService.SearchAsync(
                             options.CityGmlSourcePath,
@@ -107,7 +102,7 @@ public sealed class CliApplication
                         await WriteSearchResultAsync(result, options.OutputFormat, cancellationToken);
                         return 0;
                     }
-                case StatsCommandOptions options:
+                case CliParseResult.StatsSuccessResult { Command: StatsCommandOptions options }:
                     {
                         DatasetStatsResult result = await datasetInspectionService.GetStatsAsync(
                             options.CityGmlSourcePath,
@@ -117,7 +112,7 @@ public sealed class CliApplication
                         return 0;
                     }
                 default:
-                    throw new InvalidOperationException("CLI parse succeeded without a supported command payload.");
+                    throw new UnreachableException();
             }
         }
         catch (PlateauImportValidationException exception)

--- a/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
@@ -273,6 +273,7 @@ public static class CliArgumentsParser
                                     System.Globalization.NumberStyles.Float | System.Globalization.NumberStyles.AllowThousands,
                                     System.Globalization.CultureInfo.InvariantCulture,
                                     out terrainGridMetersPerVertex)
+                                || !double.IsFinite(terrainGridMetersPerVertex)
                                 || terrainGridMetersPerVertex <= 0.0)
                             {
                                 return CliParseResult.Failure(

--- a/src/PlateauResoniteLink.Cli/CliCommandOptions.cs
+++ b/src/PlateauResoniteLink.Cli/CliCommandOptions.cs
@@ -1,3 +1,8 @@
 namespace PlateauResoniteLink.Cli;
 
-public abstract record CliCommandOptions;
+public abstract class CliCommandOptions
+{
+    private protected CliCommandOptions()
+    {
+    }
+}

--- a/src/PlateauResoniteLink.Cli/CliParseResult.cs
+++ b/src/PlateauResoniteLink.Cli/CliParseResult.cs
@@ -1,24 +1,89 @@
+using System;
+
 namespace PlateauResoniteLink.Cli;
 
-public sealed record CliParseResult(
-    CliCommandOptions? Command,
-    string? Error,
-    bool ShowHelp)
+public abstract class CliParseResult
 {
-    public ImportCommandOptions? Options => Command as ImportCommandOptions;
+    private CliParseResult()
+    {
+    }
 
     public static CliParseResult Failure(string error)
     {
-        return new CliParseResult(null, error, ShowHelp: false);
+        return new FailureResult(error);
     }
 
     public static CliParseResult Help()
     {
-        return new CliParseResult(null, null, ShowHelp: true);
+        return HelpResult.Instance;
     }
 
-    public static CliParseResult Success(CliCommandOptions command)
+    public static CliParseResult Success(ImportCommandOptions command)
     {
-        return new CliParseResult(command, null, ShowHelp: false);
+        return new ImportSuccessResult(command);
+    }
+
+    public static CliParseResult Success(SearchCommandOptions command)
+    {
+        return new SearchSuccessResult(command);
+    }
+
+    public static CliParseResult Success(StatsCommandOptions command)
+    {
+        return new StatsSuccessResult(command);
+    }
+
+    public sealed class ImportSuccessResult : CliParseResult
+    {
+        public ImportSuccessResult(ImportCommandOptions command)
+        {
+            Command = command ?? throw new ArgumentNullException(nameof(command));
+        }
+
+        public ImportCommandOptions Command { get; }
+    }
+
+    public sealed class SearchSuccessResult : CliParseResult
+    {
+        public SearchSuccessResult(SearchCommandOptions command)
+        {
+            Command = command ?? throw new ArgumentNullException(nameof(command));
+        }
+
+        public SearchCommandOptions Command { get; }
+    }
+
+    public sealed class StatsSuccessResult : CliParseResult
+    {
+        public StatsSuccessResult(StatsCommandOptions command)
+        {
+            Command = command ?? throw new ArgumentNullException(nameof(command));
+        }
+
+        public StatsCommandOptions Command { get; }
+    }
+
+    public sealed class FailureResult : CliParseResult
+    {
+        public FailureResult(string error)
+        {
+            if (string.IsNullOrWhiteSpace(error))
+            {
+                throw new ArgumentException("CLI parse failure message must be provided.", nameof(error));
+            }
+
+            Error = error;
+        }
+
+        public string Error { get; }
+    }
+
+    public sealed class HelpResult : CliParseResult
+    {
+        public static HelpResult Instance { get; } = new();
+
+        private HelpResult()
+        {
+        }
     }
 }

--- a/src/PlateauResoniteLink.Cli/ImportCommandOptions.cs
+++ b/src/PlateauResoniteLink.Cli/ImportCommandOptions.cs
@@ -4,7 +4,7 @@ using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Cli;
 
-public sealed record ImportCommandOptions(
+public sealed class ImportCommandOptions(
     PlateauImportRequest Request,
     string WorkRoot,
     Uri? ResoniteLinkUri,
@@ -15,4 +15,27 @@ public sealed record ImportCommandOptions(
     bool DisableTerrainTileCache,
     string? CanonicalSceneDumpPath,
     bool EnableSendMetrics,
-    bool VerboseLogging) : CliCommandOptions;
+    bool VerboseLogging) : CliCommandOptions
+{
+    public PlateauImportRequest Request { get; } = Request ?? throw new ArgumentNullException(nameof(Request));
+
+    public string WorkRoot { get; } = WorkRoot ?? throw new ArgumentNullException(nameof(WorkRoot));
+
+    public Uri? ResoniteLinkUri { get; } = ResoniteLinkUri;
+
+    public int ResoniteLinkConnectionCount { get; } = ResoniteLinkConnectionCount;
+
+    public PlateauImportMemoryProfile MemoryProfile { get; } = MemoryProfile;
+
+    public bool EnableMeshBake { get; } = EnableMeshBake;
+
+    public string? TerrainTileCacheRoot { get; } = TerrainTileCacheRoot;
+
+    public bool DisableTerrainTileCache { get; } = DisableTerrainTileCache;
+
+    public string? CanonicalSceneDumpPath { get; } = CanonicalSceneDumpPath;
+
+    public bool EnableSendMetrics { get; } = EnableSendMetrics;
+
+    public bool VerboseLogging { get; } = VerboseLogging;
+}

--- a/src/PlateauResoniteLink.Cli/SearchCommandOptions.cs
+++ b/src/PlateauResoniteLink.Cli/SearchCommandOptions.cs
@@ -1,9 +1,19 @@
+using System;
 using System.Collections.Generic;
 
 namespace PlateauResoniteLink.Cli;
 
-public sealed record SearchCommandOptions(
-    string CityGmlSourcePath,
-    string MeshCode,
-    IReadOnlyList<string>? PackageNames,
-    CliOutputFormat OutputFormat) : CliCommandOptions;
+public sealed class SearchCommandOptions(
+    string cityGmlSourcePath,
+    string meshCode,
+    IReadOnlyList<string>? packageNames,
+    CliOutputFormat outputFormat) : CliCommandOptions
+{
+    public string CityGmlSourcePath { get; } = cityGmlSourcePath ?? throw new ArgumentNullException(nameof(cityGmlSourcePath));
+
+    public string MeshCode { get; } = meshCode ?? throw new ArgumentNullException(nameof(meshCode));
+
+    public IReadOnlyList<string>? PackageNames { get; } = packageNames;
+
+    public CliOutputFormat OutputFormat { get; } = outputFormat;
+}

--- a/src/PlateauResoniteLink.Cli/StatsCommandOptions.cs
+++ b/src/PlateauResoniteLink.Cli/StatsCommandOptions.cs
@@ -1,8 +1,16 @@
+using System;
 using System.Collections.Generic;
 
 namespace PlateauResoniteLink.Cli;
 
-public sealed record StatsCommandOptions(
-    string CityGmlSourcePath,
-    IReadOnlyList<string>? PackageNames,
-    CliOutputFormat OutputFormat) : CliCommandOptions;
+public sealed class StatsCommandOptions(
+    string cityGmlSourcePath,
+    IReadOnlyList<string>? packageNames,
+    CliOutputFormat outputFormat) : CliCommandOptions
+{
+    public string CityGmlSourcePath { get; } = cityGmlSourcePath ?? throw new ArgumentNullException(nameof(cityGmlSourcePath));
+
+    public IReadOnlyList<string>? PackageNames { get; } = packageNames;
+
+    public CliOutputFormat OutputFormat { get; } = outputFormat;
+}

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
@@ -348,21 +348,11 @@ public static class PlateauImportRequestValidator
         {
             Dataset = TrimToEmpty(request.Dataset),
             MeshCode = TrimToEmpty(request.MeshCode),
-            CityGmlSource = NormalizeDatasetLocation(request.CityGmlSource),
-            DemTextureSource = request.DemTextureSource is null ? null : NormalizeDatasetLocation(request.DemTextureSource),
+            CityGmlSource = request.CityGmlSource,
+            DemTextureSource = request.DemTextureSource,
             PackageNames = request.PackageNames is null
                 ? null
                 : request.PackageNames.Select(static packageName => TrimToEmpty(packageName)).ToArray(),
-        };
-    }
-
-    private static DatasetLocation NormalizeDatasetLocation(DatasetLocation source)
-    {
-        return source switch
-        {
-            LocalDatasetLocation localSource => new LocalDatasetLocation(localSource.LocalSourcePath.Trim()),
-            RemoteDatasetLocation remoteSource => remoteSource,
-            _ => source,
         };
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
@@ -215,9 +215,10 @@ public static class PlateauImportRequestValidator
             }
         }
 
-        if (normalizedRequest.TerrainGridMetersPerVertex <= 0)
+        if (!double.IsFinite(normalizedRequest.TerrainGridMetersPerVertex)
+            || normalizedRequest.TerrainGridMetersPerVertex <= 0)
         {
-            validationErrors.Add("The terrain grid meters-per-vertex value must be greater than zero.");
+            validationErrors.Add("The terrain grid meters-per-vertex value must be a finite value greater than zero.");
         }
 
         if (normalizedRequest.TerrainGridMaxResolution < 2)

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
@@ -9,14 +9,30 @@ public abstract record ValidatedDatasetLocation(DatasetSourceKind SourceKind)
     public abstract DatasetLocation ToDatasetLocation();
 }
 
-public sealed record ValidatedLocalDatasetLocation(string LocalSourcePath)
-    : ValidatedDatasetLocation(DatasetSourceKind.Local)
+public sealed record ValidatedLocalDatasetLocation : ValidatedDatasetLocation
 {
+    public ValidatedLocalDatasetLocation(string localSourcePath)
+        : base(DatasetSourceKind.Local)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localSourcePath);
+        LocalSourcePath = localSourcePath;
+    }
+
+    public string LocalSourcePath { get; }
+
     public override DatasetLocation ToDatasetLocation() => new LocalDatasetLocation(LocalSourcePath);
 }
 
-public sealed record ValidatedRemoteDatasetLocation(Uri ServerUri)
-    : ValidatedDatasetLocation(DatasetSourceKind.Remote)
+public sealed record ValidatedRemoteDatasetLocation : ValidatedDatasetLocation
 {
+    public ValidatedRemoteDatasetLocation(Uri serverUri)
+        : base(DatasetSourceKind.Remote)
+    {
+        ArgumentNullException.ThrowIfNull(serverUri);
+        ServerUri = serverUri;
+    }
+
+    public Uri ServerUri { get; }
+
     public override DatasetLocation ToDatasetLocation() => new RemoteDatasetLocation(ServerUri);
 }

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
@@ -9,24 +9,22 @@ public abstract record ValidatedDatasetLocation(DatasetSourceKind SourceKind)
     public abstract DatasetLocation ToDatasetLocation();
 }
 
-public sealed record ValidatedLocalDatasetLocation : ValidatedDatasetLocation
+public sealed record ValidatedLocalDatasetLocation(string LocalSourcePath) : ValidatedDatasetLocation(DatasetSourceKind.Local)
 {
-    public ValidatedLocalDatasetLocation(string localSourcePath)
-        : base(DatasetSourceKind.Local)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(localSourcePath);
-        LocalSourcePath = localSourcePath.Trim();
-    }
-
-    public string LocalSourcePath { get; }
+    public string LocalSourcePath { get; } = string.IsNullOrWhiteSpace(LocalSourcePath)
+        ? throw new ArgumentException("The local source path must not be empty.", nameof(LocalSourcePath))
+        : LocalSourcePath;
 
     public override DatasetLocation ToDatasetLocation() => new LocalDatasetLocation(LocalSourcePath);
 }
 
-public sealed record ValidatedRemoteDatasetLocation : ValidatedDatasetLocation
+public sealed record ValidatedRemoteDatasetLocation(Uri ServerUri) : ValidatedDatasetLocation(DatasetSourceKind.Remote)
 {
-    public ValidatedRemoteDatasetLocation(Uri serverUri)
-        : base(DatasetSourceKind.Remote)
+    public Uri ServerUri { get; } = ValidateServerUri(ServerUri);
+
+    public override DatasetLocation ToDatasetLocation() => new RemoteDatasetLocation(ServerUri);
+
+    private static Uri ValidateServerUri(Uri serverUri)
     {
         ArgumentNullException.ThrowIfNull(serverUri);
         if (!serverUri.IsAbsoluteUri)
@@ -40,10 +38,6 @@ public sealed record ValidatedRemoteDatasetLocation : ValidatedDatasetLocation
             throw new ArgumentException("The remote dataset location URI must use http or https.", nameof(serverUri));
         }
 
-        ServerUri = serverUri;
+        return serverUri;
     }
-
-    public Uri ServerUri { get; }
-
-    public override DatasetLocation ToDatasetLocation() => new RemoteDatasetLocation(ServerUri);
 }

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
@@ -15,7 +15,7 @@ public sealed record ValidatedLocalDatasetLocation : ValidatedDatasetLocation
         : base(DatasetSourceKind.Local)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(localSourcePath);
-        LocalSourcePath = localSourcePath;
+        LocalSourcePath = localSourcePath.Trim();
     }
 
     public string LocalSourcePath { get; }
@@ -29,6 +29,17 @@ public sealed record ValidatedRemoteDatasetLocation : ValidatedDatasetLocation
         : base(DatasetSourceKind.Remote)
     {
         ArgumentNullException.ThrowIfNull(serverUri);
+        if (!serverUri.IsAbsoluteUri)
+        {
+            throw new ArgumentException("The remote dataset location URI must be absolute.", nameof(serverUri));
+        }
+
+        if (!string.Equals(serverUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(serverUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("The remote dataset location URI must use http or https.", nameof(serverUri));
+        }
+
         ServerUri = serverUri;
     }
 

--- a/src/PlateauResoniteLink/Domain/Importing/PlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/PlateauImportRequest.cs
@@ -17,6 +17,17 @@ public sealed record PlateauImportRequest(
     double TerrainGridMetersPerVertex = 2.0,
     int TerrainGridMaxResolution = 1024)
 {
+#pragma warning disable IDE0032 // Backing field keeps with-expressions from assigning a null CityGmlSource.
+    private DatasetLocation cityGmlSource =
+        CityGmlSource ?? throw new ArgumentNullException(nameof(CityGmlSource));
+#pragma warning restore IDE0032
+
+    public DatasetLocation CityGmlSource
+    {
+        get => cityGmlSource;
+        init => cityGmlSource = value ?? throw new ArgumentNullException(nameof(CityGmlSource));
+    }
+
     public DatasetSourceKind CityGmlSourceKind => CityGmlSource.SourceKind;
 
     public string? CityGmlLocalSourcePath => CityGmlSource is LocalDatasetLocation localSource ? localSource.LocalSourcePath : null;

--- a/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -17,6 +17,9 @@ public sealed class PlateauImportRequestValidatorTests
         Assert.Throws<ArgumentNullException>(() => DatasetLocation.Remote(null!));
         Assert.Throws<ArgumentException>(() => new ValidatedLocalDatasetLocation(" "));
         Assert.Throws<ArgumentNullException>(() => new ValidatedRemoteDatasetLocation(null!));
+        Assert.Throws<ArgumentException>(() => new ValidatedRemoteDatasetLocation(new Uri("/dataset.zip", UriKind.Relative)));
+        Assert.Throws<ArgumentException>(() => new ValidatedRemoteDatasetLocation(new Uri("ftp://example.invalid/dataset.zip")));
+        Assert.Equal("C:/dataset", new ValidatedLocalDatasetLocation(" C:/dataset ").LocalSourcePath);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -65,7 +65,7 @@ public sealed class PlateauImportRequestValidatorTests
                 MeshCode: "53394525",
                 MeshCodePattern: meshCodePattern,
                 CityGmlSource: source,
-                TerrainGridMetersPerVertex: 0));
+                TerrainGridMetersPerVertex: double.NaN));
         Assert.Throws<ArgumentOutOfRangeException>(
             () => new ValidatedPlateauImportRequest(
                 Dataset: "tokyo23ku",
@@ -230,7 +230,21 @@ public sealed class PlateauImportRequestValidatorTests
 
         IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
 
-        Assert.Contains("The terrain grid meters-per-vertex value must be greater than zero.", errors);
+        Assert.Contains("The terrain grid meters-per-vertex value must be a finite value greater than zero.", errors);
+    }
+
+    [Fact]
+    public void ValidateRejectsNonFiniteTerrainGridMetersPerVertex()
+    {
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            CityGmlSource: DatasetLocation.Local("C:/dataset"),
+            TerrainGridMetersPerVertex: double.PositiveInfinity);
+
+        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
+
+        Assert.Contains("The terrain grid meters-per-vertex value must be a finite value greater than zero.", errors);
     }
 
     [Theory]

--- a/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
@@ -14,6 +15,72 @@ public sealed class PlateauImportRequestValidatorTests
     {
         Assert.Throws<ArgumentException>(() => DatasetLocation.Local(" "));
         Assert.Throws<ArgumentNullException>(() => DatasetLocation.Remote(null!));
+        Assert.Throws<ArgumentException>(() => new ValidatedLocalDatasetLocation(" "));
+        Assert.Throws<ArgumentNullException>(() => new ValidatedRemoteDatasetLocation(null!));
+    }
+
+    [Fact]
+    public void PlateauImportRequestRequiresCityGmlSource()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new PlateauImportRequest("tokyo23ku", "53394525", null!));
+
+        PlateauImportRequest request = new("tokyo23ku", "53394525", DatasetLocation.Local("C:/dataset"));
+        Assert.Throws<ArgumentNullException>(() => request with { CityGmlSource = null! });
+    }
+
+    [Fact]
+    public void ValidatedPlateauImportRequestRequiresValidatedPayload()
+    {
+        ValidatedLocalDatasetLocation source = new("C:/dataset");
+        Regex meshCodePattern = new(@"\A53394525\z");
+
+        Assert.Throws<ArgumentException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: " ",
+                MeshCode: "53394525",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: source));
+        Assert.Throws<ArgumentException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: " ",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: source));
+        Assert.Throws<ArgumentNullException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                MeshCodePattern: null!,
+                CityGmlSource: source));
+        Assert.Throws<ArgumentNullException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: null!));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: source,
+                TerrainGridMetersPerVertex: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: source,
+                TerrainGridMaxResolution: 1));
+
+        ValidatedPlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            MeshCodePattern: meshCodePattern,
+            CityGmlSource: source);
+
+        Assert.Throws<ArgumentNullException>(() => request with { CityGmlSource = null! });
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 using PlateauResoniteLink.Application.Importing;
@@ -19,7 +20,23 @@ public sealed class PlateauImportRequestValidatorTests
         Assert.Throws<ArgumentNullException>(() => new ValidatedRemoteDatasetLocation(null!));
         Assert.Throws<ArgumentException>(() => new ValidatedRemoteDatasetLocation(new Uri("/dataset.zip", UriKind.Relative)));
         Assert.Throws<ArgumentException>(() => new ValidatedRemoteDatasetLocation(new Uri("ftp://example.invalid/dataset.zip")));
-        Assert.Equal("C:/dataset", new ValidatedLocalDatasetLocation(" C:/dataset ").LocalSourcePath);
+        Assert.Equal(" C:/dataset ", new ValidatedLocalDatasetLocation(" C:/dataset ").LocalSourcePath);
+    }
+
+    [Fact]
+    public void ValidatedDatasetLocationEqualityIncludesSourcePayload()
+    {
+        ValidatedDatasetLocation[] locations =
+        [
+            new ValidatedLocalDatasetLocation("C:/dataset-a"),
+            new ValidatedLocalDatasetLocation("C:/dataset-b"),
+            new ValidatedRemoteDatasetLocation(new Uri("https://example.invalid/dataset-a.zip")),
+            new ValidatedRemoteDatasetLocation(new Uri("https://example.invalid/dataset-b.zip")),
+        ];
+
+        Assert.Equal(locations.Length, locations.Distinct().Count());
+        Assert.NotEqual(locations[0], locations[1]);
+        Assert.NotEqual(locations[2], locations[3]);
     }
 
     [Fact]
@@ -137,7 +154,7 @@ public sealed class PlateauImportRequestValidatorTests
     }
 
     [Fact]
-    public void TryNormalizeAndValidateTrimsAndNormalizesRequestData()
+    public void TryNormalizeAndValidateNormalizesRequestData()
     {
         using TemporaryDirectory sourceRoot = new();
         string geoTiffPath = Path.Combine(sourceRoot.Path, "53394525.tif");
@@ -146,8 +163,8 @@ public sealed class PlateauImportRequestValidatorTests
         PlateauImportRequest request = new(
             Dataset: " tokyo23ku ",
             MeshCode: " 53394525 ",
-            CityGmlSource: DatasetLocation.Local($"  {sourceRoot.Path}  "),
-            DemTextureSource: DatasetLocation.Local($"  {geoTiffPath}  "),
+            CityGmlSource: DatasetLocation.Local(sourceRoot.Path),
+            DemTextureSource: DatasetLocation.Local(geoTiffPath),
             PackageNames: [" waterbody ", " tran "]);
 
         bool success = PlateauImportRequestValidator.TryNormalizeAndValidate(

--- a/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -19,16 +19,14 @@ public sealed class CliArgumentsParserTests
                 "--resonitelink-port", "12345",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.False(result.ShowHelp);
-        Assert.NotNull(result.Options);
-        Assert.Equal("tokyo23ku", result.Options.Request.Dataset);
-        Assert.Equal("53394525", result.Options.Request.MeshCode);
-        Assert.Equal(DatasetSourceKind.Local, result.Options.Request.CityGmlSourceKind);
-        Assert.Equal("/data/plateau", result.Options.Request.CityGmlLocalSourcePath);
-        Assert.Null(result.Options.Request.DemTextureSource);
-        Assert.Equal(CliTestData.DocumentedDefaultPackageNames, result.Options.Request.PackageNames);
-        Assert.Equal(new Uri("ws://localhost:12345/"), result.Options.ResoniteLinkUri);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Equal("tokyo23ku", options.Request.Dataset);
+        Assert.Equal("53394525", options.Request.MeshCode);
+        Assert.Equal(DatasetSourceKind.Local, options.Request.CityGmlSourceKind);
+        Assert.Equal("/data/plateau", options.Request.CityGmlLocalSourcePath);
+        Assert.Null(options.Request.DemTextureSource);
+        Assert.Equal(CliTestData.DocumentedDefaultPackageNames, options.Request.PackageNames);
+        Assert.Equal(new Uri("ws://localhost:12345/"), options.ResoniteLinkUri);
     }
 
     [Fact]
@@ -43,9 +41,7 @@ public sealed class CliArgumentsParserTests
                 "--resonitelink-port", "12345",
             ]);
 
-        Assert.Equal("Unknown command 'bogus'.", result.Error);
-        Assert.False(result.ShowHelp);
-        Assert.Null(result.Options);
+        Assert.Equal("Unknown command 'bogus'.", AssertFailure(result).Error);
     }
 
     [Fact]
@@ -61,11 +57,11 @@ public sealed class CliArgumentsParserTests
                 "--resonitelink-url", "ws://localhost:12345/",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.Equal(DatasetSourceKind.Remote, result.Options!.Request.CityGmlSourceKind);
-        Assert.Equal(new Uri("https://example.invalid/plateau.zip"), result.Options.Request.CityGmlServerUri);
-        Assert.Equal(DatasetSourceKind.Remote, result.Options.Request.DemTextureSourceKind);
-        Assert.Equal(new Uri("https://example.invalid/53394525.tif"), result.Options.Request.DemTextureServerUri);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Equal(DatasetSourceKind.Remote, options.Request.CityGmlSourceKind);
+        Assert.Equal(new Uri("https://example.invalid/plateau.zip"), options.Request.CityGmlServerUri);
+        Assert.Equal(DatasetSourceKind.Remote, options.Request.DemTextureSourceKind);
+        Assert.Equal(new Uri("https://example.invalid/53394525.tif"), options.Request.DemTextureServerUri);
     }
 
     [Fact]
@@ -79,7 +75,7 @@ public sealed class CliArgumentsParserTests
                 "--resonitelink-port", "12345",
             ]);
 
-        Assert.Equal("Specify --citygml-source.", result.Error);
+        Assert.Equal("Specify --citygml-source.", AssertFailure(result).Error);
     }
 
     [Fact]
@@ -94,9 +90,9 @@ public sealed class CliArgumentsParserTests
                 "--canonical-scene-dump", "out/scene.json",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.Null(result.Options!.ResoniteLinkUri);
-        Assert.Equal("out/scene.json", result.Options.CanonicalSceneDumpPath);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Null(options.ResoniteLinkUri);
+        Assert.Equal("out/scene.json", options.CanonicalSceneDumpPath);
     }
 
     [Fact]
@@ -114,7 +110,7 @@ public sealed class CliArgumentsParserTests
 
         Assert.Equal(
             "Do not specify --resonitelink-port or --resonitelink-url when --canonical-scene-dump is used.",
-            result.Error);
+            AssertFailure(result).Error);
     }
 
     [Fact]
@@ -129,7 +125,7 @@ public sealed class CliArgumentsParserTests
                 "--canonical-scene-dump", " ",
             ]);
 
-        Assert.Equal("Specify a non-empty --canonical-scene-dump path.", result.Error);
+        Assert.Equal("Specify a non-empty --canonical-scene-dump path.", AssertFailure(result).Error);
     }
 
     [Fact]
@@ -145,8 +141,8 @@ public sealed class CliArgumentsParserTests
                 "--resonitelink-port", "12345",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.Equal(["tran", "waterbody", "tran", "brid"], result.Options!.Request.PackageNames);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Equal(["tran", "waterbody", "tran", "brid"], options.Request.PackageNames);
     }
 
     [Fact]
@@ -161,8 +157,8 @@ public sealed class CliArgumentsParserTests
                 "--resonitelink-port", "12345",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.Equal("5339452[56]", result.Options!.Request.MeshCode);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Equal("5339452[56]", options.Request.MeshCode);
     }
 
     [Fact]
@@ -178,7 +174,7 @@ public sealed class CliArgumentsParserTests
                 "--unexpected", "value",
             ]);
 
-        Assert.Equal("Unknown option '--unexpected'.", result.Error);
+        Assert.Equal("Unknown option '--unexpected'.", AssertFailure(result).Error);
     }
 
     [Fact]
@@ -193,8 +189,7 @@ public sealed class CliArgumentsParserTests
                 "--format", "json",
             ]);
 
-        Assert.Null(result.Error);
-        SearchCommandOptions command = Assert.IsType<SearchCommandOptions>(result.Command);
+        SearchCommandOptions command = AssertSuccess<SearchCommandOptions>(result);
         Assert.Equal("/data/plateau.zip", command.CityGmlSourcePath);
         Assert.Equal("5339452[56]", command.MeshCode);
         Assert.Equal(["bldg", "tran"], command.PackageNames);
@@ -211,8 +206,7 @@ public sealed class CliArgumentsParserTests
                 "--packages", "dem,bldg",
             ]);
 
-        Assert.Null(result.Error);
-        StatsCommandOptions command = Assert.IsType<StatsCommandOptions>(result.Command);
+        StatsCommandOptions command = AssertSuccess<StatsCommandOptions>(result);
         Assert.Equal("/data/plateau", command.CityGmlSourcePath);
         Assert.Equal(["dem", "bldg"], command.PackageNames);
     }
@@ -232,10 +226,10 @@ public sealed class CliArgumentsParserTests
                 "--terrain-grid-max-resolution", "512",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.Equal(TerrainMeshMode.Grid, result.Options!.Request.TerrainMeshMode);
-        Assert.Equal(4.5, result.Options.Request.TerrainGridMetersPerVertex, 6);
-        Assert.Equal(512, result.Options.Request.TerrainGridMaxResolution);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Equal(TerrainMeshMode.Grid, options.Request.TerrainMeshMode);
+        Assert.Equal(4.5, options.Request.TerrainGridMetersPerVertex, 6);
+        Assert.Equal(512, options.Request.TerrainGridMaxResolution);
     }
 
     [Fact]
@@ -251,8 +245,8 @@ public sealed class CliArgumentsParserTests
                 "--terrain-mesh", "dynamic",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.Equal(TerrainMeshMode.Dynamic, result.Options!.Request.TerrainMeshMode);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Equal(TerrainMeshMode.Dynamic, options.Request.TerrainMeshMode);
     }
 
     [Fact]
@@ -270,4 +264,26 @@ public sealed class CliArgumentsParserTests
         Assert.Contains("--geotiff-source <path-or-url>", CliArgumentsParser.HelpText, StringComparison.Ordinal);
     }
 
+    private static ImportCommandOptions AssertImportSuccess(CliParseResult result)
+    {
+        return Assert.IsType<CliParseResult.ImportSuccessResult>(result).Command;
+    }
+
+    private static TCommand AssertSuccess<TCommand>(CliParseResult result)
+        where TCommand : CliCommandOptions
+    {
+        CliCommandOptions command = result switch
+        {
+            CliParseResult.ImportSuccessResult import => import.Command,
+            CliParseResult.SearchSuccessResult search => search.Command,
+            CliParseResult.StatsSuccessResult stats => stats.Command,
+            _ => throw new InvalidOperationException("Expected successful CLI parse result."),
+        };
+        return Assert.IsType<TCommand>(command);
+    }
+
+    private static CliParseResult.FailureResult AssertFailure(CliParseResult result)
+    {
+        return Assert.IsType<CliParseResult.FailureResult>(result);
+    }
 }

--- a/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -232,6 +232,27 @@ public sealed class CliArgumentsParserTests
         Assert.Equal(512, options.Request.TerrainGridMaxResolution);
     }
 
+    [Theory]
+    [InlineData("NaN")]
+    [InlineData("Infinity")]
+    [InlineData("-Infinity")]
+    public void ParseRejectsNonFiniteTerrainGridMetersPerVertex(string metersPerVertex)
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "import",
+                "--dataset", "tokyo23ku",
+                "--mesh-code", "53394525",
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+                "--terrain-grid-meters-per-vertex", metersPerVertex,
+            ]);
+
+        Assert.Equal(
+            $"The value '{metersPerVertex}' is not a valid positive terrain grid meters-per-vertex value.",
+            AssertFailure(result).Error);
+    }
+
     [Fact]
     public void ParseParsesTerrainDynamicMode()
     {


### PR DESCRIPTION
## Summary
- make validated local/remote dataset locations reject missing payloads at construction
- keep required import request and validated request fields inside invariants, including with-expression updates
- add tests for raw and validated request payload guards

## Verification
- dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~PlateauImportRequestValidatorTests|FullyQualifiedName~DatasetLocationTests|FullyQualifiedName~ResolvedLocalPlateauImportRequestTests" -m:1 --disable-build-servers -p:UseSharedCompilation=false
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- Fake Live Sink canonical dump compared with semantic baseline via git diff --no-index: no diff; temporary dump deleted