### PR TITLE
Type raw texture payload variants

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -8,18 +8,78 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Application.Importing;
 
-public enum RawTexturePayloadFormat
+public abstract class RawTexturePayload
 {
-    Rgba32 = 0,
-    RgbaFloat32 = 1,
+    private protected RawTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        Width = width;
+        Height = height;
+        ColorProfile = colorProfile;
+        Bytes = bytes;
+    }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public string? ColorProfile { get; }
+
+    public byte[] Bytes { get; }
+
+    public abstract TResult Match<TResult>(
+        Func<Rgba32RawTexturePayload, TResult> rgba32,
+        Func<RgbaFloat32RawTexturePayload, TResult> rgbaFloat32);
 }
 
-public sealed record RawTexturePayload(
-    int Width,
-    int Height,
-    string? ColorProfile,
-    byte[] Bytes,
-    RawTexturePayloadFormat Format = RawTexturePayloadFormat.Rgba32);
+public sealed class Rgba32RawTexturePayload : RawTexturePayload
+{
+    public Rgba32RawTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] bytes)
+        : base(width, height, colorProfile, bytes)
+    {
+    }
+
+    public override TResult Match<TResult>(
+        Func<Rgba32RawTexturePayload, TResult> rgba32,
+        Func<RgbaFloat32RawTexturePayload, TResult> rgbaFloat32)
+    {
+        ArgumentNullException.ThrowIfNull(rgba32);
+        ArgumentNullException.ThrowIfNull(rgbaFloat32);
+        return rgba32(this);
+    }
+}
+
+public sealed class RgbaFloat32RawTexturePayload : RawTexturePayload
+{
+    public RgbaFloat32RawTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] bytes)
+        : base(width, height, colorProfile, bytes)
+    {
+    }
+
+    public override TResult Match<TResult>(
+        Func<Rgba32RawTexturePayload, TResult> rgba32,
+        Func<RgbaFloat32RawTexturePayload, TResult> rgbaFloat32)
+    {
+        ArgumentNullException.ThrowIfNull(rgba32);
+        ArgumentNullException.ThrowIfNull(rgbaFloat32);
+        return rgbaFloat32(this);
+    }
+}
 
 public interface ITextureImportSource
 {
@@ -32,9 +92,14 @@ public interface ITextureImportSource
     long? EstimatedByteLength { get; }
 }
 
-internal interface IRawTexturePayloadSource : ITextureImportSource
+internal interface IRgba32RawTexturePayloadSource : ITextureImportSource
 {
-    ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken);
+    ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken);
+}
+
+internal interface IRgbaFloat32RawTexturePayloadSource : ITextureImportSource
+{
+    ValueTask<RgbaFloat32RawTexturePayload> MaterializeRgbaFloat32Async(CancellationToken cancellationToken);
 }
 
 internal static class TextureImportSourceMaterializer
@@ -44,17 +109,50 @@ internal static class TextureImportSourceMaterializer
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(source);
-        if (source is not IRawTexturePayloadSource rawSource)
+        if (source is IRgba32RawTexturePayloadSource rgba32Source)
         {
-            throw new InvalidOperationException(
-                $"Texture import source '{source.GetType().Name}' cannot materialize a raw texture payload.");
+            return new ValueTask<RawTexturePayload>(MaterializeRgba32AsRawAsync(rgba32Source, cancellationToken));
         }
 
-        return rawSource.MaterializeRawAsync(cancellationToken);
+        if (source is IRgbaFloat32RawTexturePayloadSource rgbaFloat32Source)
+        {
+            return new ValueTask<RawTexturePayload>(MaterializeRgbaFloat32AsRawAsync(rgbaFloat32Source, cancellationToken));
+        }
+
+        throw new InvalidOperationException(
+            $"Texture import source '{source.GetType().Name}' cannot materialize a raw texture payload.");
+
+        static async Task<RawTexturePayload> MaterializeRgba32AsRawAsync(
+            IRgba32RawTexturePayloadSource source,
+            CancellationToken cancellationToken)
+        {
+            return await source.MaterializeRgba32Async(cancellationToken);
+        }
+
+        static async Task<RawTexturePayload> MaterializeRgbaFloat32AsRawAsync(
+            IRgbaFloat32RawTexturePayloadSource source,
+            CancellationToken cancellationToken)
+        {
+            return await source.MaterializeRgbaFloat32Async(cancellationToken);
+        }
+    }
+
+    public static ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(
+        ITextureImportSource source,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (source is not IRgba32RawTexturePayloadSource rgba32Source)
+        {
+            throw new InvalidOperationException(
+                $"Texture import source '{source.GetType().Name}' cannot materialize an RGBA32 texture payload.");
+        }
+
+        return rgba32Source.MaterializeRgba32Async(cancellationToken);
     }
 }
 
-internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
+internal sealed class InMemoryRawTextureImportSource : IRgba32RawTexturePayloadSource
 {
     private readonly byte[] bytes;
 
@@ -88,10 +186,10 @@ internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
 
     public long? EstimatedByteLength => bytes.Length;
 
-    public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return ValueTask.FromResult(new RawTexturePayload(
+        return ValueTask.FromResult(new Rgba32RawTexturePayload(
             Width,
             Height,
             ColorProfile,
@@ -99,7 +197,7 @@ internal sealed class InMemoryRawTextureImportSource : IRawTexturePayloadSource
     }
 }
 
-internal sealed class InMemoryEncodedTextureImportSource : IRawTexturePayloadSource
+internal sealed class InMemoryEncodedTextureImportSource : IRgba32RawTexturePayloadSource
 {
     private readonly byte[] bytes;
 
@@ -123,7 +221,7 @@ internal sealed class InMemoryEncodedTextureImportSource : IRawTexturePayloadSou
 
     public long? EstimatedByteLength => bytes.Length;
 
-    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public async ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         using MemoryStream stream = new(bytes, writable: false);
@@ -138,7 +236,7 @@ internal sealed class DatasetTextureImportSource(
     IPlateauDatasetContentSource datasetSource,
     string relativePath,
     string? colorProfile,
-    string identity) : IRawTexturePayloadSource
+    string identity) : IRgba32RawTexturePayloadSource
 {
     public string Identity { get; } = identity;
 
@@ -150,7 +248,7 @@ internal sealed class DatasetTextureImportSource(
         ? lengthSource.TryGetFileLength(relativePath)
         : null;
 
-    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public async ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
         await using Stream stream = await datasetSource.OpenReadAsync(relativePath, cancellationToken);
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream, cancellationToken);
@@ -161,7 +259,7 @@ internal sealed class DatasetTextureImportSource(
 internal sealed class FileTextureImportSource(
     string absolutePath,
     string colorProfile,
-    string identity) : IRawTexturePayloadSource
+    string identity) : IRgba32RawTexturePayloadSource
 {
     public string Identity { get; } = identity;
 
@@ -188,19 +286,19 @@ internal sealed class FileTextureImportSource(
         }
     }
 
-    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public async ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(absolutePath, cancellationToken);
         return TextureImportSourceFactory.CreateRawPayloadFromImage(image, ColorProfile);
     }
 }
 
-internal sealed class GeneratedTextureImportSource(
-    Func<CancellationToken, ValueTask<RawTexturePayload>> materializeRawAsync,
+internal sealed class GeneratedRgba32TextureImportSource(
+    Func<CancellationToken, ValueTask<Rgba32RawTexturePayload>> materializeRgba32Async,
     string identity,
     string description,
     string? colorProfile,
-    long? estimatedByteLength = null) : IRawTexturePayloadSource
+    long? estimatedByteLength = null) : IRgba32RawTexturePayloadSource
 {
     public string Identity { get; } = identity;
 
@@ -210,9 +308,30 @@ internal sealed class GeneratedTextureImportSource(
 
     public long? EstimatedByteLength { get; } = estimatedByteLength;
 
-    public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
-        return materializeRawAsync(cancellationToken);
+        return materializeRgba32Async(cancellationToken);
+    }
+}
+
+internal sealed class GeneratedRgbaFloat32TextureImportSource(
+    Func<CancellationToken, ValueTask<RgbaFloat32RawTexturePayload>> materializeRgbaFloat32Async,
+    string identity,
+    string description,
+    string? colorProfile,
+    long? estimatedByteLength = null) : IRgbaFloat32RawTexturePayloadSource
+{
+    public string Identity { get; } = identity;
+
+    public string Description { get; } = description;
+
+    public string? ColorProfile { get; } = colorProfile;
+
+    public long? EstimatedByteLength { get; } = estimatedByteLength;
+
+    public ValueTask<RgbaFloat32RawTexturePayload> MaterializeRgbaFloat32Async(CancellationToken cancellationToken)
+    {
+        return materializeRgbaFloat32Async(cancellationToken);
     }
 }
 
@@ -266,15 +385,30 @@ internal static class TextureImportSourceFactory
             identity ?? $"file:{Path.GetFullPath(absolutePath)}:{colorProfile}");
     }
 
