### PR TITLE
Require typed common material bindings

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -94,7 +94,7 @@ internal static class CityGmlSurfaceMaterialResolver
                 cityObject.ActualMeshCode,
                 group.First(),
                 materialIndex))
-            .Where(static material => material.ReuseScope == MaterialReuseScope.Shared)
+            .Where(static material => material is SharedCommonMaterialBinding)
             .ToArray();
     }
 
@@ -158,7 +158,43 @@ internal static class CityGmlSurfaceMaterialResolver
             representativeSurface.Material.TextureOffset,
             representativeSurface.Material.TerrainOverlay,
             representativeSurface.Material.CommonMaterial);
-        return new MaterialBinding(
+        if (commonMaterial is not null)
+        {
+            if (representativeSurface.Material.ReuseScope == MaterialReuseScope.Shared)
+            {
+                return new SharedCommonMaterialBinding(
+                    BaseColor: baseColor,
+                    MaterialType: representativeSurface.Material.MaterialType,
+                    TexturePayload: representativeSurface.Material.TexturePayload,
+                    TextureSourceKind: representativeSurface.Material.TextureSourceKind,
+                    Projection: representativeSurface.Material.Projection,
+                    DepthOffset: representativeSurface.DepthOffset,
+                    SubmeshIndices: [materialIndex],
+                    commonMaterial,
+                    TextureScale: representativeSurface.Material.TextureScale,
+                    Family: representativeSurface.Material.Family,
+                    TextureOffset: representativeSurface.Material.TextureOffset,
+                    TerrainOverlayMaterial: terrainOverlayMaterial,
+                    BundledVariantIndex: representativeSurface.Material.BundledVariantIndex);
+            }
+
+            return new PresentationCommonMaterialBinding(
+                BaseColor: baseColor,
+                MaterialType: representativeSurface.Material.MaterialType,
+                TexturePayload: representativeSurface.Material.TexturePayload,
+                TextureSourceKind: representativeSurface.Material.TextureSourceKind,
+                Projection: representativeSurface.Material.Projection,
+                DepthOffset: representativeSurface.DepthOffset,
+                SubmeshIndices: [materialIndex],
+                commonMaterial,
+                TextureScale: representativeSurface.Material.TextureScale,
+                Family: representativeSurface.Material.Family,
+                TextureOffset: representativeSurface.Material.TextureOffset,
+                TerrainOverlayMaterial: terrainOverlayMaterial,
+                BundledVariantIndex: representativeSurface.Material.BundledVariantIndex);
+        }
+
+        return new PresentationMaterialBinding(
             BaseColor: baseColor,
             MaterialType: representativeSurface.Material.MaterialType,
             TexturePayload: representativeSurface.Material.TexturePayload,
@@ -169,10 +205,8 @@ internal static class CityGmlSurfaceMaterialResolver
             TextureScale: representativeSurface.Material.TextureScale,
             Family: representativeSurface.Material.Family,
             TextureOffset: representativeSurface.Material.TextureOffset,
-            ReuseScope: representativeSurface.Material.ReuseScope,
             TerrainOverlayMaterial: terrainOverlayMaterial,
-            BundledVariantIndex: representativeSurface.Material.BundledVariantIndex,
-            CommonMaterial: commonMaterial);
+            BundledVariantIndex: representativeSurface.Material.BundledVariantIndex);
     }
 
     private static ResolvedSurfaceMaterial ResolveSurfaceMaterial(

--- a/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinition.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinition.cs
@@ -80,7 +80,7 @@ internal sealed class BundledCommonMaterialDefinition : CommonMaterialDefinition
             ? null
             : ToContract(bundledVariant.TextureSet.TextureOffset);
 
-        return new MaterialBinding(
+        return new SharedCommonMaterialBinding(
             BaseColor: CanonicalBaseColor,
             MaterialType: MaterialType.Standard,
             TexturePayload: null,
@@ -91,9 +91,8 @@ internal sealed class BundledCommonMaterialDefinition : CommonMaterialDefinition
             TextureScale: textureScale,
             Family: family,
             TextureOffset: textureOffset,
-            ReuseScope: MaterialReuseScope.Shared,
-            BundledVariantIndex: VariantIndex,
-            CommonMaterial: member);
+            commonMaterial: member,
+            BundledVariantIndex: VariantIndex);
     }
 }
 
@@ -112,7 +111,7 @@ internal sealed class GenericAlbedoCommonMaterialDefinition : CommonMaterialDefi
         DefaultCommonMaterialMember member,
         IReadOnlyList<int> submeshIndices)
     {
-        return new MaterialBinding(
+        return new SharedCommonMaterialBinding(
             BaseColor: CanonicalBaseColor,
             MaterialType: MaterialType.Standard,
             TexturePayload: null,
@@ -120,8 +119,7 @@ internal sealed class GenericAlbedoCommonMaterialDefinition : CommonMaterialDefi
             Projection: Projection,
             DepthOffset: DepthOffset,
             SubmeshIndices: submeshIndices,
-            ReuseScope: MaterialReuseScope.Shared,
-            CommonMaterial: member);
+            commonMaterial: member);
     }
 }
 
@@ -140,7 +138,7 @@ internal sealed class VertexColorCommonMaterialDefinition : CommonMaterialDefini
         DefaultCommonMaterialMember member,
         IReadOnlyList<int> submeshIndices)
     {
-        return new MaterialBinding(
+        return new SharedCommonMaterialBinding(
             BaseColor: CanonicalBaseColor,
             MaterialType: MaterialType.VertexColor,
             TexturePayload: null,
@@ -148,7 +146,6 @@ internal sealed class VertexColorCommonMaterialDefinition : CommonMaterialDefini
             Projection: Projection,
             DepthOffset: DepthOffset,
             SubmeshIndices: submeshIndices,
-            ReuseScope: MaterialReuseScope.Shared,
-            CommonMaterial: member);
+            commonMaterial: member);
     }
 }

--- a/src/PlateauResoniteLink/Application/Importing/ImportedDynamicMaterialUvNormalizer.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ImportedDynamicMaterialUvNormalizer.cs
@@ -78,10 +78,7 @@ public static class ImportedDynamicMaterialUvNormalizer
                 TextureScale = null,
                 TextureOffset = null,
             };
-            return normalized with
-            {
-                CommonMaterial = ResolveCommonMaterial(normalized),
-            };
+            return WithResolvedCommonMaterial(normalized);
         }
 
         if (!ShouldNormalizeTextureTransform(material))
@@ -94,10 +91,7 @@ public static class ImportedDynamicMaterialUvNormalizer
             TextureScale = null,
             TextureOffset = null,
         };
-        return transformNormalized with
-        {
-            CommonMaterial = ResolveCommonMaterial(transformNormalized),
-        };
+        return WithResolvedCommonMaterial(transformNormalized);
     }
 
     public static Float2 ApplyTextureTransform(
@@ -186,6 +180,60 @@ public static class ImportedDynamicMaterialUvNormalizer
             material.TextureOffset,
             material.TerrainOverlay,
             material.CommonMaterial);
+    }
+
+    private static MaterialBinding WithResolvedCommonMaterial(MaterialBinding material)
+    {
+        DefaultCommonMaterialMember? commonMaterial = ResolveCommonMaterial(material);
+        if (commonMaterial is null)
+        {
+            return new PresentationMaterialBinding(
+                material.BaseColor,
+                material.MaterialType,
+                material.TexturePayload,
+                material.TextureSourceKind,
+                material.Projection,
+                material.DepthOffset,
+                material.SubmeshIndices,
+                material.TextureScale,
+                material.Family,
+                material.TextureOffset,
+                material.TerrainOverlayMaterial,
+                material.BundledVariantIndex);
+        }
+
+        if (material.ReuseScope == MaterialReuseScope.Shared)
+        {
+            return new SharedCommonMaterialBinding(
+                material.BaseColor,
+                material.MaterialType,
+                material.TexturePayload,
+                material.TextureSourceKind,
+                material.Projection,
+                material.DepthOffset,
+                material.SubmeshIndices,
+                commonMaterial,
+                material.TextureScale,
+                material.Family,
+                material.TextureOffset,
+                material.TerrainOverlayMaterial,
+                material.BundledVariantIndex);
+        }
+
+        return new PresentationCommonMaterialBinding(
+            material.BaseColor,
+            material.MaterialType,
+            material.TexturePayload,
+            material.TextureSourceKind,
+            material.Projection,
+            material.DepthOffset,
+            material.SubmeshIndices,
+            commonMaterial,
+            material.TextureScale,
+            material.Family,
+            material.TextureOffset,
+            material.TerrainOverlayMaterial,
+            material.BundledVariantIndex);
     }
 
     private static void EnsureUniqueMaterialAssignments(ImportedCityObject cityObject)

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -202,7 +202,7 @@ public sealed record TerrainOverlayMaterialBinding(
     ThirdRegionalMeshCode MeshCode,
     TerrainTextureOverlay Overlay);
 
