### PR TITLE
Type projected city object results

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -28,7 +28,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         IDefaultMaterialResolver materialResolver,
         Action<string>? progressReporter,
         CancellationToken cancellationToken,
-        out ImportedCityObject? heightMapCityObject)
+        out TerrainGridProjectedCityObject? heightMapCityObject)
     {
         cancellationToken.ThrowIfCancellationRequested();
         heightMapCityObject = null;
@@ -151,7 +151,17 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             Z = slotPosition.Z + centerZ,
         };
 
-        heightMapCityObject = new ImportedCityObject(
+        TerrainGridGeometry geometry = new(
+            Width: width,
+            Height: height,
+            Size: new Float2(extentX, extentZ),
+            MinHeight: minHeight,
+            MaxHeight: maxHeight,
+            HeightSamples: localHeights,
+            SampleCoverage: sampleCoverage,
+            UvScale: heightMapUvScale,
+            UvOffset: heightMapUvOffset);
+        ImportedCityObject projectedCityObject = new(
             ObjectKey: cityObject.SlotKey,
             DisplayName: cityObject.DisplayName,
             PackageName: cityObject.PackageName,
@@ -160,18 +170,10 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             Transform: new Transform3D(
                 ToContractFloat3(adjustedSlotPosition),
                 ToContractQuaternion(GridMeshTerrainRotation)),
-            Geometry: new TerrainGridGeometry(
-                Width: width,
-                Height: height,
-                Size: new Float2(extentX, extentZ),
-                MinHeight: minHeight,
-                MaxHeight: maxHeight,
-                HeightSamples: localHeights,
-                SampleCoverage: sampleCoverage,
-                UvScale: heightMapUvScale,
-                UvOffset: heightMapUvOffset),
+            Geometry: geometry,
             Materials: materials,
             SourceFileRelativePath: cityObject.SourceFileRelativePath);
+        heightMapCityObject = new TerrainGridProjectedCityObject(projectedCityObject, geometry);
         return true;
     }
 
@@ -375,3 +377,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         double MinZ,
         double MaxZ);
 }
+
+internal sealed record TerrainGridProjectedCityObject(
+    ImportedCityObject CityObject,
+    TerrainGridGeometry Geometry);

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -251,7 +251,7 @@ internal static class CityGmlParsedCityObjectProjection
             materialResolver,
             progressReporter,
             cancellationToken,
-            out ImportedCityObject? heightMapCityObject);
+            out TerrainGridProjectedCityObject? heightMapCityObject);
         if (!hasGrid)
         {
             return request.TerrainMeshMode == TerrainMeshMode.Dynamic
@@ -261,24 +261,23 @@ internal static class CityGmlParsedCityObjectProjection
 
         if (request.TerrainMeshMode == TerrainMeshMode.Grid)
         {
-            return heightMapCityObject!;
+            return heightMapCityObject!.CityObject;
         }
 
-        ImportedCityObject staticCityObject = CityGmlTriangleMeshCityObjectProjection.Project(
+        TriangleMeshProjectedCityObject staticCityObject = CityGmlTriangleMeshCityObjectProjection.ProjectTriangleMesh(
             cityObject,
             globalOriginPoint,
             globalCartesian,
             demTerrainTextureOverlay,
             materialResolver);
-        TriangleMeshGeometry staticMesh = AssertTriangleMeshGeometry(staticCityObject);
         TriangleMeshGeometry rebasedStaticMesh = TriangleMeshTransformRebaser.Rebase(
-            staticMesh,
-            staticCityObject.Transform,
-            heightMapCityObject!.Transform);
-        return heightMapCityObject with
+            staticCityObject.Geometry,
+            staticCityObject.CityObject.Transform,
+            heightMapCityObject!.CityObject.Transform);
+        return heightMapCityObject.CityObject with
         {
-            Geometry = new DynamicTerrainGeometry(rebasedStaticMesh, AssertTerrainGridGeometry(heightMapCityObject)),
-            Materials = staticCityObject.Materials,
+            Geometry = new DynamicTerrainGeometry(rebasedStaticMesh, heightMapCityObject.Geometry),
+            Materials = staticCityObject.CityObject.Materials,
         };
     }
 
@@ -450,18 +449,6 @@ internal static class CityGmlParsedCityObjectProjection
             origin.Longitude,
             origin.Altitude,
             cartesian);
