### PR TITLE
Require quad road surfaces before edge selection

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -353,8 +353,7 @@ internal static class CityGmlParsedCityObjectProjection
         ParsedSurface surface,
         ParsedCityObject cityObject)
     {
-        if (surface.InteriorRings.Length != 0
-            || surface.ExteriorRing.Vertices.Length != 4)
+        if (surface.InteriorRings.Length != 0)
         {
             return [surface];
         }
@@ -375,12 +374,17 @@ internal static class CityGmlParsedCityObjectProjection
         Float3[] positions = surface.ExteriorRing.Vertices
             .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
             .ToArray();
+        if (!RoadSurfaceQuad.TryCreate(surface.ExteriorRing, positions, out RoadSurfaceQuad quad))
+        {
+            return [surface];
+        }
+
         if (!IsNearHorizontalSurface(positions))
         {
             return [surface];
         }
 
-        EdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(surface.ExteriorRing, positions);
+        EdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(quad);
         return TerrainAlignedTransportationSurfaceSplitter.Split(surface, positions, edgePair);
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -363,6 +363,11 @@ internal static class CityGmlParsedCityObjectProjection
             return [surface];
         }
 
+        if (surface.ExteriorRing.Vertices.Length != 4)
+        {
+            return [surface];
+        }
+
         GeodeticPoint cityObjectOrigin = ResolveCityObjectOrigin(cityObject);
         LocalCartesian? cityObjectCartesian = cityObject.ReferenceSystem.IsGeographic
             ? new LocalCartesian(

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
@@ -67,6 +67,11 @@ internal static class GeneratedRoadMarkingCityObjectFactory
             return [];
         }
 