-public sealed record MaterialBinding(
+public abstract record MaterialBinding(
     ColorRgba BaseColor,
     MaterialType MaterialType,
     TexturePayload? TexturePayload,
@@ -213,12 +213,124 @@ public sealed record MaterialBinding(
     Float2? TextureScale = null,
     string? Family = null,
     Float2? TextureOffset = null,
-    MaterialReuseScope ReuseScope = MaterialReuseScope.PerObject,
     TerrainOverlayMaterialBinding? TerrainOverlayMaterial = null,
-    int? BundledVariantIndex = null,
-    DefaultCommonMaterialMember? CommonMaterial = null)
+    int? BundledVariantIndex = null)
 {
     public TerrainTextureOverlay? TerrainOverlay => TerrainOverlayMaterial?.Overlay;
 
     public string? TerrainMeshCode => TerrainOverlayMaterial?.MeshCode.Value;
+
+    public abstract MaterialReuseScope ReuseScope { get; }
+
+    public virtual DefaultCommonMaterialMember? CommonMaterial => null;
+}
+
+public sealed record PresentationMaterialBinding : MaterialBinding
+{
+    public PresentationMaterialBinding(
+        ColorRgba BaseColor,
+        MaterialType MaterialType,
+        TexturePayload? TexturePayload,
+        TextureSourceKind TextureSourceKind,
+        MaterialProjection Projection,
+        MaterialDepthOffset? DepthOffset,
+        IReadOnlyList<int> SubmeshIndices,
+        Float2? TextureScale = null,
+        string? Family = null,
+        Float2? TextureOffset = null,
+        TerrainOverlayMaterialBinding? TerrainOverlayMaterial = null,
+        int? BundledVariantIndex = null)
+        : base(
+            BaseColor,
+            MaterialType,
+            TexturePayload,
+            TextureSourceKind,
+            Projection,
+            DepthOffset,
+            SubmeshIndices,
+            TextureScale,
+            Family,
+            TextureOffset,
+            TerrainOverlayMaterial,
+            BundledVariantIndex)
+    {
+    }
+
+    public override MaterialReuseScope ReuseScope => MaterialReuseScope.PerObject;
+}
+
+public sealed record PresentationCommonMaterialBinding : MaterialBinding
+{
+    public PresentationCommonMaterialBinding(
+        ColorRgba BaseColor,
+        MaterialType MaterialType,
+        TexturePayload? TexturePayload,
+        TextureSourceKind TextureSourceKind,
+        MaterialProjection Projection,
+        MaterialDepthOffset? DepthOffset,
+        IReadOnlyList<int> SubmeshIndices,
+        DefaultCommonMaterialMember commonMaterial,
+        Float2? TextureScale = null,
+        string? Family = null,
+        Float2? TextureOffset = null,
+        TerrainOverlayMaterialBinding? TerrainOverlayMaterial = null,
+        int? BundledVariantIndex = null)
+        : base(
+            BaseColor,
+            MaterialType,
+            TexturePayload,
+            TextureSourceKind,
+            Projection,
+            DepthOffset,
+            SubmeshIndices,
+            TextureScale,
+            Family,
+            TextureOffset,
+            TerrainOverlayMaterial,
+            BundledVariantIndex)
+    {
+        CommonMaterial = commonMaterial ?? throw new ArgumentNullException(nameof(commonMaterial));
+    }
+
+    public override MaterialReuseScope ReuseScope => MaterialReuseScope.PerObject;
+
+    public override DefaultCommonMaterialMember CommonMaterial { get; }
+}
+
+public sealed record SharedCommonMaterialBinding : MaterialBinding
+{
+    public SharedCommonMaterialBinding(
+        ColorRgba BaseColor,
+        MaterialType MaterialType,
+        TexturePayload? TexturePayload,
+        TextureSourceKind TextureSourceKind,
+        MaterialProjection Projection,
+        MaterialDepthOffset? DepthOffset,
+        IReadOnlyList<int> SubmeshIndices,
+        DefaultCommonMaterialMember commonMaterial,
+        Float2? TextureScale = null,
+        string? Family = null,
+        Float2? TextureOffset = null,
+        TerrainOverlayMaterialBinding? TerrainOverlayMaterial = null,
+        int? BundledVariantIndex = null)
+        : base(
+            BaseColor,
+            MaterialType,
+            TexturePayload,
+            TextureSourceKind,
+            Projection,
+            DepthOffset,
+            SubmeshIndices,
+            TextureScale,
+            Family,
+            TextureOffset,
+            TerrainOverlayMaterial,
+            BundledVariantIndex)
+    {
+        CommonMaterial = commonMaterial ?? throw new ArgumentNullException(nameof(commonMaterial));
+    }
+
+    public override MaterialReuseScope ReuseScope => MaterialReuseScope.Shared;
+
+    public override DefaultCommonMaterialMember CommonMaterial { get; }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemBakeEntryFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemBakeEntryFactory.cs
@@ -92,11 +92,11 @@ internal sealed class NonDemBakeEntryFactory(
             TextureOffset = null,
             Family = null,
             TerrainOverlayMaterial = null,
-            AssetScope = ResoniteMaterialAssetScope.Common,
+            AssetBinding = ResoniteMaterialAssetBinding.SharedCommon(
+                material.DepthOffset is null
+                    ? CommonMaterialCatalog.Create().VertexColor.Uv
+                    : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv),
             SubmeshIndices = [submeshIndex],
-            CommonMaterial = material.DepthOffset is null
-                ? CommonMaterialCatalog.Create().VertexColor.Uv
-                : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv,
         };
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
@@ -66,7 +66,7 @@ internal sealed class NonDemBakedGeometryComposer : INonDemBakedGeometryComposer
                     TexturePayload: ResoniteTextureImportFactory.CreatePayloadFromImage(
                         atlasImage ?? throw new InvalidOperationException("Non-DEM atlas image is required when an atlas layout exists."),
                         identity: textureIdentity),
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv));
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)));
         }
 
         foreach (IGrouping<NonDemPreservedMaterialGroupingKey, NonDemOrderedPreservedSubmeshEntry> preservedGroup in candidates

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeMaterialClassifier.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeMaterialClassifier.cs
@@ -116,6 +116,6 @@ internal static class NonDemCityObjectBakeMaterialClassifier
 
     private static bool CanPreserveAsCommonMaterial(ResoniteMaterialBinding material)
     {
-        return material.CommonMaterial is not null;
+        return material.AssetBinding.IsSharedCommon;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemPreservedMaterialGrouping.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemPreservedMaterialGrouping.cs
@@ -14,7 +14,8 @@ internal static class NonDemPreservedMaterialGrouping
     public static NonDemPreservedMaterialGroupingKey CreateKey(ResoniteMaterialBinding material)
     {
         ResoniteMaterialBinding normalizedMaterial = NormalizeMaterial(material);
-        if (normalizedMaterial.CommonMaterial is not null)
+        if (normalizedMaterial.AssetBinding.IsSharedCommon
+            && normalizedMaterial.CommonMaterial is not null)
         {
             return new NonDemPreservedMaterialGroupingKey(
                 normalizedMaterial.CommonMaterial,
@@ -27,14 +28,14 @@ internal static class NonDemPreservedMaterialGrouping
                 default,
                 default,
                 default,
-                default,
+                normalizedMaterial.AssetScope,
                 default,
                 default,
                 normalizedMaterial.TerrainMeshCode);
         }
 
         return new NonDemPreservedMaterialGroupingKey(
-            null,
+            normalizedMaterial.CommonMaterial,
             normalizedMaterial.BaseColor,
             normalizedMaterial.MaterialType,
             normalizedMaterial.TexturePayload,
@@ -65,9 +66,13 @@ internal static class NonDemPreservedMaterialGrouping
                 return false;
             }
 
-            if (x.CommonMaterial is not null)
+            bool xIsSharedCommon = IsSharedCommonMaterialKey(x);
+            bool yIsSharedCommon = IsSharedCommonMaterialKey(y);
+            if (xIsSharedCommon || yIsSharedCommon)
             {
-                return ResoniteTexturePayloadReferenceComparer.Instance.Equals(x.TexturePayload, y.TexturePayload)
+                return xIsSharedCommon
+                    && yIsSharedCommon
+                    && ResoniteTexturePayloadReferenceComparer.Instance.Equals(x.TexturePayload, y.TexturePayload)
                     && x.TextureSourceKind == y.TextureSourceKind
                     && EqualityComparer<TerrainTextureOverlay?>.Default.Equals(x.TerrainOverlay, y.TerrainOverlay)
                     && string.Equals(x.TerrainMeshCode, y.TerrainMeshCode, StringComparison.Ordinal);
@@ -92,7 +97,7 @@ internal static class NonDemPreservedMaterialGrouping
         {
             HashCode hash = new();
             hash.Add(obj.CommonMaterial);
-            if (obj.CommonMaterial is not null)
+            if (IsSharedCommonMaterialKey(obj))
             {
                 AddTexturePayloadHash(ref hash, obj.TexturePayload);
                 hash.Add(obj.TextureSourceKind);
@@ -115,6 +120,12 @@ internal static class NonDemPreservedMaterialGrouping
             hash.Add(obj.BundledVariantIndex);
             hash.Add(obj.TerrainMeshCode, StringComparer.Ordinal);
             return hash.ToHashCode();
+        }
+
+        private static bool IsSharedCommonMaterialKey(NonDemPreservedMaterialGroupingKey key)
+        {
+            return key.CommonMaterial is not null
+                && key.AssetScope == ResoniteMaterialAssetScope.Common;
         }
 
         private static void AddTexturePayloadHash(ref HashCode hash, ResoniteTexturePayload? texturePayload)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteDynamicMaterialUvNormalizer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteDynamicMaterialUvNormalizer.cs
@@ -14,7 +14,8 @@ public static class ResoniteDynamicMaterialUvNormalizer
 
         return material.MaterialType == ResoniteMaterialType.Standard
             && material.Projection == ResoniteMaterialProjection.Uv
-            && material.AssetScope != ResoniteMaterialAssetScope.Common
+            && (material.AssetScope != ResoniteMaterialAssetScope.Common
+                || material.TextureSourceKind == ResoniteTextureSourceKind.Dataset)
             && HasNormalizableTextureTransform(material);
     }
 
@@ -55,7 +56,7 @@ public static class ResoniteDynamicMaterialUvNormalizer
         {
             Geometry = new ResoniteTriangleMeshGeometry(new ResoniteImportedMesh(normalizedVertices, normalizedSubmeshes)),
             Materials = cityObject.Materials
-                .Select(NormalizeMaterialBinding)
+                .Select(NormalizeMaterialBindingAfterMeshUvNormalization)
                 .ToArray(),
         };
     }
@@ -77,6 +78,28 @@ public static class ResoniteDynamicMaterialUvNormalizer
                 TextureScale = null,
                 TextureOffset = null,
             };
+        }
+
+        if (material.AssetScope == ResoniteMaterialAssetScope.Common)
+        {
+            return material;
+        }
+
+        return ShouldNormalizeTextureTransform(material)
+            ? material with
+            {
+                TextureScale = null,
+                TextureOffset = null,
+            }
+            : material;
+    }
+
+    private static ResoniteMaterialBinding NormalizeMaterialBindingAfterMeshUvNormalization(ResoniteMaterialBinding material)
+    {
+        ResoniteMaterialBinding normalizedMaterial = NormalizeMaterialBinding(material);
+        if (normalizedMaterial != material)
+        {
+            return normalizedMaterial;
         }
 
         return ShouldNormalizeTextureTransform(material)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteDynamicMaterialUvNormalizer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteDynamicMaterialUvNormalizer.cs
@@ -15,7 +15,8 @@ public static class ResoniteDynamicMaterialUvNormalizer
         return material.MaterialType == ResoniteMaterialType.Standard
             && material.Projection == ResoniteMaterialProjection.Uv
             && (material.AssetScope != ResoniteMaterialAssetScope.Common
-                || material.TextureSourceKind == ResoniteTextureSourceKind.Dataset)
+                || material.TextureSourceKind == ResoniteTextureSourceKind.Dataset
+                || ResoniteSceneMaterialConventions.ShouldDemoteBundledCommonMaterial(material))
             && HasNormalizableTextureTransform(material);
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialBinding.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialBinding.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using PlateauResoniteLink.Application.Importing;
@@ -13,15 +14,72 @@ public sealed record ResoniteMaterialBinding(
     ResoniteMaterialProjection Projection,
     ResoniteMaterialDepthOffset? DepthOffset,
     IReadOnlyList<int> SubmeshIndices,
+    ResoniteMaterialAssetBinding AssetBinding,
     ResoniteFloat2? TextureScale = null,
     string? Family = null,
     ResoniteFloat2? TextureOffset = null,
-    ResoniteMaterialAssetScope AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped,
     TerrainOverlayMaterialBinding? TerrainOverlayMaterial = null,
-    int? BundledVariantIndex = null,
-    DefaultCommonMaterialMember? CommonMaterial = null)
+    int? BundledVariantIndex = null)
 {
     public TerrainTextureOverlay? TerrainOverlay => TerrainOverlayMaterial?.Overlay;
 
     public string? TerrainMeshCode => TerrainOverlayMaterial?.MeshCode.Value;
+
+    public ResoniteMaterialAssetScope AssetScope => AssetBinding.AssetScope;
+
+    public DefaultCommonMaterialMember? CommonMaterial => AssetBinding.CommonMaterial;
+}
+
+public abstract record ResoniteMaterialAssetBinding
+{
+    private ResoniteMaterialAssetBinding()
+    {
+    }
+
+    public static ResoniteMaterialAssetBinding Presentation { get; } = new PresentationMaterialAssetBinding();
+
+    public static ResoniteMaterialAssetBinding PresentationCommon(DefaultCommonMaterialMember commonMaterial)
+        => new PresentationCommonMaterialAssetBinding(commonMaterial);
+
+    public static ResoniteMaterialAssetBinding SharedCommon(DefaultCommonMaterialMember commonMaterial)
+        => new SharedCommonMaterialAssetBinding(commonMaterial);
+
+    public ResoniteMaterialAssetScope AssetScope => this is SharedCommonMaterialAssetBinding
+        ? ResoniteMaterialAssetScope.Common
+        : ResoniteMaterialAssetScope.PresentationSlotScoped;
+
+    public DefaultCommonMaterialMember? CommonMaterial => this is ICommonMaterialAssetBinding commonBinding
+        ? commonBinding.Member
+        : null;
+
+    public bool IsSharedCommon => this is SharedCommonMaterialAssetBinding;
+
+    private interface ICommonMaterialAssetBinding
+    {
+        DefaultCommonMaterialMember Member { get; }
+    }
+
+    private sealed record PresentationMaterialAssetBinding : ResoniteMaterialAssetBinding;
+
+    private sealed record PresentationCommonMaterialAssetBinding : ResoniteMaterialAssetBinding, ICommonMaterialAssetBinding
+    {
+        public PresentationCommonMaterialAssetBinding(DefaultCommonMaterialMember commonMaterial)
+        {
+            ArgumentNullException.ThrowIfNull(commonMaterial);
+            Member = commonMaterial;
+        }
+
+        public DefaultCommonMaterialMember Member { get; }
+    }
+
+    private sealed record SharedCommonMaterialAssetBinding : ResoniteMaterialAssetBinding, ICommonMaterialAssetBinding
+    {
+        public SharedCommonMaterialAssetBinding(DefaultCommonMaterialMember commonMaterial)
+        {
+            ArgumentNullException.ThrowIfNull(commonMaterial);
+            Member = commonMaterial;
+        }
+
+        public DefaultCommonMaterialMember Member { get; }
+    }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -83,22 +83,16 @@ internal static class ResoniteSceneMaterialConventions
         ArgumentNullException.ThrowIfNull(material);
         material = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
 
-        if (material.AssetScope == ResoniteMaterialAssetScope.Common
-            && material.MaterialType == ResoniteMaterialType.Standard
-            && material.TexturePayload is null
-            && material.TerrainOverlay is null
-            && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
-            && !string.IsNullOrWhiteSpace(material.Family)
-            && (!IsWhiteBaseColor(material.BaseColor)
-                || HasNonDefaultBundledTextureTransform(material)
-                || material.DepthOffset is not null))
+        if (ShouldDemoteBundledCommonMaterial(material))
         {
-            return material with
+            ResoniteMaterialBinding demotedMaterial = material with
             {
                 AssetBinding = material.CommonMaterial is { } commonMaterial
                     ? ResoniteMaterialAssetBinding.PresentationCommon(commonMaterial)
                     : ResoniteMaterialAssetBinding.Presentation,
             };
+
+            return ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(demotedMaterial);
         }
 
         if (material.AssetScope == ResoniteMaterialAssetScope.PresentationSlotScoped
@@ -117,6 +111,21 @@ internal static class ResoniteSceneMaterialConventions
         }
 
         return material;
+    }
+
+    internal static bool ShouldDemoteBundledCommonMaterial(ResoniteMaterialBinding material)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+
+        return material.AssetScope == ResoniteMaterialAssetScope.Common
+            && material.MaterialType == ResoniteMaterialType.Standard
+            && material.TexturePayload is null
+            && material.TerrainOverlay is null
+            && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
+            && !string.IsNullOrWhiteSpace(material.Family)
+            && (!IsWhiteBaseColor(material.BaseColor)
+                || HasNonDefaultBundledTextureTransform(material)
+                || material.DepthOffset is not null);
     }
 
     public static TextureIdentity CreateTextureIdentity(TextureMemberRole role)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -87,7 +87,6 @@ internal static class ResoniteSceneMaterialConventions
             && material.MaterialType == ResoniteMaterialType.Standard
             && material.TexturePayload is null
             && material.TerrainOverlay is null