-    }
-
-    private static TriangleMeshGeometry AssertTriangleMeshGeometry(ImportedCityObject cityObject)
-    {
-        return cityObject.Geometry as TriangleMeshGeometry
-            ?? throw new InvalidOperationException("Dynamic terrain static variant must be projected as a triangle mesh.");
-    }
-
-    private static TerrainGridGeometry AssertTerrainGridGeometry(ImportedCityObject cityObject)
-    {
-        return cityObject.Geometry as TerrainGridGeometry
-            ?? throw new InvalidOperationException("Dynamic terrain grid variant must be projected as a terrain grid.");
     }
 
     private static bool HasRenderableGeometry(ImportedCityObject cityObject)

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceProjectionPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceProjectionPolicy.cs
@@ -41,24 +41,24 @@ internal static class CityGmlSurfaceProjectionPolicy
             return [];
         }
 
-        SurfaceProjectionInfo[] candidates = surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
+        SurfaceProjectionInfo[] candidates = CreateSurfaceProjectionInfos(
+            surfaces,
+            cityObjectOrigin,
+            cityObjectCartesian);
 
         if (candidates.Length == 0)
         {
             return [];
         }
 
-        double objectMinimumY = candidates.Min(static info => info.MinimumY!.Value);
-        double objectMaximumY = candidates.Max(static info => info.MaximumY!.Value);
+        double objectMinimumY = candidates.Min(static info => info.MinimumY);
+        double objectMaximumY = candidates.Max(static info => info.MaximumY);
 
         return candidates
             .Where(static info => !info.IsGeneratedLod1RoofSurface)
             .Where(static info => info.IsNearHorizontal)
-            .Where(info => info.MaximumY!.Value <= objectMinimumY + BuildingBottomCullBandMeters)
-            .Where(info => objectMaximumY > info.MaximumY!.Value + BuildingBottomCullBandMeters)
+            .Where(info => info.MaximumY <= objectMinimumY + BuildingBottomCullBandMeters)
+            .Where(info => objectMaximumY > info.MaximumY + BuildingBottomCullBandMeters)
             .Select(static info => info.PolygonId)
             .ToHashSet(StringComparer.Ordinal);
     }
@@ -74,10 +74,10 @@ internal static class CityGmlSurfaceProjectionPolicy
             return null;
         }
 
-        SurfaceProjectionInfo[] surfaceInfos = surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
+        SurfaceProjectionInfo[] surfaceInfos = CreateSurfaceProjectionInfos(
+            surfaces,
+            cityObjectOrigin,
+            cityObjectCartesian);
         if (surfaceInfos.Length == 0)
         {
             return null;
@@ -118,43 +118,63 @@ internal static class CityGmlSurfaceProjectionPolicy
         return ComputePolygonNormal(positions);
     }
 
