### PR TITLE
Require raw texture dimensions at construction

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -197,8 +197,7 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
                     resolvedTexturePath,
                     "sRGB",
                     $"dataset:{resolvedTexturePath}"),
-                $"dataset:{resolvedTexturePath}",
-                TexturePayloadFormat.EncodedImage);
+                $"dataset:{resolvedTexturePath}");
             texturePayloadsByResolvedPath[resolvedTexturePath] = texturePayload;
         }
 

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -118,6 +118,7 @@ public sealed record TexturePayload
         ArgumentNullException.ThrowIfNull(binaryPayload);
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
         Identity = identity;
+        ValidateFormat(format);
         Format = format;
         Source = TextureImportSourceFactory.CreateInMemory(
             width,
@@ -142,6 +143,7 @@ public sealed record TexturePayload
         ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
         Identity = identity ?? source.Identity;
+        ValidateFormat(format);
         Format = format;
         Source = source;
     }
@@ -159,6 +161,14 @@ public sealed record TexturePayload
     public TexturePayloadFormat Format { get; init; }
 
     public ITextureImportSource Source { get; init; }
+
+    private static void ValidateFormat(TexturePayloadFormat format)
+    {
+        if (format is not (TexturePayloadFormat.RawRgba32 or TexturePayloadFormat.EncodedImage))
+        {
+            throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported texture payload format.");
+        }
+    }
 }
 
 public enum TextureSourceKind

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -143,19 +143,19 @@ public sealed record TexturePayload
         Source = source;
     }
 
-    public int? Width { get; init; }
+    public int? Width { get; }
 
-    public int? Height { get; init; }
+    public int? Height { get; }
 
-    public string? ColorProfile { get; init; }
+    public string? ColorProfile { get; }
 
-    public ImmutableArray<byte> BinaryPayload { get; init; }
+    public ImmutableArray<byte> BinaryPayload { get; }
 
-    public string? Identity { get; init; }
+    public string? Identity { get; }
 
-    public TexturePayloadFormat Format { get; init; }
+    public TexturePayloadFormat Format { get; }
 
-    public ITextureImportSource Source { get; init; }
+    public ITextureImportSource Source { get; }
 
 }
 

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -105,12 +105,11 @@ public enum TexturePayloadFormat
 public sealed record TexturePayload
 {
     public TexturePayload(
-        int? width,
-        int? height,
+        int width,
+        int height,
         string? colorProfile,
         byte[] binaryPayload,
-        string? identity = null,
-        TexturePayloadFormat format = TexturePayloadFormat.RawRgba32)
+        string? identity = null)
     {
         Width = width;
         Height = height;
@@ -118,15 +117,13 @@ public sealed record TexturePayload
         ArgumentNullException.ThrowIfNull(binaryPayload);
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
         Identity = identity;
-        ValidateFormat(format);
-        Format = format;
-        Source = TextureImportSourceFactory.CreateInMemory(
+        Format = TexturePayloadFormat.RawRgba32;
+        Source = TextureImportSourceFactory.CreateInMemoryRaw(
             width,
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"),
-            format);
+            identity ?? Guid.NewGuid().ToString("N"));
     }
 
     public TexturePayload(
@@ -134,8 +131,7 @@ public sealed record TexturePayload
         int? height,
         string? colorProfile,
         ITextureImportSource source,
-        string? identity = null,
-        TexturePayloadFormat format = TexturePayloadFormat.EncodedImage)
+        string? identity = null)
     {
         Width = width;
         Height = height;
@@ -143,8 +139,7 @@ public sealed record TexturePayload
         ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
         Identity = identity ?? source.Identity;
-        ValidateFormat(format);
-        Format = format;
+        Format = TexturePayloadFormat.EncodedImage;
         Source = source;
     }
 
@@ -162,13 +157,6 @@ public sealed record TexturePayload
 
     public ITextureImportSource Source { get; init; }
 
