### PR TITLE
Require typed common material for shared planner

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
@@ -54,11 +54,12 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
             material = ResoniteTerrainOverlayMaterialContract.ValidateMaterial(cityObject, materialIndex, material);
             reportMaterialStep($"Creating material {materialIndex + 1}/{cityObject.Materials.Count}.");
             if (material.AssetBinding.IsSharedCommon
-                && material.CommonMaterial is not null)
+                && material.CommonMaterial is { } commonMaterial)
             {
                 materialPlanTasks[materialIndex] = PlanSharedCommonRendererMaterialAsync(
                     state,
                     material,
+                    commonMaterial,
                     preparedTextureUrisByPayload,
                     preparedTerrainTextureUrisByOverlay,
                     preparedTerrainTexturePropertyBlockComponentsByMeshCode,
@@ -86,13 +87,14 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
     private static async Task<(PlannedMaterialAsset MaterialAsset, PlannedRendererMaterialBinding RendererBinding)> PlanSharedCommonRendererMaterialAsync(
         LiveSendRunState runState,
         ResoniteMaterialBinding sourceMaterial,
+        DefaultCommonMaterialMember member,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
         IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
         IReadOnlyDictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode,
         CancellationToken cancellationToken)
     {
-        DefaultCommonMaterialMember member = sourceMaterial.CommonMaterial
-            ?? throw new InvalidOperationException("Common renderer material requires a typed common material member.");
+        ArgumentNullException.ThrowIfNull(member);
+
         string familySlotName = ResoniteSceneMaterialConventions.GetCommonMaterialFamilySlotName(
             SceneImportContractMapper.ToInternal(member.CreateBinding([0])));
         if (runState.Materials.CommonMaterialFamilyWarmupTasks.TryGetValue(familySlotName, out Task? familyWarmupTask))


### PR DESCRIPTION
## Summary
- Require a typed `DefaultCommonMaterialMember` before entering the shared common material planner.
- Remove the planner-local runtime mismatch exception for a missing common material member.
- Keep the broader `ResolvedMaterial` / `MaterialBinding` closed-union cleanup as a separate PR unit, since that affects the neutral import contract and non-DEM material flow.

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --filter "FullyQualifiedName~ResoniteSceneMaterialPlanComposer|FullyQualifiedName~ResoniteLiveSceneImportTargetAssetReuseTests|FullyQualifiedName~ResoniteMaterialPlanningTests" --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink canonical dump matched `runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json`.