### PR TITLE
Require CLI import inputs before request creation

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliApplication.cs
+++ b/src/PlateauResoniteLink.Cli/CliApplication.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
@@ -45,25 +46,19 @@ public sealed class CliApplication
     {
         CliParseResult parseResult = CliArgumentsParser.Parse(args);
 
-        if (parseResult.ShowHelp)
-        {
-            await standardOutput.WriteLineAsync(CliArgumentsParser.HelpText);
-            return 0;
-        }
-
-        if (parseResult.Error is not null)
-        {
-            await standardError.WriteLineAsync(parseResult.Error);
-            await standardError.WriteLineAsync();
-            await standardError.WriteLineAsync(CliArgumentsParser.HelpText);
-            return 1;
-        }
-
         try
         {
-            switch (parseResult.Command)
+            switch (parseResult)
             {
-                case ImportCommandOptions options:
+                case CliParseResult.HelpResult:
+                    await standardOutput.WriteLineAsync(CliArgumentsParser.HelpText);
+                    return 0;
+                case CliParseResult.FailureResult failure:
+                    await standardError.WriteLineAsync(failure.Error);
+                    await standardError.WriteLineAsync();
+                    await standardError.WriteLineAsync(CliArgumentsParser.HelpText);
+                    return 1;
+                case CliParseResult.ImportSuccessResult { Command: ImportCommandOptions options }:
                     {
                         Action<string> reporter = CreateReporter(options.VerboseLogging);
                         PlateauImportService effectiveImportService = importServiceFactory.Create(options, reporter);
@@ -97,7 +92,7 @@ public sealed class CliApplication
 
                         return 0;
                     }
-                case SearchCommandOptions options:
+                case CliParseResult.SearchSuccessResult { Command: SearchCommandOptions options }:
                     {
                         DatasetSearchResult result = await datasetInspectionService.SearchAsync(
                             options.CityGmlSourcePath,
@@ -107,7 +102,7 @@ public sealed class CliApplication
                         await WriteSearchResultAsync(result, options.OutputFormat, cancellationToken);
                         return 0;
                     }
-                case StatsCommandOptions options:
+                case CliParseResult.StatsSuccessResult { Command: StatsCommandOptions options }:
                     {
                         DatasetStatsResult result = await datasetInspectionService.GetStatsAsync(
                             options.CityGmlSourcePath,
@@ -117,7 +112,7 @@ public sealed class CliApplication
                         return 0;
                     }
                 default:
-                    throw new InvalidOperationException("CLI parse succeeded without a supported command payload.");
+                    throw new UnreachableException();
             }
         }
         catch (PlateauImportValidationException exception)

--- a/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 
@@ -330,7 +331,7 @@ public static class CliArgumentsParser
                             if (TryParsePackagePatternOption(token, args, ref index, out string? packageName, out string? patternValue))
                             {
                                 packagePatterns ??= new(StringComparer.OrdinalIgnoreCase);
-                                packagePatterns[packageName!] = patternValue!;
+                                packagePatterns[packageName] = patternValue;
                                 break;
                             }
 
@@ -350,6 +351,16 @@ public static class CliArgumentsParser
             {
                 ["tran"] = new HashSet<int> { 1 }
             };
+        }
+
+        if (string.IsNullOrWhiteSpace(dataset))
+        {
+            return CliParseResult.Failure("Specify --dataset.");
+        }
+
+        if (string.IsNullOrWhiteSpace(meshCode))
+        {
+            return CliParseResult.Failure("Specify --mesh-code.");
         }
 
         if (string.IsNullOrWhiteSpace(cityGmlSourceInput))
@@ -375,9 +386,9 @@ public static class CliArgumentsParser
         }
 
         PlateauImportRequest request = new(
-            Dataset: dataset ?? string.Empty,
-            MeshCode: meshCode ?? string.Empty,
-            CityGmlSource: cityGmlSource!,
+            Dataset: dataset,
+            MeshCode: meshCode,
+            CityGmlSource: cityGmlSource,
             DemTextureSource: demTextureSource,
             PackageNames: packageNames,
             GlobalExcludeLodLevels: globalExcludeLods,
@@ -715,7 +726,9 @@ public static class CliArgumentsParser
         string token,
         string[] args,
         ref int index,
+        [NotNullWhen(true)]
         out string? packageName,
+        [NotNullWhen(true)]
         out string? patternValue)
     {
         packageName = null;
@@ -736,7 +749,9 @@ public static class CliArgumentsParser
 
     private static bool TryParseDatasetLocationInput(
         string input,
+        [NotNullWhen(true)]
         out DatasetLocation? source,
+        [NotNullWhen(false)]
         out string? error)
     {
         string trimmedInput = input.Trim();

--- a/src/PlateauResoniteLink.Cli/CliCommandOptions.cs
+++ b/src/PlateauResoniteLink.Cli/CliCommandOptions.cs
@@ -1,3 +1,8 @@
 namespace PlateauResoniteLink.Cli;
 
-public abstract record CliCommandOptions;
+public abstract class CliCommandOptions
+{
+    private protected CliCommandOptions()
+    {
+    }
+}

--- a/src/PlateauResoniteLink.Cli/CliParseResult.cs
+++ b/src/PlateauResoniteLink.Cli/CliParseResult.cs
@@ -1,24 +1,89 @@
+using System;
+
 namespace PlateauResoniteLink.Cli;
 
-public sealed record CliParseResult(
-    CliCommandOptions? Command,
-    string? Error,
-    bool ShowHelp)
+public abstract class CliParseResult
 {
-    public ImportCommandOptions? Options => Command as ImportCommandOptions;
+    private CliParseResult()
+    {
+    }
 
     public static CliParseResult Failure(string error)
     {
-        return new CliParseResult(null, error, ShowHelp: false);
+        return new FailureResult(error);
     }
 
     public static CliParseResult Help()
     {
-        return new CliParseResult(null, null, ShowHelp: true);
+        return HelpResult.Instance;
     }
 
-    public static CliParseResult Success(CliCommandOptions command)
+    public static CliParseResult Success(ImportCommandOptions command)
     {
-        return new CliParseResult(command, null, ShowHelp: false);
+        return new ImportSuccessResult(command);
+    }
+
+    public static CliParseResult Success(SearchCommandOptions command)
+    {
+        return new SearchSuccessResult(command);
+    }
+
+    public static CliParseResult Success(StatsCommandOptions command)
+    {
+        return new StatsSuccessResult(command);
+    }
+
+    public sealed class ImportSuccessResult : CliParseResult
+    {
+        public ImportSuccessResult(ImportCommandOptions command)
+        {
+            Command = command ?? throw new ArgumentNullException(nameof(command));
+        }
+
+        public ImportCommandOptions Command { get; }
+    }
+
+    public sealed class SearchSuccessResult : CliParseResult
+    {
+        public SearchSuccessResult(SearchCommandOptions command)
+        {
+            Command = command ?? throw new ArgumentNullException(nameof(command));
+        }
+
+        public SearchCommandOptions Command { get; }
+    }
+
+    public sealed class StatsSuccessResult : CliParseResult
+    {
+        public StatsSuccessResult(StatsCommandOptions command)
+        {
+            Command = command ?? throw new ArgumentNullException(nameof(command));
+        }
+
+        public StatsCommandOptions Command { get; }
+    }
+
+    public sealed class FailureResult : CliParseResult
+    {
+        public FailureResult(string error)
+        {
+            if (string.IsNullOrWhiteSpace(error))
+            {
+                throw new ArgumentException("CLI parse failure message must be provided.", nameof(error));
+            }
+
+            Error = error;
+        }
+
+        public string Error { get; }
+    }
+
+    public sealed class HelpResult : CliParseResult
+    {
+        public static HelpResult Instance { get; } = new();
+
+        private HelpResult()
+        {
+        }
     }
 }

--- a/src/PlateauResoniteLink.Cli/ImportCommandOptions.cs
+++ b/src/PlateauResoniteLink.Cli/ImportCommandOptions.cs
@@ -4,7 +4,7 @@ using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Cli;
 
-public sealed record ImportCommandOptions(
+public sealed class ImportCommandOptions(
     PlateauImportRequest Request,
     string WorkRoot,
     Uri? ResoniteLinkUri,
@@ -15,4 +15,27 @@ public sealed record ImportCommandOptions(
     bool DisableTerrainTileCache,
     string? CanonicalSceneDumpPath,
     bool EnableSendMetrics,
-    bool VerboseLogging) : CliCommandOptions;
+    bool VerboseLogging) : CliCommandOptions
+{
+    public PlateauImportRequest Request { get; } = Request ?? throw new ArgumentNullException(nameof(Request));
+
+    public string WorkRoot { get; } = WorkRoot ?? throw new ArgumentNullException(nameof(WorkRoot));
+
+    public Uri? ResoniteLinkUri { get; } = ResoniteLinkUri;
+
+    public int ResoniteLinkConnectionCount { get; } = ResoniteLinkConnectionCount;
+
+    public PlateauImportMemoryProfile MemoryProfile { get; } = MemoryProfile;
+
+    public bool EnableMeshBake { get; } = EnableMeshBake;
+
+    public string? TerrainTileCacheRoot { get; } = TerrainTileCacheRoot;
+
+    public bool DisableTerrainTileCache { get; } = DisableTerrainTileCache;
+
+    public string? CanonicalSceneDumpPath { get; } = CanonicalSceneDumpPath;
+
+    public bool EnableSendMetrics { get; } = EnableSendMetrics;
+
+    public bool VerboseLogging { get; } = VerboseLogging;
+}

--- a/src/PlateauResoniteLink.Cli/SearchCommandOptions.cs
+++ b/src/PlateauResoniteLink.Cli/SearchCommandOptions.cs
@@ -1,9 +1,19 @@
+using System;
 using System.Collections.Generic;
 
 namespace PlateauResoniteLink.Cli;
 
-public sealed record SearchCommandOptions(
-    string CityGmlSourcePath,
-    string MeshCode,
-    IReadOnlyList<string>? PackageNames,
-    CliOutputFormat OutputFormat) : CliCommandOptions;
+public sealed class SearchCommandOptions(
+    string cityGmlSourcePath,
+    string meshCode,
+    IReadOnlyList<string>? packageNames,
+    CliOutputFormat outputFormat) : CliCommandOptions
+{
+    public string CityGmlSourcePath { get; } = cityGmlSourcePath ?? throw new ArgumentNullException(nameof(cityGmlSourcePath));
+
+    public string MeshCode { get; } = meshCode ?? throw new ArgumentNullException(nameof(meshCode));
+
+    public IReadOnlyList<string>? PackageNames { get; } = packageNames;
+
+    public CliOutputFormat OutputFormat { get; } = outputFormat;
+}

--- a/src/PlateauResoniteLink.Cli/StatsCommandOptions.cs
+++ b/src/PlateauResoniteLink.Cli/StatsCommandOptions.cs
@@ -1,8 +1,16 @@
+using System;
 using System.Collections.Generic;
 
 namespace PlateauResoniteLink.Cli;
 
-public sealed record StatsCommandOptions(
-    string CityGmlSourcePath,
-    IReadOnlyList<string>? PackageNames,
-    CliOutputFormat OutputFormat) : CliCommandOptions;
+public sealed class StatsCommandOptions(
+    string cityGmlSourcePath,
+    IReadOnlyList<string>? packageNames,
+    CliOutputFormat outputFormat) : CliCommandOptions
+{
+    public string CityGmlSourcePath { get; } = cityGmlSourcePath ?? throw new ArgumentNullException(nameof(cityGmlSourcePath));
+
+    public IReadOnlyList<string>? PackageNames { get; } = packageNames;
+
+    public CliOutputFormat OutputFormat { get; } = outputFormat;
+}

--- a/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -19,16 +19,14 @@ public sealed class CliArgumentsParserTests
                 "--resonitelink-port", "12345",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.False(result.ShowHelp);
-        Assert.NotNull(result.Options);
-        Assert.Equal("tokyo23ku", result.Options.Request.Dataset);
-        Assert.Equal("53394525", result.Options.Request.MeshCode);
-        Assert.Equal(DatasetSourceKind.Local, result.Options.Request.CityGmlSourceKind);
-        Assert.Equal("/data/plateau", result.Options.Request.CityGmlLocalSourcePath);
-        Assert.Null(result.Options.Request.DemTextureSource);
-        Assert.Equal(CliTestData.DocumentedDefaultPackageNames, result.Options.Request.PackageNames);
-        Assert.Equal(new Uri("ws://localhost:12345/"), result.Options.ResoniteLinkUri);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Equal("tokyo23ku", options.Request.Dataset);
+        Assert.Equal("53394525", options.Request.MeshCode);
+        Assert.Equal(DatasetSourceKind.Local, options.Request.CityGmlSourceKind);
+        Assert.Equal("/data/plateau", options.Request.CityGmlLocalSourcePath);
+        Assert.Null(options.Request.DemTextureSource);
+        Assert.Equal(CliTestData.DocumentedDefaultPackageNames, options.Request.PackageNames);
+        Assert.Equal(new Uri("ws://localhost:12345/"), options.ResoniteLinkUri);
     }
 
     [Fact]
@@ -43,9 +41,7 @@ public sealed class CliArgumentsParserTests
                 "--resonitelink-port", "12345",
             ]);
 
-        Assert.Equal("Unknown command 'bogus'.", result.Error);
-        Assert.False(result.ShowHelp);
-        Assert.Null(result.Options);
+        Assert.Equal("Unknown command 'bogus'.", AssertFailure(result).Error);
     }
 
     [Fact]