-    private static void ValidateFormat(TexturePayloadFormat format)
-    {
-        if (format is not (TexturePayloadFormat.RawRgba32 or TexturePayloadFormat.EncodedImage))
-        {
-            throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported texture payload format.");
-        }
-    }
 }
 
 public enum TextureSourceKind

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -54,18 +54,19 @@ internal static class TextureImportSourceMaterializer
     }
 }
 
-internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
+internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
 {
     private readonly byte[] bytes;
 
-    public InMemoryTextureImportSource(
-        int? width,
-        int? height,
+    public InMemoryRawTextureImportSource(
+        int width,
+        int height,
         string? colorProfile,
         byte[] bytes,
-        string identity,
-        TexturePayloadFormat sourceFormat)
+        string identity)
     {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
         ArgumentNullException.ThrowIfNull(bytes);
         ArgumentException.ThrowIfNullOrWhiteSpace(identity);
         Width = width;
@@ -73,12 +74,11 @@ internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
         ColorProfile = colorProfile;
         this.bytes = (byte[])bytes.Clone();
         Identity = identity;
-        SourceFormat = sourceFormat;
     }
 
-    public int? Width { get; }
+    public int Width { get; }
 
-    public int? Height { get; }
+    public int Height { get; }
 
     public string Identity { get; }
 
@@ -88,35 +88,44 @@ internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
 
     public long? EstimatedByteLength => bytes.Length;
 
-    public TexturePayloadFormat SourceFormat { get; }
+    public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(new RawTexturePayload(
+            Width,
+            Height,
+            ColorProfile,
+            (byte[])bytes.Clone()));
+    }
+}
+
+internal sealed class InMemoryEncodedTextureImportSource : IRawTexturePayloadSource
+{
+    private readonly byte[] bytes;
+
+    public InMemoryEncodedTextureImportSource(
+        string? colorProfile,
+        byte[] bytes,
+        string identity)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        ColorProfile = colorProfile;
+        this.bytes = (byte[])bytes.Clone();
+        Identity = identity;
+    }
+
+    public string Identity { get; }
+
+    public string Description => $"memory:{Identity}";
+
+    public string? ColorProfile { get; }
+
+    public long? EstimatedByteLength => bytes.Length;
 
     public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return SourceFormat switch
