### PR TITLE
Localize parsed CityGML surface failures

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectReader.cs
@@ -26,7 +26,7 @@ internal static class CityGmlParsedCityObjectReader
     {
         string objectTypeName = cityObjectElement.Name.LocalName;
         string objectId = GetAttribute(cityObjectElement, Gml + "id") ?? objectTypeName;
-        string? displayName = cityObjectElement.Elements(Gml + "name").FirstOrDefault()?.Value.Trim();
+        string displayName = cityObjectElement.Elements(Gml + "name").FirstOrDefault()?.Value.Trim() ?? objectId;
         if (string.IsNullOrWhiteSpace(displayName))
         {
             displayName = objectId;
@@ -34,7 +34,7 @@ internal static class CityGmlParsedCityObjectReader
 
         string resolvedActualMeshCode = CityGmlMeshCodeBoundsFilter.ResolveActualMeshCode(
             packageName,
-            displayName!,
+            displayName,
             objectId,
             actualMeshCode,
             sharedAcrossMeshCodes);
@@ -64,13 +64,7 @@ internal static class CityGmlParsedCityObjectReader
             return null;
         }
 
-        ParsedSurface[] surfaces = preferredSurfaceElements
-            .Select(surfaceElement => CityGmlParsedSurfaceReader.Parse(surfaceElement, appearanceStore))
-            .Where(static surface => surface is not null)
-            .Select(static surface => surface!)
-            .Select(surface => CityGmlParsedSurfaceReader.ApplyPackageDefaults(packageName, surface))
-            .OrderBy(static surface => ParsedSurfaceStableSortKey.Create(surface), StringComparer.Ordinal)
-            .ToArray();
+        ParsedSurface[] surfaces = ParseSurfaces(preferredSurfaceElements, packageName, appearanceStore);
 
         if (surfaces.Length == 0)
         {
@@ -91,7 +85,7 @@ internal static class CityGmlParsedCityObjectReader
         string slotKey = SanitizeIdentifier($"{packageName}_{fileStem}_{objectId}");
         return new ParsedCityObject(
             slotKey,
-            displayName!,
+            displayName,
             packageName,
             resolvedActualMeshCode,
             lodLevel,
@@ -103,6 +97,27 @@ internal static class CityGmlParsedCityObjectReader
             MeasuredHeightMeters: measuredHeightMeters,
             BuildingAttributes: buildingAttributes,
             SourceMeshCode: actualMeshCode);
+    }
+
+    private static ParsedSurface[] ParseSurfaces(
+        IEnumerable<XElement> surfaceElements,
+        string packageName,
+        ICityGmlAppearanceStore appearanceStore)
+    {
+        List<ParsedSurface> surfaces = [];
+        foreach (XElement surfaceElement in surfaceElements)
+        {
+            if (CityGmlParsedSurfaceReader.TryParse(surfaceElement, appearanceStore) is not { } surface)
+            {
+                continue;
+            }
+
+            surfaces.Add(CityGmlParsedSurfaceReader.ApplyPackageDefaults(packageName, surface));
+        }
+
+        return surfaces
+            .OrderBy(static surface => ParsedSurfaceStableSortKey.Create(surface), StringComparer.Ordinal)
+            .ToArray();
     }
 
     private static string? GetAttribute(XElement element, XName attributeName)

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedSurfaceReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedSurfaceReader.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Xml.Linq;
@@ -11,7 +10,7 @@ internal static class CityGmlParsedSurfaceReader
 {
     private static readonly XNamespace Gml = "http://www.opengis.net/gml";
 
-    internal static ParsedSurface? Parse(XElement polygonElement, ICityGmlAppearanceStore appearanceStore)
+    internal static ParsedSurface? TryParse(XElement polygonElement, ICityGmlAppearanceStore appearanceStore)
     {
         ArgumentNullException.ThrowIfNull(polygonElement);
         ArgumentNullException.ThrowIfNull(appearanceStore);
@@ -26,24 +25,15 @@ internal static class CityGmlParsedSurfaceReader
 
         string polygonId = GetAttribute(polygonElement, Gml + "id") ?? CreateStableElementId("polygon", polygonElement);
         CityGmlResolvedAppearance appearance = appearanceStore.Resolve(polygonId);
-        ParsedRing? exteriorParsedRing = ParseRing(
+        if (TryParseRing(
             exteriorRing,
             appearance.RingUvsByRingId,
-            fallbackRingId: polygonId);
-        if (exteriorParsedRing is null)
+            fallbackRingId: polygonId) is not { } exteriorParsedRing)
         {
             return null;
         }
 
-        ParsedRing[] interiorRings = polygonElement
-            .Elements(Gml + "interior")
-            .Select(interiorElement => ParseRing(
-                interiorElement.Element(Gml + "LinearRing"),
-                appearance.RingUvsByRingId,
-                fallbackRingId: null))
-            .Where(static ring => ring is not null)
-            .Select(static ring => ring!)
-            .ToArray();
+        ParsedRing[] interiorRings = ParseInteriorRings(polygonElement, appearance.RingUvsByRingId);
 
         return new ParsedSurface(
             PolygonId: polygonId,
@@ -65,7 +55,26 @@ internal static class CityGmlParsedSurfaceReader
             : surface;
     }
 
-    private static ParsedRing? ParseRing(
+    private static ParsedRing[] ParseInteriorRings(
+        XElement polygonElement,
+        IReadOnlyDictionary<string, IReadOnlyList<Float2>>? ringUvsByRingId)
+    {
+        List<ParsedRing> rings = [];
+        foreach (XElement interiorElement in polygonElement.Elements(Gml + "interior"))
+        {
+            if (TryParseRing(
+                interiorElement.Element(Gml + "LinearRing"),
+                ringUvsByRingId,
+                fallbackRingId: null) is { } ring)
+            {
+                rings.Add(ring);
+            }
+        }
+
+        return rings.ToArray();
+    }
+
+    private static ParsedRing? TryParseRing(
         XElement? ringElement,
         IReadOnlyDictionary<string, IReadOnlyList<Float2>>? ringUvsByRingId,
         string? fallbackRingId)

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
@@ -182,6 +182,95 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
         Assert.InRange(attributes.EaveHeight.Value!.Value, 9.699999, 9.700001);
     }
 
+    [Fact]
+    public async Task SourceFilePipeline_StreamParsedCityObjectsAsync_SkipsInvalidInteriorRingsBeforeSurfaceConstruction()
+    {
+        string xml =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <core:CityModel xmlns:core="http://www.opengis.net/citygml/2.0" xmlns:gml="http://www.opengis.net/gml" xmlns:bldg="http://www.opengis.net/citygml/building/2.0">
+              <gml:boundedBy>
+                <gml:Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/6697" srsDimension="3">
+                  <gml:lowerCorner>35.0000 139.0000 0</gml:lowerCorner>
+                  <gml:upperCorner>35.0100 139.0100 12</gml:upperCorner>
+                </gml:Envelope>
+              </gml:boundedBy>
+              <core:cityObjectMember>
+                <bldg:Building gml:id="bldg-1">
+                  <bldg:lod2MultiSurface>
+                    <gml:MultiSurface>
+                      <gml:surfaceMember>
+                        <bldg:WallSurface>
+                          <gml:Polygon gml:id="poly-1">
+                            <gml:exterior>
+                              <gml:LinearRing gml:id="ring-1">
+                                <gml:posList>35.0000 139.0000 0 35.0000 139.0010 0 35.0000 139.0010 12 35.0000 139.0000 12 35.0000 139.0000 0</gml:posList>
+                              </gml:LinearRing>
+                            </gml:exterior>
+                            <gml:interior>
+                              <gml:LinearRing gml:id="invalid-interior">
+                                <gml:posList>35.0002 139.0002 1 35.0002 139.0004 1</gml:posList>
+                              </gml:LinearRing>
+                            </gml:interior>
+                            <gml:interior />
+                          </gml:Polygon>
+                        </bldg:WallSurface>
+                      </gml:surfaceMember>
+                    </gml:MultiSurface>
+                  </bldg:lod2MultiSurface>
+                </bldg:Building>
+              </core:cityObjectMember>
+            </core:CityModel>
+            """;
+        InMemoryDatasetContentSource datasetSource = new(Encoding.UTF8.GetBytes(xml));
+
+        ParsedCityObject parsedCityObject = await ParseSingleBuildingAsync(datasetSource);
+        ParsedSurface surface = Assert.Single(parsedCityObject.Surfaces);
+
+        Assert.Empty(surface.InteriorRings);
+    }
+
+    [Fact]
+    public async Task SourceFilePipeline_StreamParsedCityObjectsAsync_SkipsPolygonWithInvalidExteriorRing()
+    {
+        string xml =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <core:CityModel xmlns:core="http://www.opengis.net/citygml/2.0" xmlns:gml="http://www.opengis.net/gml" xmlns:bldg="http://www.opengis.net/citygml/building/2.0">
+              <gml:boundedBy>
+                <gml:Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/6697" srsDimension="3">
+                  <gml:lowerCorner>35.0000 139.0000 0</gml:lowerCorner>
+                  <gml:upperCorner>35.0100 139.0100 12</gml:upperCorner>
+                </gml:Envelope>
+              </gml:boundedBy>
+              <core:cityObjectMember>
+                <bldg:Building gml:id="bldg-1">
+                  <bldg:lod2MultiSurface>
+                    <gml:MultiSurface>
+                      <gml:surfaceMember>
+                        <bldg:WallSurface>
+                          <gml:Polygon gml:id="poly-1">
+                            <gml:exterior>
+                              <gml:LinearRing gml:id="invalid-exterior">
+                                <gml:posList>35.0000 139.0000 0 35.0000 139.0010 0</gml:posList>
+                              </gml:LinearRing>
+                            </gml:exterior>
+                          </gml:Polygon>
+                        </bldg:WallSurface>
+                      </gml:surfaceMember>
+                    </gml:MultiSurface>
+                  </bldg:lod2MultiSurface>
+                </bldg:Building>
+              </core:cityObjectMember>
+            </core:CityModel>
+            """;
+        InMemoryDatasetContentSource datasetSource = new(Encoding.UTF8.GetBytes(xml));
+
+        ParsedCityObject? parsedCityObject = await TryParseSingleBuildingAsync(datasetSource);
+
+        Assert.Null(parsedCityObject);
+    }
+
     private static async Task<ParsedCityObject> ParseSingleBuildingWithDetailAttributeAsync(string detailAttributeXml)
     {
         string xml =
@@ -226,6 +315,14 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
 
     private static async Task<ParsedCityObject> ParseSingleBuildingAsync(InMemoryDatasetContentSource datasetSource)
     {
+        ParsedCityObject? parsedCityObject = await TryParseSingleBuildingAsync(datasetSource);
+
+        Assert.NotNull(parsedCityObject);
+        return parsedCityObject;
+    }
+
+    private static async Task<ParsedCityObject?> TryParseSingleBuildingAsync(InMemoryDatasetContentSource datasetSource)
+    {
         SourceFileDescriptor sourceFile = new(
             "udx/bldg/53394525/metadata.gml",
             "bldg",
@@ -249,7 +346,7 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
             break;
         }
 
-        return parsedCityObject!;
+        return parsedCityObject;
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- localize invalid CityGML polygon/ring parsing at the source-file reader boundary
- replace nullable LINQ filtering plus null-forgiving surface/ring projections with explicit non-null parsed arrays
- keep `ParsedRing`/`ParsedSurface` shape unchanged instead of adding same-shape wrappers

## Verification
- `dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter FullyQualifiedName~LocalCityGmlSourceFileParserStreamingTests --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink canonical dump matched `runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json`; temporary dump removed