+        if (vertices.Length != 4)
+        {
+            return [];
+        }
+
         Float3[] positions = vertices
             .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
             .ToArray();

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
@@ -62,7 +62,7 @@ internal static class GeneratedRoadMarkingCityObjectFactory
         LocalCartesian? cityObjectCartesian)
     {
         GeodeticPoint[] vertices = surface.ExteriorRing.Vertices;
-        if (vertices.Length != 4 || surface.InteriorRings.Length != 0)
+        if (surface.InteriorRings.Length != 0)
         {
             return [];
         }
@@ -70,13 +70,18 @@ internal static class GeneratedRoadMarkingCityObjectFactory
         Float3[] positions = vertices
             .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
             .ToArray();
+        if (!RoadSurfaceQuad.TryCreate(surface.ExteriorRing, positions, out RoadSurfaceQuad quad))
+        {
+            return [];
+        }
+
         Float3? normal = PolygonNormal.Compute(positions);
         if (normal is null || Math.Abs(normal.Y) < 0.7)
         {
             return [];
         }
 
-        EdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(vertices, positions);
+        EdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(quad);
         if (edgePair.Length < 1.0 || edgePair.Width < 0.3)
         {
             return [];

--- a/src/PlateauResoniteLink/Application/Importing/RoadSurfaceEdgePairSelector.cs
+++ b/src/PlateauResoniteLink/Application/Importing/RoadSurfaceEdgePairSelector.cs
@@ -4,71 +4,46 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal static class RoadSurfaceEdgePairSelector
 {
-    internal static EdgePairSelection Select(
-        GeodeticPoint[] vertices,
-        Float3[] positions)
+    internal static EdgePairSelection Select(RoadSurfaceQuad quad)
     {
-        ValidateQuadInputs(vertices, positions);
-
-        double edge01 = Distance(positions[0], positions[1]);
-        double edge12 = Distance(positions[1], positions[2]);
-        double edge23 = Distance(positions[2], positions[3]);
-        double edge30 = Distance(positions[3], positions[0]);
+        double edge01 = Distance(quad.Position0, quad.Position1);
+        double edge12 = Distance(quad.Position1, quad.Position2);
+        double edge23 = Distance(quad.Position2, quad.Position3);
+        double edge30 = Distance(quad.Position3, quad.Position0);
 
         double pair01Length = (edge01 + edge23) * 0.5;
         double pair12Length = (edge12 + edge30) * 0.5;
 
         return pair01Length >= pair12Length
             ? new EdgePairSelection(
-                [vertices[0], vertices[1]],
-                [vertices[3], vertices[2]],
-                [positions[0], positions[1]],
-                [positions[3], positions[2]],
-                Side0Uvs: null,
-                Side1Uvs: null,
+                [quad.Vertex0, quad.Vertex1],
+                [quad.Vertex3, quad.Vertex2],
+                [quad.Position0, quad.Position1],
+                [quad.Position3, quad.Position2],
+                CreateUvs(quad.Uv0, quad.Uv1),
+                CreateUvs(quad.Uv3, quad.Uv2),
                 pair01Length,
-                (Distance(positions[0], positions[3]) + Distance(positions[1], positions[2])) * 0.5,
+                (Distance(quad.Position0, quad.Position3) + Distance(quad.Position1, quad.Position2)) * 0.5,
                 edge01,
                 edge23)
             : new EdgePairSelection(
-                [vertices[1], vertices[2]],
-                [vertices[0], vertices[3]],
-                [positions[1], positions[2]],
-                [positions[0], positions[3]],
-                Side0Uvs: null,
-                Side1Uvs: null,
+                [quad.Vertex1, quad.Vertex2],
+                [quad.Vertex0, quad.Vertex3],
+                [quad.Position1, quad.Position2],
+                [quad.Position0, quad.Position3],
+                CreateUvs(quad.Uv1, quad.Uv2),
+                CreateUvs(quad.Uv0, quad.Uv3),
                 pair12Length,
-                (Distance(positions[1], positions[0]) + Distance(positions[2], positions[3])) * 0.5,
+                (Distance(quad.Position1, quad.Position0) + Distance(quad.Position2, quad.Position3)) * 0.5,
                 edge12,
                 edge30);
     }
 
-    internal static EdgePairSelection Select(
-        ParsedRing ring,
-        Float3[] positions)
+    private static Float2[]? CreateUvs(Float2? first, Float2? second)
     {
-        ArgumentNullException.ThrowIfNull(ring);
-
-        EdgePairSelection pair = Select(ring.Vertices, positions);
-        if (ring.UVs is null || ring.UVs.Count != ring.Vertices.Length)
-        {
-            return pair;
-        }
-
-        bool usesFirstEdge = AreSamePoint(pair.Side0[0], ring.Vertices[0])
-            && AreSamePoint(pair.Side0[1], ring.Vertices[1]);
-
-        return usesFirstEdge
-            ? pair with
-            {
-                Side0Uvs = [ring.UVs[0], ring.UVs[1]],
-                Side1Uvs = [ring.UVs[3], ring.UVs[2]],
-            }
-            : pair with
-            {
-                Side0Uvs = [ring.UVs[1], ring.UVs[2]],
-                Side1Uvs = [ring.UVs[0], ring.UVs[3]],
-            };
+        return first is not null && second is not null
+            ? [first, second]
+            : null;
     }
 
     private static double Distance(Float3 left, Float3 right)
@@ -78,27 +53,65 @@ internal static class RoadSurfaceEdgePairSelector
         double deltaZ = left.Z - right.Z;
         return Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY) + (deltaZ * deltaZ));
     }
+}
 
