### PR TITLE
Separate planned texture identity roles

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -494,7 +494,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 
         Uri? albedoTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             plannedMaterial.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Albedo);
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo);
         if (albedoTextureUri is not null)
         {
             BatchPlanComponentLocator albedoTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
@@ -511,7 +511,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 
         Uri? normalTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             plannedMaterial.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Normal);
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Normal);
         if (normalTextureUri is not null)
         {
             BatchPlanComponentLocator normalTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
@@ -532,7 +532,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 
         Uri? heightTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             plannedMaterial.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Height);
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Height);
         if (heightTextureUri is not null)
         {
             BatchPlanComponentLocator heightTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
@@ -553,7 +553,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 
         Uri? metallicTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             plannedMaterial.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Metallic);
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic);
         if (metallicTextureUri is not null)
         {
             BatchPlanComponentLocator metallicTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
@@ -571,7 +571,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 
         Uri? emissionTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             plannedMaterial.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Emission);
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Emission);
         if (emissionTextureUri is not null)
         {
             BatchPlanComponentLocator emissionTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -118,7 +118,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
 
     public static Uri? TryGetPlannedTextureUri(
         IEnumerable<PlannedTextureAsset> textures,
-        ResoniteSceneMaterialConventions.TextureMemberRole role)
+        ResoniteSceneMaterialConventions.PlannedTextureRole role)
     {
         ArgumentNullException.ThrowIfNull(textures);
 
@@ -166,15 +166,15 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         AddTextureComponentReference(
             batchBuilder,
             plannedMaterial,
-            materialContainerSlotId,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
-            "AlbedoTexture",
-            materialMembers);
+                materialContainerSlotId,
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo,
+                "AlbedoTexture",
+                materialMembers);
         if (AddTextureComponentReference(
                 batchBuilder,
                 plannedMaterial,
                 materialContainerSlotId,
-                ResoniteSceneMaterialConventions.TextureMemberRole.Normal,
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Normal,
                 "NormalMap",
                 materialMembers))
         {
@@ -188,7 +188,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
                 batchBuilder,
                 plannedMaterial,
                 materialContainerSlotId,
-                ResoniteSceneMaterialConventions.TextureMemberRole.Height,
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Height,
                 "HeightMap",
                 materialMembers))
         {
@@ -200,15 +200,18 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
 
         Uri? metallicTextureUri = TryGetPlannedTextureUri(
             plannedMaterial.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Metallic);
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic);
         if (metallicTextureUri is not null)
         {
+            ResoniteSceneMaterialConventions.TextureMemberRole metallicMemberRole =
+                ResoniteSceneMaterialConventions.ToTextureMemberRole(
+                    ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic);
             ResoniteBatchOperations.PendingBatchComponent metallicTexture = batchBuilder.AddComponent(
                 materialContainerSlotId,
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
                 ResoniteSceneMaterialConventions.CreateTextureMembers(
                     metallicTextureUri,
-                    ResoniteSceneMaterialConventions.TextureMemberRole.Metallic));
+                    metallicMemberRole));
             materialMembers["MetallicMap"] = new Reference
             {
                 TargetID = metallicTexture.LocalId.Value,
@@ -223,7 +226,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
                 batchBuilder,
                 plannedMaterial,
                 materialContainerSlotId,
-                ResoniteSceneMaterialConventions.TextureMemberRole.Emission,
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Emission,
                 "EmissiveMap",
                 materialMembers))
         {
@@ -241,7 +244,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         ResoniteBatchOperations.BatchActionBuilder batchBuilder,
         PlannedDedicatedMaterialAsset plannedMaterial,
         string materialContainerSlotId,
-        ResoniteSceneMaterialConventions.TextureMemberRole textureRole,
+        ResoniteSceneMaterialConventions.PlannedTextureRole textureRole,
         string materialMemberName,
         Dictionary<string, Member> materialMembers)
     {
@@ -254,7 +257,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         ResoniteBatchOperations.PendingBatchComponent textureComponent = batchBuilder.AddComponent(
             materialContainerSlotId,
             "[FrooxEngine]FrooxEngine.StaticTexture2D",
-            ResoniteSceneMaterialConventions.CreateTextureMembers(textureUri, textureRole));
+            ResoniteSceneMaterialConventions.CreateTextureMembers(
+                textureUri,
+                ResoniteSceneMaterialConventions.ToTextureMemberRole(textureRole)));
         materialMembers[materialMemberName] = new Reference
         {
             TargetID = textureComponent.LocalId.Value,
@@ -396,23 +401,23 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         List<PlannedTextureAsset> textures = [];
         AddPlannedTextureAsset(
             textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo,
             await albedoTextureTask);
         AddPlannedTextureAsset(
             textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Normal,
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Normal,
             await normalTextureTask);
         AddPlannedTextureAsset(
             textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Height,
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Height,
             await heightTextureTask);
         AddPlannedTextureAsset(
             textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Metallic,
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic,
             await metallicTextureTask);
         AddPlannedTextureAsset(
             textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Emission,
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Emission,
             await emissionTextureTask);
         return textures;
     }