@@ -61,11 +57,11 @@ public sealed class CliArgumentsParserTests
                 "--resonitelink-url", "ws://localhost:12345/",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.Equal(DatasetSourceKind.Remote, result.Options!.Request.CityGmlSourceKind);
-        Assert.Equal(new Uri("https://example.invalid/plateau.zip"), result.Options.Request.CityGmlServerUri);
-        Assert.Equal(DatasetSourceKind.Remote, result.Options.Request.DemTextureSourceKind);
-        Assert.Equal(new Uri("https://example.invalid/53394525.tif"), result.Options.Request.DemTextureServerUri);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Equal(DatasetSourceKind.Remote, options.Request.CityGmlSourceKind);
+        Assert.Equal(new Uri("https://example.invalid/plateau.zip"), options.Request.CityGmlServerUri);
+        Assert.Equal(DatasetSourceKind.Remote, options.Request.DemTextureSourceKind);
+        Assert.Equal(new Uri("https://example.invalid/53394525.tif"), options.Request.DemTextureServerUri);
     }
 
     [Fact]
@@ -79,7 +75,7 @@ public sealed class CliArgumentsParserTests
                 "--resonitelink-port", "12345",
             ]);
 
-        Assert.Equal("Specify --citygml-source.", result.Error);
+        Assert.Equal("Specify --citygml-source.", AssertFailure(result).Error);
     }
 
     [Fact]