-        {
-            TexturePayloadFormat.RawRgba32 => CreateRawPayload(),
-            TexturePayloadFormat.EncodedImage => await DecodeEncodedImageAsync(cancellationToken),
-            _ => throw new InvalidOperationException($"Unsupported texture payload format '{SourceFormat}'."),
-        };
-    }
-
-    private RawTexturePayload CreateRawPayload()
-    {
-        if (Width is null || Height is null)
-        {
-            throw new InvalidOperationException("Raw RGBA texture payload must include width and height.");
-        }
-
-        return new RawTexturePayload(
-            Width.Value,
-            Height.Value,
-            ColorProfile,
-            (byte[])bytes.Clone());
-    }
-
-    private async ValueTask<RawTexturePayload> DecodeEncodedImageAsync(CancellationToken cancellationToken)
-    {
         using MemoryStream stream = new(bytes, writable: false);
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream, cancellationToken);
         return TextureImportSourceFactory.CreateRawPayloadFromImage(
@@ -217,7 +226,20 @@ internal static class TextureImportSourceFactory
         string identity,
         TexturePayloadFormat sourceFormat)
     {
-        return new InMemoryTextureImportSource(width, height, colorProfile, bytes, identity, sourceFormat);
+        return sourceFormat switch
+        {
+            TexturePayloadFormat.RawRgba32 => new InMemoryRawTextureImportSource(
+                width ?? throw new ArgumentException("Raw RGBA texture import source requires width.", nameof(width)),
+                height ?? throw new ArgumentException("Raw RGBA texture import source requires height.", nameof(height)),
+                colorProfile,
+                bytes,
+                identity),
+            TexturePayloadFormat.EncodedImage => new InMemoryEncodedTextureImportSource(
+                colorProfile,
+                bytes,
+                identity),
+            _ => throw new ArgumentOutOfRangeException(nameof(sourceFormat), sourceFormat, "Unsupported texture payload format."),
+        };
     }
 
     public static ITextureImportSource CreateDatasetEncodedImage(

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -218,28 +218,30 @@ internal sealed class GeneratedTextureImportSource(
 
 internal static class TextureImportSourceFactory
 {
-    public static ITextureImportSource CreateInMemory(
-        int? width,
-        int? height,
+    public static ITextureImportSource CreateInMemoryRaw(
+        int width,
+        int height,
         string? colorProfile,
         byte[] bytes,
-        string identity,
-        TexturePayloadFormat sourceFormat)
+        string identity)
     {
-        return sourceFormat switch
-        {
-            TexturePayloadFormat.RawRgba32 => new InMemoryRawTextureImportSource(
-                width ?? throw new ArgumentException("Raw RGBA texture import source requires width.", nameof(width)),
-                height ?? throw new ArgumentException("Raw RGBA texture import source requires height.", nameof(height)),
-                colorProfile,
-                bytes,
-                identity),
-            TexturePayloadFormat.EncodedImage => new InMemoryEncodedTextureImportSource(
-                colorProfile,
-                bytes,
-                identity),
-            _ => throw new ArgumentOutOfRangeException(nameof(sourceFormat), sourceFormat, "Unsupported texture payload format."),
-        };
+        return new InMemoryRawTextureImportSource(
+            width,
+            height,
+            colorProfile,
+            bytes,
+            identity);
+    }
+
+    public static ITextureImportSource CreateInMemoryEncodedImage(
+        string? colorProfile,
+        byte[] bytes,
+        string identity)
+    {
+        return new InMemoryEncodedTextureImportSource(
+            colorProfile,
+            bytes,
+            identity);
     }
 
     public static ITextureImportSource CreateDatasetEncodedImage(

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
@@ -153,13 +153,12 @@ internal sealed class DeterministicTerrainTextureAssetGenerator : ITerrainTextur
         cancellationToken.ThrowIfCancellationRequested();
         TerrainTextureSource usedSource = terrainTextureOverlay.GetRequiredPrimaryTileSource();
         return Task.FromResult(new GeneratedTerrainTexture(
-            TextureImportSourceFactory.CreateInMemory(
+            TextureImportSourceFactory.CreateInMemoryRaw(
                 2,
                 2,
                 ResoniteTextureColorProfiles.Srgb,
                 RawTextureBytes,
-                "canonical-dump-terrain-texture",
-                TexturePayloadFormat.RawRgba32),
+                "canonical-dump-terrain-texture"),
             new ResoniteFloat2(1.0, 1.0),
             new ResoniteFloat2(0.0, 0.0),
             usedSource));

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
@@ -39,7 +39,6 @@ internal static class ResoniteTextureImportFactory
             image.Height,
             colorProfile,
             rawPayload.Bytes,
-            identity ?? Guid.NewGuid().ToString("N"),
-            ResoniteTexturePayloadFormat.RawRgba32);
+            identity ?? Guid.NewGuid().ToString("N"));
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -14,12 +14,11 @@ public enum ResoniteTexturePayloadFormat
 public sealed record ResoniteTexturePayload
 {
     public ResoniteTexturePayload(
-        int? width,
-        int? height,
+        int width,
+        int height,
         string? colorProfile,
         byte[] binaryPayload,
-        string? identity = null,
-        ResoniteTexturePayloadFormat format = ResoniteTexturePayloadFormat.RawRgba32)
+        string? identity = null)
     {
         Width = width;
         Height = height;
@@ -27,14 +26,13 @@ public sealed record ResoniteTexturePayload
         ArgumentNullException.ThrowIfNull(binaryPayload);
         BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
         Identity = identity;
-        Format = format;
-        Source = TextureImportSourceFactory.CreateInMemory(
+        Format = ResoniteTexturePayloadFormat.RawRgba32;
+        Source = TextureImportSourceFactory.CreateInMemoryRaw(
             width,
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"),
-            (TexturePayloadFormat)format);
+            identity ?? Guid.NewGuid().ToString("N"));
     }
 
     public ResoniteTexturePayload(
@@ -42,8 +40,7 @@ public sealed record ResoniteTexturePayload
         int? height,
         string? colorProfile,
         ITextureImportSource source,
-        string? identity = null,
-        ResoniteTexturePayloadFormat format = ResoniteTexturePayloadFormat.EncodedImage)
+        string? identity = null)
     {
         Width = width;
         Height = height;
@@ -51,7 +48,7 @@ public sealed record ResoniteTexturePayload
         ArgumentNullException.ThrowIfNull(source);
         BinaryPayload = [];
         Identity = identity ?? source.Identity;
-        Format = format;
+        Format = ResoniteTexturePayloadFormat.EncodedImage;
         Source = source;
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -52,17 +52,17 @@ public sealed record ResoniteTexturePayload
         Source = source;
     }
 
-    public int? Width { get; init; }
+    public int? Width { get; }
 
-    public int? Height { get; init; }
+    public int? Height { get; }
 
-    public string? ColorProfile { get; init; }
+    public string? ColorProfile { get; }
 
-    public ImmutableArray<byte> BinaryPayload { get; init; }
+    public ImmutableArray<byte> BinaryPayload { get; }
 
-    public string? Identity { get; init; }
+    public string? Identity { get; }
 
-    public ResoniteTexturePayloadFormat Format { get; init; }
+    public ResoniteTexturePayloadFormat Format { get; }
 
-    public ITextureImportSource Source { get; init; }
+    public ITextureImportSource Source { get; }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -133,13 +133,22 @@ internal static class SceneImportContractMapper
 
     private static ResoniteTexturePayload ToInternal(TexturePayload payload)
     {
-        return new ResoniteTexturePayload(
-            payload.Width,
-            payload.Height,
-            payload.ColorProfile,
-            payload.Source,
-            payload.Identity,
-            ToInternal(payload.Format));
+        return payload.Format switch
+        {
+            TexturePayloadFormat.RawRgba32 => new ResoniteTexturePayload(
+                payload.Width ?? throw new InvalidOperationException("Raw texture payload requires width."),
+                payload.Height ?? throw new InvalidOperationException("Raw texture payload requires height."),
+                payload.ColorProfile,
+                payload.BinaryPayload.AsSpan().ToArray(),
+                payload.Identity),
+            TexturePayloadFormat.EncodedImage => new ResoniteTexturePayload(
+                payload.Width,
+                payload.Height,
+                payload.ColorProfile,
+                payload.Source,
+                payload.Identity),
+            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.Format, "Unsupported texture payload format."),
+        };
     }
 
     private static ResoniteMaterialType ToInternal(MaterialType materialType)
