### PR TITLE
Type Resonite texture payload variants

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -185,7 +185,16 @@ public sealed record EncodedImageTexturePayload : TexturePayload
         string? colorProfile,
         ITextureImportSource source,
         string? identity = null)
-        : base(colorProfile, identity ?? source?.Identity ?? throw new ArgumentNullException(nameof(source)), source!)
+        : this(width, height, colorProfile, CreateSource(source, identity))
+    {
+    }
+
+    private EncodedImageTexturePayload(
+        int? width,
+        int? height,
+        string? colorProfile,
+        (string Identity, ITextureImportSource Source) source)
+        : base(colorProfile, source.Identity, source.Source)
     {
         Width = width;
         Height = height;
@@ -194,6 +203,14 @@ public sealed record EncodedImageTexturePayload : TexturePayload
     public int? Width { get; }
 
     public int? Height { get; }
+
+    private static (string Identity, ITextureImportSource Source) CreateSource(
+        ITextureImportSource source,
+        string? identity)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        return (identity ?? source.Identity, source);
+    }
 }
 
 public enum TextureSourceKind

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
@@ -34,7 +34,7 @@ internal static class ResoniteTextureImportFactory
         RawTexturePayload rawPayload = TextureImportSourceFactory.CreateRawPayloadFromImage(
             image,
             colorProfile);