@@ -94,9 +90,9 @@ public sealed class CliArgumentsParserTests
                 "--canonical-scene-dump", "out/scene.json",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.Null(result.Options!.ResoniteLinkUri);
-        Assert.Equal("out/scene.json", result.Options.CanonicalSceneDumpPath);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Null(options.ResoniteLinkUri);
+        Assert.Equal("out/scene.json", options.CanonicalSceneDumpPath);
     }
 
     [Fact]
@@ -114,7 +110,7 @@ public sealed class CliArgumentsParserTests
 
         Assert.Equal(
             "Do not specify --resonitelink-port or --resonitelink-url when --canonical-scene-dump is used.",
-            result.Error);
+            AssertFailure(result).Error);
     }
 
     [Fact]
@@ -129,7 +125,7 @@ public sealed class CliArgumentsParserTests
                 "--canonical-scene-dump", " ",
             ]);
 
-        Assert.Equal("Specify a non-empty --canonical-scene-dump path.", result.Error);
+        Assert.Equal("Specify a non-empty --canonical-scene-dump path.", AssertFailure(result).Error);
     }
 
     [Fact]
@@ -145,8 +141,8 @@ public sealed class CliArgumentsParserTests
                 "--resonitelink-port", "12345",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.Equal(["tran", "waterbody", "tran", "brid"], result.Options!.Request.PackageNames);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Equal(["tran", "waterbody", "tran", "brid"], options.Request.PackageNames);
     }
 
     [Fact]