@@ -170,16 +179,6 @@ internal static class SceneImportContractMapper
             MaterialProjection.Uv => ResoniteMaterialProjection.Uv,
             MaterialProjection.Triplanar => ResoniteMaterialProjection.Triplanar,
             _ => throw new ArgumentOutOfRangeException(nameof(projection), projection, "Unsupported material projection."),
-        };
-    }
-
-    private static ResoniteTexturePayloadFormat ToInternal(TexturePayloadFormat format)
-    {
-        return format switch
-        {
-            TexturePayloadFormat.RawRgba32 => ResoniteTexturePayloadFormat.RawRgba32,
-            TexturePayloadFormat.EncodedImage => ResoniteTexturePayloadFormat.EncodedImage,
-            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported texture payload format."),
         };
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -136,8 +136,8 @@ internal static class SceneImportContractMapper
         return payload.Format switch
         {
             TexturePayloadFormat.RawRgba32 => new ResoniteTexturePayload(
-                payload.Width ?? throw new InvalidOperationException("Raw texture payload requires width."),
-                payload.Height ?? throw new InvalidOperationException("Raw texture payload requires height."),
+                payload.Width.GetValueOrDefault(),
+                payload.Height.GetValueOrDefault(),
                 payload.ColorProfile,
                 payload.BinaryPayload.AsSpan().ToArray(),
                 payload.Identity),

--- a/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Tests.Application;
+
+public sealed class TextureImportSourceFactoryTests
+{
+    [Fact]
+    public void CreateInMemoryRawRgbaRequiresDimensionsBeforeMaterialization()
+    {
+        ArgumentException widthError = Assert.Throws<ArgumentException>(
+            () => TextureImportSourceFactory.CreateInMemory(
+                width: null,
+                height: 1,
+                colorProfile: "sRGB",
+                bytes: [255, 255, 255, 255],
+                identity: "raw-without-width",
+                sourceFormat: TexturePayloadFormat.RawRgba32));
+        ArgumentException heightError = Assert.Throws<ArgumentException>(
+            () => TextureImportSourceFactory.CreateInMemory(
+                width: 1,
+                height: null,
+                colorProfile: "sRGB",
+                bytes: [255, 255, 255, 255],
+                identity: "raw-without-height",
+                sourceFormat: TexturePayloadFormat.RawRgba32));
+
+        Assert.Equal("width", widthError.ParamName);
+        Assert.Equal("height", heightError.ParamName);
+    }
+
+    [Fact]
+    public async Task CreateInMemoryEncodedImageOwnsDimensionsAfterDecode()
+    {
+        await using MemoryStream stream = new();
+        using (Image<Rgba32> image = new(1, 1, new Rgba32(1, 2, 3, 255)))
+        {
+            await image.SaveAsPngAsync(stream);
+        }
+
+        ITextureImportSource source = TextureImportSourceFactory.CreateInMemory(
+            width: null,
+            height: null,
+            colorProfile: "sRGB",
+            bytes: stream.ToArray(),
+            identity: "encoded-without-dimensions",
+            sourceFormat: TexturePayloadFormat.EncodedImage);
+
+        RawTexturePayload payload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            source,
+            CancellationToken.None);
+
+        Assert.Equal(1, payload.Width);
+        Assert.Equal(1, payload.Height);
+        Assert.Equal([1, 2, 3, 255], payload.Bytes);
+    }
+
+    [Fact]
+    public void TexturePayloadRejectsUnsupportedFormatAtConstructionBoundary()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new TexturePayload(
+                width: 1,
+                height: 1,
+                colorProfile: "sRGB",
+                binaryPayload: [255, 255, 255, 255],
+                identity: "invalid-format",
+                format: (TexturePayloadFormat)999));
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,27 +12,22 @@ namespace PlateauResoniteLink.Tests.Application;
 public sealed class TextureImportSourceFactoryTests
 {
     [Fact]
-    public void CreateInMemoryRawRgbaRequiresDimensionsBeforeMaterialization()
+    public async Task CreateInMemoryRawRgbaRequiresDimensionsAtConstruction()
     {
-        ArgumentException widthError = Assert.Throws<ArgumentException>(
-            () => TextureImportSourceFactory.CreateInMemory(
-                width: null,
-                height: 1,
-                colorProfile: "sRGB",
-                bytes: [255, 255, 255, 255],
-                identity: "raw-without-width",
-                sourceFormat: TexturePayloadFormat.RawRgba32));
-        ArgumentException heightError = Assert.Throws<ArgumentException>(
-            () => TextureImportSourceFactory.CreateInMemory(
-                width: 1,
-                height: null,
-                colorProfile: "sRGB",
-                bytes: [255, 255, 255, 255],
-                identity: "raw-without-height",
-                sourceFormat: TexturePayloadFormat.RawRgba32));
+        ITextureImportSource source = TextureImportSourceFactory.CreateInMemoryRaw(
+            width: 1,
+            height: 1,
+            colorProfile: "sRGB",
+            bytes: [255, 255, 255, 255],
+            identity: "raw-with-dimensions");
 
-        Assert.Equal("width", widthError.ParamName);
-        Assert.Equal("height", heightError.ParamName);
+        RawTexturePayload payload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            source,
+            CancellationToken.None);
+
+        Assert.Equal(1, payload.Width);
+        Assert.Equal(1, payload.Height);
+        Assert.Equal([255, 255, 255, 255], payload.Bytes);
     }
 
     [Fact]
@@ -45,13 +39,10 @@ public sealed class TextureImportSourceFactoryTests
             await image.SaveAsPngAsync(stream);
         }
 