-    public static ITextureImportSource CreateGeneratedImage(
-        Func<CancellationToken, ValueTask<RawTexturePayload>> materializeRawAsync,
+    public static ITextureImportSource CreateGeneratedRgba32Image(
+        Func<CancellationToken, ValueTask<Rgba32RawTexturePayload>> materializeRgba32Async,
         string identity,
         string description,
         string? colorProfile,
         long? estimatedByteLength = null)
     {
-        return new GeneratedTextureImportSource(
-            materializeRawAsync,
+        return new GeneratedRgba32TextureImportSource(
+            materializeRgba32Async,
+            identity,
+            description,
+            colorProfile,
+            estimatedByteLength);
+    }
+
+    public static ITextureImportSource CreateGeneratedRgbaFloat32Image(
+        Func<CancellationToken, ValueTask<RgbaFloat32RawTexturePayload>> materializeRgbaFloat32Async,
+        string identity,
+        string description,
+        string? colorProfile,
+        long? estimatedByteLength = null)
+    {
+        return new GeneratedRgbaFloat32TextureImportSource(
+            materializeRgbaFloat32Async,
             identity,
             description,
             colorProfile,
@@ -290,7 +424,7 @@ internal static class TextureImportSourceFactory
         ArgumentNullException.ThrowIfNull(image);
         Image<Rgba32> retainedImage = image.Clone();
         object gate = new();
-        return CreateGeneratedImage(
+        return CreateGeneratedRgba32Image(
             cancellationToken =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -305,14 +439,14 @@ internal static class TextureImportSourceFactory
             (long)image.Width * image.Height * 4);
     }
 
-    public static RawTexturePayload CreateRawPayloadFromImage(
+    public static Rgba32RawTexturePayload CreateRawPayloadFromImage(
         Image<Rgba32> image,
         string? colorProfile)
     {
         ArgumentNullException.ThrowIfNull(image);
         byte[] rawBytes = new byte[image.Width * image.Height * 4];
         image.CopyPixelDataTo(rawBytes);
-        return new RawTexturePayload(
+        return new Rgba32RawTexturePayload(
             image.Width,
             image.Height,
             colorProfile,

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClientCanonicalDump.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClientCanonicalDump.cs
@@ -139,8 +139,7 @@ internal static class SceneSinkRecordingClientCanonicalDump
         List<JsonObject> textureNodes = [];
         for (int index = 0; index < client.ImportedTexturePayloads.Count; index++)
         {
-            RawTexturePayload texture = client.ImportedTexturePayloads[index];
-            if (texture.Format != RawTexturePayloadFormat.Rgba32)
+            if (client.ImportedTexturePayloads[index] is not Rgba32RawTexturePayload texture)
             {
                 continue;
             }
@@ -164,8 +163,7 @@ internal static class SceneSinkRecordingClientCanonicalDump
         List<JsonObject> hdrTextureNodes = [];
         for (int index = 0; index < client.ImportedTexturePayloads.Count; index++)
         {
-            RawTexturePayload texture = client.ImportedTexturePayloads[index];
-            if (texture.Format != RawTexturePayloadFormat.RgbaFloat32)
+            if (client.ImportedTexturePayloads[index] is not RgbaFloat32RawTexturePayload texture)
             {
                 continue;
             }
@@ -398,16 +396,16 @@ internal static class SceneSinkRecordingClientCanonicalDump
 
     private static string CreateTextureToken(RawTexturePayload texture)
     {
-        return texture.Format == RawTexturePayloadFormat.RgbaFloat32
-            ? string.Create(
+        return texture.Match(
+            rgba32 => string.Create(
                 CultureInfo.InvariantCulture,
-                $"hdr-texture:{texture.Width}x{texture.Height}:{HashBytes(texture.Bytes)}")
-            : string.Create(
+                $"texture:{rgba32.Width}x{rgba32.Height}:{rgba32.ColorProfile}:{HashBytes(rgba32.Bytes)}"),
+            rgbaFloat32 => string.Create(
                 CultureInfo.InvariantCulture,
-                $"texture:{texture.Width}x{texture.Height}:{texture.ColorProfile}:{HashBytes(texture.Bytes)}");
+                $"hdr-texture:{rgbaFloat32.Width}x{rgbaFloat32.Height}:{HashBytes(rgbaFloat32.Bytes)}"));
     }
 
-    private static string CreateHdrTextureToken(RawTexturePayload texture)
+    private static string CreateHdrTextureToken(RgbaFloat32RawTexturePayload texture)
     {
         return string.Create(
             CultureInfo.InvariantCulture,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
@@ -211,7 +211,7 @@ internal static class ResoniteCityObjectPreparation
 
     public static ITextureImportSource PrepareTerrainGridDisplacementTexture(ResoniteTerrainGridGeometry geometry)
     {
-        return TextureImportSourceFactory.CreateGeneratedImage(
+        return TextureImportSourceFactory.CreateGeneratedRgbaFloat32Image(
             cancellationToken =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -223,7 +223,7 @@ internal static class ResoniteCityObjectPreparation
             estimatedByteLength: checked((long)geometry.Width * geometry.Height * 4L * sizeof(float)));
     }
 
-    private static RawTexturePayload CreateTerrainGridDisplacementPayload(ResoniteTerrainGridGeometry geometry)
+    private static RgbaFloat32RawTexturePayload CreateTerrainGridDisplacementPayload(ResoniteTerrainGridGeometry geometry)
     {
         float[] rawPixels = new float[geometry.Width * geometry.Height * 4];
         double heightRange = Math.Max(geometry.MaxHeight - geometry.MinHeight, 0.0);
@@ -249,12 +249,11 @@ internal static class ResoniteCityObjectPreparation
 
         byte[] rawBytes = new byte[rawPixels.Length * sizeof(float)];
         Buffer.BlockCopy(rawPixels, 0, rawBytes, 0, rawBytes.Length);
-        return new RawTexturePayload(
+        return new RgbaFloat32RawTexturePayload(
             geometry.Width,
             geometry.Height,
-            ColorProfile: null,
-            rawBytes,
-            RawTexturePayloadFormat.RgbaFloat32);
+            colorProfile: null,
+            rawBytes);
     }
 
     public static string CreateTriangleMeshDiagnosticSummary(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImageLoader.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImageLoader.cs
@@ -25,14 +25,9 @@ internal sealed class ResoniteTextureImageLoader
         ITextureImportSource textureSource,
         CancellationToken cancellationToken)
     {
-        RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+        Rgba32RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRgba32Async(
             textureSource,
             cancellationToken);
-        if (rawPayload.Format != RawTexturePayloadFormat.Rgba32)
-        {
-            throw new InvalidOperationException(
-                $"Unsupported texture payload format '{rawPayload.Format}' for image loading.");
-        }
 
         return Image.LoadPixelData<Rgba32>(
             rawPayload.Bytes,

--- a/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkClient.cs
+++ b/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkClient.cs
@@ -164,12 +164,9 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
         RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
             textureSource,
             cancellationToken);
-        AssetData result = rawPayload.Format switch
-        {
-            RawTexturePayloadFormat.Rgba32 => await ImportRawTextureAsync(rawPayload, cancellationToken),
-            RawTexturePayloadFormat.RgbaFloat32 => await ImportRawHdrTextureAsync(rawPayload, cancellationToken),
-            _ => throw new InvalidOperationException($"Unsupported texture payload format '{rawPayload.Format}'."),
-        };
+        AssetData result = await rawPayload.Match(
+            rgba32 => ImportRawTextureAsync(rgba32, cancellationToken),
+            rgbaFloat32 => ImportRawHdrTextureAsync(rgbaFloat32, cancellationToken));
 
         EnsureSuccess(result, "import texture");
         return result.AssetURL ?? throw new InvalidOperationException("ResoniteLink returned a null texture asset URL.");
@@ -253,7 +250,7 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
             "component");
     }
 
-    private Task<AssetData> ImportRawTextureAsync(RawTexturePayload rawPayload, CancellationToken cancellationToken)
+    private Task<AssetData> ImportRawTextureAsync(Rgba32RawTexturePayload rawPayload, CancellationToken cancellationToken)
     {
         return ExecuteSerializedAsync(
             "import_texture",
@@ -268,7 +265,7 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
             cancellationToken);
     }
 
-    private Task<AssetData> ImportRawHdrTextureAsync(RawTexturePayload rawPayload, CancellationToken cancellationToken)
+    private Task<AssetData> ImportRawHdrTextureAsync(RgbaFloat32RawTexturePayload rawPayload, CancellationToken cancellationToken)
     {
         return ExecuteSerializedAsync(
             "import_texture",

--- a/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,6 +26,7 @@ public sealed class TextureImportSourceFactoryTests
             source,
             CancellationToken.None);
 
+        Assert.IsType<Rgba32RawTexturePayload>(payload);
         Assert.Equal(1, payload.Width);
         Assert.Equal(1, payload.Height);
         Assert.Equal([255, 255, 255, 255], payload.Bytes);
@@ -48,9 +50,36 @@ public sealed class TextureImportSourceFactoryTests
             source,
             CancellationToken.None);
 
+        Assert.IsType<Rgba32RawTexturePayload>(payload);
         Assert.Equal(1, payload.Width);
         Assert.Equal(1, payload.Height);
         Assert.Equal([1, 2, 3, 255], payload.Bytes);
+    }
+
+    [Fact]
+    public async Task CreateGeneratedRgbaFloat32ImageDoesNotMaterializeAsRgba32()
+    {
+        ITextureImportSource source = TextureImportSourceFactory.CreateGeneratedRgbaFloat32Image(
+            _ => ValueTask.FromResult(new RgbaFloat32RawTexturePayload(
+                width: 1,
+                height: 1,
+                colorProfile: null,
+                bytes: new byte[16])),
+            identity: "hdr",
+            description: "hdr",
+            colorProfile: null,
+            estimatedByteLength: 16);
+
+        RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            source,
+            CancellationToken.None);
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await TextureImportSourceMaterializer.MaterializeRgba32Async(
+                source,
+                CancellationToken.None));
+
+        Assert.IsType<RgbaFloat32RawTexturePayload>(rawPayload);
+        Assert.Contains("cannot materialize an RGBA32 texture payload", exception.Message, System.StringComparison.Ordinal);
     }
 
 }

--- a/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
@@ -24,25 +24,24 @@ internal static class TextureImportSourceTestFactory
             identity ?? $"test-rgba32:{width}:{height}:{Guid.NewGuid():N}");
     }
 
-    public static IReadOnlyList<RawTexturePayload> ImportedRgba32Textures(SceneSinkRecordingClient client)
+    public static IReadOnlyList<Rgba32RawTexturePayload> ImportedRgba32Textures(SceneSinkRecordingClient client)
     {
         return client.ImportedTexturePayloads
-            .Where(static payload => payload.Format == RawTexturePayloadFormat.Rgba32)
+            .OfType<Rgba32RawTexturePayload>()
             .ToArray();
     }
 
-    public static IReadOnlyList<RawTexturePayload> ImportedHdrTextures(SceneSinkRecordingClient client)
+    public static IReadOnlyList<RgbaFloat32RawTexturePayload> ImportedHdrTextures(SceneSinkRecordingClient client)
     {
         return client.ImportedTexturePayloads
-            .Where(static payload => payload.Format == RawTexturePayloadFormat.RgbaFloat32)
+            .OfType<RgbaFloat32RawTexturePayload>()
             .ToArray();
     }
 
-    public static bool IsSolidColorTexture(RawTexturePayload texture, byte r, byte g, byte b)
+    public static bool IsSolidColorTexture(Rgba32RawTexturePayload texture, byte r, byte g, byte b)
     {
         byte[] expectedPixel = [r, g, b, 255];
-        return texture.Format == RawTexturePayloadFormat.Rgba32
-            && texture.Width == 2
+        return texture.Width == 2
             && texture.Height == 2
             && texture.Bytes.Chunk(4).All(pixel => pixel.SequenceEqual(expectedPixel));
     }

--- a/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
@@ -378,7 +378,7 @@ public sealed class ResoniteLinkClientTests
         }
     }
 
-    private sealed class InstrumentedTextureImportSource : IRawTexturePayloadSource
+    private sealed class InstrumentedTextureImportSource : IRgba32RawTexturePayloadSource
     {
         public int MaterializeCallCount { get; private set; }
 
@@ -390,11 +390,11 @@ public sealed class ResoniteLinkClientTests
 
         public long? EstimatedByteLength => 4;
 
-        public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+        public ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             MaterializeCallCount++;
-            return ValueTask.FromResult(new RawTexturePayload(
+            return ValueTask.FromResult(new Rgba32RawTexturePayload(
                 1,
                 1,
                 ResoniteTextureColorProfiles.Srgb,


### PR DESCRIPTION
## Summary
- replace `RawTexturePayloadFormat` with concrete raw texture payload variants for RGBA32 and RGBA float32 payloads
- split raw texture source materialization into RGBA32 and RGBA float32 capabilities at source creation boundaries
- route transport, image loading, canonical dump, and tests through typed payload variants instead of runtime format checks

## Verification
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Fake Live Sink canonical dump for `plateau-13213-higashimurayama-shi-2020` / `53395325` / `dem,bldg` / grid; diff against `runtime/windows/resonite/semantic-baselines/type-dem-grid-projection-result/baseline-parent/higashi-53395325-dem-bldg-grid-geotiff.json` stayed at the known parent-stack `96 +75/-21` delta; temporary dump removed.