@@ -161,8 +157,8 @@ public sealed class CliArgumentsParserTests
                 "--resonitelink-port", "12345",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.Equal("5339452[56]", result.Options!.Request.MeshCode);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Equal("5339452[56]", options.Request.MeshCode);
     }
 
     [Fact]
@@ -178,7 +174,7 @@ public sealed class CliArgumentsParserTests
                 "--unexpected", "value",
             ]);
 
-        Assert.Equal("Unknown option '--unexpected'.", result.Error);
+        Assert.Equal("Unknown option '--unexpected'.", AssertFailure(result).Error);
     }
 
     [Fact]
@@ -193,8 +189,7 @@ public sealed class CliArgumentsParserTests
                 "--format", "json",
             ]);
 
-        Assert.Null(result.Error);
-        SearchCommandOptions command = Assert.IsType<SearchCommandOptions>(result.Command);
+        SearchCommandOptions command = AssertSuccess<SearchCommandOptions>(result);
         Assert.Equal("/data/plateau.zip", command.CityGmlSourcePath);
         Assert.Equal("5339452[56]", command.MeshCode);
         Assert.Equal(["bldg", "tran"], command.PackageNames);
@@ -211,8 +206,7 @@ public sealed class CliArgumentsParserTests
                 "--packages", "dem,bldg",
             ]);
 