-    private static SurfaceProjectionInfo CreateSurfaceProjectionInfo(
-        ParsedSurface surface,
+    private static SurfaceProjectionInfo[] CreateSurfaceProjectionInfos(
+        IEnumerable<ParsedSurface> surfaces,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
+        List<SurfaceProjectionInfo> infos = [];
+        foreach (ParsedSurface surface in surfaces)
+        {
+            if (TryCreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian, out SurfaceProjectionInfo info))
+            {
+                infos.Add(info);
+            }
+        }
+
+        return [.. infos];
+    }
+
+    private static bool TryCreateSurfaceProjectionInfo(
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        out SurfaceProjectionInfo info)
+    {
+        info = default;
         Float3[] positions = surface.Vertices
             .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
             .ToArray();
         if (positions.Length == 0)
         {
-            return new SurfaceProjectionInfo(surface.PolygonId, null, null, false, IsGeneratedLod1RoofSurface(surface.PolygonId));
+            return false;
         }
 
         Float3? normal = ComputePolygonNormal(positions);
         bool isNearHorizontal = normal is not null && Math.Abs(normal.Y) >= 0.98;
 
-        return new SurfaceProjectionInfo(
+        info = new SurfaceProjectionInfo(
             surface.PolygonId,
             positions.Min(static position => position.Y),
             positions.Max(static position => position.Y),
             isNearHorizontal,
             IsGeneratedLod1RoofSurface(surface.PolygonId));
+        return true;
     }
 
     private static (double MinimumY, double MaximumY) ResolveFacadeUvVerticalRange(
         IReadOnlyList<SurfaceProjectionInfo> contextSurfaceInfos,
         IReadOnlyList<SurfaceProjectionInfo> allSurfaceInfos)
     {
-        double minimumY = contextSurfaceInfos.Min(static info => info.MinimumY!.Value);
-        double maximumY = contextSurfaceInfos.Max(static info => info.MaximumY!.Value);
+        double minimumY = contextSurfaceInfos.Min(static info => info.MinimumY);
+        double maximumY = contextSurfaceInfos.Max(static info => info.MaximumY);
         if (maximumY - minimumY > 1e-6 || contextSurfaceInfos.Count == allSurfaceInfos.Count)
         {
             return (minimumY, maximumY);
         }
 
-        double fallbackMinimumY = allSurfaceInfos.Min(static info => info.MinimumY!.Value);
-        double fallbackMaximumY = allSurfaceInfos.Max(static info => info.MaximumY!.Value);
+        double fallbackMinimumY = allSurfaceInfos.Min(static info => info.MinimumY);
+        double fallbackMaximumY = allSurfaceInfos.Max(static info => info.MaximumY);
         return fallbackMaximumY - fallbackMinimumY > maximumY - minimumY
             ? (fallbackMinimumY, fallbackMaximumY)
             : (minimumY, maximumY);
@@ -215,8 +235,8 @@ internal static class CityGmlSurfaceProjectionPolicy
 
     private readonly record struct SurfaceProjectionInfo(
         string PolygonId,
-        double? MinimumY,
-        double? MaximumY,
+        double MinimumY,
+        double MaximumY,
         bool IsNearHorizontal,
         bool IsGeneratedLod1RoofSurface);
 }

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
@@ -17,6 +17,21 @@ internal static class CityGmlTriangleMeshCityObjectProjection
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
+        return ProjectTriangleMesh(
+            cityObject,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlay,
+            materialResolver).CityObject;
+    }
+
+    internal static TriangleMeshProjectedCityObject ProjectTriangleMesh(
+        ParsedCityObject cityObject,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IDefaultMaterialResolver materialResolver)
+    {
         double? geometryHeightMeters = cityObject.GeometryHeightMeters
             ?? ResolveGeometryHeightMeters(cityObject.Surfaces);
         cityObject = GeneratedLod1RoofCityObjectFactory.Create(cityObject) with
@@ -104,16 +119,18 @@ internal static class CityGmlTriangleMeshCityObjectProjection
             materials.Add(CityGmlSurfaceMaterialResolver.CreateMaterialBinding(cityObject.ActualMeshCode, representativeSurface, materialIndex));
         }
 
-        return new ImportedCityObject(
+        TriangleMeshGeometry geometry = new(new ImportedMesh(vertices.ToArray(), submeshes.ToArray()));
+        ImportedCityObject projectedCityObject = new(
             ObjectKey: cityObject.SlotKey,
             DisplayName: cityObject.DisplayName,
             PackageName: cityObject.PackageName,
             ActualMeshCode: cityObject.ActualMeshCode,
             LodLevel: cityObject.LodLevel,
             Transform: new Transform3D(ToContractFloat3(slotPosition)),
-            Mesh: new ImportedMesh(vertices.ToArray(), submeshes.ToArray()),
+            Geometry: geometry,
             Materials: materials,
             SourceFileRelativePath: cityObject.SourceFileRelativePath);
+        return new TriangleMeshProjectedCityObject(projectedCityObject, geometry);
     }
 
     private static GeodeticPoint ResolveCityObjectOrigin(ParsedCityObject cityObject)
@@ -177,3 +194,7 @@ internal static class CityGmlTriangleMeshCityObjectProjection
 
     private static Float3 ToContractFloat3(Float3 value) => new(value.X, value.Y, value.Z);
 }
+
+internal sealed record TriangleMeshProjectedCityObject(
+    ImportedCityObject CityObject,
+    TriangleMeshGeometry Geometry);

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -152,10 +152,10 @@ internal static class GeneratedLod1RoofCityObjectFactory
             return false;
         }
 
