### PR TITLE
Type texture payload variants

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -188,7 +188,7 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
     {
         if (!texturePayloadsByResolvedPath.TryGetValue(resolvedTexturePath, out TexturePayload? texturePayload))
         {
-            texturePayload = new TexturePayload(
+            texturePayload = new EncodedImageTexturePayload(
                 null,
                 null,
                 "sRGB",

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -96,67 +96,104 @@ public sealed record MeshSubmesh(
     int Index,
     IReadOnlyList<int> TriangleVertexIndices);
 
-public enum TexturePayloadFormat
+public abstract record TexturePayload
 {
-    RawRgba32 = 0,
-    EncodedImage = 1,
+    private protected TexturePayload(
+        string? colorProfile,
+        string identity,
+        ITextureImportSource source)
+    {
+        if (string.IsNullOrWhiteSpace(identity))
+        {
+            throw new ArgumentException("Texture payload identity must be provided.", nameof(identity));
+        }
+
+        ColorProfile = colorProfile;
+        Identity = identity;
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+    }
+
+    public string? ColorProfile { get; }
+
+    public string Identity { get; }
+
+    public ITextureImportSource Source { get; }
 }
 
-public sealed record TexturePayload
+public sealed record RawRgba32TexturePayload : TexturePayload
 {
-    public TexturePayload(
+    public RawRgba32TexturePayload(
         int width,
         int height,
         string? colorProfile,
         byte[] binaryPayload,
         string? identity = null)
-    {
-        Width = width;
-        Height = height;
-        ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(binaryPayload);
-        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
-        Identity = identity;
-        Format = TexturePayloadFormat.RawRgba32;
-        Source = TextureImportSourceFactory.CreateInMemoryRaw(
+        : this(
             width,
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"));
+            CreateSource(width, height, colorProfile, binaryPayload, identity))
+    {
     }
 
-    public TexturePayload(
+    private RawRgba32TexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        (string Identity, ITextureImportSource Source) source)
+        : base(colorProfile, source.Identity, source.Source)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        Width = width;
+        Height = height;
+        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
+    }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public ImmutableArray<byte> BinaryPayload { get; }
+
+    private static (string Identity, ITextureImportSource Source) CreateSource(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        string? identity)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
+        return (
+            effectiveIdentity,
+            TextureImportSourceFactory.CreateInMemoryRaw(
+                width,
+                height,
+                colorProfile,
+                binaryPayload,
+                effectiveIdentity));
+    }
+}
+
+public sealed record EncodedImageTexturePayload : TexturePayload
+{
+    public EncodedImageTexturePayload(
         int? width,
         int? height,
         string? colorProfile,
         ITextureImportSource source,
         string? identity = null)
+        : base(colorProfile, identity ?? source?.Identity ?? throw new ArgumentNullException(nameof(source)), source!)
     {
         Width = width;
         Height = height;
-        ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(source);
-        BinaryPayload = [];
-        Identity = identity ?? source.Identity;
-        Format = TexturePayloadFormat.EncodedImage;
-        Source = source;
     }
 
     public int? Width { get; }
 
     public int? Height { get; }
-
-    public string? ColorProfile { get; }
-
-    public ImmutableArray<byte> BinaryPayload { get; }
-
-    public string? Identity { get; }
-
-    public TexturePayloadFormat Format { get; }
-
-    public ITextureImportSource Source { get; }
-
 }
 
 public enum TextureSourceKind

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -133,21 +133,21 @@ internal static class SceneImportContractMapper
 
     private static ResoniteTexturePayload ToInternal(TexturePayload payload)
     {
-        return payload.Format switch
+        return payload switch
         {
-            TexturePayloadFormat.RawRgba32 => new ResoniteTexturePayload(
-                payload.Width.GetValueOrDefault(),
-                payload.Height.GetValueOrDefault(),
-                payload.ColorProfile,
-                payload.BinaryPayload.AsSpan().ToArray(),
-                payload.Identity),
-            TexturePayloadFormat.EncodedImage => new ResoniteTexturePayload(
-                payload.Width,
-                payload.Height,
-                payload.ColorProfile,
-                payload.Source,
-                payload.Identity),
-            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.Format, "Unsupported texture payload format."),
+            RawRgba32TexturePayload raw => new ResoniteTexturePayload(
+                raw.Width,
+                raw.Height,
+                raw.ColorProfile,
+                raw.BinaryPayload.AsSpan().ToArray(),
+                raw.Identity),
+            EncodedImageTexturePayload encoded => new ResoniteTexturePayload(
+                encoded.Width,
+                encoded.Height,
+                encoded.ColorProfile,
+                encoded.Source,
+                encoded.Identity),
+            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.GetType(), "Unsupported texture payload type."),
         };
     }
 

--- a/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
@@ -9,7 +9,7 @@ public sealed class TexturePayloadTests
     {
         byte[] source = [1, 2, 3, 4];
 
-        TexturePayload payload = new(1, 1, "sRGB", source, "dataset:texture");
+        RawRgba32TexturePayload payload = new(1, 1, "sRGB", source, "dataset:texture");
         source[0] = 9;
 
         Assert.Equal<byte>([1, 2, 3, 4], payload.BinaryPayload);

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
@@ -13,7 +13,7 @@ public sealed class DefaultMaterialResolverTests
     [Fact]
     public void ResolveMaterialUsesDatasetTextureWhenPresent()
     {
-        TexturePayload payload = new(4, 4, "srgb", new byte[4 * 4 * 4], "udx/bldg/53394525/appearance/roof.png");
+        TexturePayload payload = new RawRgba32TexturePayload(4, 4, "srgb", new byte[4 * 4 * 4], "udx/bldg/53394525/appearance/roof.png");
 
         ResolvedMaterial material = resolver.ResolveMaterial(new DefaultMaterialRequest(
             "bldg",
@@ -41,7 +41,7 @@ public sealed class DefaultMaterialResolverTests
     public void ResolveMaterialUsesDatasetTextureBeforeBuildingFallback(int surfaceRoleValue)
     {
         DefaultMaterialSurfaceRole surfaceRole = (DefaultMaterialSurfaceRole)surfaceRoleValue;
-        TexturePayload payload = new(4, 4, "srgb", new byte[4 * 4 * 4], $"udx/bldg/53394525/appearance/{surfaceRole}.png");
+        TexturePayload payload = new RawRgba32TexturePayload(4, 4, "srgb", new byte[4 * 4 * 4], $"udx/bldg/53394525/appearance/{surfaceRole}.png");
 
         ResolvedMaterial material = resolver.ResolveMaterial(new DefaultMaterialRequest(
             "bldg",

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -720,7 +720,7 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
 
     private static TexturePayload CreateTexturePayload(string identity)
     {
-        return new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], identity);
+        return new RawRgba32TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], identity);
     }
 
     private static double ComputeParsedNormalY(ParsedSurface surface)

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
@@ -65,7 +65,7 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
                 "textured-road",
                 width: 4.0,
                 length: 12.0,
-                texturePayload: new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")));
+                texturePayload: new RawRgba32TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")));
 
         ParsedCityObject? marking = GeneratedRoadMarkingCityObjectFactory.Create(road, new GeodeticPoint(0.0, 0.0, 0.0), cityObjectCartesian: null);
 
@@ -83,7 +83,7 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
                     "textured-road",
                     width: 4.0,
                     length: 12.0,
-                    texturePayload: new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")),
+                    texturePayload: new RawRgba32TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")),
                 CreateRoadSurface(
                     "plain-road",
                     width: 4.0,

--- a/tests/PlateauResoniteLink.Tests/Profiles/ImportedDynamicMaterialUvNormalizerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/ImportedDynamicMaterialUvNormalizerTests.cs
@@ -270,7 +270,7 @@ public sealed class ImportedDynamicMaterialUvNormalizerTests
         return new MaterialBinding(
             BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
             MaterialType: MaterialType.Standard,
-            TexturePayload: new TexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),
+            TexturePayload: new RawRgba32TexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),
             TextureSourceKind: TextureSourceKind.Dataset,
             Projection: MaterialProjection.Uv,
             DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -3856,7 +3856,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
     private static TexturePayload CreateTexturePayload(string identity)
     {
-        return new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], identity);
+        return new RawRgba32TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], identity);
     }
 
     private static HashSet<string> GetCulledSurfaceIdsBeforeProjectionForTest(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -543,13 +543,13 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
     private static TexturePayload ToContractTexturePayload(ResoniteTexturePayload payload)
         => payload.Format switch
         {
-            ResoniteTexturePayloadFormat.RawRgba32 => new TexturePayload(
-                payload.Width.GetValueOrDefault(),
-                payload.Height.GetValueOrDefault(),
+            ResoniteTexturePayloadFormat.RawRgba32 => new RawRgba32TexturePayload(
+                payload.Width ?? throw new InvalidOperationException("Raw texture payload requires width."),
+                payload.Height ?? throw new InvalidOperationException("Raw texture payload requires height."),
                 payload.ColorProfile,
                 payload.BinaryPayload.AsSpan().ToArray(),
                 payload.Identity),
-            ResoniteTexturePayloadFormat.EncodedImage => new TexturePayload(
+            ResoniteTexturePayloadFormat.EncodedImage => new EncodedImageTexturePayload(
                 payload.Width,
                 payload.Height,
                 payload.ColorProfile,

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -42,6 +42,35 @@ public sealed class SceneImportContractMapperTests
         Assert.Equal(3, mapped.BundledVariantIndex);
     }
 
+    [Fact]
+    public void ToInternalMaterialBindingsMapsRawTextureDimensionsWithoutNullableGuards()
+    {
+        MaterialBinding[] bindings =
+        [
+            new(
+                BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+                MaterialType: MaterialType.Standard,
+                TexturePayload: new RawRgba32TexturePayload(
+                    width: 2,
+                    height: 1,
+                    colorProfile: "sRGB",
+                    binaryPayload: [1, 2, 3, 4, 5, 6, 7, 8],
+                    identity: "raw:texture"),
+                TextureSourceKind: TextureSourceKind.Dataset,
+                Projection: MaterialProjection.Uv,
+                DepthOffset: null,
+                SubmeshIndices: [0]),
+        ];
+
+        ResoniteMaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToInternal(bindings));
+
+        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, mapped.TexturePayload!.Format);
+        Assert.Equal(2, mapped.TexturePayload.Width);
+        Assert.Equal(1, mapped.TexturePayload.Height);
+        Assert.Equal("raw:texture", mapped.TexturePayload.Identity);
+        Assert.Equal<byte>([1, 2, 3, 4, 5, 6, 7, 8], mapped.TexturePayload.BinaryPayload);
+    }
+
     [Theory]
     [InlineData(nameof(MaterialBinding.MaterialType))]
     [InlineData(nameof(MaterialBinding.TextureSourceKind))]
@@ -142,7 +171,7 @@ public sealed class SceneImportContractMapperTests
 
     private static TexturePayload CreateEncodedTexturePayload()
     {
-        return new TexturePayload(
+        return new EncodedImageTexturePayload(
             width: 2,
             height: 2,
             colorProfile: "sRGB",


### PR DESCRIPTION
## Summary
- Split neutral `TexturePayload` into `RawRgba32TexturePayload` and `EncodedImageTexturePayload`.
- Remove the contract-level `TexturePayloadFormat` discriminator and raw `Width ?? throw` / `Height ?? throw` path from `SceneImportContractMapper`.
- Update upstream appearance loading and test helpers to choose the concrete texture payload variant at creation time.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (1021 passed)
- Fake Live Sink canonical dump completed for `plateau-13213-higashimurayama-shi-2020` mesh `53395325`, packages `dem,bldg`, terrain mesh `grid`.
- `git diff --no-index` against the semantic baseline was non-empty only in the already-stacked PresentationCommon dedicated-material output from the parent branch; no texture payload variant-specific dump regression was observed. Temporary dump was deleted.

## Notes
- This is intentionally not a same-shape wrapper: raw payloads are the only contract type with non-null `Width`, `Height`, and `BinaryPayload`; encoded image payloads carry source-backed image data with optional dimensions.
- Target-internal `ResoniteTexturePayloadFormat` remains a separate follow-up candidate because it is downstream of the neutral import contract boundary.