-            && material.CommonMaterial is null
             && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
             && !string.IsNullOrWhiteSpace(material.Family)
             && (!IsWhiteBaseColor(material.BaseColor)
@@ -96,7 +95,9 @@ internal static class ResoniteSceneMaterialConventions
         {
             return material with
             {
-                AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped,
+                AssetBinding = material.CommonMaterial is { } commonMaterial
+                    ? ResoniteMaterialAssetBinding.PresentationCommon(commonMaterial)
+                    : ResoniteMaterialAssetBinding.Presentation,
             };
         }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
@@ -53,7 +53,8 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
                 cityObject.Materials[materialIndex]);
             material = ResoniteTerrainOverlayMaterialContract.ValidateMaterial(cityObject, materialIndex, material);
             reportMaterialStep($"Creating material {materialIndex + 1}/{cityObject.Materials.Count}.");
-            if (material.CommonMaterial is not null)
+            if (material.AssetBinding.IsSharedCommon
+                && material.CommonMaterial is not null)
             {
                 materialPlanTasks[materialIndex] = PlanSharedCommonRendererMaterialAsync(
                     state,

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -122,8 +122,7 @@ internal static class SceneImportContractMapper
             binding.TextureScale is null ? null : ToInternal(binding.TextureScale),
             binding.Family,
             binding.TextureOffset is null ? null : ToInternal(binding.TextureOffset),
-            binding.ReuseScope == MaterialReuseScope.Shared
-                && (binding.TerrainOverlayMaterial is null || binding.CommonMaterial is not null)
+            binding is SharedCommonMaterialBinding
                 ? ResoniteMaterialAssetScope.Common
                 : ResoniteMaterialAssetScope.PresentationSlotScoped,
             binding.TerrainOverlayMaterial,

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -112,22 +112,29 @@ internal static class SceneImportContractMapper
     internal static ResoniteMaterialBinding ToInternal(MaterialBinding binding)
     {
         return new ResoniteMaterialBinding(
-            ToInternal(binding.BaseColor),
-            ToInternal(binding.MaterialType),
-            binding.TexturePayload is null ? null : ToInternal(binding.TexturePayload),
-            ToInternal(binding.TextureSourceKind),
-            ToInternal(binding.Projection),
-            binding.DepthOffset is null ? null : ToInternal(binding.DepthOffset),
-            binding.SubmeshIndices,
-            binding.TextureScale is null ? null : ToInternal(binding.TextureScale),
-            binding.Family,
-            binding.TextureOffset is null ? null : ToInternal(binding.TextureOffset),
-            binding is SharedCommonMaterialBinding
-                ? ResoniteMaterialAssetScope.Common
-                : ResoniteMaterialAssetScope.PresentationSlotScoped,
-            binding.TerrainOverlayMaterial,
-            binding.BundledVariantIndex,
-            binding.CommonMaterial);
+            BaseColor: ToInternal(binding.BaseColor),
+            MaterialType: ToInternal(binding.MaterialType),
+            TexturePayload: binding.TexturePayload is null ? null : ToInternal(binding.TexturePayload),
+            TextureSourceKind: ToInternal(binding.TextureSourceKind),
+            Projection: ToInternal(binding.Projection),
+            DepthOffset: binding.DepthOffset is null ? null : ToInternal(binding.DepthOffset),
+            SubmeshIndices: binding.SubmeshIndices,
+            AssetBinding: ToInternalAssetBinding(binding),
+            TextureScale: binding.TextureScale is null ? null : ToInternal(binding.TextureScale),
+            Family: binding.Family,
+            TextureOffset: binding.TextureOffset is null ? null : ToInternal(binding.TextureOffset),
+            TerrainOverlayMaterial: binding.TerrainOverlayMaterial,
+            BundledVariantIndex: binding.BundledVariantIndex);
+    }
+
+    private static ResoniteMaterialAssetBinding ToInternalAssetBinding(MaterialBinding binding)
+    {
+        return binding switch
+        {
+            SharedCommonMaterialBinding sharedCommon => ResoniteMaterialAssetBinding.SharedCommon(sharedCommon.CommonMaterial),
+            PresentationCommonMaterialBinding presentationCommon => ResoniteMaterialAssetBinding.PresentationCommon(presentationCommon.CommonMaterial),
+            _ => ResoniteMaterialAssetBinding.Presentation,
+        };
     }
 
     private static ResoniteTexturePayload ToInternal(TexturePayload payload)

--- a/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
@@ -186,7 +186,7 @@ public sealed class ImportServiceFactoryTests
                                 new MeshSubmesh(0, [0, 1, 2]),
                             ])),
                         [
-                            new MaterialBinding(new ColorRgba(1, 1, 1, 1),
+                            new PresentationMaterialBinding(new ColorRgba(1, 1, 1, 1),
                                 MaterialType.Standard,
                                 null,
                                 TextureSourceKind.Dataset,

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGridChunkBoundaryAlignmentPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGridChunkBoundaryAlignmentPolicyTests.cs
@@ -195,7 +195,7 @@ public sealed class DemTerrainGridChunkBoundaryAlignmentPolicyTests
         IReadOnlyList<double> heightSamples,
         IReadOnlyList<TerrainGridSampleCoverage>? sampleCoverage = null)
     {
-        MaterialBinding material = new(
+        MaterialBinding material = new PresentationMaterialBinding(
             BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
             MaterialType: MaterialType.Standard,
             TexturePayload: null,

--- a/tests/PlateauResoniteLink.Tests/Profiles/ImportedDynamicMaterialUvNormalizerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/ImportedDynamicMaterialUvNormalizerTests.cs
@@ -41,7 +41,7 @@ public sealed class ImportedDynamicMaterialUvNormalizerTests
     [Fact]
     public void NormalizeMaterialBinding_ClearsBundledFamilyUvTransformAfterNormalization()
     {
-        MaterialBinding material = new(
+        MaterialBinding material = new PresentationMaterialBinding(
             BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
             MaterialType: MaterialType.Standard,
             TexturePayload: null,
@@ -89,7 +89,7 @@ public sealed class ImportedDynamicMaterialUvNormalizerTests
                 {
                     SubmeshIndices = [0],
                 },
-                new MaterialBinding(
+                new PresentationMaterialBinding(
                     BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
                     MaterialType: MaterialType.Standard,
                     TexturePayload: null,
@@ -148,7 +148,7 @@ public sealed class ImportedDynamicMaterialUvNormalizerTests
                 {
                     SubmeshIndices = [0],
                 },
-                new MaterialBinding(
+                new PresentationMaterialBinding(
                     BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
                     MaterialType: MaterialType.Standard,
                     TexturePayload: null,
@@ -267,7 +267,7 @@ public sealed class ImportedDynamicMaterialUvNormalizerTests
         Float2? textureOffset,
         TerrainTextureOverlay? terrainOverlay = null)
     {
-        return new MaterialBinding(
+        return new PresentationMaterialBinding(
             BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
             MaterialType: MaterialType.Standard,
             TexturePayload: new TexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -2328,7 +2328,10 @@ public sealed class LocalCityGmlObjectProjectionTests
             cartesian);
 
         Assert.DoesNotContain(materialBindings, static binding => binding.BaseColor == new ColorRgba(1.0, 0.0, 0.0, 1.0));
-        Assert.Contains(materialBindings, static binding => binding.BaseColor == new ColorRgba(0.0, 0.0, 1.0, 1.0));
+        Assert.Contains(
+            materialBindings,
+            static binding => binding is SharedCommonMaterialBinding shared
+                && shared.CommonMaterial.Kind == DefaultCommonMaterialMemberKind.Bundled);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 
-using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Targets;
@@ -20,8 +19,7 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
             NonDemMaterialBakeCategory.PreservedCommonMaterial,
             NonDemCityObjectBakeMaterialClassifier.Classify(CreateTexturelessMaterial() with
             {
-                AssetScope = ResoniteMaterialAssetScope.Common,
-                CommonMaterial = CommonMaterialCatalog.Create().Generic.Uv,
+                AssetBinding = ResoniteMaterialAssetBindingTestFactory.SharedGenericUv(),
             }));
         Assert.Equal(
             NonDemMaterialBakeCategory.PreservedTextureless,
@@ -123,6 +121,7 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
             ResoniteTextureSourceKind.Bundled,
             ResoniteMaterialProjection.Uv,
             DepthOffset: null,
-            SubmeshIndices: [0]);
+            SubmeshIndices: [0],
+            ResoniteMaterialAssetBinding.Presentation);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Targets;
@@ -20,6 +21,13 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
             NonDemCityObjectBakeMaterialClassifier.Classify(CreateTexturelessMaterial() with
             {
                 AssetBinding = ResoniteMaterialAssetBindingTestFactory.SharedGenericUv(),
+            }));
+        Assert.Equal(
+            NonDemMaterialBakeCategory.AtlasCandidate,
+            NonDemCityObjectBakeMaterialClassifier.Classify(CreateDatasetTextureMaterial() with
+            {
+                Family = "facade",
+                AssetBinding = ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv),
             }));
         Assert.Equal(
             NonDemMaterialBakeCategory.PreservedTextureless,
@@ -53,6 +61,19 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
             {
                 RequireAtlasCandidateMaterial = false,
                 PreserveTexturelessMaterials = false,
+            }));
+        Assert.True(NonDemCityObjectBakeMaterialClassifier.CanBufferCityObjectMaterials(
+            CreateCityObject(
+                [
+                    CreateDatasetTextureMaterial() with
+                    {
+                        Family = "facade",
+                        AssetBinding = ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv),
+                    },
+                ]),
+            requireAtlasCandidate with
+            {
+                PreserveCommonMaterials = false,
             }));
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -345,7 +345,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(2, cityObject.Mesh.Submeshes.Count);
         Assert.Contains(
             cityObject.Materials,
-            static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.Facade, StringComparison.Ordinal)
+            static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.FacadeHighriseGlass, StringComparison.Ordinal)
                 && material.AssetScope == ResoniteMaterialAssetScope.PresentationSlotScoped);
         Assert.Contains(cityObject.Materials, static material => material.TexturePayload is not null);
     }
@@ -360,7 +360,7 @@ public sealed class NonDemCityObjectBakerTests
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
 
         ResoniteMaterialBinding material = Assert.Single(cityObject.Materials);
-        Assert.Equal(BundledDefaultMaterialFamilies.Facade, material.Family);
+        Assert.Equal(BundledDefaultMaterialFamilies.FacadeHighriseGlass, material.Family);
         Assert.Equal(ResoniteMaterialAssetScope.Common, material.AssetScope);
         Assert.Equal(new ResoniteFloat2(1.0 / 6.0, 1.0 / 6.0), material.TextureScale);
         Assert.Equal(new ResoniteFloat2(0.0, 0.5 / 6.0), material.TextureOffset);
@@ -383,7 +383,7 @@ public sealed class NonDemCityObjectBakerTests
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         ResoniteMaterialBinding[] preservedFacadeMaterials = cityObject.Materials
-            .Where(static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.Facade, StringComparison.Ordinal))
+            .Where(static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.FacadeHighriseGlass, StringComparison.Ordinal))
             .ToArray();
 
         Assert.Equal(3, cityObject.Materials.Count);
@@ -438,7 +438,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -447,6 +448,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: new ResoniteMaterialDepthOffset(1.0, 1.0),
                     SubmeshIndices: [1],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Roof,
                     TextureOffset: new ResoniteFloat2(0.125, 0.25),
                     BundledVariantIndex: 0),
@@ -458,6 +460,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: new ResoniteMaterialDepthOffset(2.0, 2.0),
                     SubmeshIndices: [2],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Roof,
                     TextureOffset: new ResoniteFloat2(0.25, 0.5),
                     BundledVariantIndex: 1),