-        ITextureImportSource source = TextureImportSourceFactory.CreateInMemory(
-            width: null,
-            height: null,
+        ITextureImportSource source = TextureImportSourceFactory.CreateInMemoryEncodedImage(
             colorProfile: "sRGB",
             bytes: stream.ToArray(),
-            identity: "encoded-without-dimensions",
-            sourceFormat: TexturePayloadFormat.EncodedImage);
+            identity: "encoded-without-dimensions");
 
         RawTexturePayload payload = await TextureImportSourceMaterializer.MaterializeRawAsync(
             source,
@@ -62,16 +53,4 @@ public sealed class TextureImportSourceFactoryTests
         Assert.Equal([1, 2, 3, 255], payload.Bytes);
     }
 
-    [Fact]
-    public void TexturePayloadRejectsUnsupportedFormatAtConstructionBoundary()
-    {
-        Assert.Throws<ArgumentOutOfRangeException>(
-            () => new TexturePayload(
-                width: 1,
-                height: 1,
-                colorProfile: "sRGB",
-                binaryPayload: [255, 255, 255, 255],
-                identity: "invalid-format",
-                format: (TexturePayloadFormat)999));
-    }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -541,13 +541,22 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         => Enumerable.Repeat(TerrainGridSampleCoverage.Measured, count).ToArray();
 
     private static TexturePayload ToContractTexturePayload(ResoniteTexturePayload payload)