-        Assert.Null(result.Error);
-        StatsCommandOptions command = Assert.IsType<StatsCommandOptions>(result.Command);
+        StatsCommandOptions command = AssertSuccess<StatsCommandOptions>(result);
         Assert.Equal("/data/plateau", command.CityGmlSourcePath);
         Assert.Equal(["dem", "bldg"], command.PackageNames);
     }
@@ -232,10 +226,10 @@ public sealed class CliArgumentsParserTests
                 "--terrain-grid-max-resolution", "512",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.Equal(TerrainMeshMode.Grid, result.Options!.Request.TerrainMeshMode);
-        Assert.Equal(4.5, result.Options.Request.TerrainGridMetersPerVertex, 6);
-        Assert.Equal(512, result.Options.Request.TerrainGridMaxResolution);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Equal(TerrainMeshMode.Grid, options.Request.TerrainMeshMode);
+        Assert.Equal(4.5, options.Request.TerrainGridMetersPerVertex, 6);
+        Assert.Equal(512, options.Request.TerrainGridMaxResolution);
     }
 
     [Fact]
@@ -251,8 +245,8 @@ public sealed class CliArgumentsParserTests
                 "--terrain-mesh", "dynamic",
             ]);
 
-        Assert.Null(result.Error);
-        Assert.Equal(TerrainMeshMode.Dynamic, result.Options!.Request.TerrainMeshMode);
+        ImportCommandOptions options = AssertImportSuccess(result);
+        Assert.Equal(TerrainMeshMode.Dynamic, options.Request.TerrainMeshMode);
     }
 
     [Fact]
@@ -270,4 +264,26 @@ public sealed class CliArgumentsParserTests
         Assert.Contains("--geotiff-source <path-or-url>", CliArgumentsParser.HelpText, StringComparison.Ordinal);
     }
 
+    private static ImportCommandOptions AssertImportSuccess(CliParseResult result)
+    {
+        return Assert.IsType<CliParseResult.ImportSuccessResult>(result).Command;
+    }
+
+    private static TCommand AssertSuccess<TCommand>(CliParseResult result)
+        where TCommand : CliCommandOptions
+    {
+        CliCommandOptions command = result switch
+        {
+            CliParseResult.ImportSuccessResult import => import.Command,
+            CliParseResult.SearchSuccessResult search => search.Command,
+            CliParseResult.StatsSuccessResult stats => stats.Command,
+            _ => throw new InvalidOperationException("Expected successful CLI parse result."),
+        };
+        return Assert.IsType<TCommand>(command);
+    }
+
+    private static CliParseResult.FailureResult AssertFailure(CliParseResult result)
+    {
+        return Assert.IsType<CliParseResult.FailureResult>(result);
+    }
 }

--- a/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -78,6 +78,56 @@ public sealed class CliArgumentsParserTests
         Assert.Equal("Specify --citygml-source.", AssertFailure(result).Error);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData(" ")]
+    public void ParseImportRequiresDatasetAtCliBoundary(string? dataset)
+    {
+        string[] args = dataset is null
+            ? [
+                "import",
+                "--mesh-code", "53394525",
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+            ]
+            : [
+                "import",
+                "--dataset", dataset,
+                "--mesh-code", "53394525",
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+            ];
+
+        CliParseResult result = CliArgumentsParser.Parse(args);
+
+        Assert.Equal("Specify --dataset.", AssertFailure(result).Error);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(" ")]
+    public void ParseImportRequiresMeshCodeAtCliBoundary(string? meshCode)
+    {
+        string[] args = meshCode is null
+            ? [
+                "import",
+                "--dataset", "tokyo23ku",
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+            ]
+            : [
+                "import",
+                "--dataset", "tokyo23ku",
+                "--mesh-code", meshCode,
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+            ];
+
+        CliParseResult result = CliArgumentsParser.Parse(args);
+
+        Assert.Equal("Specify --mesh-code.", AssertFailure(result).Error);
+    }
+
     [Fact]
     public void ParseParsesCanonicalSceneDumpImportWithoutResoniteLinkEndpoint()
     {


### PR DESCRIPTION
## Summary
- reject missing or blank import `--dataset` and `--mesh-code` at the CLI parse boundary before creating `PlateauImportRequest`
- stop converting missing required CLI values into empty strings for downstream validation
- express successful helper outputs with `NotNullWhen` so parsed dataset locations and package pattern values do not need null-forgiving access

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (1011 passed)
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020`, mesh `53395325`, packages `dem,bldg`, terrain mesh `grid` matched the baseline with `git diff --no-index`; temp dump removed