@@ -531,7 +534,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -543,7 +547,7 @@ public sealed class NonDemCityObjectBakerTests
                     Family: BundledDefaultMaterialFamilies.Roof,
                     TextureOffset: new ResoniteFloat2(0.125, 0.25),
                     BundledVariantIndex: 0,
-                    AssetScope: ResoniteMaterialAssetScope.Common),
+                    AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.Roof, 0)),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -555,7 +559,7 @@ public sealed class NonDemCityObjectBakerTests
                     Family: BundledDefaultMaterialFamilies.Roof,
                     TextureOffset: new ResoniteFloat2(0.25, 0.5),
                     BundledVariantIndex: 1,
-                    AssetScope: ResoniteMaterialAssetScope.Common),
+                    AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.Roof, 1)),
             ],
         };
 
@@ -665,7 +669,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -674,6 +679,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [1],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Roof,
                     BundledVariantIndex: 0),
                 new ResoniteMaterialBinding(
@@ -684,6 +690,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [2],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Roof,
                     BundledVariantIndex: 0),
             ],
@@ -843,9 +850,8 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.Common,
-                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay),
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay),
+                    AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv()),
             ],
         };
         ResoniteConstructionCityObject secondCityObject = firstCityObject with
@@ -1185,7 +1191,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: $"{sourceUnitKey}.gml");
     }
@@ -1242,7 +1249,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1250,7 +1258,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [1]),
+                    SubmeshIndices: [1],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: $"{sourceUnitKey}.gml");
     }
@@ -1274,8 +1283,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.Common,
-                    CommonMaterial: commonMaterial),
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(commonMaterial)),
             ],
         };
     }
@@ -1297,8 +1305,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
             ],
         };
     }
@@ -1335,7 +1342,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(0.4, 0.4, 0.4, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1344,8 +1352,8 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [1],
-                    Family: BundledDefaultMaterialFamilies.Facade,
-                    AssetScope: ResoniteMaterialAssetScope.Common,
+                    Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0),
                     BundledVariantIndex: 0),
             ],
             SourceFileRelativePath: $"{sourceUnitKey}.gml");
@@ -1370,6 +1378,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     TextureScale: textureScale,
                     TextureOffset: textureOffset),
             ],
@@ -1410,8 +1419,8 @@ public sealed class NonDemCityObjectBakerTests
                         BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.X,
                         BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.Y),
                     TextureOffset: new ResoniteFloat2(0.0, 0.5 / 6.0),
-                    Family: BundledDefaultMaterialFamilies.Facade,
-                    AssetScope: ResoniteMaterialAssetScope.Common,
+                    Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+                    AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0),
                     BundledVariantIndex: 0),
             ],
             SourceFileRelativePath: $"{sourceUnitKey}.gml");
@@ -1452,6 +1461,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Facade),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
@@ -1461,6 +1471,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [1],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Facade),
             ],
             SourceFileRelativePath: $"{sourceUnitKey}.gml");
@@ -1504,7 +1515,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(0.5, 0.5, 0.5, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1513,8 +1525,8 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [1],
-                    Family: BundledDefaultMaterialFamilies.Facade,
-                    AssetScope: ResoniteMaterialAssetScope.Common,
+                    Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+                    AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0),
                     BundledVariantIndex: 0),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(0.5, 0.5, 0.5, 1.0),
@@ -1524,8 +1536,8 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [2],
-                    Family: BundledDefaultMaterialFamilies.Facade,
-                    AssetScope: ResoniteMaterialAssetScope.Common,
+                    Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+                    AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 1),
                     BundledVariantIndex: 1),
             ],
             SourceFileRelativePath: $"{sourceUnitKey}.gml");
@@ -1569,7 +1581,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(0.85, 0.85, 0.85, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1578,6 +1591,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [1],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Roof,
                     BundledVariantIndex: 0),
                 new ResoniteMaterialBinding(
@@ -1588,6 +1602,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [2],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Roof,
                     BundledVariantIndex: 1),
             ],

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -351,7 +351,7 @@ public sealed class NonDemCityObjectBakerTests
     }
 
     [Fact]
-    public async Task FlushAllAsyncKeepsBundledFacadeCommonTransformOnMaterial()
+    public async Task FlushAllAsyncDemotesBundledFacadeCommonTransformToMeshUv()
     {
         NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);
 
@@ -362,11 +362,14 @@ public sealed class NonDemCityObjectBakerTests
         ResoniteMaterialBinding material = Assert.Single(cityObject.Materials);
         Assert.Equal(BundledDefaultMaterialFamilies.FacadeHighriseGlass, material.Family);
         Assert.Equal(ResoniteMaterialAssetScope.Common, material.AssetScope);