-        return new ResoniteTexturePayload(
+        return new RawRgba32ResoniteTexturePayload(
             image.Width,
             image.Height,
             colorProfile,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -5,64 +5,119 @@ using PlateauResoniteLink.Application.Importing;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-public enum ResoniteTexturePayloadFormat
+public abstract class ResoniteTexturePayload
 {
-    RawRgba32,
-    EncodedImage,
+    private protected ResoniteTexturePayload(
+        string? colorProfile,
+        string identity,
+        ITextureImportSource source)
+    {
+        if (string.IsNullOrWhiteSpace(identity))
+        {
+            throw new ArgumentException("Resonite texture payload identity must be provided.", nameof(identity));
+        }
+
+        ColorProfile = colorProfile;
+        Identity = identity;
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+    }
+
+    public string? ColorProfile { get; }
+
+    public string Identity { get; }
+
+    public ITextureImportSource Source { get; }
 }
 
-public sealed record ResoniteTexturePayload
+public sealed class RawRgba32ResoniteTexturePayload : ResoniteTexturePayload
 {
-    public ResoniteTexturePayload(
+    public RawRgba32ResoniteTexturePayload(
         int width,
         int height,
         string? colorProfile,
         byte[] binaryPayload,
         string? identity = null)
-    {
-        Width = width;
-        Height = height;
-        ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(binaryPayload);
-        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
-        Identity = identity;
-        Format = ResoniteTexturePayloadFormat.RawRgba32;
-        Source = TextureImportSourceFactory.CreateInMemoryRaw(
+        : this(
             width,
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"));
+            CreateSource(width, height, colorProfile, binaryPayload, identity))
+    {
     }
 
-    public ResoniteTexturePayload(
+    private RawRgba32ResoniteTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        (string Identity, ITextureImportSource Source) source)
+        : base(colorProfile, source.Identity, source.Source)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        Width = width;
+        Height = height;
+        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
+    }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public ImmutableArray<byte> BinaryPayload { get; }
+
+    private static (string Identity, ITextureImportSource Source) CreateSource(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        string? identity)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
+        return (
+            effectiveIdentity,
+            TextureImportSourceFactory.CreateInMemoryRaw(
+                width,
+                height,
+                colorProfile,
+                binaryPayload,
+                effectiveIdentity));
+    }
+}
+
+public sealed class EncodedImageResoniteTexturePayload : ResoniteTexturePayload
+{
+    public EncodedImageResoniteTexturePayload(
         int? width,
         int? height,
         string? colorProfile,
         ITextureImportSource source,
         string? identity = null)
+        : this(width, height, colorProfile, CreateSource(source, identity))
+    {
+    }
+
+    private EncodedImageResoniteTexturePayload(
+        int? width,
+        int? height,
+        string? colorProfile,
+        (string Identity, ITextureImportSource Source) source)
+        : base(colorProfile, source.Identity, source.Source)
     {
         Width = width;
         Height = height;
-        ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(source);
-        BinaryPayload = [];
-        Identity = identity ?? source.Identity;
-        Format = ResoniteTexturePayloadFormat.EncodedImage;
-        Source = source;
     }
 
     public int? Width { get; }
 
     public int? Height { get; }
 
-    public string? ColorProfile { get; }
-
-    public ImmutableArray<byte> BinaryPayload { get; }
-
-    public string? Identity { get; }
-
-    public ResoniteTexturePayloadFormat Format { get; }
-
-    public ITextureImportSource Source { get; }
+    private static (string Identity, ITextureImportSource Source) CreateSource(
+        ITextureImportSource source,
+        string? identity)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        return (identity ?? source.Identity, source);
+    }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -135,13 +135,13 @@ internal static class SceneImportContractMapper
     {
         return payload switch
         {
-            RawRgba32TexturePayload raw => new ResoniteTexturePayload(
+            RawRgba32TexturePayload raw => new RawRgba32ResoniteTexturePayload(
                 raw.Width,
                 raw.Height,
                 raw.ColorProfile,
                 raw.BinaryPayload.AsSpan().ToArray(),
                 raw.Identity),
-            EncodedImageTexturePayload encoded => new ResoniteTexturePayload(
+            EncodedImageTexturePayload encoded => new EncodedImageResoniteTexturePayload(
                 encoded.Width,
                 encoded.Height,
                 encoded.ColorProfile,

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
@@ -104,7 +104,7 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
     {
         return CreateTexturelessMaterial() with
         {
-            TexturePayload = new ResoniteTexturePayload(
+            TexturePayload = new RawRgba32ResoniteTexturePayload(
                 width: 1,
                 height: 1,
                 colorProfile: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -29,12 +29,9 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Single(cityObject.Mesh.Submeshes);
         Assert.Equal(6, cityObject.Mesh.Vertices.Count);
         Assert.Equal("unit-a.gml", cityObject.SourceFileRelativePath);
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, atlasPayload.Format);
-        Assert.NotNull(atlasPayload.Width);
-        Assert.NotNull(atlasPayload.Height);
-        Assert.InRange(atlasPayload.Width!.Value, 1, 32);
-        Assert.InRange(atlasPayload.Height!.Value, 1, 32);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        Assert.InRange(atlasPayload.Width, 1, 32);
+        Assert.InRange(atlasPayload.Height, 1, 32);
         Assert.Equal(CommonMaterialCatalog.Create().Generic.Uv, cityObject.Materials[0].CommonMaterial);
     }
 
@@ -63,8 +60,7 @@ public sealed class NonDemCityObjectBakerTests
             new ResoniteFloat2(0.5, 0.0)));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, atlasPayload.Format);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
         Assert.Equal(1, atlasPayload.Width);
         Assert.Equal(1, atlasPayload.Height);
         Assert.Null(cityObject.Materials[0].TextureScale);
@@ -152,7 +148,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.NotSame(payload, material.TexturePayload);
         Assert.NotNull(material.TexturePayload);
         Assert.Contains("atlastex-", material.TexturePayload.Identity, StringComparison.Ordinal);
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, material.TexturePayload.Format);
+        Assert.IsType<RawRgba32ResoniteTexturePayload>(material.TexturePayload);
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
     }
@@ -212,7 +208,7 @@ public sealed class NonDemCityObjectBakerTests
             new ResoniteFloat2(0.0, 0.0)));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload);
 
         Assert.Equal(2, atlasPayload.Width);
         Assert.Equal(1, atlasPayload.Height);
@@ -261,8 +257,7 @@ public sealed class NonDemCityObjectBakerTests
             null));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, atlasPayload.Format);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
         Assert.Equal(4, atlasPayload.Width);
         Assert.Equal(1, atlasPayload.Height);
         Assert.Equal(new Rgba32(255, 0, 0, 255), ReadPixel(atlasPayload, 0, 0));
@@ -285,7 +280,7 @@ public sealed class NonDemCityObjectBakerTests
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         ResoniteMaterialBinding material = Assert.Single(cityObject.Materials);
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(material.TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(material.TexturePayload);
 
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
@@ -325,7 +320,7 @@ public sealed class NonDemCityObjectBakerTests
                 "unit-a"));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
 
         Assert.Equal(2, atlasPayload.Width);
         Assert.Equal(1, atlasPayload.Height);
@@ -771,7 +766,7 @@ public sealed class NonDemCityObjectBakerTests
         await AssertBufferedAsync(baker, CreateLod2Building("building-c", CreateCheckerPayload("textures/c.png", new Rgba32(0, 0, 255, 255), new Rgba32(255, 0, 255, 255), 3, 3), 4, "unit-a"));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
         Assert.Equal(16, atlasPayload.Width);
         Assert.Equal(8, atlasPayload.Height);
     }
