### PR TITLE
Return null for unidentified raster metadata

### DIFF
--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
@@ -199,6 +199,34 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
     }
 
     [Fact]
+    public async Task TryReadMetadataAsyncReturnsNullWhenFileCannotBeIdentifiedAsRaster()
+    {
+        using TemporaryDirectory workDirectory = new();
+        string rasterPath = Path.Combine(workDirectory.Path, "not-a-raster.tif");
+        await File.WriteAllTextAsync(rasterPath, "not a raster");
+
+        GeoReferencedRasterMetadata? metadata =
+            await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(
+                rasterPath,
+                CancellationToken.None);
+
+        Assert.Null(metadata);
+    }
+
+    [Fact]
+    public async Task TryReadMetadataAsyncReturnsNullWhenStreamCannotBeIdentifiedAsRaster()
+    {
+        using MemoryStream stream = new("not a raster"u8.ToArray());
+
+        GeoReferencedRasterMetadata? metadata =
+            await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(
+                stream,
+                CancellationToken.None);
+
+        Assert.Null(metadata);
+    }
+
+    [Fact]
     public void TryCropUsesMercatorVerticalInterpolationForEpsg3857()
     {
         using Image<Rgba32> sourceImage = new(4, 4);


### PR DESCRIPTION
## Summary
- make `TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync` return `null` when ImageSharp cannot identify a raster instead of throwing from the Try API
- keep unidentified file and stream raster inputs localized at the metadata boundary
- cover unidentified file and seekable stream inputs

## Verification
- `git diff --check`
- `dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter FullyQualifiedName~TerrainTextureGeoReferencedRasterSupportTests --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (18 passed)
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (1013 passed)
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020`, mesh `53395325`, packages `dem,bldg`, terrain mesh `grid` matched the baseline with `git diff --no-index`; temp dump removed