-        Assert.Equal(new ResoniteFloat2(1.0 / 6.0, 1.0 / 6.0), material.TextureScale);
-        Assert.Equal(new ResoniteFloat2(0.0, 0.5 / 6.0), material.TextureOffset);
-        Assert.Equal(new ResoniteFloat2(0.0, 0.0), cityObject.Mesh.Vertices[0].UV0);
-        Assert.Equal(new ResoniteFloat2(1.0, 0.0), cityObject.Mesh.Vertices[1].UV0);
-        Assert.Equal(new ResoniteFloat2(0.0, 1.0), cityObject.Mesh.Vertices[2].UV0);
+        Assert.Null(material.TextureScale);
+        Assert.Null(material.TextureOffset);
+        Assert.Equal(0.0, cityObject.Mesh.Vertices[0].UV0.X, 12);
+        Assert.Equal(5.0 / 6.0, cityObject.Mesh.Vertices[0].UV0.Y, 12);
+        Assert.Equal(10.0 / 6.0, cityObject.Mesh.Vertices[1].UV0.X, 12);
+        Assert.Equal(5.0 / 6.0, cityObject.Mesh.Vertices[1].UV0.Y, 12);
+        Assert.Equal(0.0, cityObject.Mesh.Vertices[2].UV0.X, 12);
+        Assert.Equal(15.0 / 6.0, cityObject.Mesh.Vertices[2].UV0.Y, 12);
     }
 
     [Fact]
@@ -480,6 +483,8 @@ public sealed class NonDemCityObjectBakerTests
         Assert.All(preservedRoofMaterials, static material => Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, material.AssetScope));
         Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 0 && material.TextureOffset is null);
         Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 1 && material.TextureOffset is null);
+        Assert.NotEqual(new ResoniteFloat2(0.0, 0.0), cityObject.Mesh.Vertices[3].UV0);
+        Assert.NotEqual(new ResoniteFloat2(0.0, 0.0), cityObject.Mesh.Vertices[6].UV0);
     }
 
     [Fact]
@@ -573,8 +578,8 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(3, cityObject.Materials.Count);
         Assert.Equal(2, preservedRoofMaterials.Length);
         Assert.All(preservedRoofMaterials, static material => Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, material.AssetScope));
-        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 0 && material.TextureOffset == new ResoniteFloat2(0.125, 0.25));
-        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 1 && material.TextureOffset == new ResoniteFloat2(0.25, 0.5));
+        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 0 && material.TextureOffset is null);
+        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 1 && material.TextureOffset is null);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
@@ -1,4 +1,3 @@
-using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Targets;
@@ -10,8 +9,7 @@ public sealed class NonDemPreservedMaterialGroupingTests
     {
         ResoniteMaterialBinding commonMaterial = CreateTexturelessMaterial() with
         {
-            AssetScope = ResoniteMaterialAssetScope.Common,
-            CommonMaterial = CommonMaterialCatalog.Create().Generic.Uv,
+            AssetBinding = ResoniteMaterialAssetBindingTestFactory.SharedGenericUv(),
         };
         ResoniteTexturePayload texture = new(
             width: 1,
@@ -68,6 +66,7 @@ public sealed class NonDemPreservedMaterialGroupingTests
             ResoniteTextureSourceKind.Bundled,
             ResoniteMaterialProjection.Uv,
             DepthOffset: null,
-            SubmeshIndices: [0]);
+            SubmeshIndices: [0],
+            ResoniteMaterialAssetBinding.Presentation);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
@@ -1,3 +1,4 @@
+using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Targets;
@@ -50,6 +51,26 @@ public sealed class NonDemPreservedMaterialGroupingTests
             BaseColor = new ResoniteColor(1.0, 0.0, 0.0, 1.0),
         });
         NonDemPreservedMaterialGroupingKey blue = NonDemPreservedMaterialGrouping.CreateKey(CreateTexturelessMaterial() with
+        {
+            BaseColor = new ResoniteColor(0.0, 0.0, 1.0, 1.0),
+        });
+
+        Assert.False(NonDemPreservedMaterialGrouping.KeyComparer.Equals(red, blue));
+    }
+
+    [Fact]
+    public void CreateKeyKeepsPresentationCommonMaterialTintDistinct()
+    {
+        ResoniteMaterialBinding presentationCommonMaterial = CreateTexturelessMaterial() with
+        {
+            AssetBinding = ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv),
+        };
+
+        NonDemPreservedMaterialGroupingKey red = NonDemPreservedMaterialGrouping.CreateKey(presentationCommonMaterial with
+        {
+            BaseColor = new ResoniteColor(1.0, 0.0, 0.0, 1.0),
+        });
+        NonDemPreservedMaterialGroupingKey blue = NonDemPreservedMaterialGrouping.CreateKey(presentationCommonMaterial with
         {
             BaseColor = new ResoniteColor(0.0, 0.0, 1.0, 1.0),
         });

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
@@ -50,11 +50,11 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: new ResoniteFloat2(1.0, 1.0),
             TextureOffset: new ResoniteFloat2(0.0, 0.0),
             Family: BundledDefaultMaterialFamilies.Facade,
-            BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+            BundledVariantIndex: 0);
 
         ResoniteMaterialBinding normalized = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
 
@@ -104,13 +104,14 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
                     TexturePayload: null,
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
-                    DepthOffset: null,
-                    SubmeshIndices: [1],
-                    TextureScale: new ResoniteFloat2(1.0, 1.0),
+            DepthOffset: null,
+            SubmeshIndices: [1],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+            TextureScale: new ResoniteFloat2(1.0, 1.0),
                     TextureOffset: new ResoniteFloat2(0.0, 0.0),
                     Family: BundledDefaultMaterialFamilies.Facade,
-                    BundledVariantIndex: bundledVariantIndex,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
+                    BundledVariantIndex: bundledVariantIndex
+                    ),
             ],
             SourceFileRelativePath: "unit-a.gml");
 
@@ -156,7 +157,6 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
                     BundledVariantIndex = 0,
                     TextureScale = textureScale,
                     TextureOffset = textureOffset,
-                    AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped,
                 },
             ],
         };
@@ -207,11 +207,12 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
                     Projection: ResoniteMaterialProjection.Triplanar,
                     DepthOffset: null,
                     SubmeshIndices: [1],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     TextureScale: new ResoniteFloat2(1.0, 1.0),
                     TextureOffset: new ResoniteFloat2(0.0, 0.0),
                     Family: null,
-                    BundledVariantIndex: null,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
+                    BundledVariantIndex: null
+                    ),
             ],
             SourceFileRelativePath: "unit-a.gml");
 
@@ -293,9 +294,9 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: textureScale,
             TextureOffset: textureOffset,
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
             TerrainOverlayMaterial: terrainOverlay is null
                 ? null
                 : new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), terrainOverlay));

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -158,6 +158,50 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
+    public async Task ExecuteAsyncKeepsPresentationCommonPayloadMaterialDedicated()
+    {
+        using TemporaryDirectory datasetDirectory = new();
+        ImportedSceneMetadata metadata = CreateMetadata(datasetDirectory.Path);
+        using SceneSinkRecordingClient client = new();
+        ResoniteConstructionCityObject cityObject = CreatePayloadTriangleCityObject(
+            "presentation-common-payload",
+            ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(255, 0, 0, "textures/presentation-common.png")) with
+        {
+            Materials =
+                [
+                    CreatePayloadTriangleCityObject(
+                        "presentation-common-payload-source",
+                        ResoniteLiveSceneImportTargetTestSupport.CreateSolidColorPayload(255, 0, 0, "textures/presentation-common.png"))
+                        .Materials[0] with
+                    {
+                        BaseColor = new ResoniteColor(0.8, 0.7, 0.6, 1.0),
+                        AssetBinding = ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv),
+                    },
+                ],
+        };
+
+        await ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(
+            metadata,
+            [cityObject],
+            client,
+            enableMeshBake: false);
+
+        string materialId = GetRendererMaterialReferenceTarget(client, "CityObject presentation-common-payload");
+        AddComponent materialComponent = Assert.Single(
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, materialId, StringComparison.Ordinal));
+
+        Assert.DoesNotContain(
+            "PLATEAU Shared Assets/Common Materials/",
+            client.SlotPaths[materialComponent.ContainerSlotId],
+            StringComparison.Ordinal);
+        Field_colorX albedo = Assert.IsType<Field_colorX>(materialComponent.Data.Members["AlbedoColor"]);
+        Assert.Equal(0.8f, albedo.Value.r, 6);
+        Assert.Equal(0.7f, albedo.Value.g, 6);
+        Assert.Equal(0.6f, albedo.Value.b, 6);
+    }
+
+    [Fact]
     public async Task ExecuteAsyncReusesSharedCommonMaterialForPayloadAlbedoOverridesWithExplicitNoOpTransform()
     {
         using TemporaryDirectory datasetDirectory = new();
@@ -1542,7 +1586,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     TextureScale: textureScale,
                     Family: null,
                     TextureOffset: textureOffset,
-                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(CommonMaterialCatalog.Create().Generic.Uv)),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }
@@ -1572,7 +1616,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     DepthOffset: null,
                     SubmeshIndices: [0],
                     Family: null,
-                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(CommonMaterialCatalog.Create().Generic.Uv)),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1582,7 +1626,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     DepthOffset: null,
                     SubmeshIndices: [1],
                     Family: null,
-                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(CommonMaterialCatalog.Create().Generic.Uv)),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }
@@ -1684,7 +1728,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     DepthOffset: null,
                     SubmeshIndices: [1],
                     Family: null,
-                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(CommonMaterialCatalog.Create().Generic.Uv)),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -1506,11 +1506,10 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     SubmeshIndices: [0],
                     TextureScale: textureScale,
                     Family: family,
-                    AssetScope: commonMaterial is null
-                        ? ResoniteMaterialAssetScope.PresentationSlotScoped
-                        : ResoniteMaterialAssetScope.Common,
                     BundledVariantIndex: 0,
-                    CommonMaterial: commonMaterial),
+                    AssetBinding: commonMaterial is null
+                        ? ResoniteMaterialAssetBinding.Presentation
+                        : ResoniteMaterialAssetBinding.SharedCommon(commonMaterial)),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }
@@ -1543,8 +1542,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     TextureScale: textureScale,
                     Family: null,
                     TextureOffset: textureOffset,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }
@@ -1574,8 +1572,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     DepthOffset: null,
                     SubmeshIndices: [0],
                     Family: null,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1585,8 +1582,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     DepthOffset: null,
                     SubmeshIndices: [1],
                     Family: null,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }
@@ -1620,7 +1616,8 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }
@@ -1647,8 +1644,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.Common,
-                    CommonMaterial: CommonMaterialCatalog.Create().VertexColor.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(CommonMaterialCatalog.Create().VertexColor.Uv)),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }
@@ -1677,9 +1673,8 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     DepthOffset: null,
                     SubmeshIndices: [0],
                     Family: BundledDefaultMaterialFamilies.WallResidentialPlasterLow,
-                    AssetScope: ResoniteMaterialAssetScope.Common,
                     BundledVariantIndex: 0,
-                    CommonMaterial: CommonMaterialCatalog.Create().WallResidentialPlasterLow.ResidentialPlasterLow),
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(CommonMaterialCatalog.Create().WallResidentialPlasterLow.ResidentialPlasterLow)),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1689,8 +1684,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     DepthOffset: null,
                     SubmeshIndices: [1],
                     Family: null,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -662,7 +662,8 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
                     ResoniteTextureSourceKind.Bundled,
                     ResoniteMaterialProjection.Uv,
                     null,