-    private static void ValidateQuadInputs<TPoint>(TPoint[] vertices, Float3[] positions)
+internal readonly record struct RoadSurfaceQuad(
+    GeodeticPoint Vertex0,
+    GeodeticPoint Vertex1,
+    GeodeticPoint Vertex2,
+    GeodeticPoint Vertex3,
+    Float3 Position0,
+    Float3 Position1,
+    Float3 Position2,
+    Float3 Position3,
+    Float2? Uv0,
+    Float2? Uv1,
+    Float2? Uv2,
+    Float2? Uv3)
+{
+    internal static bool TryCreate(
+        ParsedRing ring,
+        Float3[] positions,
+        out RoadSurfaceQuad quad)
+    {
+        ArgumentNullException.ThrowIfNull(ring);
+        ArgumentNullException.ThrowIfNull(positions);
+
+        Float2[]? uvs = ring.UVs is { Count: 4 }
+            ? [ring.UVs[0], ring.UVs[1], ring.UVs[2], ring.UVs[3]]
+            : null;
+        return TryCreate(ring.Vertices, positions, uvs, out quad);
+    }
+
+    private static bool TryCreate(
+        GeodeticPoint[] vertices,
+        Float3[] positions,
+        Float2[]? uvs,
+        out RoadSurfaceQuad quad)
     {
         ArgumentNullException.ThrowIfNull(vertices);
         ArgumentNullException.ThrowIfNull(positions);
-        if (vertices.Length != 4)
+
+        if (vertices.Length != 4 || positions.Length != 4)
         {
-            throw new ArgumentException("Road surface edge-pair selection requires exactly four vertices.", nameof(vertices));
+            quad = default;
+            return false;
         }
 
-        if (positions.Length != 4)
-        {
-            throw new ArgumentException("Road surface edge-pair selection requires exactly four positions.", nameof(positions));
-        }
-    }
-
-    private static bool AreSamePoint(GeodeticPoint left, GeodeticPoint right)
-    {
-        return Math.Abs(left.Latitude - right.Latitude) < 1e-8
-            && Math.Abs(left.Longitude - right.Longitude) < 1e-8
-            && Math.Abs(left.Altitude - right.Altitude) < 1e-8;
+        quad = new RoadSurfaceQuad(
+            vertices[0],
+            vertices[1],
+            vertices[2],
+            vertices[3],
+            positions[0],
+            positions[1],
+            positions[2],
+            positions[3],
+            uvs?[0],
+            uvs?[1],
+            uvs?[2],
+            uvs?[3]);
+        return true;
     }
 }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
@@ -114,26 +114,15 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
     }
 
     [Fact]
-    public void RoadSurfaceEdgePairSelectorRejectsNonQuadInputsWithClearPrecondition()
+    public void CreateSkipsNonQuadRoadSurfaceAtQuadBoundary()
     {
-        GeodeticPoint[] vertices =
-        [
-            new(0.0, 0.0, 0.0),
-            new(1.0, 0.0, 0.0),
-            new(1.0, 1.0, 0.0),
-        ];
-        Float3[] positions =
-        [
-            new(0.0, 0.0, 0.0),
-            new(1.0, 0.0, 0.0),
-            new(1.0, 0.0, 1.0),
-        ];
+        ParsedCityObject road = CreateRoadObject(
+            packageName: "tran",
+            surface: CreateTriangleRoadSurface("triangle-road"));
 
-        ArgumentException exception = Assert.Throws<ArgumentException>(
-            () => RoadSurfaceEdgePairSelector.Select(vertices, positions));
+        ParsedCityObject? marking = GeneratedRoadMarkingCityObjectFactory.Create(road, new GeodeticPoint(0.0, 0.0, 0.0), cityObjectCartesian: null);
 
-        Assert.Equal("vertices", exception.ParamName);
-        Assert.Contains("exactly four vertices", exception.Message, StringComparison.Ordinal);
+        Assert.Null(marking);
     }
 
     private static ParsedCityObject CreateRoadObject(string packageName, ParsedSurface surface)
@@ -178,5 +167,23 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
             InteriorRings: [],
             new ColorRgba(0.2, 0.2, 0.2, 1.0),
             texturePayload);
+    }
+
+    private static ParsedSurface CreateTriangleRoadSurface(string polygonId)
+    {
+        GeodeticPoint[] vertices =
+        [
+            new(0.0, 0.0, 0.0),
+            new(12.0, 0.0, 0.0),
+            new(12.0, 4.0, 0.0),
+        ];
+
+        return new ParsedSurface(
+            polygonId,
+            ParsedSurfaceSemantic.Ground,
+            new ParsedRing($"{polygonId}-ring", vertices, UVs: null),
+            InteriorRings: [],
+            new ColorRgba(0.2, 0.2, 0.2, 1.0),
+            TexturePayload: null);
     }
 }


### PR DESCRIPTION
## Summary
- Replace the road edge-pair selector raw-array precondition with a `RoadSurfaceQuad` input.
- Localize non-quad road surface handling at the road marking and terrain-aligned subdivision boundaries.
- Replace the exception-focused non-quad selector test with a boundary skip regression.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink canonical dump matched `runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json`