@@ -962,7 +957,7 @@ public sealed class NonDemCityObjectBakerTests
                 "unit-a"));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
         Assert.Equal(512, atlasPayload.Width);
         Assert.Equal(512, atlasPayload.Height);
     }
@@ -1055,7 +1050,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal("atlasbake-unit-a-bldg-lod2-3", cityObject.SlotKey);
         Assert.Equal(
             "atlastex-unit-a.gml-3",
-            Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Identity);
+            Assert.IsType<RawRgba32ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Identity);
     }
 
     private static NonDemCityObjectBaker CreateBaker(
@@ -1140,11 +1135,9 @@ public sealed class NonDemCityObjectBakerTests
         return ResoniteTextureImportFactory.CreatePayloadFromImage(image, identity: identity);
     }
 
-    private static Rgba32 ReadPixel(ResoniteTexturePayload payload, int x, int y)
+    private static Rgba32 ReadPixel(RawRgba32ResoniteTexturePayload payload, int x, int y)
     {
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, payload.Format);
-        Assert.NotNull(payload.Width);
-        int width = payload.Width.Value;
+        int width = payload.Width;
         int offset = ((y * width) + x) * 4;
         ReadOnlySpan<byte> bytes = payload.BinaryPayload.AsSpan();
         return new Rgba32(

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
@@ -13,7 +13,7 @@ public sealed class NonDemPreservedMaterialGroupingTests
             AssetScope = ResoniteMaterialAssetScope.Common,
             CommonMaterial = CommonMaterialCatalog.Create().Generic.Uv,
         };