@@ -482,7 +487,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
 
     private static void AddPlannedTextureAsset(
         List<PlannedTextureAsset> textures,
-        ResoniteSceneMaterialConventions.TextureMemberRole role,
+        ResoniteSceneMaterialConventions.PlannedTextureRole role,
         Uri? assetUri)
     {
         if (assetUri is null)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -24,6 +24,15 @@ internal static class ResoniteSceneMaterialConventions
         TerrainMainTextureOverride,
     }
 
+    internal enum PlannedTextureRole
+    {
+        Albedo,
+        Normal,
+        Height,
+        Metallic,
+        Emission,
+    }
+
     internal readonly record struct TextureSamplingPolicy(
         string? PreferredProfile,
         string? WrapMode);
@@ -128,17 +137,30 @@ internal static class ResoniteSceneMaterialConventions
                 || material.DepthOffset is not null);
     }
 
-    public static TextureIdentity CreateTextureIdentity(TextureMemberRole role)
+    public static TextureIdentity CreateTextureIdentity(PlannedTextureRole role)
     {
         return new TextureIdentity(role switch
         {
-            TextureMemberRole.Albedo => "albedo",
-            TextureMemberRole.Normal => "normal",
-            TextureMemberRole.Height => "height",
-            TextureMemberRole.Metallic => "metallic",
-            TextureMemberRole.Emission => "emission",
-            _ => throw new InvalidOperationException($"Texture role '{role}' does not have a planned texture identity."),
+            PlannedTextureRole.Albedo => "albedo",
+            PlannedTextureRole.Normal => "normal",
+            PlannedTextureRole.Height => "height",
+            PlannedTextureRole.Metallic => "metallic",
+            PlannedTextureRole.Emission => "emission",
+            _ => throw new InvalidOperationException($"Planned texture role '{role}' is unsupported."),
         });
+    }
+
+    public static TextureMemberRole ToTextureMemberRole(PlannedTextureRole role)
+    {
+        return role switch
+        {
+            PlannedTextureRole.Albedo => TextureMemberRole.Albedo,
+            PlannedTextureRole.Normal => TextureMemberRole.Normal,
+            PlannedTextureRole.Height => TextureMemberRole.Height,
+            PlannedTextureRole.Metallic => TextureMemberRole.Metallic,
+            PlannedTextureRole.Emission => TextureMemberRole.Emission,
+            _ => throw new InvalidOperationException($"Planned texture role '{role}' is unsupported."),
+        };
     }
 
     public static TextureSamplingPolicy GetTextureSamplingPolicy(TextureMemberRole role)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -123,20 +123,20 @@ public sealed class ResoniteMaterialPlanningTests
 
         Assert.Equal(importCountAfterBase + 3, ImportedRgba32Textures(client).Count);
         Assert.NotEqual(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Albedo));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo));
         Assert.NotEqual(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Normal),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Normal));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Normal),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Normal));
         Assert.NotEqual(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Height),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Height));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Height),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Height));
         Assert.Equal(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Metallic),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Metallic));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic));
         Assert.Equal(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Emission),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Emission));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Emission),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Emission));
     }
 
     [Fact]