-                    [0]),
+                    [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -350,7 +350,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 Projection: ResoniteMaterialProjection.Uv,
                 DepthOffset: terrainAlignedDepthOffset,
                 SubmeshIndices: [0],
-                AssetScope: ResoniteMaterialAssetScope.Common));
+                AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv()));
         bool terrainAlignedGenericSlotExistedWhenSendWorkersStarted = false;
         ResoniteMaterialPlanning materialPlanning = new(CreateBundledDefaultMaterialAssetStore());
         await using ResoniteLiveSceneImportTarget importTarget = new(
@@ -422,7 +422,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 Projection: ResoniteMaterialProjection.Uv,
                 DepthOffset: new ResoniteMaterialDepthOffset(-10.0, -10.0),
                 SubmeshIndices: [0],
-                AssetScope: ResoniteMaterialAssetScope.Common));
+                AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv()));
         bool materialSlotExistedWhenSendWorkersStarted = false;
         await using ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(
             routedClient,
@@ -535,7 +535,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             [
                 demObject.Materials[0] with
                 {
-                    CommonMaterial = CommonMaterialCatalog.Create().Generic.Uv,
+                AssetBinding = ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv),
                 },
             ],
         };
@@ -1094,7 +1094,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     ResoniteTextureSourceKind.Dataset,
                     ResoniteMaterialProjection.Uv,
                     null,
-                    [0]),
+                    [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             CollisionEnabled: true,
             SourceFileRelativePath: sourceFileRelativePath);
@@ -1121,7 +1122,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     ResoniteMaterialProjection.Uv,
                     null,
                     [0],
-                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay)),
+                    AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay)),
             ],
             CollisionEnabled: true,
             SourceFileRelativePath: sourceFileRelativePath);
@@ -1153,9 +1155,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     TextureScale: textureScale,
                     Family: family,
                     TextureOffset: textureOffset,
-                    AssetScope: ResoniteMaterialAssetScope.Common,
                     BundledVariantIndex: variantIndex,
-                    CommonMaterial: CommonMaterialCatalog.Create().FacadeHighriseGlass.Facade001),
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(CommonMaterialCatalog.Create().FacadeHighriseGlass.Facade001)),
             ],
             CollisionEnabled: true,
             SourceFileRelativePath: "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml");
@@ -1183,10 +1184,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: depthOffset,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.Common,
-                    CommonMaterial: depthOffset is null
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(depthOffset is null
                         ? CommonMaterialCatalog.Create().VertexColor.Uv
-                        : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv),
+                        : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv)),
             ],
             CollisionEnabled: true,
             SourceFileRelativePath: "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml");
@@ -1214,10 +1214,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: payloadDepthOffset,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.Common,
-                    CommonMaterial: payloadDepthOffset is null
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(payloadDepthOffset is null
                         ? CommonMaterialCatalog.Create().VertexColor.Uv
-                        : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv),
+                        : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv)),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1230,7 +1229,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [1],
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
             ],
             CollisionEnabled: true,
             SourceFileRelativePath: "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml");

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -484,21 +484,64 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
 
     public static MaterialBinding ToContractMaterial(ResoniteMaterialBinding binding)
     {
-        return new MaterialBinding(
-            ToContractColor(binding.BaseColor),
+        ColorRgba baseColor = ToContractColor(binding.BaseColor);
+        TexturePayload? texturePayload = binding.TexturePayload is null ? null : ToContractTexturePayload(binding.TexturePayload);
+        MaterialDepthOffset? depthOffset = binding.DepthOffset is null
+            ? null
+            : new MaterialDepthOffset(binding.DepthOffset.Factor, binding.DepthOffset.Units);
+        Float2? textureScale = binding.TextureScale is null ? null : ToContractFloat2(binding.TextureScale);
+        Float2? textureOffset = binding.TextureOffset is null ? null : ToContractFloat2(binding.TextureOffset);
+
+        if (binding.CommonMaterial is not null
+            && binding.AssetScope == ResoniteMaterialAssetScope.Common)
+        {
+            return new SharedCommonMaterialBinding(
+                baseColor,
+                (MaterialType)binding.MaterialType,
+                texturePayload,
+                (TextureSourceKind)binding.TextureSourceKind,
+                (MaterialProjection)binding.Projection,
+                depthOffset,
+                binding.SubmeshIndices,
+                binding.CommonMaterial,
+                textureScale,
+                binding.Family,
+                textureOffset,
+                binding.TerrainOverlayMaterial,
+                binding.BundledVariantIndex);
+        }
+
+        if (binding.CommonMaterial is not null)
+        {
+            return new PresentationCommonMaterialBinding(
+                baseColor,
+                (MaterialType)binding.MaterialType,
+                texturePayload,
+                (TextureSourceKind)binding.TextureSourceKind,
+                (MaterialProjection)binding.Projection,
+                depthOffset,
+                binding.SubmeshIndices,
+                binding.CommonMaterial,
+                textureScale,
+                binding.Family,
+                textureOffset,
+                binding.TerrainOverlayMaterial,
+                binding.BundledVariantIndex);
+        }
+
+        return new PresentationMaterialBinding(
+            baseColor,
             (MaterialType)binding.MaterialType,
-            binding.TexturePayload is null ? null : ToContractTexturePayload(binding.TexturePayload),
+            texturePayload,
             (TextureSourceKind)binding.TextureSourceKind,
             (MaterialProjection)binding.Projection,
-            binding.DepthOffset is null ? null : new MaterialDepthOffset(binding.DepthOffset.Factor, binding.DepthOffset.Units),
+            depthOffset,
             binding.SubmeshIndices,
-            binding.TextureScale is null ? null : ToContractFloat2(binding.TextureScale),
+            textureScale,
             binding.Family,
-            binding.TextureOffset is null ? null : ToContractFloat2(binding.TextureOffset),
-            binding.AssetScope == ResoniteMaterialAssetScope.Common ? MaterialReuseScope.Shared : MaterialReuseScope.PerObject,
+            textureOffset,
             binding.TerrainOverlayMaterial,
-            binding.BundledVariantIndex,
-            binding.CommonMaterial);
+            binding.BundledVariantIndex);
     }
 
     private static Transform3D ToContractTransform(ResoniteTransform transform)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -64,11 +64,12 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TexturePayload: null,
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
-                    TextureScale: null,
-                    TextureOffset: null,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(MeshCode), overlay)),
+                    AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                    TextureScale: null,
+                    TextureOffset: null,
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay)),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -453,7 +454,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(MeshCode), overlay)),
+                    AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay)),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -523,7 +525,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -686,7 +689,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -836,7 +840,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(MeshCode), overlay)),
+                    AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay)),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -900,7 +905,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             CollisionEnabled: false,
             SourceFileRelativePath: $"udx/bldg/{MeshCode}/plateau_{DatasetName}_bldg_{MeshCode}.gml");
@@ -947,7 +953,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(MeshCode), overlay)),
+                    AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay)),
             ]
         );
         ResoniteConstructionCityObject withoutOverlay = withOverlay with
@@ -998,9 +1005,10 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     TextureScale: null,
-                    TextureOffset: null,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
+                    TextureOffset: null
+                    ),
             ]
         );
         ResoniteConstructionCityObject withBake = baseline with
@@ -1054,7 +1062,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.RoadUv),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
@@ -1063,7 +1071,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [1]),
+                    SubmeshIndices: [1],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: sourceFile);
 
@@ -1103,7 +1112,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: sourceFile);
 
@@ -1149,7 +1159,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: sourceFile);
 
@@ -1202,7 +1213,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: sourceFile);
 
@@ -1254,9 +1266,9 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     TextureScale: new ResoniteFloat2(0.5, 0.5),
                     Family: BundledDefaultMaterialFamilies.Facade,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
                     BundledVariantIndex: 0),
             ],
             SourceFileRelativePath: sourceFile);
@@ -1328,10 +1340,10 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     TextureScale: new ResoniteFloat2(0.5, 0.5),
                     TextureOffset: new ResoniteFloat2(0.125, 0.25),
                     Family: BundledDefaultMaterialFamilies.Facade,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
                     BundledVariantIndex: 0),
             ],
             SourceFileRelativePath: sourceFile);
@@ -1394,7 +1406,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [1]),
+                    SubmeshIndices: [1],
+                    ResoniteMaterialAssetBinding.Presentation),
             ]
         );
 
@@ -1432,7 +1445,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [1]),
+                    SubmeshIndices: [1],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -1462,7 +1476,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1470,7 +1485,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0, 1]),
+                    SubmeshIndices: [0, 1],
+                    ResoniteMaterialAssetBinding.Presentation),
             ]
         );
 
@@ -1513,6 +1529,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     TextureScale: new ResoniteFloat2(2.0, 0.5),
                     TextureOffset: new ResoniteFloat2(0.25, 0.75)),
                 new ResoniteMaterialBinding(
@@ -1522,7 +1539,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0, 1]),
+                    SubmeshIndices: [0, 1],
+                    ResoniteMaterialAssetBinding.Presentation),
             ]
         );
 
@@ -1553,7 +1571,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ]
         );
 
@@ -1599,7 +1618,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ]
         );
 
@@ -1666,7 +1686,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
     }
@@ -1694,10 +1715,11 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TexturePayload: null,
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
-                    TextureScale: null,
-                    TextureOffset: null,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                    AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                    TextureScale: null,
+                    TextureOffset: null,
                     TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(meshCode), overlay)),
             ],
             SourceFileRelativePath: $"udx/{packageName}/{meshCode}/plateau_{DatasetName}_{packageName}_{meshCode}.gml");
@@ -1710,7 +1732,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
             Materials = cityObject.Materials
                 .Select(static material => material with
                 {
-                    CommonMaterial = CommonMaterialCatalog.Create().Generic.Uv,
+                    AssetBinding = ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv),
                 })
                 .ToArray(),
         };

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetYOffsetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetYOffsetTests.cs
@@ -82,7 +82,8 @@ public sealed class ResoniteLiveSceneImportTargetYOffsetTests
             TextureSourceKind: ResoniteTextureSourceKind.Bundled,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
-            SubmeshIndices: [0]);
+            SubmeshIndices: [0],
+            ResoniteMaterialAssetBinding.Presentation);
     }
 
     private static double GetSlotY(Slot slot)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialAssetBindingTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialAssetBindingTestFactory.cs