-        => new(
-            payload.Width,
-            payload.Height,
-            payload.ColorProfile,
-            payload.BinaryPayload.AsSpan().ToArray(),
-            payload.Identity,
-            (TexturePayloadFormat)payload.Format);
+        => payload.Format switch
+        {
+            ResoniteTexturePayloadFormat.RawRgba32 => new TexturePayload(
+                payload.Width ?? throw new InvalidOperationException("Raw texture payload requires width."),
+                payload.Height ?? throw new InvalidOperationException("Raw texture payload requires height."),
+                payload.ColorProfile,
+                payload.BinaryPayload.AsSpan().ToArray(),
+                payload.Identity),
+            ResoniteTexturePayloadFormat.EncodedImage => new TexturePayload(
+                payload.Width,
+                payload.Height,
+                payload.ColorProfile,
+                payload.Source,
+                payload.Identity),
+            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.Format, "Unsupported texture payload format."),
+        };
 
 }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -544,8 +544,8 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         => payload.Format switch
         {
             ResoniteTexturePayloadFormat.RawRgba32 => new TexturePayload(
-                payload.Width ?? throw new InvalidOperationException("Raw texture payload requires width."),
-                payload.Height ?? throw new InvalidOperationException("Raw texture payload requires height."),
+                payload.Width.GetValueOrDefault(),
+                payload.Height.GetValueOrDefault(),
                 payload.ColorProfile,
                 payload.BinaryPayload.AsSpan().ToArray(),
                 payload.Identity),

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -46,7 +46,6 @@ public sealed class SceneImportContractMapperTests
     [InlineData(nameof(MaterialBinding.MaterialType))]
     [InlineData(nameof(MaterialBinding.TextureSourceKind))]
     [InlineData(nameof(MaterialBinding.Projection))]
-    [InlineData(nameof(TexturePayload.Format))]
     public void ToInternalMaterialBindingsRejectsUnsupportedContractEnumValues(string invalidField)
     {
         MaterialBinding binding = CreateValidBinding() with
@@ -54,9 +53,6 @@ public sealed class SceneImportContractMapperTests
             MaterialType = invalidField == nameof(MaterialBinding.MaterialType) ? (MaterialType)999 : MaterialType.Standard,
             TextureSourceKind = invalidField == nameof(MaterialBinding.TextureSourceKind) ? (TextureSourceKind)999 : TextureSourceKind.Dataset,
             Projection = invalidField == nameof(MaterialBinding.Projection) ? (MaterialProjection)999 : MaterialProjection.Uv,
-            TexturePayload = invalidField == nameof(TexturePayload.Format)
-                ? new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", (TexturePayloadFormat)999)
-                : new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
         };
 
         Assert.Throws<ArgumentOutOfRangeException>(() => SceneImportContractMapper.ToInternal(binding));

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -16,7 +16,7 @@ public sealed class SceneImportContractMapperTests
             new(
                 BaseColor: new ColorRgba(0.1, 0.2, 0.3, 0.4),
                 MaterialType: MaterialType.Standard,
-                TexturePayload: new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
+                TexturePayload: CreateEncodedTexturePayload(),
                 TextureSourceKind: TextureSourceKind.Dataset,
                 Projection: MaterialProjection.Uv,
                 DepthOffset: new MaterialDepthOffset(-1.5, 2.5),
@@ -133,10 +133,22 @@ public sealed class SceneImportContractMapperTests
         return new MaterialBinding(
             BaseColor: new ColorRgba(0.1, 0.2, 0.3, 0.4),
             MaterialType: MaterialType.Standard,
-            TexturePayload: new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
+            TexturePayload: CreateEncodedTexturePayload(),
             TextureSourceKind: TextureSourceKind.Dataset,
             Projection: MaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0]);
+    }
+
+    private static TexturePayload CreateEncodedTexturePayload()
+    {
+        return new TexturePayload(
+            width: 2,
+            height: 2,
+            colorProfile: "sRGB",
+            source: TextureImportSourceFactory.CreateInMemoryEncodedImage(
+                colorProfile: "sRGB",
+                bytes: [1, 2, 3, 4],
+                identity: "dataset:texture"));
     }
 }

--- a/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
@@ -16,13 +16,12 @@ internal static class TextureImportSourceTestFactory
         byte[] rawRgba32Bytes,
         string? identity = null)
     {
-        return TextureImportSourceFactory.CreateInMemory(
+        return TextureImportSourceFactory.CreateInMemoryRaw(
             width,
             height,
             colorProfile,
             rawRgba32Bytes,
-            identity ?? $"test-rgba32:{width}:{height}:{Guid.NewGuid():N}",
-            TexturePayloadFormat.RawRgba32);
+            identity ?? $"test-rgba32:{width}:{height}:{Guid.NewGuid():N}");
     }
 
     public static IReadOnlyList<RawTexturePayload> ImportedRgba32Textures(SceneSinkRecordingClient client)


### PR DESCRIPTION
## Summary
- split in-memory texture source creation into raw and encoded entrypoints so raw textures require width/height at the call site
- make raw TexturePayload/ResoniteTexturePayload byte constructors dimension-required and encoded source-backed constructors format-fixed
- update mapper/test/canonical dump helpers to route raw vs encoded payloads through the typed entrypoints

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (1006 passed)
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020`, mesh `53395325`, packages `dem,bldg`, terrain mesh `grid` matched the baseline with `git diff --no-index`; temp dump removed