@@ -163,23 +163,23 @@ public sealed class ResoniteMaterialPlanningTests
 
         Assert.Equal(importCountAfterBase + 2, ImportedRgba32Textures(client).Count);
         Assert.NotEqual(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Albedo));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo));
         Assert.Equal(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Normal),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Normal));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Normal),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Normal));
         Assert.Equal(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Height),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Height));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Height),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Height));
         Assert.Equal(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Metallic),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Metallic));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic));
         Assert.Null(ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             basePlannedAsset.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Emission));
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Emission));
         Assert.NotNull(ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             colorVariantPlannedAsset.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Emission));
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Emission));
     }
 
     [Fact]
@@ -271,7 +271,7 @@ public sealed class ResoniteMaterialPlanningTests
             material,
             [
                 new PlannedTextureAsset(
-                    ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
+                    ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo),
                     new Uri("resdb:///texture/albedo", UriKind.Absolute)),
             ],
             PreserveDedicatedMaterialSlot: false);
@@ -294,10 +294,10 @@ public sealed class ResoniteMaterialPlanningTests
             material,
             [
                 new PlannedTextureAsset(
-                    ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
+                    ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo),
                     new Uri("resdb:///texture/albedo", UriKind.Absolute)),
                 new PlannedTextureAsset(
-                    ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.TextureMemberRole.Emission),
+                    ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.PlannedTextureRole.Emission),
                     new Uri("resdb:///texture/emission", UriKind.Absolute)),
             ],
             PreserveDedicatedMaterialSlot: false);
@@ -443,7 +443,7 @@ public sealed class ResoniteMaterialPlanningTests
 
     private static Uri GetTextureUri(
         PlannedDedicatedMaterialAsset plannedAsset,
-        ResoniteSceneMaterialConventions.TextureMemberRole role)
+        ResoniteSceneMaterialConventions.PlannedTextureRole role)
     {
         return ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedAsset.Textures, role)
             ?? throw new InvalidOperationException($"Missing planned texture role '{role}'.");

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -57,23 +57,23 @@ public sealed class ResoniteSceneMaterialConventionsTests
         Assert.Equal(
             new TextureIdentity("albedo"),
             ResoniteSceneMaterialConventions.CreateTextureIdentity(
-                ResoniteSceneMaterialConventions.TextureMemberRole.Albedo));
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo));
         Assert.Equal(
             new TextureIdentity("normal"),
             ResoniteSceneMaterialConventions.CreateTextureIdentity(
-                ResoniteSceneMaterialConventions.TextureMemberRole.Normal));
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Normal));
         Assert.Equal(
             new TextureIdentity("height"),
             ResoniteSceneMaterialConventions.CreateTextureIdentity(
-                ResoniteSceneMaterialConventions.TextureMemberRole.Height));
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Height));
         Assert.Equal(
             new TextureIdentity("metallic"),
             ResoniteSceneMaterialConventions.CreateTextureIdentity(
-                ResoniteSceneMaterialConventions.TextureMemberRole.Metallic));
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic));
         Assert.Equal(
             new TextureIdentity("emission"),
             ResoniteSceneMaterialConventions.CreateTextureIdentity(
-                ResoniteSceneMaterialConventions.TextureMemberRole.Emission));
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Emission));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Split planned texture identity roles from Resonite texture member roles.
- Keep `TerrainMainTextureOverride` available only for component member creation, not for planned texture identity lookup.
- Update material planning and batch emission paths to use `PlannedTextureRole` for planned texture assets.

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --filter "FullyQualifiedName~ResoniteMaterialPlanningTests|FullyQualifiedName~ResoniteSceneMaterialConventionsTests|FullyQualifiedName~ResoniteSceneBatchEmissionPlanningTests" --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink canonical dump matched `runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json`.