@@ -1,0 +1,90 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+internal static class ResoniteMaterialAssetBindingTestFactory
+{
+    internal static ResoniteMaterialAssetBinding SharedBundled(string family, int variantIndex)
+    {
+        return ResoniteMaterialAssetBinding.SharedCommon(SelectBundledMember(family, variantIndex));
+    }
+
+    internal static ResoniteMaterialAssetBinding SharedGenericUv()
+    {
+        return ResoniteMaterialAssetBinding.SharedCommon(CommonMaterialCatalog.Create().Generic.Uv);
+    }
+
+    internal static DefaultCommonMaterialMember SelectBundledMember(string family, int variantIndex)
+    {
+        CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials = CommonMaterialCatalog.Create();
+        return family switch
+        {
+            BundledDefaultMaterialFamilies.CityFurniture => variantIndex switch
+            {
+                0 => commonMaterials.CityFurniture.Plaster002,
+                1 => commonMaterials.CityFurniture.Plaster001,
+                2 => commonMaterials.CityFurniture.Plaster003,
+                3 => commonMaterials.CityFurniture.Plaster004,
+                4 => commonMaterials.CityFurniture.Plaster005,
+                _ => commonMaterials.CityFurniture.Plaster006,
+            },
+            BundledDefaultMaterialFamilies.FacadeHighriseGlass => variantIndex switch
+            {
+                0 => commonMaterials.FacadeHighriseGlass.Facade001,
+                1 => commonMaterials.FacadeHighriseGlass.Facade005,
+                _ => commonMaterials.FacadeHighriseGlass.Facade006,
+            },
+            BundledDefaultMaterialFamilies.FacadeHighriseNightLow => variantIndex == 0
+                ? commonMaterials.FacadeHighriseNightLow.Facade002
+                : commonMaterials.FacadeHighriseNightLow.Facade011,
+            BundledDefaultMaterialFamilies.FacadeMidriseGrid => variantIndex == 0
+                ? commonMaterials.FacadeMidriseGrid.Facade014
+                : commonMaterials.FacadeMidriseGrid.Facade015,
+            BundledDefaultMaterialFamilies.Other => variantIndex switch
+            {
+                0 => commonMaterials.Other.Concrete012,
+                1 => commonMaterials.Other.Ground054,
+                2 => commonMaterials.Other.Plaster002,
+                3 => commonMaterials.Other.Plaster001,
+                4 => commonMaterials.Other.Plaster003,
+                5 => commonMaterials.Other.Plaster004,
+                6 => commonMaterials.Other.Plaster005,
+                7 => commonMaterials.Other.Plaster006,
+                _ => commonMaterials.Other.TextureCanFacade0022,
+            },
+            BundledDefaultMaterialFamilies.RoadTriplanar => variantIndex switch
+            {
+                0 => commonMaterials.RoadTriplanar.Road012A,
+                1 => commonMaterials.RoadTriplanar.Road013A,
+                2 => commonMaterials.RoadTriplanar.Road014A,
+                _ => commonMaterials.RoadTriplanar.Road015A,
+            },
+            BundledDefaultMaterialFamilies.RoadUv => variantIndex switch
+            {
+                0 => commonMaterials.RoadUv.Road012A,
+                1 => commonMaterials.RoadUv.Road013A,
+                2 => commonMaterials.RoadUv.Road014A,
+                _ => commonMaterials.RoadUv.Road015A,
+            },
+            BundledDefaultMaterialFamilies.Roof => variantIndex switch
+            {
+                0 => commonMaterials.Roof.Concrete012,
+                1 => commonMaterials.Roof.Concrete033,
+                2 => commonMaterials.Roof.RoofingTiles012A,
+                _ => commonMaterials.Roof.RoofingTiles014B,
+            },
+            BundledDefaultMaterialFamilies.Vegetation => variantIndex == 0
+                ? commonMaterials.Vegetation.Ground054
+                : commonMaterials.Vegetation.Concrete012,
+            BundledDefaultMaterialFamilies.WallResidentialPlasterLow => variantIndex == 0
+                ? commonMaterials.WallResidentialPlasterLow.ResidentialPlasterLow
+                : commonMaterials.WallResidentialPlasterLow.ResidentialPlasterDark,
+            _ => throw new InvalidOperationException(
+                $"Bundled family '{family}' variant {variantIndex} is not represented by this test factory."),
+        };
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
@@ -29,8 +29,8 @@ public sealed class ResoniteMaterialComponentPolicyTests
             SubmeshIndices: [0],
             TextureScale: new ResoniteFloat2(0.5, 0.25),
             TextureOffset: new ResoniteFloat2(0.125, 0.75),
-            Family: BundledDefaultMaterialFamilies.Facade,
-            AssetScope: ResoniteMaterialAssetScope.Common,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0),
             BundledVariantIndex: 0);
 
         string componentType = ResoniteMaterialComponentPolicy.GetComponentType(material);
@@ -69,8 +69,8 @@ public sealed class ResoniteMaterialComponentPolicyTests
             SubmeshIndices: [0],
             TextureScale: new ResoniteFloat2(1.0, 1.0),
             TextureOffset: new ResoniteFloat2(0.0, 0.0),
-            Family: BundledDefaultMaterialFamilies.Facade,
-            AssetScope: ResoniteMaterialAssetScope.Common,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0),
             BundledVariantIndex: 0);
 
         Dictionary<string, Member> members = ResoniteMaterialComponentPolicy.CreateMembers(material);
@@ -90,7 +90,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         Dictionary<string, Member> members = ResoniteMaterialComponentPolicy.CreateMembers(material);
 
@@ -109,9 +109,9 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: new ResoniteFloat2(0.5, 0.25),
-            TextureOffset: new ResoniteFloat2(0.125, 0.75),
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+            TextureOffset: new ResoniteFloat2(0.125, 0.75));
 
         InvalidOperationException error = Assert.Throws<InvalidOperationException>(
             () => ResoniteMaterialComponentPolicy.CreateMembers(material));
@@ -131,6 +131,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Triplanar,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: new ResoniteFloat2(0.25, 0.125),
             Family: BundledDefaultMaterialFamilies.RoadTriplanar,
             BundledVariantIndex: 0);
@@ -141,7 +142,8 @@ public sealed class ResoniteMaterialComponentPolicyTests
             TextureSourceKind: ResoniteTextureSourceKind.Bundled,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
-            SubmeshIndices: [0]);
+            SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation);
 
         Dictionary<string, Member> triplanarMembers = ResoniteMaterialComponentPolicy.CreateMembers(triplanarMaterial);
         Dictionary<string, Member> wireframeMembers = ResoniteMaterialComponentPolicy.CreateMembers(wireframeMaterial);
@@ -175,9 +177,9 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: new ResoniteFloat2(1.0, 1.0),
-            TextureOffset: new ResoniteFloat2(0.125, 0.75),
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+            TextureOffset: new ResoniteFloat2(0.125, 0.75));
 
         ResoniteMaterialBinding normalized = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
 
@@ -198,17 +200,17 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureOffset: new ResoniteFloat2(0.125, 0.75),
             TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(
                 ThirdRegionalMeshCode.Parse("53394525"),
                 new TerrainTextureOverlay(
-                PackageName: "dem",
-            MeshCode: ThirdRegionalMeshCode.Parse("53394525"),
-                UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
-                ZoomLevel: 17,
-                GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
-                    MaxTextureSize: 512)),
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+                    PackageName: "dem",
+                    MeshCode: ThirdRegionalMeshCode.Parse("53394525"),
+                    UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
+                    ZoomLevel: 17,
+                    GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+                    MaxTextureSize: 512)));
 
         InvalidOperationException error = Assert.Throws<InvalidOperationException>(
             () => ResoniteMaterialComponentPolicy.CreateMembers(material));
@@ -227,7 +229,8 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
-            Family: BundledDefaultMaterialFamilies.Facade,
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
             BundledVariantIndex: 0);
 
         bool resolved = ResoniteMaterialComponentPolicy.TryGetBundledCompanionTextureSet(
@@ -284,7 +287,8 @@ public sealed class ResoniteMaterialComponentPolicyTests
                 Projection: ResoniteMaterialProjection.Uv,
                 DepthOffset: null,
                 SubmeshIndices: [0],
-                Family: BundledDefaultMaterialFamilies.Facade,
+                AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
                 BundledVariantIndex: variantIndex);
 
             bool resolved = ResoniteMaterialComponentPolicy.TryGetBundledCompanionTextureSet(
@@ -311,6 +315,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Triplanar,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             Family: BundledDefaultMaterialFamilies.CityFurniture,
             BundledVariantIndex: 0);
 
@@ -353,7 +358,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Family: BundledDefaultMaterialFamilies.WallResidentialPlasterLow,
             BundledVariantIndex: 0,
             TextureScale: new ResoniteFloat2(1.0 / 3.0, 1.0 / 3.0),
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.WallResidentialPlasterLow, 0));
 
         bool resolved = ResoniteMaterialComponentPolicy.TryGetBundledCompanionTextureSet(
             new BundledDefaultMaterialAssetStore(),
@@ -390,7 +395,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Family: BundledDefaultMaterialFamilies.WallResidentialPlasterLow,
             BundledVariantIndex: 1,
             TextureScale: new ResoniteFloat2(1.0 / 3.0, 1.0 / 3.0),
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.WallResidentialPlasterLow, 1));
 
         bool resolved = ResoniteMaterialComponentPolicy.TryGetBundledCompanionTextureSet(
             new BundledDefaultMaterialAssetStore(),
@@ -422,7 +427,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
             SubmeshIndices: [0],
             Family: BundledDefaultMaterialFamilies.FacadeHighriseNightLow,
             BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseNightLow, 0));
 
         bool resolved = ResoniteMaterialComponentPolicy.TryGetBundledCompanionTextureSet(
             new BundledDefaultMaterialAssetStore(),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -46,8 +46,8 @@ public sealed class ResoniteMaterialPlanningTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
-            Family: BundledDefaultMaterialFamilies.Facade,
-            AssetScope: ResoniteMaterialAssetScope.Common,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0),
             BundledVariantIndex: 0);
         _ = ResoniteMaterialComponentPolicy.TryGetBundledCompanionTextureSet(
             new BundledDefaultMaterialAssetStore(),
@@ -194,7 +194,8 @@ public sealed class ResoniteMaterialPlanningTests
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
-            SubmeshIndices: [0]);
+            SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation);
 
         PlannedDedicatedMaterialAsset preserved = await planning.PlanDedicatedMaterialAssetAsync(
             client,
@@ -240,6 +241,7 @@ public sealed class ResoniteMaterialPlanningTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: new ResoniteFloat2(0.4, 0.8),
             TextureOffset: new ResoniteFloat2(0.1, 0.2),
             TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay));
@@ -264,7 +266,7 @@ public sealed class ResoniteMaterialPlanningTests
     public void AddCommonMaterialComponentsDoesNotCreateEmissionMembersWithoutEmissionSource()
     {
         ResoniteBatchOperations.BatchActionBuilder batchBuilder = new();
-        ResoniteMaterialBinding material = CreateBundledMaterial(BundledDefaultMaterialFamilies.Facade, 0);
+        ResoniteMaterialBinding material = CreateBundledMaterial(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0);
         PlannedDedicatedMaterialAsset plannedMaterial = new(
             material,
             [
@@ -330,7 +332,8 @@ public sealed class ResoniteMaterialPlanningTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
-            TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay));
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+            TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay));
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextures = new()
         {
             [overlay] = new GeneratedTerrainTexture(
@@ -358,7 +361,8 @@ public sealed class ResoniteMaterialPlanningTests
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
-            SubmeshIndices: [0]);
+            SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation);
         ResoniteMaterialBinding secondMaterial = firstMaterial with
         {
         };
