### PR TITLE
Reject unsafe archive entry keys at indexing

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/PlateauDatasetContentSourceFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauDatasetContentSourceFactory.cs
@@ -369,7 +369,11 @@ internal static class PlateauDatasetContentSourceFactory
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                string entryKey = archiveFileLayoutPolicy.NormalizeRelativePath(entry.Key ?? string.Empty);
+                if (!TryNormalizeArchiveEntryKey(entry, archiveFileLayoutPolicy, out string entryKey))
+                {
+                    continue;
+                }
+
                 if (IsSupportedArchiveFile(entryKey))
                 {
                     await IndexArchiveAsync(
@@ -438,10 +442,8 @@ internal static class PlateauDatasetContentSourceFactory
 
             IArchiveEntry entry = archive.Entries.FirstOrDefault(candidate =>
                     !candidate.IsDirectory
-                    && string.Equals(
-                        archiveFileLayoutPolicy.NormalizeRelativePath(candidate.Key ?? string.Empty),
-                        archiveFileLayoutPolicy.NormalizeRelativePath(entryKey),
-                        StringComparison.Ordinal))
+                    && TryNormalizeArchiveEntryKey(candidate, archiveFileLayoutPolicy, out string candidateKey)
+                    && string.Equals(candidateKey, archiveFileLayoutPolicy.NormalizeRelativePath(entryKey), StringComparison.Ordinal))
                 ?? throw new FileNotFoundException($"The dataset entry '{entryKey}' was not found in '{archivePath}'.");
 
             await using Stream entryStream = await entry.OpenEntryStreamAsync(cancellationToken);
@@ -456,6 +458,42 @@ internal static class PlateauDatasetContentSourceFactory
             string extension = Path.GetExtension(path);
             return string.Equals(extension, ".zip", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(extension, ".7z", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool TryNormalizeArchiveEntryKey(
+            IArchiveEntry entry,
+            IArchiveFileLayoutPolicy archiveFileLayoutPolicy,
+            out string entryKey)
+        {
+            entryKey = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(entry.Key))
+            {
+                return false;
+            }
+
+            string rawKey = entry.Key.Replace('\\', '/').Trim();
+            if (rawKey.StartsWith('/')
+                || Path.IsPathFullyQualified(rawKey)
+                || (rawKey.Length >= 2 && rawKey[1] == ':'))
+            {
+                return false;
+            }
+
+            string normalizedKey = archiveFileLayoutPolicy.NormalizeRelativePath(rawKey);
+            if (normalizedKey.Length == 0)
+            {
+                return false;
+            }
+
+            string[] segments = normalizedKey.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Any(static segment => segment is "." or ".."))
+            {
+                return false;
+            }
+
+            entryKey = normalizedKey;
+            return true;
         }
 
     }

--- a/tests/PlateauResoniteLink.Tests/Sources/ArchivePlateauDatasetContentSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Sources/ArchivePlateauDatasetContentSourceFactoryTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -97,6 +98,34 @@ public sealed class ArchivePlateauDatasetContentSourceFactoryTests
         string secondLocalFilePath = await secondDatasetSource.EnsureLocalFileAsync(relativePath, outputRoot);
 
         Assert.NotEqual(Path.GetDirectoryName(firstLocalFilePath), Path.GetDirectoryName(secondLocalFilePath));
+    }
+
+    [Fact]
+    public async Task CreateAsyncIndexesOnlyArchiveEntriesWithSafeRelativePaths()
+    {
+        byte[] archiveBytes = CreateZipArchive(
+            ("udx/bldg/area/plateau_tokyo23ku_bldg_533944.gml", "<CityModel />"),
+            ("../../outside.txt", "escape"),
+            ("/absolute.txt", "absolute"),
+            ("C:/outside/windows-absolute.txt", "drive"),
+            ("udx/./texture.png", "dot"));
+
+        using TemporaryDirectory workRoot = new();
+        string archivePath = Path.Combine(workRoot.Path, "malicious.zip");
+        await File.WriteAllBytesAsync(archivePath, archiveBytes);
+
+        IPlateauDatasetContentSource datasetSource = await PlateauDatasetContentSourceFactory.CreateAsync(
+            archivePath,
+            new RemoteArchiveDistributionPolicy(),
+            new ArchiveFileLayoutPolicy());
+
+        string[] files = datasetSource.EnumerateFiles().ToArray();
+
+        Assert.Equal(["udx/bldg/area/plateau_tokyo23ku_bldg_533944.gml"], files);
+        Assert.False(datasetSource.FileExists("outside.txt"));
+        Assert.False(datasetSource.FileExists("absolute.txt"));
+        Assert.False(datasetSource.FileExists("C:/outside/windows-absolute.txt"));
+        Assert.False(datasetSource.FileExists("udx/texture.png"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- normalize archive entry keys at the archive indexing boundary instead of converting missing keys to empty paths
- skip empty, absolute, drive-rooted, and traversal archive entries before they can surface through dataset file lookup
- cover unsafe archive entries so only safe dataset-relative paths are indexed

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (1007 passed)
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020`, mesh `53395325`, packages `dem,bldg`, terrain mesh `grid` matched the baseline with `git diff --no-index`; temp dump removed