-        ResoniteTexturePayload texture = new(
+        ResoniteTexturePayload texture = new RawRgba32ResoniteTexturePayload(
             width: 1,
             height: 1,
             colorProfile: null,
@@ -32,7 +32,7 @@ public sealed class NonDemPreservedMaterialGroupingTests
         });
         NonDemPreservedMaterialGroupingKey differentTexture = NonDemPreservedMaterialGrouping.CreateKey(commonMaterial with
         {
-            TexturePayload = new ResoniteTexturePayload(
+            TexturePayload = new RawRgba32ResoniteTexturePayload(
                 width: 1,
                 height: 1,
                 colorProfile: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
@@ -288,7 +288,7 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
         return new ResoniteMaterialBinding(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -71,7 +71,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             r, g, b, 255,
             r, g, b, 255,
         ];
-        return new ResoniteTexturePayload(2, 2, ResoniteTextureColorProfiles.Srgb, rawBytes, identity);
+        return new RawRgba32ResoniteTexturePayload(2, 2, ResoniteTextureColorProfiles.Srgb, rawBytes, identity);
     }
 
     public static ImportedSceneMetadata CreateMetadata(
@@ -541,21 +541,21 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         => Enumerable.Repeat(TerrainGridSampleCoverage.Measured, count).ToArray();
 
     private static TexturePayload ToContractTexturePayload(ResoniteTexturePayload payload)
-        => payload.Format switch
+        => payload switch
         {
-            ResoniteTexturePayloadFormat.RawRgba32 => new RawRgba32TexturePayload(
-                payload.Width ?? throw new InvalidOperationException("Raw texture payload requires width."),
-                payload.Height ?? throw new InvalidOperationException("Raw texture payload requires height."),
-                payload.ColorProfile,
-                payload.BinaryPayload.AsSpan().ToArray(),
-                payload.Identity),
-            ResoniteTexturePayloadFormat.EncodedImage => new EncodedImageTexturePayload(
-                payload.Width,
-                payload.Height,
-                payload.ColorProfile,
-                payload.Source,
-                payload.Identity),
-            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.Format, "Unsupported texture payload format."),
+            RawRgba32ResoniteTexturePayload raw => new RawRgba32TexturePayload(
+                raw.Width,
+                raw.Height,
+                raw.ColorProfile,
+                raw.BinaryPayload.AsSpan().ToArray(),
+                raw.Identity),
+            EncodedImageResoniteTexturePayload encoded => new EncodedImageTexturePayload(
+                encoded.Width,
+                encoded.Height,
+                encoded.ColorProfile,
+                encoded.Source,
+                encoded.Identity),
+            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.GetType(), "Unsupported texture payload type."),
         };
 
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -993,7 +993,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
-                    TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/uv-bake-budget.png"),
+                    TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/uv-bake-budget.png"),
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
@@ -104,7 +104,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
         ResoniteMaterialBinding material = new(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic.png"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic.png"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
@@ -170,7 +170,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
         ResoniteMaterialBinding material = new(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/direct-terrain-grid-style.png"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/direct-terrain-grid-style.png"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -354,7 +354,7 @@ public sealed class ResoniteMaterialPlanningTests
         ResoniteMaterialBinding firstMaterial = new(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], identity: "payload-a"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], identity: "payload-a"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -151,7 +151,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
         ResoniteMaterialBinding material = new(
             BaseColor: new ResoniteColor(0.1, 0.2, 0.3, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/payload-a.png"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/payload-a.png"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: new ResoniteMaterialDepthOffset(2.0, 3.0),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
@@ -9,7 +9,7 @@ public sealed class ResoniteTexturePayloadTests
     {
         byte[] source = [4, 3, 2, 1];
 
-        ResoniteTexturePayload payload = new(1, 1, "sRGB", source, "dataset:texture");
+        RawRgba32ResoniteTexturePayload payload = new(1, 1, "sRGB", source, "dataset:texture");
         source[0] = 9;
 
         Assert.Equal<byte>([4, 3, 2, 1], payload.BinaryPayload);

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -32,8 +32,8 @@ public sealed class SceneImportContractMapperTests
 
         Assert.Equal(0.1, mapped.BaseColor.R, 9);
         Assert.Equal(0.2, mapped.BaseColor.G, 9);
-        Assert.Equal("dataset:texture", mapped.TexturePayload!.Identity);
-        Assert.Equal(ResoniteTexturePayloadFormat.EncodedImage, mapped.TexturePayload.Format);
+        EncodedImageResoniteTexturePayload encodedPayload = Assert.IsType<EncodedImageResoniteTexturePayload>(mapped.TexturePayload);
+        Assert.Equal("dataset:texture", encodedPayload.Identity);
         Assert.Equal(-1.5, mapped.DepthOffset!.Factor, 9);
         Assert.Equal(2.5, mapped.DepthOffset.Units, 9);
         Assert.Equal(0.25, mapped.TextureScale!.X, 9);
@@ -64,11 +64,11 @@ public sealed class SceneImportContractMapperTests
 
         ResoniteMaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToInternal(bindings));
 
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, mapped.TexturePayload!.Format);
-        Assert.Equal(2, mapped.TexturePayload.Width);
-        Assert.Equal(1, mapped.TexturePayload.Height);
-        Assert.Equal("raw:texture", mapped.TexturePayload.Identity);
-        Assert.Equal<byte>([1, 2, 3, 4, 5, 6, 7, 8], mapped.TexturePayload.BinaryPayload);
+        RawRgba32ResoniteTexturePayload rawPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(mapped.TexturePayload);
+        Assert.Equal(2, rawPayload.Width);
+        Assert.Equal(1, rawPayload.Height);
+        Assert.Equal("raw:texture", rawPayload.Identity);
+        Assert.Equal<byte>([1, 2, 3, 4, 5, 6, 7, 8], rawPayload.BinaryPayload);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- Split target-internal `ResoniteTexturePayload` into `RawRgba32ResoniteTexturePayload` and `EncodedImageResoniteTexturePayload` so raw payload dimensions and bytes are available without nullable fallback.
- Removed `ResoniteTexturePayloadFormat` and switched target/test adapters to concrete payload pattern matching.
- Removed the remaining null-forgiving encoded-source handoff in the neutral texture contract and target payload constructors.

## Notes
- The target payload variants are classes rather than records so the hierarchy stays closed by `private protected` construction without record copy-constructor escape, and so existing reference-identity behavior stays unchanged.
- This is not a same-shape wrapper split: raw payloads carry non-null `Width`, `Height`, and `BinaryPayload`; encoded payloads carry an import source and optional metadata dimensions.

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (1021 passed)
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020` / `53395325` / `dem,bldg` / `grid` completed. `git diff --no-index` against `runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json` showed the existing parent-stack dedicated-material delta (`96 +75/-21`), with no new texture-payload-shaped regression. The generated dump was deleted and is not committed.

## Review Gate
- Base PR #353 is CLEAN, CI green, has PR-body THUMBS_UP, and has no review threads.
- Parent PR #352 is CLEAN and THUMBS_UP; GitHub still reports one old non-outdated unresolved thread for the dedicated-material issue that this stack already changes. This PR is based on #353 and does not add new material binding behavior.