@@ -414,7 +418,11 @@ public sealed class ResoniteMaterialPlanningTests
             Family: projection == ResoniteMaterialProjection.Uv
                 ? BundledDefaultMaterialFamilies.RoadUv
                 : BundledDefaultMaterialFamilies.RoadTriplanar,
-            AssetScope: ResoniteMaterialAssetScope.Common,
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(
+                projection == ResoniteMaterialProjection.Uv
+                    ? BundledDefaultMaterialFamilies.RoadUv
+                    : BundledDefaultMaterialFamilies.RoadTriplanar,
+                0),
             BundledVariantIndex: 0);
     }
 
@@ -429,7 +437,7 @@ public sealed class ResoniteMaterialPlanningTests
             DepthOffset: null,
             SubmeshIndices: [0],
             Family: family,
-            AssetScope: ResoniteMaterialAssetScope.Common,
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(family, variantIndex),
             BundledVariantIndex: variantIndex);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -343,7 +343,8 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                 Projection: ResoniteMaterialProjection.Uv,
                 DepthOffset: null,
-                SubmeshIndices: [0]),
+                SubmeshIndices: [0],
+                ResoniteMaterialAssetBinding.Presentation),
             [new PlannedTextureAsset(new TextureIdentity("albedo"), new Uri("resdb:///texture/albedo"))],
             PreserveDedicatedMaterialSlot: true,
             DedicatedMaterialSlotName: "material-000-pbs-uv-uv");
@@ -411,7 +412,8 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                 Projection: ResoniteMaterialProjection.Uv,
                 DepthOffset: null,
-                SubmeshIndices: [0]),
+                SubmeshIndices: [0],
+                ResoniteMaterialAssetBinding.Presentation),
             [
                 new PlannedTextureAsset(new TextureIdentity("albedo"), new Uri("resdb:///texture/albedo")),
                 new PlannedTextureAsset(new TextureIdentity("normal"), new Uri("resdb:///texture/normal")),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -363,6 +363,8 @@ public sealed class ResoniteSceneMaterialConventionsTests
 
         Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, normalized.AssetScope);
         Assert.Equal(new ResoniteColor(0.8, 0.7, 0.6, 1.0), normalized.BaseColor);
+        Assert.Null(normalized.TextureScale);
+        Assert.Null(normalized.TextureOffset);
     }
 
     [Fact]
@@ -386,7 +388,8 @@ public sealed class ResoniteSceneMaterialConventionsTests
 
         Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, normalized.AssetScope);
         Assert.Equal(new ResoniteMaterialDepthOffset(1.0, 1.0), normalized.DepthOffset);
-        Assert.Equal(new ResoniteFloat2(0.125, 0.25), normalized.TextureOffset);
+        Assert.Null(normalized.TextureScale);
+        Assert.Null(normalized.TextureOffset);
     }
 
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -89,9 +89,9 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             TextureScale: FacadeDefaultTilesPerMeter(),
             TextureOffset: new ResoniteFloat2(0.0, 0.5 / 6.0),
-            Family: BundledDefaultMaterialFamilies.Facade,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
             BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0));
 
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
@@ -111,9 +111,9 @@ public sealed class ResoniteSceneMaterialConventionsTests
             DepthOffset: null,
             SubmeshIndices: [0],
             TextureScale: new ResoniteFloat2(0.5, 0.5),
-            Family: BundledDefaultMaterialFamilies.Facade,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
             BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0));
 
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
@@ -134,9 +134,9 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             TextureScale: new ResoniteFloat2(1.0 / 6.0, 1.0 / 6.0),
             TextureOffset: new ResoniteFloat2(0.0, 0.5 / 6.0),
-            Family: BundledDefaultMaterialFamilies.Facade,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
             BundledVariantIndex: 1,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 1));
 
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
@@ -156,11 +156,11 @@ public sealed class ResoniteSceneMaterialConventionsTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: new ResoniteMaterialDepthOffset(2.0, 3.0),
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: new ResoniteFloat2(0.5, 0.25),
             TextureOffset: new ResoniteFloat2(0.125, 0.75),
-            Family: BundledDefaultMaterialFamilies.Facade,
-            BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+            BundledVariantIndex: 0);
 
         string slotName = ResoniteSceneMaterialConventions.CreateDedicatedMaterialSlotName(material, materialIndex: 0);
 
@@ -182,7 +182,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation);
 
         Assert.Throws<ArgumentOutOfRangeException>(
             () => ResoniteSceneMaterialConventions.CreateDedicatedMaterialSlotName(material, materialIndex: -1));
@@ -203,7 +203,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             TextureOffset: new ResoniteFloat2(0.25, 0.75),
             Family: null,
             BundledVariantIndex: null,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
@@ -226,7 +226,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             TextureOffset: new ResoniteFloat2(0.0, 0.0),
             Family: null,
             BundledVariantIndex: null,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
@@ -248,7 +248,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             Family: null,
             TextureOffset: null,
             BundledVariantIndex: null,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         IReadOnlyList<string> slotLookupNames = ResoniteSceneMaterialConventions.CreateCommonMaterialSlotLookupNames(material);
 
@@ -268,7 +268,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             TextureScale: null,
             TextureOffset: new ResoniteFloat2(0.25, 0.75),
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         IReadOnlyList<string> slotLookupNames = ResoniteSceneMaterialConventions.CreateCommonMaterialSlotLookupNames(material);
 
@@ -290,7 +290,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             TextureScale: null,
             Family: null,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
@@ -313,8 +313,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay),
             Family: null,
-            AssetScope: ResoniteMaterialAssetScope.Common,
-            CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         ResoniteMaterialBinding normalized = ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
 
@@ -356,9 +355,9 @@ public sealed class ResoniteSceneMaterialConventionsTests
             DepthOffset: null,
             SubmeshIndices: [0],
             TextureScale: FacadeDefaultTilesPerMeter(),
-            Family: BundledDefaultMaterialFamilies.Facade,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
             BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0));
 
         ResoniteMaterialBinding normalized = ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
 
@@ -379,9 +378,9 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             TextureScale: FacadeDefaultTilesPerMeter(),
             TextureOffset: new ResoniteFloat2(0.125, 0.25),
-            Family: BundledDefaultMaterialFamilies.Facade,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
             BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0));
 
         ResoniteMaterialBinding normalized = ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
 
@@ -427,7 +426,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             Family: family,
             BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(family, 0));
     }
 
     private static ResoniteMaterialBinding CreateGenericCommonMaterial(ResoniteMaterialDepthOffset? depthOffset)
@@ -440,7 +439,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: depthOffset,
             SubmeshIndices: [0],
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
     }
 
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -13,7 +13,7 @@ public sealed class SceneImportContractMapperTests
     {
         MaterialBinding[] bindings =
         [
-            new(
+            new PresentationMaterialBinding(
                 BaseColor: new ColorRgba(0.1, 0.2, 0.3, 0.4),
                 MaterialType: MaterialType.Standard,
                 TexturePayload: new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
@@ -24,7 +24,6 @@ public sealed class SceneImportContractMapperTests
                 TextureScale: new Float2(0.25, 0.5),
                 Family: "roof",
                 TextureOffset: new Float2(0.75, 0.125),
-                ReuseScope: MaterialReuseScope.Shared,
                 BundledVariantIndex: 3),
         ];
 
@@ -38,8 +37,23 @@ public sealed class SceneImportContractMapperTests
         Assert.Equal(2.5, mapped.DepthOffset.Units, 9);
         Assert.Equal(0.25, mapped.TextureScale!.X, 9);
         Assert.Equal(0.125, mapped.TextureOffset!.Y, 9);
-        Assert.Equal(ResoniteMaterialAssetScope.Common, mapped.AssetScope);
+        Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, mapped.AssetScope);
         Assert.Equal(3, mapped.BundledVariantIndex);
+    }
+
+    [Fact]
+    public void ToInternalMaterialBindingsUsesCommonScopeOnlyForTypedCommonMaterial()
+    {
+        DefaultCommonMaterialMember commonMaterial = CommonMaterialCatalog.Create().Generic.Uv;
+        MaterialBinding[] bindings =
+        [
+            commonMaterial.CreateBinding([0]),
+        ];
+
+        ResoniteMaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToInternal(bindings));
+
+        Assert.Equal(ResoniteMaterialAssetScope.Common, mapped.AssetScope);
+        Assert.Equal(commonMaterial, mapped.CommonMaterial);
     }
 
     [Theory]
@@ -77,7 +91,7 @@ public sealed class SceneImportContractMapperTests
         DefaultCommonMaterialMember commonMaterial = CommonMaterialCatalog.Create().Generic.Uv;
         MaterialBinding[] bindings =
         [
-            new(
+            new SharedCommonMaterialBinding(
                 BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
                 MaterialType: MaterialType.Standard,
                 TexturePayload: null,
@@ -85,9 +99,8 @@ public sealed class SceneImportContractMapperTests
                 Projection: MaterialProjection.Uv,
                 DepthOffset: null,
                 SubmeshIndices: [0],
-                ReuseScope: MaterialReuseScope.Shared,
-                TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay),
-                CommonMaterial: commonMaterial),
+                commonMaterial,
+                TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay)),
         ];
 
         ResoniteMaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToInternal(bindings));
@@ -112,7 +125,7 @@ public sealed class SceneImportContractMapperTests
             ]);
         MaterialBinding[] bindings =
         [
-            new(
+            new PresentationMaterialBinding(
                 BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
                 MaterialType: MaterialType.Standard,
                 TexturePayload: null,
@@ -120,7 +133,6 @@ public sealed class SceneImportContractMapperTests
                 Projection: MaterialProjection.Uv,
                 DepthOffset: null,
                 SubmeshIndices: [0],
-                ReuseScope: MaterialReuseScope.Shared,
                 TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay)),
         ];
 
@@ -134,7 +146,7 @@ public sealed class SceneImportContractMapperTests
 
     private static MaterialBinding CreateValidBinding()
     {
-        return new MaterialBinding(
+        return new PresentationMaterialBinding(
             BaseColor: new ColorRgba(0.1, 0.2, 0.3, 0.4),
             MaterialType: MaterialType.Standard,
             TexturePayload: new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),


### PR DESCRIPTION
## Summary
- Split `MaterialBinding` into presentation, presentation-common, and shared-common contract cases.
- Require `DefaultCommonMaterialMember` at construction time for both common-material-backed binding cases.
- Map shared common asset scope from `SharedCommonMaterialBinding` instead of inferring it from nullable `CommonMaterial` or `ReuseScope` combinations.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink canonical dump matched `runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json` via `git diff --no-index`.