-        SurfaceProjectionInfo[] surfaceInfos = cityObject.Surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
+        SurfaceProjectionInfo[] surfaceInfos = CreateSurfaceProjectionInfos(
+            cityObject.Surfaces,
+            cityObjectOrigin,
+            cityObjectCartesian);
         if (surfaceInfos.Length == 0)
         {
             return false;
@@ -188,19 +188,19 @@ internal static class GeneratedLod1RoofCityObjectFactory
         out ParsedSurface[]? topSurfaces)
     {
         topSurfaces = null;
-        SurfaceProjectionInfo[] surfaceInfos = cityObject.Surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
+        SurfaceProjectionInfo[] surfaceInfos = CreateSurfaceProjectionInfos(
+            cityObject.Surfaces,
+            cityObjectOrigin,
+            cityObjectCartesian);
         if (surfaceInfos.Length == 0)
         {
             return false;
         }
 
-        double objectMaximumY = surfaceInfos.Max(static info => info.MaximumY!.Value);
+        double objectMaximumY = surfaceInfos.Max(static info => info.MaximumY);
         SurfaceProjectionInfo[] topSurfaceInfos = surfaceInfos
             .Where(static info => info.IsNearHorizontal)
-            .Where(info => info.MaximumY!.Value >= objectMaximumY - 0.1)
+            .Where(info => info.MaximumY >= objectMaximumY - 0.1)
             .ToArray();
         if (topSurfaceInfos.Length == 0
             || topSurfaceInfos.Any(static info => info.Surface.InteriorRings.Length != 0))
@@ -217,10 +217,10 @@ internal static class GeneratedLod1RoofCityObjectFactory
             .ToArray();
         if (lowerSurfaceInfos.Length != 0)
         {
-            double objectMinimumY = lowerSurfaceInfos.Min(static info => info.MinimumY!.Value);
+            double objectMinimumY = lowerSurfaceInfos.Min(static info => info.MinimumY);
             topSurfaceInfos = topSurfaceInfos
-                .Where(info => info.MinimumY!.Value > objectMinimumY + BuildingBottomCullBandMeters)
-                .Where(info => info.MinimumY!.Value - NoWallRoofThicknessMeters > objectMinimumY + BuildingBottomCullBandMeters)
+                .Where(info => info.MinimumY > objectMinimumY + BuildingBottomCullBandMeters)
+                .Where(info => info.MinimumY - NoWallRoofThicknessMeters > objectMinimumY + BuildingBottomCullBandMeters)
                 .ToArray();
             if (topSurfaceInfos.Length == 0)
             {
@@ -442,22 +442,22 @@ internal static class GeneratedLod1RoofCityObjectFactory
         out Lod1RoofFootprint? footprint)
     {
         footprint = null;
-        SurfaceProjectionInfo[] surfaceInfos = cityObject.Surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
+        SurfaceProjectionInfo[] surfaceInfos = CreateSurfaceProjectionInfos(
+            cityObject.Surfaces,
+            cityObjectOrigin,
+            cityObjectCartesian);
         if (surfaceInfos.Length == 0)
         {
             return false;
         }
 
-        double objectMinimumY = surfaceInfos.Min(static info => info.MinimumY!.Value);
-        double objectMaximumY = surfaceInfos.Max(static info => info.MaximumY!.Value);
+        double objectMinimumY = surfaceInfos.Min(static info => info.MinimumY);
+        double objectMaximumY = surfaceInfos.Max(static info => info.MaximumY);
         double geometryHeight = objectMaximumY - objectMinimumY;
         SurfaceProjectionInfo[] topCandidates = surfaceInfos
             .Where(static info => info.IsNearHorizontal)
-            .Where(info => info.MaximumY!.Value >= objectMaximumY - 0.1)
-            .Where(info => info.MinimumY!.Value > objectMinimumY + BuildingBottomCullBandMeters)
+            .Where(info => info.MaximumY >= objectMaximumY - 0.1)
+            .Where(info => info.MinimumY > objectMinimumY + BuildingBottomCullBandMeters)
             .ToArray();
         if (topCandidates.Length != 1)
         {
@@ -495,27 +495,47 @@ internal static class GeneratedLod1RoofCityObjectFactory
         return true;
     }
 
-    private static SurfaceProjectionInfo CreateSurfaceProjectionInfo(
-        ParsedSurface surface,
+    private static SurfaceProjectionInfo[] CreateSurfaceProjectionInfos(
+        IEnumerable<ParsedSurface> surfaces,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian cityObjectCartesian)
     {
+        List<SurfaceProjectionInfo> infos = [];
+        foreach (ParsedSurface surface in surfaces)
+        {
+            if (TryCreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian, out SurfaceProjectionInfo info))
+            {
+                infos.Add(info);
+            }
+        }
+
+        return [.. infos];
+    }
+
+    private static bool TryCreateSurfaceProjectionInfo(
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian cityObjectCartesian,
+        out SurfaceProjectionInfo info)
+    {
+        info = default;
         Float3[] positions = surface.Vertices
             .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
             .ToArray();
         if (positions.Length == 0)
         {
-            return new SurfaceProjectionInfo(surface, null, null, false);
+            return false;
         }
 
         Float3? normal = ComputePolygonNormal(positions);
         bool isNearHorizontal = normal is not null && Math.Abs(normal.Y) >= 0.98;
 
-        return new SurfaceProjectionInfo(
+        info = new SurfaceProjectionInfo(
             surface,
             positions.Min(static position => position.Y),
             positions.Max(static position => position.Y),
             isNearHorizontal);
+        return true;
     }
 
     private static GeodeticPoint[] RemoveClosingPoint(GeodeticPoint[] vertices)
@@ -682,8 +702,8 @@ internal static class GeneratedLod1RoofCityObjectFactory
 
     private readonly record struct SurfaceProjectionInfo(
         ParsedSurface Surface,
-        double? MinimumY,
-        double? MaximumY,
+        double MinimumY,
+        double MaximumY,
         bool IsNearHorizontal);
 
     private readonly record struct NoWallRoofRing(

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceProjectionPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceProjectionPolicyTests.cs
@@ -101,6 +101,28 @@ public sealed class CityGmlSurfaceProjectionPolicyTests
     }
 
     [Fact]
+    public void TryCreateFacadeUvProjectionContextSkipsEmptySurfacesBeforeResolvingHeightRange()
+    {
+        GeodeticPoint origin = new(35.0, 139.0, 0.0);
+        LocalCartesian cartesian = CreateCartesian(origin);
+        ParsedSurface empty = CreateSurface("empty", ParsedSurfaceSemantic.Wall, []);
+        ParsedSurface wall = CreateSurface(
+            "wall",
+            ParsedSurfaceSemantic.Wall,
+            CreateVerticalQuadVertices(origin, widthMeters: 8.0, heightMeters: 6.0));
+
+        FacadeUvProjectionContext? context = CityGmlSurfaceProjectionPolicy.TryCreateFacadeUvProjectionContext(
+            "bldg",
+            [empty, wall],
+            origin,
+            cartesian);
+
+        Assert.NotNull(context);
+        Assert.InRange(context.Value.MinimumY, -1e-5, 1e-5);
+        Assert.InRange(context.Value.MaximumY, 6.0 - 1e-5, 6.0 + 1e-5);
+    }
+
+    [Fact]
     public void GetCulledSurfaceIdsBeforeProjectionKeepsGeneratedNoWallRoofBottomAtObjectMinimum()
     {
         GeodeticPoint origin = new(35.0, 139.0, 0.0);

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -509,6 +509,33 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
     }
 
     [Fact]
+    public void CreateSkipsEmptySurfacesBeforeSelectingGeneratedRoofTopCandidate()
+    {
+        ParsedSurface empty = CreateSurface("empty", ParsedSurfaceSemantic.Roof, [], null, texturePayload: null);
+        ParsedSurface top = CreateSurface(
+            "lod1-top",
+            ParsedSurfaceSemantic.Roof,
+            altitude: 10.0);
+        ParsedSurface bottom = CreateSurface(
+            "lod1-bottom",
+            ParsedSurfaceSemantic.Ground,
+            altitude: 0.0);
+        ParsedCityObject cityObject = CreateCityObject(
+            [empty, top, bottom],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with
+            {
+                RoofShape = new BuildingCodeValue<CityGmlRoofShape>(CityGmlRoofShape.Shed, "shed"),
+            });
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.DoesNotContain(generated.Surfaces, static surface => surface.PolygonId == "lod1-top");
+        Assert.Contains(generated.Surfaces, static surface => surface.PolygonId == "empty");
+        Assert.Equal(4, generated.Surfaces.Count(static surface => surface.PolygonId.Contains("_generated_", System.StringComparison.Ordinal)));
+    }
+
+    [Fact]
     public void CreateSkipsObjectThatAlreadyHasGeneratedRoofSurface()
     {
         ParsedCityObject cityObject = CreateCityObject(


### PR DESCRIPTION
## Summary
- make surface projection info represent only projected surfaces with concrete height ranges
- skip empty surfaces at projection-info creation before facade UV, bottom cull, and generated LOD1 roof selection logic
- remove nullable height checks and null-forgiving height access from both projection policy paths

## Verification
- `dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~CityGmlSurfaceProjectionPolicyTests|FullyQualifiedName~GeneratedLod1RoofCityObjectFactoryTests" --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (36 passed)
- `git diff --check`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (1015 passed)
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020`, mesh `53395325`, packages `dem,bldg`, terrain mesh `grid` matched the baseline with `git diff --no-index`; temp dump removed