### PR TITLE
[codex] Rescue safe type refactors

### DIFF
--- a/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
+++ b/src/PlateauResoniteLink.Cli/CliArgumentsParser.cs
@@ -273,6 +273,7 @@ public static class CliArgumentsParser
                                     System.Globalization.NumberStyles.Float | System.Globalization.NumberStyles.AllowThousands,
                                     System.Globalization.CultureInfo.InvariantCulture,
                                     out terrainGridMetersPerVertex)
+                                || !double.IsFinite(terrainGridMetersPerVertex)
                                 || terrainGridMetersPerVertex <= 0.0)
                             {
                                 return CliParseResult.Failure(
@@ -355,6 +356,16 @@ public static class CliArgumentsParser
         if (string.IsNullOrWhiteSpace(cityGmlSourceInput))
         {
             return CliParseResult.Failure("Specify --citygml-source.");
+        }
+
+        if (string.IsNullOrWhiteSpace(dataset))
+        {
+            return CliParseResult.Failure("Specify --dataset.");
+        }
+
+        if (string.IsNullOrWhiteSpace(meshCode))
+        {
+            return CliParseResult.Failure("Specify --mesh-code.");
         }
 
         if (!TryParseDatasetLocationInput(cityGmlSourceInput, out DatasetLocation? cityGmlSource, out string? sourceError))

--- a/src/PlateauResoniteLink/Application/Importing/BuildingAttributeModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/BuildingAttributeModels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace PlateauResoniteLink.Application.Importing;
@@ -49,28 +50,23 @@ internal enum PlateauBuildingStructure
     Other,
 }
 
-internal enum BuildingMetricValueKind
-{
-    Missing = 0,
-    Known,
-    Invalid,
-}
-
 internal sealed record BuildingCodeValue<T>(T Value, string Code);
 
-internal sealed record BuildingMetricValue(BuildingMetricValueKind Kind, double? Value, string? Raw)
+internal sealed record BuildingMetricValue
 {
-    public static BuildingMetricValue Missing { get; } = new(BuildingMetricValueKind.Missing, null, null);
-
-    public static BuildingMetricValue Known(double value)
+    public BuildingMetricValue(double value)
     {
-        return new BuildingMetricValue(BuildingMetricValueKind.Known, value, null);
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
+
+        if (!double.IsFinite(value))
+        {
+            throw new ArgumentOutOfRangeException(nameof(value));
+        }
+
+        Value = value;
     }
 
-    public static BuildingMetricValue Invalid(string raw)
-    {
-        return new BuildingMetricValue(BuildingMetricValueKind.Invalid, null, raw);
-    }
+    public double Value { get; }
 }
 
 internal sealed record BuildingAttributeContext(
@@ -80,13 +76,13 @@ internal sealed record BuildingAttributeContext(
     IReadOnlyList<BuildingCodeValue<PlateauBuildingStructure>> Structures,
     IReadOnlyList<string> CityGmlClassCodes,
     IReadOnlyList<string> CityGmlFunctionCodes,
-    BuildingMetricValue MeasuredHeightMeters,
-    BuildingMetricValue StoreysAboveGround,
-    BuildingMetricValue StoreysBelowGround,
-    BuildingMetricValue BuildingFootprintArea,
-    BuildingMetricValue BuildingRoofEdgeArea,
-    BuildingMetricValue BuildingHeight,
-    BuildingMetricValue EaveHeight)
+    BuildingMetricValue? MeasuredHeightMeters,
+    BuildingMetricValue? StoreysAboveGround,
+    BuildingMetricValue? StoreysBelowGround,
+    BuildingMetricValue? BuildingFootprintArea,
+    BuildingMetricValue? BuildingRoofEdgeArea,
+    BuildingMetricValue? BuildingHeight,
+    BuildingMetricValue? EaveHeight)
 {
     public static BuildingAttributeContext Empty { get; } = new(
         RoofShape: null,
@@ -95,11 +91,11 @@ internal sealed record BuildingAttributeContext(
         Structures: [],
         CityGmlClassCodes: [],
         CityGmlFunctionCodes: [],
-        MeasuredHeightMeters: BuildingMetricValue.Missing,
-        StoreysAboveGround: BuildingMetricValue.Missing,
-        StoreysBelowGround: BuildingMetricValue.Missing,
-        BuildingFootprintArea: BuildingMetricValue.Missing,
-        BuildingRoofEdgeArea: BuildingMetricValue.Missing,
-        BuildingHeight: BuildingMetricValue.Missing,
-        EaveHeight: BuildingMetricValue.Missing);
+        MeasuredHeightMeters: null,
+        StoreysAboveGround: null,
+        StoreysBelowGround: null,
+        BuildingFootprintArea: null,
+        BuildingRoofEdgeArea: null,
+        BuildingHeight: null,
+        EaveHeight: null);
 }

--- a/src/PlateauResoniteLink/Application/Importing/BuildingAttributeParser.cs
+++ b/src/PlateauResoniteLink/Application/Importing/BuildingAttributeParser.cs
@@ -125,36 +125,36 @@ internal static class BuildingAttributeParser
         };
     }
 
-    private static BuildingMetricValue ParseIntegerMetricValue(XElement? element)
+    private static BuildingMetricValue? ParseIntegerMetricValue(XElement? element)
     {
         if (element is null)
         {
-            return BuildingMetricValue.Missing;
+            return null;
         }
 
         string rawValue = element.Value.Trim();
         if (IsPlateauMissingMetricToken(rawValue))
         {
-            return BuildingMetricValue.Missing;
+            return null;
         }
 
         return int.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value)
             && value >= 0
-                ? BuildingMetricValue.Known(value)
-                : BuildingMetricValue.Invalid(rawValue);
+                ? new BuildingMetricValue(value)
+                : null;
     }
 
-    private static BuildingMetricValue ParseMetricValue(XElement? element, bool requireMeters)
+    private static BuildingMetricValue? ParseMetricValue(XElement? element, bool requireMeters)
     {
         if (element is null)
         {
-            return BuildingMetricValue.Missing;
+            return null;
         }
 
         string rawValue = element.Value.Trim();
         if (IsPlateauMissingMetricToken(rawValue))
         {
-            return BuildingMetricValue.Missing;
+            return null;
         }
 
         string? unitOfMeasure = element.Attribute("uom")?.Value.Trim();
@@ -162,13 +162,14 @@ internal static class BuildingAttributeParser
             && !string.IsNullOrWhiteSpace(unitOfMeasure)
             && !string.Equals(unitOfMeasure, "m", StringComparison.OrdinalIgnoreCase))
         {
-            return BuildingMetricValue.Invalid(rawValue);
+            return null;
         }
 
         return double.TryParse(rawValue, NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
+            && double.IsFinite(value)
             && value > 0.0
-                ? BuildingMetricValue.Known(value)
-                : BuildingMetricValue.Invalid(rawValue);
+                ? new BuildingMetricValue(value)
+                : null;
     }
 
     private static bool IsPlateauMissingMetricToken(string rawValue)

--- a/src/PlateauResoniteLink/Application/Importing/BuildingAttributeQueries.cs
+++ b/src/PlateauResoniteLink/Application/Importing/BuildingAttributeQueries.cs
@@ -7,23 +7,23 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal static class BuildingAttributeQueries
 {
-    internal static int? TryGetKnownPositiveInteger(BuildingMetricValue metric)
+    internal static int? TryGetKnownPositiveInteger(BuildingMetricValue? metric)
     {
-        if (metric.Kind != BuildingMetricValueKind.Known || !metric.Value.HasValue)
+        if (metric is null)
         {
             return null;
         }
 
-        int value = (int)Math.Round(metric.Value.Value, MidpointRounding.AwayFromZero);
-        return Math.Abs(metric.Value.Value - value) < 1e-9
+        int value = (int)Math.Round(metric.Value, MidpointRounding.AwayFromZero);
+        return Math.Abs(metric.Value - value) < 1e-9
             && (value == 0 || FacadeFloorMetrics.IsUsableFloorCount(value))
                 ? value
                 : null;
     }
 
-    internal static double? TryGetKnownPositiveMetric(BuildingMetricValue metric)
+    internal static double? TryGetKnownPositiveMetric(BuildingMetricValue? metric)
     {
-        return metric.Kind == BuildingMetricValueKind.Known && metric.Value is > 0.0
+        return metric is not null && metric.Value > 0.0
             ? metric.Value
             : null;
     }

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlAppearanceStore.cs
@@ -188,7 +188,7 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
     {
         if (!texturePayloadsByResolvedPath.TryGetValue(resolvedTexturePath, out TexturePayload? texturePayload))
         {
-            texturePayload = new TexturePayload(
+            texturePayload = new EncodedImageTexturePayload(
                 null,
                 null,
                 "sRGB",
@@ -197,8 +197,7 @@ internal sealed class CityGmlAppearanceStore : ICityGmlAppearanceStore
                     resolvedTexturePath,
                     "sRGB",
                     $"dataset:{resolvedTexturePath}"),
-                $"dataset:{resolvedTexturePath}",
-                TexturePayloadFormat.EncodedImage);
+                $"dataset:{resolvedTexturePath}");
             texturePayloadsByResolvedPath[resolvedTexturePath] = texturePayload;
         }
 

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -28,7 +28,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         IDefaultMaterialResolver materialResolver,
         Action<string>? progressReporter,
         CancellationToken cancellationToken,
-        out ImportedCityObject? heightMapCityObject)
+        out TerrainGridProjectedCityObject? heightMapCityObject)
     {
         cancellationToken.ThrowIfCancellationRequested();
         heightMapCityObject = null;
@@ -151,7 +151,17 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             Z = slotPosition.Z + centerZ,
         };
 
-        heightMapCityObject = new ImportedCityObject(
+        TerrainGridGeometry geometry = new(
+            Width: width,
+            Height: height,
+            Size: new Float2(extentX, extentZ),
+            MinHeight: minHeight,
+            MaxHeight: maxHeight,
+            HeightSamples: localHeights,
+            SampleCoverage: sampleCoverage,
+            UvScale: heightMapUvScale,
+            UvOffset: heightMapUvOffset);
+        ImportedCityObject projectedCityObject = new(
             ObjectKey: cityObject.SlotKey,
             DisplayName: cityObject.DisplayName,
             PackageName: cityObject.PackageName,
@@ -160,18 +170,10 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             Transform: new Transform3D(
                 ToContractFloat3(adjustedSlotPosition),
                 ToContractQuaternion(GridMeshTerrainRotation)),
-            Geometry: new TerrainGridGeometry(
-                Width: width,
-                Height: height,
-                Size: new Float2(extentX, extentZ),
-                MinHeight: minHeight,
-                MaxHeight: maxHeight,
-                HeightSamples: localHeights,
-                SampleCoverage: sampleCoverage,
-                UvScale: heightMapUvScale,
-                UvOffset: heightMapUvOffset),
+            Geometry: geometry,
             Materials: materials,
             SourceFileRelativePath: cityObject.SourceFileRelativePath);
+        heightMapCityObject = new TerrainGridProjectedCityObject(projectedCityObject, geometry);
         return true;
     }
 
@@ -375,3 +377,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         double MinZ,
         double MaxZ);
 }
+
+internal sealed record TerrainGridProjectedCityObject(
+    ImportedCityObject CityObject,
+    TerrainGridGeometry Geometry);

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -32,7 +32,7 @@ internal static class CityGmlParsedCityObjectProjection
 
         LocalCityGmlObjectProjection.ValidateCompatibleReferenceSystem(
             referenceSystem,
-            sourceFile.CityObjects.FirstOrDefault()?.ReferenceSystem ?? referenceSystem);
+            sourceFile.ReferenceSystem);
 
         ParsedCityObject[] projectedInputCityObjects =
             DemCityObjectAggregation.AggregateBySourceFileAndThirdMesh(

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -353,13 +353,17 @@ internal static class CityGmlParsedCityObjectProjection
         ParsedSurface surface,
         ParsedCityObject cityObject)
     {
-        if (surface.InteriorRings.Length != 0
-            || surface.ExteriorRing.Vertices.Length != 4)
+        if (surface.InteriorRings.Length != 0)
         {
             return [surface];
         }
 
         if (!ShouldSubdivideTerrainAlignedCityObject(cityObject.PackageName, cityObject.LodLevel))
+        {
+            return [surface];
+        }
+
+        if (surface.ExteriorRing.Vertices.Length != 4)
         {
             return [surface];
         }
@@ -375,12 +379,17 @@ internal static class CityGmlParsedCityObjectProjection
         Float3[] positions = surface.ExteriorRing.Vertices
             .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
             .ToArray();
+        if (!RoadSurfaceQuad.TryCreate(surface.ExteriorRing, positions, out RoadSurfaceQuad quad))
+        {
+            return [surface];
+        }
+
         if (!IsNearHorizontalSurface(positions))
         {
             return [surface];
         }
 
-        EdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(surface.ExteriorRing, positions);
+        EdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(quad);
         return TerrainAlignedTransportationSurfaceSplitter.Split(surface, positions, edgePair);
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -251,7 +251,7 @@ internal static class CityGmlParsedCityObjectProjection
             materialResolver,
             progressReporter,
             cancellationToken,
-            out ImportedCityObject? heightMapCityObject);
+            out TerrainGridProjectedCityObject? heightMapCityObject);
         if (!hasGrid)
         {
             return request.TerrainMeshMode == TerrainMeshMode.Dynamic
@@ -261,24 +261,23 @@ internal static class CityGmlParsedCityObjectProjection
 
         if (request.TerrainMeshMode == TerrainMeshMode.Grid)
         {
-            return heightMapCityObject!;
+            return heightMapCityObject!.CityObject;
         }
 
-        ImportedCityObject staticCityObject = CityGmlTriangleMeshCityObjectProjection.Project(
+        TriangleMeshProjectedCityObject staticCityObject = CityGmlTriangleMeshCityObjectProjection.ProjectTriangleMesh(
             cityObject,
             globalOriginPoint,
             globalCartesian,
             demTerrainTextureOverlay,
             materialResolver);
-        TriangleMeshGeometry staticMesh = AssertTriangleMeshGeometry(staticCityObject);
         TriangleMeshGeometry rebasedStaticMesh = TriangleMeshTransformRebaser.Rebase(
-            staticMesh,
-            staticCityObject.Transform,
-            heightMapCityObject!.Transform);
-        return heightMapCityObject with
+            staticCityObject.Geometry,
+            staticCityObject.CityObject.Transform,
+            heightMapCityObject!.CityObject.Transform);
+        return heightMapCityObject.CityObject with
         {
-            Geometry = new DynamicTerrainGeometry(rebasedStaticMesh, AssertTerrainGridGeometry(heightMapCityObject)),
-            Materials = staticCityObject.Materials,
+            Geometry = new DynamicTerrainGeometry(rebasedStaticMesh, heightMapCityObject.Geometry),
+            Materials = staticCityObject.CityObject.Materials,
         };
     }
 
@@ -459,18 +458,6 @@ internal static class CityGmlParsedCityObjectProjection
             origin.Longitude,
             origin.Altitude,
             cartesian);
-    }
-
-    private static TriangleMeshGeometry AssertTriangleMeshGeometry(ImportedCityObject cityObject)
-    {
-        return cityObject.Geometry as TriangleMeshGeometry
-            ?? throw new InvalidOperationException("Dynamic terrain static variant must be projected as a triangle mesh.");
-    }
-
-    private static TerrainGridGeometry AssertTerrainGridGeometry(ImportedCityObject cityObject)
-    {
-        return cityObject.Geometry as TerrainGridGeometry
-            ?? throw new InvalidOperationException("Dynamic terrain grid variant must be projected as a terrain grid.");
     }
 
     private static bool HasRenderableGeometry(ImportedCityObject cityObject)

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectReader.cs
@@ -26,7 +26,7 @@ internal static class CityGmlParsedCityObjectReader
     {
         string objectTypeName = cityObjectElement.Name.LocalName;
         string objectId = GetAttribute(cityObjectElement, Gml + "id") ?? objectTypeName;
-        string? displayName = cityObjectElement.Elements(Gml + "name").FirstOrDefault()?.Value.Trim();
+        string displayName = cityObjectElement.Elements(Gml + "name").FirstOrDefault()?.Value.Trim() ?? objectId;
         if (string.IsNullOrWhiteSpace(displayName))
         {
             displayName = objectId;
@@ -34,7 +34,7 @@ internal static class CityGmlParsedCityObjectReader
 
         string resolvedActualMeshCode = CityGmlMeshCodeBoundsFilter.ResolveActualMeshCode(
             packageName,
-            displayName!,
+            displayName,
             objectId,
             actualMeshCode,
             sharedAcrossMeshCodes);
@@ -64,13 +64,7 @@ internal static class CityGmlParsedCityObjectReader
             return null;
         }
 
-        ParsedSurface[] surfaces = preferredSurfaceElements
-            .Select(surfaceElement => CityGmlParsedSurfaceReader.Parse(surfaceElement, appearanceStore))
-            .Where(static surface => surface is not null)
-            .Select(static surface => surface!)
-            .Select(surface => CityGmlParsedSurfaceReader.ApplyPackageDefaults(packageName, surface))
-            .OrderBy(static surface => ParsedSurfaceStableSortKey.Create(surface), StringComparer.Ordinal)
-            .ToArray();
+        ParsedSurface[] surfaces = ParseSurfaces(preferredSurfaceElements, packageName, appearanceStore);
 
         if (surfaces.Length == 0)
         {
@@ -91,7 +85,7 @@ internal static class CityGmlParsedCityObjectReader
         string slotKey = SanitizeIdentifier($"{packageName}_{fileStem}_{objectId}");
         return new ParsedCityObject(
             slotKey,
-            displayName!,
+            displayName,
             packageName,
             resolvedActualMeshCode,
             lodLevel,
@@ -103,6 +97,27 @@ internal static class CityGmlParsedCityObjectReader
             MeasuredHeightMeters: measuredHeightMeters,
             BuildingAttributes: buildingAttributes,
             SourceMeshCode: actualMeshCode);
+    }
+
+    private static ParsedSurface[] ParseSurfaces(
+        IEnumerable<XElement> surfaceElements,
+        string packageName,
+        ICityGmlAppearanceStore appearanceStore)
+    {
+        List<ParsedSurface> surfaces = [];
+        foreach (XElement surfaceElement in surfaceElements)
+        {
+            if (CityGmlParsedSurfaceReader.TryParse(surfaceElement, appearanceStore) is not { } surface)
+            {
+                continue;
+            }
+
+            surfaces.Add(CityGmlParsedSurfaceReader.ApplyPackageDefaults(packageName, surface));
+        }
+
+        return surfaces
+            .OrderBy(static surface => ParsedSurfaceStableSortKey.Create(surface), StringComparer.Ordinal)
+            .ToArray();
     }
 
     private static string? GetAttribute(XElement element, XName attributeName)

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedSurfaceReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedSurfaceReader.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Xml.Linq;
@@ -11,7 +10,7 @@ internal static class CityGmlParsedSurfaceReader
 {
     private static readonly XNamespace Gml = "http://www.opengis.net/gml";
 
-    internal static ParsedSurface? Parse(XElement polygonElement, ICityGmlAppearanceStore appearanceStore)
+    internal static ParsedSurface? TryParse(XElement polygonElement, ICityGmlAppearanceStore appearanceStore)
     {
         ArgumentNullException.ThrowIfNull(polygonElement);
         ArgumentNullException.ThrowIfNull(appearanceStore);
@@ -26,24 +25,15 @@ internal static class CityGmlParsedSurfaceReader
 
         string polygonId = GetAttribute(polygonElement, Gml + "id") ?? CreateStableElementId("polygon", polygonElement);
         CityGmlResolvedAppearance appearance = appearanceStore.Resolve(polygonId);
-        ParsedRing? exteriorParsedRing = ParseRing(
+        if (TryParseRing(
             exteriorRing,
             appearance.RingUvsByRingId,
-            fallbackRingId: polygonId);
-        if (exteriorParsedRing is null)
+            fallbackRingId: polygonId) is not { } exteriorParsedRing)
         {
             return null;
         }
 
-        ParsedRing[] interiorRings = polygonElement
-            .Elements(Gml + "interior")
-            .Select(interiorElement => ParseRing(
-                interiorElement.Element(Gml + "LinearRing"),
-                appearance.RingUvsByRingId,
-                fallbackRingId: null))
-            .Where(static ring => ring is not null)
-            .Select(static ring => ring!)
-            .ToArray();
+        ParsedRing[] interiorRings = ParseInteriorRings(polygonElement, appearance.RingUvsByRingId);
 
         return new ParsedSurface(
             PolygonId: polygonId,
@@ -65,7 +55,26 @@ internal static class CityGmlParsedSurfaceReader
             : surface;
     }
 
-    private static ParsedRing? ParseRing(
+    private static ParsedRing[] ParseInteriorRings(
+        XElement polygonElement,
+        IReadOnlyDictionary<string, IReadOnlyList<Float2>>? ringUvsByRingId)
+    {
+        List<ParsedRing> rings = [];
+        foreach (XElement interiorElement in polygonElement.Elements(Gml + "interior"))
+        {
+            if (TryParseRing(
+                interiorElement.Element(Gml + "LinearRing"),
+                ringUvsByRingId,
+                fallbackRingId: null) is { } ring)
+            {
+                rings.Add(ring);
+            }
+        }
+
+        return rings.ToArray();
+    }
+
+    private static ParsedRing? TryParseRing(
         XElement? ringElement,
         IReadOnlyDictionary<string, IReadOnlyList<Float2>>? ringUvsByRingId,
         string? fallbackRingId)

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceMaterialResolver.cs
@@ -281,9 +281,7 @@ internal static class CityGmlSurfaceMaterialResolver
             FloorsAboveGround: cityObject.FloorsAboveGround,
             MeasuredHeightMeters: cityObject.MeasuredHeightMeters,
             GeometryHeightMeters: cityObject.GeometryHeightMeters,
-            FootprintAreaSquareMeters: cityObject.BuildingAttributes is null
-                ? null
-                : BuildingAttributeQueries.TryGetKnownPositiveMetric(cityObject.BuildingAttributes.BuildingFootprintArea),
+            FootprintAreaSquareMeters: BuildingAttributeQueries.TryGetKnownPositiveMetric(cityObject.BuildingAttributes.BuildingFootprintArea),
             SurfaceRole: ToDefaultMaterialSurfaceRole(face.Role)));
         MaterialDepthOffset? depthOffset = cityObject.TerrainAligned
             ? TerrainAlignedDepthOffset

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceProjectionPolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlSurfaceProjectionPolicy.cs
@@ -41,24 +41,24 @@ internal static class CityGmlSurfaceProjectionPolicy
             return [];
         }
 
-        SurfaceProjectionInfo[] candidates = surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
+        SurfaceProjectionInfo[] candidates = CreateSurfaceProjectionInfos(
+            surfaces,
+            cityObjectOrigin,
+            cityObjectCartesian);
 
         if (candidates.Length == 0)
         {
             return [];
         }
 
-        double objectMinimumY = candidates.Min(static info => info.MinimumY!.Value);
-        double objectMaximumY = candidates.Max(static info => info.MaximumY!.Value);
+        double objectMinimumY = candidates.Min(static info => info.MinimumY);
+        double objectMaximumY = candidates.Max(static info => info.MaximumY);
 
         return candidates
             .Where(static info => !info.IsGeneratedLod1RoofSurface)
             .Where(static info => info.IsNearHorizontal)
-            .Where(info => info.MaximumY!.Value <= objectMinimumY + BuildingBottomCullBandMeters)
-            .Where(info => objectMaximumY > info.MaximumY!.Value + BuildingBottomCullBandMeters)
+            .Where(info => info.MaximumY <= objectMinimumY + BuildingBottomCullBandMeters)
+            .Where(info => objectMaximumY > info.MaximumY + BuildingBottomCullBandMeters)
             .Select(static info => info.PolygonId)
             .ToHashSet(StringComparer.Ordinal);
     }
@@ -74,10 +74,10 @@ internal static class CityGmlSurfaceProjectionPolicy
             return null;
         }
 
-        SurfaceProjectionInfo[] surfaceInfos = surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
+        SurfaceProjectionInfo[] surfaceInfos = CreateSurfaceProjectionInfos(
+            surfaces,
+            cityObjectOrigin,
+            cityObjectCartesian);
         if (surfaceInfos.Length == 0)
         {
             return null;
@@ -118,43 +118,63 @@ internal static class CityGmlSurfaceProjectionPolicy
         return ComputePolygonNormal(positions);
     }
 
-    private static SurfaceProjectionInfo CreateSurfaceProjectionInfo(
-        ParsedSurface surface,
+    private static SurfaceProjectionInfo[] CreateSurfaceProjectionInfos(
+        IEnumerable<ParsedSurface> surfaces,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian)
     {
+        List<SurfaceProjectionInfo> infos = [];
+        foreach (ParsedSurface surface in surfaces)
+        {
+            if (TryCreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian, out SurfaceProjectionInfo info))
+            {
+                infos.Add(info);
+            }
+        }
+
+        return [.. infos];
+    }
+
+    private static bool TryCreateSurfaceProjectionInfo(
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian? cityObjectCartesian,
+        out SurfaceProjectionInfo info)
+    {
+        info = default;
         Float3[] positions = surface.Vertices
             .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
             .ToArray();
         if (positions.Length == 0)
         {
-            return new SurfaceProjectionInfo(surface.PolygonId, null, null, false, IsGeneratedLod1RoofSurface(surface.PolygonId));
+            return false;
         }
 
         Float3? normal = ComputePolygonNormal(positions);
         bool isNearHorizontal = normal is not null && Math.Abs(normal.Y) >= 0.98;
 
-        return new SurfaceProjectionInfo(
+        info = new SurfaceProjectionInfo(
             surface.PolygonId,
             positions.Min(static position => position.Y),
             positions.Max(static position => position.Y),
             isNearHorizontal,
             IsGeneratedLod1RoofSurface(surface.PolygonId));
+        return true;
     }
 
     private static (double MinimumY, double MaximumY) ResolveFacadeUvVerticalRange(
         IReadOnlyList<SurfaceProjectionInfo> contextSurfaceInfos,
         IReadOnlyList<SurfaceProjectionInfo> allSurfaceInfos)
     {
-        double minimumY = contextSurfaceInfos.Min(static info => info.MinimumY!.Value);
-        double maximumY = contextSurfaceInfos.Max(static info => info.MaximumY!.Value);
+        double minimumY = contextSurfaceInfos.Min(static info => info.MinimumY);
+        double maximumY = contextSurfaceInfos.Max(static info => info.MaximumY);
         if (maximumY - minimumY > 1e-6 || contextSurfaceInfos.Count == allSurfaceInfos.Count)
         {
             return (minimumY, maximumY);
         }
 
-        double fallbackMinimumY = allSurfaceInfos.Min(static info => info.MinimumY!.Value);
-        double fallbackMaximumY = allSurfaceInfos.Max(static info => info.MaximumY!.Value);
+        double fallbackMinimumY = allSurfaceInfos.Min(static info => info.MinimumY);
+        double fallbackMaximumY = allSurfaceInfos.Max(static info => info.MaximumY);
         return fallbackMaximumY - fallbackMinimumY > maximumY - minimumY
             ? (fallbackMinimumY, fallbackMaximumY)
             : (minimumY, maximumY);
@@ -215,8 +235,8 @@ internal static class CityGmlSurfaceProjectionPolicy
 
     private readonly record struct SurfaceProjectionInfo(
         string PolygonId,
-        double? MinimumY,
-        double? MaximumY,
+        double MinimumY,
+        double MaximumY,
         bool IsNearHorizontal,
         bool IsGeneratedLod1RoofSurface);
 }

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlTriangleMeshCityObjectProjection.cs
@@ -17,6 +17,21 @@ internal static class CityGmlTriangleMeshCityObjectProjection
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IDefaultMaterialResolver materialResolver)
     {
+        return ProjectTriangleMesh(
+            cityObject,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlay,
+            materialResolver).CityObject;
+    }
+
+    internal static TriangleMeshProjectedCityObject ProjectTriangleMesh(
+        ParsedCityObject cityObject,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IDefaultMaterialResolver materialResolver)
+    {
         double? geometryHeightMeters = cityObject.GeometryHeightMeters
             ?? ResolveGeometryHeightMeters(cityObject.Surfaces);
         cityObject = GeneratedLod1RoofCityObjectFactory.Create(cityObject) with
@@ -104,16 +119,18 @@ internal static class CityGmlTriangleMeshCityObjectProjection
             materials.Add(CityGmlSurfaceMaterialResolver.CreateMaterialBinding(cityObject.ActualMeshCode, representativeSurface, materialIndex));
         }
 
-        return new ImportedCityObject(
+        TriangleMeshGeometry geometry = new(new ImportedMesh(vertices.ToArray(), submeshes.ToArray()));
+        ImportedCityObject projectedCityObject = new(
             ObjectKey: cityObject.SlotKey,
             DisplayName: cityObject.DisplayName,
             PackageName: cityObject.PackageName,
             ActualMeshCode: cityObject.ActualMeshCode,
             LodLevel: cityObject.LodLevel,
             Transform: new Transform3D(ToContractFloat3(slotPosition)),
-            Mesh: new ImportedMesh(vertices.ToArray(), submeshes.ToArray()),
+            Geometry: geometry,
             Materials: materials,
             SourceFileRelativePath: cityObject.SourceFileRelativePath);
+        return new TriangleMeshProjectedCityObject(projectedCityObject, geometry);
     }
 
     private static GeodeticPoint ResolveCityObjectOrigin(ParsedCityObject cityObject)
@@ -177,3 +194,7 @@ internal static class CityGmlTriangleMeshCityObjectProjection
 
     private static Float3 ToContractFloat3(Float3 value) => new(value.X, value.Y, value.Z);
 }
+
+internal sealed record TriangleMeshProjectedCityObject(
+    ImportedCityObject CityObject,
+    TriangleMeshGeometry Geometry);

--- a/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -40,21 +41,21 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
         ValidatedLocalDatasetLocation resolvedSource = await ResolveRequiredLocalDatasetLocationAsync(
             request.CityGmlSource,
             workRoot,
-            resourcePrefix: "source-archive",
+            resourcePrefix: ResolvedLocalPlateauImportRequest.RemoteCityGmlResourcePrefix,
             invalidateLocalFileCache: true,
             cancellationToken);
         ValidatedLocalDatasetLocation? resolvedDemTextureSource = await ResolveOptionalLocalDatasetLocationAsync(
             request.DemTextureSource,
             workRoot,
-            resourcePrefix: "source-ortho",
+            resourcePrefix: ResolvedLocalPlateauImportRequest.RemoteDemTextureResourcePrefix,
             invalidateLocalFileCache: false,
             cancellationToken);
 
         return ResolvedLocalPlateauImportRequest.Create(
             request,
-            workRoot,
             resolvedSource,
-            resolvedDemTextureSource);
+            resolvedDemTextureSource,
+            workRoot);
     }
 
     private async Task<ValidatedLocalDatasetLocation> ResolveRequiredLocalDatasetLocationAsync(
@@ -64,14 +65,17 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
         bool invalidateLocalFileCache,
         CancellationToken cancellationToken)
     {
-        ValidatedLocalDatasetLocation? resolvedSource = await ResolveOptionalLocalDatasetLocationAsync(
-            source,
-            workRoot,
-            resourcePrefix,
-            invalidateLocalFileCache,
-            cancellationToken);
-        return resolvedSource
-            ?? throw new InvalidOperationException("The normalized CityGML source must resolve to a local dataset location.");
+        return source switch
+        {
+            ValidatedLocalDatasetLocation localSource => localSource,
+            ValidatedRemoteDatasetLocation remoteSource => await ResolveRemoteDatasetLocationAsync(
+                remoteSource,
+                workRoot,
+                resourcePrefix,
+                invalidateLocalFileCache,
+                cancellationToken),
+            _ => throw new UnreachableException("Validated dataset locations are restricted to local and remote locations."),
+        };
     }
 
     private async Task<ValidatedLocalDatasetLocation?> ResolveOptionalLocalDatasetLocationAsync(
@@ -81,12 +85,31 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
         bool invalidateLocalFileCache,
         CancellationToken cancellationToken)
     {
-        if (source is null || source is ValidatedLocalDatasetLocation)
+        if (source is null)
         {
-            return source as ValidatedLocalDatasetLocation;
+            return null;
         }
 
-        ValidatedRemoteDatasetLocation remoteSource = (ValidatedRemoteDatasetLocation)source;
+        return source switch
+        {
+            ValidatedLocalDatasetLocation localSource => localSource,
+            ValidatedRemoteDatasetLocation remoteSource => await ResolveRemoteDatasetLocationAsync(
+                remoteSource,
+                workRoot,
+                resourcePrefix,
+                invalidateLocalFileCache,
+                cancellationToken),
+            _ => throw new UnreachableException("Validated dataset locations are restricted to local and remote locations."),
+        };
+    }
+
+    private async Task<ValidatedLocalDatasetLocation> ResolveRemoteDatasetLocationAsync(
+        ValidatedRemoteDatasetLocation remoteSource,
+        string workRoot,
+        string resourcePrefix,
+        bool invalidateLocalFileCache,
+        CancellationToken cancellationToken)
+    {
         string resourcePath = RemoteDatasetResourceLayout.GetRemoteResourcePath(
             workRoot,
             remoteSource.ServerUri,

--- a/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CkanPlateauDatasetSourceResolver.cs
@@ -26,7 +26,7 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
         this.archiveFileLayoutPolicy = archiveFileLayoutPolicy ?? throw new ArgumentNullException(nameof(archiveFileLayoutPolicy));
     }
 
-    public async Task<ValidatedPlateauImportRequest> ResolveAsync(
+    public async Task<ResolvedLocalPlateauImportRequest> ResolveAsync(
         ValidatedPlateauImportRequest request,
         string workRoot,
         CancellationToken cancellationToken = default)
@@ -37,27 +37,44 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
         _ = archiveFileLayoutPolicy.CreateSafePathSegment(request.Dataset);
         _ = TryCreateSafePathSegment(request.MeshCode, out _);
 
-        ValidatedDatasetLocation resolvedSource = await ResolveOptionalRemoteDatasetLocationAsync(
+        ValidatedLocalDatasetLocation resolvedSource = await ResolveRequiredLocalDatasetLocationAsync(
             request.CityGmlSource,
             workRoot,
             resourcePrefix: "source-archive",
             invalidateLocalFileCache: true,
-            cancellationToken) ?? throw new InvalidOperationException("The normalized CityGML source must resolve to a local or remote location.");
-        ValidatedDatasetLocation? resolvedDemTextureSource = await ResolveOptionalRemoteDatasetLocationAsync(
+            cancellationToken);
+        ValidatedLocalDatasetLocation? resolvedDemTextureSource = await ResolveOptionalLocalDatasetLocationAsync(
             request.DemTextureSource,
             workRoot,
             resourcePrefix: "source-ortho",
             invalidateLocalFileCache: false,
             cancellationToken);
 
-        return request with
-        {
-            CityGmlSource = resolvedSource,
-            DemTextureSource = resolvedDemTextureSource!,
-        };
+        return ResolvedLocalPlateauImportRequest.Create(
+            request,
+            workRoot,
+            resolvedSource,
+            resolvedDemTextureSource);
     }
 
-    private async Task<ValidatedDatasetLocation?> ResolveOptionalRemoteDatasetLocationAsync(
+    private async Task<ValidatedLocalDatasetLocation> ResolveRequiredLocalDatasetLocationAsync(
+        ValidatedDatasetLocation source,
+        string workRoot,
+        string resourcePrefix,
+        bool invalidateLocalFileCache,
+        CancellationToken cancellationToken)
+    {
+        ValidatedLocalDatasetLocation? resolvedSource = await ResolveOptionalLocalDatasetLocationAsync(
+            source,
+            workRoot,
+            resourcePrefix,
+            invalidateLocalFileCache,
+            cancellationToken);
+        return resolvedSource
+            ?? throw new InvalidOperationException("The normalized CityGML source must resolve to a local dataset location.");
+    }
+
+    private async Task<ValidatedLocalDatasetLocation?> ResolveOptionalLocalDatasetLocationAsync(
         ValidatedDatasetLocation? source,
         string workRoot,
         string resourcePrefix,
@@ -66,7 +83,7 @@ internal sealed class CkanPlateauDatasetSourceResolver : IPlateauDatasetSourceRe
     {
         if (source is null || source is ValidatedLocalDatasetLocation)
         {
-            return source;
+            return source as ValidatedLocalDatasetLocation;
         }
 
         ValidatedRemoteDatasetLocation remoteSource = (ValidatedRemoteDatasetLocation)source;

--- a/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinition.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinition.cs
@@ -1,29 +1,27 @@
+using System;
+using System.Collections.Generic;
+
 using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Application.Importing;
 
-internal sealed class CommonMaterialDefinition
+internal abstract class CommonMaterialDefinition
 {
-    internal CommonMaterialDefinition(
-        DefaultCommonMaterialMemberKind kind,
+    private protected static readonly ColorRgba CanonicalBaseColor = new(1.0, 1.0, 1.0, 1.0);
+
+    private protected CommonMaterialDefinition(
         MaterialProjection projection,
         string memberName,
-        MaterialDepthOffset? depthOffset = null,
-        string? family = null,
-        int? bundledVariantIndex = null)
+        MaterialDepthOffset? depthOffset)
     {
-        Kind = kind;
+        ArgumentNullException.ThrowIfNull(memberName);
+
         Projection = projection;
         MemberName = memberName;
         DepthOffset = depthOffset;
-        Family = family;
-        BundledVariantIndex = bundledVariantIndex;
-        BundledVariant = family is null || bundledVariantIndex is null
-            ? null
-            : BundledDefaultMaterialFamilies.GetVariantDefinition(family, bundledVariantIndex.Value);
     }
 
-    public DefaultCommonMaterialMemberKind Kind { get; }
+    public abstract DefaultCommonMaterialMemberKind Kind { get; }
 
     public MaterialProjection Projection { get; }
 
@@ -31,9 +29,123 @@ internal sealed class CommonMaterialDefinition
 
     public MaterialDepthOffset? DepthOffset { get; }
 
-    public string? Family { get; }
+    public virtual string? Family => null;
 
-    public int? BundledVariantIndex { get; }
+    public virtual int? BundledVariantIndex => null;
 
-    public BundledDefaultMaterialVariant? BundledVariant { get; }
+    public virtual BundledDefaultMaterialVariant? BundledVariant => null;
+
+    internal abstract SharedCommonMaterialBinding CreateBinding(
+        DefaultCommonMaterialMember member,
+        IReadOnlyList<int> submeshIndices);
+
+    private protected static Float2 ToContract(ScalarPair value) => new(value.X, value.Y);
+}
+
+internal sealed class BundledCommonMaterialDefinition : CommonMaterialDefinition
+{
+    private readonly BundledDefaultMaterialVariant bundledVariant;
+    private readonly string family;
+
+    internal BundledCommonMaterialDefinition(
+        MaterialProjection projection,
+        string memberName,
+        string family,
+        int bundledVariantIndex)
+        : base(projection, memberName, depthOffset: null)
+    {
+        ArgumentNullException.ThrowIfNull(family);
+
+        this.family = family;
+        VariantIndex = bundledVariantIndex;
+        bundledVariant = BundledDefaultMaterialFamilies.GetVariantDefinition(family, bundledVariantIndex);
+    }
+
+    public override DefaultCommonMaterialMemberKind Kind => DefaultCommonMaterialMemberKind.Bundled;
+
+    public override string? Family => family;
+
+    public override int? BundledVariantIndex => VariantIndex;
+
+    public int VariantIndex { get; }
+
+    public override BundledDefaultMaterialVariant? BundledVariant => bundledVariant;
+
+    internal override SharedCommonMaterialBinding CreateBinding(
+        DefaultCommonMaterialMember member,
+        IReadOnlyList<int> submeshIndices)
+    {
+        Float2 textureScale = ToContract(bundledVariant.TextureSet.TextureScale);
+        Float2? textureOffset = bundledVariant.TextureSet.TextureOffset is null
+            ? null
+            : ToContract(bundledVariant.TextureSet.TextureOffset);
+
+        return new SharedCommonMaterialBinding(
+            BaseColor: CanonicalBaseColor,
+            MaterialType: MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: TextureSourceKind.Bundled,
+            Projection: Projection,
+            DepthOffset: null,
+            SubmeshIndices: submeshIndices,
+            TextureScale: textureScale,
+            Family: family,
+            TextureOffset: textureOffset,
+            commonMaterial: member,
+            BundledVariantIndex: VariantIndex);
+    }
+}
+
+internal sealed class GenericAlbedoCommonMaterialDefinition : CommonMaterialDefinition
+{
+    internal GenericAlbedoCommonMaterialDefinition(
+        string memberName,
+        MaterialDepthOffset? depthOffset)
+        : base(MaterialProjection.Uv, memberName, depthOffset)
+    {
+    }
+
+    public override DefaultCommonMaterialMemberKind Kind => DefaultCommonMaterialMemberKind.GenericAlbedo;
+
+    internal override SharedCommonMaterialBinding CreateBinding(
+        DefaultCommonMaterialMember member,
+        IReadOnlyList<int> submeshIndices)
+    {
+        return new SharedCommonMaterialBinding(
+            BaseColor: CanonicalBaseColor,
+            MaterialType: MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: TextureSourceKind.Dataset,
+            Projection: Projection,
+            DepthOffset: DepthOffset,
+            SubmeshIndices: submeshIndices,
+            commonMaterial: member);
+    }
+}
+
+internal sealed class VertexColorCommonMaterialDefinition : CommonMaterialDefinition
+{
+    internal VertexColorCommonMaterialDefinition(
+        string memberName,
+        MaterialDepthOffset? depthOffset)
+        : base(MaterialProjection.Uv, memberName, depthOffset)
+    {
+    }
+
+    public override DefaultCommonMaterialMemberKind Kind => DefaultCommonMaterialMemberKind.VertexColor;
+
+    internal override SharedCommonMaterialBinding CreateBinding(
+        DefaultCommonMaterialMember member,
+        IReadOnlyList<int> submeshIndices)
+    {
+        return new SharedCommonMaterialBinding(
+            BaseColor: CanonicalBaseColor,
+            MaterialType: MaterialType.VertexColor,
+            TexturePayload: null,
+            TextureSourceKind: TextureSourceKind.Bundled,
+            Projection: Projection,
+            DepthOffset: DepthOffset,
+            SubmeshIndices: submeshIndices,
+            commonMaterial: member);
+    }
 }

--- a/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinitions.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinitions.cs
@@ -71,30 +71,25 @@ internal static class CommonMaterialDefinitions
     public static readonly CommonMaterialDefinition WallSchoolPublicDark = Bundled(BundledDefaultMaterialFamilies.WallSchoolPublicBand, 1, "SchoolPublicDark");
     public static readonly CommonMaterialDefinition WallWoodRuralLight = Bundled(BundledDefaultMaterialFamilies.WallWoodRural, 0, "WoodRuralLight");
 
-    private static CommonMaterialDefinition Bundled(string family, int variantIndex, string memberName)
+    private static BundledCommonMaterialDefinition Bundled(string family, int variantIndex, string memberName)
     {
-        return new CommonMaterialDefinition(
-            DefaultCommonMaterialMemberKind.Bundled,
+        return new BundledCommonMaterialDefinition(
             GetBundledProjection(family),
             memberName,
-            family: family,
-            bundledVariantIndex: variantIndex);
+            family,
+            variantIndex);
     }
 
-    private static CommonMaterialDefinition Generic(string memberName, MaterialDepthOffset? depthOffset)
+    private static GenericAlbedoCommonMaterialDefinition Generic(string memberName, MaterialDepthOffset? depthOffset)
     {
-        return new CommonMaterialDefinition(
-            DefaultCommonMaterialMemberKind.GenericAlbedo,
-            MaterialProjection.Uv,
+        return new GenericAlbedoCommonMaterialDefinition(
             memberName,
             depthOffset);
     }
 
-    private static CommonMaterialDefinition VertexColor(string memberName, MaterialDepthOffset? depthOffset)
+    private static VertexColorCommonMaterialDefinition VertexColor(string memberName, MaterialDepthOffset? depthOffset)
     {
-        return new CommonMaterialDefinition(
-            DefaultCommonMaterialMemberKind.VertexColor,
-            MaterialProjection.Uv,
+        return new VertexColorCommonMaterialDefinition(
             memberName,
             depthOffset);
     }

--- a/src/PlateauResoniteLink/Application/Importing/ConstructionCityObjectDraft.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ConstructionCityObjectDraft.cs
@@ -47,7 +47,7 @@ internal sealed record ConstructionCityObjectDraft(
 
     public double? MeasuredHeightMeters => Source.MeasuredHeightMeters;
 
-    public BuildingAttributeContext? BuildingAttributes => Source.BuildingAttributes;
+    public BuildingAttributeContext BuildingAttributes => Source.BuildingAttributes;
 
     public double? GeometryHeightMeters => Source.GeometryHeightMeters;
 

--- a/src/PlateauResoniteLink/Application/Importing/DefaultCommonMaterialMember.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultCommonMaterialMember.cs
@@ -7,8 +7,6 @@ namespace PlateauResoniteLink.Application.Importing;
 
 public sealed class DefaultCommonMaterialMember : IEquatable<DefaultCommonMaterialMember>
 {
-    private static readonly ColorRgba CanonicalBaseColor = new(1.0, 1.0, 1.0, 1.0);
-
     private DefaultCommonMaterialMember(CommonMaterialDefinition definition)
     {
         Definition = definition ?? throw new ArgumentNullException(nameof(definition));
@@ -52,57 +50,8 @@ public sealed class DefaultCommonMaterialMember : IEquatable<DefaultCommonMateri
     {
         ArgumentNullException.ThrowIfNull(submeshIndices);
 
-        return Kind switch
-        {
-            DefaultCommonMaterialMemberKind.Bundled => CreateBundledBinding(submeshIndices),
-            DefaultCommonMaterialMemberKind.GenericAlbedo => new SharedCommonMaterialBinding(
-                BaseColor: CanonicalBaseColor,
-                MaterialType: MaterialType.Standard,
-                TexturePayload: null,
-                TextureSourceKind: TextureSourceKind.Dataset,
-                Projection: Projection,
-                DepthOffset: DepthOffset,
-                SubmeshIndices: submeshIndices,
-                commonMaterial: this),
-            DefaultCommonMaterialMemberKind.VertexColor => new SharedCommonMaterialBinding(
-                BaseColor: CanonicalBaseColor,
-                MaterialType: MaterialType.VertexColor,
-                TexturePayload: null,
-                TextureSourceKind: TextureSourceKind.Bundled,
-                Projection: Projection,
-                DepthOffset: DepthOffset,
-                SubmeshIndices: submeshIndices,
-                commonMaterial: this),
-            _ => throw new InvalidOperationException($"Unsupported common material member kind '{Kind}'."),
-        };
+        return Definition.CreateBinding(this, submeshIndices);
     }
-
-    private SharedCommonMaterialBinding CreateBundledBinding(IReadOnlyList<int> submeshIndices)
-    {
-        string family = Family ?? throw new InvalidOperationException("Bundled common material member requires a family.");
-        int variantIndex = BundledVariantIndex ?? 0;
-        BundledDefaultMaterialVariant variant = BundledVariant
-            ?? throw new InvalidOperationException("Bundled common material member requires a variant.");
-        Float2 textureScale = ToContract(variant.TextureSet.TextureScale);
-        Float2? textureOffset = variant.TextureSet.TextureOffset is null
-            ? null
-            : ToContract(variant.TextureSet.TextureOffset);
-        return new SharedCommonMaterialBinding(
-            BaseColor: CanonicalBaseColor,
-            MaterialType: MaterialType.Standard,
-            TexturePayload: null,
-            TextureSourceKind: TextureSourceKind.Bundled,
-            Projection: Projection,
-            DepthOffset: null,
-            SubmeshIndices: submeshIndices,
-            TextureScale: textureScale,
-            Family: family,
-            TextureOffset: textureOffset,
-            commonMaterial: this,
-            BundledVariantIndex: variantIndex);
-    }
-
-    private static Float2 ToContract(ScalarPair value) => new(value.X, value.Y);
 }
 
 public enum DefaultCommonMaterialMemberKind

--- a/src/PlateauResoniteLink/Application/Importing/DefaultCommonMaterialMember.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultCommonMaterialMember.cs
@@ -55,7 +55,7 @@ public sealed class DefaultCommonMaterialMember : IEquatable<DefaultCommonMateri
         return Kind switch
         {
             DefaultCommonMaterialMemberKind.Bundled => CreateBundledBinding(submeshIndices),
-            DefaultCommonMaterialMemberKind.GenericAlbedo => new MaterialBinding(
+            DefaultCommonMaterialMemberKind.GenericAlbedo => new SharedCommonMaterialBinding(
                 BaseColor: CanonicalBaseColor,
                 MaterialType: MaterialType.Standard,
                 TexturePayload: null,
@@ -63,9 +63,8 @@ public sealed class DefaultCommonMaterialMember : IEquatable<DefaultCommonMateri
                 Projection: Projection,
                 DepthOffset: DepthOffset,
                 SubmeshIndices: submeshIndices,
-                ReuseScope: MaterialReuseScope.Shared,
-                CommonMaterial: this),
-            DefaultCommonMaterialMemberKind.VertexColor => new MaterialBinding(
+                commonMaterial: this),
+            DefaultCommonMaterialMemberKind.VertexColor => new SharedCommonMaterialBinding(
                 BaseColor: CanonicalBaseColor,
                 MaterialType: MaterialType.VertexColor,
                 TexturePayload: null,
@@ -73,13 +72,12 @@ public sealed class DefaultCommonMaterialMember : IEquatable<DefaultCommonMateri
                 Projection: Projection,
                 DepthOffset: DepthOffset,
                 SubmeshIndices: submeshIndices,
-                ReuseScope: MaterialReuseScope.Shared,
-                CommonMaterial: this),
+                commonMaterial: this),
             _ => throw new InvalidOperationException($"Unsupported common material member kind '{Kind}'."),
         };
     }
 
-    private MaterialBinding CreateBundledBinding(IReadOnlyList<int> submeshIndices)
+    private SharedCommonMaterialBinding CreateBundledBinding(IReadOnlyList<int> submeshIndices)
     {
         string family = Family ?? throw new InvalidOperationException("Bundled common material member requires a family.");
         int variantIndex = BundledVariantIndex ?? 0;
@@ -89,7 +87,7 @@ public sealed class DefaultCommonMaterialMember : IEquatable<DefaultCommonMateri
         Float2? textureOffset = variant.TextureSet.TextureOffset is null
             ? null
             : ToContract(variant.TextureSet.TextureOffset);
-        return new MaterialBinding(
+        return new SharedCommonMaterialBinding(
             BaseColor: CanonicalBaseColor,
             MaterialType: MaterialType.Standard,
             TexturePayload: null,
@@ -100,9 +98,8 @@ public sealed class DefaultCommonMaterialMember : IEquatable<DefaultCommonMateri
             TextureScale: textureScale,
             Family: family,
             TextureOffset: textureOffset,
-            ReuseScope: MaterialReuseScope.Shared,
-            BundledVariantIndex: variantIndex,
-            CommonMaterial: this);
+            commonMaterial: this,
+            BundledVariantIndex: variantIndex);
     }
 
     private static Float2 ToContract(ScalarPair value) => new(value.X, value.Y);

--- a/src/PlateauResoniteLink/Application/Importing/DefaultImportedSceneSourceComposer.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultImportedSceneSourceComposer.cs
@@ -15,7 +15,7 @@ internal sealed class DefaultImportedSceneSourceComposer(
     private const string PlateauLicenseUrl = "https://www.mlit.go.jp/plateau/site-policy/";
 
     public IImportedSceneSource Compose(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         ImportedSceneSourceSnapshot readResult,
         IImportedObjectUnitOptimizer objectUnitOptimizer,
         Action<string>? progressReporter = null)
@@ -25,16 +25,17 @@ internal sealed class DefaultImportedSceneSourceComposer(
         ArgumentNullException.ThrowIfNull(objectUnitOptimizer);
         ImportedSceneSourceDataset documentSet = readResult.DocumentSet;
         ImportedSceneSourceContext discoveryContext = readResult.DiscoveryContext;
+        PlateauImportRequest importRequest = request.ToImportRequest();
 
         ImportedSceneMetadata metadata = new(
             SchemaVersion: "3.0",
             SceneName: $"PLATEAU {request.Dataset} {request.MeshCode}",
-            Request: request,
+            Request: importRequest,
             SourceDataset: new PlateauSourceDataset(
                 PackageNames: documentSet.PackageNames.ToArray(),
                 SourceFiles: documentSet.RelativeSourceFiles.ToArray(),
                 SelectedMeshCodes: documentSet.SelectedMeshCodes),
-            Attribution: CreateAttribution(request),
+            Attribution: CreateAttribution(importRequest),
             GeodeticOrigin: new GeodeticOrigin(
                 Latitude: discoveryContext.GlobalOriginPoint.Latitude,
                 Longitude: discoveryContext.GlobalOriginPoint.Longitude,
@@ -42,7 +43,7 @@ internal sealed class DefaultImportedSceneSourceComposer(
 
         return new StreamingImportedSceneSource(
             metadata,
-            request,
+            importRequest,
             readResult,
             geometryProjector,
             demTextureSourcePolicy,

--- a/src/PlateauResoniteLink/Application/Importing/DefaultImportedSceneSourceFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultImportedSceneSourceFactory.cs
@@ -2,8 +2,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Application.Importing;
 
 internal sealed class DefaultImportedSceneSourceFactory : IImportedSceneSourceFactory
@@ -26,7 +24,7 @@ internal sealed class DefaultImportedSceneSourceFactory : IImportedSceneSourceFa
     }
 
     public Task<IImportedSceneSource> CreateAsync(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default)
     {
@@ -35,7 +33,7 @@ internal sealed class DefaultImportedSceneSourceFactory : IImportedSceneSourceFa
     }
 
     private async Task<IImportedSceneSource> CreateResolvedCoreAsync(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         Action<string>? progressReporter,
         CancellationToken cancellationToken)
     {

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialFamilyOverride.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialFamilyOverride.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal sealed class DefaultMaterialFamilyOverride
+{
+    public static readonly DefaultMaterialFamilyOverride CityFurniture = new(
+        BundledDefaultMaterialFamilies.CityFurniture,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 6) switch
+        {
+            0 => catalog.CityFurniture.Plaster002,
+            1 => catalog.CityFurniture.Plaster001,
+            2 => catalog.CityFurniture.Plaster003,
+            3 => catalog.CityFurniture.Plaster004,
+            4 => catalog.CityFurniture.Plaster005,
+            _ => catalog.CityFurniture.Plaster006,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride FacadeHighriseGlass = new(
+        BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 3) switch
+        {
+            0 => catalog.FacadeHighriseGlass.Facade001,
+            1 => catalog.FacadeHighriseGlass.Facade005,
+            _ => catalog.FacadeHighriseGlass.Facade006,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride FacadeHighriseNightLow = new(
+        BundledDefaultMaterialFamilies.FacadeHighriseNightLow,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.FacadeHighriseNightLow.Facade002
+            : catalog.FacadeHighriseNightLow.Facade011);
+
+    public static readonly DefaultMaterialFamilyOverride FacadeMidriseGrid = new(
+        BundledDefaultMaterialFamilies.FacadeMidriseGrid,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.FacadeMidriseGrid.Facade014
+            : catalog.FacadeMidriseGrid.Facade015);
+
+    public static readonly DefaultMaterialFamilyOverride Other = new(
+        BundledDefaultMaterialFamilies.Other,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 9) switch
+        {
+            0 => catalog.Other.Concrete012,
+            1 => catalog.Other.Ground054,
+            2 => catalog.Other.Plaster002,
+            3 => catalog.Other.Plaster001,
+            4 => catalog.Other.Plaster003,
+            5 => catalog.Other.Plaster004,
+            6 => catalog.Other.Plaster005,
+            7 => catalog.Other.Plaster006,
+            _ => catalog.Other.TextureCanFacade0022,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride RoadTriplanar = new(
+        BundledDefaultMaterialFamilies.RoadTriplanar,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 4) switch
+        {
+            0 => catalog.RoadTriplanar.Road012A,
+            1 => catalog.RoadTriplanar.Road013A,
+            2 => catalog.RoadTriplanar.Road014A,
+            _ => catalog.RoadTriplanar.Road015A,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride RoadUv = new(
+        BundledDefaultMaterialFamilies.RoadUv,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 4) switch
+        {
+            0 => catalog.RoadUv.Road012A,
+            1 => catalog.RoadUv.Road013A,
+            2 => catalog.RoadUv.Road014A,
+            _ => catalog.RoadUv.Road015A,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride Roof = new(
+        BundledDefaultMaterialFamilies.Roof,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 4) switch
+        {
+            0 => catalog.Roof.Concrete012,
+            1 => catalog.Roof.Concrete033,
+            2 => catalog.Roof.RoofingTiles012A,
+            _ => catalog.Roof.RoofingTiles014B,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride Vegetation = new(
+        BundledDefaultMaterialFamilies.Vegetation,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.Vegetation.Ground054
+            : catalog.Vegetation.Concrete012);
+
+    public static readonly DefaultMaterialFamilyOverride WallApartmentTileMid = new(
+        BundledDefaultMaterialFamilies.WallApartmentTileMid,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.WallApartmentTileMid.ApartmentTileMid
+            : catalog.WallApartmentTileMid.ApartmentTileDark);
+
+    public static readonly DefaultMaterialFamilyOverride WallBrickRetro = new(
+        BundledDefaultMaterialFamilies.WallBrickRetro,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.WallBrickRetro.BrickRetro
+            : catalog.WallBrickRetro.BrickDark);
+
+    public static readonly DefaultMaterialFamilyOverride WallCommercialPanel = new(
+        BundledDefaultMaterialFamilies.WallCommercialPanel,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.WallCommercialPanel.CommercialPanel
+            : catalog.WallCommercialPanel.CommercialPanelDark);
+
+    public static readonly DefaultMaterialFamilyOverride WallFactoryMetal = new(
+        BundledDefaultMaterialFamilies.WallFactoryMetal,
+        static (catalog, _) => catalog.WallFactoryMetal.FactoryMetal);
+
+    public static readonly DefaultMaterialFamilyOverride WallRcPaintedMid = new(
+        BundledDefaultMaterialFamilies.WallRcPaintedMid,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.WallRcPaintedMid.RcPaintedMid
+            : catalog.WallRcPaintedMid.RcPaintedDark);
+
+    public static readonly DefaultMaterialFamilyOverride WallResidentialPlasterLow = new(
+        BundledDefaultMaterialFamilies.WallResidentialPlasterLow,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.WallResidentialPlasterLow.ResidentialPlasterLow
+            : catalog.WallResidentialPlasterLow.ResidentialPlasterDark);
+
+    public static readonly DefaultMaterialFamilyOverride WallResidentialTileLow = new(
+        BundledDefaultMaterialFamilies.WallResidentialTileLow,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 4) switch
+        {
+            0 => catalog.WallResidentialTileLow.ResidentialTileLow,
+            1 => catalog.WallResidentialTileLow.ResidentialTileDark,
+            2 => catalog.WallResidentialTileLow.ResidentialTileDarkIrregular,
+            _ => catalog.WallResidentialTileLow.ResidentialSidingBrickGray,
+        });
+
+    public static readonly DefaultMaterialFamilyOverride WallSchoolPublicBand = new(
+        BundledDefaultMaterialFamilies.WallSchoolPublicBand,
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 2) == 0
+            ? catalog.WallSchoolPublicBand.SchoolPublicBand
+            : catalog.WallSchoolPublicBand.SchoolPublicDark);
+
+    public static readonly DefaultMaterialFamilyOverride WallWoodRural = new(
+        BundledDefaultMaterialFamilies.WallWoodRural,
+        static (catalog, _) => catalog.WallWoodRural.WoodRuralLight);
+
+    public static readonly IReadOnlyList<DefaultMaterialFamilyOverride> All =
+    [
+        CityFurniture,
+        FacadeHighriseGlass,
+        FacadeHighriseNightLow,
+        FacadeMidriseGrid,
+        Other,
+        RoadTriplanar,
+        RoadUv,
+        Roof,
+        Vegetation,
+        WallApartmentTileMid,
+        WallBrickRetro,
+        WallCommercialPanel,
+        WallFactoryMetal,
+        WallRcPaintedMid,
+        WallResidentialPlasterLow,
+        WallResidentialTileLow,
+        WallSchoolPublicBand,
+        WallWoodRural,
+    ];
+
+    private readonly Func<CommonMaterialCatalog<DefaultCommonMaterialMember>, string, DefaultCommonMaterialMember> selectMember;
+
+    private DefaultMaterialFamilyOverride(
+        string family,
+        Func<CommonMaterialCatalog<DefaultCommonMaterialMember>, string, DefaultCommonMaterialMember> selectMember)
+    {
+        Family = family;
+        this.selectMember = selectMember;
+    }
+
+    public string Family { get; }
+
+    internal DefaultCommonMaterialMember SelectMember(
+        CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials,
+        string variantSelectionKey)
+    {
+        return selectMember(commonMaterials, variantSelectionKey);
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialRequest.cs
@@ -17,7 +17,7 @@ internal sealed record DefaultMaterialRequest(
     bool PreferUvProjection,
     string? FamilyOverride,
     string VariantSelectionKey,
-    BuildingAttributeContext? BuildingAttributes = null,
+    BuildingAttributeContext BuildingAttributes,
     int? FloorsAboveGround = null,
     double? MeasuredHeightMeters = null,
     double? GeometryHeightMeters = null,

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialRequest.cs
@@ -15,7 +15,7 @@ internal sealed record DefaultMaterialRequest(
     string PackageName,
     TexturePayload? TexturePayload,
     bool PreferUvProjection,
-    string? FamilyOverride,
+    DefaultMaterialFamilyOverride? FamilyOverride,
     string VariantSelectionKey,
     BuildingAttributeContext BuildingAttributes,
     int? FloorsAboveGround = null,

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
@@ -53,7 +53,7 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
 
         DefaultCommonMaterialMember commonMaterial = request.FamilyOverride is null
             ? SelectBundledMemberForRequest(request, commonMaterials)
-            : SelectFamilyOverrideMember(commonMaterials, request.FamilyOverride, request.VariantSelectionKey);
+            : request.FamilyOverride.SelectMember(commonMaterials, request.VariantSelectionKey);
         string family = commonMaterial.Family
             ?? throw new InvalidOperationException("Selected default material member is not a bundled material.");
         int bundledVariantIndex = commonMaterial.BundledVariantIndex
@@ -101,58 +101,28 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
 
         if (PlateauPackageCatalog.IsBuildingPackage(request.PackageName))
         {
-            return SelectRoofMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.Roof.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (PlateauPackageCatalog.IsRoadPackage(request.PackageName)
             || PlateauPackageCatalog.IsPathLikePackage(request.PackageName))
         {
             return request.PreferUvProjection
-                ? SelectRoadUvMember(commonMaterials, request.VariantSelectionKey)
-                : SelectRoadTriplanarMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.RoadUv.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.RoadTriplanar.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (PlateauPackageCatalog.IsVegetationPackage(request.PackageName))
         {
-            return SelectVegetationMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.Vegetation.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (PlateauPackageCatalog.IsCityFurniturePackage(request.PackageName))
         {
-            return SelectCityFurnitureMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.CityFurniture.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        return SelectOtherMember(commonMaterials, request.VariantSelectionKey);
-    }
-
-    private static DefaultCommonMaterialMember SelectFamilyOverrideMember(
-        CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials,
-        string family,
-        string variantSelectionKey)
-    {
-        return family switch
-        {
-            BundledDefaultMaterialFamilies.CityFurniture => SelectCityFurnitureMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.FacadeHighriseGlass => SelectFacadeHighriseGlassMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.FacadeHighriseNightLow => SelectFacadeHighriseNightLowMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.FacadeMidriseGrid => SelectFacadeMidriseGridMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.Other => SelectOtherMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.RoadTriplanar => SelectRoadTriplanarMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.RoadUv => SelectRoadUvMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.Roof => SelectRoofMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.Vegetation => SelectVegetationMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallApartmentTileMid => SelectWallApartmentTileMidMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallBrickRetro => SelectWallBrickRetroMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallCommercialPanel => SelectWallCommercialPanelMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallFactoryMetal => commonMaterials.WallFactoryMetal.FactoryMetal,
-            BundledDefaultMaterialFamilies.WallRcPaintedMid => SelectWallRcPaintedMidMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallResidentialPlasterLow => SelectWallResidentialPlasterLowMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallResidentialTileLow => SelectWallResidentialTileLowMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallSchoolPublicBand => SelectWallSchoolPublicBandMember(commonMaterials, variantSelectionKey),
-            BundledDefaultMaterialFamilies.WallWoodRural => commonMaterials.WallWoodRural.WoodRuralLight,
-            _ => throw new InvalidOperationException(
-                $"Bundled material family override '{family}' is not codebase-reachable and is not part of the common material catalog."),
-        };
+        return DefaultMaterialFamilyOverride.Other.SelectMember(commonMaterials, request.VariantSelectionKey);
     }
 
     private static DefaultCommonMaterialMember SelectBuildingFacadeMember(
@@ -169,20 +139,20 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         if (scale.Landmark)
         {
             return BuildingAttributePredicates.HasNightOccupancy(attributes)
-                ? SelectFacadeHighriseNightLowMember(commonMaterials, request.VariantSelectionKey)
-                : SelectFacadeHighriseGlassMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.FacadeHighriseNightLow.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.FacadeHighriseGlass.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (scale.Highrise)
         {
             return BuildingAttributePredicates.HasNightOccupancy(attributes)
-                ? SelectFacadeHighriseNightLowMember(commonMaterials, request.VariantSelectionKey)
-                : SelectFacadeHighriseGlassMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.FacadeHighriseNightLow.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.FacadeHighriseGlass.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (scale.Midrise && BuildingAttributePredicates.HasFacadeLikeMidriseUse(attributes))
         {
-            return SelectFacadeMidriseGridMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.FacadeMidriseGrid.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasRawBuildingCode(attributes, "431")
@@ -201,170 +171,56 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
 
         if (BuildingAttributePredicates.HasBrickLikeStructure(attributes))
         {
-            return SelectWallBrickRetroMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.WallBrickRetro.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Commercial)
             || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Office))
         {
             return scale.LowRise
-                ? SelectWallCommercialPanelMember(commonMaterials, request.VariantSelectionKey)
-                : SelectWallRcPaintedMidMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.WallCommercialPanel.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.WallRcPaintedMid.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Public)
             || BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Education))
         {
-            return SelectWallSchoolPublicBandMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.WallSchoolPublicBand.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.Apartment))
         {
             return scale.LowRise
-                ? SelectWallResidentialTileLowMember(commonMaterials, request.VariantSelectionKey)
-                : SelectWallApartmentTileMidMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.WallResidentialTileLow.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.WallApartmentTileMid.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.MixedResidential))
         {
             return scale.LowRise
-                ? SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey)
-                : SelectWallApartmentTileMidMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.WallResidentialPlasterLow.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.WallApartmentTileMid.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.HasUse(attributes, PlateauBuildingUse.DetachedResidential))
         {
             return IsWeightedAlternate(request.VariantSelectionKey)
-                ? SelectWallResidentialTileLowMember(commonMaterials, request.VariantSelectionKey)
-                : SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey);
+                ? DefaultMaterialFamilyOverride.WallResidentialTileLow.SelectMember(commonMaterials, request.VariantSelectionKey)
+                : DefaultMaterialFamilyOverride.WallResidentialPlasterLow.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
         if (BuildingAttributePredicates.IsRobustStructure(attributes) || scale.MidOrHighRise)
         {
-            return SelectWallRcPaintedMidMember(commonMaterials, request.VariantSelectionKey);
+            return DefaultMaterialFamilyOverride.WallRcPaintedMid.SelectMember(commonMaterials, request.VariantSelectionKey);
         }
 
-        return SelectWallResidentialPlasterLowMember(commonMaterials, request.VariantSelectionKey);
+        return DefaultMaterialFamilyOverride.WallResidentialPlasterLow.SelectMember(commonMaterials, request.VariantSelectionKey);
     }
 
     private static bool IsWeightedAlternate(string variantSelectionKey)
     {
         return StableVariantSelector.SelectBucket($"{variantSelectionKey}:residential-wall-weight", 5) == 0;
     }
-
-    private static DefaultCommonMaterialMember SelectCityFurnitureMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 6) switch
-        {
-            0 => commonMaterials.CityFurniture.Plaster002,
-            1 => commonMaterials.CityFurniture.Plaster001,
-            2 => commonMaterials.CityFurniture.Plaster003,
-            3 => commonMaterials.CityFurniture.Plaster004,
-            4 => commonMaterials.CityFurniture.Plaster005,
-            _ => commonMaterials.CityFurniture.Plaster006,
-        };
-
-    private static DefaultCommonMaterialMember SelectFacadeHighriseGlassMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 3) switch
-        {
-            0 => commonMaterials.FacadeHighriseGlass.Facade001,
-            1 => commonMaterials.FacadeHighriseGlass.Facade005,
-            _ => commonMaterials.FacadeHighriseGlass.Facade006,
-        };
-
-    private static DefaultCommonMaterialMember SelectFacadeHighriseNightLowMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.FacadeHighriseNightLow.Facade002
-            : commonMaterials.FacadeHighriseNightLow.Facade011;
-
-    private static DefaultCommonMaterialMember SelectFacadeMidriseGridMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.FacadeMidriseGrid.Facade014
-            : commonMaterials.FacadeMidriseGrid.Facade015;
-
-    private static DefaultCommonMaterialMember SelectOtherMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 9) switch
-        {
-            0 => commonMaterials.Other.Concrete012,
-            1 => commonMaterials.Other.Ground054,
-            2 => commonMaterials.Other.Plaster002,
-            3 => commonMaterials.Other.Plaster001,
-            4 => commonMaterials.Other.Plaster003,
-            5 => commonMaterials.Other.Plaster004,
-            6 => commonMaterials.Other.Plaster005,
-            7 => commonMaterials.Other.Plaster006,
-            _ => commonMaterials.Other.TextureCanFacade0022,
-        };
-
-    private static DefaultCommonMaterialMember SelectRoadTriplanarMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 4) switch
-        {
-            0 => commonMaterials.RoadTriplanar.Road012A,
-            1 => commonMaterials.RoadTriplanar.Road013A,
-            2 => commonMaterials.RoadTriplanar.Road014A,
-            _ => commonMaterials.RoadTriplanar.Road015A,
-        };
-
-    private static DefaultCommonMaterialMember SelectRoadUvMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 4) switch
-        {
-            0 => commonMaterials.RoadUv.Road012A,
-            1 => commonMaterials.RoadUv.Road013A,
-            2 => commonMaterials.RoadUv.Road014A,
-            _ => commonMaterials.RoadUv.Road015A,
-        };
-
-    private static DefaultCommonMaterialMember SelectRoofMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 4) switch
-        {
-            0 => commonMaterials.Roof.Concrete012,
-            1 => commonMaterials.Roof.Concrete033,
-            2 => commonMaterials.Roof.RoofingTiles012A,
-            _ => commonMaterials.Roof.RoofingTiles014B,
-        };
-
-    private static DefaultCommonMaterialMember SelectVegetationMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.Vegetation.Ground054
-            : commonMaterials.Vegetation.Concrete012;
-
-    private static DefaultCommonMaterialMember SelectWallApartmentTileMidMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.WallApartmentTileMid.ApartmentTileMid
-            : commonMaterials.WallApartmentTileMid.ApartmentTileDark;
-
-    private static DefaultCommonMaterialMember SelectWallBrickRetroMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.WallBrickRetro.BrickRetro
-            : commonMaterials.WallBrickRetro.BrickDark;
-
-    private static DefaultCommonMaterialMember SelectWallCommercialPanelMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.WallCommercialPanel.CommercialPanel
-            : commonMaterials.WallCommercialPanel.CommercialPanelDark;
-
-    private static DefaultCommonMaterialMember SelectWallRcPaintedMidMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.WallRcPaintedMid.RcPaintedMid
-            : commonMaterials.WallRcPaintedMid.RcPaintedDark;
-
-    private static DefaultCommonMaterialMember SelectWallResidentialPlasterLowMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.WallResidentialPlasterLow.ResidentialPlasterLow
-            : commonMaterials.WallResidentialPlasterLow.ResidentialPlasterDark;
-
-    private static DefaultCommonMaterialMember SelectWallResidentialTileLowMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 4) switch
-        {
-            0 => commonMaterials.WallResidentialTileLow.ResidentialTileLow,
-            1 => commonMaterials.WallResidentialTileLow.ResidentialTileDark,
-            2 => commonMaterials.WallResidentialTileLow.ResidentialTileDarkIrregular,
-            _ => commonMaterials.WallResidentialTileLow.ResidentialSidingBrickGray,
-        };
-
-    private static DefaultCommonMaterialMember SelectWallSchoolPublicBandMember(CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials, string key) =>
-        StableVariantSelector.SelectBucket(key, 2) == 0
-            ? commonMaterials.WallSchoolPublicBand.SchoolPublicBand
-            : commonMaterials.WallSchoolPublicBand.SchoolPublicDark;
 
     private static Float2 ToContractFloat2(Domain.Importing.ScalarPair value) => new(value.X, value.Y);
 }

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialResolver.cs
@@ -159,7 +159,7 @@ internal sealed class DefaultMaterialResolver : IDefaultMaterialResolver
         DefaultMaterialRequest request,
         CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials)
     {
-        BuildingAttributeContext attributes = request.BuildingAttributes ?? BuildingAttributeContext.Empty;
+        BuildingAttributeContext attributes = request.BuildingAttributes;
         BuildingFacadeScale scale = BuildingFacadeScale.Classify(
             request.FloorsAboveGround,
             request.MeasuredHeightMeters,

--- a/src/PlateauResoniteLink/Application/Importing/DemSourceDiscoverySupport.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemSourceDiscoverySupport.cs
@@ -16,7 +16,10 @@ internal static class DemSourceDiscoverySupport
 
         CachedSourceFileDescriptor[] cachedDemSourceFiles = demParsedSourceFiles
             .Where(static parsed => parsed.CityObjects.Length > 0)
-            .Select(static parsed => new CachedSourceFileDescriptor(parsed.SourceFile, parsed.CityObjects))
+            .Select(static parsed => new CachedSourceFileDescriptor(
+                parsed.SourceFile,
+                parsed.CityObjects,
+                parsed.ReferenceSystem))
             .ToArray();
         TerrainHeightTriangle[] terrainTriangles = demParsedSourceFiles
             .SelectMany(static parsed => parsed.TerrainTriangles)

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
@@ -51,8 +51,7 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
     {
         ArgumentNullException.ThrowIfNull(datasetContentSourceFactory);
 
-        if (source is not LocalDatasetLocation localSource
-            || string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
+        if (source is not LocalDatasetLocation localSource)
         {
             return null;
         }

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainGeoReferencedRasterCatalog.cs
@@ -154,19 +154,17 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
         GeographicRectangle overlayBounds,
         CancellationToken cancellationToken)
     {
-        foreach (TerrainTextureGeoReferencedRasterSource rasterSource in ResolveCandidateRasterSources(meshCode))
+        foreach (ITerrainTextureRasterContentSource rasterSource in ResolveCandidateRasterSources(meshCode))
         {
             GeoReferencedRasterMetadata? metadata = await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(
                 rasterSource,
                 cancellationToken);
-            if (metadata is null
-                || !metadata.IsUsable
-                || !Contains(metadata.GeographicBounds, overlayBounds))
+            if (metadata is null || !Contains(metadata.GeographicBounds, overlayBounds))
             {
                 continue;
             }
 
-            return rasterSource with { Metadata = metadata };
+            return new TerrainTextureGeoReferencedRasterSource(rasterSource, metadata);
         }
 
         return null;
@@ -191,11 +189,11 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
         }
     }
 
-    private TerrainTextureGeoReferencedRasterSource[] ResolveCandidateRasterSources(ThirdRegionalMeshCode meshCode)
+    private ITerrainTextureRasterContentSource[] ResolveCandidateRasterSources(ThirdRegionalMeshCode meshCode)
     {
         if (directRasterPath is not null)
         {
-            return [new TerrainTextureGeoReferencedRasterSource(directRasterPath)];
+            return [new LocalTerrainTextureRasterContentSource(directRasterPath)];
         }
 
         if (contentSource is null)
@@ -226,11 +224,11 @@ internal sealed class DemTerrainGeoReferencedRasterCatalog : IDemTerrainGeoRefer
         }
 
         return relativePaths
-            .Select(relativePath => new TerrainTextureGeoReferencedRasterSource(
-                new DatasetTerrainTextureRasterContentSource(
+            .Select(relativePath =>
+                (ITerrainTextureRasterContentSource)new DatasetTerrainTextureRasterContentSource(
                     $"dataset:{contentSource.SourcePath}:{relativePath}",
                     relativePath,
-                    EnsureLocalRasterFileAsync)))
+                    EnsureLocalRasterFileAsync))
             .ToArray();
     }
 

--- a/src/PlateauResoniteLink/Application/Importing/DemTextureSourcePolicy.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTextureSourcePolicy.cs
@@ -193,12 +193,12 @@ internal sealed class DefaultDemTextureSourcePolicy(
                 region.MeshCode,
                 region.GeographicBounds,
                 cancellationToken);
-            if (rasterSource?.Metadata is { IsUsable: true } metadata)
+            if (rasterSource is not null)
             {
                 candidates.Add(new DemTextureSourceCandidate(
                     DemTextureSourcePreference.GeoReferencedRaster,
                     rasterSource,
-                    EffectivePixelAreaSquareMeters: metadata.PixelWidthMeters * metadata.PixelHeightMeters));
+                    EffectivePixelAreaSquareMeters: rasterSource.Metadata.PixelWidthMeters * rasterSource.Metadata.PixelHeightMeters));
             }
         }
 

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -90,7 +90,6 @@ internal static class GeneratedLod1RoofCityObjectFactory
     private static bool IsNoWallBuilding(ParsedCityObject cityObject)
     {
         return cityObject.LodLevel >= 1
-            && cityObject.BuildingAttributes is not null
             && NoWallBuildingClassCodes.Any(code => BuildingAttributePredicates.HasExactCityGmlClassCode(cityObject.BuildingAttributes, code));
     }
 
@@ -491,7 +490,7 @@ internal static class GeneratedLod1RoofCityObjectFactory
             length,
             width,
             geometryHeight,
-            cityObject.BuildingAttributes ?? BuildingAttributeContext.Empty,
+            cityObject.BuildingAttributes,
             firstEdgeIsLongAxis);
         return true;
     }

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedLod1RoofCityObjectFactory.cs
@@ -152,10 +152,10 @@ internal static class GeneratedLod1RoofCityObjectFactory
             return false;
         }
 
-        SurfaceProjectionInfo[] surfaceInfos = cityObject.Surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
+        SurfaceProjectionInfo[] surfaceInfos = CreateSurfaceProjectionInfos(
+            cityObject.Surfaces,
+            cityObjectOrigin,
+            cityObjectCartesian);
         if (surfaceInfos.Length == 0)
         {
             return false;
@@ -188,19 +188,19 @@ internal static class GeneratedLod1RoofCityObjectFactory
         out ParsedSurface[]? topSurfaces)
     {
         topSurfaces = null;
-        SurfaceProjectionInfo[] surfaceInfos = cityObject.Surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
+        SurfaceProjectionInfo[] surfaceInfos = CreateSurfaceProjectionInfos(
+            cityObject.Surfaces,
+            cityObjectOrigin,
+            cityObjectCartesian);
         if (surfaceInfos.Length == 0)
         {
             return false;
         }
 
-        double objectMaximumY = surfaceInfos.Max(static info => info.MaximumY!.Value);
+        double objectMaximumY = surfaceInfos.Max(static info => info.MaximumY);
         SurfaceProjectionInfo[] topSurfaceInfos = surfaceInfos
             .Where(static info => info.IsNearHorizontal)
-            .Where(info => info.MaximumY!.Value >= objectMaximumY - 0.1)
+            .Where(info => info.MaximumY >= objectMaximumY - 0.1)
             .ToArray();
         if (topSurfaceInfos.Length == 0
             || topSurfaceInfos.Any(static info => info.Surface.InteriorRings.Length != 0))
@@ -217,10 +217,10 @@ internal static class GeneratedLod1RoofCityObjectFactory
             .ToArray();
         if (lowerSurfaceInfos.Length != 0)
         {
-            double objectMinimumY = lowerSurfaceInfos.Min(static info => info.MinimumY!.Value);
+            double objectMinimumY = lowerSurfaceInfos.Min(static info => info.MinimumY);
             topSurfaceInfos = topSurfaceInfos
-                .Where(info => info.MinimumY!.Value > objectMinimumY + BuildingBottomCullBandMeters)
-                .Where(info => info.MinimumY!.Value - NoWallRoofThicknessMeters > objectMinimumY + BuildingBottomCullBandMeters)
+                .Where(info => info.MinimumY > objectMinimumY + BuildingBottomCullBandMeters)
+                .Where(info => info.MinimumY - NoWallRoofThicknessMeters > objectMinimumY + BuildingBottomCullBandMeters)
                 .ToArray();
             if (topSurfaceInfos.Length == 0)
             {
@@ -442,22 +442,22 @@ internal static class GeneratedLod1RoofCityObjectFactory
         out Lod1RoofFootprint? footprint)
     {
         footprint = null;
-        SurfaceProjectionInfo[] surfaceInfos = cityObject.Surfaces
-            .Select(surface => CreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian))
-            .Where(static info => info.MinimumY.HasValue && info.MaximumY.HasValue)
-            .ToArray();
+        SurfaceProjectionInfo[] surfaceInfos = CreateSurfaceProjectionInfos(
+            cityObject.Surfaces,
+            cityObjectOrigin,
+            cityObjectCartesian);
         if (surfaceInfos.Length == 0)
         {
             return false;
         }
 
-        double objectMinimumY = surfaceInfos.Min(static info => info.MinimumY!.Value);
-        double objectMaximumY = surfaceInfos.Max(static info => info.MaximumY!.Value);
+        double objectMinimumY = surfaceInfos.Min(static info => info.MinimumY);
+        double objectMaximumY = surfaceInfos.Max(static info => info.MaximumY);
         double geometryHeight = objectMaximumY - objectMinimumY;
         SurfaceProjectionInfo[] topCandidates = surfaceInfos
             .Where(static info => info.IsNearHorizontal)
-            .Where(info => info.MaximumY!.Value >= objectMaximumY - 0.1)
-            .Where(info => info.MinimumY!.Value > objectMinimumY + BuildingBottomCullBandMeters)
+            .Where(info => info.MaximumY >= objectMaximumY - 0.1)
+            .Where(info => info.MinimumY > objectMinimumY + BuildingBottomCullBandMeters)
             .ToArray();
         if (topCandidates.Length != 1)
         {
@@ -495,27 +495,47 @@ internal static class GeneratedLod1RoofCityObjectFactory
         return true;
     }
 
-    private static SurfaceProjectionInfo CreateSurfaceProjectionInfo(
-        ParsedSurface surface,
+    private static SurfaceProjectionInfo[] CreateSurfaceProjectionInfos(
+        IEnumerable<ParsedSurface> surfaces,
         GeodeticPoint cityObjectOrigin,
         LocalCartesian cityObjectCartesian)
     {
+        List<SurfaceProjectionInfo> infos = [];
+        foreach (ParsedSurface surface in surfaces)
+        {
+            if (TryCreateSurfaceProjectionInfo(surface, cityObjectOrigin, cityObjectCartesian, out SurfaceProjectionInfo info))
+            {
+                infos.Add(info);
+            }
+        }
+
+        return [.. infos];
+    }
+
+    private static bool TryCreateSurfaceProjectionInfo(
+        ParsedSurface surface,
+        GeodeticPoint cityObjectOrigin,
+        LocalCartesian cityObjectCartesian,
+        out SurfaceProjectionInfo info)
+    {
+        info = default;
         Float3[] positions = surface.Vertices
             .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
             .ToArray();
         if (positions.Length == 0)
         {
-            return new SurfaceProjectionInfo(surface, null, null, false);
+            return false;
         }
 
         Float3? normal = ComputePolygonNormal(positions);
         bool isNearHorizontal = normal is not null && Math.Abs(normal.Y) >= 0.98;
 
-        return new SurfaceProjectionInfo(
+        info = new SurfaceProjectionInfo(
             surface,
             positions.Min(static position => position.Y),
             positions.Max(static position => position.Y),
             isNearHorizontal);
+        return true;
     }
 
     private static GeodeticPoint[] RemoveClosingPoint(GeodeticPoint[] vertices)
@@ -682,8 +702,8 @@ internal static class GeneratedLod1RoofCityObjectFactory
 
     private readonly record struct SurfaceProjectionInfo(
         ParsedSurface Surface,
-        double? MinimumY,
-        double? MaximumY,
+        double MinimumY,
+        double MaximumY,
         bool IsNearHorizontal);
 
     private readonly record struct NoWallRoofRing(

--- a/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/GeneratedRoadMarkingCityObjectFactory.cs
@@ -62,7 +62,12 @@ internal static class GeneratedRoadMarkingCityObjectFactory
         LocalCartesian? cityObjectCartesian)
     {
         GeodeticPoint[] vertices = surface.ExteriorRing.Vertices;
-        if (vertices.Length != 4 || surface.InteriorRings.Length != 0)
+        if (surface.InteriorRings.Length != 0)
+        {
+            return [];
+        }
+
+        if (vertices.Length != 4)
         {
             return [];
         }
@@ -70,13 +75,18 @@ internal static class GeneratedRoadMarkingCityObjectFactory
         Float3[] positions = vertices
             .Select(point => CreateScenePosition(point, cityObjectOrigin, cityObjectCartesian))
             .ToArray();
+        if (!RoadSurfaceQuad.TryCreate(surface.ExteriorRing, positions, out RoadSurfaceQuad quad))
+        {
+            return [];
+        }
+
         Float3? normal = PolygonNormal.Compute(positions);
         if (normal is null || Math.Abs(normal.Y) < 0.7)
         {
             return [];
         }
 
-        EdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(vertices, positions);
+        EdgePairSelection edgePair = RoadSurfaceEdgePairSelector.Select(quad);
         if (edgePair.Length < 1.0 || edgePair.Width < 0.3)
         {
             return [];

--- a/src/PlateauResoniteLink/Application/Importing/ICityGmlDocumentReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ICityGmlDocumentReader.cs
@@ -2,14 +2,12 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Application.Importing;
 
 internal interface ICityGmlDocumentReader
 {
     Task<ImportedSceneSourceSnapshot> ReadAsync(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/PlateauResoniteLink/Application/Importing/IImportedSceneSourceComposer.cs
+++ b/src/PlateauResoniteLink/Application/Importing/IImportedSceneSourceComposer.cs
@@ -1,13 +1,11 @@
 using System;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Application.Importing;
 
 internal interface IImportedSceneSourceComposer
 {
     IImportedSceneSource Compose(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         ImportedSceneSourceSnapshot readResult,
         IImportedObjectUnitOptimizer objectUnitOptimizer,
         Action<string>? progressReporter = null);

--- a/src/PlateauResoniteLink/Application/Importing/IImportedSceneSourceFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/IImportedSceneSourceFactory.cs
@@ -2,14 +2,12 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Application.Importing;
 
 public interface IImportedSceneSourceFactory
 {
     Task<IImportedSceneSource> CreateAsync(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/PlateauResoniteLink/Application/Importing/IPlateauDatasetSourceResolver.cs
+++ b/src/PlateauResoniteLink/Application/Importing/IPlateauDatasetSourceResolver.cs
@@ -5,7 +5,7 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal interface IPlateauDatasetSourceResolver
 {
-    Task<ValidatedPlateauImportRequest> ResolveAsync(
+    Task<ResolvedLocalPlateauImportRequest> ResolveAsync(
         ValidatedPlateauImportRequest request,
         string workRoot,
         CancellationToken cancellationToken = default);

--- a/src/PlateauResoniteLink/Application/Importing/ImportExecutionResult.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ImportExecutionResult.cs
@@ -2,7 +2,28 @@ using System.Collections.Generic;
 
 namespace PlateauResoniteLink.Application.Importing;
 
-public sealed record ImportExecutionResult(
-    ImportedSceneMetadata Metadata,
-    IReadOnlyList<string> Destinations,
-    IReadOnlyList<ImportDataSourceUsage>? DataSourceUsages = null);
+public sealed record ImportExecutionResult
+{
+    public ImportExecutionResult(
+        ImportedSceneMetadata Metadata,
+        IReadOnlyList<string> Destinations)
+        : this(Metadata, Destinations, [])
+    {
+    }
+
+    public ImportExecutionResult(
+        ImportedSceneMetadata Metadata,
+        IReadOnlyList<string> Destinations,
+        IReadOnlyList<ImportDataSourceUsage> DataSourceUsages)
+    {
+        this.Metadata = Metadata;
+        this.Destinations = Destinations;
+        this.DataSourceUsages = DataSourceUsages;
+    }
+
+    public ImportedSceneMetadata Metadata { get; init; }
+
+    public IReadOnlyList<string> Destinations { get; init; }
+
+    public IReadOnlyList<ImportDataSourceUsage> DataSourceUsages { get; init; }
+}

--- a/src/PlateauResoniteLink/Application/Importing/ImportedSceneSourceDiscoveryPipeline.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ImportedSceneSourceDiscoveryPipeline.cs
@@ -25,14 +25,14 @@ internal static class ImportedSceneSourceDiscoveryPipeline
         ArgumentNullException.ThrowIfNull(appearanceStoreFactory);
         ArgumentNullException.ThrowIfNull(lodSelector);
 
-        if (request.CityGmlSource is not LocalDatasetLocation localSource || string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
+        if (request.CityGmlSource is not LocalDatasetLocation localSource)
         {
             throw new PlateauImportValidationException(
                 [LocalCityGmlImportErrorMessages.MissingLocalSourcePath()]);
         }
 
         IPlateauDatasetContentSource datasetSource = await datasetContentSourceFactory.CreateAsync(
-            localSource.LocalSourcePath!,
+            localSource.LocalSourcePath,
             cancellationToken);
         Stopwatch totalStopwatch = Stopwatch.StartNew();
         Stopwatch scanStopwatch = Stopwatch.StartNew();
@@ -59,7 +59,7 @@ internal static class ImportedSceneSourceDiscoveryPipeline
         if (sourceFiles.Length == 0)
         {
             throw new PlateauImportValidationException(
-                [LocalCityGmlImportErrorMessages.NoMatchingFiles(request, localSource.LocalSourcePath!)]);
+                [LocalCityGmlImportErrorMessages.NoMatchingFiles(request, localSource.LocalSourcePath)]);
         }
 
         LodFilteringStrategy lodFilteringStrategy = new(

--- a/src/PlateauResoniteLink/Application/Importing/ImportedSceneSourceDiscoveryPipeline.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ImportedSceneSourceDiscoveryPipeline.cs
@@ -13,7 +13,7 @@ namespace PlateauResoniteLink.Application.Importing;
 internal static class ImportedSceneSourceDiscoveryPipeline
 {
     internal static async Task<ImportedSceneSourceSnapshot> ReadDocumentSetCoreAsync(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         IPlateauDatasetContentSourceFactory datasetContentSourceFactory,
         ICityGmlAppearanceStoreFactory appearanceStoreFactory,
         ICityGmlLodSelector lodSelector,
@@ -25,14 +25,8 @@ internal static class ImportedSceneSourceDiscoveryPipeline
         ArgumentNullException.ThrowIfNull(appearanceStoreFactory);
         ArgumentNullException.ThrowIfNull(lodSelector);
 
-        if (request.CityGmlSource is not LocalDatasetLocation localSource)
-        {
-            throw new PlateauImportValidationException(
-                [LocalCityGmlImportErrorMessages.MissingLocalSourcePath()]);
-        }
-
         IPlateauDatasetContentSource datasetSource = await datasetContentSourceFactory.CreateAsync(
-            localSource.LocalSourcePath,
+            request.CityGmlLocalSourcePath,
             cancellationToken);
         Stopwatch totalStopwatch = Stopwatch.StartNew();
         Stopwatch scanStopwatch = Stopwatch.StartNew();
@@ -59,7 +53,7 @@ internal static class ImportedSceneSourceDiscoveryPipeline
         if (sourceFiles.Length == 0)
         {
             throw new PlateauImportValidationException(
-                [LocalCityGmlImportErrorMessages.NoMatchingFiles(request, localSource.LocalSourcePath)]);
+                [LocalCityGmlImportErrorMessages.NoMatchingFiles(request.ToImportRequest(), request.CityGmlLocalSourcePath)]);
         }
 
         LodFilteringStrategy lodFilteringStrategy = new(

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlDocumentReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlDocumentReader.cs
@@ -2,8 +2,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using PlateauResoniteLink.Domain.Importing;
-
 namespace PlateauResoniteLink.Application.Importing;
 
 internal sealed class LocalCityGmlDocumentReader : ICityGmlDocumentReader
@@ -23,7 +21,7 @@ internal sealed class LocalCityGmlDocumentReader : ICityGmlDocumentReader
     }
 
     public async Task<ImportedSceneSourceSnapshot> ReadAsync(
-        PlateauImportRequest request,
+        ResolvedLocalPlateauImportRequest request,
         Action<string>? progressReporter = null,
         CancellationToken cancellationToken = default)
     {

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedObjectModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedObjectModels.cs
@@ -43,10 +43,10 @@ internal sealed record ParsedCityObject(
     CoordinateReferenceSystem ReferenceSystem,
     string SourceFileRelativePath,
     bool SharedAcrossMeshCodes,
+    BuildingAttributeContext BuildingAttributes,
     bool TerrainAligned = false,
     GeodeticPoint? GeodeticOriginOverride = null,
     int? FloorsAboveGround = null,
     double? MeasuredHeightMeters = null,
-    BuildingAttributeContext? BuildingAttributes = null,
     double? GeometryHeightMeters = null,
     string? SourceMeshCode = null);

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedSourceFileModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedSourceFileModels.cs
@@ -13,7 +13,8 @@ internal sealed record SourceFileDescriptor(
 
 internal sealed record CachedSourceFileDescriptor(
     SourceFileDescriptor SourceFile,
-    ParsedCityObject[] CityObjects)
+    ParsedCityObject[] CityObjects,
+    CoordinateReferenceSystem ReferenceSystem)
 {
     public string RelativePath => SourceFile.RelativePath;
 
@@ -69,6 +70,6 @@ internal sealed class SourceFilePipeline
 internal sealed record ParsedSourceFileResult(
     SourceFileDescriptor SourceFile,
     ParsedCityObject[] CityObjects,
-    CoordinateReferenceSystem? ReferenceSystem,
+    CoordinateReferenceSystem ReferenceSystem,
     TerrainHeightTriangle[] TerrainTriangles,
     TimeSpan Elapsed);

--- a/src/PlateauResoniteLink/Application/Importing/PlateauDatasetContentSourceFactory.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauDatasetContentSourceFactory.cs
@@ -369,7 +369,11 @@ internal static class PlateauDatasetContentSourceFactory
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                string entryKey = archiveFileLayoutPolicy.NormalizeRelativePath(entry.Key ?? string.Empty);
+                if (!TryNormalizeArchiveEntryKey(entry, archiveFileLayoutPolicy, out string entryKey))
+                {
+                    continue;
+                }
+
                 if (IsSupportedArchiveFile(entryKey))
                 {
                     await IndexArchiveAsync(
@@ -438,10 +442,8 @@ internal static class PlateauDatasetContentSourceFactory
 
             IArchiveEntry entry = archive.Entries.FirstOrDefault(candidate =>
                     !candidate.IsDirectory
-                    && string.Equals(
-                        archiveFileLayoutPolicy.NormalizeRelativePath(candidate.Key ?? string.Empty),
-                        archiveFileLayoutPolicy.NormalizeRelativePath(entryKey),
-                        StringComparison.Ordinal))
+                    && TryNormalizeArchiveEntryKey(candidate, archiveFileLayoutPolicy, out string candidateKey)
+                    && string.Equals(candidateKey, archiveFileLayoutPolicy.NormalizeRelativePath(entryKey), StringComparison.Ordinal))
                 ?? throw new FileNotFoundException($"The dataset entry '{entryKey}' was not found in '{archivePath}'.");
 
             await using Stream entryStream = await entry.OpenEntryStreamAsync(cancellationToken);
@@ -456,6 +458,42 @@ internal static class PlateauDatasetContentSourceFactory
             string extension = Path.GetExtension(path);
             return string.Equals(extension, ".zip", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(extension, ".7z", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool TryNormalizeArchiveEntryKey(
+            IArchiveEntry entry,
+            IArchiveFileLayoutPolicy archiveFileLayoutPolicy,
+            out string entryKey)
+        {
+            entryKey = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(entry.Key))
+            {
+                return false;
+            }
+
+            string rawKey = entry.Key.Replace('\\', '/').Trim();
+            if (rawKey.StartsWith('/')
+                || Path.IsPathFullyQualified(rawKey)
+                || (rawKey.Length >= 2 && rawKey[1] == ':'))
+            {
+                return false;
+            }
+
+            string normalizedKey = archiveFileLayoutPolicy.NormalizeRelativePath(rawKey);
+            if (normalizedKey.Length == 0)
+            {
+                return false;
+            }
+
+            string[] segments = normalizedKey.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Any(static segment => segment is "." or ".."))
+            {
+                return false;
+            }
+
+            entryKey = normalizedKey;
+            return true;
         }
 
     }

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
@@ -361,6 +361,7 @@ public static class PlateauImportRequestValidator
         return source switch
         {
             LocalDatasetLocation localSource => new LocalDatasetLocation(localSource.LocalSourcePath.Trim()),
+            RemoteDatasetLocation remoteSource => remoteSource,
             _ => source,
         };
     }

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportRequestValidator.cs
@@ -137,12 +137,6 @@ public static class PlateauImportRequestValidator
         switch (normalizedRequest.CityGmlSource)
         {
             case LocalDatasetLocation localSource:
-                if (string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
-                {
-                    validationErrors.Add("The --citygml-source value is required.");
-                    break;
-                }
-
                 if (!Directory.Exists(localSource.LocalSourcePath)
                     && !File.Exists(localSource.LocalSourcePath))
                 {
@@ -167,12 +161,6 @@ public static class PlateauImportRequestValidator
                 validatedCityGmlSource = new ValidatedLocalDatasetLocation(localSource.LocalSourcePath);
                 break;
             case RemoteDatasetLocation remoteSource:
-                if (remoteSource.ServerUri is null)
-                {
-                    validationErrors.Add("The --citygml-source value is required.");
-                    break;
-                }
-
                 if (!remoteSource.ServerUri.IsAbsoluteUri)
                 {
                     validationErrors.Add("The --citygml-source value must be an absolute URI.");
@@ -194,12 +182,6 @@ public static class PlateauImportRequestValidator
             switch (normalizedRequest.DemTextureSource)
             {
                 case LocalDatasetLocation localSource:
-                    if (string.IsNullOrWhiteSpace(localSource.LocalSourcePath))
-                    {
-                        validationErrors.Add("The --geotiff-source value must not be empty.");
-                        break;
-                    }
-
                     if (!File.Exists(localSource.LocalSourcePath))
                     {
                         validationErrors.Add($"The GeoTIFF source path '{localSource.LocalSourcePath}' must point to an existing file.");
@@ -216,12 +198,6 @@ public static class PlateauImportRequestValidator
                     validatedDemTextureSource = new ValidatedLocalDatasetLocation(localSource.LocalSourcePath);
                     break;
                 case RemoteDatasetLocation remoteSource:
-                    if (remoteSource.ServerUri is null)
-                    {
-                        validationErrors.Add("The --geotiff-source value must not be empty.");
-                        break;
-                    }
-
                     if (!remoteSource.ServerUri.IsAbsoluteUri)
                     {
                         validationErrors.Add("The --geotiff-source value must be an absolute URI.");
@@ -239,9 +215,10 @@ public static class PlateauImportRequestValidator
             }
         }
 
-        if (normalizedRequest.TerrainGridMetersPerVertex <= 0)
+        if (!double.IsFinite(normalizedRequest.TerrainGridMetersPerVertex)
+            || normalizedRequest.TerrainGridMetersPerVertex <= 0)
         {
-            validationErrors.Add("The terrain grid meters-per-vertex value must be greater than zero.");
+            validationErrors.Add("The terrain grid meters-per-vertex value must be a finite value greater than zero.");
         }
 
         if (normalizedRequest.TerrainGridMaxResolution < 2)
@@ -383,13 +360,7 @@ public static class PlateauImportRequestValidator
     {
         return source switch
         {
-            LocalDatasetLocation localSource => new LocalDatasetLocation(
-                string.IsNullOrWhiteSpace(localSource.LocalSourcePath)
-                    ? null
-                    : localSource.LocalSourcePath.Trim()),
-            RemoteDatasetLocation remoteSource => remoteSource.ServerUri is null
-                ? new RemoteDatasetLocation(null)
-                : remoteSource,
+            LocalDatasetLocation localSource => new LocalDatasetLocation(localSource.LocalSourcePath.Trim()),
             _ => source,
         };
     }

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
@@ -45,11 +45,11 @@ internal sealed class PlateauImportService(
 
         try
         {
-            PlateauImportRequest resolvedRequest =
-                (await datasetSourceResolver.ResolveAsync(
-                    validatedRequest,
-                    datasetWorkRoot,
-                    cancellationToken)).ToImportRequest();
+            ResolvedLocalPlateauImportRequest resolvedRequest = await datasetSourceResolver.ResolveAsync(
+                validatedRequest,
+                datasetWorkRoot,
+                cancellationToken);
+            PlateauImportRequest resolvedImportRequest = resolvedRequest.ToImportRequest();
             ReportProgress(
                 PlateauLog.Debug("import", $"Resolved CityGML source for '{resolvedRequest.Dataset}' mesh-code '{resolvedRequest.MeshCode}'."));
 
@@ -68,12 +68,11 @@ internal sealed class PlateauImportService(
                     "import",
                     $"Setup will use {this.commonMaterials.Count} codebase-reachable common materials."));
 
-            LocalDatasetLocation resolvedCityGmlSource = (LocalDatasetLocation)resolvedRequest.CityGmlSource;
             SceneImportExecutionPlan executionPlan = SceneImportExecutionPlan.Create(
                 normalizedRequest,
-                resolvedRequest,
+                resolvedImportRequest,
                 metadata,
-                resolvedCityGmlSource.LocalSourcePath,
+                resolvedRequest.CityGmlLocalSourcePath,
                 datasetWorkRoot,
                 this.commonMaterials);
 

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
@@ -39,7 +39,6 @@ internal sealed class PlateauImportService(
         ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
 
         ValidatedPlateauImportRequest validatedRequest = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(request);
-        PlateauImportRequest normalizedRequest = validatedRequest.ToImportRequest();
         string datasetWorkRoot = archiveFileLayoutPolicy.ResolveDatasetRoot(workRoot, validatedRequest.Dataset);
         ExceptionDispatchInfo? failure = null;
 
@@ -49,7 +48,6 @@ internal sealed class PlateauImportService(
                 validatedRequest,
                 datasetWorkRoot,
                 cancellationToken);
-            PlateauImportRequest resolvedImportRequest = resolvedRequest.ToImportRequest();
             ReportProgress(
                 PlateauLog.Debug("import", $"Resolved CityGML source for '{resolvedRequest.Dataset}' mesh-code '{resolvedRequest.MeshCode}'."));
 
@@ -69,10 +67,8 @@ internal sealed class PlateauImportService(
                     $"Setup will use {this.commonMaterials.Count} codebase-reachable common materials."));
 
             SceneImportExecutionPlan executionPlan = SceneImportExecutionPlan.Create(
-                normalizedRequest,
-                resolvedImportRequest,
+                resolvedRequest,
                 metadata,
-                resolvedRequest.CityGmlLocalSourcePath,
                 datasetWorkRoot,
                 this.commonMaterials);
 

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
@@ -154,7 +154,7 @@ internal sealed class PlateauImportService(
                 UsedCount: 1))
             .ToList();
 
-        if (executionResult.DataSourceUsages is { Count: > 0 })
+        if (executionResult.DataSourceUsages.Count > 0)
         {
             usages.AddRange(executionResult.DataSourceUsages);
         }

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
@@ -68,11 +68,12 @@ internal sealed class PlateauImportService(
                     "import",
                     $"Setup will use {this.commonMaterials.Count} codebase-reachable common materials."));
 
+            LocalDatasetLocation resolvedCityGmlSource = (LocalDatasetLocation)resolvedRequest.CityGmlSource;
             SceneImportExecutionPlan executionPlan = SceneImportExecutionPlan.Create(
                 normalizedRequest,
                 resolvedRequest,
                 metadata,
-                resolvedRequest.CityGmlLocalSourcePath!,
+                resolvedCityGmlSource.LocalSourcePath,
                 datasetWorkRoot,
                 this.commonMaterials);
 

--- a/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+public sealed record ResolvedLocalPlateauImportRequest
+{
+    private readonly ValidatedLocalDatasetLocation? demTextureSource;
+
+    public ResolvedLocalPlateauImportRequest(
+        string Dataset,
+        string MeshCode,
+        string CityGmlLocalSourcePath,
+        LocalDatasetLocation? DemTextureSource = null,
+        IReadOnlyList<string>? PackageNames = null,
+        IReadOnlySet<int>? GlobalExcludeLodLevels = null,
+        IReadOnlyDictionary<string, IReadOnlySet<int>>? ExcludeLodLevelsByPackage = null,
+        IReadOnlyDictionary<string, string>? PackagePatterns = null,
+        bool IncludeMarkingAlways = true,
+        TerrainMeshMode TerrainMeshMode = TerrainMeshMode.Static,
+        double TerrainGridMetersPerVertex = 2.0,
+        int TerrainGridMaxResolution = 1024)
+    {
+        ValidatedLocalDatasetLocation cityGmlSource = new(RequireNonEmpty(CityGmlLocalSourcePath, nameof(CityGmlLocalSourcePath)));
+        ValidatedLocalDatasetLocation? validatedDemTextureSource = ToResolvedDemTextureSource(DemTextureSource, nameof(DemTextureSource));
+        ValidatedRequest = CreateResolvedRequest(
+            Dataset,
+            MeshCode,
+            cityGmlSource,
+            validatedDemTextureSource,
+            PackageNames,
+            GlobalExcludeLodLevels,
+            ExcludeLodLevelsByPackage,
+            PackagePatterns,
+            IncludeMarkingAlways,
+            TerrainMeshMode,
+            TerrainGridMetersPerVertex,
+            TerrainGridMaxResolution);
+        CityGmlSource = cityGmlSource;
+        demTextureSource = validatedDemTextureSource;
+    }
+
+    private ResolvedLocalPlateauImportRequest(
+        ValidatedPlateauImportRequest request,
+        ValidatedLocalDatasetLocation cityGmlSource,
+        ValidatedLocalDatasetLocation? demTextureSource)
+    {
+        ValidatedRequest = request with
+        {
+            CityGmlSource = cityGmlSource,
+            DemTextureSource = demTextureSource,
+        };
+        CityGmlSource = cityGmlSource;
+        this.demTextureSource = demTextureSource;
+    }
+
+    internal ValidatedPlateauImportRequest ValidatedRequest { get; }
+
+    internal ValidatedLocalDatasetLocation CityGmlSource { get; }
+
+    public string Dataset => ValidatedRequest.Dataset;
+
+    public string MeshCode => ValidatedRequest.MeshCode;
+
+    public string CityGmlLocalSourcePath => CityGmlSource.LocalSourcePath;
+
+    public LocalDatasetLocation? DemTextureSource => demTextureSource is null
+        ? null
+        : new LocalDatasetLocation(demTextureSource.LocalSourcePath);
+
+    public string? DemTextureLocalSourcePath => demTextureSource?.LocalSourcePath;
+
+    public IReadOnlyList<string>? PackageNames => ValidatedRequest.PackageNames;
+
+    public IReadOnlySet<int>? GlobalExcludeLodLevels => ValidatedRequest.GlobalExcludeLodLevels;
+
+    public IReadOnlyDictionary<string, IReadOnlySet<int>>? ExcludeLodLevelsByPackage => ValidatedRequest.ExcludeLodLevelsByPackage;
+
+    public IReadOnlyDictionary<string, string>? PackagePatterns => ValidatedRequest.PackagePatterns;
+
+    public bool IncludeMarkingAlways => ValidatedRequest.IncludeMarkingAlways;
+
+    public TerrainMeshMode TerrainMeshMode => ValidatedRequest.TerrainMeshMode;
+
+    public double TerrainGridMetersPerVertex => ValidatedRequest.TerrainGridMetersPerVertex;
+
+    public int TerrainGridMaxResolution => ValidatedRequest.TerrainGridMaxResolution;
+
+    public PlateauImportRequest ToImportRequest()
+    {
+        return (ValidatedRequest with
+        {
+            CityGmlSource = CityGmlSource,
+            DemTextureSource = demTextureSource,
+        }).ToImportRequest();
+    }
+
+    internal static ResolvedLocalPlateauImportRequest Create(
+        ValidatedPlateauImportRequest request,
+        string workRoot,
+        ValidatedLocalDatasetLocation cityGmlSource,
+        ValidatedLocalDatasetLocation? demTextureSource)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
+        ArgumentNullException.ThrowIfNull(cityGmlSource);
+
+        ValidateResolvedSource(request.CityGmlSource, cityGmlSource, workRoot, "source-archive", nameof(cityGmlSource));
+        ValidateResolvedOptionalSource(request.DemTextureSource, demTextureSource, workRoot, "source-ortho", nameof(demTextureSource));
+
+        return new ResolvedLocalPlateauImportRequest(request, cityGmlSource, demTextureSource);
+    }
+
+    private static void ValidateResolvedOptionalSource(
+        ValidatedDatasetLocation? requestedSource,
+        ValidatedLocalDatasetLocation? resolvedSource,
+        string workRoot,
+        string remotePathPrefix,
+        string parameterName)
+    {
+        if (requestedSource is null || resolvedSource is null)
+        {
+            if (requestedSource is not null || resolvedSource is not null)
+            {
+                throw new ArgumentException(
+                    "Resolved local source presence must match the requested source presence.",
+                    parameterName);
+            }
+
+            return;
+        }
+
+        ValidateResolvedSource(requestedSource, resolvedSource, workRoot, remotePathPrefix, parameterName);
+    }
+
+    private static void ValidateResolvedSource(
+        ValidatedDatasetLocation requestedSource,
+        ValidatedLocalDatasetLocation resolvedSource,
+        string workRoot,
+        string remotePathPrefix,
+        string parameterName)
+    {
+        switch (requestedSource)
+        {
+            case ValidatedLocalDatasetLocation requestedLocal
+                when string.Equals(requestedLocal.LocalSourcePath, resolvedSource.LocalSourcePath, StringComparison.Ordinal):
+                return;
+            case ValidatedRemoteDatasetLocation requestedRemote
+                when RemoteDatasetResourceLayout.MatchesRemoteResourcePath(
+                    workRoot,
+                    requestedRemote.ServerUri,
+                    remotePathPrefix,
+                    resolvedSource.LocalSourcePath):
+                return;
+            default:
+                throw new ArgumentException(
+                    "Resolved local source must match the requested local source or the expected remote materialization path.",
+                    parameterName);
+        }
+    }
+
+    private static ValidatedPlateauImportRequest CreateResolvedRequest(
+        string dataset,
+        string meshCode,
+        ValidatedLocalDatasetLocation cityGmlSource,
+        ValidatedLocalDatasetLocation? demTextureSource,
+        IReadOnlyList<string>? packageNames,
+        IReadOnlySet<int>? globalExcludeLodLevels,
+        IReadOnlyDictionary<string, IReadOnlySet<int>>? excludeLodLevelsByPackage,
+        IReadOnlyDictionary<string, string>? packagePatterns,
+        bool includeMarkingAlways,
+        TerrainMeshMode terrainMeshMode,
+        double terrainGridMetersPerVertex,
+        int terrainGridMaxResolution)
+    {
+        string requiredDataset = RequireNonEmpty(dataset, nameof(dataset));
+        string requiredMeshCode = RequireNonEmpty(meshCode, nameof(meshCode));
+        string[]? normalizedPackageNames = NormalizePackageNames(packageNames);
+        Dictionary<string, IReadOnlySet<int>>? normalizedPackageExclusions = NormalizePackageExclusionMap(excludeLodLevelsByPackage);
+        Dictionary<string, string>? normalizedPackagePatterns = NormalizePackagePatternMap(packagePatterns);
+        if (!MeshCodeRequestSyntax.TryCreateSelectionRegex(requiredMeshCode, out Regex? meshCodePattern, out string? meshCodeError))
+        {
+            throw new ArgumentException(meshCodeError, nameof(meshCode));
+        }
+
+        meshCodePattern ??= new Regex(
+            $@"\A(?:{Regex.Escape(requiredMeshCode)})\z",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant,
+            TimeSpan.FromSeconds(1));
+
+        return new ValidatedPlateauImportRequest(
+            requiredDataset,
+            requiredMeshCode,
+            meshCodePattern,
+            cityGmlSource,
+            demTextureSource,
+            normalizedPackageNames,
+            globalExcludeLodLevels,
+            normalizedPackageExclusions,
+            normalizedPackagePatterns,
+            includeMarkingAlways,
+            terrainMeshMode,
+            terrainGridMetersPerVertex,
+            terrainGridMaxResolution);
+    }
+
+    private static ValidatedLocalDatasetLocation? ToResolvedDemTextureSource(
+        LocalDatasetLocation? source,
+        string parameterName)
+    {
+        return source is null
+            ? null
+            : new ValidatedLocalDatasetLocation(RequireNonEmpty(source.LocalSourcePath, parameterName));
+    }
+
+    private static string[]? NormalizePackageNames(IReadOnlyList<string>? packageNames)
+    {
+        if (packageNames is null)
+        {
+            return null;
+        }
+
+        if (packageNames.Count == 0)
+        {
+            throw new ArgumentException("At least one package name is required when packages are specified.", nameof(packageNames));
+        }
+
+        return PlateauPackageCatalog.NormalizeRequestedPackageNames(packageNames);
+    }
+
+    private static Dictionary<string, IReadOnlySet<int>>? NormalizePackageExclusionMap(
+        IReadOnlyDictionary<string, IReadOnlySet<int>>? exclusionsByPackage)
+    {
+        if (exclusionsByPackage is null)
+        {
+            return null;
+        }
+
+        Dictionary<string, IReadOnlySet<int>> normalized = new(StringComparer.OrdinalIgnoreCase);
+        foreach ((string packageName, IReadOnlySet<int> excludedLods) in exclusionsByPackage)
+        {
+            string normalizedPackageName = NormalizePackageMapKey(packageName, nameof(exclusionsByPackage));
+            if (!normalized.TryAdd(normalizedPackageName, excludedLods))
+            {
+                throw new ArgumentException(
+                    $"The {nameof(exclusionsByPackage)} value contains duplicate package keys after normalization: {normalizedPackageName}.",
+                    nameof(exclusionsByPackage));
+            }
+        }
+
+        return normalized;
+    }
+
+    private static Dictionary<string, string>? NormalizePackagePatternMap(
+        IReadOnlyDictionary<string, string>? patternsByPackage)
+    {
+        if (patternsByPackage is null)
+        {
+            return null;
+        }
+
+        Dictionary<string, string> normalized = new(StringComparer.OrdinalIgnoreCase);
+        foreach ((string packageName, string pattern) in patternsByPackage)
+        {
+            string normalizedPackageName = NormalizePackageMapKey(packageName, nameof(patternsByPackage));
+            if (!normalized.TryAdd(normalizedPackageName, pattern))
+            {
+                throw new ArgumentException(
+                    $"The {nameof(patternsByPackage)} value contains duplicate package keys after normalization: {normalizedPackageName}.",
+                    nameof(patternsByPackage));
+            }
+        }
+
+        return normalized;
+    }
+
+    private static string NormalizePackageMapKey(string packageName, string parameterName)
+    {
+        if (!PlateauPackageCatalog.TryNormalizePackageName(packageName, out string normalizedPackageName))
+        {
+            throw new ArgumentException(
+                $"Unsupported package '{packageName}'. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.",
+                parameterName);
+        }
+
+        return normalizedPackageName;
+    }
+
+    private static string RequireNonEmpty(string? value, string parameterName)
+    {
+        string? trimmedValue = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmedValue)
+            ? throw new ArgumentException("The value must not be empty.", parameterName)
+            : trimmedValue;
+    }
+}

--- a/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ResolvedLocalPlateauImportRequest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 using PlateauResoniteLink.Domain.Importing;
 
@@ -8,40 +7,10 @@ namespace PlateauResoniteLink.Application.Importing;
 
 public sealed record ResolvedLocalPlateauImportRequest
 {
-    private readonly ValidatedLocalDatasetLocation? demTextureSource;
+    internal const string RemoteCityGmlResourcePrefix = "source-archive";
+    internal const string RemoteDemTextureResourcePrefix = "source-ortho";
 
-    public ResolvedLocalPlateauImportRequest(
-        string Dataset,
-        string MeshCode,
-        string CityGmlLocalSourcePath,
-        LocalDatasetLocation? DemTextureSource = null,
-        IReadOnlyList<string>? PackageNames = null,
-        IReadOnlySet<int>? GlobalExcludeLodLevels = null,
-        IReadOnlyDictionary<string, IReadOnlySet<int>>? ExcludeLodLevelsByPackage = null,
-        IReadOnlyDictionary<string, string>? PackagePatterns = null,
-        bool IncludeMarkingAlways = true,
-        TerrainMeshMode TerrainMeshMode = TerrainMeshMode.Static,
-        double TerrainGridMetersPerVertex = 2.0,
-        int TerrainGridMaxResolution = 1024)
-    {
-        ValidatedLocalDatasetLocation cityGmlSource = new(RequireNonEmpty(CityGmlLocalSourcePath, nameof(CityGmlLocalSourcePath)));
-        ValidatedLocalDatasetLocation? validatedDemTextureSource = ToResolvedDemTextureSource(DemTextureSource, nameof(DemTextureSource));
-        ValidatedRequest = CreateResolvedRequest(
-            Dataset,
-            MeshCode,
-            cityGmlSource,
-            validatedDemTextureSource,
-            PackageNames,
-            GlobalExcludeLodLevels,
-            ExcludeLodLevelsByPackage,
-            PackagePatterns,
-            IncludeMarkingAlways,
-            TerrainMeshMode,
-            TerrainGridMetersPerVertex,
-            TerrainGridMaxResolution);
-        CityGmlSource = cityGmlSource;
-        demTextureSource = validatedDemTextureSource;
-    }
+    private readonly ValidatedLocalDatasetLocation? demTextureSource;
 
     private ResolvedLocalPlateauImportRequest(
         ValidatedPlateauImportRequest request,
@@ -98,202 +67,88 @@ public sealed record ResolvedLocalPlateauImportRequest
         }).ToImportRequest();
     }
 
-    internal static ResolvedLocalPlateauImportRequest Create(
+    public static ResolvedLocalPlateauImportRequest Create(
         ValidatedPlateauImportRequest request,
-        string workRoot,
         ValidatedLocalDatasetLocation cityGmlSource,
-        ValidatedLocalDatasetLocation? demTextureSource)
+        ValidatedLocalDatasetLocation? demTextureSource,
+        string? workRoot = null)
     {
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
         ArgumentNullException.ThrowIfNull(cityGmlSource);
-
-        ValidateResolvedSource(request.CityGmlSource, cityGmlSource, workRoot, "source-archive", nameof(cityGmlSource));
-        ValidateResolvedOptionalSource(request.DemTextureSource, demTextureSource, workRoot, "source-ortho", nameof(demTextureSource));
+        ValidateResolvedLocalSource(
+            request.CityGmlSource,
+            cityGmlSource,
+            workRoot,
+            RemoteCityGmlResourcePrefix,
+            nameof(cityGmlSource));
+        ValidateResolvedOptionalLocalSource(
+            request.DemTextureSource,
+            demTextureSource,
+            workRoot,
+            RemoteDemTextureResourcePrefix,
+            nameof(demTextureSource));
 
         return new ResolvedLocalPlateauImportRequest(request, cityGmlSource, demTextureSource);
     }
 
-    private static void ValidateResolvedOptionalSource(
-        ValidatedDatasetLocation? requestedSource,
-        ValidatedLocalDatasetLocation? resolvedSource,
-        string workRoot,
-        string remotePathPrefix,
+    private static void ValidateResolvedLocalSource(
+        ValidatedDatasetLocation requestedSource,
+        ValidatedLocalDatasetLocation resolvedSource,
+        string? workRoot,
+        string remoteResourcePrefix,
         string parameterName)
     {
-        if (requestedSource is null || resolvedSource is null)
+        if (requestedSource is ValidatedLocalDatasetLocation requestedLocalSource
+            && !string.Equals(
+                requestedLocalSource.LocalSourcePath,
+                resolvedSource.LocalSourcePath,
+                StringComparison.Ordinal))
         {
-            if (requestedSource is not null || resolvedSource is not null)
+            throw new ArgumentException(
+                "Resolved local dataset source must match the requested local dataset source.",
+                parameterName);
+        }
+
+        if (requestedSource is ValidatedRemoteDatasetLocation requestedRemoteSource)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
+            if (!RemoteDatasetResourceLayout.MatchesRemoteResourcePath(
+                    workRoot,
+                    requestedRemoteSource.ServerUri,
+                    remoteResourcePrefix,
+                    resolvedSource.LocalSourcePath))
             {
                 throw new ArgumentException(
-                    "Resolved local source presence must match the requested source presence.",
+                    "Resolved local dataset source must match the requested remote dataset source cache path.",
+                    parameterName);
+            }
+        }
+    }
+
+    private static void ValidateResolvedOptionalLocalSource(
+        ValidatedDatasetLocation? requestedSource,
+        ValidatedLocalDatasetLocation? resolvedSource,
+        string? workRoot,
+        string remoteResourcePrefix,
+        string parameterName)
+    {
+        if (requestedSource is null)
+        {
+            if (resolvedSource is not null)
+            {
+                throw new ArgumentException(
+                    "Resolved local dataset source must be omitted when no source was requested.",
                     parameterName);
             }
 
             return;
         }
 
-        ValidateResolvedSource(requestedSource, resolvedSource, workRoot, remotePathPrefix, parameterName);
-    }
-
-    private static void ValidateResolvedSource(
-        ValidatedDatasetLocation requestedSource,
-        ValidatedLocalDatasetLocation resolvedSource,
-        string workRoot,
-        string remotePathPrefix,
-        string parameterName)
-    {
-        switch (requestedSource)
+        if (resolvedSource is null)
         {
-            case ValidatedLocalDatasetLocation requestedLocal
-                when string.Equals(requestedLocal.LocalSourcePath, resolvedSource.LocalSourcePath, StringComparison.Ordinal):
-                return;
-            case ValidatedRemoteDatasetLocation requestedRemote
-                when RemoteDatasetResourceLayout.MatchesRemoteResourcePath(
-                    workRoot,
-                    requestedRemote.ServerUri,
-                    remotePathPrefix,
-                    resolvedSource.LocalSourcePath):
-                return;
-            default:
-                throw new ArgumentException(
-                    "Resolved local source must match the requested local source or the expected remote materialization path.",
-                    parameterName);
-        }
-    }
-
-    private static ValidatedPlateauImportRequest CreateResolvedRequest(
-        string dataset,
-        string meshCode,
-        ValidatedLocalDatasetLocation cityGmlSource,
-        ValidatedLocalDatasetLocation? demTextureSource,
-        IReadOnlyList<string>? packageNames,
-        IReadOnlySet<int>? globalExcludeLodLevels,
-        IReadOnlyDictionary<string, IReadOnlySet<int>>? excludeLodLevelsByPackage,
-        IReadOnlyDictionary<string, string>? packagePatterns,
-        bool includeMarkingAlways,
-        TerrainMeshMode terrainMeshMode,
-        double terrainGridMetersPerVertex,
-        int terrainGridMaxResolution)
-    {
-        string requiredDataset = RequireNonEmpty(dataset, nameof(dataset));
-        string requiredMeshCode = RequireNonEmpty(meshCode, nameof(meshCode));
-        string[]? normalizedPackageNames = NormalizePackageNames(packageNames);
-        Dictionary<string, IReadOnlySet<int>>? normalizedPackageExclusions = NormalizePackageExclusionMap(excludeLodLevelsByPackage);
-        Dictionary<string, string>? normalizedPackagePatterns = NormalizePackagePatternMap(packagePatterns);
-        if (!MeshCodeRequestSyntax.TryCreateSelectionRegex(requiredMeshCode, out Regex? meshCodePattern, out string? meshCodeError))
-        {
-            throw new ArgumentException(meshCodeError, nameof(meshCode));
+            throw new ArgumentNullException(parameterName);
         }
 
-        meshCodePattern ??= new Regex(
-            $@"\A(?:{Regex.Escape(requiredMeshCode)})\z",
-            RegexOptions.Compiled | RegexOptions.CultureInvariant,
-            TimeSpan.FromSeconds(1));
-
-        return new ValidatedPlateauImportRequest(
-            requiredDataset,
-            requiredMeshCode,
-            meshCodePattern,
-            cityGmlSource,
-            demTextureSource,
-            normalizedPackageNames,
-            globalExcludeLodLevels,
-            normalizedPackageExclusions,
-            normalizedPackagePatterns,
-            includeMarkingAlways,
-            terrainMeshMode,
-            terrainGridMetersPerVertex,
-            terrainGridMaxResolution);
-    }
-
-    private static ValidatedLocalDatasetLocation? ToResolvedDemTextureSource(
-        LocalDatasetLocation? source,
-        string parameterName)
-    {
-        return source is null
-            ? null
-            : new ValidatedLocalDatasetLocation(RequireNonEmpty(source.LocalSourcePath, parameterName));
-    }
-
-    private static string[]? NormalizePackageNames(IReadOnlyList<string>? packageNames)
-    {
-        if (packageNames is null)
-        {
-            return null;
-        }
-
-        if (packageNames.Count == 0)
-        {
-            throw new ArgumentException("At least one package name is required when packages are specified.", nameof(packageNames));
-        }
-
-        return PlateauPackageCatalog.NormalizeRequestedPackageNames(packageNames);
-    }
-
-    private static Dictionary<string, IReadOnlySet<int>>? NormalizePackageExclusionMap(
-        IReadOnlyDictionary<string, IReadOnlySet<int>>? exclusionsByPackage)
-    {
-        if (exclusionsByPackage is null)
-        {
-            return null;
-        }
-
-        Dictionary<string, IReadOnlySet<int>> normalized = new(StringComparer.OrdinalIgnoreCase);
-        foreach ((string packageName, IReadOnlySet<int> excludedLods) in exclusionsByPackage)
-        {
-            string normalizedPackageName = NormalizePackageMapKey(packageName, nameof(exclusionsByPackage));
-            if (!normalized.TryAdd(normalizedPackageName, excludedLods))
-            {
-                throw new ArgumentException(
-                    $"The {nameof(exclusionsByPackage)} value contains duplicate package keys after normalization: {normalizedPackageName}.",
-                    nameof(exclusionsByPackage));
-            }
-        }
-
-        return normalized;
-    }
-
-    private static Dictionary<string, string>? NormalizePackagePatternMap(
-        IReadOnlyDictionary<string, string>? patternsByPackage)
-    {
-        if (patternsByPackage is null)
-        {
-            return null;
-        }
-
-        Dictionary<string, string> normalized = new(StringComparer.OrdinalIgnoreCase);
-        foreach ((string packageName, string pattern) in patternsByPackage)
-        {
-            string normalizedPackageName = NormalizePackageMapKey(packageName, nameof(patternsByPackage));
-            if (!normalized.TryAdd(normalizedPackageName, pattern))
-            {
-                throw new ArgumentException(
-                    $"The {nameof(patternsByPackage)} value contains duplicate package keys after normalization: {normalizedPackageName}.",
-                    nameof(patternsByPackage));
-            }
-        }
-
-        return normalized;
-    }
-
-    private static string NormalizePackageMapKey(string packageName, string parameterName)
-    {
-        if (!PlateauPackageCatalog.TryNormalizePackageName(packageName, out string normalizedPackageName))
-        {
-            throw new ArgumentException(
-                $"Unsupported package '{packageName}'. Supported packages: {string.Join(", ", PlateauPackageCatalog.SupportedPackageNames)}.",
-                parameterName);
-        }
-
-        return normalizedPackageName;
-    }
-
-    private static string RequireNonEmpty(string? value, string parameterName)
-    {
-        string? trimmedValue = value?.Trim();
-        return string.IsNullOrWhiteSpace(trimmedValue)
-            ? throw new ArgumentException("The value must not be empty.", parameterName)
-            : trimmedValue;
+        ValidateResolvedLocalSource(requestedSource, resolvedSource, workRoot, remoteResourcePrefix, parameterName);
     }
 }

--- a/src/PlateauResoniteLink/Application/Importing/RoadSurfaceEdgePairSelector.cs
+++ b/src/PlateauResoniteLink/Application/Importing/RoadSurfaceEdgePairSelector.cs
@@ -4,71 +4,46 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal static class RoadSurfaceEdgePairSelector
 {
-    internal static EdgePairSelection Select(
-        GeodeticPoint[] vertices,
-        Float3[] positions)
+    internal static EdgePairSelection Select(RoadSurfaceQuad quad)
     {
-        ValidateQuadInputs(vertices, positions);
-
-        double edge01 = Distance(positions[0], positions[1]);
-        double edge12 = Distance(positions[1], positions[2]);
-        double edge23 = Distance(positions[2], positions[3]);
-        double edge30 = Distance(positions[3], positions[0]);
+        double edge01 = Distance(quad.Position0, quad.Position1);
+        double edge12 = Distance(quad.Position1, quad.Position2);
+        double edge23 = Distance(quad.Position2, quad.Position3);
+        double edge30 = Distance(quad.Position3, quad.Position0);
 
         double pair01Length = (edge01 + edge23) * 0.5;
         double pair12Length = (edge12 + edge30) * 0.5;
 
         return pair01Length >= pair12Length
             ? new EdgePairSelection(
-                [vertices[0], vertices[1]],
-                [vertices[3], vertices[2]],
-                [positions[0], positions[1]],
-                [positions[3], positions[2]],
-                Side0Uvs: null,
-                Side1Uvs: null,
+                [quad.Vertex0, quad.Vertex1],
+                [quad.Vertex3, quad.Vertex2],
+                [quad.Position0, quad.Position1],
+                [quad.Position3, quad.Position2],
+                CreateUvs(quad.Uv0, quad.Uv1),
+                CreateUvs(quad.Uv3, quad.Uv2),
                 pair01Length,
-                (Distance(positions[0], positions[3]) + Distance(positions[1], positions[2])) * 0.5,
+                (Distance(quad.Position0, quad.Position3) + Distance(quad.Position1, quad.Position2)) * 0.5,
                 edge01,
                 edge23)
             : new EdgePairSelection(
-                [vertices[1], vertices[2]],
-                [vertices[0], vertices[3]],
-                [positions[1], positions[2]],
-                [positions[0], positions[3]],
-                Side0Uvs: null,
-                Side1Uvs: null,
+                [quad.Vertex1, quad.Vertex2],
+                [quad.Vertex0, quad.Vertex3],
+                [quad.Position1, quad.Position2],
+                [quad.Position0, quad.Position3],
+                CreateUvs(quad.Uv1, quad.Uv2),
+                CreateUvs(quad.Uv0, quad.Uv3),
                 pair12Length,
-                (Distance(positions[1], positions[0]) + Distance(positions[2], positions[3])) * 0.5,
+                (Distance(quad.Position1, quad.Position0) + Distance(quad.Position2, quad.Position3)) * 0.5,
                 edge12,
                 edge30);
     }
 
-    internal static EdgePairSelection Select(
-        ParsedRing ring,
-        Float3[] positions)
+    private static Float2[]? CreateUvs(Float2? first, Float2? second)
     {
-        ArgumentNullException.ThrowIfNull(ring);
-
-        EdgePairSelection pair = Select(ring.Vertices, positions);
-        if (ring.UVs is null || ring.UVs.Count != ring.Vertices.Length)
-        {
-            return pair;
-        }
-
-        bool usesFirstEdge = AreSamePoint(pair.Side0[0], ring.Vertices[0])
-            && AreSamePoint(pair.Side0[1], ring.Vertices[1]);
-
-        return usesFirstEdge
-            ? pair with
-            {
-                Side0Uvs = [ring.UVs[0], ring.UVs[1]],
-                Side1Uvs = [ring.UVs[3], ring.UVs[2]],
-            }
-            : pair with
-            {
-                Side0Uvs = [ring.UVs[1], ring.UVs[2]],
-                Side1Uvs = [ring.UVs[0], ring.UVs[3]],
-            };
+        return first is not null && second is not null
+            ? [first, second]
+            : null;
     }
 
     private static double Distance(Float3 left, Float3 right)
@@ -78,27 +53,65 @@ internal static class RoadSurfaceEdgePairSelector
         double deltaZ = left.Z - right.Z;
         return Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY) + (deltaZ * deltaZ));
     }
+}
 
-    private static void ValidateQuadInputs<TPoint>(TPoint[] vertices, Float3[] positions)
+internal readonly record struct RoadSurfaceQuad(
+    GeodeticPoint Vertex0,
+    GeodeticPoint Vertex1,
+    GeodeticPoint Vertex2,
+    GeodeticPoint Vertex3,
+    Float3 Position0,
+    Float3 Position1,
+    Float3 Position2,
+    Float3 Position3,
+    Float2? Uv0,
+    Float2? Uv1,
+    Float2? Uv2,
+    Float2? Uv3)
+{
+    internal static bool TryCreate(
+        ParsedRing ring,
+        Float3[] positions,
+        out RoadSurfaceQuad quad)
+    {
+        ArgumentNullException.ThrowIfNull(ring);
+        ArgumentNullException.ThrowIfNull(positions);
+
+        Float2[]? uvs = ring.UVs is { Count: 4 }
+            ? [ring.UVs[0], ring.UVs[1], ring.UVs[2], ring.UVs[3]]
+            : null;
+        return TryCreate(ring.Vertices, positions, uvs, out quad);
+    }
+
+    private static bool TryCreate(
+        GeodeticPoint[] vertices,
+        Float3[] positions,
+        Float2[]? uvs,
+        out RoadSurfaceQuad quad)
     {
         ArgumentNullException.ThrowIfNull(vertices);
         ArgumentNullException.ThrowIfNull(positions);
-        if (vertices.Length != 4)
+
+        if (vertices.Length != 4 || positions.Length != 4)
         {
-            throw new ArgumentException("Road surface edge-pair selection requires exactly four vertices.", nameof(vertices));
+            quad = default;
+            return false;
         }
 
-        if (positions.Length != 4)
-        {
-            throw new ArgumentException("Road surface edge-pair selection requires exactly four positions.", nameof(positions));
-        }
-    }
-
-    private static bool AreSamePoint(GeodeticPoint left, GeodeticPoint right)
-    {
-        return Math.Abs(left.Latitude - right.Latitude) < 1e-8
-            && Math.Abs(left.Longitude - right.Longitude) < 1e-8
-            && Math.Abs(left.Altitude - right.Altitude) < 1e-8;
+        quad = new RoadSurfaceQuad(
+            vertices[0],
+            vertices[1],
+            vertices[2],
+            vertices[3],
+            positions[0],
+            positions[1],
+            positions[2],
+            positions[3],
+            uvs?[0],
+            uvs?[1],
+            uvs?[2],
+            uvs?[3]);
+        return true;
     }
 }
 

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -96,69 +96,121 @@ public sealed record MeshSubmesh(
     int Index,
     IReadOnlyList<int> TriangleVertexIndices);
 
-public enum TexturePayloadFormat
+public abstract record TexturePayload
 {
-    RawRgba32 = 0,
-    EncodedImage = 1,
+    private protected TexturePayload(
+        string? colorProfile,
+        string identity,
+        ITextureImportSource source)
+    {
+        if (string.IsNullOrWhiteSpace(identity))
+        {
+            throw new ArgumentException("Texture payload identity must be provided.", nameof(identity));
+        }
+
+        ColorProfile = colorProfile;
+        Identity = identity;
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+    }
+
+    public string? ColorProfile { get; }
+
+    public string Identity { get; }
+
+    public ITextureImportSource Source { get; }
 }
 
-public sealed record TexturePayload
+public sealed record RawRgba32TexturePayload : TexturePayload
 {
-    public TexturePayload(
-        int? width,
-        int? height,
+    public RawRgba32TexturePayload(
+        int width,
+        int height,
         string? colorProfile,
         byte[] binaryPayload,
-        string? identity = null,
-        TexturePayloadFormat format = TexturePayloadFormat.RawRgba32)
-    {
-        Width = width;
-        Height = height;
-        ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(binaryPayload);
-        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
-        Identity = identity;
-        Format = format;
-        Source = TextureImportSourceFactory.CreateInMemory(
+        string? identity = null)
+        : this(
             width,
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"),
-            format);
+            CreateSource(width, height, colorProfile, binaryPayload, identity))
+    {
     }
 
-    public TexturePayload(
+    private RawRgba32TexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        (string Identity, ITextureImportSource Source) source)
+        : base(colorProfile, source.Identity, source.Source)
+    {
+        Rgba32RawTexturePayload.ValidateByteLength(width, height, binaryPayload);
+        Width = width;
+        Height = height;
+        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
+    }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public ImmutableArray<byte> BinaryPayload { get; }
+
+    private static (string Identity, ITextureImportSource Source) CreateSource(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        string? identity)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
+        return (
+            effectiveIdentity,
+            TextureImportSourceFactory.CreateInMemoryRaw(
+                width,
+                height,
+                colorProfile,
+                binaryPayload,
+                effectiveIdentity));
+    }
+}
+
+public sealed record EncodedImageTexturePayload : TexturePayload
+{
+    public EncodedImageTexturePayload(
         int? width,
         int? height,
         string? colorProfile,
         ITextureImportSource source,
-        string? identity = null,
-        TexturePayloadFormat format = TexturePayloadFormat.EncodedImage)
+        string? identity = null)
+        : this(width, height, colorProfile, CreateSource(source, identity))
+    {
+    }
+
+    private EncodedImageTexturePayload(
+        int? width,
+        int? height,
+        string? colorProfile,
+        (string Identity, ITextureImportSource Source) source)
+        : base(colorProfile, source.Identity, source.Source)
     {
         Width = width;
         Height = height;
-        ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(source);
-        BinaryPayload = [];
-        Identity = identity ?? source.Identity;
-        Format = format;
-        Source = source;
     }
 
-    public int? Width { get; init; }
+    public int? Width { get; }
 
-    public int? Height { get; init; }
+    public int? Height { get; }
 
-    public string? ColorProfile { get; init; }
-
-    public ImmutableArray<byte> BinaryPayload { get; init; }
-
-    public string? Identity { get; init; }
-
-    public TexturePayloadFormat Format { get; init; }
-
-    public ITextureImportSource Source { get; init; }
+    private static (string Identity, ITextureImportSource Source) CreateSource(
+        ITextureImportSource source,
+        string? identity)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        return (identity ?? source.Identity, source);
+    }
 }
 
 public enum TextureSourceKind

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportContractTypes.cs
@@ -202,7 +202,7 @@ public sealed record TerrainOverlayMaterialBinding(
     ThirdRegionalMeshCode MeshCode,
     TerrainTextureOverlay Overlay);
 
-public sealed record MaterialBinding(
+public record MaterialBinding(
     ColorRgba BaseColor,
     MaterialType MaterialType,
     TexturePayload? TexturePayload,
@@ -221,4 +221,107 @@ public sealed record MaterialBinding(
     public TerrainTextureOverlay? TerrainOverlay => TerrainOverlayMaterial?.Overlay;
 
     public string? TerrainMeshCode => TerrainOverlayMaterial?.MeshCode.Value;
+}
+
+public sealed record PresentationMaterialBinding : MaterialBinding
+{
+    public PresentationMaterialBinding(
+        ColorRgba BaseColor,
+        MaterialType MaterialType,
+        TexturePayload? TexturePayload,
+        TextureSourceKind TextureSourceKind,
+        MaterialProjection Projection,
+        MaterialDepthOffset? DepthOffset,
+        IReadOnlyList<int> SubmeshIndices,
+        Float2? TextureScale = null,
+        string? Family = null,
+        Float2? TextureOffset = null,
+        TerrainOverlayMaterialBinding? TerrainOverlayMaterial = null,
+        int? BundledVariantIndex = null)
+        : base(
+            BaseColor,
+            MaterialType,
+            TexturePayload,
+            TextureSourceKind,
+            Projection,
+            DepthOffset,
+            SubmeshIndices,
+            TextureScale,
+            Family,
+            TextureOffset,
+            MaterialReuseScope.PerObject,
+            TerrainOverlayMaterial,
+            BundledVariantIndex)
+    {
+    }
+}
+
+public sealed record PresentationCommonMaterialBinding : MaterialBinding
+{
+    public PresentationCommonMaterialBinding(
+        ColorRgba BaseColor,
+        MaterialType MaterialType,
+        TexturePayload? TexturePayload,
+        TextureSourceKind TextureSourceKind,
+        MaterialProjection Projection,
+        MaterialDepthOffset? DepthOffset,
+        IReadOnlyList<int> SubmeshIndices,
+        DefaultCommonMaterialMember commonMaterial,
+        Float2? TextureScale = null,
+        string? Family = null,
+        Float2? TextureOffset = null,
+        TerrainOverlayMaterialBinding? TerrainOverlayMaterial = null,
+        int? BundledVariantIndex = null)
+        : base(
+            BaseColor,
+            MaterialType,
+            TexturePayload,
+            TextureSourceKind,
+            Projection,
+            DepthOffset,
+            SubmeshIndices,
+            TextureScale,
+            Family,
+            TextureOffset,
+            MaterialReuseScope.PerObject,
+            TerrainOverlayMaterial,
+            BundledVariantIndex,
+            commonMaterial)
+    {
+    }
+}
+
+public sealed record SharedCommonMaterialBinding : MaterialBinding
+{
+    public SharedCommonMaterialBinding(
+        ColorRgba BaseColor,
+        MaterialType MaterialType,
+        TexturePayload? TexturePayload,
+        TextureSourceKind TextureSourceKind,
+        MaterialProjection Projection,
+        MaterialDepthOffset? DepthOffset,
+        IReadOnlyList<int> SubmeshIndices,
+        DefaultCommonMaterialMember commonMaterial,
+        Float2? TextureScale = null,
+        string? Family = null,
+        Float2? TextureOffset = null,
+        TerrainOverlayMaterialBinding? TerrainOverlayMaterial = null,
+        int? BundledVariantIndex = null)
+        : base(
+            BaseColor,
+            MaterialType,
+            TexturePayload,
+            TextureSourceKind,
+            Projection,
+            DepthOffset,
+            SubmeshIndices,
+            TextureScale,
+            Family,
+            TextureOffset,
+            MaterialReuseScope.Shared,
+            TerrainOverlayMaterial,
+            BundledVariantIndex,
+            commonMaterial)
+    {
+    }
 }

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionPlan.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionPlan.cs
@@ -8,105 +8,58 @@ namespace PlateauResoniteLink.Application.Importing;
 
 public sealed record SceneImportExecutionPlan
 {
-    public SceneImportExecutionPlan(
-        PlateauImportRequest normalizedRequest,
-        PlateauImportRequest resolvedRequest,
+    private SceneImportExecutionPlan(
         SceneImportRequest sceneImportRequest)
     {
-        ArgumentNullException.ThrowIfNull(normalizedRequest);
-        ArgumentNullException.ThrowIfNull(resolvedRequest);
         ArgumentNullException.ThrowIfNull(sceneImportRequest);
 
-        ValidateRequestConsistency(normalizedRequest, resolvedRequest, sceneImportRequest.Metadata.Request, sceneImportRequest.WorkRoot);
-
-        NormalizedRequest = normalizedRequest;
-        ResolvedRequest = resolvedRequest;
         SceneImportRequest = sceneImportRequest;
     }
-
-    public PlateauImportRequest NormalizedRequest { get; }
-
-    public PlateauImportRequest ResolvedRequest { get; }
 
     public SceneImportRequest SceneImportRequest { get; }
 
     public static SceneImportExecutionPlan Create(
-        PlateauImportRequest normalizedRequest,
-        PlateauImportRequest resolvedRequest,
+        ResolvedLocalPlateauImportRequest resolvedRequest,
         ImportedSceneMetadata metadata,
-        string resolvedSourcePath,
         string workRoot,
         CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials)
     {
         ArgumentNullException.ThrowIfNull(metadata);
-        ArgumentException.ThrowIfNullOrWhiteSpace(resolvedSourcePath);
+        ArgumentNullException.ThrowIfNull(resolvedRequest);
         ArgumentException.ThrowIfNullOrWhiteSpace(workRoot);
         ArgumentNullException.ThrowIfNull(commonMaterials);
 
+        PlateauImportRequest resolvedImportRequest = resolvedRequest.ToImportRequest();
+        ValidateMetadataRequestConsistency(resolvedImportRequest, metadata.Request);
+
         return new SceneImportExecutionPlan(
-            normalizedRequest,
-            resolvedRequest,
             new SceneImportRequest(
                 metadata,
-                resolvedSourcePath,
                 workRoot,
                 commonMaterials));
     }
 
-    private static void ValidateRequestConsistency(
-        PlateauImportRequest normalizedRequest,
-        PlateauImportRequest resolvedRequest,
-        PlateauImportRequest importRequest,
-        string workRoot)
+    private static void ValidateMetadataRequestConsistency(
+        PlateauImportRequest expectedRequest,
+        PlateauImportRequest metadataRequest)
     {
-        if (!string.Equals(normalizedRequest.Dataset, importRequest.Dataset, StringComparison.Ordinal)
-            || !string.Equals(normalizedRequest.MeshCode, importRequest.MeshCode, StringComparison.Ordinal)
-            || !HasCompatibleSourceResolution(normalizedRequest.CityGmlSource, resolvedRequest.CityGmlSource, workRoot, "source-archive")
-            || !HasCompatibleSourceResolution(normalizedRequest.DemTextureSource, resolvedRequest.DemTextureSource, workRoot, "source-ortho")
-            || !SourcesEqual(resolvedRequest.CityGmlSource, importRequest.CityGmlSource)
-            || !SourcesEqual(resolvedRequest.DemTextureSource, importRequest.DemTextureSource)
-            || normalizedRequest.IncludeMarkingAlways != importRequest.IncludeMarkingAlways
-            || normalizedRequest.TerrainMeshMode != importRequest.TerrainMeshMode
-            || normalizedRequest.TerrainGridMetersPerVertex != importRequest.TerrainGridMetersPerVertex
-            || normalizedRequest.TerrainGridMaxResolution != importRequest.TerrainGridMaxResolution
-            || !SequenceEqual(normalizedRequest.PackageNames, importRequest.PackageNames)
-            || !SetEqual(normalizedRequest.GlobalExcludeLodLevels, importRequest.GlobalExcludeLodLevels)
-            || !DictionaryOfSetsEqual(normalizedRequest.ExcludeLodLevelsByPackage, importRequest.ExcludeLodLevelsByPackage)
-            || !DictionaryEqual(normalizedRequest.PackagePatterns, importRequest.PackagePatterns))
+        if (!string.Equals(expectedRequest.Dataset, metadataRequest.Dataset, StringComparison.Ordinal)
+            || !string.Equals(expectedRequest.MeshCode, metadataRequest.MeshCode, StringComparison.Ordinal)
+            || !SourcesEqual(expectedRequest.CityGmlSource, metadataRequest.CityGmlSource)
+            || !SourcesEqual(expectedRequest.DemTextureSource, metadataRequest.DemTextureSource)
+            || expectedRequest.IncludeMarkingAlways != metadataRequest.IncludeMarkingAlways
+            || expectedRequest.TerrainMeshMode != metadataRequest.TerrainMeshMode
+            || expectedRequest.TerrainGridMetersPerVertex != metadataRequest.TerrainGridMetersPerVertex
+            || expectedRequest.TerrainGridMaxResolution != metadataRequest.TerrainGridMaxResolution
+            || !SequenceEqual(expectedRequest.PackageNames, metadataRequest.PackageNames)
+            || !SetEqual(expectedRequest.GlobalExcludeLodLevels, metadataRequest.GlobalExcludeLodLevels)
+            || !DictionaryOfSetsEqual(expectedRequest.ExcludeLodLevelsByPackage, metadataRequest.ExcludeLodLevelsByPackage)
+            || !DictionaryEqual(expectedRequest.PackagePatterns, metadataRequest.PackagePatterns))
         {
             throw new ArgumentException(
-                "Scene import execution plan requires normalized and import requests to match for execution identity and import options. Only source-resolved location values may differ.",
-                nameof(importRequest));
+                "Scene import execution plan requires imported scene metadata to carry the resolved local import request.",
+                nameof(metadataRequest));
         }
-    }
-
-    private static bool HasCompatibleSourceResolution(
-        DatasetLocation? normalizedSource,
-        DatasetLocation? resolvedSource,
-        string workRoot,
-        string remotePathPrefix)
-    {
-        if (normalizedSource is null || resolvedSource is null)
-        {
-            return normalizedSource is null && resolvedSource is null;
-        }
-
-        if (normalizedSource.SourceKind == resolvedSource.SourceKind)
-        {
-            return SourcesEqual(normalizedSource, resolvedSource);
-        }
-
-        if (normalizedSource is RemoteDatasetLocation remoteSource
-            && resolvedSource is LocalDatasetLocation localSource)
-        {
-            return RemoteDatasetResourceLayout.MatchesRemoteResourcePath(
-                workRoot,
-                remoteSource.ServerUri,
-                remotePathPrefix,
-                localSource.LocalSourcePath);
-        }
-
-        return false;
     }
 
     private static bool SourcesEqual(DatasetLocation? left, DatasetLocation? right)

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionPlan.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionPlan.cs
@@ -101,7 +101,7 @@ public sealed record SceneImportExecutionPlan
         {
             return RemoteDatasetResourceLayout.MatchesRemoteResourcePath(
                 workRoot,
-                remoteSource.ServerUri!,
+                remoteSource.ServerUri,
                 remotePathPrefix,
                 localSource.LocalSourcePath);
         }

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionResult.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportExecutionResult.cs
@@ -6,8 +6,41 @@ namespace PlateauResoniteLink.Application.Importing;
 /// Target-side execution summary for one scene import run.
 /// ProcessedCityObjectCount represents successful sends, not source-side geometry availability.
 /// </summary>
-public sealed record SceneImportExecutionResult(
-    IReadOnlyList<string> Destinations,
-    int ProcessedCityObjectCount,
-    int FailedCityObjectCount = 0,
-    IReadOnlyList<ImportDataSourceUsage>? DataSourceUsages = null);
+public sealed record SceneImportExecutionResult
+{
+    public SceneImportExecutionResult(
+        IReadOnlyList<string> Destinations,
+        int ProcessedCityObjectCount,
+        int FailedCityObjectCount = 0)
+        : this(Destinations, ProcessedCityObjectCount, FailedCityObjectCount, [])
+    {
+    }
+
+    public SceneImportExecutionResult(
+        IReadOnlyList<string> Destinations,
+        int ProcessedCityObjectCount,
+        IReadOnlyList<ImportDataSourceUsage> DataSourceUsages)
+        : this(Destinations, ProcessedCityObjectCount, 0, DataSourceUsages)
+    {
+    }
+
+    public SceneImportExecutionResult(
+        IReadOnlyList<string> Destinations,
+        int ProcessedCityObjectCount,
+        int FailedCityObjectCount,
+        IReadOnlyList<ImportDataSourceUsage> DataSourceUsages)
+    {
+        this.Destinations = Destinations;
+        this.ProcessedCityObjectCount = ProcessedCityObjectCount;
+        this.FailedCityObjectCount = FailedCityObjectCount;
+        this.DataSourceUsages = DataSourceUsages;
+    }
+
+    public IReadOnlyList<string> Destinations { get; init; }
+
+    public int ProcessedCityObjectCount { get; init; }
+
+    public int FailedCityObjectCount { get; init; }
+
+    public IReadOnlyList<ImportDataSourceUsage> DataSourceUsages { get; init; }
+}

--- a/src/PlateauResoniteLink/Application/Importing/SceneImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/SceneImportRequest.cs
@@ -2,6 +2,5 @@ namespace PlateauResoniteLink.Application.Importing;
 
 public sealed record SceneImportRequest(
     ImportedSceneMetadata Metadata,
-    string ResolvedSourcePath,
     string WorkRoot,
     CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials);

--- a/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
@@ -209,7 +209,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
         int yieldedCount = 0;
         ProjectionTerrainOverlayContext projectionTerrainOverlayContext = await terrainOverlayContextResolver.GetAsync(cancellationToken);
         bool isDemSourceFile = string.Equals(sourceFile.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase);
-        List<ParsedCityObject> parsedDemCityObjects = [];
+        StreamingDemProjectionSource? demProjectionSource = null;
         X3DMaterialWarningStatistics fileWarningStatistics = new();
 
         await foreach (ParsedCityObject parsedCityObject in sourceFile.StreamParsedCityObjectsAsync(cancellationToken))
@@ -218,16 +218,19 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
             parsedCount++;
             fileWarningStatistics.Add(parsedCityObject);
             x3DMaterialWarningStatistics.Add(parsedCityObject);
-            resolvedReferenceSystem ??= ResolveReferenceSystem(parsedCityObject.ReferenceSystem);
+            CoordinateReferenceSystem parsedReferenceSystem = parsedCityObject.ReferenceSystem;
+            CoordinateReferenceSystem resolvedObjectReferenceSystem = ResolveReferenceSystem(parsedReferenceSystem);
+            resolvedReferenceSystem ??= resolvedObjectReferenceSystem;
             globalCartesian ??= CreateGlobalCartesian(resolvedReferenceSystem);
             if (isDemSourceFile)
             {
-                parsedDemCityObjects.Add(parsedCityObject);
+                demProjectionSource ??= new StreamingDemProjectionSource(sourceFile.SourceFile);
+                demProjectionSource.Add(parsedCityObject);
                 continue;
             }
 
             foreach (ImportedCityObject cityObject in geometryProjector.ProjectCityObjects(
-                         new CachedSourceFileDescriptor(sourceFile.SourceFile, [parsedCityObject]),
+                         new CachedSourceFileDescriptor(sourceFile.SourceFile, [parsedCityObject], parsedReferenceSystem),
                          resolvedReferenceSystem,
                          globalOriginPoint,
                          globalCartesian,
@@ -244,17 +247,18 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
             }
         }
 
-        if (isDemSourceFile && parsedDemCityObjects.Count > 0)
+        if (demProjectionSource is not null)
         {
             ParsedCityObject[] aggregatedDemCityObjects =
                 DemCityObjectAggregation.AggregateBySourceFileAndThirdMesh(
-                    sourceFile.SourceFile,
-                    parsedDemCityObjects);
+                    demProjectionSource.SourceFile,
+                    demProjectionSource.CityObjects);
             foreach (ImportedCityObject cityObject in geometryProjector.ProjectCityObjects(
-                         new CachedSourceFileDescriptor(sourceFile.SourceFile, aggregatedDemCityObjects),
-                         resolvedReferenceSystem
-                             ?? throw new PlateauImportValidationException(
-                                 [$"CityGML file '{sourceFile.SourceFile.RelativePath}' does not declare a supported coordinate reference system."]),
+                         new CachedSourceFileDescriptor(
+                             demProjectionSource.SourceFile,
+                             aggregatedDemCityObjects,
+                             demProjectionSource.ReferenceSystem),
+                         demProjectionSource.ReferenceSystem,
                          globalOriginPoint,
                          globalCartesian,
                          projectionTerrainOverlayContext.Overlays,
@@ -277,6 +281,26 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
                 "import",
                 $"City object producer projected '{sourceFile.SourceFile.RelativePath}' "
                 + $"(parsed_city_objects={parsedCount}, yielded={yieldedCount}, elapsed={fileStopwatch.Elapsed.TotalSeconds:F3}s)."));
+    }
+
+    private sealed class StreamingDemProjectionSource(SourceFileDescriptor sourceFile)
+    {
+        private readonly List<ParsedCityObject> cityObjects = [];
+        private CoordinateReferenceSystem? referenceSystem;
+
+        public SourceFileDescriptor SourceFile { get; } = sourceFile;
+
+        public CoordinateReferenceSystem ReferenceSystem => referenceSystem
+            ?? CoordinateReferenceSystem.Parse((string?)null);
+
+        public IReadOnlyList<ParsedCityObject> CityObjects => cityObjects;
+
+        public void Add(ParsedCityObject cityObject)
+        {
+            referenceSystem ??= cityObject.ReferenceSystem;
+            ValidateCompatibleReferenceSystem(referenceSystem, cityObject.ReferenceSystem);
+            cityObjects.Add(cityObject);
+        }
     }
 
     private async IAsyncEnumerable<ImportedObjectUnit> CreateObjectUnitsAsync(
@@ -338,9 +362,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
 
     private CoordinateReferenceSystem ResolveReferenceSystem(ParsedSourceFileResult parsedSourceFile)
     {
-        return ResolveReferenceSystem(parsedSourceFile.ReferenceSystem
-            ?? throw new PlateauImportValidationException(
-                [$"CityGML file '{parsedSourceFile.SourceFile.RelativePath}' does not declare a supported coordinate reference system."]));
+        return ResolveReferenceSystem(parsedSourceFile.ReferenceSystem);
     }
 
     private static void ValidateCompatibleReferenceSystem(

--- a/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
@@ -291,7 +291,8 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
         public SourceFileDescriptor SourceFile { get; } = sourceFile;
 
         public CoordinateReferenceSystem ReferenceSystem => referenceSystem
-            ?? CoordinateReferenceSystem.Parse((string?)null);
+            ?? throw new InvalidOperationException(
+                $"DEM projection source '{SourceFile.RelativePath}' has no parsed city objects and no reference system.");
 
         public IReadOnlyList<ParsedCityObject> CityObjects => cityObjects;
 

--- a/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainOverlayMaterialSourcePartitioner.cs
@@ -81,7 +81,7 @@ internal static class TerrainOverlayMaterialSourcePartitioner
         }
 
         double cityObjectMinAltitude = CityObjectAltitudeMetricsResolver.GetMinimumAltitude(cityObjectVertices);
-        TerrainMaterialSourceMeshCode materialSourceMeshCode = TerrainMaterialSourceMeshCode.Parse(
+        TerrainMaterialSourceMeshCode materialSourceMeshCode = TerrainMaterialSourceMeshCode.ParseRequired(
             string.IsNullOrWhiteSpace(cityObject.SourceMeshCode)
                 ? cityObject.ActualMeshCode
                 : cityObject.SourceMeshCode);
@@ -293,36 +293,46 @@ internal static class TerrainOverlayMaterialSourcePartitioner
             cityObject.Surfaces.SelectMany(static surface => surface.Vertices));
     }
 
-    private readonly record struct TerrainMaterialSourceMeshCode(
-        ThirdRegionalMeshCode? ThirdMeshCode,
-        SecondRegionalMeshCode? SecondMeshCode)
+    private abstract record TerrainMaterialSourceMeshCode
     {
-        public bool IsThirdRegionalMesh => ThirdMeshCode.HasValue;
+        public abstract bool IsThirdRegionalMesh { get; }
 
-        public static TerrainMaterialSourceMeshCode Parse(string meshCode)
+        public static TerrainMaterialSourceMeshCode ParseRequired(string meshCode)
         {
             if (ThirdRegionalMeshCode.TryParse(meshCode, out ThirdRegionalMeshCode thirdMeshCode))
             {
-                return new TerrainMaterialSourceMeshCode(thirdMeshCode, SecondMeshCode: null);
+                return new Third(thirdMeshCode);
             }
 
             if (SecondRegionalMeshCode.TryParse(meshCode, out SecondRegionalMeshCode secondMeshCode))
             {
-                return new TerrainMaterialSourceMeshCode(ThirdMeshCode: null, secondMeshCode);
+                return new Second(secondMeshCode);
             }
 
-            return new TerrainMaterialSourceMeshCode(ThirdMeshCode: null, SecondMeshCode: null);
+            throw new PlateauImportValidationException(
+                [$"Terrain overlay material source mesh-code '{meshCode}' must be a valid second- or third-level mesh-code."]);
         }
 
-        public bool Contains(ThirdRegionalMeshCode overlayMeshCode)
-        {
-            if (ThirdMeshCode is { } thirdMeshCode)
-            {
-                return thirdMeshCode == overlayMeshCode;
-            }
+        public abstract bool Contains(ThirdRegionalMeshCode overlayMeshCode);
 
-            return SecondMeshCode is { } secondMeshCode
-                && secondMeshCode == overlayMeshCode.Parent;
+        private sealed record Third(ThirdRegionalMeshCode MeshCode) : TerrainMaterialSourceMeshCode
+        {
+            public override bool IsThirdRegionalMesh => true;
+
+            public override bool Contains(ThirdRegionalMeshCode overlayMeshCode)
+            {
+                return MeshCode == overlayMeshCode;
+            }
+        }
+
+        private sealed record Second(SecondRegionalMeshCode MeshCode) : TerrainMaterialSourceMeshCode
+        {
+            public override bool IsThirdRegionalMesh => false;
+
+            public override bool Contains(ThirdRegionalMeshCode overlayMeshCode)
+            {
+                return MeshCode == overlayMeshCode.Parent;
+            }
         }
     }
 }

--- a/src/PlateauResoniteLink/Application/Importing/TerrainTextureGeoReferencedRasterCropper.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainTextureGeoReferencedRasterCropper.cs
@@ -15,11 +15,6 @@ internal static class TerrainTextureGeoReferencedRasterCropper
         GeoReferencedRasterMetadata metadata,
         GeographicRectangle requestedBounds)
     {
-        if (!metadata.IsUsable)
-        {
-            return null;
-        }
-
         GeographicRectangle rasterBounds = metadata.GeographicBounds;
         GeographicRectangle intersection = new(
             Math.Max(requestedBounds.MinLatitude, rasterBounds.MinLatitude),

--- a/src/PlateauResoniteLink/Application/Importing/TerrainTextureGeoReferencedRasterMetadataReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TerrainTextureGeoReferencedRasterMetadataReader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Security;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,12 +22,19 @@ internal static class TerrainTextureGeoReferencedRasterMetadataReader
     private const int ProjectedCSTypeGeoKey = 3072;
 
     public static async Task<GeoReferencedRasterMetadata?> TryReadMetadataAsync(
-        TerrainTextureGeoReferencedRasterSource source,
+        ITerrainTextureRasterContentSource source,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(source);
-        await using Stream stream = await source.OpenReadAsync(cancellationToken);
-        return await TryReadMetadataAsync(stream, cancellationToken);
+        try
+        {
+            await using Stream stream = await source.OpenReadAsync(cancellationToken);
+            return await TryReadMetadataAsync(stream, cancellationToken);
+        }
+        catch (Exception exception) when (IsCandidateRasterReadFailure(exception))
+        {
+            return null;
+        }
     }
 
     public static async Task<GeoReferencedRasterMetadata?> TryReadMetadataAsync(
@@ -38,42 +46,45 @@ internal static class TerrainTextureGeoReferencedRasterMetadataReader
             return null;
         }
 
-        ImageInfo imageInfo;
         try
         {
-            imageInfo = await Image.IdentifyAsync(sourcePath, cancellationToken)
-                ?? throw new InvalidOperationException($"Failed to identify raster '{sourcePath}'.");
+            ImageInfo? identifiedImage = await Image.IdentifyAsync(sourcePath, cancellationToken);
+            if (identifiedImage is null)
+            {
+                return null;
+            }
+
+            ImageInfo imageInfo = identifiedImage;
+            ExifProfile? exifProfile = imageInfo.Metadata.ExifProfile;
+            GeoTiffTagSnapshot? tiffTags = await GeoTiffTagReader.TryReadAsync(sourcePath, cancellationToken);
+
+            double[]? tiePoints = TryGetDoubleArray(exifProfile, ExifTag.ModelTiePoint)
+                ?? tiffTags?.ModelTiePoint;
+            double[]? pixelScale = TryGetDoubleArray(exifProfile, ExifTag.PixelScale)
+                ?? tiffTags?.PixelScale;
+            double[]? modelTransform = TryGetDoubleArray(exifProfile, ExifTag.ModelTransform)
+                ?? tiffTags?.ModelTransform;
+            ushort[]? geoKeyDirectory = TryGetUnsignedShortArray(exifProfile, "GeoKeyDirectoryTag")
+                ?? tiffTags?.GeoKeyDirectory;
+            double[]? geoDoubleParams = TryGetNamedDoubleArray(exifProfile, "GeoDoubleParamsTag")
+                ?? tiffTags?.GeoDoubleParams;
+            string? geoAsciiParams = TryGetNamedString(exifProfile, "GeoAsciiParamsTag")
+                ?? tiffTags?.GeoAsciiParams;
+
+            return TryCreateMetadata(
+                imageInfo.Width,
+                imageInfo.Height,
+                tiePoints,
+                pixelScale,
+                modelTransform,
+                geoKeyDirectory,
+                geoDoubleParams,
+                geoAsciiParams);
         }
-        catch (UnknownImageFormatException)
+        catch (Exception exception) when (IsCandidateRasterReadFailure(exception))
         {
             return null;
         }
-
-        ExifProfile? exifProfile = imageInfo.Metadata.ExifProfile;
-        GeoTiffTagSnapshot? tiffTags = await GeoTiffTagReader.TryReadAsync(sourcePath, cancellationToken);
-
-        double[]? tiePoints = TryGetDoubleArray(exifProfile, ExifTag.ModelTiePoint)
-            ?? tiffTags?.ModelTiePoint;
-        double[]? pixelScale = TryGetDoubleArray(exifProfile, ExifTag.PixelScale)
-            ?? tiffTags?.PixelScale;
-        double[]? modelTransform = TryGetDoubleArray(exifProfile, ExifTag.ModelTransform)
-            ?? tiffTags?.ModelTransform;
-        ushort[]? geoKeyDirectory = TryGetUnsignedShortArray(exifProfile, "GeoKeyDirectoryTag")
-            ?? tiffTags?.GeoKeyDirectory;
-        double[]? geoDoubleParams = TryGetNamedDoubleArray(exifProfile, "GeoDoubleParamsTag")
-            ?? tiffTags?.GeoDoubleParams;
-        string? geoAsciiParams = TryGetNamedString(exifProfile, "GeoAsciiParamsTag")
-            ?? tiffTags?.GeoAsciiParams;
-
-        return TryCreateMetadata(
-            imageInfo.Width,
-            imageInfo.Height,
-            tiePoints,
-            pixelScale,
-            modelTransform,
-            geoKeyDirectory,
-            geoDoubleParams,
-            geoAsciiParams);
     }
 
     public static async Task<GeoReferencedRasterMetadata?> TryReadMetadataAsync(
@@ -90,41 +101,54 @@ internal static class TerrainTextureGeoReferencedRasterMetadataReader
         try
         {
             stream.Seek(0, SeekOrigin.Begin);
-            imageInfo = await Image.IdentifyAsync(stream, cancellationToken)
-                ?? throw new InvalidOperationException("Failed to identify raster stream.");
+            ImageInfo? identifiedImage = await Image.IdentifyAsync(stream, cancellationToken);
+            if (identifiedImage is null)
+            {
+                return null;
+            }
+
+            imageInfo = identifiedImage;
+            ExifProfile? exifProfile = imageInfo.Metadata.ExifProfile;
+            stream.Seek(0, SeekOrigin.Begin);
+            GeoTiffTagSnapshot? tiffTags = await GeoTiffTagReader.TryReadAsync(stream, cancellationToken);
+
+            double[]? tiePoints = TryGetDoubleArray(exifProfile, ExifTag.ModelTiePoint)
+                ?? tiffTags?.ModelTiePoint;
+            double[]? pixelScale = TryGetDoubleArray(exifProfile, ExifTag.PixelScale)
+                ?? tiffTags?.PixelScale;
+            double[]? modelTransform = TryGetDoubleArray(exifProfile, ExifTag.ModelTransform)
+                ?? tiffTags?.ModelTransform;
+            ushort[]? geoKeyDirectory = TryGetUnsignedShortArray(exifProfile, "GeoKeyDirectoryTag")
+                ?? tiffTags?.GeoKeyDirectory;
+            double[]? geoDoubleParams = TryGetNamedDoubleArray(exifProfile, "GeoDoubleParamsTag")
+                ?? tiffTags?.GeoDoubleParams;
+            string? geoAsciiParams = TryGetNamedString(exifProfile, "GeoAsciiParamsTag")
+                ?? tiffTags?.GeoAsciiParams;
+
+            return TryCreateMetadata(
+                imageInfo.Width,
+                imageInfo.Height,
+                tiePoints,
+                pixelScale,
+                modelTransform,
+                geoKeyDirectory,
+                geoDoubleParams,
+                geoAsciiParams);
         }
-        catch (UnknownImageFormatException)
+        catch (Exception exception) when (IsCandidateRasterReadFailure(exception))
         {
             return null;
         }
-
-        ExifProfile? exifProfile = imageInfo.Metadata.ExifProfile;
-        stream.Seek(0, SeekOrigin.Begin);
-        GeoTiffTagSnapshot? tiffTags = await GeoTiffTagReader.TryReadAsync(stream, cancellationToken);
-
-        double[]? tiePoints = TryGetDoubleArray(exifProfile, ExifTag.ModelTiePoint)
-            ?? tiffTags?.ModelTiePoint;
-        double[]? pixelScale = TryGetDoubleArray(exifProfile, ExifTag.PixelScale)
-            ?? tiffTags?.PixelScale;
-        double[]? modelTransform = TryGetDoubleArray(exifProfile, ExifTag.ModelTransform)
-            ?? tiffTags?.ModelTransform;
-        ushort[]? geoKeyDirectory = TryGetUnsignedShortArray(exifProfile, "GeoKeyDirectoryTag")
-            ?? tiffTags?.GeoKeyDirectory;
-        double[]? geoDoubleParams = TryGetNamedDoubleArray(exifProfile, "GeoDoubleParamsTag")
-            ?? tiffTags?.GeoDoubleParams;
-        string? geoAsciiParams = TryGetNamedString(exifProfile, "GeoAsciiParamsTag")
-            ?? tiffTags?.GeoAsciiParams;
-
-        return TryCreateMetadata(
-            imageInfo.Width,
-            imageInfo.Height,
-            tiePoints,
-            pixelScale,
-            modelTransform,
-            geoKeyDirectory,
-            geoDoubleParams,
-            geoAsciiParams);
     }
+
+    private static bool IsCandidateRasterReadFailure(Exception exception) =>
+        exception is UnknownImageFormatException
+            or IOException
+            or UnauthorizedAccessException
+            or SecurityException
+            or InvalidDataException
+            or OverflowException
+            or ArgumentOutOfRangeException;
 
     internal static GeoReferencedRasterMetadata? TryCreateMetadata(
         int pixelWidth,
@@ -161,13 +185,9 @@ internal static class TerrainTextureGeoReferencedRasterMetadataReader
         GeographicRectangle? geographicBounds = TryConvertToGeographicBounds(
             coordinateSystemIdentifier,
             modelBounds);
-        if (geographicBounds is null)
+        if (geographicBounds is null || string.IsNullOrWhiteSpace(coordinateSystemIdentifier))
         {
-            return new GeoReferencedRasterMetadata(
-                modelBounds.ToFallbackGeographicRectangle(),
-                coordinateSystemIdentifier,
-                PixelWidthMeters: 0.0,
-                PixelHeightMeters: 0.0);
+            return null;
         }
 
         return new GeoReferencedRasterMetadata(
@@ -635,11 +655,5 @@ internal static class TerrainTextureGeoReferencedRasterMetadataReader
         double MinX,
         double MinY,
         double MaxX,
-        double MaxY)
-    {
-        public GeographicRectangle ToFallbackGeographicRectangle()
-        {
-            return new GeographicRectangle(MinY, MaxY, MinX, MaxX);
-        }
-    }
+        double MaxY);
 }

--- a/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/TextureImportSource.cs
@@ -8,18 +8,120 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Application.Importing;
 
-public enum RawTexturePayloadFormat
+public abstract class RawTexturePayload
 {
-    Rgba32 = 0,
-    RgbaFloat32 = 1,
+    private protected RawTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        Width = width;
+        Height = height;
+        ColorProfile = colorProfile;
+        Bytes = bytes;
+    }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public string? ColorProfile { get; }
+
+    public byte[] Bytes { get; }
+
+    public abstract TResult Match<TResult>(
+        Func<Rgba32RawTexturePayload, TResult> rgba32,
+        Func<RgbaFloat32RawTexturePayload, TResult> rgbaFloat32);
 }
 
-public sealed record RawTexturePayload(
-    int Width,
-    int Height,
-    string? ColorProfile,
-    byte[] Bytes,
-    RawTexturePayloadFormat Format = RawTexturePayloadFormat.Rgba32);
+public sealed class Rgba32RawTexturePayload : RawTexturePayload
+{
+    private const int BytesPerPixel = 4;
+
+    public Rgba32RawTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] bytes)
+        : base(width, height, colorProfile, bytes)
+    {
+        ValidateByteLength(width, height, bytes);
+    }
+
+    internal static void ValidateByteLength(
+        int width,
+        int height,
+        byte[] bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        int expectedByteLength = checked(width * height * BytesPerPixel);
+        if (bytes.Length != expectedByteLength)
+        {
+            throw new ArgumentException(
+                $"RGBA32 texture payload length must be width * height * {BytesPerPixel} bytes ({expectedByteLength}), but was {bytes.Length}.",
+                nameof(bytes));
+        }
+    }
+
+    public override TResult Match<TResult>(
+        Func<Rgba32RawTexturePayload, TResult> rgba32,
+        Func<RgbaFloat32RawTexturePayload, TResult> rgbaFloat32)
+    {
+        ArgumentNullException.ThrowIfNull(rgba32);
+        ArgumentNullException.ThrowIfNull(rgbaFloat32);
+        return rgba32(this);
+    }
+}
+
+public sealed class RgbaFloat32RawTexturePayload : RawTexturePayload
+{
+    private const int BytesPerPixel = 16;
+
+    public RgbaFloat32RawTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] bytes)
+        : base(width, height, colorProfile, bytes)
+    {
+        ValidateByteLength(width, height, bytes);
+    }
+
+    internal static void ValidateByteLength(
+        int width,
+        int height,
+        byte[] bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        int expectedByteLength = checked(width * height * BytesPerPixel);
+        if (bytes.Length != expectedByteLength)
+        {
+            throw new ArgumentException(
+                $"RGBA float32 texture payload length must be width * height * {BytesPerPixel} bytes ({expectedByteLength}), but was {bytes.Length}.",
+                nameof(bytes));
+        }
+    }
+
+    public override TResult Match<TResult>(
+        Func<Rgba32RawTexturePayload, TResult> rgba32,
+        Func<RgbaFloat32RawTexturePayload, TResult> rgbaFloat32)
+    {
+        ArgumentNullException.ThrowIfNull(rgba32);
+        ArgumentNullException.ThrowIfNull(rgbaFloat32);
+        return rgbaFloat32(this);
+    }
+}
 
 public interface ITextureImportSource
 {
@@ -32,9 +134,14 @@ public interface ITextureImportSource
     long? EstimatedByteLength { get; }
 }
 
-internal interface IRawTexturePayloadSource : ITextureImportSource
+internal interface IRgba32RawTexturePayloadSource : ITextureImportSource
 {
-    ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken);
+    ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken);
+}
+
+internal interface IRgbaFloat32RawTexturePayloadSource : ITextureImportSource
+{
+    ValueTask<RgbaFloat32RawTexturePayload> MaterializeRgbaFloat32Async(CancellationToken cancellationToken);
 }
 
 internal static class TextureImportSourceMaterializer
@@ -44,41 +151,75 @@ internal static class TextureImportSourceMaterializer
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(source);
-        if (source is not IRawTexturePayloadSource rawSource)
+        if (source is IRgba32RawTexturePayloadSource rgba32Source)
         {
-            throw new InvalidOperationException(
-                $"Texture import source '{source.GetType().Name}' cannot materialize a raw texture payload.");
+            return new ValueTask<RawTexturePayload>(MaterializeRgba32AsRawAsync(rgba32Source, cancellationToken));
         }
 
-        return rawSource.MaterializeRawAsync(cancellationToken);
+        if (source is IRgbaFloat32RawTexturePayloadSource rgbaFloat32Source)
+        {
+            return new ValueTask<RawTexturePayload>(MaterializeRgbaFloat32AsRawAsync(rgbaFloat32Source, cancellationToken));
+        }
+
+        throw new InvalidOperationException(
+            $"Texture import source '{source.GetType().Name}' cannot materialize a raw texture payload.");
+
+        static async Task<RawTexturePayload> MaterializeRgba32AsRawAsync(
+            IRgba32RawTexturePayloadSource source,
+            CancellationToken cancellationToken)
+        {
+            return await source.MaterializeRgba32Async(cancellationToken);
+        }
+
+        static async Task<RawTexturePayload> MaterializeRgbaFloat32AsRawAsync(
+            IRgbaFloat32RawTexturePayloadSource source,
+            CancellationToken cancellationToken)
+        {
+            return await source.MaterializeRgbaFloat32Async(cancellationToken);
+        }
+    }
+
+    public static ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(
+        ITextureImportSource source,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (source is not IRgba32RawTexturePayloadSource rgba32Source)
+        {
+            throw new InvalidOperationException(
+                $"Texture import source '{source.GetType().Name}' cannot materialize an RGBA32 texture payload.");
+        }
+
+        return rgba32Source.MaterializeRgba32Async(cancellationToken);
     }
 }
 
-internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
+internal sealed class InMemoryRawTextureImportSource : IRgba32RawTexturePayloadSource
 {
     private readonly byte[] bytes;
 
-    public InMemoryTextureImportSource(
-        int? width,
-        int? height,
+    public InMemoryRawTextureImportSource(
+        int width,
+        int height,
         string? colorProfile,
         byte[] bytes,
-        string identity,
-        TexturePayloadFormat sourceFormat)
+        string identity)
     {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
         ArgumentNullException.ThrowIfNull(bytes);
         ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        Rgba32RawTexturePayload.ValidateByteLength(width, height, bytes);
         Width = width;
         Height = height;
         ColorProfile = colorProfile;
         this.bytes = (byte[])bytes.Clone();
         Identity = identity;
-        SourceFormat = sourceFormat;
     }
 
-    public int? Width { get; }
+    public int Width { get; }
 
-    public int? Height { get; }
+    public int Height { get; }
 
     public string Identity { get; }
 
@@ -88,35 +229,44 @@ internal sealed class InMemoryTextureImportSource : IRawTexturePayloadSource
 
     public long? EstimatedByteLength => bytes.Length;
 
-    public TexturePayloadFormat SourceFormat { get; }
-
-    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return SourceFormat switch
-        {
-            TexturePayloadFormat.RawRgba32 => CreateRawPayload(),
-            TexturePayloadFormat.EncodedImage => await DecodeEncodedImageAsync(cancellationToken),
-            _ => throw new InvalidOperationException($"Unsupported texture payload format '{SourceFormat}'."),
-        };
-    }
-
-    private RawTexturePayload CreateRawPayload()
-    {
-        if (Width is null || Height is null)
-        {
-            throw new InvalidOperationException("Raw RGBA texture payload must include width and height.");
-        }
-
-        return new RawTexturePayload(
-            Width.Value,
-            Height.Value,
+        return ValueTask.FromResult(new Rgba32RawTexturePayload(
+            Width,
+            Height,
             ColorProfile,
-            (byte[])bytes.Clone());
+            (byte[])bytes.Clone()));
+    }
+}
+
+internal sealed class InMemoryEncodedTextureImportSource : IRgba32RawTexturePayloadSource
+{
+    private readonly byte[] bytes;
+
+    public InMemoryEncodedTextureImportSource(
+        string? colorProfile,
+        byte[] bytes,
+        string identity)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
+        ColorProfile = colorProfile;
+        this.bytes = (byte[])bytes.Clone();
+        Identity = identity;
     }
 
-    private async ValueTask<RawTexturePayload> DecodeEncodedImageAsync(CancellationToken cancellationToken)
+    public string Identity { get; }
+
+    public string Description => $"memory:{Identity}";
+
+    public string? ColorProfile { get; }
+
+    public long? EstimatedByteLength => bytes.Length;
+
+    public async ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         using MemoryStream stream = new(bytes, writable: false);
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream, cancellationToken);
         return TextureImportSourceFactory.CreateRawPayloadFromImage(
@@ -129,7 +279,7 @@ internal sealed class DatasetTextureImportSource(
     IPlateauDatasetContentSource datasetSource,
     string relativePath,
     string? colorProfile,
-    string identity) : IRawTexturePayloadSource
+    string identity) : IRgba32RawTexturePayloadSource
 {
     public string Identity { get; } = identity;
 
@@ -141,7 +291,7 @@ internal sealed class DatasetTextureImportSource(
         ? lengthSource.TryGetFileLength(relativePath)
         : null;
 
-    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public async ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
         await using Stream stream = await datasetSource.OpenReadAsync(relativePath, cancellationToken);
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream, cancellationToken);
@@ -152,7 +302,7 @@ internal sealed class DatasetTextureImportSource(
 internal sealed class FileTextureImportSource(
     string absolutePath,
     string colorProfile,
-    string identity) : IRawTexturePayloadSource
+    string identity) : IRgba32RawTexturePayloadSource
 {
     public string Identity { get; } = identity;
 
@@ -179,19 +329,19 @@ internal sealed class FileTextureImportSource(
         }
     }
 
-    public async ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public async ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(absolutePath, cancellationToken);
         return TextureImportSourceFactory.CreateRawPayloadFromImage(image, ColorProfile);
     }
 }
 
-internal sealed class GeneratedTextureImportSource(
-    Func<CancellationToken, ValueTask<RawTexturePayload>> materializeRawAsync,
+internal sealed class GeneratedRgba32TextureImportSource(
+    Func<CancellationToken, ValueTask<Rgba32RawTexturePayload>> materializeRgba32Async,
     string identity,
     string description,
     string? colorProfile,
-    long? estimatedByteLength = null) : IRawTexturePayloadSource
+    long? estimatedByteLength = null) : IRgba32RawTexturePayloadSource
 {
     public string Identity { get; } = identity;
 
@@ -201,23 +351,59 @@ internal sealed class GeneratedTextureImportSource(
 
     public long? EstimatedByteLength { get; } = estimatedByteLength;
 
-    public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+    public ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
     {
-        return materializeRawAsync(cancellationToken);
+        return materializeRgba32Async(cancellationToken);
+    }
+}
+
+internal sealed class GeneratedRgbaFloat32TextureImportSource(
+    Func<CancellationToken, ValueTask<RgbaFloat32RawTexturePayload>> materializeRgbaFloat32Async,
+    string identity,
+    string description,
+    string? colorProfile,
+    long? estimatedByteLength = null) : IRgbaFloat32RawTexturePayloadSource
+{
+    public string Identity { get; } = identity;
+
+    public string Description { get; } = description;
+
+    public string? ColorProfile { get; } = colorProfile;
+
+    public long? EstimatedByteLength { get; } = estimatedByteLength;
+
+    public ValueTask<RgbaFloat32RawTexturePayload> MaterializeRgbaFloat32Async(CancellationToken cancellationToken)
+    {
+        return materializeRgbaFloat32Async(cancellationToken);
     }
 }
 
 internal static class TextureImportSourceFactory
 {
-    public static ITextureImportSource CreateInMemory(
-        int? width,
-        int? height,
+    public static ITextureImportSource CreateInMemoryRaw(
+        int width,
+        int height,
         string? colorProfile,
         byte[] bytes,
-        string identity,
-        TexturePayloadFormat sourceFormat)
+        string identity)
     {
-        return new InMemoryTextureImportSource(width, height, colorProfile, bytes, identity, sourceFormat);
+        return new InMemoryRawTextureImportSource(
+            width,
+            height,
+            colorProfile,
+            bytes,
+            identity);
+    }
+
+    public static ITextureImportSource CreateInMemoryEncodedImage(
+        string? colorProfile,
+        byte[] bytes,
+        string identity)
+    {
+        return new InMemoryEncodedTextureImportSource(
+            colorProfile,
+            bytes,
+            identity);
     }
 
     public static ITextureImportSource CreateDatasetEncodedImage(
@@ -242,15 +428,30 @@ internal static class TextureImportSourceFactory
             identity ?? $"file:{Path.GetFullPath(absolutePath)}:{colorProfile}");
     }
 
-    public static ITextureImportSource CreateGeneratedImage(
-        Func<CancellationToken, ValueTask<RawTexturePayload>> materializeRawAsync,
+    public static ITextureImportSource CreateGeneratedRgba32Image(
+        Func<CancellationToken, ValueTask<Rgba32RawTexturePayload>> materializeRgba32Async,
         string identity,
         string description,
         string? colorProfile,
         long? estimatedByteLength = null)
     {
-        return new GeneratedTextureImportSource(
-            materializeRawAsync,
+        return new GeneratedRgba32TextureImportSource(
+            materializeRgba32Async,
+            identity,
+            description,
+            colorProfile,
+            estimatedByteLength);
+    }
+
+    public static ITextureImportSource CreateGeneratedRgbaFloat32Image(
+        Func<CancellationToken, ValueTask<RgbaFloat32RawTexturePayload>> materializeRgbaFloat32Async,
+        string identity,
+        string description,
+        string? colorProfile,
+        long? estimatedByteLength = null)
+    {
+        return new GeneratedRgbaFloat32TextureImportSource(
+            materializeRgbaFloat32Async,
             identity,
             description,
             colorProfile,
@@ -266,7 +467,7 @@ internal static class TextureImportSourceFactory
         ArgumentNullException.ThrowIfNull(image);
         Image<Rgba32> retainedImage = image.Clone();
         object gate = new();
-        return CreateGeneratedImage(
+        return CreateGeneratedRgba32Image(
             cancellationToken =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -281,14 +482,14 @@ internal static class TextureImportSourceFactory
             (long)image.Width * image.Height * 4);
     }
 
-    public static RawTexturePayload CreateRawPayloadFromImage(
+    public static Rgba32RawTexturePayload CreateRawPayloadFromImage(
         Image<Rgba32> image,
         string? colorProfile)
     {
         ArgumentNullException.ThrowIfNull(image);
         byte[] rawBytes = new byte[image.Width * image.Height * 4];
         image.CopyPixelDataTo(rawBytes);
-        return new RawTexturePayload(
+        return new Rgba32RawTexturePayload(
             image.Width,
             image.Height,
             colorProfile,

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedDatasetLocation.cs
@@ -4,19 +4,47 @@ using PlateauResoniteLink.Domain.Importing;
 
 namespace PlateauResoniteLink.Application.Importing;
 
-public abstract record ValidatedDatasetLocation(DatasetSourceKind SourceKind)
+public abstract record ValidatedDatasetLocation
 {
+    private protected ValidatedDatasetLocation(DatasetSourceKind sourceKind)
+    {
+        SourceKind = sourceKind;
+    }
+
+    public DatasetSourceKind SourceKind { get; }
+
     public abstract DatasetLocation ToDatasetLocation();
 }
 
-public sealed record ValidatedLocalDatasetLocation(string LocalSourcePath)
-    : ValidatedDatasetLocation(DatasetSourceKind.Local)
+public sealed record ValidatedLocalDatasetLocation(string LocalSourcePath) : ValidatedDatasetLocation(DatasetSourceKind.Local)
 {
+    public string LocalSourcePath { get; } = string.IsNullOrWhiteSpace(LocalSourcePath)
+        ? throw new ArgumentException("The local source path must not be empty.", nameof(LocalSourcePath))
+        : LocalSourcePath;
+
     public override DatasetLocation ToDatasetLocation() => new LocalDatasetLocation(LocalSourcePath);
 }
 
-public sealed record ValidatedRemoteDatasetLocation(Uri ServerUri)
-    : ValidatedDatasetLocation(DatasetSourceKind.Remote)
+public sealed record ValidatedRemoteDatasetLocation(Uri ServerUri) : ValidatedDatasetLocation(DatasetSourceKind.Remote)
 {
+    public Uri ServerUri { get; } = ValidateServerUri(ServerUri);
+
     public override DatasetLocation ToDatasetLocation() => new RemoteDatasetLocation(ServerUri);
+
+    private static Uri ValidateServerUri(Uri serverUri)
+    {
+        ArgumentNullException.ThrowIfNull(serverUri);
+        if (!serverUri.IsAbsoluteUri)
+        {
+            throw new ArgumentException("The remote dataset location URI must be absolute.", nameof(serverUri));
+        }
+
+        if (!string.Equals(serverUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(serverUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("The remote dataset location URI must use http or https.", nameof(serverUri));
+        }
+
+        return serverUri;
+    }
 }

--- a/src/PlateauResoniteLink/Application/Importing/ValidatedPlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ValidatedPlateauImportRequest.cs
@@ -22,6 +22,57 @@ public sealed record ValidatedPlateauImportRequest(
     double TerrainGridMetersPerVertex = 2.0,
     int TerrainGridMaxResolution = 1024)
 {
+#pragma warning disable IDE0032 // Backing fields keep with-expressions inside validated invariants.
+    private string dataset = RequireNonWhiteSpace(Dataset, nameof(Dataset));
+    private string meshCode = RequireNonWhiteSpace(MeshCode, nameof(MeshCode));
+    private Regex meshCodePattern = MeshCodePattern ?? throw new ArgumentNullException(nameof(MeshCodePattern));
+    private ValidatedDatasetLocation cityGmlSource =
+        CityGmlSource ?? throw new ArgumentNullException(nameof(CityGmlSource));
+    private double terrainGridMetersPerVertex = RequirePositive(
+        TerrainGridMetersPerVertex,
+        nameof(TerrainGridMetersPerVertex));
+    private int terrainGridMaxResolution = RequireMinimum(
+        TerrainGridMaxResolution,
+        2,
+        nameof(TerrainGridMaxResolution));
+#pragma warning restore IDE0032
+
+    public string Dataset
+    {
+        get => dataset;
+        init => dataset = RequireNonWhiteSpace(value, nameof(Dataset));
+    }
+
+    public string MeshCode
+    {
+        get => meshCode;
+        init => meshCode = RequireNonWhiteSpace(value, nameof(MeshCode));
+    }
+
+    public Regex MeshCodePattern
+    {
+        get => meshCodePattern;
+        init => meshCodePattern = value ?? throw new ArgumentNullException(nameof(MeshCodePattern));
+    }
+
+    public ValidatedDatasetLocation CityGmlSource
+    {
+        get => cityGmlSource;
+        init => cityGmlSource = value ?? throw new ArgumentNullException(nameof(CityGmlSource));
+    }
+
+    public double TerrainGridMetersPerVertex
+    {
+        get => terrainGridMetersPerVertex;
+        init => terrainGridMetersPerVertex = RequirePositive(value, nameof(TerrainGridMetersPerVertex));
+    }
+
+    public int TerrainGridMaxResolution
+    {
+        get => terrainGridMaxResolution;
+        init => terrainGridMaxResolution = RequireMinimum(value, 2, nameof(TerrainGridMaxResolution));
+    }
+
     public DatasetSourceKind CityGmlSourceKind => CityGmlSource.SourceKind;
 
     public string? CityGmlLocalSourcePath => CityGmlSource is ValidatedLocalDatasetLocation localSource ? localSource.LocalSourcePath : null;
@@ -52,5 +103,25 @@ public sealed record ValidatedPlateauImportRequest(
             TerrainMeshMode,
             TerrainGridMetersPerVertex,
             TerrainGridMaxResolution);
+    }
+
+    private static string RequireNonWhiteSpace(string value, string parameterName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value, parameterName);
+        return value;
+    }
+
+    private static double RequirePositive(double value, string parameterName)
+    {
+        return double.IsFinite(value) && value > 0
+            ? value
+            : throw new ArgumentOutOfRangeException(parameterName, value, "The value must be finite and greater than zero.");
+    }
+
+    private static int RequireMinimum(int value, int minimum, string parameterName)
+    {
+        return value >= minimum
+            ? value
+            : throw new ArgumentOutOfRangeException(parameterName, value, $"The value must be at least {minimum}.");
     }
 }

--- a/src/PlateauResoniteLink/Domain/Importing/DatasetLocation.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/DatasetLocation.cs
@@ -4,20 +4,38 @@ namespace PlateauResoniteLink.Domain.Importing;
 
 public abstract record DatasetLocation(DatasetSourceKind SourceKind)
 {
-    public static DatasetLocation Local(string? localSourcePath)
+    public static DatasetLocation Local(string localSourcePath)
     {
         return new LocalDatasetLocation(localSourcePath);
     }
 
-    public static DatasetLocation Remote(Uri? serverUri)
+    public static DatasetLocation Remote(Uri serverUri)
     {
         return new RemoteDatasetLocation(serverUri);
     }
 
 }
 
-public sealed record LocalDatasetLocation(string? LocalSourcePath)
-    : DatasetLocation(DatasetSourceKind.Local);
+public sealed record LocalDatasetLocation : DatasetLocation
+{
+    public LocalDatasetLocation(string localSourcePath)
+        : base(DatasetSourceKind.Local)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localSourcePath);
+        LocalSourcePath = localSourcePath;
+    }
 
-public sealed record RemoteDatasetLocation(Uri? ServerUri)
-    : DatasetLocation(DatasetSourceKind.Remote);
+    public string LocalSourcePath { get; }
+}
+
+public sealed record RemoteDatasetLocation : DatasetLocation
+{
+    public RemoteDatasetLocation(Uri serverUri)
+        : base(DatasetSourceKind.Remote)
+    {
+        ArgumentNullException.ThrowIfNull(serverUri);
+        ServerUri = serverUri;
+    }
+
+    public Uri ServerUri { get; }
+}

--- a/src/PlateauResoniteLink/Domain/Importing/PlateauImportRequest.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/PlateauImportRequest.cs
@@ -17,6 +17,17 @@ public sealed record PlateauImportRequest(
     double TerrainGridMetersPerVertex = 2.0,
     int TerrainGridMaxResolution = 1024)
 {
+#pragma warning disable IDE0032 // Backing field keeps with-expressions from assigning a null CityGmlSource.
+    private DatasetLocation cityGmlSource =
+        CityGmlSource ?? throw new ArgumentNullException(nameof(CityGmlSource));
+#pragma warning restore IDE0032
+
+    public DatasetLocation CityGmlSource
+    {
+        get => cityGmlSource;
+        init => cityGmlSource = value ?? throw new ArgumentNullException(nameof(CityGmlSource));
+    }
+
     public DatasetSourceKind CityGmlSourceKind => CityGmlSource.SourceKind;
 
     public string? CityGmlLocalSourcePath => CityGmlSource is LocalDatasetLocation localSource ? localSource.LocalSourcePath : null;

--- a/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -98,6 +99,24 @@ public sealed record TerrainTextureGeoReferencedRasterSource(
 
 public sealed record TerrainTextureOverlay
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Style",
+        "IDE0032:Use auto property",
+        Justification = "The init setter validates with-expression updates before changing overlay identity state.")]
+    private string packageName = "";
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Style",
+        "IDE0032:Use auto property",
+        Justification = "The init setter validates with-expression updates before changing overlay identity state.")]
+    private int maxTextureSize;
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Style",
+        "IDE0032:Use auto property",
+        Justification = "The init setter snapshots and rejects null source elements for with-expression updates.")]
+    private IReadOnlyList<TerrainTextureSource> sources = [];
+
     public TerrainTextureOverlay(
         string PackageName,
         ThirdRegionalMeshCode MeshCode,
@@ -106,17 +125,11 @@ public sealed record TerrainTextureOverlay
         IReadOnlyList<TerrainTextureSource> Sources,
         TerrainTextureLicenseMode LicenseMode = TerrainTextureLicenseMode.Unknown)
     {
-        this.PackageName = string.IsNullOrWhiteSpace(PackageName)
-            ? throw new ArgumentException("Terrain texture package name must be provided.", nameof(PackageName))
-            : PackageName.ToLowerInvariant();
+        this.PackageName = PackageName;
         this.MeshCode = MeshCode;
         this.GeographicBounds = GeographicBounds;
-        this.MaxTextureSize = MaxTextureSize > 0
-            ? MaxTextureSize
-            : throw new ArgumentOutOfRangeException(nameof(MaxTextureSize));
-        this.Sources = Sources is { Count: > 0 }
-            ? Sources.ToArray()
-            : throw new ArgumentException("At least one terrain texture source must be provided.", nameof(Sources));
+        this.MaxTextureSize = MaxTextureSize;
+        this.Sources = Sources;
         this.LicenseMode = LicenseMode;
     }
 
@@ -159,15 +172,31 @@ public sealed record TerrainTextureOverlay
     {
     }
 
-    public string PackageName { get; init; }
+    public string PackageName
+    {
+        get => packageName;
+        init => packageName = string.IsNullOrWhiteSpace(value)
+            ? throw new ArgumentException("Terrain texture package name must be provided.", nameof(value))
+            : value.ToLowerInvariant();
+    }
 
     public ThirdRegionalMeshCode MeshCode { get; init; }
 
     public GeographicRectangle GeographicBounds { get; init; }
 
-    public int MaxTextureSize { get; init; }
+    public int MaxTextureSize
+    {
+        get => maxTextureSize;
+        init => maxTextureSize = value > 0
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(value));
+    }
 
-    public IReadOnlyList<TerrainTextureSource> Sources { get; init; }
+    public IReadOnlyList<TerrainTextureSource> Sources
+    {
+        get => sources;
+        init => sources = CreateSourceSnapshot(value);
+    }
 
     public TerrainTextureLicenseMode LicenseMode { get; init; }
 
@@ -231,6 +260,25 @@ public sealed record TerrainTextureOverlay
                 $"Terrain texture source '{source.GetType().Name}' does not provide a web tile URL.");
     }
 
+    private static ReadOnlyCollection<TerrainTextureSource> CreateSourceSnapshot(
+        IReadOnlyList<TerrainTextureSource> sources)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+
+        if (sources.Count == 0)
+        {
+            throw new ArgumentException("At least one terrain texture source must be provided.", nameof(sources));
+        }
+
+        TerrainTextureSource[] snapshot = new TerrainTextureSource[sources.Count];
+        for (int index = 0; index < sources.Count; index++)
+        {
+            snapshot[index] = sources[index]
+                ?? throw new ArgumentException("Terrain texture sources cannot contain null.", nameof(sources));
+        }
+
+        return Array.AsReadOnly(snapshot);
+    }
 }
 
 internal static class TerrainTextureDescriptorFormatting

--- a/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/TerrainTextureOverlay.cs
@@ -30,18 +30,26 @@ public sealed record TerrainTextureTileSource(string UrlTemplate, int ZoomLevel)
 
 public sealed record GeoReferencedRasterMetadata(
     GeographicRectangle GeographicBounds,
-    string? CoordinateSystemIdentifier,
+    string CoordinateSystemIdentifier,
     double PixelWidthMeters,
     double PixelHeightMeters)
 {
-    public bool IsUsable => !string.IsNullOrWhiteSpace(CoordinateSystemIdentifier)
-        && PixelWidthMeters > 0.0
-        && PixelHeightMeters > 0.0;
+    public string CoordinateSystemIdentifier { get; init; } = string.IsNullOrWhiteSpace(CoordinateSystemIdentifier)
+        ? throw new ArgumentException("Geo-referenced raster coordinate system identifier must be provided.", nameof(CoordinateSystemIdentifier))
+        : CoordinateSystemIdentifier;
+
+    public double PixelWidthMeters { get; init; } = PixelWidthMeters > 0.0
+        ? PixelWidthMeters
+        : throw new ArgumentOutOfRangeException(nameof(PixelWidthMeters));
+
+    public double PixelHeightMeters { get; init; } = PixelHeightMeters > 0.0
+        ? PixelHeightMeters
+        : throw new ArgumentOutOfRangeException(nameof(PixelHeightMeters));
 
     public string IdentityKey =>
         string.Create(
             CultureInfo.InvariantCulture,
-            $"georaster-meta-crs-{CoordinateSystemIdentifier ?? "none"}-pixel-{TerrainTextureDescriptorFormatting.FormatRounded(PixelWidthMeters)}x{TerrainTextureDescriptorFormatting.FormatRounded(PixelHeightMeters)}-bounds-{TerrainTextureDescriptorFormatting.FormatBounds(GeographicBounds)}");
+            $"georaster-meta-crs-{CoordinateSystemIdentifier}-pixel-{TerrainTextureDescriptorFormatting.FormatRounded(PixelWidthMeters)}x{TerrainTextureDescriptorFormatting.FormatRounded(PixelHeightMeters)}-bounds-{TerrainTextureDescriptorFormatting.FormatBounds(GeographicBounds)}");
 }
 
 public interface ITerrainTextureRasterContentSource
@@ -76,11 +84,11 @@ public sealed record LocalTerrainTextureRasterContentSource(string SourcePath) :
 
 public sealed record TerrainTextureGeoReferencedRasterSource(
     ITerrainTextureRasterContentSource ContentSource,
-    GeoReferencedRasterMetadata? Metadata = null) : TerrainTextureSource
+    GeoReferencedRasterMetadata Metadata) : TerrainTextureSource
 {
     public TerrainTextureGeoReferencedRasterSource(
         string sourcePath,
-        GeoReferencedRasterMetadata? metadata = null)
+        GeoReferencedRasterMetadata metadata)
         : this(new LocalTerrainTextureRasterContentSource(sourcePath), metadata)
     {
     }
@@ -88,10 +96,11 @@ public sealed record TerrainTextureGeoReferencedRasterSource(
     public ITerrainTextureRasterContentSource ContentSource { get; init; } =
         ContentSource ?? throw new ArgumentNullException(nameof(ContentSource));
 
-    public GeoReferencedRasterMetadata? Metadata { get; init; } = Metadata;
+    public GeoReferencedRasterMetadata Metadata { get; init; } =
+        Metadata ?? throw new ArgumentNullException(nameof(Metadata));
 
     public override string IdentityKey =>
-        string.Create(CultureInfo.InvariantCulture, $"georaster-{ContentSource.IdentityKey}-meta-{Metadata?.IdentityKey ?? "none"}");
+        string.Create(CultureInfo.InvariantCulture, $"georaster-{ContentSource.IdentityKey}-meta-{Metadata.IdentityKey}");
 
     public ValueTask<Stream> OpenReadAsync(CancellationToken cancellationToken) =>
         ContentSource.OpenReadAsync(cancellationToken);

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
@@ -153,13 +153,12 @@ internal sealed class DeterministicTerrainTextureAssetGenerator : ITerrainTextur
         cancellationToken.ThrowIfCancellationRequested();
         TerrainTextureSource usedSource = terrainTextureOverlay.GetRequiredPrimaryTileSource();
         return Task.FromResult(new GeneratedTerrainTexture(
-            TextureImportSourceFactory.CreateInMemory(
+            TextureImportSourceFactory.CreateInMemoryRaw(
                 2,
                 2,
                 ResoniteTextureColorProfiles.Srgb,
                 RawTextureBytes,
-                "canonical-dump-terrain-texture",
-                TexturePayloadFormat.RawRgba32),
+                "canonical-dump-terrain-texture"),
             new ResoniteFloat2(1.0, 1.0),
             new ResoniteFloat2(0.0, 0.0),
             usedSource));

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/CanonicalSceneDumpSink.cs
@@ -151,7 +151,7 @@ internal sealed class DeterministicTerrainTextureAssetGenerator : ITerrainTextur
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        TerrainTextureSource? usedSource = terrainTextureOverlay.GetRequiredPrimaryTileSource();
+        TerrainTextureSource usedSource = terrainTextureOverlay.GetRequiredPrimaryTileSource();
         return Task.FromResult(new GeneratedTerrainTexture(
             TextureImportSourceFactory.CreateInMemory(
                 2,

--- a/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClientCanonicalDump.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Diagnostics/SceneSinkRecordingClientCanonicalDump.cs
@@ -139,8 +139,7 @@ internal static class SceneSinkRecordingClientCanonicalDump
         List<JsonObject> textureNodes = [];
         for (int index = 0; index < client.ImportedTexturePayloads.Count; index++)
         {
-            RawTexturePayload texture = client.ImportedTexturePayloads[index];
-            if (texture.Format != RawTexturePayloadFormat.Rgba32)
+            if (client.ImportedTexturePayloads[index] is not Rgba32RawTexturePayload texture)
             {
                 continue;
             }
@@ -164,8 +163,7 @@ internal static class SceneSinkRecordingClientCanonicalDump
         List<JsonObject> hdrTextureNodes = [];
         for (int index = 0; index < client.ImportedTexturePayloads.Count; index++)
         {
-            RawTexturePayload texture = client.ImportedTexturePayloads[index];
-            if (texture.Format != RawTexturePayloadFormat.RgbaFloat32)
+            if (client.ImportedTexturePayloads[index] is not RgbaFloat32RawTexturePayload texture)
             {
                 continue;
             }
@@ -398,16 +396,16 @@ internal static class SceneSinkRecordingClientCanonicalDump
 
     private static string CreateTextureToken(RawTexturePayload texture)
     {
-        return texture.Format == RawTexturePayloadFormat.RgbaFloat32
-            ? string.Create(
+        return texture.Match(
+            rgba32 => string.Create(
                 CultureInfo.InvariantCulture,
-                $"hdr-texture:{texture.Width}x{texture.Height}:{HashBytes(texture.Bytes)}")
-            : string.Create(
+                $"texture:{rgba32.Width}x{rgba32.Height}:{rgba32.ColorProfile}:{HashBytes(rgba32.Bytes)}"),
+            rgbaFloat32 => string.Create(
                 CultureInfo.InvariantCulture,
-                $"texture:{texture.Width}x{texture.Height}:{texture.ColorProfile}:{HashBytes(texture.Bytes)}");
+                $"hdr-texture:{rgbaFloat32.Width}x{rgbaFloat32.Height}:{HashBytes(rgbaFloat32.Bytes)}"));
     }
 
-    private static string CreateHdrTextureToken(RawTexturePayload texture)
+    private static string CreateHdrTextureToken(RgbaFloat32RawTexturePayload texture)
     {
         return string.Create(
             CultureInfo.InvariantCulture,

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -233,7 +233,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
                 ref nextFieldLocator);
         }
 
-        return new PlannedBatchEmission(
+        return PlannedBatchEmission.Create(
             slotEmissions,
             componentEmissions,
             slotResolutionTargets,

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/IResoniteBatchEmissionPlanner.cs
@@ -494,7 +494,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 
         Uri? albedoTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             plannedMaterial.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Albedo);
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo);
         if (albedoTextureUri is not null)
         {
             BatchPlanComponentLocator albedoTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
@@ -511,7 +511,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 
         Uri? normalTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             plannedMaterial.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Normal);
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Normal);
         if (normalTextureUri is not null)
         {
             BatchPlanComponentLocator normalTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
@@ -532,7 +532,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 
         Uri? heightTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             plannedMaterial.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Height);
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Height);
         if (heightTextureUri is not null)
         {
             BatchPlanComponentLocator heightTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
@@ -553,7 +553,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 
         Uri? metallicTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             plannedMaterial.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Metallic);
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic);
         if (metallicTextureUri is not null)
         {
             BatchPlanComponentLocator metallicTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);
@@ -571,7 +571,7 @@ internal sealed class ResoniteBatchEmissionPlanner : IResoniteBatchEmissionPlann
 
         Uri? emissionTextureUri = ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             plannedMaterial.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Emission);
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Emission);
         if (emissionTextureUri is not null)
         {
             BatchPlanComponentLocator emissionTextureId = CreateBatchPlanComponentLocator(ref nextComponentLocator);

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -118,7 +118,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
 
     public static Uri? TryGetPlannedTextureUri(
         IEnumerable<PlannedTextureAsset> textures,
-        ResoniteSceneMaterialConventions.TextureMemberRole role)
+        ResoniteSceneMaterialConventions.PlannedTextureRole role)
     {
         ArgumentNullException.ThrowIfNull(textures);
 
@@ -166,15 +166,15 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         AddTextureComponentReference(
             batchBuilder,
             plannedMaterial,
-            materialContainerSlotId,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
-            "AlbedoTexture",
-            materialMembers);
+                materialContainerSlotId,
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo,
+                "AlbedoTexture",
+                materialMembers);
         if (AddTextureComponentReference(
                 batchBuilder,
                 plannedMaterial,
                 materialContainerSlotId,
-                ResoniteSceneMaterialConventions.TextureMemberRole.Normal,
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Normal,
                 "NormalMap",
                 materialMembers))
         {
@@ -188,7 +188,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
                 batchBuilder,
                 plannedMaterial,
                 materialContainerSlotId,
-                ResoniteSceneMaterialConventions.TextureMemberRole.Height,
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Height,
                 "HeightMap",
                 materialMembers))
         {
@@ -200,15 +200,18 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
 
         Uri? metallicTextureUri = TryGetPlannedTextureUri(
             plannedMaterial.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Metallic);
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic);
         if (metallicTextureUri is not null)
         {
+            ResoniteSceneMaterialConventions.TextureMemberRole metallicMemberRole =
+                ResoniteSceneMaterialConventions.ToTextureMemberRole(
+                    ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic);
             ResoniteBatchOperations.PendingBatchComponent metallicTexture = batchBuilder.AddComponent(
                 materialContainerSlotId,
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
                 ResoniteSceneMaterialConventions.CreateTextureMembers(
                     metallicTextureUri,
-                    ResoniteSceneMaterialConventions.TextureMemberRole.Metallic));
+                    metallicMemberRole));
             materialMembers["MetallicMap"] = new Reference
             {
                 TargetID = metallicTexture.LocalId.Value,
@@ -223,7 +226,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
                 batchBuilder,
                 plannedMaterial,
                 materialContainerSlotId,
-                ResoniteSceneMaterialConventions.TextureMemberRole.Emission,
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Emission,
                 "EmissiveMap",
                 materialMembers))
         {
@@ -241,7 +244,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         ResoniteBatchOperations.BatchActionBuilder batchBuilder,
         PlannedDedicatedMaterialAsset plannedMaterial,
         string materialContainerSlotId,
-        ResoniteSceneMaterialConventions.TextureMemberRole textureRole,
+        ResoniteSceneMaterialConventions.PlannedTextureRole textureRole,
         string materialMemberName,
         Dictionary<string, Member> materialMembers)
     {
@@ -254,7 +257,9 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         ResoniteBatchOperations.PendingBatchComponent textureComponent = batchBuilder.AddComponent(
             materialContainerSlotId,
             "[FrooxEngine]FrooxEngine.StaticTexture2D",
-            ResoniteSceneMaterialConventions.CreateTextureMembers(textureUri, textureRole));
+            ResoniteSceneMaterialConventions.CreateTextureMembers(
+                textureUri,
+                ResoniteSceneMaterialConventions.ToTextureMemberRole(textureRole)));
         materialMembers[materialMemberName] = new Reference
         {
             TargetID = textureComponent.LocalId.Value,
@@ -396,23 +401,23 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         List<PlannedTextureAsset> textures = [];
         AddPlannedTextureAsset(
             textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo,
             await albedoTextureTask);
         AddPlannedTextureAsset(
             textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Normal,
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Normal,
             await normalTextureTask);
         AddPlannedTextureAsset(
             textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Height,
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Height,
             await heightTextureTask);
         AddPlannedTextureAsset(
             textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Metallic,
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic,
             await metallicTextureTask);
         AddPlannedTextureAsset(
             textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Emission,
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Emission,
             await emissionTextureTask);
         return textures;
     }
@@ -482,7 +487,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
 
     private static void AddPlannedTextureAsset(
         List<PlannedTextureAsset> textures,
-        ResoniteSceneMaterialConventions.TextureMemberRole role,
+        ResoniteSceneMaterialConventions.PlannedTextureRole role,
         Uri? assetUri)
     {
         if (assetUri is null)

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -116,18 +116,12 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         PlannedSlotTargetReference target,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId)
     {
-        if (target.Canonical is ResoniteSlotLocator canonical)
+        return target switch
         {
-            return canonical.Value;
-        }
-
-        if (target.Planned is BatchPlanSlotLocator planned
-            && pendingSlotsByPlanId.TryGetValue(planned, out ResoniteBatchOperations.PendingBatchSlot pendingSlot))
-        {
-            return pendingSlot.LocalId.Value;
-        }
-
-        throw new InvalidOperationException("Batch slot target did not resolve to a planned or canonical slot.");
+            PlannedSlotTargetReference.CanonicalSlotTarget canonicalSlot => canonicalSlot.Locator.Value,
+            PlannedSlotTargetReference.PlannedSlotTarget plannedSlot => pendingSlotsByPlanId[plannedSlot.Locator].LocalId.Value,
+            _ => throw new InvalidOperationException("Batch slot target did not resolve to an executable target."),
+        };
     }
 
     private static string ResolveWorldElementId(
@@ -137,34 +131,15 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
-        if (target.CanonicalSlot is ResoniteSlotLocator canonicalSlot)
+        return target switch
         {
-            return canonicalSlot.Value;
-        }
-
-        if (target.CanonicalComponent is ResoniteComponentLocator canonicalComponent)
-        {
-            return canonicalComponent.Value;
-        }
-
-        if (target.PlannedSlot is BatchPlanSlotLocator plannedSlot
-            && pendingSlotsByPlanId.TryGetValue(plannedSlot, out ResoniteBatchOperations.PendingBatchSlot pendingSlot))
-        {
-            return pendingSlot.LocalId.Value;
-        }
-
-        if (target.PlannedComponent is BatchPlanComponentLocator plannedComponent
-            && pendingComponentsByPlanId.TryGetValue(plannedComponent, out ResoniteBatchOperations.PendingBatchComponent pendingComponent))
-        {
-            return pendingComponent.LocalId.Value;
-        }
-
-        if (target.PlannedField is BatchPlanFieldLocator plannedField)
-        {
-            return ResolveFieldId(plannedField, pendingFieldsByPlanId, batchBuilder).Value;
-        }
-
-        throw new InvalidOperationException("Batch world element reference did not resolve to a planned or canonical entity.");
+            PlannedWorldElementReference.CanonicalSlotElement canonicalSlot => canonicalSlot.Locator.Value,
+            PlannedWorldElementReference.CanonicalComponentElement canonicalComponent => canonicalComponent.Locator.Value,
+            PlannedWorldElementReference.PlannedSlotElement plannedSlot => pendingSlotsByPlanId[plannedSlot.Locator].LocalId.Value,
+            PlannedWorldElementReference.PlannedComponentElement plannedComponent => pendingComponentsByPlanId[plannedComponent.Locator].LocalId.Value,
+            PlannedWorldElementReference.PlannedFieldElement plannedField => ResolveFieldId(plannedField.Locator, pendingFieldsByPlanId, batchBuilder).Value,
+            _ => throw new InvalidOperationException("Batch world element reference did not resolve to an executable target."),
+        };
     }
 
     private static Dictionary<string, Member> TranslateMembers(

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResonitePlannedBatchEmissionInterpreter.cs
@@ -116,12 +116,9 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         PlannedSlotTargetReference target,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId)
     {
-        return target switch
-        {
-            PlannedSlotTargetReference.CanonicalSlotTarget canonicalSlot => canonicalSlot.Locator.Value,
-            PlannedSlotTargetReference.PlannedSlotTarget plannedSlot => pendingSlotsByPlanId[plannedSlot.Locator].LocalId.Value,
-            _ => throw new InvalidOperationException("Batch slot target did not resolve to an executable target."),
-        };
+        return target.Match(
+            static canonicalSlot => canonicalSlot.Value,
+            plannedSlot => pendingSlotsByPlanId[plannedSlot].LocalId.Value);
     }
 
     private static string ResolveWorldElementId(
@@ -131,15 +128,12 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
-        return target switch
-        {
-            PlannedWorldElementReference.CanonicalSlotElement canonicalSlot => canonicalSlot.Locator.Value,
-            PlannedWorldElementReference.CanonicalComponentElement canonicalComponent => canonicalComponent.Locator.Value,
-            PlannedWorldElementReference.PlannedSlotElement plannedSlot => pendingSlotsByPlanId[plannedSlot.Locator].LocalId.Value,
-            PlannedWorldElementReference.PlannedComponentElement plannedComponent => pendingComponentsByPlanId[plannedComponent.Locator].LocalId.Value,
-            PlannedWorldElementReference.PlannedFieldElement plannedField => ResolveFieldId(plannedField.Locator, pendingFieldsByPlanId, batchBuilder).Value,
-            _ => throw new InvalidOperationException("Batch world element reference did not resolve to an executable target."),
-        };
+        return target.Match(
+            static canonicalSlot => canonicalSlot.Value,
+            static canonicalComponent => canonicalComponent.Value,
+            plannedSlot => pendingSlotsByPlanId[plannedSlot].LocalId.Value,
+            plannedComponent => pendingComponentsByPlanId[plannedComponent].LocalId.Value,
+            plannedField => ResolveFieldId(plannedField, pendingFieldsByPlanId, batchBuilder).Value);
     }
 
     private static Dictionary<string, Member> TranslateMembers(
@@ -162,31 +156,31 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
-        return member switch
-        {
-            PlannedLiteralMember literal => literal.Value,
-            PlannedElementReferenceMember reference => new Reference
+        return member.Match(
+            literal: static literal => literal,
+            reference: reference => new Reference
             {
                 TargetID = ResolveWorldElementId(
-                    reference.Target,
+                    reference,
                     pendingSlotsByPlanId,
                     pendingComponentsByPlanId,
                     pendingFieldsByPlanId,
                     batchBuilder),
             },
-            PlannedAddressableFieldMember addressableField => TranslateAddressableField(
+            addressableField: addressableField => TranslateAddressableField(
                 addressableField,
                 pendingFieldsByPlanId,
                 batchBuilder),
-            PlannedAddressableReferenceMember addressableReference => TranslateAddressableReference(
-                addressableReference,
+            addressableReference: (identity, target) => TranslateAddressableReference(
+                identity,
+                target,
                 pendingSlotsByPlanId,
                 pendingComponentsByPlanId,
                 pendingFieldsByPlanId,
                 batchBuilder),
-            PlannedSyncListMember syncList => new SyncList
+            list: elements => new SyncList
             {
-                Elements = syncList.Elements
+                Elements = elements
                     .Select(element => TranslateMember(
                         element,
                         pendingSlotsByPlanId,
@@ -194,24 +188,23 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
                         pendingFieldsByPlanId,
                         batchBuilder))
                     .ToList(),
-            },
-            _ => throw new InvalidOperationException($"Unsupported planned member type '{member.GetType().Name}'."),
-        };
+            });
     }
 
     private static Reference TranslateAddressableReference(
-        PlannedAddressableReferenceMember addressableReference,
+        BatchPlanFieldLocator identity,
+        PlannedWorldElementReference target,
         Dictionary<BatchPlanSlotLocator, ResoniteBatchOperations.PendingBatchSlot> pendingSlotsByPlanId,
         Dictionary<BatchPlanComponentLocator, ResoniteBatchOperations.PendingBatchComponent> pendingComponentsByPlanId,
         Dictionary<BatchPlanFieldLocator, ResoniteBatchOperations.BatchTemporaryFieldId> pendingFieldsByPlanId,
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
-        string fieldId = ResolveFieldId(addressableReference.Identity, pendingFieldsByPlanId, batchBuilder).Value;
+        string fieldId = ResolveFieldId(identity, pendingFieldsByPlanId, batchBuilder).Value;
         return new Reference
         {
             ID = fieldId,
             TargetID = ResolveWorldElementId(
-                addressableReference.Target,
+                target,
                 pendingSlotsByPlanId,
                 pendingComponentsByPlanId,
                 pendingFieldsByPlanId,
@@ -225,32 +218,7 @@ internal sealed class PlannedBatchEmissionInterpreter : IResoniteSceneBatchEmitt
         ResoniteBatchOperations.BatchActionBuilder batchBuilder)
     {
         string fieldId = ResolveFieldId(addressableField.Identity, pendingFieldsByPlanId, batchBuilder).Value;
-        return addressableField.Value switch
-        {
-            Field_int2 value => new Field_int2
-            {
-                ID = fieldId,
-                Value = value.Value,
-            },
-            Field_bool value => new Field_bool
-            {
-                ID = fieldId,
-                Value = value.Value,
-            },
-            Field_float value => new Field_float
-            {
-                ID = fieldId,
-                Value = value.Value,
-            },
-            Reference value => new Reference
-            {
-                ID = fieldId,
-                TargetID = value.TargetID,
-                TargetType = value.TargetType,
-            },
-            _ => throw new InvalidOperationException(
-                $"Unsupported planned addressable field member type '{addressableField.Value.GetType().Name}'."),
-        };
+        return addressableField.Bind(fieldId);
     }
 
     private static ResoniteBatchOperations.BatchTemporaryFieldId ResolveFieldId(

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
@@ -59,19 +59,69 @@ internal sealed record SharedTerrainTextureAsset(
     CreatedComponent TextureComponent,
     CreatedComponent MainTexturePropertyBlockComponent);
 
-internal sealed record LiveSendRunPlan(
-    ResoniteSceneSetupInfo SetupInfo,
-    string ResolvedWorkRoot,
-    ResoniteLocalOrigin RequestLocalOrigin,
-    IReadOnlyDictionary<string, string> SourceFileSlotNamesByRelativePath,
-    ResoniteImportBudgetProfile ResourceBudget,
-    LiveSendQueuePlan Queue,
-    bool MeshBakeEnabled);
+internal sealed record LiveSendRunPlan
+{
+    public LiveSendRunPlan(
+        ResoniteSceneSetupInfo SetupInfo,
+        string ResolvedWorkRoot,
+        ResoniteLocalOrigin RequestLocalOrigin,
+        IReadOnlyDictionary<string, string> SourceFileSlotNamesByRelativePath,
+        ResoniteImportBudgetProfile ResourceBudget,
+        LiveSendQueuePlan Queue,
+        bool MeshBakeEnabled)
+    {
+        ArgumentNullException.ThrowIfNull(SetupInfo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(ResolvedWorkRoot);
+        ArgumentNullException.ThrowIfNull(SourceFileSlotNamesByRelativePath);
+        ArgumentNullException.ThrowIfNull(ResourceBudget);
+        ArgumentNullException.ThrowIfNull(Queue);
 
-internal sealed record LiveSendQueuePlan(
-    int ConnectionCount,
-    int QueueCapacity,
-    long MemoryBudgetBytes);
+        this.SetupInfo = SetupInfo;
+        this.ResolvedWorkRoot = ResolvedWorkRoot;
+        this.RequestLocalOrigin = RequestLocalOrigin;
+        this.SourceFileSlotNamesByRelativePath = SourceFileSlotNamesByRelativePath;
+        this.ResourceBudget = ResourceBudget;
+        this.Queue = Queue;
+        this.MeshBakeEnabled = MeshBakeEnabled;
+    }
+
+    public ResoniteSceneSetupInfo SetupInfo { get; }
+
+    public string ResolvedWorkRoot { get; }
+
+    public ResoniteLocalOrigin RequestLocalOrigin { get; }
+
+    public IReadOnlyDictionary<string, string> SourceFileSlotNamesByRelativePath { get; }
+
+    public ResoniteImportBudgetProfile ResourceBudget { get; }
+
+    public LiveSendQueuePlan Queue { get; }
+
+    public bool MeshBakeEnabled { get; }
+}
+
+internal sealed record LiveSendQueuePlan
+{
+    public LiveSendQueuePlan(
+        int ConnectionCount,
+        int QueueCapacity,
+        long MemoryBudgetBytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(QueueCapacity, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(MemoryBudgetBytes, 1);
+
+        this.ConnectionCount = ConnectionCount;
+        this.QueueCapacity = QueueCapacity;
+        this.MemoryBudgetBytes = MemoryBudgetBytes;
+    }
+
+    public int ConnectionCount { get; }
+
+    public int QueueCapacity { get; }
+
+    public long MemoryBudgetBytes { get; }
+}
 
 internal sealed record LiveSendRunContext(
     LiveSendRunPlan Plan,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemBakeEntryFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemBakeEntryFactory.cs
@@ -92,11 +92,11 @@ internal sealed class NonDemBakeEntryFactory(
             TextureOffset = null,
             Family = null,
             TerrainOverlayMaterial = null,
-            AssetScope = ResoniteMaterialAssetScope.Common,
+            AssetBinding = ResoniteMaterialAssetBinding.SharedCommon(
+                material.DepthOffset is null
+                    ? CommonMaterialCatalog.Create().VertexColor.Uv
+                    : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv),
             SubmeshIndices = [submeshIndex],
-            CommonMaterial = material.DepthOffset is null
-                ? CommonMaterialCatalog.Create().VertexColor.Uv
-                : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv,
         };
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemBakeEntryFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemBakeEntryFactory.cs
@@ -11,23 +11,23 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal interface INonDemAtlasOrPreservedEntryFactory
+internal interface INonDemBakeEntryFactory
 {
-    Task<NonDemAtlasOrPreservedEntry> CreateAsync(
+    Task<NonDemBakeEntry> CreateAsync(
         ResoniteConstructionCityObject cityObject,
         ResoniteMeshSubmesh submesh,
         ResoniteMaterialBinding material,
         CancellationToken cancellationToken);
 }
 
-internal sealed class NonDemAtlasOrPreservedEntryFactory(
+internal sealed class NonDemBakeEntryFactory(
     ResoniteTextureImageLoader textureImageLoader,
-    int maxAtlasTextureEdge) : INonDemAtlasOrPreservedEntryFactory
+    int maxAtlasTextureEdge) : INonDemBakeEntryFactory
 {
     private readonly ResoniteTextureImageLoader textureImageLoader = textureImageLoader
         ?? throw new ArgumentNullException(nameof(textureImageLoader));
 
-    public async Task<NonDemAtlasOrPreservedEntry> CreateAsync(
+    public async Task<NonDemBakeEntry> CreateAsync(
         ResoniteConstructionCityObject cityObject,
         ResoniteMeshSubmesh submesh,
         ResoniteMaterialBinding material,
@@ -50,9 +50,8 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
             Rgba32 tintedUniformColor = NonDemTextureImageProcessing.MultiplyPixel(
                 uniformDatasetColor,
                 NonDemTextureImageProcessing.ToPixel(material.BaseColor));
-            return new NonDemAtlasOrPreservedEntry(
-                AtlasEntry: null,
-                PreservedEntry: new NonDemPreservedSubmeshEntry(
+            return new NonDemBakeEntry.Preserved(
+                new NonDemPreservedSubmeshEntry(
                     cityObject,
                     submesh,
                     CreateVertexColorMaterial(material, submesh.Index),
@@ -68,8 +67,8 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
             targetHeight);
 
         NonDemTextureImageProcessing.ApplyBaseColor(bakedImage, material.BaseColor);
-        return new NonDemAtlasOrPreservedEntry(
-            AtlasEntry: new NonDemAtlasBatchEntry(
+        return new NonDemBakeEntry.Atlas(
+            new NonDemAtlasBatchEntry(
                 cityObject,
                 submesh,
                 material,
@@ -78,8 +77,7 @@ internal sealed class NonDemAtlasOrPreservedEntryFactory(
                     NonDemTextureImageProcessing.MultiplyPixel(
                         detectedBackgroundColor,
                         NonDemTextureImageProcessing.ToPixel(material.BaseColor))),
-                uvBounds),
-            PreservedEntry: null);
+                uvBounds));
     }
 
     private static ResoniteMaterialBinding CreateVertexColorMaterial(ResoniteMaterialBinding material, int submeshIndex)

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemBakedGeometryComposer.cs
@@ -66,7 +66,7 @@ internal sealed class NonDemBakedGeometryComposer : INonDemBakedGeometryComposer
                     TexturePayload: ResoniteTextureImportFactory.CreatePayloadFromImage(
                         atlasImage ?? throw new InvalidOperationException("Non-DEM atlas image is required when an atlas layout exists."),
                         identity: textureIdentity),
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv));
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)));
         }
 
         foreach (IGrouping<NonDemPreservedMaterialGroupingKey, NonDemOrderedPreservedSubmeshEntry> preservedGroup in candidates

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeCandidateFactory.cs
@@ -8,18 +8,18 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal interface INonDemCityObjectBakeCandidateFactory
 {
-    Task<NonDemCityObjectBakeCandidate?> CreateAsync(
+    Task<NonDemCityObjectBakeCandidate> CreateAsync(
         NonDemBufferedCityObject bufferedCityObject,
         CancellationToken cancellationToken);
 }
 
 internal sealed class NonDemCityObjectBakeCandidateFactory(
-    INonDemAtlasOrPreservedEntryFactory entryFactory) : INonDemCityObjectBakeCandidateFactory
+    INonDemBakeEntryFactory entryFactory) : INonDemCityObjectBakeCandidateFactory
 {
-    private readonly INonDemAtlasOrPreservedEntryFactory entryFactory = entryFactory
+    private readonly INonDemBakeEntryFactory entryFactory = entryFactory
         ?? throw new ArgumentNullException(nameof(entryFactory));
 
-    public async Task<NonDemCityObjectBakeCandidate?> CreateAsync(
+    public async Task<NonDemCityObjectBakeCandidate> CreateAsync(
         NonDemBufferedCityObject bufferedCityObject,
         CancellationToken cancellationToken)
     {
@@ -40,7 +40,6 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
 
         List<NonDemAtlasBatchEntry> atlasEntries = [];
         List<NonDemPreservedSubmeshEntry> preservedEntries = [];
-        bool hadAtlasCandidateMaterial = false;
         foreach (ResoniteMeshSubmesh submesh in normalizedCityObject.Mesh.Submeshes.OrderBy(static candidate => candidate.Index))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -54,21 +53,12 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
             switch (category)
             {
                 case NonDemMaterialBakeCategory.AtlasCandidate:
-                    hadAtlasCandidateMaterial = true;
-                    NonDemAtlasOrPreservedEntry bakeEntry = await entryFactory.CreateAsync(
+                    NonDemBakeEntry bakeEntry = await entryFactory.CreateAsync(
                         normalizedCityObject,
                         submesh,
                         material,
                         cancellationToken);
-                    if (bakeEntry.AtlasEntry is not null)
-                    {
-                        atlasEntries.Add(bakeEntry.AtlasEntry);
-                    }
-
-                    if (bakeEntry.PreservedEntry is not null)
-                    {
-                        preservedEntries.Add(bakeEntry.PreservedEntry);
-                    }
+                    bakeEntry.AddTo(atlasEntries, preservedEntries);
 
                     break;
                 case NonDemMaterialBakeCategory.PreservedCommonMaterial when policy.PreserveCommonMaterials:
@@ -80,11 +70,6 @@ internal sealed class NonDemCityObjectBakeCandidateFactory(
                     preservedEntries.Add(new NonDemPreservedSubmeshEntry(normalizedCityObject, normalizedSubmesh, normalizedMaterial));
                     break;
             }
-        }
-
-        if (policy.RequireAtlasCandidateMaterial && !hadAtlasCandidateMaterial)
-        {
-            return null;
         }
 
         if (atlasEntries.Count == 0 && preservedEntries.Count == 0)

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBakeModels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using PlateauResoniteLink.Domain.Importing;
@@ -9,9 +10,56 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed record NonDemMaterialAtlasTile(Image<Rgba32> Image, Rgba32 BackgroundColor);
 
-internal sealed record NonDemAtlasOrPreservedEntry(
-    NonDemAtlasBatchEntry? AtlasEntry,
-    NonDemPreservedSubmeshEntry? PreservedEntry);
+internal abstract record NonDemBakeEntry
+{
+    private NonDemBakeEntry()
+    {
+    }
+
+    internal abstract void AddTo(
+        List<NonDemAtlasBatchEntry> atlasEntries,
+        List<NonDemPreservedSubmeshEntry> preservedEntries);
+
+    internal sealed record Atlas : NonDemBakeEntry
+    {
+        public Atlas(NonDemAtlasBatchEntry entry)
+        {
+            ArgumentNullException.ThrowIfNull(entry);
+            Entry = entry;
+        }
+
+        public NonDemAtlasBatchEntry Entry { get; }
+
+        internal override void AddTo(
+            List<NonDemAtlasBatchEntry> atlasEntries,
+            List<NonDemPreservedSubmeshEntry> preservedEntries)
+        {
+            ArgumentNullException.ThrowIfNull(atlasEntries);
+            ArgumentNullException.ThrowIfNull(preservedEntries);
+            atlasEntries.Add(Entry);
+        }
+    }
+
+    internal sealed record Preserved : NonDemBakeEntry
+    {
+        public Preserved(NonDemPreservedSubmeshEntry entry)
+        {
+            ArgumentNullException.ThrowIfNull(entry);
+            Entry = entry;
+        }
+
+        public NonDemPreservedSubmeshEntry Entry { get; }
+
+        internal override void AddTo(
+            List<NonDemAtlasBatchEntry> atlasEntries,
+            List<NonDemPreservedSubmeshEntry> preservedEntries)
+        {
+            ArgumentNullException.ThrowIfNull(atlasEntries);
+            ArgumentNullException.ThrowIfNull(preservedEntries);
+            preservedEntries.Add(Entry);
+        }
+    }
+}
 
 internal readonly record struct NonDemBufferedCityObject(
     ResoniteConstructionCityObject CityObject,

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -34,10 +34,10 @@ internal sealed class NonDemCityObjectBaker(
             return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: false, []));
         }
 
-        cityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
-        NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(cityObject, policy);
+        ResoniteConstructionCityObject normalizedCityObject = ResoniteDynamicMaterialUvNormalizer.Normalize(cityObject);
+        NonDemSourceFileBatchKey sourceFileKey = NonDemSourceFileBatching.CreateKey(normalizedCityObject, policy);
         List<ResoniteConstructionCityObject> readyCityObjects = [];
-        sourceFileBuffer.Add(sourceFileKey, new NonDemBufferedCityObject(cityObject, policy));
+        sourceFileBuffer.Add(sourceFileKey, new NonDemBufferedCityObject(normalizedCityObject, policy));
         BakedInputCityObjectCount++;
         return ValueTask.FromResult(new BufferedCityObjectBufferResult(Buffered: true, readyCityObjects));
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitter.cs
@@ -39,11 +39,7 @@ internal sealed class NonDemSourceFileBakeEmitter(
                      StringComparer.Ordinal))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            NonDemCityObjectBakeCandidate? candidate = await candidateFactory.CreateAsync(bufferedCityObject, cancellationToken);
-            if (candidate is null)
-            {
-                continue;
-            }
+            NonDemCityObjectBakeCandidate candidate = await candidateFactory.CreateAsync(bufferedCityObject, cancellationToken);
 
             if (candidate.AtlasEntries.Count == 0 && !batchFitPolicy.RequiresBakeEmission(candidate))
             {

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeEmitterFactory.cs
@@ -15,7 +15,7 @@ internal sealed class NonDemSourceFileBakeEmitterFactory(
             atlasBudget.TilePaddingPixels);
         return new NonDemSourceFileBakeEmitter(
             new NonDemCityObjectBakeCandidateFactory(
-                new NonDemAtlasOrPreservedEntryFactory(textureImageLoader, atlasBudget.EffectiveMaxAtlasTextureEdge)),
+                new NonDemBakeEntryFactory(textureImageLoader, atlasBudget.EffectiveMaxAtlasTextureEdge)),
             new NonDemCityObjectBakeAssembler(
                 layoutFactory,
                 new NonDemAtlasImageRenderer(atlasBudget.TilePaddingPixels),

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCityObjectPreparation.cs
@@ -211,7 +211,7 @@ internal static class ResoniteCityObjectPreparation
 
     public static ITextureImportSource PrepareTerrainGridDisplacementTexture(ResoniteTerrainGridGeometry geometry)
     {
-        return TextureImportSourceFactory.CreateGeneratedImage(
+        return TextureImportSourceFactory.CreateGeneratedRgbaFloat32Image(
             cancellationToken =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -223,7 +223,7 @@ internal static class ResoniteCityObjectPreparation
             estimatedByteLength: checked((long)geometry.Width * geometry.Height * 4L * sizeof(float)));
     }
 
-    private static RawTexturePayload CreateTerrainGridDisplacementPayload(ResoniteTerrainGridGeometry geometry)
+    private static RgbaFloat32RawTexturePayload CreateTerrainGridDisplacementPayload(ResoniteTerrainGridGeometry geometry)
     {
         float[] rawPixels = new float[geometry.Width * geometry.Height * 4];
         double heightRange = Math.Max(geometry.MaxHeight - geometry.MinHeight, 0.0);
@@ -249,12 +249,11 @@ internal static class ResoniteCityObjectPreparation
 
         byte[] rawBytes = new byte[rawPixels.Length * sizeof(float)];
         Buffer.BlockCopy(rawPixels, 0, rawBytes, 0, rawBytes.Length);
-        return new RawTexturePayload(
+        return new RgbaFloat32RawTexturePayload(
             geometry.Width,
             geometry.Height,
-            ColorProfile: null,
-            rawBytes,
-            RawTexturePayloadFormat.RgbaFloat32);
+            colorProfile: null,
+            rawBytes);
     }
 
     public static string CreateTriangleMeshDiagnosticSummary(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteDynamicMaterialUvNormalizer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteDynamicMaterialUvNormalizer.cs
@@ -14,7 +14,9 @@ public static class ResoniteDynamicMaterialUvNormalizer
 
         return material.MaterialType == ResoniteMaterialType.Standard
             && material.Projection == ResoniteMaterialProjection.Uv
-            && material.AssetScope != ResoniteMaterialAssetScope.Common
+            && (material.AssetScope != ResoniteMaterialAssetScope.Common
+                || material.TextureSourceKind == ResoniteTextureSourceKind.Dataset
+                || ResoniteSceneMaterialConventions.ShouldDemoteBundledCommonMaterial(material))
             && HasNormalizableTextureTransform(material);
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
@@ -25,12 +25,8 @@ internal sealed class ResoniteLiveSendConnectionInitializer : IResoniteLiveSendC
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(request.SetupInfo);
-        ArgumentNullException.ThrowIfNull(request.ConnectionRequest);
         ArgumentNullException.ThrowIfNull(runPlan);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
 
         ReportProgress(
             context,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendConnectionInitializer.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Logging;
-using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
@@ -27,7 +26,7 @@ internal sealed class ResoniteLiveSendConnectionInitializer : IResoniteLiveSendC
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(request.SetupInfo);
-        ArgumentNullException.ThrowIfNull(request.NormalizedRequest);
+        ArgumentNullException.ThrowIfNull(request.ConnectionRequest);
         ArgumentNullException.ThrowIfNull(runPlan);
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(context.Endpoint);
@@ -47,9 +46,7 @@ internal sealed class ResoniteLiveSendConnectionInitializer : IResoniteLiveSendC
                 $"Connecting ResoniteLink connection pool to {context.Endpoint} "
                 + $"with {request.ConnectionCount} available routed connection(s)."));
         await context.ClientSession.EnsureConnectedAsync(
-            new LiveSendConnectionRequest(
-                request.NormalizedRequest.Dataset,
-                request.NormalizedRequest.MeshCode),
+            request.ConnectionRequest,
             cancellationToken);
         connectionStopwatch.Stop();
         ReportProgress(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendFinalizer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendFinalizer.cs
@@ -141,8 +141,29 @@ internal sealed class ResoniteLiveSendFinalizer(
     }
 }
 
-internal sealed record LiveSendFinalizationContext(
-    Uri Endpoint,
-    LiveSendEnqueueContext EnqueueContext,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
+internal sealed record LiveSendFinalizationContext
+{
+    public LiveSendFinalizationContext(
+        Uri Endpoint,
+        LiveSendEnqueueContext EnqueueContext,
+        ResoniteLinkSendDiagnostics Diagnostics,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(Endpoint);
+        ArgumentNullException.ThrowIfNull(EnqueueContext);
+        ArgumentNullException.ThrowIfNull(Diagnostics);
+
+        this.Endpoint = Endpoint;
+        this.EnqueueContext = EnqueueContext;
+        this.Diagnostics = Diagnostics;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public Uri Endpoint { get; }
+
+    public LiveSendEnqueueContext EnqueueContext { get; }
+
+    public ResoniteLinkSendDiagnostics Diagnostics { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendPhaseContextFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendPhaseContextFactory.cs
@@ -18,9 +18,6 @@ internal sealed class ResoniteLiveSendPhaseContextFactory : IResoniteLiveSendPha
     public LiveSendRunStartContext CreateRunStartContext(LiveSendRunExecutionContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
 
         return new LiveSendRunStartContext(
             context.Endpoint,
@@ -32,8 +29,6 @@ internal sealed class ResoniteLiveSendPhaseContextFactory : IResoniteLiveSendPha
     public LiveSendEnqueueContext CreateEnqueueContext(LiveSendRunExecutionContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentOutOfRangeException.ThrowIfLessThan(context.ConnectionCount, 1);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
 
         return new LiveSendEnqueueContext(
             context.ConnectionCount,
@@ -46,8 +41,6 @@ internal sealed class ResoniteLiveSendPhaseContextFactory : IResoniteLiveSendPha
         LiveSendEnqueueContext enqueueContext)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
         ArgumentNullException.ThrowIfNull(enqueueContext);
 
         return new LiveSendFinalizationContext(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunExecutor.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunExecutor.cs
@@ -8,12 +8,37 @@ using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed record LiveSendRunExecutionContext(
-    Uri Endpoint,
-    int ConnectionCount,
-    ILiveSendClientSession ClientSession,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
+internal sealed record LiveSendRunExecutionContext
+{
+    public LiveSendRunExecutionContext(
+        Uri Endpoint,
+        int ConnectionCount,
+        ILiveSendClientSession ClientSession,
+        ResoniteLinkSendDiagnostics Diagnostics,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(Endpoint);
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
+        ArgumentNullException.ThrowIfNull(ClientSession);
+        ArgumentNullException.ThrowIfNull(Diagnostics);
+
+        this.Endpoint = Endpoint;
+        this.ConnectionCount = ConnectionCount;
+        this.ClientSession = ClientSession;
+        this.Diagnostics = Diagnostics;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public Uri Endpoint { get; }
+
+    public int ConnectionCount { get; }
+
+    public ILiveSendClientSession ClientSession { get; }
+
+    public ResoniteLinkSendDiagnostics Diagnostics { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}
 
 internal interface IResoniteLiveSendRunExecutor
 {
@@ -70,10 +95,6 @@ internal sealed class ResoniteLiveSendRunExecutor(
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(objectUnits);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentOutOfRangeException.ThrowIfLessThan(context.ConnectionCount, 1);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
 
         bool completedSuccessfully = false;
         LiveSendRunState? state = null;

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
@@ -38,9 +38,7 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
     {
         ArgumentNullException.ThrowIfNull(runPlan);
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
 
         ReportProgress(
             context,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -7,21 +7,77 @@ using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed record LiveSendRunStartRequest(
-    ResoniteSceneSetupInfo SetupInfo,
-    string WorkRoot,
-    CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials,
-    LiveSendConnectionRequest ConnectionRequest,
-    ResoniteLocalOrigin RequestLocalOrigin,
-    ResoniteImportMemoryProfile MemoryProfile,
-    int ConnectionCount,
-    bool MeshBakeEnabled);
+internal sealed record LiveSendRunStartRequest
+{
+    public LiveSendRunStartRequest(
+        ResoniteSceneSetupInfo SetupInfo,
+        string WorkRoot,
+        CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials,
+        LiveSendConnectionRequest ConnectionRequest,
+        ResoniteLocalOrigin RequestLocalOrigin,
+        ResoniteImportMemoryProfile MemoryProfile,
+        int ConnectionCount,
+        bool MeshBakeEnabled)
+    {
+        ArgumentNullException.ThrowIfNull(SetupInfo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(WorkRoot);
+        ArgumentNullException.ThrowIfNull(CommonMaterials);
+        ArgumentNullException.ThrowIfNull(ConnectionRequest);
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
 
-internal sealed record LiveSendRunStartContext(
-    Uri Endpoint,
-    ILiveSendClientSession ClientSession,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
+        this.SetupInfo = SetupInfo;
+        this.WorkRoot = WorkRoot;
+        this.CommonMaterials = CommonMaterials;
+        this.ConnectionRequest = ConnectionRequest;
+        this.RequestLocalOrigin = RequestLocalOrigin;
+        this.MemoryProfile = MemoryProfile;
+        this.ConnectionCount = ConnectionCount;
+        this.MeshBakeEnabled = MeshBakeEnabled;
+    }
+
+    public ResoniteSceneSetupInfo SetupInfo { get; }
+
+    public string WorkRoot { get; }
+
+    public CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials { get; }
+
+    public LiveSendConnectionRequest ConnectionRequest { get; }
+
+    public ResoniteLocalOrigin RequestLocalOrigin { get; }
+
+    public ResoniteImportMemoryProfile MemoryProfile { get; }
+
+    public int ConnectionCount { get; }
+
+    public bool MeshBakeEnabled { get; }
+}
+
+internal sealed record LiveSendRunStartContext
+{
+    public LiveSendRunStartContext(
+        Uri Endpoint,
+        ILiveSendClientSession ClientSession,
+        ResoniteLinkSendDiagnostics Diagnostics,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(Endpoint);
+        ArgumentNullException.ThrowIfNull(ClientSession);
+        ArgumentNullException.ThrowIfNull(Diagnostics);
+
+        this.Endpoint = Endpoint;
+        this.ClientSession = ClientSession;
+        this.Diagnostics = Diagnostics;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public Uri Endpoint { get; }
+
+    public ILiveSendClientSession ClientSession { get; }
+
+    public ResoniteLinkSendDiagnostics Diagnostics { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}
 
 internal interface IResoniteLiveSendRunStarter
 {
@@ -45,13 +101,6 @@ internal sealed class ResoniteLiveSendRunStarter(
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(request.SetupInfo);
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkRoot);
-        ArgumentNullException.ThrowIfNull(request.CommonMaterials);
-        ArgumentNullException.ThrowIfNull(request.ConnectionRequest);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
 
         LiveSendRunPlan runPlan = runPlanFactory.Create(
             request.SetupInfo,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunStarter.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
-using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -12,7 +11,7 @@ internal sealed record LiveSendRunStartRequest(
     ResoniteSceneSetupInfo SetupInfo,
     string WorkRoot,
     CommonMaterialCatalog<DefaultCommonMaterialMember> CommonMaterials,
-    PlateauImportRequest NormalizedRequest,
+    LiveSendConnectionRequest ConnectionRequest,
     ResoniteLocalOrigin RequestLocalOrigin,
     ResoniteImportMemoryProfile MemoryProfile,
     int ConnectionCount,
@@ -49,7 +48,7 @@ internal sealed class ResoniteLiveSendRunStarter(
         ArgumentNullException.ThrowIfNull(request.SetupInfo);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.WorkRoot);
         ArgumentNullException.ThrowIfNull(request.CommonMaterials);
-        ArgumentNullException.ThrowIfNull(request.NormalizedRequest);
+        ArgumentNullException.ThrowIfNull(request.ConnectionRequest);
         ArgumentNullException.ThrowIfNull(context.Endpoint);
         ArgumentNullException.ThrowIfNull(context.ClientSession);
         ArgumentNullException.ThrowIfNull(context.Diagnostics);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendStartRequestFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendStartRequestFactory.cs
@@ -1,6 +1,7 @@
 using System;
 
 using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
@@ -29,7 +30,7 @@ internal sealed class ResoniteLiveSendStartRequestFactory : IResoniteLiveSendSta
             CreateSceneSetupInfo(request),
             request.WorkRoot,
             request.CommonMaterials,
-            plan.NormalizedRequest,
+            new LiveSendConnectionRequest(request.Metadata.Request.Dataset, request.Metadata.Request.MeshCode),
             CreateLocalOrigin(request.Metadata.GeodeticOrigin),
             memoryProfile,
             connectionCount,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
@@ -6,10 +6,28 @@ using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed record LiveSendWorkerLaunchRequest(
-    LiveSendRunState State,
-    LiveSendQueuePlan QueuePlan,
-    ResoniteImportBudgetProfile ResourceBudget);
+internal sealed record LiveSendWorkerLaunchRequest
+{
+    public LiveSendWorkerLaunchRequest(
+        LiveSendRunState State,
+        LiveSendQueuePlan QueuePlan,
+        ResoniteImportBudgetProfile ResourceBudget)
+    {
+        ArgumentNullException.ThrowIfNull(State);
+        ArgumentNullException.ThrowIfNull(QueuePlan);
+        ArgumentNullException.ThrowIfNull(ResourceBudget);
+
+        this.State = State;
+        this.QueuePlan = QueuePlan;
+        this.ResourceBudget = ResourceBudget;
+    }
+
+    public LiveSendRunState State { get; }
+
+    public LiveSendQueuePlan QueuePlan { get; }
+
+    public ResoniteImportBudgetProfile ResourceBudget { get; }
+}
 
 internal interface IResoniteLiveSendWorkerLauncher
 {
@@ -29,15 +47,8 @@ internal sealed class ResoniteLiveSendWorkerLauncher(
         LiveSendRunStartContext context)
     {
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(request.State);
-        ArgumentNullException.ThrowIfNull(request.QueuePlan);
-        ArgumentNullException.ThrowIfNull(request.ResourceBudget);
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(context.Endpoint);
-        ArgumentNullException.ThrowIfNull(context.ClientSession);
-        ArgumentNullException.ThrowIfNull(context.Diagnostics);
         int connectionCount = request.QueuePlan.ConnectionCount;
-        ArgumentOutOfRangeException.ThrowIfLessThan(connectionCount, 1);
 
         ReportProgress(
             context,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialBinding.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialBinding.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using PlateauResoniteLink.Application.Importing;
@@ -13,15 +14,76 @@ public sealed record ResoniteMaterialBinding(
     ResoniteMaterialProjection Projection,
     ResoniteMaterialDepthOffset? DepthOffset,
     IReadOnlyList<int> SubmeshIndices,
+    ResoniteMaterialAssetBinding AssetBinding,
     ResoniteFloat2? TextureScale = null,
     string? Family = null,
     ResoniteFloat2? TextureOffset = null,
-    ResoniteMaterialAssetScope AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped,
     TerrainOverlayMaterialBinding? TerrainOverlayMaterial = null,
-    int? BundledVariantIndex = null,
-    DefaultCommonMaterialMember? CommonMaterial = null)
+    int? BundledVariantIndex = null)
 {
     public TerrainTextureOverlay? TerrainOverlay => TerrainOverlayMaterial?.Overlay;
 
     public string? TerrainMeshCode => TerrainOverlayMaterial?.MeshCode.Value;
+
+    public ResoniteMaterialAssetScope AssetScope => AssetBinding.AssetScope;
+
+    public DefaultCommonMaterialMember? CommonMaterial => AssetBinding.CommonMaterial;
+}
+
+public abstract record ResoniteMaterialAssetBinding
+{
+    private ResoniteMaterialAssetBinding()
+    {
+    }
+
+    public static ResoniteMaterialAssetBinding Presentation { get; } = new PresentationMaterialAssetBinding();
+
+    public static ResoniteMaterialAssetBinding Shared { get; } = new SharedMaterialAssetBinding();
+
+    public static ResoniteMaterialAssetBinding PresentationCommon(DefaultCommonMaterialMember commonMaterial)
+        => new PresentationCommonMaterialAssetBinding(commonMaterial);
+
+    public static ResoniteMaterialAssetBinding SharedCommon(DefaultCommonMaterialMember commonMaterial)
+        => new SharedCommonMaterialAssetBinding(commonMaterial);
+
+    public ResoniteMaterialAssetScope AssetScope => this is SharedMaterialAssetBinding or SharedCommonMaterialAssetBinding
+        ? ResoniteMaterialAssetScope.Common
+        : ResoniteMaterialAssetScope.PresentationSlotScoped;
+
+    public DefaultCommonMaterialMember? CommonMaterial => this is ICommonMaterialAssetBinding commonBinding
+        ? commonBinding.Member
+        : null;
+
+    public bool IsSharedCommon => this is SharedCommonMaterialAssetBinding;
+
+    private interface ICommonMaterialAssetBinding
+    {
+        DefaultCommonMaterialMember Member { get; }
+    }
+
+    private sealed record PresentationMaterialAssetBinding : ResoniteMaterialAssetBinding;
+
+    private sealed record SharedMaterialAssetBinding : ResoniteMaterialAssetBinding;
+
+    private sealed record PresentationCommonMaterialAssetBinding : ResoniteMaterialAssetBinding, ICommonMaterialAssetBinding
+    {
+        public PresentationCommonMaterialAssetBinding(DefaultCommonMaterialMember commonMaterial)
+        {
+            ArgumentNullException.ThrowIfNull(commonMaterial);
+            Member = commonMaterial;
+        }
+
+        public DefaultCommonMaterialMember Member { get; }
+    }
+
+    private sealed record SharedCommonMaterialAssetBinding : ResoniteMaterialAssetBinding, ICommonMaterialAssetBinding
+    {
+        public SharedCommonMaterialAssetBinding(DefaultCommonMaterialMember commonMaterial)
+        {
+            ArgumentNullException.ThrowIfNull(commonMaterial);
+            Member = commonMaterial;
+        }
+
+        public DefaultCommonMaterialMember Member { get; }
+    }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectEnqueuer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectEnqueuer.cs
@@ -218,7 +218,24 @@ internal sealed class ResoniteQueuedCityObjectEnqueuer : IResoniteQueuedCityObje
     }
 }
 
-internal sealed record LiveSendEnqueueContext(
-    int ConnectionCount,
-    Func<IResoniteLinkClient> GetRoutedClient,
-    Action<string>? ProgressReporter);
+internal sealed record LiveSendEnqueueContext
+{
+    public LiveSendEnqueueContext(
+        int ConnectionCount,
+        Func<IResoniteLinkClient> GetRoutedClient,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
+        ArgumentNullException.ThrowIfNull(GetRoutedClient);
+
+        this.ConnectionCount = ConnectionCount;
+        this.GetRoutedClient = GetRoutedClient;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public int ConnectionCount { get; }
+
+    public Func<IResoniteLinkClient> GetRoutedClient { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectWorker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectWorker.cs
@@ -167,9 +167,34 @@ internal sealed class ResoniteQueuedCityObjectWorker(
     }
 }
 
-internal sealed record LiveSendWorkerContext(
-    Uri Endpoint,
-    int ConnectionCount,
-    Func<IResoniteLinkClient> GetRoutedClient,
-    ResoniteLinkSendDiagnostics Diagnostics,
-    Action<string>? ProgressReporter);
+internal sealed record LiveSendWorkerContext
+{
+    public LiveSendWorkerContext(
+        Uri Endpoint,
+        int ConnectionCount,
+        Func<IResoniteLinkClient> GetRoutedClient,
+        ResoniteLinkSendDiagnostics Diagnostics,
+        Action<string>? ProgressReporter)
+    {
+        ArgumentNullException.ThrowIfNull(Endpoint);
+        ArgumentOutOfRangeException.ThrowIfLessThan(ConnectionCount, 1);
+        ArgumentNullException.ThrowIfNull(GetRoutedClient);
+        ArgumentNullException.ThrowIfNull(Diagnostics);
+
+        this.Endpoint = Endpoint;
+        this.ConnectionCount = ConnectionCount;
+        this.GetRoutedClient = GetRoutedClient;
+        this.Diagnostics = Diagnostics;
+        this.ProgressReporter = ProgressReporter;
+    }
+
+    public Uri Endpoint { get; }
+
+    public int ConnectionCount { get; }
+
+    public Func<IResoniteLinkClient> GetRoutedClient { get; }
+
+    public ResoniteLinkSendDiagnostics Diagnostics { get; }
+
+    public Action<string>? ProgressReporter { get; }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
@@ -167,7 +167,7 @@ internal sealed class ResoniteQueuedTexturePreparer(
         {
             TerrainTextureGeoReferencedRasterSource rasterSource => string.Create(
                 CultureInfo.InvariantCulture,
-                $"GeoTIFF(source='{rasterSource.ContentSource.Description}', crs='{rasterSource.Metadata?.CoordinateSystemIdentifier ?? "unknown"}')"),
+                $"Geo-referenced raster(source='{rasterSource.ContentSource.Description}', crs='{rasterSource.Metadata.CoordinateSystemIdentifier}')"),
             TerrainTextureTileSource tileSource when IsGsiFallbackSource(tileSource) => string.Create(
                 CultureInfo.InvariantCulture,
                 $"GSI seamless photo tile(z={tileSource.ZoomLevel})"),

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedTexturePreparer.cs
@@ -89,7 +89,7 @@ internal sealed class ResoniteQueuedTexturePreparer(
         GeneratedTerrainTexture terrainTexture = await terrainTextureAssetGenerator.EnsureTextureAsync(
             terrainTextureOverlay,
             cancellationToken);
-        TerrainTextureSource[] usedSources = GetTrackedTerrainTextureSources(terrainTexture, terrainTextureOverlay);
+        TerrainTextureSource[] usedSources = GetTrackedTerrainTextureSources(terrainTexture);
         foreach (TerrainTextureSource usedSource in usedSources)
         {
             int useCount = state.DemSourceUseCounts.AddOrUpdate(
@@ -119,20 +119,11 @@ internal sealed class ResoniteQueuedTexturePreparer(
     }
 
     private static TerrainTextureSource[] GetTrackedTerrainTextureSources(
-        GeneratedTerrainTexture terrainTexture,
-        TerrainTextureOverlay terrainTextureOverlay)
+        GeneratedTerrainTexture terrainTexture)
     {
-        if (terrainTexture.UsedSources is { Count: > 0 })
-        {
-            return terrainTexture.UsedSources
-                .Distinct()
-                .ToArray();
-        }
-
-        return
-        [
-            terrainTexture.UsedSource ?? terrainTextureOverlay.PrimarySource,
-        ];
+        return terrainTexture.UsedSources
+            .Distinct()
+            .ToArray();
     }
 
     private async Task EnsureGsiFallbackLicenseAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -118,86 +118,70 @@ internal sealed record PlannedDynamicTerrainMeshBundle(
     public PlannedWorldElementReference InitialMeshTarget => GridMeshTarget;
 }
 
-internal readonly record struct PlannedSlotTargetReference
+internal abstract record PlannedSlotTargetReference
 {
-    private PlannedSlotTargetReference(ResoniteSlotLocator? canonical, BatchPlanSlotLocator? planned)
+    private PlannedSlotTargetReference()
     {
-        Canonical = canonical;
-        Planned = planned;
     }
-
-    public ResoniteSlotLocator? Canonical { get; }
-
-    public BatchPlanSlotLocator? Planned { get; }
-
-    public bool IsCanonical => Canonical is not null;
-
-    public bool IsPlanned => Planned is not null;
 
     public static PlannedSlotTargetReference CanonicalSlot(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedSlotTargetReference(locator, null);
+        return new CanonicalSlotTarget(locator);
     }
 
     public static PlannedSlotTargetReference PlannedSlot(BatchPlanSlotLocator locator)
     {
-        return new PlannedSlotTargetReference(null, locator);
+        return new PlannedSlotTarget(locator);
     }
+
+    internal sealed record CanonicalSlotTarget(ResoniteSlotLocator Locator) : PlannedSlotTargetReference;
+
+    internal sealed record PlannedSlotTarget(BatchPlanSlotLocator Locator) : PlannedSlotTargetReference;
 }
 
-internal readonly record struct PlannedWorldElementReference
+internal abstract record PlannedWorldElementReference
 {
-    private PlannedWorldElementReference(
-        ResoniteSlotLocator? canonicalSlot,
-        ResoniteComponentLocator? canonicalComponent,
-        BatchPlanSlotLocator? plannedSlot,
-        BatchPlanComponentLocator? plannedComponent,
-        BatchPlanFieldLocator? plannedField)
+    private PlannedWorldElementReference()
     {
-        CanonicalSlot = canonicalSlot;
-        CanonicalComponent = canonicalComponent;
-        PlannedSlot = plannedSlot;
-        PlannedComponent = plannedComponent;
-        PlannedField = plannedField;
     }
-
-    public ResoniteSlotLocator? CanonicalSlot { get; }
-
-    public ResoniteComponentLocator? CanonicalComponent { get; }
-
-    public BatchPlanSlotLocator? PlannedSlot { get; }
-
-    public BatchPlanComponentLocator? PlannedComponent { get; }
-
-    public BatchPlanFieldLocator? PlannedField { get; }
 
     public static PlannedWorldElementReference Canonical(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedWorldElementReference(locator, null, null, null, null);
+        return new CanonicalSlotElement(locator);
     }
 
     public static PlannedWorldElementReference Canonical(ResoniteComponentLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
-        return new PlannedWorldElementReference(null, locator, null, null, null);
+        return new CanonicalComponentElement(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanSlotLocator locator)
     {
-        return new PlannedWorldElementReference(null, null, locator, null, null);
+        return new PlannedSlotElement(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanComponentLocator locator)
     {
-        return new PlannedWorldElementReference(null, null, null, locator, null);
+        return new PlannedComponentElement(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanFieldLocator locator)
     {
-        return new PlannedWorldElementReference(null, null, null, null, locator);
+        return new PlannedFieldElement(locator);
     }
+
+    internal sealed record CanonicalSlotElement(ResoniteSlotLocator Locator) : PlannedWorldElementReference;
+
+    internal sealed record CanonicalComponentElement(ResoniteComponentLocator Locator) : PlannedWorldElementReference;
+
+    internal sealed record PlannedSlotElement(BatchPlanSlotLocator Locator) : PlannedWorldElementReference;
+
+    internal sealed record PlannedComponentElement(BatchPlanComponentLocator Locator) : PlannedWorldElementReference;
+
+    internal sealed record PlannedFieldElement(BatchPlanFieldLocator Locator) : PlannedWorldElementReference;
 }
 
 internal abstract record PlannedMember;
@@ -296,8 +280,126 @@ internal sealed record PlannedBatchComponentEmission(
     string ComponentType,
     IReadOnlyDictionary<string, PlannedMember> Members);
 
-internal sealed record PlannedBatchEmission(
-    IReadOnlyList<PlannedBatchSlotEmission> SlotEmissions,
-    IReadOnlyList<PlannedBatchComponentEmission> ComponentEmissions,
-    IReadOnlyList<BatchPlanSlotLocator> SlotResolutionTargets,
-    IReadOnlyList<BatchPlanComponentLocator> ComponentResolutionTargets);
+internal sealed record PlannedBatchEmission
+{
+    private PlannedBatchEmission(
+        IReadOnlyList<PlannedBatchSlotEmission> slotEmissions,
+        IReadOnlyList<PlannedBatchComponentEmission> componentEmissions,
+        IReadOnlyList<BatchPlanSlotLocator> slotResolutionTargets,
+        IReadOnlyList<BatchPlanComponentLocator> componentResolutionTargets)
+    {
+        SlotEmissions = slotEmissions;
+        ComponentEmissions = componentEmissions;
+        SlotResolutionTargets = slotResolutionTargets;
+        ComponentResolutionTargets = componentResolutionTargets;
+    }
+
+    public IReadOnlyList<PlannedBatchSlotEmission> SlotEmissions { get; }
+
+    public IReadOnlyList<PlannedBatchComponentEmission> ComponentEmissions { get; }
+
+    public IReadOnlyList<BatchPlanSlotLocator> SlotResolutionTargets { get; }
+
+    public IReadOnlyList<BatchPlanComponentLocator> ComponentResolutionTargets { get; }
+
+    public static PlannedBatchEmission Create(
+        IReadOnlyList<PlannedBatchSlotEmission> slotEmissions,
+        IReadOnlyList<PlannedBatchComponentEmission> componentEmissions,
+        IReadOnlyList<BatchPlanSlotLocator> slotResolutionTargets,
+        IReadOnlyList<BatchPlanComponentLocator> componentResolutionTargets)
+    {
+        ValidatePlannedReferences(slotEmissions, componentEmissions, slotResolutionTargets, componentResolutionTargets);
+        return new PlannedBatchEmission(slotEmissions, componentEmissions, slotResolutionTargets, componentResolutionTargets);
+    }
+
+    private static void ValidatePlannedReferences(
+        IReadOnlyList<PlannedBatchSlotEmission> slotEmissions,
+        IReadOnlyList<PlannedBatchComponentEmission> componentEmissions,
+        IReadOnlyList<BatchPlanSlotLocator> slotResolutionTargets,
+        IReadOnlyList<BatchPlanComponentLocator> componentResolutionTargets)
+    {
+        HashSet<BatchPlanSlotLocator> emittedSlots = [];
+        foreach (PlannedBatchSlotEmission slotEmission in slotEmissions)
+        {
+            if (slotEmission.ParentTarget is PlannedSlotTargetReference.PlannedSlotTarget plannedParent
+                && !emittedSlots.Contains(plannedParent.Locator))
+            {
+                throw new InvalidOperationException("Planned slot parent target must reference an earlier planned slot.");
+            }
+
+            emittedSlots.Add(slotEmission.Identity);
+        }
+
+        foreach (BatchPlanSlotLocator slotResolutionTarget in slotResolutionTargets)
+        {
+            if (!emittedSlots.Contains(slotResolutionTarget))
+            {
+                throw new InvalidOperationException("Planned slot resolution target must reference an emitted planned slot.");
+            }
+        }
+
+        HashSet<BatchPlanComponentLocator> emittedComponents = [];
+        foreach (PlannedBatchComponentEmission componentEmission in componentEmissions)
+        {
+            if (componentEmission.ContainerTarget is PlannedSlotTargetReference.PlannedSlotTarget plannedContainer
+                && !emittedSlots.Contains(plannedContainer.Locator))
+            {
+                throw new InvalidOperationException("Planned component container target must reference an emitted planned slot.");
+            }
+
+            foreach (PlannedWorldElementReference target in EnumerateMemberTargets(componentEmission.Members.Values))
+            {
+                ValidateWorldElementReference(target, emittedSlots, emittedComponents);
+            }
+
+            emittedComponents.Add(componentEmission.Identity);
+        }
+
+        foreach (BatchPlanComponentLocator componentResolutionTarget in componentResolutionTargets)
+        {
+            if (!emittedComponents.Contains(componentResolutionTarget))
+            {
+                throw new InvalidOperationException("Planned component resolution target must reference an emitted planned component.");
+            }
+        }
+    }
+
+    private static void ValidateWorldElementReference(
+        PlannedWorldElementReference target,
+        HashSet<BatchPlanSlotLocator> emittedSlots,
+        HashSet<BatchPlanComponentLocator> emittedComponents)
+    {
+        switch (target)
+        {
+            case PlannedWorldElementReference.PlannedSlotElement plannedSlot
+                when !emittedSlots.Contains(plannedSlot.Locator):
+                throw new InvalidOperationException("Planned world element target must reference an emitted planned slot.");
+            case PlannedWorldElementReference.PlannedComponentElement plannedComponent
+                when !emittedComponents.Contains(plannedComponent.Locator):
+                throw new InvalidOperationException("Planned world element target must reference an earlier planned component.");
+        }
+    }
+
+    private static IEnumerable<PlannedWorldElementReference> EnumerateMemberTargets(IEnumerable<PlannedMember> members)
+    {
+        foreach (PlannedMember member in members)
+        {
+            switch (member)
+            {
+                case PlannedElementReferenceMember reference:
+                    yield return reference.Target;
+                    break;
+                case PlannedAddressableReferenceMember reference:
+                    yield return reference.Target;
+                    break;
+                case PlannedSyncListMember syncList:
+                    foreach (PlannedWorldElementReference nestedTarget in EnumerateMemberTargets(syncList.Elements))
+                    {
+                        yield return nestedTarget;
+                    }
+
+                    break;
+            }
+        }
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -124,6 +124,10 @@ internal abstract record PlannedSlotTargetReference
     {
     }
 
+    public abstract T Match<T>(
+        Func<ResoniteSlotLocator, T> canonicalSlot,
+        Func<BatchPlanSlotLocator, T> plannedSlot);
+
     public static PlannedSlotTargetReference CanonicalSlot(ResoniteSlotLocator locator)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(locator.Value);
@@ -132,12 +136,28 @@ internal abstract record PlannedSlotTargetReference
 
     public static PlannedSlotTargetReference PlannedSlot(BatchPlanSlotLocator locator)
     {
-        return new PlannedSlotTarget(locator);
+        return new BatchSlotTarget(locator);
     }
 
-    internal sealed record CanonicalSlotTarget(ResoniteSlotLocator Locator) : PlannedSlotTargetReference;
+    internal sealed record CanonicalSlotTarget(ResoniteSlotLocator Locator) : PlannedSlotTargetReference
+    {
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<BatchPlanSlotLocator, T> plannedSlot)
+        {
+            return canonicalSlot(Locator);
+        }
+    }
 
-    internal sealed record PlannedSlotTarget(BatchPlanSlotLocator Locator) : PlannedSlotTargetReference;
+    internal sealed record BatchSlotTarget(BatchPlanSlotLocator Locator) : PlannedSlotTargetReference
+    {
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<BatchPlanSlotLocator, T> plannedSlot)
+        {
+            return plannedSlot(Locator);
+        }
+    }
 }
 
 internal abstract record PlannedWorldElementReference
@@ -145,6 +165,13 @@ internal abstract record PlannedWorldElementReference
     private PlannedWorldElementReference()
     {
     }
+
+    public abstract T Match<T>(
+        Func<ResoniteSlotLocator, T> canonicalSlot,
+        Func<ResoniteComponentLocator, T> canonicalComponent,
+        Func<BatchPlanSlotLocator, T> plannedSlot,
+        Func<BatchPlanComponentLocator, T> plannedComponent,
+        Func<BatchPlanFieldLocator, T> plannedField);
 
     public static PlannedWorldElementReference Canonical(ResoniteSlotLocator locator)
     {
@@ -160,74 +187,243 @@ internal abstract record PlannedWorldElementReference
 
     public static PlannedWorldElementReference Planned(BatchPlanSlotLocator locator)
     {
-        return new PlannedSlotElement(locator);
+        return new BatchSlotElement(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanComponentLocator locator)
     {
-        return new PlannedComponentElement(locator);
+        return new BatchComponentElement(locator);
     }
 
     public static PlannedWorldElementReference Planned(BatchPlanFieldLocator locator)
     {
-        return new PlannedFieldElement(locator);
+        return new BatchFieldElement(locator);
     }
 
-    internal sealed record CanonicalSlotElement(ResoniteSlotLocator Locator) : PlannedWorldElementReference;
+    internal sealed record CanonicalSlotElement(ResoniteSlotLocator Locator) : PlannedWorldElementReference
+    {
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<ResoniteComponentLocator, T> canonicalComponent,
+            Func<BatchPlanSlotLocator, T> plannedSlot,
+            Func<BatchPlanComponentLocator, T> plannedComponent,
+            Func<BatchPlanFieldLocator, T> plannedField)
+        {
+            return canonicalSlot(Locator);
+        }
+    }
 
-    internal sealed record CanonicalComponentElement(ResoniteComponentLocator Locator) : PlannedWorldElementReference;
+    internal sealed record CanonicalComponentElement(ResoniteComponentLocator Locator) : PlannedWorldElementReference
+    {
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<ResoniteComponentLocator, T> canonicalComponent,
+            Func<BatchPlanSlotLocator, T> plannedSlot,
+            Func<BatchPlanComponentLocator, T> plannedComponent,
+            Func<BatchPlanFieldLocator, T> plannedField)
+        {
+            return canonicalComponent(Locator);
+        }
+    }
 
-    internal sealed record PlannedSlotElement(BatchPlanSlotLocator Locator) : PlannedWorldElementReference;
+    internal sealed record BatchSlotElement(BatchPlanSlotLocator Locator) : PlannedWorldElementReference
+    {
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<ResoniteComponentLocator, T> canonicalComponent,
+            Func<BatchPlanSlotLocator, T> plannedSlot,
+            Func<BatchPlanComponentLocator, T> plannedComponent,
+            Func<BatchPlanFieldLocator, T> plannedField)
+        {
+            return plannedSlot(Locator);
+        }
+    }
 
-    internal sealed record PlannedComponentElement(BatchPlanComponentLocator Locator) : PlannedWorldElementReference;
+    internal sealed record BatchComponentElement(BatchPlanComponentLocator Locator) : PlannedWorldElementReference
+    {
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<ResoniteComponentLocator, T> canonicalComponent,
+            Func<BatchPlanSlotLocator, T> plannedSlot,
+            Func<BatchPlanComponentLocator, T> plannedComponent,
+            Func<BatchPlanFieldLocator, T> plannedField)
+        {
+            return plannedComponent(Locator);
+        }
+    }
 
-    internal sealed record PlannedFieldElement(BatchPlanFieldLocator Locator) : PlannedWorldElementReference;
+    internal sealed record BatchFieldElement(BatchPlanFieldLocator Locator) : PlannedWorldElementReference
+    {
+        public override T Match<T>(
+            Func<ResoniteSlotLocator, T> canonicalSlot,
+            Func<ResoniteComponentLocator, T> canonicalComponent,
+            Func<BatchPlanSlotLocator, T> plannedSlot,
+            Func<BatchPlanComponentLocator, T> plannedComponent,
+            Func<BatchPlanFieldLocator, T> plannedField)
+        {
+            return plannedField(Locator);
+        }
+    }
 }
 
-internal abstract record PlannedMember;
+internal abstract record PlannedMember
+{
+    private protected PlannedMember()
+    {
+    }
 
-internal sealed record PlannedLiteralMember(Member Value) : PlannedMember;
+    public abstract T Match<T>(
+        Func<Member, T> literal,
+        Func<PlannedWorldElementReference, T> reference,
+        Func<PlannedAddressableFieldMember, T> addressableField,
+        Func<BatchPlanFieldLocator, PlannedWorldElementReference, T> addressableReference,
+        Func<IReadOnlyList<PlannedMember>, T> list);
+}
 
-internal sealed record PlannedElementReferenceMember(PlannedWorldElementReference Target) : PlannedMember;
+internal sealed record PlannedLiteralMember(Member Value) : PlannedMember
+{
+    public override T Match<T>(
+        Func<Member, T> literal,
+        Func<PlannedWorldElementReference, T> reference,
+        Func<PlannedAddressableFieldMember, T> addressableField,
+        Func<BatchPlanFieldLocator, PlannedWorldElementReference, T> addressableReference,
+        Func<IReadOnlyList<PlannedMember>, T> list)
+    {
+        return literal(Value);
+    }
+}
 
-internal sealed record PlannedAddressableFieldMember(BatchPlanFieldLocator Identity, Member Value) : PlannedMember;
+internal sealed record PlannedElementReferenceMember(PlannedWorldElementReference Target) : PlannedMember
+{
+    public override T Match<T>(
+        Func<Member, T> literal,
+        Func<PlannedWorldElementReference, T> reference,
+        Func<PlannedAddressableFieldMember, T> addressableField,
+        Func<BatchPlanFieldLocator, PlannedWorldElementReference, T> addressableReference,
+        Func<IReadOnlyList<PlannedMember>, T> list)
+    {
+        return reference(Target);
+    }
+}
+
+internal abstract record PlannedAddressableFieldMember(BatchPlanFieldLocator Identity) : PlannedMember
+{
+    public abstract Member Value { get; }
+
+    public abstract Member Bind(string fieldId);
+
+    public override T Match<T>(
+        Func<Member, T> literal,
+        Func<PlannedWorldElementReference, T> reference,
+        Func<PlannedAddressableFieldMember, T> addressableField,
+        Func<BatchPlanFieldLocator, PlannedWorldElementReference, T> addressableReference,
+        Func<IReadOnlyList<PlannedMember>, T> list)
+    {
+        return addressableField(this);
+    }
+
+    internal sealed record Int2(BatchPlanFieldLocator Identity, Field_int2 FieldValue)
+        : PlannedAddressableFieldMember(Identity)
+    {
+        public override Member Value => FieldValue;
+
+        public override Member Bind(string fieldId)
+        {
+            return new Field_int2
+            {
+                ID = fieldId,
+                Value = FieldValue.Value,
+            };
+        }
+    }
+
+    internal sealed record Bool(BatchPlanFieldLocator Identity, Field_bool FieldValue)
+        : PlannedAddressableFieldMember(Identity)
+    {
+        public override Member Value => FieldValue;
+
+        public override Member Bind(string fieldId)
+        {
+            return new Field_bool
+            {
+                ID = fieldId,
+                Value = FieldValue.Value,
+            };
+        }
+    }
+
+    internal sealed record Float(BatchPlanFieldLocator Identity, Field_float FieldValue)
+        : PlannedAddressableFieldMember(Identity)
+    {
+        public override Member Value => FieldValue;
+
+        public override Member Bind(string fieldId)
+        {
+            return new Field_float
+            {
+                ID = fieldId,
+                Value = FieldValue.Value,
+            };
+        }
+    }
+}
 
 internal sealed record PlannedAddressableReferenceMember(
     BatchPlanFieldLocator Identity,
     PlannedWorldElementReference Target)
-    : PlannedMember;
+    : PlannedMember
+{
+    public override T Match<T>(
+        Func<Member, T> literal,
+        Func<PlannedWorldElementReference, T> reference,
+        Func<PlannedAddressableFieldMember, T> addressableField,
+        Func<BatchPlanFieldLocator, PlannedWorldElementReference, T> addressableReference,
+        Func<IReadOnlyList<PlannedMember>, T> list)
+    {
+        return addressableReference(Identity, Target);
+    }
+}
 
-internal sealed record PlannedSyncListMember(IReadOnlyList<PlannedMember> Elements) : PlannedMember;
+internal sealed record PlannedSyncListMember(IReadOnlyList<PlannedMember> Elements) : PlannedMember
+{
+    public override T Match<T>(
+        Func<Member, T> literal,
+        Func<PlannedWorldElementReference, T> reference,
+        Func<PlannedAddressableFieldMember, T> addressableField,
+        Func<BatchPlanFieldLocator, PlannedWorldElementReference, T> addressableReference,
+        Func<IReadOnlyList<PlannedMember>, T> list)
+    {
+        return list(Elements);
+    }
+}
 
 internal sealed record PlannedDriverTargetBundle(
     PlannedAddressableFieldMember Field,
     PlannedElementReferenceMember Target,
     PlannedLiteralMember DefaultValue)
 {
-    public static PlannedDriverTargetBundle Create(BatchPlanFieldLocator fieldIdentity, Member defaultValue)
+    public static PlannedDriverTargetBundle Create(BatchPlanFieldLocator fieldIdentity, Field_bool defaultValue)
     {
         ArgumentNullException.ThrowIfNull(defaultValue);
         return new PlannedDriverTargetBundle(
-            new PlannedAddressableFieldMember(fieldIdentity, defaultValue),
+            new PlannedAddressableFieldMember.Bool(fieldIdentity, defaultValue),
             new PlannedElementReferenceMember(PlannedWorldElementReference.Planned(fieldIdentity)),
-            new PlannedLiteralMember(CloneDriverDefaultValue(defaultValue)));
+            new PlannedLiteralMember(new Field_bool
+            {
+                Value = defaultValue.Value,
+            }));
     }
 
-    private static Member CloneDriverDefaultValue(Member value)
+    public static PlannedDriverTargetBundle Create(BatchPlanFieldLocator fieldIdentity, Field_float defaultValue)
     {
-        return value switch
-        {
-            Field_bool field => new Field_bool
+        ArgumentNullException.ThrowIfNull(defaultValue);
+        return new PlannedDriverTargetBundle(
+            new PlannedAddressableFieldMember.Float(fieldIdentity, defaultValue),
+            new PlannedElementReferenceMember(PlannedWorldElementReference.Planned(fieldIdentity)),
+            new PlannedLiteralMember(new Field_float
             {
-                Value = field.Value,
-            },
-            Field_float field => new Field_float
-            {
-                Value = field.Value,
-            },
-            _ => throw new InvalidOperationException(
-                $"Unsupported planned driver default value type '{value.GetType().Name}'."),
-        };
+                Value = defaultValue.Value,
+            }));
     }
 }
 
@@ -244,10 +440,22 @@ internal static class PlannedMembers
         return new PlannedElementReferenceMember(target);
     }
 
-    public static PlannedMember AddressableField(BatchPlanFieldLocator identity, Member value)
+    public static PlannedMember AddressableField(BatchPlanFieldLocator identity, Field_int2 value)
     {
         ArgumentNullException.ThrowIfNull(value);
-        return new PlannedAddressableFieldMember(identity, value);
+        return new PlannedAddressableFieldMember.Int2(identity, value);
+    }
+
+    public static PlannedMember AddressableField(BatchPlanFieldLocator identity, Field_bool value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return new PlannedAddressableFieldMember.Bool(identity, value);
+    }
+
+    public static PlannedMember AddressableField(BatchPlanFieldLocator identity, Field_float value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return new PlannedAddressableFieldMember.Float(identity, value);
     }
 
     public static PlannedMember AddressableReference(BatchPlanFieldLocator identity, PlannedWorldElementReference target)
@@ -321,7 +529,7 @@ internal sealed record PlannedBatchEmission
         HashSet<BatchPlanSlotLocator> emittedSlots = [];
         foreach (PlannedBatchSlotEmission slotEmission in slotEmissions)
         {
-            if (slotEmission.ParentTarget is PlannedSlotTargetReference.PlannedSlotTarget plannedParent
+            if (slotEmission.ParentTarget is PlannedSlotTargetReference.BatchSlotTarget plannedParent
                 && !emittedSlots.Contains(plannedParent.Locator))
             {
                 throw new InvalidOperationException("Planned slot parent target must reference an earlier planned slot.");
@@ -341,7 +549,7 @@ internal sealed record PlannedBatchEmission
         HashSet<BatchPlanComponentLocator> emittedComponents = [];
         foreach (PlannedBatchComponentEmission componentEmission in componentEmissions)
         {
-            if (componentEmission.ContainerTarget is PlannedSlotTargetReference.PlannedSlotTarget plannedContainer
+            if (componentEmission.ContainerTarget is PlannedSlotTargetReference.BatchSlotTarget plannedContainer
                 && !emittedSlots.Contains(plannedContainer.Locator))
             {
                 throw new InvalidOperationException("Planned component container target must reference an emitted planned slot.");
@@ -371,10 +579,10 @@ internal sealed record PlannedBatchEmission
     {
         switch (target)
         {
-            case PlannedWorldElementReference.PlannedSlotElement plannedSlot
+            case PlannedWorldElementReference.BatchSlotElement plannedSlot
                 when !emittedSlots.Contains(plannedSlot.Locator):
                 throw new InvalidOperationException("Planned world element target must reference an emitted planned slot.");
-            case PlannedWorldElementReference.PlannedComponentElement plannedComponent
+            case PlannedWorldElementReference.BatchComponentElement plannedComponent
                 when !emittedComponents.Contains(plannedComponent.Locator):
                 throw new InvalidOperationException("Planned world element target must reference an earlier planned component.");
         }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -24,6 +24,15 @@ internal static class ResoniteSceneMaterialConventions
         TerrainMainTextureOverride,
     }
 
+    internal enum PlannedTextureRole
+    {
+        Albedo,
+        Normal,
+        Height,
+        Metallic,
+        Emission,
+    }
+
     internal readonly record struct TextureSamplingPolicy(
         string? PreferredProfile,
         string? WrapMode);
@@ -118,17 +127,45 @@ internal static class ResoniteSceneMaterialConventions
         return material;
     }
 
-    public static TextureIdentity CreateTextureIdentity(TextureMemberRole role)
+    internal static bool ShouldDemoteBundledCommonMaterial(ResoniteMaterialBinding material)
+    {
+        ArgumentNullException.ThrowIfNull(material);
+
+        return material.AssetScope == ResoniteMaterialAssetScope.Common
+            && material.MaterialType == ResoniteMaterialType.Standard
+            && material.TexturePayload is null
+            && material.TerrainOverlay is null
+            && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
+            && !string.IsNullOrWhiteSpace(material.Family)
+            && (!IsWhiteBaseColor(material.BaseColor)
+                || HasNonDefaultBundledTextureTransform(material)
+                || material.DepthOffset is not null);
+    }
+
+    public static TextureIdentity CreateTextureIdentity(PlannedTextureRole role)
     {
         return new TextureIdentity(role switch
         {
-            TextureMemberRole.Albedo => "albedo",
-            TextureMemberRole.Normal => "normal",
-            TextureMemberRole.Height => "height",
-            TextureMemberRole.Metallic => "metallic",
-            TextureMemberRole.Emission => "emission",
-            _ => throw new InvalidOperationException($"Texture role '{role}' does not have a planned texture identity."),
+            PlannedTextureRole.Albedo => "albedo",
+            PlannedTextureRole.Normal => "normal",
+            PlannedTextureRole.Height => "height",
+            PlannedTextureRole.Metallic => "metallic",
+            PlannedTextureRole.Emission => "emission",
+            _ => throw new InvalidOperationException($"Planned texture role '{role}' is unsupported."),
         });
+    }
+
+    public static TextureMemberRole ToTextureMemberRole(PlannedTextureRole role)
+    {
+        return role switch
+        {
+            PlannedTextureRole.Albedo => TextureMemberRole.Albedo,
+            PlannedTextureRole.Normal => TextureMemberRole.Normal,
+            PlannedTextureRole.Height => TextureMemberRole.Height,
+            PlannedTextureRole.Metallic => TextureMemberRole.Metallic,
+            PlannedTextureRole.Emission => TextureMemberRole.Emission,
+            _ => throw new InvalidOperationException($"Planned texture role '{role}' is unsupported."),
+        };
     }
 
     public static TextureSamplingPolicy GetTextureSamplingPolicy(TextureMemberRole role)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -92,21 +92,16 @@ internal static class ResoniteSceneMaterialConventions
         ArgumentNullException.ThrowIfNull(material);
         material = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
 
-        if (material.AssetScope == ResoniteMaterialAssetScope.Common
-            && material.MaterialType == ResoniteMaterialType.Standard
-            && material.TexturePayload is null
-            && material.TerrainOverlay is null
-            && material.CommonMaterial is null
-            && material.TextureSourceKind == ResoniteTextureSourceKind.Bundled
-            && !string.IsNullOrWhiteSpace(material.Family)
-            && (!IsWhiteBaseColor(material.BaseColor)
-                || HasNonDefaultBundledTextureTransform(material)
-                || material.DepthOffset is not null))
+        if (ShouldDemoteBundledCommonMaterial(material))
         {
-            return material with
+            ResoniteMaterialBinding demotedMaterial = material with
             {
-                AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped,
+                AssetBinding = material.CommonMaterial is { } commonMaterial
+                    ? ResoniteMaterialAssetBinding.PresentationCommon(commonMaterial)
+                    : ResoniteMaterialAssetBinding.Presentation,
             };
+
+            return ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(demotedMaterial);
         }
 
         if (material.AssetScope == ResoniteMaterialAssetScope.PresentationSlotScoped

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
@@ -53,11 +53,12 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
                 cityObject.Materials[materialIndex]);
             material = ResoniteTerrainOverlayMaterialContract.ValidateMaterial(cityObject, materialIndex, material);
             reportMaterialStep($"Creating material {materialIndex + 1}/{cityObject.Materials.Count}.");
-            if (material.CommonMaterial is not null)
+            if (material.CommonMaterial is { } commonMaterial)
             {
                 materialPlanTasks[materialIndex] = PlanSharedCommonRendererMaterialAsync(
                     state,
                     material,
+                    commonMaterial,
                     preparedTextureUrisByPayload,
                     preparedTerrainTextureUrisByOverlay,
                     preparedTerrainTexturePropertyBlockComponentsByMeshCode,
@@ -85,13 +86,14 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
     private static async Task<(PlannedMaterialAsset MaterialAsset, PlannedRendererMaterialBinding RendererBinding)> PlanSharedCommonRendererMaterialAsync(
         LiveSendRunState runState,
         ResoniteMaterialBinding sourceMaterial,
+        DefaultCommonMaterialMember member,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
         IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
         IReadOnlyDictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode,
         CancellationToken cancellationToken)
     {
-        DefaultCommonMaterialMember member = sourceMaterial.CommonMaterial
-            ?? throw new InvalidOperationException("Common renderer material requires a typed common material member.");
+        ArgumentNullException.ThrowIfNull(member);
+
         string familySlotName = ResoniteSceneMaterialConventions.GetCommonMaterialFamilySlotName(
             SceneImportContractMapper.ToInternal(member.CreateBinding([0])));
         if (runState.Materials.CommonMaterialFamilyWarmupTasks.TryGetValue(familySlotName, out Task? familyWarmupTask))

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImageLoader.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImageLoader.cs
@@ -25,14 +25,9 @@ internal sealed class ResoniteTextureImageLoader
         ITextureImportSource textureSource,
         CancellationToken cancellationToken)
     {
-        RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+        Rgba32RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRgba32Async(
             textureSource,
             cancellationToken);
-        if (rawPayload.Format != RawTexturePayloadFormat.Rgba32)
-        {
-            throw new InvalidOperationException(
-                $"Unsupported texture payload format '{rawPayload.Format}' for image loading.");
-        }
 
         return Image.LoadPixelData<Rgba32>(
             rawPayload.Bytes,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTextureImportFactory.cs
@@ -34,12 +34,11 @@ internal static class ResoniteTextureImportFactory
         RawTexturePayload rawPayload = TextureImportSourceFactory.CreateRawPayloadFromImage(
             image,
             colorProfile);
-        return new ResoniteTexturePayload(
+        return new RawRgba32ResoniteTexturePayload(
             image.Width,
             image.Height,
             colorProfile,
             rawPayload.Bytes,
-            identity ?? Guid.NewGuid().ToString("N"),
-            ResoniteTexturePayloadFormat.RawRgba32);
+            identity ?? Guid.NewGuid().ToString("N"));
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteTexturePayload.cs
@@ -5,67 +5,119 @@ using PlateauResoniteLink.Application.Importing;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-public enum ResoniteTexturePayloadFormat
+public abstract class ResoniteTexturePayload
 {
-    RawRgba32,
-    EncodedImage,
+    private protected ResoniteTexturePayload(
+        string? colorProfile,
+        string identity,
+        ITextureImportSource source)
+    {
+        if (string.IsNullOrWhiteSpace(identity))
+        {
+            throw new ArgumentException("Resonite texture payload identity must be provided.", nameof(identity));
+        }
+
+        ColorProfile = colorProfile;
+        Identity = identity;
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+    }
+
+    public string? ColorProfile { get; }
+
+    public string Identity { get; }
+
+    public ITextureImportSource Source { get; }
 }
 
-public sealed record ResoniteTexturePayload
+public sealed class RawRgba32ResoniteTexturePayload : ResoniteTexturePayload
 {
-    public ResoniteTexturePayload(
-        int? width,
-        int? height,
+    public RawRgba32ResoniteTexturePayload(
+        int width,
+        int height,
         string? colorProfile,
         byte[] binaryPayload,
-        string? identity = null,
-        ResoniteTexturePayloadFormat format = ResoniteTexturePayloadFormat.RawRgba32)
-    {
-        Width = width;
-        Height = height;
-        ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(binaryPayload);
-        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
-        Identity = identity;
-        Format = format;
-        Source = TextureImportSourceFactory.CreateInMemory(
+        string? identity = null)
+        : this(
             width,
             height,
             colorProfile,
             binaryPayload,
-            identity ?? Guid.NewGuid().ToString("N"),
-            (TexturePayloadFormat)format);
+            CreateSource(width, height, colorProfile, binaryPayload, identity))
+    {
     }
 
-    public ResoniteTexturePayload(
+    private RawRgba32ResoniteTexturePayload(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        (string Identity, ITextureImportSource Source) source)
+        : base(colorProfile, source.Identity, source.Source)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        Width = width;
+        Height = height;
+        BinaryPayload = ImmutableArray.CreateRange(binaryPayload);
+    }
+
+    public int Width { get; }
+
+    public int Height { get; }
+
+    public ImmutableArray<byte> BinaryPayload { get; }
+
+    private static (string Identity, ITextureImportSource Source) CreateSource(
+        int width,
+        int height,
+        string? colorProfile,
+        byte[] binaryPayload,
+        string? identity)
+    {
+        ArgumentNullException.ThrowIfNull(binaryPayload);
+        string effectiveIdentity = identity ?? Guid.NewGuid().ToString("N");
+        return (
+            effectiveIdentity,
+            TextureImportSourceFactory.CreateInMemoryRaw(
+                width,
+                height,
+                colorProfile,
+                binaryPayload,
+                effectiveIdentity));
+    }
+}
+
+public sealed class EncodedImageResoniteTexturePayload : ResoniteTexturePayload
+{
+    public EncodedImageResoniteTexturePayload(
         int? width,
         int? height,
         string? colorProfile,
         ITextureImportSource source,
-        string? identity = null,
-        ResoniteTexturePayloadFormat format = ResoniteTexturePayloadFormat.EncodedImage)
+        string? identity = null)
+        : this(width, height, colorProfile, CreateSource(source, identity))
+    {
+    }
+
+    private EncodedImageResoniteTexturePayload(
+        int? width,
+        int? height,
+        string? colorProfile,
+        (string Identity, ITextureImportSource Source) source)
+        : base(colorProfile, source.Identity, source.Source)
     {
         Width = width;
         Height = height;
-        ColorProfile = colorProfile;
-        ArgumentNullException.ThrowIfNull(source);
-        BinaryPayload = [];
-        Identity = identity ?? source.Identity;
-        Format = format;
-        Source = source;
     }
 
-    public int? Width { get; init; }
+    public int? Width { get; }
 
-    public int? Height { get; init; }
+    public int? Height { get; }
 
-    public string? ColorProfile { get; init; }
-
-    public ImmutableArray<byte> BinaryPayload { get; init; }
-
-    public string? Identity { get; init; }
-
-    public ResoniteTexturePayloadFormat Format { get; init; }
-
-    public ITextureImportSource Source { get; init; }
+    private static (string Identity, ITextureImportSource Source) CreateSource(
+        ITextureImportSource source,
+        string? identity)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        return (identity ?? source.Identity, source);
+    }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -150,13 +150,22 @@ internal static class SceneImportContractMapper
 
     private static ResoniteTexturePayload ToInternal(TexturePayload payload)
     {
-        return new ResoniteTexturePayload(
-            payload.Width,
-            payload.Height,
-            payload.ColorProfile,
-            payload.Source,
-            payload.Identity,
-            ToInternal(payload.Format));
+        return payload switch
+        {
+            RawRgba32TexturePayload raw => new RawRgba32ResoniteTexturePayload(
+                raw.Width,
+                raw.Height,
+                raw.ColorProfile,
+                raw.BinaryPayload.AsSpan().ToArray(),
+                raw.Identity),
+            EncodedImageTexturePayload encoded => new EncodedImageResoniteTexturePayload(
+                encoded.Width,
+                encoded.Height,
+                encoded.ColorProfile,
+                encoded.Source,
+                encoded.Identity),
+            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.GetType(), "Unsupported texture payload type."),
+        };
     }
 
     private static ResoniteMaterialType ToInternal(MaterialType materialType)
@@ -187,16 +196,6 @@ internal static class SceneImportContractMapper
             MaterialProjection.Uv => ResoniteMaterialProjection.Uv,
             MaterialProjection.Triplanar => ResoniteMaterialProjection.Triplanar,
             _ => throw new ArgumentOutOfRangeException(nameof(projection), projection, "Unsupported material projection."),
-        };
-    }
-
-    private static ResoniteTexturePayloadFormat ToInternal(TexturePayloadFormat format)
-    {
-        return format switch
-        {
-            TexturePayloadFormat.RawRgba32 => ResoniteTexturePayloadFormat.RawRgba32,
-            TexturePayloadFormat.EncodedImage => ResoniteTexturePayloadFormat.EncodedImage,
-            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported texture payload format."),
         };
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -113,10 +113,10 @@ internal static class SceneImportContractMapper
     {
         return new ResoniteMaterialBinding(
             ToInternal(binding.BaseColor),
-            (ResoniteMaterialType)binding.MaterialType,
+            ToInternal(binding.MaterialType),
             binding.TexturePayload is null ? null : ToInternal(binding.TexturePayload),
-            (ResoniteTextureSourceKind)binding.TextureSourceKind,
-            (ResoniteMaterialProjection)binding.Projection,
+            ToInternal(binding.TextureSourceKind),
+            ToInternal(binding.Projection),
             binding.DepthOffset is null ? null : ToInternal(binding.DepthOffset),
             binding.SubmeshIndices,
             binding.TextureScale is null ? null : ToInternal(binding.TextureScale),
@@ -139,7 +139,48 @@ internal static class SceneImportContractMapper
             payload.ColorProfile,
             payload.Source,
             payload.Identity,
-            (ResoniteTexturePayloadFormat)payload.Format);
+            ToInternal(payload.Format));
+    }
+
+    private static ResoniteMaterialType ToInternal(MaterialType materialType)
+    {
+        return materialType switch
+        {
+            MaterialType.Standard => ResoniteMaterialType.Standard,
+            MaterialType.Wireframe => ResoniteMaterialType.Wireframe,
+            MaterialType.VertexColor => ResoniteMaterialType.VertexColor,
+            _ => throw new ArgumentOutOfRangeException(nameof(materialType), materialType, "Unsupported material type."),
+        };
+    }
+
+    private static ResoniteTextureSourceKind ToInternal(TextureSourceKind sourceKind)
+    {
+        return sourceKind switch
+        {
+            TextureSourceKind.Dataset => ResoniteTextureSourceKind.Dataset,
+            TextureSourceKind.Bundled => ResoniteTextureSourceKind.Bundled,
+            _ => throw new ArgumentOutOfRangeException(nameof(sourceKind), sourceKind, "Unsupported texture source kind."),
+        };
+    }
+
+    private static ResoniteMaterialProjection ToInternal(MaterialProjection projection)
+    {
+        return projection switch
+        {
+            MaterialProjection.Uv => ResoniteMaterialProjection.Uv,
+            MaterialProjection.Triplanar => ResoniteMaterialProjection.Triplanar,
+            _ => throw new ArgumentOutOfRangeException(nameof(projection), projection, "Unsupported material projection."),
+        };
+    }
+
+    private static ResoniteTexturePayloadFormat ToInternal(TexturePayloadFormat format)
+    {
+        return format switch
+        {
+            TexturePayloadFormat.RawRgba32 => ResoniteTexturePayloadFormat.RawRgba32,
+            TexturePayloadFormat.EncodedImage => ResoniteTexturePayloadFormat.EncodedImage,
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported texture payload format."),
+        };
     }
 
     private static ResoniteMaterialDepthOffset ToInternal(MaterialDepthOffset value) => new(value.Factor, value.Units);

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -112,23 +112,40 @@ internal static class SceneImportContractMapper
     internal static ResoniteMaterialBinding ToInternal(MaterialBinding binding)
     {
         return new ResoniteMaterialBinding(
-            ToInternal(binding.BaseColor),
-            ToInternal(binding.MaterialType),
-            binding.TexturePayload is null ? null : ToInternal(binding.TexturePayload),
-            ToInternal(binding.TextureSourceKind),
-            ToInternal(binding.Projection),
-            binding.DepthOffset is null ? null : ToInternal(binding.DepthOffset),
-            binding.SubmeshIndices,
-            binding.TextureScale is null ? null : ToInternal(binding.TextureScale),
-            binding.Family,
-            binding.TextureOffset is null ? null : ToInternal(binding.TextureOffset),
-            binding.ReuseScope == MaterialReuseScope.Shared
-                && (binding.TerrainOverlayMaterial is null || binding.CommonMaterial is not null)
-                ? ResoniteMaterialAssetScope.Common
-                : ResoniteMaterialAssetScope.PresentationSlotScoped,
-            binding.TerrainOverlayMaterial,
-            binding.BundledVariantIndex,
-            binding.CommonMaterial);
+            BaseColor: ToInternal(binding.BaseColor),
+            MaterialType: ToInternal(binding.MaterialType),
+            TexturePayload: binding.TexturePayload is null ? null : ToInternal(binding.TexturePayload),
+            TextureSourceKind: ToInternal(binding.TextureSourceKind),
+            Projection: ToInternal(binding.Projection),
+            DepthOffset: binding.DepthOffset is null ? null : ToInternal(binding.DepthOffset),
+            SubmeshIndices: binding.SubmeshIndices,
+            AssetBinding: ToInternalAssetBinding(binding),
+            TextureScale: binding.TextureScale is null ? null : ToInternal(binding.TextureScale),
+            Family: binding.Family,
+            TextureOffset: binding.TextureOffset is null ? null : ToInternal(binding.TextureOffset),
+            TerrainOverlayMaterial: binding.TerrainOverlayMaterial,
+            BundledVariantIndex: binding.BundledVariantIndex);
+    }
+
+    private static ResoniteMaterialAssetBinding ToInternalAssetBinding(MaterialBinding binding)
+    {
+        return binding switch
+        {
+            SharedCommonMaterialBinding { CommonMaterial: { } commonMaterial } =>
+                ResoniteMaterialAssetBinding.SharedCommon(commonMaterial),
+            PresentationCommonMaterialBinding { CommonMaterial: { } commonMaterial } =>
+                ResoniteMaterialAssetBinding.PresentationCommon(commonMaterial),
+            _ when binding.ReuseScope == MaterialReuseScope.Shared
+                && binding.CommonMaterial is { } commonMaterial
+                && (binding.TerrainOverlayMaterial is null || binding.CommonMaterial is not null) =>
+                ResoniteMaterialAssetBinding.SharedCommon(commonMaterial),
+            _ when binding.ReuseScope == MaterialReuseScope.Shared
+                && binding.TerrainOverlayMaterial is null =>
+                ResoniteMaterialAssetBinding.Shared,
+            _ => binding.CommonMaterial is { } commonMaterial
+                ? ResoniteMaterialAssetBinding.PresentationCommon(commonMaterial)
+                : ResoniteMaterialAssetBinding.Presentation,
+        };
     }
 
     private static ResoniteTexturePayload ToInternal(TexturePayload payload)

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -23,26 +23,80 @@ internal interface ITerrainTextureAssetGenerator
         CancellationToken cancellationToken);
 }
 
-internal sealed record GeneratedTerrainTexture(
-    ITextureImportSource TextureSource,
-    TextureUvRect OccupiedUvRect,
-    TerrainTextureSource? UsedSource = null,
-    IReadOnlyList<TerrainTextureSource>? UsedSources = null)
+internal sealed record GeneratedTerrainTexture
 {
     public GeneratedTerrainTexture(
         ITextureImportSource textureSource,
         ResoniteFloat2 canvasScale,
         ResoniteFloat2 canvasOffset,
-        TerrainTextureSource? usedSource = null,
-        IReadOnlyList<TerrainTextureSource>? usedSources = null)
+        TerrainTextureSource usedSource)
         : this(
             textureSource,
             TextureUvRect.FromScaleOffsetValue(
                 new ScalarPair(canvasScale.X, canvasScale.Y),
                 new ScalarPair(canvasOffset.X, canvasOffset.Y)),
-            usedSource,
+            CreateSingleUsedSourceSnapshot(usedSource))
+    {
+    }
+
+    public GeneratedTerrainTexture(
+        ITextureImportSource textureSource,
+        ResoniteFloat2 canvasScale,
+        ResoniteFloat2 canvasOffset,
+        IReadOnlyList<TerrainTextureSource> usedSources)
+        : this(
+            textureSource,
+            TextureUvRect.FromScaleOffsetValue(
+                new ScalarPair(canvasScale.X, canvasScale.Y),
+                new ScalarPair(canvasOffset.X, canvasOffset.Y)),
             usedSources)
     {
+    }
+
+    public GeneratedTerrainTexture(
+        ITextureImportSource textureSource,
+        TextureUvRect occupiedUvRect,
+        IReadOnlyList<TerrainTextureSource> usedSources)
+    {
+        ArgumentNullException.ThrowIfNull(textureSource);
+
+        TerrainTextureSource[] trackedSources = CreateUsedSourceSnapshot(usedSources);
+        if (trackedSources.Length == 0)
+        {
+            throw new ArgumentException("Generated terrain texture must track at least one source.", nameof(usedSources));
+        }
+
+        TextureSource = textureSource;
+        OccupiedUvRect = occupiedUvRect;
+        UsedSources = Array.AsReadOnly(trackedSources);
+    }
+
+    public ITextureImportSource TextureSource { get; }
+
+    public TextureUvRect OccupiedUvRect { get; }
+
+    public TerrainTextureSource UsedSource => UsedSources[0];
+
+    public IReadOnlyList<TerrainTextureSource> UsedSources { get; }
+
+    private static TerrainTextureSource[] CreateSingleUsedSourceSnapshot(TerrainTextureSource usedSource)
+    {
+        ArgumentNullException.ThrowIfNull(usedSource);
+        return [usedSource];
+    }
+
+    private static TerrainTextureSource[] CreateUsedSourceSnapshot(IReadOnlyList<TerrainTextureSource> usedSources)
+    {
+        ArgumentNullException.ThrowIfNull(usedSources);
+
+        TerrainTextureSource[] sources = new TerrainTextureSource[usedSources.Count];
+        for (int index = 0; index < usedSources.Count; index++)
+        {
+            sources[index] = usedSources[index]
+                ?? throw new ArgumentException("Generated terrain texture sources cannot contain null.", nameof(usedSources));
+        }
+
+        return sources.Distinct().ToArray();
     }
 }
 
@@ -79,7 +133,7 @@ internal sealed class TerrainTextureAssetGenerator(
         Image<Rgba32>? composedTexture = null;
         TextureUvRect? composedOccupiedUvRect = null;
         List<TerrainTextureSource> usedSources = [];
-        TerrainTextureSource? usedSource = null;
+        TerrainTextureSource? textureIdentitySource = null;
 
         for (int sourceIndex = 0; sourceIndex < terrainTextureOverlay.Sources.Count; sourceIndex++)
         {
@@ -113,7 +167,7 @@ internal sealed class TerrainTextureAssetGenerator(
                 {
                     composedTexture = image.Clone();
                     composedOccupiedUvRect = sourceImage.OccupiedUvRect;
-                    usedSource = terrainTextureSource;
+                    textureIdentitySource = terrainTextureSource;
                     usedSources.Add(terrainTextureSource);
                 }
                 else
@@ -121,7 +175,7 @@ internal sealed class TerrainTextureAssetGenerator(
                     using Image<Rgba32> resizedImage = ResizeSourceImage(image, composedTexture.Width, composedTexture.Height);
                     if (FillTransparentPixels(composedTexture, resizedImage))
                     {
-                        usedSource = terrainTextureSource;
+                        textureIdentitySource = terrainTextureSource;
                         usedSources.Add(terrainTextureSource);
                     }
                 }
@@ -140,14 +194,15 @@ internal sealed class TerrainTextureAssetGenerator(
 
         using (composedTexture)
         {
-            TerrainTextureSource terrainTextureSource = usedSource ?? terrainTextureOverlay.PrimarySource;
+            TerrainTextureSource terrainTextureSource = textureIdentitySource
+                ?? throw new InvalidOperationException("Generated terrain texture must have at least one rendered source.");
             GeneratedTerrainTexture generatedTexture = CreateGeneratedTexture(
                 composedTexture,
                 terrainTextureOverlay.MaxTextureSize,
                 terrainTextureSource,
                 usedSources,
                 composedOccupiedUvRect);
-            return new CachedTerrainTexture(generatedTexture, terrainTextureSource);
+            return new CachedTerrainTexture(generatedTexture);
         }
     }
 
@@ -264,9 +319,20 @@ internal sealed class TerrainTextureAssetGenerator(
         generatedTexture = new GeneratedTerrainTexture(
             CreateTextureSource(canvasImage, usedSource),
             occupiedUvRect,
-            usedSource,
-            usedSources.Distinct().ToArray());
+            CreateUsedSourcesWithIdentityFirst(usedSource, usedSources));
         return true;
+    }
+
+    private static TerrainTextureSource[] CreateUsedSourcesWithIdentityFirst(
+        TerrainTextureSource identitySource,
+        IReadOnlyList<TerrainTextureSource> usedSources)
+    {
+        return
+        [
+            identitySource,
+            .. usedSources
+                .Where(source => source != identitySource),
+        ];
     }
 
     private static TextureUvRect CreateOccupiedUvRect(
@@ -413,8 +479,6 @@ internal sealed class TerrainTextureAssetGenerator(
             ResoniteTextureColorProfiles.Srgb);
     }
 
-    private sealed record CachedTerrainTexture(
-        GeneratedTerrainTexture GeneratedTexture,
-        TerrainTextureSource UsedSource);
+    private sealed record CachedTerrainTexture(GeneratedTerrainTexture GeneratedTexture);
 
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/TerrainTextureAssetGenerator.cs
@@ -126,6 +126,10 @@ internal sealed class TerrainTextureAssetGenerator(
         return cachedTexture.GeneratedTexture;
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Each non-null TerrainTextureSourceImage is disposed by the using block before the next source is evaluated.")]
     private async Task<CachedTerrainTexture> CreateTextureAsync(
         TerrainTextureOverlay terrainTextureOverlay,
         CancellationToken cancellationToken)
@@ -144,8 +148,8 @@ internal sealed class TerrainTextureAssetGenerator(
                     terrainTextureOverlay,
                     tileSource,
                     cancellationToken),
-                TerrainTextureGeoReferencedRasterSource rasterSource => await TryCreateTextureFromGeoReferencedRasterSourceAsync(
-                    terrainTextureOverlay,
+                TerrainTextureGeoReferencedRasterSource rasterSource => await CreateTextureFromGeoReferencedRasterSourceAsync(
+                    terrainTextureOverlay.GeographicBounds,
                     rasterSource,
                     cancellationToken),
                 _ => null,
@@ -210,45 +214,34 @@ internal sealed class TerrainTextureAssetGenerator(
         "Reliability",
         "CA2000:Dispose objects before losing scope",
         Justification = "The returned source image owns and disposes the cropped raster image.")]
-    private static async Task<TerrainTextureSourceImage?> TryCreateTextureFromGeoReferencedRasterSourceAsync(
-        TerrainTextureOverlay terrainTextureOverlay,
+    private static async Task<TerrainTextureSourceImage?> CreateTextureFromGeoReferencedRasterSourceAsync(
+        GeographicRectangle geographicBounds,
         TerrainTextureGeoReferencedRasterSource rasterSource,
         CancellationToken cancellationToken)
     {
+        Image<Rgba32> sourceImage;
         try
         {
-            GeoReferencedRasterMetadata? metadata = rasterSource.Metadata
-                ?? await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(rasterSource, cancellationToken);
-            if (metadata is null || !metadata.IsUsable)
+            await using Stream sourceStream = await rasterSource.OpenReadAsync(cancellationToken);
+            sourceImage = await Image.LoadAsync<Rgba32>(sourceStream, cancellationToken);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            return null;
+        }
+
+        using (sourceImage)
+        {
+            Image<Rgba32>? cropped = TerrainTextureGeoReferencedRasterCropper.TryCrop(
+                sourceImage,
+                rasterSource.Metadata,
+                geographicBounds);
+            if (cropped is null)
             {
                 return null;
             }
 
-            await using Stream sourceStream = await rasterSource.OpenReadAsync(cancellationToken);
-            using Image<Rgba32> sourceImage = await Image.LoadAsync<Rgba32>(sourceStream, cancellationToken);
-            Image<Rgba32>? cropped = TerrainTextureGeoReferencedRasterCropper.TryCrop(
-                sourceImage,
-                metadata,
-                terrainTextureOverlay.GeographicBounds);
-            return cropped is null
-                ? null
-                : new TerrainTextureSourceImage(cropped, null);
-        }
-        catch (UnknownImageFormatException)
-        {
-            return null;
-        }
-        catch (InvalidImageContentException)
-        {
-            return null;
-        }
-        catch (IOException)
-        {
-            return null;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return null;
+            return new TerrainTextureSourceImage(cropped, null);
         }
     }
 

--- a/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkClient.cs
+++ b/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkClient.cs
@@ -164,12 +164,9 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
         RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
             textureSource,
             cancellationToken);
-        AssetData result = rawPayload.Format switch
-        {
-            RawTexturePayloadFormat.Rgba32 => await ImportRawTextureAsync(rawPayload, cancellationToken),
-            RawTexturePayloadFormat.RgbaFloat32 => await ImportRawHdrTextureAsync(rawPayload, cancellationToken),
-            _ => throw new InvalidOperationException($"Unsupported texture payload format '{rawPayload.Format}'."),
-        };
+        AssetData result = await rawPayload.Match(
+            rgba32 => ImportRawTextureAsync(rgba32, cancellationToken),
+            rgbaFloat32 => ImportRawHdrTextureAsync(rgbaFloat32, cancellationToken));
 
         EnsureSuccess(result, "import texture");
         return result.AssetURL ?? throw new InvalidOperationException("ResoniteLink returned a null texture asset URL.");
@@ -253,7 +250,7 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
             "component");
     }
 
-    private Task<AssetData> ImportRawTextureAsync(RawTexturePayload rawPayload, CancellationToken cancellationToken)
+    private Task<AssetData> ImportRawTextureAsync(Rgba32RawTexturePayload rawPayload, CancellationToken cancellationToken)
     {
         return ExecuteSerializedAsync(
             "import_texture",
@@ -268,7 +265,7 @@ internal sealed class ResoniteLinkClient : IResoniteLinkClient
             cancellationToken);
     }
 
-    private Task<AssetData> ImportRawHdrTextureAsync(RawTexturePayload rawPayload, CancellationToken cancellationToken)
+    private Task<AssetData> ImportRawHdrTextureAsync(RgbaFloat32RawTexturePayload rawPayload, CancellationToken cancellationToken)
     {
         return ExecuteSerializedAsync(
             "import_texture",

--- a/tests/PlateauResoniteLink.Tests/Application/Importing/ResolvedLocalPlateauImportRequestTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/Importing/ResolvedLocalPlateauImportRequestTestFactory.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Tests.Application.Importing;
+
+internal static class ResolvedLocalPlateauImportRequestTestFactory
+{
+    public static ResolvedLocalPlateauImportRequest Create(
+        string cityGmlLocalSourcePath = "C:\\tmp\\plateau",
+        string dataset = "tokyo23ku",
+        string meshCode = "53394525",
+        IReadOnlyList<string>? packageNames = null,
+        string? demTextureLocalSourcePath = null)
+    {
+        ValidatedLocalDatasetLocation? demTextureSource = demTextureLocalSourcePath is null
+            ? null
+            : new ValidatedLocalDatasetLocation(demTextureLocalSourcePath);
+        ValidatedPlateauImportRequest request = CreateValidatedRequest(
+            cityGmlLocalSourcePath,
+            dataset,
+            meshCode,
+            packageNames,
+            demTextureLocalSourcePath);
+        return ResolvedLocalPlateauImportRequest.Create(
+            request,
+            new ValidatedLocalDatasetLocation(cityGmlLocalSourcePath),
+            demTextureSource);
+    }
+
+    public static ValidatedPlateauImportRequest CreateValidatedRequest(
+        string cityGmlLocalSourcePath = "C:\\tmp\\plateau",
+        string dataset = "tokyo23ku",
+        string meshCode = "53394525",
+        IReadOnlyList<string>? packageNames = null,
+        string? demTextureLocalSourcePath = null)
+    {
+        ValidatedLocalDatasetLocation? demTextureSource = demTextureLocalSourcePath is null
+            ? null
+            : new ValidatedLocalDatasetLocation(demTextureLocalSourcePath);
+        return new ValidatedPlateauImportRequest(
+            dataset,
+            meshCode,
+            new Regex($@"\A(?:{Regex.Escape(meshCode)})\z", RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1)),
+            new ValidatedLocalDatasetLocation(cityGmlLocalSourcePath),
+            demTextureSource,
+            packageNames);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Application/LocalCityGmlDocumentReaderTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/LocalCityGmlDocumentReaderTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Tests.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.Application;
 
@@ -24,12 +25,7 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: fixturePath,
-                PackageNames: ["bldg"]
-));
+            CreateResolvedRequest(fixturePath, ["bldg"]));
         ImportedSceneSourceDataset documentSet = readResult.DocumentSet;
 
         Assert.Equal(fixturePath, documentSet.DatasetSource.SourcePath);
@@ -53,12 +49,7 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: datasetSource.SourcePath,
-                PackageNames: ["dem"]
-));
+            CreateResolvedRequest(datasetSource.SourcePath, ["dem"]));
         ImportedSceneSourceDataset documentSet = readResult.DocumentSet;
 
         Assert.Equal(["udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml"], documentSet.RelativeSourceFiles);
@@ -79,12 +70,7 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: fixturePath,
-                PackageNames: ["dem", "tran"]
-));
+            CreateResolvedRequest(fixturePath, ["dem", "tran"]));
 
         GeodeticCoordinate expectedOrigin = MeshCodeBounds.TryParse("53394525")!.GetGeodeticCenter();
         Assert.Equal(["53394525"], readResult.DocumentSet.SelectedMeshCodes);
@@ -102,6 +88,15 @@ public sealed class LocalCityGmlDocumentReaderTests
             Assert.Equal(datasetSource.SourcePath, sourcePath);
             return Task.FromResult(datasetSource);
         }
+    }
+
+    private static ResolvedLocalPlateauImportRequest CreateResolvedRequest(
+        string cityGmlLocalSourcePath,
+        IReadOnlyList<string> packageNames)
+    {
+        return ResolvedLocalPlateauImportRequestTestFactory.Create(
+            cityGmlLocalSourcePath: cityGmlLocalSourcePath,
+            packageNames: packageNames);
     }
 
     private sealed class CountingDatasetContentSource(

--- a/tests/PlateauResoniteLink.Tests/Application/LocalCityGmlDocumentReaderTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/LocalCityGmlDocumentReaderTests.cs
@@ -24,10 +24,10 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new PlateauImportRequest(
+            new ResolvedLocalPlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "53394525",
-                CityGmlSource: DatasetLocation.Local(fixturePath),
+                CityGmlLocalSourcePath: fixturePath,
                 PackageNames: ["bldg"]
 ));
         ImportedSceneSourceDataset documentSet = readResult.DocumentSet;
@@ -53,10 +53,10 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new PlateauImportRequest(
+            new ResolvedLocalPlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "53394525",
-                CityGmlSource: DatasetLocation.Local(datasetSource.SourcePath),
+                CityGmlLocalSourcePath: datasetSource.SourcePath,
                 PackageNames: ["dem"]
 ));
         ImportedSceneSourceDataset documentSet = readResult.DocumentSet;
@@ -79,10 +79,10 @@ public sealed class LocalCityGmlDocumentReaderTests
             new CityGmlLodSelector());
 
         ImportedSceneSourceSnapshot readResult = await reader.ReadAsync(
-            new PlateauImportRequest(
+            new ResolvedLocalPlateauImportRequest(
                 Dataset: "tokyo23ku",
                 MeshCode: "53394525",
-                CityGmlSource: DatasetLocation.Local(fixturePath),
+                CityGmlLocalSourcePath: fixturePath,
                 PackageNames: ["dem", "tran"]
 ));
 

--- a/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/PlateauImportRequestValidatorTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
@@ -10,16 +12,95 @@ namespace PlateauResoniteLink.Tests.Application;
 public sealed class PlateauImportRequestValidatorTests
 {
     [Fact]
-    public void ValidateRequiresCityGmlSource()
+    public void DatasetLocationFactoriesRequireSourcePayload()
     {
-        PlateauImportRequest request = new(
+        Assert.Throws<ArgumentException>(() => DatasetLocation.Local(" "));
+        Assert.Throws<ArgumentNullException>(() => DatasetLocation.Remote(null!));
+        Assert.Throws<ArgumentException>(() => new ValidatedLocalDatasetLocation(" "));
+        Assert.Throws<ArgumentNullException>(() => new ValidatedRemoteDatasetLocation(null!));
+        Assert.Throws<ArgumentException>(() => new ValidatedRemoteDatasetLocation(new Uri("/dataset.zip", UriKind.Relative)));
+        Assert.Throws<ArgumentException>(() => new ValidatedRemoteDatasetLocation(new Uri("ftp://example.invalid/dataset.zip")));
+        Assert.Equal(" C:/dataset ", new ValidatedLocalDatasetLocation(" C:/dataset ").LocalSourcePath);
+    }
+
+    [Fact]
+    public void ValidatedDatasetLocationEqualityIncludesSourcePayload()
+    {
+        ValidatedDatasetLocation[] locations =
+        [
+            new ValidatedLocalDatasetLocation("C:/dataset-a"),
+            new ValidatedLocalDatasetLocation("C:/dataset-b"),
+            new ValidatedRemoteDatasetLocation(new Uri("https://example.invalid/dataset-a.zip")),
+            new ValidatedRemoteDatasetLocation(new Uri("https://example.invalid/dataset-b.zip")),
+        ];
+
+        Assert.Equal(locations.Length, locations.Distinct().Count());
+        Assert.NotEqual(locations[0], locations[1]);
+        Assert.NotEqual(locations[2], locations[3]);
+    }
+
+    [Fact]
+    public void PlateauImportRequestRequiresCityGmlSource()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new PlateauImportRequest("tokyo23ku", "53394525", null!));
+
+        PlateauImportRequest request = new("tokyo23ku", "53394525", DatasetLocation.Local("C:/dataset"));
+        Assert.Throws<ArgumentNullException>(() => request with { CityGmlSource = null! });
+    }
+
+    [Fact]
+    public void ValidatedPlateauImportRequestRequiresValidatedPayload()
+    {
+        ValidatedLocalDatasetLocation source = new("C:/dataset");
+        Regex meshCodePattern = new(@"\A53394525\z");
+
+        Assert.Throws<ArgumentException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: " ",
+                MeshCode: "53394525",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: source));
+        Assert.Throws<ArgumentException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: " ",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: source));
+        Assert.Throws<ArgumentNullException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                MeshCodePattern: null!,
+                CityGmlSource: source));
+        Assert.Throws<ArgumentNullException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: null!));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: source,
+                TerrainGridMetersPerVertex: double.NaN));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ValidatedPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                MeshCodePattern: meshCodePattern,
+                CityGmlSource: source,
+                TerrainGridMaxResolution: 1));
+
+        ValidatedPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Remote(null));
+            MeshCodePattern: meshCodePattern,
+            CityGmlSource: source);
 
-        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
-
-        Assert.Contains("The --citygml-source value is required.", errors);
+        Assert.Throws<ArgumentNullException>(() => request with { CityGmlSource = null! });
     }
 
     [Fact]
@@ -73,7 +154,7 @@ public sealed class PlateauImportRequestValidatorTests
     }
 
     [Fact]
-    public void TryNormalizeAndValidateTrimsAndNormalizesRequestData()
+    public void TryNormalizeAndValidateNormalizesRequestData()
     {
         using TemporaryDirectory sourceRoot = new();
         string geoTiffPath = Path.Combine(sourceRoot.Path, "53394525.tif");
@@ -169,7 +250,21 @@ public sealed class PlateauImportRequestValidatorTests
 
         IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
 
-        Assert.Contains("The terrain grid meters-per-vertex value must be greater than zero.", errors);
+        Assert.Contains("The terrain grid meters-per-vertex value must be a finite value greater than zero.", errors);
+    }
+
+    [Fact]
+    public void ValidateRejectsNonFiniteTerrainGridMetersPerVertex()
+    {
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            CityGmlSource: DatasetLocation.Local("C:/dataset"),
+            TerrainGridMetersPerVertex: double.PositiveInfinity);
+
+        IReadOnlyList<string> errors = PlateauImportRequestValidator.Validate(request);
+
+        Assert.Contains("The terrain grid meters-per-vertex value must be a finite value greater than zero.", errors);
     }
 
     [Theory]

--- a/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Tests.Application;
+
+public sealed class ResolvedLocalPlateauImportRequestTests
+{
+    [Fact]
+    public void ConstructorTrimsResolvedBoundaryStrings()
+    {
+        ResolvedLocalPlateauImportRequest request = new(
+            Dataset: " plateau-13213 ",
+            MeshCode: " 53395325 ",
+            CityGmlLocalSourcePath: " C:/data/source.zip ",
+            DemTextureSource: new LocalDatasetLocation(" C:/data/ortho.7z "));
+
+        Assert.Equal("plateau-13213", request.Dataset);
+        Assert.Equal("53395325", request.MeshCode);
+        Assert.Equal("C:/data/source.zip", request.CityGmlLocalSourcePath);
+        Assert.Equal("C:/data/ortho.7z", request.DemTextureLocalSourcePath);
+    }
+
+    [Fact]
+    public void ConstructorNormalizesPackageNamesAtResolvedBoundary()
+    {
+        ResolvedLocalPlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            CityGmlLocalSourcePath: "/tmp/plateau",
+            PackageNames: [" BLDG ", "waterbody", "bldg"]);
+
+        Assert.Equal(["bldg", "wtr"], request.PackageNames);
+    }
+
+    [Fact]
+    public void ConstructorRejectsEmptyPackageNames()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new ResolvedLocalPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlLocalSourcePath: "/tmp/plateau",
+                PackageNames: []));
+    }
+
+    [Fact]
+    public void ConstructorRejectsUnsupportedPackageNames()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new ResolvedLocalPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlLocalSourcePath: "/tmp/plateau",
+                PackageNames: ["unknown"]));
+    }
+
+    [Fact]
+    public void ConstructorNormalizesPackageOptionMapKeysAtResolvedBoundary()
+    {
+        ResolvedLocalPlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            CityGmlLocalSourcePath: "/tmp/plateau",
+            ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
+            {
+                [" BLDG "] = new HashSet<int> { 1 },
+                ["waterbody"] = new HashSet<int> { 2 },
+            },
+            PackagePatterns: new Dictionary<string, string>
+            {
+                [" BLDG "] = "_bldg_",
+                ["waterbody"] = "_wtr_",
+            });
+
+        Assert.Equal([1], request.ExcludeLodLevelsByPackage!["bldg"]);
+        Assert.Equal([2], request.ExcludeLodLevelsByPackage!["wtr"]);
+        Assert.Equal("_bldg_", request.PackagePatterns!["bldg"]);
+        Assert.Equal("_wtr_", request.PackagePatterns!["wtr"]);
+    }
+
+    [Fact]
+    public void ConstructorRejectsDuplicatePackageOptionMapKeysAfterNormalization()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new ResolvedLocalPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlLocalSourcePath: "/tmp/plateau",
+                ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
+                {
+                    [" BLDG "] = new HashSet<int> { 1 },
+                    ["bldg"] = new HashSet<int> { 2 },
+                }));
+
+        Assert.Throws<ArgumentException>(
+            () => new ResolvedLocalPlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlLocalSourcePath: "/tmp/plateau",
+                PackagePatterns: new Dictionary<string, string>
+                {
+                    ["waterbody"] = "_wtr_",
+                    ["wtr"] = "_wtr_",
+                }));
+    }
+
+    [Fact]
+    public void ConstructorKeepsLocalDemTextureSource()
+    {
+        ResolvedLocalPlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            CityGmlLocalSourcePath: "/tmp/plateau",
+            DemTextureSource: new LocalDatasetLocation("/tmp/ortho.tif"));
+
+        LocalDatasetLocation demTextureSource = Assert.IsType<LocalDatasetLocation>(request.DemTextureSource);
+        Assert.Equal("/tmp/ortho.tif", demTextureSource.LocalSourcePath);
+    }
+
+    [Fact]
+    public void CreateKeepsResolvedRemoteDemTextureSource()
+    {
+        string workRoot = "work";
+        Uri cityGmlUri = new("https://example.test/tokyo.zip");
+        Uri demTextureUri = new("https://example.test/ortho.tif");
+        ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlSource: DatasetLocation.Remote(cityGmlUri),
+                DemTextureSource: DatasetLocation.Remote(demTextureUri)));
+
+        ResolvedLocalPlateauImportRequest resolvedRequest = ResolvedLocalPlateauImportRequest.Create(
+            request,
+            workRoot,
+            new ValidatedLocalDatasetLocation(
+                RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, cityGmlUri, "source-archive")),
+            new ValidatedLocalDatasetLocation(
+                RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, demTextureUri, "source-ortho")));
+
+        Assert.Equal(
+            RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, demTextureUri, "source-ortho"),
+            resolvedRequest.DemTextureLocalSourcePath);
+    }
+
+    [Fact]
+    public void CreateRejectsLocalCityGmlSourceMismatch()
+    {
+        ValidatedPlateauImportRequest request = CreateValidatedRequest(
+            new ValidatedLocalDatasetLocation("/tmp/plateau-a"));
+
+        Assert.Throws<ArgumentException>(
+            () => ResolvedLocalPlateauImportRequest.Create(
+                request,
+                "work",
+                new ValidatedLocalDatasetLocation("/tmp/plateau-b"),
+                demTextureSource: null));
+    }
+
+    [Fact]
+    public void CreateRejectsRemoteCityGmlSourceMismatch()
+    {
+        Uri cityGmlUri = new("https://example.test/tokyo.zip");
+        ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlSource: DatasetLocation.Remote(cityGmlUri)));
+
+        Assert.Throws<ArgumentException>(
+            () => ResolvedLocalPlateauImportRequest.Create(
+                request,
+                "work",
+                new ValidatedLocalDatasetLocation("/tmp/unexpected.zip"),
+                demTextureSource: null));
+    }
+
+    [Fact]
+    public void CreateRejectsDifferentResolvedLocalDemTextureSource()
+    {
+        ValidatedPlateauImportRequest request = CreateValidatedRequest(
+            new ValidatedLocalDatasetLocation("/tmp/plateau"),
+            new ValidatedLocalDatasetLocation("/tmp/ortho-a.tif"));
+
+        Assert.Throws<ArgumentException>(
+            () => ResolvedLocalPlateauImportRequest.Create(
+                request,
+                "work",
+                new ValidatedLocalDatasetLocation("/tmp/plateau"),
+                new ValidatedLocalDatasetLocation("/tmp/ortho-b.tif")));
+    }
+
+    [Fact]
+    public void CreateRejectsResolvedDemTextureSourceWhenNoneWasRequested()
+    {
+        ValidatedPlateauImportRequest request = CreateValidatedRequest(
+            new ValidatedLocalDatasetLocation("/tmp/plateau"));
+
+        Assert.Throws<ArgumentException>(
+            () => ResolvedLocalPlateauImportRequest.Create(
+                request,
+                "work",
+                new ValidatedLocalDatasetLocation("/tmp/plateau"),
+                new ValidatedLocalDatasetLocation("/tmp/ortho.tif")));
+    }
+
+    [Fact]
+    public void CreateRejectsUnresolvedDemTextureSourceWhenOneWasRequested()
+    {
+        ValidatedPlateauImportRequest request = CreateValidatedRequest(
+            new ValidatedLocalDatasetLocation("/tmp/plateau"),
+            new ValidatedLocalDatasetLocation("/tmp/ortho.tif"));
+
+        Assert.Throws<ArgumentException>(
+            () => ResolvedLocalPlateauImportRequest.Create(
+                request,
+                "work",
+                new ValidatedLocalDatasetLocation("/tmp/plateau"),
+                demTextureSource: null));
+    }
+
+    private static ValidatedPlateauImportRequest CreateValidatedRequest(
+        ValidatedDatasetLocation cityGmlSource,
+        ValidatedDatasetLocation? demTextureSource = null)
+    {
+        return new ValidatedPlateauImportRequest(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394525",
+            MeshCodePattern: new Regex("^53394525$", RegexOptions.CultureInvariant),
+            CityGmlSource: cityGmlSource,
+            DemTextureSource: demTextureSource);
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/ResolvedLocalPlateauImportRequestTests.cs
@@ -1,237 +1,135 @@
 using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Tests.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.Application;
 
 public sealed class ResolvedLocalPlateauImportRequestTests
 {
     [Fact]
-    public void ConstructorTrimsResolvedBoundaryStrings()
+    public void CreateCarriesPackageNamesFromValidatedRequest()
     {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: " plateau-13213 ",
-            MeshCode: " 53395325 ",
-            CityGmlLocalSourcePath: " C:/data/source.zip ",
-            DemTextureSource: new LocalDatasetLocation(" C:/data/ortho.7z "));
-
-        Assert.Equal("plateau-13213", request.Dataset);
-        Assert.Equal("53395325", request.MeshCode);
-        Assert.Equal("C:/data/source.zip", request.CityGmlLocalSourcePath);
-        Assert.Equal("C:/data/ortho.7z", request.DemTextureLocalSourcePath);
-    }
-
-    [Fact]
-    public void ConstructorNormalizesPackageNamesAtResolvedBoundary()
-    {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            PackageNames: [" BLDG ", "waterbody", "bldg"]);
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            packageNames: ["bldg", "wtr"]);
 
         Assert.Equal(["bldg", "wtr"], request.PackageNames);
     }
 
     [Fact]
-    public void ConstructorRejectsEmptyPackageNames()
+    public void CreateCarriesLocalDemTextureSource()
     {
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                PackageNames: []));
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            demTextureLocalSourcePath: "C:\\tmp\\ortho.tif");
+
+        Assert.Equal("C:\\tmp\\ortho.tif", request.DemTextureLocalSourcePath);
     }
 
     [Fact]
-    public void ConstructorRejectsUnsupportedPackageNames()
+    public void CreateRejectsDifferentResolvedLocalCityGmlSource()
     {
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                PackageNames: ["unknown"]));
-    }
+        ValidatedPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.CreateValidatedRequest(
+            cityGmlLocalSourcePath: "C:\\tmp\\plateau-a");
 
-    [Fact]
-    public void ConstructorNormalizesPackageOptionMapKeysAtResolvedBoundary()
-    {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
-            {
-                [" BLDG "] = new HashSet<int> { 1 },
-                ["waterbody"] = new HashSet<int> { 2 },
-            },
-            PackagePatterns: new Dictionary<string, string>
-            {
-                [" BLDG "] = "_bldg_",
-                ["waterbody"] = "_wtr_",
-            });
-
-        Assert.Equal([1], request.ExcludeLodLevelsByPackage!["bldg"]);
-        Assert.Equal([2], request.ExcludeLodLevelsByPackage!["wtr"]);
-        Assert.Equal("_bldg_", request.PackagePatterns!["bldg"]);
-        Assert.Equal("_wtr_", request.PackagePatterns!["wtr"]);
-    }
-
-    [Fact]
-    public void ConstructorRejectsDuplicatePackageOptionMapKeysAfterNormalization()
-    {
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                ExcludeLodLevelsByPackage: new Dictionary<string, IReadOnlySet<int>>
-                {
-                    [" BLDG "] = new HashSet<int> { 1 },
-                    ["bldg"] = new HashSet<int> { 2 },
-                }));
-
-        Assert.Throws<ArgumentException>(
-            () => new ResolvedLocalPlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlLocalSourcePath: "/tmp/plateau",
-                PackagePatterns: new Dictionary<string, string>
-                {
-                    ["waterbody"] = "_wtr_",
-                    ["wtr"] = "_wtr_",
-                }));
-    }
-
-    [Fact]
-    public void ConstructorKeepsLocalDemTextureSource()
-    {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            DemTextureSource: new LocalDatasetLocation("/tmp/ortho.tif"));
-
-        LocalDatasetLocation demTextureSource = Assert.IsType<LocalDatasetLocation>(request.DemTextureSource);
-        Assert.Equal("/tmp/ortho.tif", demTextureSource.LocalSourcePath);
-    }
-
-    [Fact]
-    public void CreateKeepsResolvedRemoteDemTextureSource()
-    {
-        string workRoot = "work";
-        Uri cityGmlUri = new("https://example.test/tokyo.zip");
-        Uri demTextureUri = new("https://example.test/ortho.tif");
-        ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
-            new PlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlSource: DatasetLocation.Remote(cityGmlUri),
-                DemTextureSource: DatasetLocation.Remote(demTextureUri)));
-
-        ResolvedLocalPlateauImportRequest resolvedRequest = ResolvedLocalPlateauImportRequest.Create(
-            request,
-            workRoot,
-            new ValidatedLocalDatasetLocation(
-                RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, cityGmlUri, "source-archive")),
-            new ValidatedLocalDatasetLocation(
-                RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, demTextureUri, "source-ortho")));
-
-        Assert.Equal(
-            RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, demTextureUri, "source-ortho"),
-            resolvedRequest.DemTextureLocalSourcePath);
-    }
-
-    [Fact]
-    public void CreateRejectsLocalCityGmlSourceMismatch()
-    {
-        ValidatedPlateauImportRequest request = CreateValidatedRequest(
-            new ValidatedLocalDatasetLocation("/tmp/plateau-a"));
-
-        Assert.Throws<ArgumentException>(
+        ArgumentException exception = Assert.Throws<ArgumentException>(
             () => ResolvedLocalPlateauImportRequest.Create(
                 request,
-                "work",
-                new ValidatedLocalDatasetLocation("/tmp/plateau-b"),
-                demTextureSource: null));
-    }
+                new ValidatedLocalDatasetLocation("C:\\tmp\\plateau-b"),
+                null));
 
-    [Fact]
-    public void CreateRejectsRemoteCityGmlSourceMismatch()
-    {
-        Uri cityGmlUri = new("https://example.test/tokyo.zip");
-        ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
-            new PlateauImportRequest(
-                Dataset: "tokyo23ku",
-                MeshCode: "53394525",
-                CityGmlSource: DatasetLocation.Remote(cityGmlUri)));
-
-        Assert.Throws<ArgumentException>(
-            () => ResolvedLocalPlateauImportRequest.Create(
-                request,
-                "work",
-                new ValidatedLocalDatasetLocation("/tmp/unexpected.zip"),
-                demTextureSource: null));
+        Assert.Equal("cityGmlSource", exception.ParamName);
     }
 
     [Fact]
     public void CreateRejectsDifferentResolvedLocalDemTextureSource()
     {
-        ValidatedPlateauImportRequest request = CreateValidatedRequest(
-            new ValidatedLocalDatasetLocation("/tmp/plateau"),
-            new ValidatedLocalDatasetLocation("/tmp/ortho-a.tif"));
+        ValidatedPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.CreateValidatedRequest(
+            demTextureLocalSourcePath: "C:\\tmp\\ortho-a.tif");
 
-        Assert.Throws<ArgumentException>(
+        ArgumentException exception = Assert.Throws<ArgumentException>(
             () => ResolvedLocalPlateauImportRequest.Create(
                 request,
-                "work",
-                new ValidatedLocalDatasetLocation("/tmp/plateau"),
-                new ValidatedLocalDatasetLocation("/tmp/ortho-b.tif")));
+                new ValidatedLocalDatasetLocation("C:\\tmp\\plateau"),
+                new ValidatedLocalDatasetLocation("C:\\tmp\\ortho-b.tif")));
+
+        Assert.Equal("demTextureSource", exception.ParamName);
     }
 
     [Fact]
     public void CreateRejectsResolvedDemTextureSourceWhenNoneWasRequested()
     {
-        ValidatedPlateauImportRequest request = CreateValidatedRequest(
-            new ValidatedLocalDatasetLocation("/tmp/plateau"));
+        ValidatedPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.CreateValidatedRequest();
 
-        Assert.Throws<ArgumentException>(
+        ArgumentException exception = Assert.Throws<ArgumentException>(
             () => ResolvedLocalPlateauImportRequest.Create(
                 request,
-                "work",
-                new ValidatedLocalDatasetLocation("/tmp/plateau"),
-                new ValidatedLocalDatasetLocation("/tmp/ortho.tif")));
+                new ValidatedLocalDatasetLocation("C:\\tmp\\plateau"),
+                new ValidatedLocalDatasetLocation("C:\\tmp\\ortho.tif")));
+
+        Assert.Equal("demTextureSource", exception.ParamName);
     }
 
     [Fact]
-    public void CreateRejectsUnresolvedDemTextureSourceWhenOneWasRequested()
+    public void CreateRejectsRemoteCityGmlSourceResolvedOutsideExpectedCachePath()
     {
-        ValidatedPlateauImportRequest request = CreateValidatedRequest(
-            new ValidatedLocalDatasetLocation("/tmp/plateau"),
-            new ValidatedLocalDatasetLocation("/tmp/ortho.tif"));
+        using TemporaryDirectory workRoot = new();
+        ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlSource: DatasetLocation.Remote(new Uri("https://example.test/source.zip"))));
 
-        Assert.Throws<ArgumentException>(
+        ArgumentException exception = Assert.Throws<ArgumentException>(
             () => ResolvedLocalPlateauImportRequest.Create(
                 request,
-                "work",
-                new ValidatedLocalDatasetLocation("/tmp/plateau"),
-                demTextureSource: null));
+                new ValidatedLocalDatasetLocation("C:\\tmp\\other.zip"),
+                null,
+                workRoot.Path));
+
+        Assert.Equal("cityGmlSource", exception.ParamName);
     }
 
-    private static ValidatedPlateauImportRequest CreateValidatedRequest(
-        ValidatedDatasetLocation cityGmlSource,
-        ValidatedDatasetLocation? demTextureSource = null)
+    [Fact]
+    public void CreateAcceptsRemoteCityGmlSourceResolvedToExpectedCachePath()
     {
-        return new ValidatedPlateauImportRequest(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            MeshCodePattern: new Regex("^53394525$", RegexOptions.CultureInvariant),
-            CityGmlSource: cityGmlSource,
-            DemTextureSource: demTextureSource);
+        using TemporaryDirectory workRoot = new();
+        Uri sourceUri = new("https://example.test/source.zip");
+        ValidatedPlateauImportRequest request = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlSource: DatasetLocation.Remote(sourceUri)));
+        string expectedSourcePath = RemoteDatasetResourceLayout.GetRemoteResourcePath(
+            workRoot.Path,
+            sourceUri,
+            ResolvedLocalPlateauImportRequest.RemoteCityGmlResourcePrefix);
+
+        ResolvedLocalPlateauImportRequest resolvedRequest = ResolvedLocalPlateauImportRequest.Create(
+            request,
+            new ValidatedLocalDatasetLocation(expectedSourcePath),
+            null,
+            workRoot.Path);
+
+        Assert.Equal(expectedSourcePath, resolvedRequest.CityGmlLocalSourcePath);
+    }
+
+    [Fact]
+    public void CreateRejectsRemoteDemTextureSourceResolvedOutsideExpectedCachePath()
+    {
+        using TemporaryDirectory workRoot = new();
+        ValidatedPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.CreateValidatedRequest() with
+        {
+            DemTextureSource = new ValidatedRemoteDatasetLocation(new Uri("https://example.test/ortho.tif")),
+        };
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(
+            () => ResolvedLocalPlateauImportRequest.Create(
+                request,
+                new ValidatedLocalDatasetLocation("C:\\tmp\\plateau"),
+                new ValidatedLocalDatasetLocation("C:\\tmp\\other.tif"),
+                workRoot.Path));
+
+        Assert.Equal("demTextureSource", exception.ParamName);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TextureImportSourceFactoryTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PlateauResoniteLink.Application.Importing;
+
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PlateauResoniteLink.Tests.Application;
+
+public sealed class TextureImportSourceFactoryTests
+{
+    [Fact]
+    public async Task CreateInMemoryRawRgbaRequiresDimensionsAtConstruction()
+    {
+        ITextureImportSource source = TextureImportSourceFactory.CreateInMemoryRaw(
+            width: 1,
+            height: 1,
+            colorProfile: "sRGB",
+            bytes: [255, 255, 255, 255],
+            identity: "raw-with-dimensions");
+
+        RawTexturePayload payload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            source,
+            CancellationToken.None);
+
+        Assert.IsType<Rgba32RawTexturePayload>(payload);
+        Assert.Equal(1, payload.Width);
+        Assert.Equal(1, payload.Height);
+        Assert.Equal([255, 255, 255, 255], payload.Bytes);
+    }
+
+    [Fact]
+    public void CreateInMemoryRawRgbaRejectsByteLengthMismatch()
+    {
+        Assert.Throws<ArgumentException>(
+            () => TextureImportSourceFactory.CreateInMemoryRaw(
+                width: 2,
+                height: 2,
+                colorProfile: "sRGB",
+                bytes: [255, 255, 255, 255],
+                identity: "raw-with-invalid-byte-length"));
+    }
+
+    [Fact]
+    public void CreateInMemoryRawRgbaRejectsByteLengthOverflow()
+    {
+        Assert.Throws<OverflowException>(
+            () => TextureImportSourceFactory.CreateInMemoryRaw(
+                width: int.MaxValue,
+                height: int.MaxValue,
+                colorProfile: "sRGB",
+                bytes: [255, 255, 255, 255],
+                identity: "raw-with-overflow-byte-length"));
+    }
+
+    [Fact]
+    public async Task CreateInMemoryEncodedImageOwnsDimensionsAfterDecode()
+    {
+        await using MemoryStream stream = new();
+        using (Image<Rgba32> image = new(1, 1, new Rgba32(1, 2, 3, 255)))
+        {
+            await image.SaveAsPngAsync(stream);
+        }
+
+        ITextureImportSource source = TextureImportSourceFactory.CreateInMemoryEncodedImage(
+            colorProfile: "sRGB",
+            bytes: stream.ToArray(),
+            identity: "encoded-without-dimensions");
+
+        RawTexturePayload payload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            source,
+            CancellationToken.None);
+
+        Assert.IsType<Rgba32RawTexturePayload>(payload);
+        Assert.Equal(1, payload.Width);
+        Assert.Equal(1, payload.Height);
+        Assert.Equal([1, 2, 3, 255], payload.Bytes);
+    }
+
+    [Fact]
+    public async Task CreateGeneratedRgbaFloat32ImageDoesNotMaterializeAsRgba32()
+    {
+        ITextureImportSource source = TextureImportSourceFactory.CreateGeneratedRgbaFloat32Image(
+            _ => ValueTask.FromResult(new RgbaFloat32RawTexturePayload(
+                width: 1,
+                height: 1,
+                colorProfile: null,
+                bytes: new byte[16])),
+            identity: "hdr",
+            description: "hdr",
+            colorProfile: null,
+            estimatedByteLength: 16);
+
+        RawTexturePayload rawPayload = await TextureImportSourceMaterializer.MaterializeRawAsync(
+            source,
+            CancellationToken.None);
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await TextureImportSourceMaterializer.MaterializeRgba32Async(
+                source,
+                CancellationToken.None));
+
+        Assert.IsType<RgbaFloat32RawTexturePayload>(rawPayload);
+        Assert.Contains("cannot materialize an RGBA32 texture payload", exception.Message, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RgbaFloat32RawTexturePayloadRejectsByteLengthMismatch()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new RgbaFloat32RawTexturePayload(
+                width: 2,
+                height: 2,
+                colorProfile: null,
+                bytes: new byte[16]));
+    }
+
+    [Fact]
+    public void RgbaFloat32RawTexturePayloadRejectsByteLengthOverflow()
+    {
+        Assert.Throws<OverflowException>(
+            () => new RgbaFloat32RawTexturePayload(
+                width: int.MaxValue,
+                height: int.MaxValue,
+                colorProfile: null,
+                bytes: new byte[16]));
+    }
+
+}

--- a/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/TexturePayloadTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using PlateauResoniteLink.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.Application;
@@ -9,9 +11,56 @@ public sealed class TexturePayloadTests
     {
         byte[] source = [1, 2, 3, 4];
 
-        TexturePayload payload = new(1, 1, "sRGB", source, "dataset:texture");
+        RawRgba32TexturePayload payload = new(1, 1, "sRGB", source, "dataset:texture");
         source[0] = 9;
 
         Assert.Equal<byte>([1, 2, 3, 4], payload.BinaryPayload);
+    }
+    [Fact]
+    public void ConstructorRejectsRawRgbaByteLengthMismatch()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new RawRgba32TexturePayload(2, 2, "sRGB", [255, 255, 255, 255], "dataset:texture"));
+    }
+
+    [Fact]
+    public void ConstructorRejectsRawRgbaByteLengthOverflow()
+    {
+        Assert.Throws<OverflowException>(
+            () => new RawRgba32TexturePayload(
+                int.MaxValue,
+                int.MaxValue,
+                "sRGB",
+                [255, 255, 255, 255],
+                "dataset:texture"));
+    }
+
+    [Fact]
+    public void ConstructorCarriesIdentityAndColorProfileOnPayloadAndSource()
+    {
+        RawRgba32TexturePayload payload = new(1, 1, "sRGB", [1, 2, 3, 4], "dataset:texture");
+
+        Assert.Equal("dataset:texture", payload.Identity);
+        Assert.Equal("sRGB", payload.ColorProfile);
+        Assert.Equal("dataset:texture", payload.Source.Identity);
+        Assert.Equal("sRGB", payload.Source.ColorProfile);
+    }
+
+    [Fact]
+    public void ConstructorRejectsTextureSourceWithoutIdentity()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new EncodedImageTexturePayload(null, null, null, new BlankIdentityTextureImportSource()));
+    }
+
+    private sealed class BlankIdentityTextureImportSource : ITextureImportSource
+    {
+        public string Identity => " ";
+
+        public string Description => "blank";
+
+        public string? ColorProfile => null;
+
+        public long? EstimatedByteLength => null;
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/CliArgumentsParserTests.cs
@@ -83,6 +83,34 @@ public sealed class CliArgumentsParserTests
     }
 
     [Fact]
+    public void ParseRequiresDatasetBeforeCreatingImportRequest()
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "import",
+                "--mesh-code", "53394525",
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+            ]);
+
+        Assert.Equal("Specify --dataset.", result.Error);
+    }
+
+    [Fact]
+    public void ParseRequiresMeshCodeBeforeCreatingImportRequest()
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "import",
+                "--dataset", "tokyo23ku",
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+            ]);
+
+        Assert.Equal("Specify --mesh-code.", result.Error);
+    }
+
+    [Fact]
     public void ParseParsesCanonicalSceneDumpImportWithoutResoniteLinkEndpoint()
     {
         CliParseResult result = CliArgumentsParser.Parse(
@@ -236,6 +264,24 @@ public sealed class CliArgumentsParserTests
         Assert.Equal(TerrainMeshMode.Grid, result.Options!.Request.TerrainMeshMode);
         Assert.Equal(4.5, result.Options.Request.TerrainGridMetersPerVertex, 6);
         Assert.Equal(512, result.Options.Request.TerrainGridMaxResolution);
+    }
+
+    [Fact]
+    public void ParseRejectsNonFiniteTerrainGridMetersPerVertex()
+    {
+        CliParseResult result = CliArgumentsParser.Parse(
+            [
+                "import",
+                "--dataset", "tokyo23ku",
+                "--mesh-code", "53394525",
+                "--citygml-source", "/data/plateau",
+                "--resonitelink-port", "12345",
+                "--terrain-grid-meters-per-vertex", "Infinity",
+            ]);
+
+        Assert.Equal(
+            "The value 'Infinity' is not a valid positive terrain grid meters-per-vertex value.",
+            result.Error);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
@@ -81,12 +81,16 @@ public sealed class ImportServiceFactoryTests
 
     private sealed class StubPlateauDatasetSourceResolver : IPlateauDatasetSourceResolver
     {
-        public Task<ValidatedPlateauImportRequest> ResolveAsync(
+        public Task<ResolvedLocalPlateauImportRequest> ResolveAsync(
             ValidatedPlateauImportRequest request,
             string workRoot,
             CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(request);
+            ValidatedLocalDatasetLocation localSource = Assert.IsType<ValidatedLocalDatasetLocation>(request.CityGmlSource);
+            ValidatedLocalDatasetLocation? localDemTextureSource = request.DemTextureSource is null
+                ? null
+                : Assert.IsType<ValidatedLocalDatasetLocation>(request.DemTextureSource);
+            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(request, workRoot, localSource, localDemTextureSource));
         }
     }
 
@@ -134,7 +138,7 @@ public sealed class ImportServiceFactoryTests
         public int CreateCallCount { get; private set; }
 
         public Task<IImportedSceneSource> CreateAsync(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             Action<string>? progressReporter = null,
             CancellationToken cancellationToken = default)
         {
@@ -143,7 +147,7 @@ public sealed class ImportServiceFactoryTests
             ImportedSceneMetadata metadata = new(
                 "3.0",
                 $"PLATEAU {request.Dataset} {request.MeshCode}",
-                request,
+                request.ToImportRequest(),
                 new PlateauSourceDataset(["bldg"], [], []),
                 new Attribution(
                     new LicenseMetadata(true, "credit", "license", "https://example.invalid")),

--- a/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Cli/ImportServiceFactoryTests.cs
@@ -90,7 +90,7 @@ public sealed class ImportServiceFactoryTests
             ValidatedLocalDatasetLocation? localDemTextureSource = request.DemTextureSource is null
                 ? null
                 : Assert.IsType<ValidatedLocalDatasetLocation>(request.DemTextureSource);
-            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(request, workRoot, localSource, localDemTextureSource));
+            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(request, localSource, localDemTextureSource, workRoot));
         }
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/BuildingAttributeParserTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/BuildingAttributeParserTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -36,7 +37,7 @@ public sealed class BuildingAttributeParserTests
     }
 
     [Fact]
-    public void ParseTreatsPlateauMissingSentinelsAsMissingMetrics()
+    public void ParseDropsPlateauMissingSentinelsBeforeAttributeContext()
     {
         XElement element = XElement.Parse(
             """
@@ -49,13 +50,13 @@ public sealed class BuildingAttributeParserTests
 
         BuildingAttributeContext attributes = BuildingAttributeParser.Parse(element);
 
-        Assert.Equal(BuildingMetricValueKind.Missing, attributes.MeasuredHeightMeters.Kind);
-        Assert.Equal(BuildingMetricValueKind.Missing, attributes.StoreysAboveGround.Kind);
-        Assert.Equal(BuildingMetricValueKind.Missing, attributes.StoreysBelowGround.Kind);
+        Assert.Null(attributes.MeasuredHeightMeters);
+        Assert.Null(attributes.StoreysAboveGround);
+        Assert.Null(attributes.StoreysBelowGround);
     }
 
     [Fact]
-    public void ParseRejectsNonMeterHeightButKeepsAreaWithoutMeterRequirement()
+    public void ParseDropsNonMeterHeightButKeepsAreaWithoutMeterRequirement()
     {
         XElement element = XElement.Parse(
             """
@@ -70,12 +71,47 @@ public sealed class BuildingAttributeParserTests
 
         BuildingAttributeContext attributes = BuildingAttributeParser.Parse(element);
 
-        Assert.Equal(BuildingMetricValueKind.Invalid, attributes.MeasuredHeightMeters.Kind);
-        Assert.Equal("12", attributes.MeasuredHeightMeters.Raw);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.BuildingFootprintArea.Kind);
-        Assert.Equal(160.5, attributes.BuildingFootprintArea.Value);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.BuildingHeight.Kind);
-        Assert.Equal(9.25, attributes.BuildingHeight.Value);
+        Assert.Null(attributes.MeasuredHeightMeters);
+        Assert.NotNull(attributes.BuildingFootprintArea);
+        Assert.NotNull(attributes.BuildingHeight);
+        BuildingMetricValue footprintArea = attributes.BuildingFootprintArea;
+        BuildingMetricValue buildingHeight = attributes.BuildingHeight;
+        Assert.Equal(160.5, footprintArea.Value);
+        Assert.Equal(9.25, buildingHeight.Value);
+    }
+
+    [Fact]
+    public void ParseDropsBlankMetricElementsBeforeAttributeContext()
+    {
+        XElement element = XElement.Parse(
+            """
+            <bldg:Building xmlns:bldg="urn:bldg">
+              <bldg:measuredHeight uom="m"> </bldg:measuredHeight>
+            </bldg:Building>
+            """);
+
+        BuildingAttributeContext attributes = BuildingAttributeParser.Parse(element);
+
+        Assert.Null(attributes.MeasuredHeightMeters);
+    }
+
+    [Fact]
+    public void ParseDropsNonFiniteMetricTextBeforeAttributeContext()
+    {
+        XElement element = XElement.Parse(
+            """
+            <bldg:Building xmlns:bldg="urn:bldg">
+              <bldg:measuredHeight uom="m">Infinity</bldg:measuredHeight>
+              <bldg:BuildingDetailAttribute>
+                <bldg:buildingHeight uom="m">1e309</bldg:buildingHeight>
+              </bldg:BuildingDetailAttribute>
+            </bldg:Building>
+            """);
+
+        BuildingAttributeContext attributes = BuildingAttributeParser.Parse(element);
+
+        Assert.Null(attributes.MeasuredHeightMeters);
+        Assert.Null(attributes.BuildingHeight);
     }
 
     [Fact]
@@ -92,5 +128,13 @@ public sealed class BuildingAttributeParserTests
         BuildingAttributeContext attributes = BuildingAttributeParser.Parse(element);
 
         Assert.Equal(["402101"], attributes.CityGmlFunctionCodes.ToArray());
+    }
+
+    [Fact]
+    public void MetricValueFactoriesRejectInvalidPayloadShapes()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BuildingMetricValue(double.NaN));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BuildingMetricValue(double.PositiveInfinity));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BuildingMetricValue(-1.0));
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceMaterialResolverTests.cs
@@ -24,7 +24,8 @@ public sealed class CityGmlSurfaceMaterialResolverTests
             ],
             ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
             SourceFileRelativePath: "udx/dem/53394525/sample.gml",
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
 
         ResolvedSurfaceMaterial? representativeSurface = CityGmlSurfaceMaterialResolver.EnumerateSurfaces(
                 ConstructionCityObjectDraft.FromParsedCityObject(cityObject),
@@ -161,7 +162,8 @@ public sealed class CityGmlSurfaceMaterialResolverTests
             Surfaces: surfaces,
             ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
             SourceFileRelativePath: "udx/bldg/53394525/sample.gml",
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private static TerrainTextureOverlay CreateOverlay(string meshCode)

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceProjectionPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlSurfaceProjectionPolicyTests.cs
@@ -101,6 +101,28 @@ public sealed class CityGmlSurfaceProjectionPolicyTests
     }
 
     [Fact]
+    public void TryCreateFacadeUvProjectionContextSkipsEmptySurfacesBeforeResolvingHeightRange()
+    {
+        GeodeticPoint origin = new(35.0, 139.0, 0.0);
+        LocalCartesian cartesian = CreateCartesian(origin);
+        ParsedSurface empty = CreateSurface("empty", ParsedSurfaceSemantic.Wall, []);
+        ParsedSurface wall = CreateSurface(
+            "wall",
+            ParsedSurfaceSemantic.Wall,
+            CreateVerticalQuadVertices(origin, widthMeters: 8.0, heightMeters: 6.0));
+
+        FacadeUvProjectionContext? context = CityGmlSurfaceProjectionPolicy.TryCreateFacadeUvProjectionContext(
+            "bldg",
+            [empty, wall],
+            origin,
+            cartesian);
+
+        Assert.NotNull(context);
+        Assert.InRange(context.Value.MinimumY, -1e-5, 1e-5);
+        Assert.InRange(context.Value.MaximumY, 6.0 - 1e-5, 6.0 + 1e-5);
+    }
+
+    [Fact]
     public void GetCulledSurfaceIdsBeforeProjectionKeepsGeneratedNoWallRoofBottomAtObjectMinimum()
     {
         GeodeticPoint origin = new(35.0, 139.0, 0.0);

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlTerrainConformerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlTerrainConformerTests.cs
@@ -63,6 +63,7 @@ public sealed class CityGmlTerrainConformerTests
             ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4979"),
             SourceFileRelativePath: $"udx/{packageName}/53394525/{packageName}.gml",
             SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty,
             TerrainAligned: false);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
@@ -17,10 +17,7 @@ public sealed class DefaultImportedSceneSourceComposerTests
     [Fact]
     public void ComposeMapsDocumentSetBoundaryIntoImportedSceneMetadata()
     {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau");
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create();
         PlateauImportRequest importRequest = request.ToImportRequest();
 
         TerrainTextureOverlay overlay = new(
@@ -71,12 +68,9 @@ public sealed class DefaultImportedSceneSourceComposerTests
     [Fact]
     public async Task ComposedStreamingSourcePreflightValidatesExplicitDemTextureSource()
     {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            PackageNames: ["dem"],
-            DemTextureSource: new LocalDatasetLocation("/tmp/plateau/ortho.tif"));
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            packageNames: ["dem"],
+            demTextureLocalSourcePath: "C:\\tmp\\plateau\\ortho.tif");
         PlateauImportRequest importRequest = request.ToImportRequest();
         ImportedSceneSourceSnapshot readResult = new(
             new ImportedSceneSourceDataset(

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceComposerTests.cs
@@ -17,10 +17,11 @@ public sealed class DefaultImportedSceneSourceComposerTests
     [Fact]
     public void ComposeMapsDocumentSetBoundaryIntoImportedSceneMetadata()
     {
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("/tmp/plateau"));
+            CityGmlLocalSourcePath: "/tmp/plateau");
+        PlateauImportRequest importRequest = request.ToImportRequest();
 
         TerrainTextureOverlay overlay = new(
             PackageName: "bldg",
@@ -51,7 +52,7 @@ public sealed class DefaultImportedSceneSourceComposerTests
 
         Assert.Equal("3.0", source.Metadata.SchemaVersion);
         Assert.Equal("PLATEAU tokyo23ku 53394525", source.Metadata.SceneName);
-        Assert.Same(request, source.Metadata.Request);
+        Assert.Equal(importRequest, source.Metadata.Request);
         Assert.Equal(documentSet.PackageNames, source.Metadata.SourceDataset.PackageNames);
         Assert.Equal(documentSet.RelativeSourceFiles, source.Metadata.SourceDataset.SourceFiles);
         Assert.Equal(documentSet.SelectedMeshCodes, source.Metadata.SourceDataset.SelectedMeshCodes);
@@ -70,12 +71,13 @@ public sealed class DefaultImportedSceneSourceComposerTests
     [Fact]
     public async Task ComposedStreamingSourcePreflightValidatesExplicitDemTextureSource()
     {
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("/tmp/plateau"),
+            CityGmlLocalSourcePath: "/tmp/plateau",
             PackageNames: ["dem"],
-            DemTextureSource: DatasetLocation.Local("/tmp/plateau/ortho.tif"));
+            DemTextureSource: new LocalDatasetLocation("/tmp/plateau/ortho.tif"));
+        PlateauImportRequest importRequest = request.ToImportRequest();
         ImportedSceneSourceSnapshot readResult = new(
             new ImportedSceneSourceDataset(
                 new EmptyDatasetContentSource(),
@@ -106,7 +108,7 @@ public sealed class DefaultImportedSceneSourceComposerTests
         await preflight.ValidateBeforeSinkSetupAsync();
 
         Assert.Equal(1, demTextureSourcePolicy.ResolveCallCount);
-        Assert.Same(request, demTextureSourcePolicy.LastRequest);
+        Assert.Equal(importRequest, demTextureSourcePolicy.LastRequest);
         Assert.NotEmpty(demTextureSourcePolicy.LastOverlayRegions!);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceFactoryTests.cs
@@ -42,10 +42,7 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             new PassthroughImportedObjectUnitOptimizer());
         Action<string> progressReporter = _ => { };
 
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau");
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create();
 
         IImportedSceneSource result = await factory.CreateAsync(request, progressReporter);
 
@@ -76,12 +73,8 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             reader,
             composer,
             new PassthroughImportedObjectUnitOptimizer());
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            PackageNames: ["dem"]
-);
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            packageNames: ["dem"]);
 
         _ = await factory.CreateAsync(request);
 
@@ -122,12 +115,9 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             reader,
             composer,
             new PassthroughImportedObjectUnitOptimizer());
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: "/tmp/plateau",
-            PackageNames: ["dem"],
-            DemTextureSource: new LocalDatasetLocation("C:\\ortho\\53394525.tif"));
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            packageNames: ["dem"],
+            demTextureLocalSourcePath: "C:\\ortho\\53394525.tif");
 
         _ = await factory.CreateAsync(request);
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultImportedSceneSourceFactoryTests.cs
@@ -42,10 +42,10 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             new PassthroughImportedObjectUnitOptimizer());
         Action<string> progressReporter = _ => { };
 
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("/tmp/plateau"));
+            CityGmlLocalSourcePath: "/tmp/plateau");
 
         IImportedSceneSource result = await factory.CreateAsync(request, progressReporter);
 
@@ -76,10 +76,10 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             reader,
             composer,
             new PassthroughImportedObjectUnitOptimizer());
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("/tmp/plateau"),
+            CityGmlLocalSourcePath: "/tmp/plateau",
             PackageNames: ["dem"]
 );
 
@@ -122,12 +122,12 @@ public sealed class DefaultImportedSceneSourceFactoryTests
             reader,
             composer,
             new PassthroughImportedObjectUnitOptimizer());
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("/tmp/plateau"),
+            CityGmlLocalSourcePath: "/tmp/plateau",
             PackageNames: ["dem"],
-            DemTextureSource: DatasetLocation.Local("C:\\ortho\\53394525.tif"));
+            DemTextureSource: new LocalDatasetLocation("C:\\ortho\\53394525.tif"));
 
         _ = await factory.CreateAsync(request);
 
@@ -151,14 +151,14 @@ public sealed class DefaultImportedSceneSourceFactoryTests
                     new GeodeticPoint(35.0, 139.0, 0.0)));
         }
 
-        public PlateauImportRequest? LastRequest { get; private set; }
+        public ResolvedLocalPlateauImportRequest? LastRequest { get; private set; }
 
         public Action<string>? LastProgressReporter { get; private set; }
 
         public ImportedSceneSourceSnapshot ReadResult { get; }
 
         public Task<ImportedSceneSourceSnapshot> ReadAsync(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             Action<string>? progressReporter = null,
             CancellationToken cancellationToken = default)
         {
@@ -172,14 +172,14 @@ public sealed class DefaultImportedSceneSourceFactoryTests
     {
         internal IImportedSceneSource ImportedSceneSource { get; } = importedSceneSource;
 
-        public PlateauImportRequest? LastRequest { get; private set; }
+        public ResolvedLocalPlateauImportRequest? LastRequest { get; private set; }
 
         public ImportedSceneSourceSnapshot? LastReadResult { get; private set; }
 
         public Action<string>? LastProgressReporter { get; private set; }
 
         public IImportedSceneSource Compose(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             ImportedSceneSourceSnapshot readResult,
             IImportedObjectUnitOptimizer objectUnitOptimizer,
             Action<string>? progressReporter = null)

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
@@ -21,6 +21,7 @@ public sealed class DefaultMaterialResolverTests
             PreferUvProjection: true,
             FamilyOverride: null,
             VariantSelectionKey: "bldg:uv",
+            BuildingAttributes: BuildingAttributeContext.Empty,
             SurfaceRole: DefaultMaterialSurfaceRole.Wall));
 
         Assert.Equal(MaterialType.Standard, material.MaterialType);
@@ -48,6 +49,7 @@ public sealed class DefaultMaterialResolverTests
             PreferUvProjection: true,
             FamilyOverride: null,
             VariantSelectionKey: $"bldg:{surfaceRole}:texture",
+            BuildingAttributes: BuildingAttributeContext.Empty,
             SurfaceRole: surfaceRole));
 
         Assert.Equal(MaterialType.Standard, material.MaterialType);
@@ -115,6 +117,7 @@ public sealed class DefaultMaterialResolverTests
             PreferUvProjection: true,
             FamilyOverride: null,
             VariantSelectionKey: $"bldg:{surfaceRole}:fallback",
+            BuildingAttributes: BuildingAttributeContext.Empty,
             SurfaceRole: surfaceRole));
 
         Assert.Equal(MaterialType.Standard, material.MaterialType);
@@ -134,7 +137,8 @@ public sealed class DefaultMaterialResolverTests
             TexturePayload: null,
             PreferUvProjection: false,
             FamilyOverride: null,
-            VariantSelectionKey: "luse:tri"));
+            VariantSelectionKey: "luse:tri",
+            BuildingAttributes: BuildingAttributeContext.Empty));
 
         Assert.Equal(MaterialType.Wireframe, material.MaterialType);
         Assert.Null(material.TexturePayload);
@@ -472,6 +476,7 @@ public sealed class DefaultMaterialResolverTests
                 PreferUvProjection: true,
                 FamilyOverride: BundledDefaultMaterialFamilies.Facade,
                 VariantSelectionKey: "bldg:uv:0",
+                BuildingAttributes: BuildingAttributeContext.Empty,
                 SurfaceRole: DefaultMaterialSurfaceRole.Wall)));
 
         Assert.Contains("not codebase-reachable", error.Message, StringComparison.Ordinal);
@@ -516,7 +521,8 @@ public sealed class DefaultMaterialResolverTests
             TexturePayload: null,
             PreferUvProjection: false,
             FamilyOverride: null,
-            VariantSelectionKey: variantSelectionKey);
+            VariantSelectionKey: variantSelectionKey,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private static DefaultMaterialRequest CreateBuildingWallRequest(
@@ -533,7 +539,7 @@ public sealed class DefaultMaterialResolverTests
             PreferUvProjection: true,
             FamilyOverride: null,
             VariantSelectionKey: variantSelectionKey,
-            BuildingAttributes: attributes,
+            BuildingAttributes: attributes ?? BuildingAttributeContext.Empty,
             FloorsAboveGround: floorsAboveGround,
             MeasuredHeightMeters: measuredHeightMeters,
             GeometryHeightMeters: geometryHeightMeters,

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
@@ -13,7 +13,7 @@ public sealed class DefaultMaterialResolverTests
     [Fact]
     public void ResolveMaterialUsesDatasetTextureWhenPresent()
     {
-        TexturePayload payload = new(4, 4, "srgb", new byte[4 * 4 * 4], "udx/bldg/53394525/appearance/roof.png");
+        TexturePayload payload = new RawRgba32TexturePayload(4, 4, "srgb", new byte[4 * 4 * 4], "udx/bldg/53394525/appearance/roof.png");
 
         ResolvedMaterial material = resolver.ResolveMaterial(new DefaultMaterialRequest(
             "bldg",
@@ -41,7 +41,7 @@ public sealed class DefaultMaterialResolverTests
     public void ResolveMaterialUsesDatasetTextureBeforeBuildingFallback(int surfaceRoleValue)
     {
         DefaultMaterialSurfaceRole surfaceRole = (DefaultMaterialSurfaceRole)surfaceRoleValue;
-        TexturePayload payload = new(4, 4, "srgb", new byte[4 * 4 * 4], $"udx/bldg/53394525/appearance/{surfaceRole}.png");
+        TexturePayload payload = new RawRgba32TexturePayload(4, 4, "srgb", new byte[4 * 4 * 4], $"udx/bldg/53394525/appearance/{surfaceRole}.png");
 
         ResolvedMaterial material = resolver.ResolveMaterial(new DefaultMaterialRequest(
             "bldg",

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
@@ -467,19 +467,23 @@ public sealed class DefaultMaterialResolverTests
     }
 
     [Fact]
-    public void ResolveMaterialRejectsExplicitFacadeOverrideOutsideCodebaseReachableFamilies()
+    public void ResolveMaterialAcceptsEveryTypedFamilyOverride()
     {
-        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
-            () => resolver.ResolveMaterial(new DefaultMaterialRequest(
+        foreach (DefaultMaterialFamilyOverride familyOverride in DefaultMaterialFamilyOverride.All)
+        {
+            ResolvedMaterial material = resolver.ResolveMaterial(new DefaultMaterialRequest(
                 "bldg",
                 TexturePayload: null,
                 PreferUvProjection: true,
-                FamilyOverride: BundledDefaultMaterialFamilies.Facade,
-                VariantSelectionKey: "bldg:uv:0",
+                FamilyOverride: familyOverride,
+                VariantSelectionKey: $"typed-family:{familyOverride.Family}:0",
                 BuildingAttributes: BuildingAttributeContext.Empty,
-                SurfaceRole: DefaultMaterialSurfaceRole.Wall)));
+                SurfaceRole: DefaultMaterialSurfaceRole.Wall));
 
-        Assert.Contains("not codebase-reachable", error.Message, StringComparison.Ordinal);
+            Assert.Equal(familyOverride.Family, material.Family);
+            Assert.Equal(TextureSourceKind.Bundled, material.TextureSourceKind);
+            Assert.Null(material.TexturePayload);
+        }
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemCityObjectAggregationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemCityObjectAggregationTests.cs
@@ -85,6 +85,7 @@ public sealed class DemCityObjectAggregationTests
             Surfaces: [surface],
             referenceSystem,
             sourceFileRelativePath,
-            SharedAcrossMeshCodes: true);
+            SharedAcrossMeshCodes: true,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemSourceDiscoverySupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemSourceDiscoverySupportTests.cs
@@ -129,6 +129,7 @@ public sealed class DemSourceDiscoverySupportTests
             ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
             SourceFileRelativePath: "udx/dem/53394525/sample.gml",
             SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty,
             TerrainAligned: false,
             GeodeticOriginOverride: null);
     }
@@ -155,6 +156,7 @@ public sealed class DemSourceDiscoverySupportTests
             ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
             SourceFileRelativePath: "udx/dem/53394525/empty-geometry.gml",
             SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty,
             TerrainAligned: false,
             GeodeticOriginOverride: null);
     }

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemSourceDiscoverySupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemSourceDiscoverySupportTests.cs
@@ -35,6 +35,7 @@ public sealed class DemSourceDiscoverySupportTests
 
         CachedSourceFileDescriptor cachedSourceFile = Assert.Single(result.CachedDemSourceFiles);
         Assert.Equal("udx/dem/53394525/sample.gml", cachedSourceFile.RelativePath);
+        Assert.Equal(CoordinateReferenceSystem.Parse("EPSG:4326"), cachedSourceFile.ReferenceSystem);
         Assert.Equal(3, result.TerrainTriangles.Length);
         Assert.Equal(1, result.ParsedCityObjectCount);
     }

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainGeoReferencedRasterCatalogTests.cs
@@ -101,7 +101,7 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
             CancellationToken.None);
 
         TerrainTextureGeoReferencedRasterSource resolvedResult = Assert.IsType<TerrainTextureGeoReferencedRasterSource>(result);
-        Assert.Equal("EPSG:4326", resolvedResult.Metadata?.CoordinateSystemIdentifier);
+        Assert.Equal("EPSG:4326", resolvedResult.Metadata.CoordinateSystemIdentifier);
         Assert.Equal(1, datasetSource.EnsureLocalFileCallCount);
         Assert.Equal(0, datasetSource.OpenReadCallCount);
 
@@ -170,7 +170,7 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await firstCall);
         TerrainTextureGeoReferencedRasterSource? secondResult = await secondCall;
         TerrainTextureGeoReferencedRasterSource resolvedSecondResult = Assert.IsType<TerrainTextureGeoReferencedRasterSource>(secondResult);
-        Assert.Equal("EPSG:4326", resolvedSecondResult.Metadata?.CoordinateSystemIdentifier);
+        Assert.Equal("EPSG:4326", resolvedSecondResult.Metadata.CoordinateSystemIdentifier);
 
         TerrainTextureGeoReferencedRasterSource? thirdResult = await catalog.TryResolveRasterSourceAsync(
             new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, ThirdRegionalMeshCode.Parse("53394525"), bounds),
@@ -183,7 +183,7 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
     }
 
     [Fact]
-    public async Task TryResolveRasterSourceAsyncEvictsFaultedBackgroundTaskAfterCanceledWaiter()
+    public async Task TryResolveRasterSourceAsyncTreatsFaultedCandidateMaterializationAsUnavailableAfterCanceledWaiter()
     {
         using TemporaryDirectory datasetRoot = new();
         FaultingGateableDatasetContentSource datasetSource = CreateFaultingGateableDatasetSource(datasetRoot.Path);
@@ -203,35 +203,15 @@ public sealed class DemTerrainGeoReferencedRasterCatalogTests
         datasetSource.ReleaseOpenRead.TrySetResult();
         await datasetSource.BackgroundCompletion.Task.WaitAsync(CancellationToken.None);
 
-        await AssertEventuallyRetriesFaultedBackgroundTaskAsync(catalog, datasetSource, bounds);
-        Assert.Equal(2, datasetSource.EnsureLocalFileCallCount);
+        TerrainTextureGeoReferencedRasterSource? retryResult = await catalog.TryResolveRasterSourceAsync(
+            new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, ThirdRegionalMeshCode.Parse("53394525"), bounds),
+            ThirdRegionalMeshCode.Parse("53394525"),
+            bounds,
+            CancellationToken.None);
+
+        Assert.Null(retryResult);
+        Assert.Equal(1, datasetSource.EnsureLocalFileCallCount);
         Assert.Equal(0, datasetSource.OpenReadCallCount);
-    }
-
-    private static async Task AssertEventuallyRetriesFaultedBackgroundTaskAsync(
-        DemTerrainGeoReferencedRasterCatalog catalog,
-        FaultingGateableDatasetContentSource datasetSource,
-        GeographicRectangle bounds)
-    {
-        for (int attempt = 0; attempt < 50; attempt++)
-        {
-            await Assert.ThrowsAnyAsync<IOException>(async () => await catalog.TryResolveRasterSourceAsync(
-                    new DemTerrainRasterCacheKey("tokyo23ku", catalog.CacheScope, ThirdRegionalMeshCode.Parse("53394525"), bounds),
-                    ThirdRegionalMeshCode.Parse("53394525"),
-                    bounds,
-                    CancellationToken.None));
-
-            if (datasetSource.EnsureLocalFileCallCount == 2)
-            {
-                return;
-            }
-
-            await Task.Delay(20);
-        }
-
-        Assert.Fail(
-            $"Faulted background task was not evicted after 50 retry attempts. "
-            + $"Observed EnsureLocalFileCallCount={datasetSource.EnsureLocalFileCallCount}.");
     }
 
     private static RecordingDatasetContentSource CreateDatasetSource(string datasetRoot)

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemTerrainOverlayAssignmentTests.cs
@@ -422,7 +422,8 @@ public sealed class DemTerrainOverlayAssignmentTests
             Surfaces: [surface],
             ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
             SourceFileRelativePath: "udx/dem/53394525/sample.gml",
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private static ParsedSurface CreateGeneratedSurface(

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -509,6 +509,33 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
     }
 
     [Fact]
+    public void CreateSkipsEmptySurfacesBeforeSelectingGeneratedRoofTopCandidate()
+    {
+        ParsedSurface empty = CreateSurface("empty", ParsedSurfaceSemantic.Roof, [], null, texturePayload: null);
+        ParsedSurface top = CreateSurface(
+            "lod1-top",
+            ParsedSurfaceSemantic.Roof,
+            altitude: 10.0);
+        ParsedSurface bottom = CreateSurface(
+            "lod1-bottom",
+            ParsedSurfaceSemantic.Ground,
+            altitude: 0.0);
+        ParsedCityObject cityObject = CreateCityObject(
+            [empty, top, bottom],
+            CoordinateReferenceSystem.Parse("EPSG:6697"),
+            BuildingAttributeContext.Empty with
+            {
+                RoofShape = new BuildingCodeValue<CityGmlRoofShape>(CityGmlRoofShape.Shed, "shed"),
+            });
+
+        ParsedCityObject generated = GeneratedLod1RoofCityObjectFactory.Create(cityObject);
+
+        Assert.DoesNotContain(generated.Surfaces, static surface => surface.PolygonId == "lod1-top");
+        Assert.Contains(generated.Surfaces, static surface => surface.PolygonId == "empty");
+        Assert.Equal(4, generated.Surfaces.Count(static surface => surface.PolygonId.Contains("_generated_", System.StringComparison.Ordinal)));
+    }
+
+    [Fact]
     public void CreateSkipsObjectThatAlreadyHasGeneratedRoofSurface()
     {
         ParsedCityObject cityObject = CreateCityObject(

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedLod1RoofCityObjectFactoryTests.cs
@@ -747,7 +747,7 @@ public sealed class GeneratedLod1RoofCityObjectFactoryTests
 
     private static TexturePayload CreateTexturePayload(string identity)
     {
-        return new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], identity);
+        return new RawRgba32TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], identity);
     }
 
     private static double ComputeParsedNormalY(ParsedSurface surface)

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
@@ -65,7 +65,7 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
                 "textured-road",
                 width: 4.0,
                 length: 12.0,
-                texturePayload: new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")));
+                texturePayload: new RawRgba32TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")));
 
         ParsedCityObject? marking = GeneratedRoadMarkingCityObjectFactory.Create(road, new GeodeticPoint(0.0, 0.0, 0.0), cityObjectCartesian: null);
 
@@ -83,7 +83,7 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
                     "textured-road",
                     width: 4.0,
                     length: 12.0,
-                    texturePayload: new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")),
+                    texturePayload: new RawRgba32TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], "road-texture")),
                 CreateRoadSurface(
                     "plain-road",
                     width: 4.0,

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
@@ -114,26 +114,15 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
     }
 
     [Fact]
-    public void RoadSurfaceEdgePairSelectorRejectsNonQuadInputsWithClearPrecondition()
+    public void CreateSkipsNonQuadRoadSurfaceAtQuadBoundary()
     {
-        GeodeticPoint[] vertices =
-        [
-            new(0.0, 0.0, 0.0),
-            new(1.0, 0.0, 0.0),
-            new(1.0, 1.0, 0.0),
-        ];
-        Float3[] positions =
-        [
-            new(0.0, 0.0, 0.0),
-            new(1.0, 0.0, 0.0),
-            new(1.0, 0.0, 1.0),
-        ];
+        ParsedCityObject road = CreateRoadObject(
+            packageName: "tran",
+            surface: CreateTriangleRoadSurface("triangle-road"));
 
-        ArgumentException exception = Assert.Throws<ArgumentException>(
-            () => RoadSurfaceEdgePairSelector.Select(vertices, positions));
+        ParsedCityObject? marking = GeneratedRoadMarkingCityObjectFactory.Create(road, new GeodeticPoint(0.0, 0.0, 0.0), cityObjectCartesian: null);
 
-        Assert.Equal("vertices", exception.ParamName);
-        Assert.Contains("exactly four vertices", exception.Message, StringComparison.Ordinal);
+        Assert.Null(marking);
     }
 
     private static ParsedCityObject CreateRoadObject(string packageName, ParsedSurface surface)
@@ -178,5 +167,23 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
             InteriorRings: [],
             new ColorRgba(0.2, 0.2, 0.2, 1.0),
             texturePayload);
+    }
+
+    private static ParsedSurface CreateTriangleRoadSurface(string polygonId)
+    {
+        GeodeticPoint[] vertices =
+        [
+            new(0.0, 0.0, 0.0),
+            new(12.0, 0.0, 0.0),
+            new(12.0, 4.0, 0.0),
+        ];
+
+        return new ParsedSurface(
+            polygonId,
+            ParsedSurfaceSemantic.Ground,
+            new ParsedRing($"{polygonId}-ring", vertices, UVs: null),
+            InteriorRings: [],
+            new ColorRgba(0.2, 0.2, 0.2, 1.0),
+            TexturePayload: null);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/GeneratedRoadMarkingCityObjectFactoryTests.cs
@@ -153,6 +153,7 @@ public sealed class GeneratedRoadMarkingCityObjectFactoryTests
             new CoordinateReferenceSystem("local", Geocentric: null, CompatibilityKey: "local"),
             "udx/tran/road.gml",
             SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty,
             TerrainAligned: true);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/ImportedDynamicMaterialUvNormalizerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/ImportedDynamicMaterialUvNormalizerTests.cs
@@ -270,7 +270,7 @@ public sealed class ImportedDynamicMaterialUvNormalizerTests
         return new MaterialBinding(
             BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
             MaterialType: MaterialType.Standard,
-            TexturePayload: new TexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),
+            TexturePayload: new RawRgba32TexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),
             TextureSourceKind: TextureSourceKind.Dataset,
             Projection: MaterialProjection.Uv,
             DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlGeometryProjectorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlGeometryProjectorTests.cs
@@ -50,7 +50,8 @@ public sealed class LocalCityGmlGeometryProjectorTests
                     Surfaces: [],
                     ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:6697"),
                     SourceFileRelativePath: "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml",
-                    SharedAcrossMeshCodes: false),
+                    SharedAcrossMeshCodes: false,
+                    BuildingAttributes: BuildingAttributeContext.Empty),
             ]);
 
         PlateauImportValidationException exception = Assert.Throws<PlateauImportValidationException>(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlGeometryProjectorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlGeometryProjectorTests.cs
@@ -34,6 +34,7 @@ public sealed class LocalCityGmlGeometryProjectorTests
     public void ProjectCityObjectsValidatesReferenceSystemBeforeProjectingCanonicalObjects()
     {
         LocalCityGmlGeometryProjector projector = new(new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
+        CoordinateReferenceSystem sourceReferenceSystem = CoordinateReferenceSystem.Parse("EPSG:6697");
         CachedSourceFileDescriptor sourceFile = new(
             new SourceFileDescriptor(
                 RelativePath: "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml",
@@ -48,11 +49,43 @@ public sealed class LocalCityGmlGeometryProjectorTests
                     ActualMeshCode: "53394525",
                     LodLevel: 1,
                     Surfaces: [],
-                    ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:6697"),
+                    ReferenceSystem: sourceReferenceSystem,
                     SourceFileRelativePath: "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml",
                     SharedAcrossMeshCodes: false,
                     BuildingAttributes: BuildingAttributeContext.Empty),
-            ]);
+            ],
+            sourceReferenceSystem);
+
+        PlateauImportValidationException exception = Assert.Throws<PlateauImportValidationException>(
+            () => projector.ProjectCityObjects(
+                    sourceFile,
+                    CoordinateReferenceSystem.Parse("EPSG:6696"),
+                    new GeodeticPoint(35.0, 139.0, 0.0),
+                    globalCartesian: new LocalCartesian(35.0, 139.0, 0.0, new Geocentric(Ellipsoid.GRS80)),
+                    demTerrainTextureOverlays: [],
+                    requestedMeshCodeBounds: [],
+                    request: new PlateauImportRequest(
+                        Dataset: "tokyo23ku",
+                        MeshCode: "53394525",
+                        CityGmlSource: DatasetLocation.Local("C:\\fixture"),
+                        PackageNames: ["bldg"]))
+                .ToArray());
+
+        Assert.Contains("Mixed CityGML coordinate reference systems are not supported", exception.Errors.Single());
+    }
+
+    [Fact]
+    public void ProjectCityObjectsValidatesSourceFileReferenceSystemWhenSourceFileHasNoCityObjects()
+    {
+        LocalCityGmlGeometryProjector projector = new(new DefaultMaterialResolver(CommonMaterialCatalog.Create()));
+        CachedSourceFileDescriptor sourceFile = new(
+            new SourceFileDescriptor(
+                RelativePath: "udx/bldg/53394525/empty.gml",
+                PackageName: "bldg",
+                MatchedMeshCode: "53394525",
+                RequiresMeshCodeBoundsFilter: false),
+            [],
+            CoordinateReferenceSystem.Parse("EPSG:6697"));
 
         PlateauImportValidationException exception = Assert.Throws<PlateauImportValidationException>(
             () => projector.ProjectCityObjects(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -538,8 +538,8 @@ public sealed class LocalCityGmlObjectProjectionTests
             {
                 CityGmlFunctionCodes = ["401"],
                 Structures = [new BuildingCodeValue<PlateauBuildingStructure>(structure, CreateStructureTypeCode(structure))],
-                MeasuredHeightMeters = BuildingMetricValue.Known(8.0),
-                BuildingFootprintArea = BuildingMetricValue.Known(100.0),
+                MeasuredHeightMeters = new BuildingMetricValue(8.0),
+                BuildingFootprintArea = new BuildingMetricValue(100.0),
             });
 
         ImportedCityObject projected = LocalCityGmlObjectProjection.ProjectCityObject(
@@ -597,8 +597,8 @@ public sealed class LocalCityGmlObjectProjectionTests
             {
                 CityGmlFunctionCodes = ["401"],
                 Structures = [new BuildingCodeValue<PlateauBuildingStructure>(structure, CreateStructureTypeCode(structure))],
-                MeasuredHeightMeters = BuildingMetricValue.Known(8.0),
-                BuildingFootprintArea = BuildingMetricValue.Known(100.0),
+                MeasuredHeightMeters = new BuildingMetricValue(8.0),
+                BuildingFootprintArea = new BuildingMetricValue(100.0),
             });
 
         ImportedCityObject projected = LocalCityGmlObjectProjection.ProjectCityObject(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -68,10 +68,11 @@ public sealed class LocalCityGmlObjectProjectionTests
     {
         string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
         LocalCityGmlDocumentReader documentReader = CreateDocumentReader();
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local(fixturePath));
+            CityGmlLocalSourcePath: fixturePath);
+        PlateauImportRequest importRequest = request.ToImportRequest();
 
         DefaultImportedSceneSourceFactory factory = new(
             documentReader,
@@ -87,7 +88,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         Assert.Equal("3.0", source.Metadata.SchemaVersion);
         Assert.Equal("PLATEAU tokyo23ku 53394525", source.Metadata.SceneName);
-        Assert.Same(request, source.Metadata.Request);
+        Assert.Equal(importRequest, source.Metadata.Request);
         Assert.Contains("bldg", source.Metadata.SourceDataset.PackageNames);
         Assert.Contains("53394525", source.Metadata.SourceDataset.SelectedMeshCodes!);
         Assert.NotEmpty(source.Metadata.SourceDataset.SourceFiles);

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -3854,7 +3854,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
     private static TexturePayload CreateTexturePayload(string identity)
     {
-        return new TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], identity);
+        return new RawRgba32TexturePayload(1, 1, "sRGB", [255, 255, 255, 255], identity);
     }
 
     private static HashSet<string> GetCulledSurfaceIdsBeforeProjectionForTest(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -3615,7 +3615,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             SharedAcrossMeshCodes: false,
             FloorsAboveGround: floorsAboveGround,
             MeasuredHeightMeters: measuredHeightMeters,
-            BuildingAttributes: buildingAttributes);
+            BuildingAttributes: buildingAttributes ?? BuildingAttributeContext.Empty);
     }
 
     private static BuildingAttributeContext CreateBuildingAttributes(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -68,10 +68,8 @@ public sealed class LocalCityGmlObjectProjectionTests
     {
         string fixturePath = TestData.GetFixturePath("LocalPlateauDataset");
         LocalCityGmlDocumentReader documentReader = CreateDocumentReader();
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: fixturePath);
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            cityGmlLocalSourcePath: fixturePath);
         PlateauImportRequest importRequest = request.ToImportRequest();
 
         DefaultImportedSceneSourceFactory factory = new(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
@@ -172,15 +172,17 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
         Assert.Contains(attributes.Structures, value => value.Value == PlateauBuildingStructure.Wood && value.Code == "601");
         Assert.Equal(["3001"], attributes.CityGmlClassCodes);
         Assert.Equal(["401"], attributes.CityGmlFunctionCodes);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.MeasuredHeightMeters.Kind);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.StoreysAboveGround.Kind);
-        Assert.Equal(BuildingMetricValueKind.Missing, attributes.StoreysBelowGround.Kind);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.BuildingFootprintArea.Kind);
-        Assert.Equal(BuildingMetricValueKind.Missing, attributes.BuildingRoofEdgeArea.Kind);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.BuildingHeight.Kind);
-        Assert.Equal(BuildingMetricValueKind.Known, attributes.EaveHeight.Kind);
-        Assert.InRange(attributes.BuildingFootprintArea.Value!.Value, 120.499999, 120.500001);
-        Assert.InRange(attributes.EaveHeight.Value!.Value, 9.699999, 9.700001);
+        Assert.NotNull(attributes.MeasuredHeightMeters);
+        Assert.NotNull(attributes.StoreysAboveGround);
+        Assert.Null(attributes.StoreysBelowGround);
+        Assert.NotNull(attributes.BuildingFootprintArea);
+        Assert.Null(attributes.BuildingRoofEdgeArea);
+        Assert.NotNull(attributes.BuildingHeight);
+        Assert.NotNull(attributes.EaveHeight);
+        BuildingMetricValue footprintArea = attributes.BuildingFootprintArea;
+        BuildingMetricValue eaveHeight = attributes.EaveHeight;
+        Assert.InRange(footprintArea.Value, 120.499999, 120.500001);
+        Assert.InRange(eaveHeight.Value, 9.699999, 9.700001);
     }
 
     private static async Task<ParsedCityObject> ParseSingleBuildingWithDetailAttributeAsync(string detailAttributeXml)
@@ -439,7 +441,6 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
 
         throw new InvalidOperationException("No city object was parsed.");
     }
-
     private sealed class GateableDatasetContentSource(byte[] payload, int gateOffset) : IPlateauDatasetContentSource
     {
         private readonly TaskCompletionSource releaseSignal = new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
@@ -185,6 +185,95 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
         Assert.InRange(eaveHeight.Value, 9.699999, 9.700001);
     }
 
+    [Fact]
+    public async Task SourceFilePipeline_StreamParsedCityObjectsAsync_SkipsInvalidInteriorRingsBeforeSurfaceConstruction()
+    {
+        string xml =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <core:CityModel xmlns:core="http://www.opengis.net/citygml/2.0" xmlns:gml="http://www.opengis.net/gml" xmlns:bldg="http://www.opengis.net/citygml/building/2.0">
+              <gml:boundedBy>
+                <gml:Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/6697" srsDimension="3">
+                  <gml:lowerCorner>35.0000 139.0000 0</gml:lowerCorner>
+                  <gml:upperCorner>35.0100 139.0100 12</gml:upperCorner>
+                </gml:Envelope>
+              </gml:boundedBy>
+              <core:cityObjectMember>
+                <bldg:Building gml:id="bldg-1">
+                  <bldg:lod2MultiSurface>
+                    <gml:MultiSurface>
+                      <gml:surfaceMember>
+                        <bldg:WallSurface>
+                          <gml:Polygon gml:id="poly-1">
+                            <gml:exterior>
+                              <gml:LinearRing gml:id="ring-1">
+                                <gml:posList>35.0000 139.0000 0 35.0000 139.0010 0 35.0000 139.0010 12 35.0000 139.0000 12 35.0000 139.0000 0</gml:posList>
+                              </gml:LinearRing>
+                            </gml:exterior>
+                            <gml:interior>
+                              <gml:LinearRing gml:id="invalid-interior">
+                                <gml:posList>35.0002 139.0002 1 35.0002 139.0004 1</gml:posList>
+                              </gml:LinearRing>
+                            </gml:interior>
+                            <gml:interior />
+                          </gml:Polygon>
+                        </bldg:WallSurface>
+                      </gml:surfaceMember>
+                    </gml:MultiSurface>
+                  </bldg:lod2MultiSurface>
+                </bldg:Building>
+              </core:cityObjectMember>
+            </core:CityModel>
+            """;
+        InMemoryDatasetContentSource datasetSource = new(Encoding.UTF8.GetBytes(xml));
+
+        ParsedCityObject parsedCityObject = await ParseSingleBuildingAsync(datasetSource);
+        ParsedSurface surface = Assert.Single(parsedCityObject.Surfaces);
+
+        Assert.Empty(surface.InteriorRings);
+    }
+
+    [Fact]
+    public async Task SourceFilePipeline_StreamParsedCityObjectsAsync_SkipsPolygonWithInvalidExteriorRing()
+    {
+        string xml =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <core:CityModel xmlns:core="http://www.opengis.net/citygml/2.0" xmlns:gml="http://www.opengis.net/gml" xmlns:bldg="http://www.opengis.net/citygml/building/2.0">
+              <gml:boundedBy>
+                <gml:Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/6697" srsDimension="3">
+                  <gml:lowerCorner>35.0000 139.0000 0</gml:lowerCorner>
+                  <gml:upperCorner>35.0100 139.0100 12</gml:upperCorner>
+                </gml:Envelope>
+              </gml:boundedBy>
+              <core:cityObjectMember>
+                <bldg:Building gml:id="bldg-1">
+                  <bldg:lod2MultiSurface>
+                    <gml:MultiSurface>
+                      <gml:surfaceMember>
+                        <bldg:WallSurface>
+                          <gml:Polygon gml:id="poly-1">
+                            <gml:exterior>
+                              <gml:LinearRing gml:id="invalid-exterior">
+                                <gml:posList>35.0000 139.0000 0 35.0000 139.0010 0</gml:posList>
+                              </gml:LinearRing>
+                            </gml:exterior>
+                          </gml:Polygon>
+                        </bldg:WallSurface>
+                      </gml:surfaceMember>
+                    </gml:MultiSurface>
+                  </bldg:lod2MultiSurface>
+                </bldg:Building>
+              </core:cityObjectMember>
+            </core:CityModel>
+            """;
+        InMemoryDatasetContentSource datasetSource = new(Encoding.UTF8.GetBytes(xml));
+
+        ParsedCityObject? parsedCityObject = await TryParseSingleBuildingAsync(datasetSource);
+
+        Assert.Null(parsedCityObject);
+    }
+
     private static async Task<ParsedCityObject> ParseSingleBuildingWithDetailAttributeAsync(string detailAttributeXml)
     {
         string xml =
@@ -229,6 +318,14 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
 
     private static async Task<ParsedCityObject> ParseSingleBuildingAsync(InMemoryDatasetContentSource datasetSource)
     {
+        ParsedCityObject? parsedCityObject = await TryParseSingleBuildingAsync(datasetSource);
+
+        Assert.NotNull(parsedCityObject);
+        return parsedCityObject;
+    }
+
+    private static async Task<ParsedCityObject?> TryParseSingleBuildingAsync(InMemoryDatasetContentSource datasetSource)
+    {
         SourceFileDescriptor sourceFile = new(
             "udx/bldg/53394525/metadata.gml",
             "bldg",
@@ -252,7 +349,7 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
             break;
         }
 
-        return parsedCityObject!;
+        return parsedCityObject;
     }
 
     [Theory]

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileParserStreamingTests.cs
@@ -162,8 +162,7 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
         Assert.NotNull(parsedCityObject.MeasuredHeightMeters);
         Assert.InRange(parsedCityObject.MeasuredHeightMeters!.Value, 11.799999, 11.800001);
 
-        Assert.NotNull(parsedCityObject.BuildingAttributes);
-        BuildingAttributeContext attributes = parsedCityObject.BuildingAttributes!;
+        BuildingAttributeContext attributes = parsedCityObject.BuildingAttributes;
         Assert.NotNull(attributes.RoofShape);
         Assert.Equal(CityGmlRoofShape.Shed, attributes.RoofShape!.Value);
         Assert.Equal("5", attributes.RoofShape.Code);
@@ -368,8 +367,7 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
         CityGmlRoofShape expectedShape = (CityGmlRoofShape)expectedShapeValue;
         ParsedCityObject parsedCityObject = await ParseSingleBuildingWithRoofTypeAsync(roofTypeCode);
 
-        Assert.NotNull(parsedCityObject.BuildingAttributes);
-        BuildingCodeValue<CityGmlRoofShape>? roofShape = parsedCityObject.BuildingAttributes!.RoofShape;
+        BuildingCodeValue<CityGmlRoofShape>? roofShape = parsedCityObject.BuildingAttributes.RoofShape;
         Assert.NotNull(roofShape);
         Assert.Equal(expectedShape, roofShape!.Value);
         Assert.Equal(roofTypeCode, roofShape.Code);
@@ -389,8 +387,7 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
             $"<uro:buildingStructureType>{structureCode}</uro:buildingStructureType>");
         PlateauBuildingStructure expectedStructure = (PlateauBuildingStructure)expectedStructureValue;
 
-        Assert.NotNull(parsedCityObject.BuildingAttributes);
-        BuildingCodeValue<PlateauBuildingStructure> structure = Assert.Single(parsedCityObject.BuildingAttributes!.Structures);
+        BuildingCodeValue<PlateauBuildingStructure> structure = Assert.Single(parsedCityObject.BuildingAttributes.Structures);
         Assert.Equal(expectedStructure, structure.Value);
         Assert.Equal(structureCode, structure.Code);
     }
@@ -408,8 +405,7 @@ public sealed class LocalCityGmlSourceFileParserStreamingTests
             $"<uro:detailedUsage>{detailedUsageCode}</uro:detailedUsage>");
         PlateauBuildingUse expectedUse = (PlateauBuildingUse)expectedUseValue;
 
-        Assert.NotNull(parsedCityObject.BuildingAttributes);
-        BuildingCodeValue<PlateauBuildingUse> detailedUse = Assert.Single(parsedCityObject.BuildingAttributes!.DetailedUses);
+        BuildingCodeValue<PlateauBuildingUse> detailedUse = Assert.Single(parsedCityObject.BuildingAttributes.DetailedUses);
         Assert.Equal(expectedUse, detailedUse.Value);
         Assert.Equal(detailedUsageCode, detailedUse.Code);
     }

--- a/tests/PlateauResoniteLink.Tests/Profiles/Lod1RoofShapePolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/Lod1RoofShapePolicyTests.cs
@@ -86,13 +86,13 @@ public sealed class Lod1RoofShapePolicyTests
             Structures: CreateCodeValues(structures),
             CityGmlClassCodes: [],
             CityGmlFunctionCodes: cityGmlFunctionCodes ?? [],
-            MeasuredHeightMeters: BuildingMetricValue.Missing,
-            StoreysAboveGround: BuildingMetricValue.Missing,
-            StoreysBelowGround: BuildingMetricValue.Missing,
-            BuildingFootprintArea: footprintArea.HasValue ? BuildingMetricValue.Known(footprintArea.Value) : BuildingMetricValue.Missing,
-            BuildingRoofEdgeArea: BuildingMetricValue.Missing,
-            BuildingHeight: BuildingMetricValue.Missing,
-            EaveHeight: BuildingMetricValue.Missing);
+            MeasuredHeightMeters: null,
+            StoreysAboveGround: null,
+            StoreysBelowGround: null,
+            BuildingFootprintArea: footprintArea.HasValue ? new BuildingMetricValue(footprintArea.Value) : null,
+            BuildingRoofEdgeArea: null,
+            BuildingHeight: null,
+            EaveHeight: null);
     }
 
     private static BuildingCodeValue<T>[] CreateCodeValues<T>(T[]? values)

--- a/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
@@ -292,7 +292,8 @@ public sealed class StreamingImportedSceneSourceStreamingTests
             Surfaces: [surface],
             ReferenceSystem: referenceSystem,
             SourceFileRelativePath: $"udx/{packageName}/53394525/{objectKey}.gml",
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private sealed class RecordingGeometryProjector : ICityGmlGeometryProjector

--- a/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
@@ -54,6 +54,89 @@ public sealed class StreamingImportedSceneSourceStreamingTests
     }
 
     [Fact]
+    public async Task ReadCityObjectsAsync_UsesCurrentParsedObjectReferenceSystemForDescriptor()
+    {
+        CoordinateReferenceSystem firstReferenceSystem =
+            CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        CoordinateReferenceSystem secondReferenceSystem =
+            CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6668");
+        GeodeticPoint globalOriginPoint = new(35.0, 139.0, 0.0);
+        RecordingGeometryProjector geometryProjector = new();
+
+        SourceFilePipeline bldgPipeline = CreatePipeline(
+            new SourceFileDescriptor("udx/bldg/53394525/building.gml", "bldg", "53394525", RequiresMeshCodeBoundsFilter: false),
+            [
+                CreateParsedCityObject("bldg", "first-building", "First Building", firstReferenceSystem, lodLevel: 1),
+                CreateParsedCityObject("bldg", "second-building", "Second Building", secondReferenceSystem, lodLevel: 1),
+            ],
+            streamFactory: static (sourceFile, cityObjects, beforeYield, cancellationToken) =>
+                StreamSingleParsedCityObjectAsync(sourceFile, cityObjects, beforeYield, cancellationToken));
+
+        StreamingImportedSceneSource source = CreateSource(
+            firstReferenceSystem,
+            globalOriginPoint,
+            [bldgPipeline],
+            geometryProjector);
+
+        List<ImportedCityObject> yieldedObjects = [];
+        await foreach (ImportedCityObject cityObject in source.ReadCityObjectsAsync())
+        {
+            yieldedObjects.Add(cityObject);
+        }
+
+        Assert.Equal(2, yieldedObjects.Count);
+        Assert.Collection(
+            geometryProjector.CallRecords,
+            first =>
+            {
+                Assert.Equal(firstReferenceSystem.SrsName, first.SourceFileReferenceSystem.SrsName);
+                Assert.Equal(firstReferenceSystem.SrsName, first.CityObjectReferenceSystem.SrsName);
+            },
+            second =>
+            {
+                Assert.Equal(secondReferenceSystem.SrsName, second.SourceFileReferenceSystem.SrsName);
+                Assert.Equal(secondReferenceSystem.SrsName, second.CityObjectReferenceSystem.SrsName);
+            });
+    }
+
+    [Fact]
+    public async Task ReadCityObjectsAsync_RejectsIncompatibleReferenceSystemAfterFirstStreamedObject()
+    {
+        CoordinateReferenceSystem firstReferenceSystem =
+            CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        CoordinateReferenceSystem secondReferenceSystem =
+            CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6696");
+        GeodeticPoint globalOriginPoint = new(35.0, 139.0, 0.0);
+
+        SourceFilePipeline bldgPipeline = CreatePipeline(
+            new SourceFileDescriptor("udx/bldg/53394525/building.gml", "bldg", "53394525", RequiresMeshCodeBoundsFilter: false),
+            [
+                CreateParsedCityObject("bldg", "first-building", "First Building", firstReferenceSystem, lodLevel: 1),
+                CreateParsedCityObject("bldg", "second-building", "Second Building", secondReferenceSystem, lodLevel: 1),
+            ],
+            streamFactory: static (sourceFile, cityObjects, beforeYield, cancellationToken) =>
+                StreamSingleParsedCityObjectAsync(sourceFile, cityObjects, beforeYield, cancellationToken));
+
+        StreamingImportedSceneSource source = CreateSource(
+            firstReferenceSystem,
+            globalOriginPoint,
+            [bldgPipeline]);
+
+        PlateauImportValidationException exception = await Assert.ThrowsAsync<PlateauImportValidationException>(
+            async () =>
+            {
+                await foreach (ImportedCityObject _ in source.ReadCityObjectsAsync())
+                {
+                }
+            });
+
+        Assert.Contains(
+            "Mixed CityGML coordinate reference systems are not supported",
+            exception.Errors.Single(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ReadCityObjectsAsync_CompletesAfterDelayedDemPipelineIsReleased()
     {
         CoordinateReferenceSystem referenceSystem =
@@ -168,7 +251,9 @@ public sealed class StreamingImportedSceneSourceStreamingTests
         return new ParsedSourceFileResult(
             sourceFile,
             cityObjects,
-            cityObjects.Length == 0 ? null : cityObjects[0].ReferenceSystem,
+            cityObjects.Length == 0
+                ? CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697")
+                : cityObjects[0].ReferenceSystem,
             string.Equals(sourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
                 ? DemSourceDiscoverySupport.CreateTerrainHeightTriangles(cityObjects)
                 : [],
@@ -197,8 +282,10 @@ public sealed class StreamingImportedSceneSourceStreamingTests
     private static StreamingImportedSceneSource CreateSource(
         CoordinateReferenceSystem referenceSystem,
         GeodeticPoint globalOriginPoint,
-        IReadOnlyList<SourceFilePipeline> sourceFilePipelines)
+        IReadOnlyList<SourceFilePipeline> sourceFilePipelines,
+        RecordingGeometryProjector? geometryProjector = null)
     {
+        _ = referenceSystem;
         string[] packageNames = sourceFilePipelines
             .Select(static pipeline => pipeline.SourceFile.PackageName)
             .Distinct(StringComparer.Ordinal)
@@ -234,7 +321,7 @@ public sealed class StreamingImportedSceneSourceStreamingTests
             metadata,
             request,
             readResult,
-            new RecordingGeometryProjector(),
+            geometryProjector ?? new RecordingGeometryProjector(),
             new StubDemTextureSourcePolicy(),
             new PassthroughImportedObjectUnitOptimizer());
     }
@@ -299,8 +386,11 @@ public sealed class StreamingImportedSceneSourceStreamingTests
     private sealed class RecordingGeometryProjector : ICityGmlGeometryProjector
     {
         private readonly ConcurrentQueue<string> calls = [];
+        private readonly ConcurrentQueue<ReferenceSystemCallRecord> callRecords = [];
 
         public IReadOnlyCollection<string> Calls => calls.ToArray();
+
+        public IReadOnlyCollection<ReferenceSystemCallRecord> CallRecords => callRecords.ToArray();
 
         public IEnumerable<ImportedCityObject> ProjectCityObjects(
             CachedSourceFileDescriptor sourceFile,
@@ -330,6 +420,9 @@ public sealed class StreamingImportedSceneSourceStreamingTests
                 }
 
                 calls.Enqueue(cityObject.PackageName);
+                callRecords.Enqueue(new ReferenceSystemCallRecord(
+                    sourceFile.ReferenceSystem,
+                    cityObject.ReferenceSystem));
                 yield return new ImportedCityObject(
                     cityObject.SlotKey,
                     cityObject.DisplayName,
@@ -350,6 +443,10 @@ public sealed class StreamingImportedSceneSourceStreamingTests
             }
         }
     }
+
+    private sealed record ReferenceSystemCallRecord(
+        CoordinateReferenceSystem SourceFileReferenceSystem,
+        CoordinateReferenceSystem CityObjectReferenceSystem);
 
     private sealed class EmptyDatasetContentSource : IPlateauDatasetContentSource
     {

--- a/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceTests.cs
@@ -812,7 +812,8 @@ public sealed class StreamingImportedSceneSourceTests
             Surfaces: surfaces,
             ReferenceSystem: referenceSystem,
             SourceFileRelativePath: sourceFile.RelativePath,
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private static ParsedCityObject CreateParsedCityObjectInMesh53394525(
@@ -846,7 +847,8 @@ public sealed class StreamingImportedSceneSourceTests
             ],
             ReferenceSystem: referenceSystem,
             SourceFileRelativePath: sourceFile.RelativePath,
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private static ParsedCityObject CreateRenderableParsedCityObject(
@@ -884,7 +886,8 @@ public sealed class StreamingImportedSceneSourceTests
             ],
             ReferenceSystem: referenceSystem,
             SourceFileRelativePath: sourceFile.RelativePath,
-            SharedAcrossMeshCodes: false);
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty);
     }
 
     private static async Task WaitForConditionAsync(Func<bool> predicate, TimeSpan timeout)

--- a/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayMaterialSourcePartitionerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/TerrainOverlayMaterialSourcePartitionerTests.cs
@@ -58,6 +58,32 @@ public sealed class TerrainOverlayMaterialSourcePartitionerTests
         Assert.Equal(ParsedSurfaceSemantic.Wall, noWallSide.Semantic);
     }
 
+    [Fact]
+    public void PartitionParsedCityObjectRejectsInvalidTerrainMaterialSourceMeshCodeBeforeOverlayFallback()
+    {
+        MeshCodeBounds meshBounds = MeshCodeBounds.TryParse("53394525")!;
+        ParsedCityObject cityObject = new(
+            SlotKey: "bldg-invalid-mesh",
+            DisplayName: "Invalid mesh building",
+            PackageName: "bldg",
+            ActualMeshCode: "not-a-mesh",
+            LodLevel: 2,
+            Surfaces: [CreateHorizontalSurface("roof", altitude: 10.0, meshBounds: meshBounds)],
+            ReferenceSystem: CoordinateReferenceSystem.Parse("EPSG:4326"),
+            SourceFileRelativePath: "udx/bldg/not-a-mesh/bldg.gml",
+            SharedAcrossMeshCodes: false,
+            BuildingAttributes: BuildingAttributeContext.Empty with { CityGmlClassCodes = ["3003"] });
+
+        PlateauImportValidationException exception = Assert.Throws<PlateauImportValidationException>(
+            () => TerrainOverlayMaterialSourcePartitioner.PartitionParsedCityObject(
+                    cityObject,
+                    [CreateOverlay(meshBounds)],
+                    [meshBounds])
+                .ToArray());
+        string error = Assert.Single(exception.Errors);
+        Assert.Contains("must be a valid second- or third-level mesh-code", error);
+    }
+
     private static ParsedSurface CreateHorizontalSurface(string polygonId, double altitude, MeshCodeBounds meshBounds)
     {
         return new ParsedSurface(

--- a/tests/PlateauResoniteLink.Tests/Sources/ArchivePlateauDatasetContentSourceFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Sources/ArchivePlateauDatasetContentSourceFactoryTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -97,6 +98,34 @@ public sealed class ArchivePlateauDatasetContentSourceFactoryTests
         string secondLocalFilePath = await secondDatasetSource.EnsureLocalFileAsync(relativePath, outputRoot);
 
         Assert.NotEqual(Path.GetDirectoryName(firstLocalFilePath), Path.GetDirectoryName(secondLocalFilePath));
+    }
+
+    [Fact]
+    public async Task CreateAsyncIndexesOnlyArchiveEntriesWithSafeRelativePaths()
+    {
+        byte[] archiveBytes = CreateZipArchive(
+            ("udx/bldg/area/plateau_tokyo23ku_bldg_533944.gml", "<CityModel />"),
+            ("../../outside.txt", "escape"),
+            ("/absolute.txt", "absolute"),
+            ("C:/outside/windows-absolute.txt", "drive"),
+            ("udx/./texture.png", "dot"));
+
+        using TemporaryDirectory workRoot = new();
+        string archivePath = Path.Combine(workRoot.Path, "malicious.zip");
+        await File.WriteAllBytesAsync(archivePath, archiveBytes);
+
+        IPlateauDatasetContentSource datasetSource = await PlateauDatasetContentSourceFactory.CreateAsync(
+            archivePath,
+            new RemoteArchiveDistributionPolicy(),
+            new ArchiveFileLayoutPolicy());
+
+        string[] files = datasetSource.EnumerateFiles().ToArray();
+
+        Assert.Equal(["udx/bldg/area/plateau_tokyo23ku_bldg_533944.gml"], files);
+        Assert.False(datasetSource.FileExists("outside.txt"));
+        Assert.False(datasetSource.FileExists("absolute.txt"));
+        Assert.False(datasetSource.FileExists("C:/outside/windows-absolute.txt"));
+        Assert.False(datasetSource.FileExists("udx/texture.png"));
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Sources/CkanPlateauDatasetSourceResolverCacheTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Sources/CkanPlateauDatasetSourceResolverCacheTests.cs
@@ -84,7 +84,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolved = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolved = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", @"^533944\d$", "https://example.test/direct.zip"),
             workRoot.Path);
 
@@ -104,7 +104,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolved = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolved = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944|533945/branch", "https://example.test/direct.zip"),
             workRoot.Path);
 
@@ -143,11 +143,11 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest firstRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest firstRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example-a.test/533944.zip"),
             workRoot.Path);
 
-        ValidatedPlateauImportRequest secondRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest secondRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example-b.test/533944.zip"),
             workRoot.Path);
 
@@ -187,11 +187,11 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
         Uri archiveUri = new("https://example.test/533944.zip", UriKind.Absolute);
 
-        ValidatedPlateauImportRequest firstRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest firstRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", archiveUri),
             workRoot.Path);
 
-        ValidatedPlateauImportRequest secondRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest secondRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "53394525", archiveUri),
             workRoot.Path);
 
@@ -214,7 +214,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", archiveUri),
             workRoot.Path);
 
@@ -244,7 +244,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = new(httpClient, archivePolicy, new ArchiveFileLayoutPolicy());
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", archiveUri),
             workRoot.Path);
 
@@ -297,7 +297,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         Assert.Empty(Directory.EnumerateFiles(workRoot.Path, "533944.zip", SearchOption.AllDirectories));
         Assert.Empty(Directory.EnumerateFiles(workRoot.Path, "*.tmp", SearchOption.AllDirectories));
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", archiveUri),
             workRoot.Path);
 
@@ -365,7 +365,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
         using TemporaryDirectory workRoot = new();
 
-        ValidatedPlateauImportRequest firstRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest firstRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/533944.zip"),
             workRoot.Path);
 
@@ -374,7 +374,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
             workRoot.Path,
             firstRequest.CityGmlLocalSourcePath);
 
-        ValidatedPlateauImportRequest secondRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest secondRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/533944.zip"),
             workRoot.Path);
 
@@ -421,7 +421,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
         using TemporaryDirectory workRoot = new();
 
-        ValidatedPlateauImportRequest firstRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest firstRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/533944.zip"),
             workRoot.Path);
 
@@ -433,7 +433,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
             workRoot.Path,
             firstArchivePath);
 
-        ValidatedPlateauImportRequest secondRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest secondRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/533944.zip"),
             workRoot.Path);
 
@@ -466,7 +466,7 @@ public sealed class CkanPlateauDatasetSourceResolverCacheTests
         using HttpClient httpClient = new(handler);
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", archiveUri),
             workRoot.Path);
 

--- a/tests/PlateauResoniteLink.Tests/Sources/CkanPlateauDatasetSourceResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Sources/CkanPlateauDatasetSourceResolverTests.cs
@@ -62,11 +62,11 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/direct.zip"),
             workRoot.Path);
 
-        Assert.Equal(DatasetSourceKind.Local, resolvedRequest.CityGmlSourceKind);
+        Assert.False(string.IsNullOrWhiteSpace(resolvedRequest.CityGmlLocalSourcePath));
         await AssertResolvedArchiveContainsAsync(
             resolvedRequest,
             "direct.zip",
@@ -97,11 +97,11 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/direct.7z"),
             workRoot.Path);
 
-        Assert.Equal(DatasetSourceKind.Local, resolvedRequest.CityGmlSourceKind);
+        Assert.False(string.IsNullOrWhiteSpace(resolvedRequest.CityGmlLocalSourcePath));
         await AssertResolvedArchiveContainsAsync(
             resolvedRequest,
             "direct.7z",
@@ -132,11 +132,11 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "53394611", "https://example.test/wrapped.zip"),
             workRoot.Path);
 
-        Assert.Equal(DatasetSourceKind.Local, resolvedRequest.CityGmlSourceKind);
+        Assert.False(string.IsNullOrWhiteSpace(resolvedRequest.CityGmlLocalSourcePath));
         await AssertResolvedArchiveContainsAsync(
             resolvedRequest,
             "wrapped.zip",
@@ -167,11 +167,11 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "53394611", "https://example.test/wrapped.7z"),
             workRoot.Path);
 
-        Assert.Equal(DatasetSourceKind.Local, resolvedRequest.CityGmlSourceKind);
+        Assert.False(string.IsNullOrWhiteSpace(resolvedRequest.CityGmlLocalSourcePath));
         await AssertResolvedArchiveContainsAsync(
             resolvedRequest,
             "wrapped.7z",
@@ -214,11 +214,11 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/official-packages.zip"),
             workRoot.Path);
 
-        Assert.Equal(DatasetSourceKind.Local, resolvedRequest.CityGmlSourceKind);
+        Assert.False(string.IsNullOrWhiteSpace(resolvedRequest.CityGmlLocalSourcePath));
         await AssertResolvedArchiveContainsAsync(resolvedRequest, "official-packages.zip", "udx/area/plateau_tokyo23ku_area_533944.gml");
         await AssertResolvedArchiveContainsAsync(resolvedRequest, "official-packages.zip", "udx/cons/plateau_tokyo23ku_cons_533944.gml");
         await AssertResolvedArchiveContainsAsync(resolvedRequest, "official-packages.zip", "udx/ifld/plateau_tokyo23ku_ifld_533944.gml");
@@ -270,11 +270,11 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", "https://example.test/official-packages.7z"),
             workRoot.Path);
 
-        Assert.Equal(DatasetSourceKind.Local, resolvedRequest.CityGmlSourceKind);
+        Assert.False(string.IsNullOrWhiteSpace(resolvedRequest.CityGmlLocalSourcePath));
         await AssertResolvedArchiveContainsAsync(resolvedRequest, "official-packages.7z", "udx/area/plateau_tokyo23ku_area_533944.gml");
         await AssertResolvedArchiveContainsAsync(resolvedRequest, "official-packages.7z", "udx/cons/plateau_tokyo23ku_cons_533944.gml");
         await AssertResolvedArchiveContainsAsync(resolvedRequest, "official-packages.7z", "udx/ifld/plateau_tokyo23ku_ifld_533944.gml");
@@ -435,7 +435,7 @@ public sealed class CkanPlateauDatasetSourceResolverTests
 
         CkanPlateauDatasetSourceResolver resolver = CreateResolver(httpClient);
 
-        ValidatedPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
+        ResolvedLocalPlateauImportRequest resolvedRequest = await resolver.ResolveAsync(
             CreateValidatedRemoteRequest("tokyo23ku", "533944", archiveUri),
             workRoot);
 
@@ -446,7 +446,7 @@ public sealed class CkanPlateauDatasetSourceResolverTests
     }
 
     private static async Task AssertResolvedArchiveContainsAsync(
-        ValidatedPlateauImportRequest resolvedRequest,
+        ResolvedLocalPlateauImportRequest resolvedRequest,
         string expectedArchiveFileName,
         string expectedRelativePath)
     {

--- a/tests/PlateauResoniteLink.Tests/Targets/LiveSendRunContractTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/LiveSendRunContractTests.cs
@@ -1,0 +1,100 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Transport.ResoniteLink;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Test names describe contract cases.")]
+public sealed class LiveSendRunContractTests
+{
+    [Fact]
+    public void StartRequest_RejectsIncompleteRunInputsAtConstruction()
+    {
+        ResoniteSceneSetupInfo setupInfo = CreateSetupInfo();
+
+        Assert.Throws<ArgumentNullException>(() => new LiveSendRunStartRequest(
+            null!,
+            "work",
+            CommonMaterialCatalog.Create(),
+            new LiveSendConnectionRequest("dataset", "53394525"),
+            new ResoniteLocalOrigin(0, 0, 0),
+            ResoniteImportMemoryProfile.Large,
+            1,
+            MeshBakeEnabled: true));
+        Assert.Throws<ArgumentException>(() => new LiveSendRunStartRequest(
+            setupInfo,
+            " ",
+            CommonMaterialCatalog.Create(),
+            new LiveSendConnectionRequest("dataset", "53394525"),
+            new ResoniteLocalOrigin(0, 0, 0),
+            ResoniteImportMemoryProfile.Large,
+            1,
+            MeshBakeEnabled: true));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LiveSendRunStartRequest(
+            setupInfo,
+            "work",
+            CommonMaterialCatalog.Create(),
+            new LiveSendConnectionRequest("dataset", "53394525"),
+            new ResoniteLocalOrigin(0, 0, 0),
+            ResoniteImportMemoryProfile.Large,
+            0,
+            MeshBakeEnabled: true));
+    }
+
+    [Fact]
+    public void RunContexts_RejectMissingSessionStateAtConstruction()
+    {
+        Assert.Throws<ArgumentNullException>(() => new LiveSendRunStartContext(
+            null!,
+            new DelegatingClientSession(),
+            ResoniteLinkSendDiagnostics.Disabled,
+            ProgressReporter: null));
+        Assert.Throws<ArgumentNullException>(() => new LiveSendRunExecutionContext(
+            new Uri("ws://localhost:12345/"),
+            1,
+            null!,
+            ResoniteLinkSendDiagnostics.Disabled,
+            ProgressReporter: null));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LiveSendRunExecutionContext(
+            new Uri("ws://localhost:12345/"),
+            0,
+            new DelegatingClientSession(),
+            ResoniteLinkSendDiagnostics.Disabled,
+            ProgressReporter: null));
+    }
+
+    [Fact]
+    public void QueueAndWorkerContracts_RejectNonExecutableInputsAtConstruction()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LiveSendQueuePlan(
+            ConnectionCount: 0,
+            QueueCapacity: 1,
+            MemoryBudgetBytes: 1));
+        Assert.Throws<ArgumentNullException>(() => new LiveSendEnqueueContext(
+            ConnectionCount: 1,
+            GetRoutedClient: null!,
+            ProgressReporter: null));
+        Assert.Throws<ArgumentNullException>(() => new LiveSendWorkerContext(
+            new Uri("ws://localhost:12345/"),
+            ConnectionCount: 1,
+            GetRoutedClient: null!,
+            ResoniteLinkSendDiagnostics.Disabled,
+            ProgressReporter: null));
+    }
+
+    private static ResoniteSceneSetupInfo CreateSetupInfo()
+    {
+        return new ResoniteSceneSetupInfo(
+            "dataset",
+            "53394525",
+            Array.Empty<string>(),
+            Array.Empty<string>(),
+            new ResoniteLicenseAttributionMetadata(
+                RequireCredit: false,
+                CreditText: null,
+                LicenseName: null,
+                LicenseUrl: null));
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeCandidateFactoryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeCandidateFactoryTests.cs
@@ -1,0 +1,15 @@
+using System;
+
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class NonDemCityObjectBakeCandidateFactoryTests
+{
+    [Fact]
+    public void BakeEntryVariantsRejectNullPayload()
+    {
+        Assert.Throws<ArgumentNullException>(() => new NonDemBakeEntry.Atlas(null!));
+        Assert.Throws<ArgumentNullException>(() => new NonDemBakeEntry.Preserved(null!));
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 
-using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Targets;
@@ -20,8 +19,7 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
             NonDemMaterialBakeCategory.PreservedCommonMaterial,
             NonDemCityObjectBakeMaterialClassifier.Classify(CreateTexturelessMaterial() with
             {
-                AssetScope = ResoniteMaterialAssetScope.Common,
-                CommonMaterial = CommonMaterialCatalog.Create().Generic.Uv,
+                AssetBinding = ResoniteMaterialAssetBindingTestFactory.SharedGenericUv(),
             }));
         Assert.Equal(
             NonDemMaterialBakeCategory.PreservedTextureless,
@@ -123,6 +121,7 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
             ResoniteTextureSourceKind.Bundled,
             ResoniteMaterialProjection.Uv,
             DepthOffset: null,
-            SubmeshIndices: [0]);
+            SubmeshIndices: [0],
+            ResoniteMaterialAssetBinding.Presentation);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakeMaterialClassifierTests.cs
@@ -102,7 +102,7 @@ public sealed class NonDemCityObjectBakeMaterialClassifierTests
     {
         return CreateTexturelessMaterial() with
         {
-            TexturePayload = new ResoniteTexturePayload(
+            TexturePayload = new RawRgba32ResoniteTexturePayload(
                 width: 1,
                 height: 1,
                 colorProfile: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -893,6 +893,36 @@ public sealed class NonDemCityObjectBakerTests
     }
 
     [Fact]
+    public async Task TryBufferAsyncRejectsDuplicateMaterialBindingsBeforeDynamicUvNormalization()
+    {
+        NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);
+        ResoniteConstructionCityObject cityObject = CreateUvScaledLod2Building(
+            "duplicate-dynamic",
+            CreatePayload("textures/duplicate-dynamic.png", new Rgba32(255, 0, 0, 255), 4, 4),
+            "unit-a",
+            new ResoniteFloat2(2.0, 0.5),
+            new ResoniteFloat2(0.25, 0.75));
+        ResoniteMaterialBinding material = Assert.Single(cityObject.Materials);
+        cityObject = cityObject with
+        {
+            Materials =
+            [
+                material,
+                material with
+                {
+                    BaseColor = new ResoniteColor(0.5, 1.0, 1.0, 1.0),
+                },
+            ],
+        };
+
+        BufferedCityObjectBufferResult result = await baker.TryBufferAsync(cityObject);
+
+        Assert.False(result.Buffered);
+        Assert.Empty(result.ReadyCityObjects);
+        Assert.Empty(await baker.FlushAllAsync());
+    }
+
+    [Fact]
     public async Task TryBufferAsyncBuffersLodlessNonDemCityObjects()
     {
         NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -29,12 +29,9 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Single(cityObject.Mesh.Submeshes);
         Assert.Equal(6, cityObject.Mesh.Vertices.Count);
         Assert.Equal("unit-a.gml", cityObject.SourceFileRelativePath);
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, atlasPayload.Format);
-        Assert.NotNull(atlasPayload.Width);
-        Assert.NotNull(atlasPayload.Height);
-        Assert.InRange(atlasPayload.Width!.Value, 1, 32);
-        Assert.InRange(atlasPayload.Height!.Value, 1, 32);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        Assert.InRange(atlasPayload.Width, 1, 32);
+        Assert.InRange(atlasPayload.Height, 1, 32);
         Assert.Equal(CommonMaterialCatalog.Create().Generic.Uv, cityObject.Materials[0].CommonMaterial);
     }
 
@@ -63,8 +60,7 @@ public sealed class NonDemCityObjectBakerTests
             new ResoniteFloat2(0.5, 0.0)));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, atlasPayload.Format);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
         Assert.Equal(1, atlasPayload.Width);
         Assert.Equal(1, atlasPayload.Height);
         Assert.Null(cityObject.Materials[0].TextureScale);
@@ -152,7 +148,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.NotSame(payload, material.TexturePayload);
         Assert.NotNull(material.TexturePayload);
         Assert.Contains("atlastex-", material.TexturePayload.Identity, StringComparison.Ordinal);
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, material.TexturePayload.Format);
+        Assert.IsType<RawRgba32ResoniteTexturePayload>(material.TexturePayload);
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
     }
@@ -212,7 +208,7 @@ public sealed class NonDemCityObjectBakerTests
             new ResoniteFloat2(0.0, 0.0)));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload);
 
         Assert.Equal(2, atlasPayload.Width);
         Assert.Equal(1, atlasPayload.Height);
@@ -261,8 +257,7 @@ public sealed class NonDemCityObjectBakerTests
             null));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, atlasPayload.Format);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
         Assert.Equal(4, atlasPayload.Width);
         Assert.Equal(1, atlasPayload.Height);
         Assert.Equal(new Rgba32(255, 0, 0, 255), ReadPixel(atlasPayload, 0, 0));
@@ -285,7 +280,7 @@ public sealed class NonDemCityObjectBakerTests
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         ResoniteMaterialBinding material = Assert.Single(cityObject.Materials);
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(material.TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(material.TexturePayload);
 
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
@@ -325,7 +320,7 @@ public sealed class NonDemCityObjectBakerTests
                 "unit-a"));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
 
         Assert.Equal(2, atlasPayload.Width);
         Assert.Equal(1, atlasPayload.Height);
@@ -783,7 +778,7 @@ public sealed class NonDemCityObjectBakerTests
         await AssertBufferedAsync(baker, CreateLod2Building("building-c", CreateCheckerPayload("textures/c.png", new Rgba32(0, 0, 255, 255), new Rgba32(255, 0, 255, 255), 3, 3), 4, "unit-a"));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
         Assert.Equal(16, atlasPayload.Width);
         Assert.Equal(8, atlasPayload.Height);
     }
@@ -973,7 +968,7 @@ public sealed class NonDemCityObjectBakerTests
                 "unit-a"));
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
-        ResoniteTexturePayload atlasPayload = Assert.IsType<ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
+        RawRgba32ResoniteTexturePayload atlasPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(cityObject.Materials[0].TexturePayload);
         Assert.Equal(512, atlasPayload.Width);
         Assert.Equal(512, atlasPayload.Height);
     }
@@ -1066,7 +1061,7 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal("atlasbake-unit-a-bldg-lod2-3", cityObject.SlotKey);
         Assert.Equal(
             "atlastex-unit-a.gml-3",
-            Assert.IsType<ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Identity);
+            Assert.IsType<RawRgba32ResoniteTexturePayload>(Assert.Single(cityObject.Materials).TexturePayload).Identity);
     }
 
     private static NonDemCityObjectBaker CreateBaker(
@@ -1151,11 +1146,9 @@ public sealed class NonDemCityObjectBakerTests
         return ResoniteTextureImportFactory.CreatePayloadFromImage(image, identity: identity);
     }
 
-    private static Rgba32 ReadPixel(ResoniteTexturePayload payload, int x, int y)
+    private static Rgba32 ReadPixel(RawRgba32ResoniteTexturePayload payload, int x, int y)
     {
-        Assert.Equal(ResoniteTexturePayloadFormat.RawRgba32, payload.Format);
-        Assert.NotNull(payload.Width);
-        int width = payload.Width.Value;
+        int width = payload.Width;
         int offset = ((y * width) + x) * 4;
         ReadOnlySpan<byte> bytes = payload.BinaryPayload.AsSpan();
         return new Rgba32(

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemCityObjectBakerTests.cs
@@ -345,13 +345,13 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(2, cityObject.Mesh.Submeshes.Count);
         Assert.Contains(
             cityObject.Materials,
-            static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.Facade, StringComparison.Ordinal)
+            static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.FacadeHighriseGlass, StringComparison.Ordinal)
                 && material.AssetScope == ResoniteMaterialAssetScope.PresentationSlotScoped);
         Assert.Contains(cityObject.Materials, static material => material.TexturePayload is not null);
     }
 
     [Fact]
-    public async Task FlushAllAsyncKeepsBundledFacadeCommonTransformOnMaterial()
+    public async Task FlushAllAsyncDemotesBundledFacadeCommonTransformToMeshUv()
     {
         NonDemCityObjectBaker baker = CreateBaker(maxAtlasSize: 32, tilePaddingPixels: 1);
 
@@ -360,13 +360,16 @@ public sealed class NonDemCityObjectBakerTests
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
 
         ResoniteMaterialBinding material = Assert.Single(cityObject.Materials);
-        Assert.Equal(BundledDefaultMaterialFamilies.Facade, material.Family);
+        Assert.Equal(BundledDefaultMaterialFamilies.FacadeHighriseGlass, material.Family);
         Assert.Equal(ResoniteMaterialAssetScope.Common, material.AssetScope);
-        Assert.Equal(new ResoniteFloat2(1.0 / 6.0, 1.0 / 6.0), material.TextureScale);
-        Assert.Equal(new ResoniteFloat2(0.0, 0.5 / 6.0), material.TextureOffset);
-        Assert.Equal(new ResoniteFloat2(0.0, 0.0), cityObject.Mesh.Vertices[0].UV0);
-        Assert.Equal(new ResoniteFloat2(1.0, 0.0), cityObject.Mesh.Vertices[1].UV0);
-        Assert.Equal(new ResoniteFloat2(0.0, 1.0), cityObject.Mesh.Vertices[2].UV0);
+        Assert.Null(material.TextureScale);
+        Assert.Null(material.TextureOffset);
+        Assert.Equal(0.0, cityObject.Mesh.Vertices[0].UV0.X, 12);
+        Assert.Equal(5.0 / 6.0, cityObject.Mesh.Vertices[0].UV0.Y, 12);
+        Assert.Equal(10.0 / 6.0, cityObject.Mesh.Vertices[1].UV0.X, 12);
+        Assert.Equal(5.0 / 6.0, cityObject.Mesh.Vertices[1].UV0.Y, 12);
+        Assert.Equal(0.0, cityObject.Mesh.Vertices[2].UV0.X, 12);
+        Assert.Equal(15.0 / 6.0, cityObject.Mesh.Vertices[2].UV0.Y, 12);
     }
 
     [Fact]
@@ -383,7 +386,7 @@ public sealed class NonDemCityObjectBakerTests
 
         ResoniteConstructionCityObject cityObject = Assert.Single(await baker.FlushAllAsync());
         ResoniteMaterialBinding[] preservedFacadeMaterials = cityObject.Materials
-            .Where(static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.Facade, StringComparison.Ordinal))
+            .Where(static material => string.Equals(material.Family, BundledDefaultMaterialFamilies.FacadeHighriseGlass, StringComparison.Ordinal))
             .ToArray();
 
         Assert.Equal(3, cityObject.Materials.Count);
@@ -438,7 +441,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -447,6 +451,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: new ResoniteMaterialDepthOffset(1.0, 1.0),
                     SubmeshIndices: [1],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Roof,
                     TextureOffset: new ResoniteFloat2(0.125, 0.25),
                     BundledVariantIndex: 0),
@@ -458,6 +463,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: new ResoniteMaterialDepthOffset(2.0, 2.0),
                     SubmeshIndices: [2],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Roof,
                     TextureOffset: new ResoniteFloat2(0.25, 0.5),
                     BundledVariantIndex: 1),
@@ -477,6 +483,8 @@ public sealed class NonDemCityObjectBakerTests
         Assert.All(preservedRoofMaterials, static material => Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, material.AssetScope));
         Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 0 && material.TextureOffset is null);
         Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 1 && material.TextureOffset is null);
+        Assert.NotEqual(new ResoniteFloat2(0.0, 0.0), cityObject.Mesh.Vertices[3].UV0);
+        Assert.NotEqual(new ResoniteFloat2(0.0, 0.0), cityObject.Mesh.Vertices[6].UV0);
     }
 
     [Fact]
@@ -531,7 +539,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -543,7 +552,7 @@ public sealed class NonDemCityObjectBakerTests
                     Family: BundledDefaultMaterialFamilies.Roof,
                     TextureOffset: new ResoniteFloat2(0.125, 0.25),
                     BundledVariantIndex: 0,
-                    AssetScope: ResoniteMaterialAssetScope.Common),
+                    AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.Roof, 0)),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -555,7 +564,7 @@ public sealed class NonDemCityObjectBakerTests
                     Family: BundledDefaultMaterialFamilies.Roof,
                     TextureOffset: new ResoniteFloat2(0.25, 0.5),
                     BundledVariantIndex: 1,
-                    AssetScope: ResoniteMaterialAssetScope.Common),
+                    AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.Roof, 1)),
             ],
         };
 
@@ -569,8 +578,8 @@ public sealed class NonDemCityObjectBakerTests
         Assert.Equal(3, cityObject.Materials.Count);
         Assert.Equal(2, preservedRoofMaterials.Length);
         Assert.All(preservedRoofMaterials, static material => Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, material.AssetScope));
-        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 0 && material.TextureOffset == new ResoniteFloat2(0.125, 0.25));
-        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 1 && material.TextureOffset == new ResoniteFloat2(0.25, 0.5));
+        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 0 && material.TextureOffset is null);
+        Assert.Contains(preservedRoofMaterials, static material => material.BundledVariantIndex == 1 && material.TextureOffset is null);
     }
 
     [Fact]
@@ -665,7 +674,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -674,6 +684,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [1],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Roof,
                     BundledVariantIndex: 0),
                 new ResoniteMaterialBinding(
@@ -684,6 +695,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [2],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Roof,
                     BundledVariantIndex: 0),
             ],
@@ -843,9 +855,8 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.Common,
-                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay),
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay),
+                    AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv()),
             ],
         };
         ResoniteConstructionCityObject secondCityObject = firstCityObject with
@@ -1185,7 +1196,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: $"{sourceUnitKey}.gml");
     }
@@ -1242,7 +1254,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1250,7 +1263,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [1]),
+                    SubmeshIndices: [1],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: $"{sourceUnitKey}.gml");
     }
@@ -1274,8 +1288,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.Common,
-                    CommonMaterial: commonMaterial),
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(commonMaterial)),
             ],
         };
     }
@@ -1297,8 +1310,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
             ],
         };
     }
@@ -1335,7 +1347,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(0.4, 0.4, 0.4, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1344,8 +1357,8 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [1],
-                    Family: BundledDefaultMaterialFamilies.Facade,
-                    AssetScope: ResoniteMaterialAssetScope.Common,
+                    Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0),
                     BundledVariantIndex: 0),
             ],
             SourceFileRelativePath: $"{sourceUnitKey}.gml");
@@ -1370,6 +1383,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     TextureScale: textureScale,
                     TextureOffset: textureOffset),
             ],
@@ -1410,8 +1424,8 @@ public sealed class NonDemCityObjectBakerTests
                         BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.X,
                         BundledDefaultMaterialProfiles.FacadeDefaultTilesPerMeterValue.Y),
                     TextureOffset: new ResoniteFloat2(0.0, 0.5 / 6.0),
-                    Family: BundledDefaultMaterialFamilies.Facade,
-                    AssetScope: ResoniteMaterialAssetScope.Common,
+                    Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+                    AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0),
                     BundledVariantIndex: 0),
             ],
             SourceFileRelativePath: $"{sourceUnitKey}.gml");
@@ -1452,6 +1466,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Facade),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
@@ -1461,6 +1476,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [1],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Facade),
             ],
             SourceFileRelativePath: $"{sourceUnitKey}.gml");
@@ -1504,7 +1520,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(0.5, 0.5, 0.5, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1513,8 +1530,8 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [1],
-                    Family: BundledDefaultMaterialFamilies.Facade,
-                    AssetScope: ResoniteMaterialAssetScope.Common,
+                    Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+                    AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0),
                     BundledVariantIndex: 0),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(0.5, 0.5, 0.5, 1.0),
@@ -1524,8 +1541,8 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [2],
-                    Family: BundledDefaultMaterialFamilies.Facade,
-                    AssetScope: ResoniteMaterialAssetScope.Common,
+                    Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+                    AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 1),
                     BundledVariantIndex: 1),
             ],
             SourceFileRelativePath: $"{sourceUnitKey}.gml");
@@ -1569,7 +1586,8 @@ public sealed class NonDemCityObjectBakerTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(0.85, 0.85, 0.85, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1578,6 +1596,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [1],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Roof,
                     BundledVariantIndex: 0),
                 new ResoniteMaterialBinding(
@@ -1588,6 +1607,7 @@ public sealed class NonDemCityObjectBakerTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [2],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.Roof,
                     BundledVariantIndex: 1),
             ],

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
@@ -1,4 +1,3 @@
-using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Targets.Resonite;
 
 namespace PlateauResoniteLink.Tests.Targets;
@@ -10,8 +9,7 @@ public sealed class NonDemPreservedMaterialGroupingTests
     {
         ResoniteMaterialBinding commonMaterial = CreateTexturelessMaterial() with
         {
-            AssetScope = ResoniteMaterialAssetScope.Common,
-            CommonMaterial = CommonMaterialCatalog.Create().Generic.Uv,
+            AssetBinding = ResoniteMaterialAssetBindingTestFactory.SharedGenericUv(),
         };
         ResoniteTexturePayload texture = new(
             width: 1,
@@ -68,6 +66,7 @@ public sealed class NonDemPreservedMaterialGroupingTests
             ResoniteTextureSourceKind.Bundled,
             ResoniteMaterialProjection.Uv,
             DepthOffset: null,
-            SubmeshIndices: [0]);
+            SubmeshIndices: [0],
+            ResoniteMaterialAssetBinding.Presentation);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemPreservedMaterialGroupingTests.cs
@@ -11,7 +11,7 @@ public sealed class NonDemPreservedMaterialGroupingTests
         {
             AssetBinding = ResoniteMaterialAssetBindingTestFactory.SharedGenericUv(),
         };
-        ResoniteTexturePayload texture = new(
+        ResoniteTexturePayload texture = new RawRgba32ResoniteTexturePayload(
             width: 1,
             height: 1,
             colorProfile: null,
@@ -30,7 +30,7 @@ public sealed class NonDemPreservedMaterialGroupingTests
         });
         NonDemPreservedMaterialGroupingKey differentTexture = NonDemPreservedMaterialGrouping.CreateKey(commonMaterial with
         {
-            TexturePayload = new ResoniteTexturePayload(
+            TexturePayload = new RawRgba32ResoniteTexturePayload(
                 width: 1,
                 height: 1,
                 colorProfile: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
@@ -289,7 +289,7 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
         return new ResoniteMaterialBinding(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic-uv.png"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteDynamicMaterialUvNormalizerTests.cs
@@ -50,11 +50,11 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: new ResoniteFloat2(1.0, 1.0),
             TextureOffset: new ResoniteFloat2(0.0, 0.0),
             Family: BundledDefaultMaterialFamilies.Facade,
-            BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+            BundledVariantIndex: 0);
 
         ResoniteMaterialBinding normalized = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
 
@@ -104,13 +104,14 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
                     TexturePayload: null,
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
-                    DepthOffset: null,
-                    SubmeshIndices: [1],
-                    TextureScale: new ResoniteFloat2(1.0, 1.0),
+            DepthOffset: null,
+            SubmeshIndices: [1],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+            TextureScale: new ResoniteFloat2(1.0, 1.0),
                     TextureOffset: new ResoniteFloat2(0.0, 0.0),
                     Family: BundledDefaultMaterialFamilies.Facade,
-                    BundledVariantIndex: bundledVariantIndex,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
+                    BundledVariantIndex: bundledVariantIndex
+                    ),
             ],
             SourceFileRelativePath: "unit-a.gml");
 
@@ -156,7 +157,6 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
                     BundledVariantIndex = 0,
                     TextureScale = textureScale,
                     TextureOffset = textureOffset,
-                    AssetScope = ResoniteMaterialAssetScope.PresentationSlotScoped,
                 },
             ],
         };
@@ -207,11 +207,12 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
                     Projection: ResoniteMaterialProjection.Triplanar,
                     DepthOffset: null,
                     SubmeshIndices: [1],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     TextureScale: new ResoniteFloat2(1.0, 1.0),
                     TextureOffset: new ResoniteFloat2(0.0, 0.0),
                     Family: null,
-                    BundledVariantIndex: null,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
+                    BundledVariantIndex: null
+                    ),
             ],
             SourceFileRelativePath: "unit-a.gml");
 
@@ -293,9 +294,9 @@ public sealed class ResoniteDynamicMaterialUvNormalizerTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: textureScale,
             TextureOffset: textureOffset,
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
             TerrainOverlayMaterial: terrainOverlay is null
                 ? null
                 : new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), terrainOverlay));

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -1506,11 +1506,10 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     SubmeshIndices: [0],
                     TextureScale: textureScale,
                     Family: family,
-                    AssetScope: commonMaterial is null
-                        ? ResoniteMaterialAssetScope.PresentationSlotScoped
-                        : ResoniteMaterialAssetScope.Common,
                     BundledVariantIndex: 0,
-                    CommonMaterial: commonMaterial),
+                    AssetBinding: commonMaterial is null
+                        ? ResoniteMaterialAssetBinding.Presentation
+                        : ResoniteMaterialAssetBinding.SharedCommon(commonMaterial)),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }
@@ -1543,8 +1542,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     TextureScale: textureScale,
                     Family: null,
                     TextureOffset: textureOffset,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }
@@ -1574,8 +1572,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     DepthOffset: null,
                     SubmeshIndices: [0],
                     Family: null,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1585,8 +1582,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     DepthOffset: null,
                     SubmeshIndices: [1],
                     Family: null,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }
@@ -1620,7 +1616,8 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }
@@ -1647,8 +1644,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.Common,
-                    CommonMaterial: CommonMaterialCatalog.Create().VertexColor.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(CommonMaterialCatalog.Create().VertexColor.Uv)),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }
@@ -1677,9 +1673,8 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     DepthOffset: null,
                     SubmeshIndices: [0],
                     Family: BundledDefaultMaterialFamilies.WallResidentialPlasterLow,
-                    AssetScope: ResoniteMaterialAssetScope.Common,
                     BundledVariantIndex: 0,
-                    CommonMaterial: CommonMaterialCatalog.Create().WallResidentialPlasterLow.ResidentialPlasterLow),
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(CommonMaterialCatalog.Create().WallResidentialPlasterLow.ResidentialPlasterLow)),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1689,8 +1684,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     DepthOffset: null,
                     SubmeshIndices: [1],
                     Family: null,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetConfigurationTests.cs
@@ -662,7 +662,8 @@ public sealed class ResoniteLiveSceneImportTargetConfigurationTests
                     ResoniteTextureSourceKind.Bundled,
                     ResoniteMaterialProjection.Uv,
                     null,
-                    [0]),
+                    [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: sourceFileRelativePath);
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -752,8 +752,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
                 new ResoniteFloat2(0.0, 0.0),
-                gsiFallbackSource,
-                [rasterSource, gsiFallbackSource]));
+                [gsiFallbackSource, rasterSource]));
         await using ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(
             routedClient,
             terrainTextureGenerator,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -932,10 +932,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         using SceneSinkRecordingClient routedClient = new();
         DelegatingClientSession session = new(routedClient);
         await using ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(routedClient, session: session);
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local(TestData.GetFixturePath("LocalPlateauDatasetParentMeshPackages")),
+            CityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDatasetParentMeshPackages"),
             PackageNames: ["dem"]
 );
         ImportedSceneSourceSnapshot readResult = await new LocalCityGmlDocumentReader(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -281,13 +281,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             request,
             ["udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml"]);
         CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials = CommonMaterialCatalog.Create();
-        SceneImportExecutionPlan plan = SceneImportExecutionPlan.Create(
-            request,
-            request,
+        SceneImportExecutionPlan plan = ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(
             metadata,
-            request.CityGmlLocalSourcePath!,
             workDirectory.Path,
-            commonMaterials);
+            commonMaterials: commonMaterials);
 
         InvalidOperationException error = await Assert.ThrowsAsync<InvalidOperationException>(() => importTarget.ExecuteAsync(
             plan,
@@ -323,11 +320,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             request,
             ["udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml"]);
 
-        SceneImportExecutionPlan plan = SceneImportExecutionPlan.Create(
-            request,
-            request,
+        SceneImportExecutionPlan plan = ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(
             metadata,
-            request.CityGmlLocalSourcePath!,
             workDirectory.Path,
             commonMaterials: CommonMaterialCatalog.Create());
 
@@ -389,13 +383,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         ResoniteConstructionCityObject cityObject = CreateMixedSharedMaterialAndPayloadCityObject(
             "runtime-shared-texture",
             terrainAlignedDepthOffset);
-        SceneImportExecutionPlan plan = SceneImportExecutionPlan.Create(
-            request,
-            request,
+        SceneImportExecutionPlan plan = ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(
             metadata,
-            request.CityGmlLocalSourcePath!,
             workDirectory.Path,
-            ResoniteLiveSceneImportTargetTestSupport.CreateReferencedCommonMaterials([cityObject], enableMeshBake: false));
+            commonMaterials: ResoniteLiveSceneImportTargetTestSupport.CreateReferencedCommonMaterials([cityObject], enableMeshBake: false));
 
         _ = await importTarget.ExecuteAsync(
             plan,
@@ -453,13 +444,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         ResoniteConstructionCityObject cityObject = CreateVertexColorTriangleCityObject(
             "terrain-aligned-vertex-common",
             new ResoniteMaterialDepthOffset(-10.0, -10.0));
-        SceneImportExecutionPlan plan = SceneImportExecutionPlan.Create(
-            request,
-            request,
+        SceneImportExecutionPlan plan = ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(
             metadata,
-            request.CityGmlLocalSourcePath!,
             workDirectory.Path,
-            ResoniteLiveSceneImportTargetTestSupport.CreateReferencedCommonMaterials([cityObject], enableMeshBake: true));
+            commonMaterials: ResoniteLiveSceneImportTargetTestSupport.CreateReferencedCommonMaterials([cityObject], enableMeshBake: true));
 
         _ = await importTarget.ExecuteAsync(
             plan,
@@ -932,12 +920,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         using SceneSinkRecordingClient routedClient = new();
         DelegatingClientSession session = new(routedClient);
         await using ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(routedClient, session: session);
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDatasetParentMeshPackages"),
-            PackageNames: ["dem"]
-);
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            cityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDatasetParentMeshPackages"),
+            packageNames: ["dem"]);
         ImportedSceneSourceSnapshot readResult = await new LocalCityGmlDocumentReader(
             new DefaultPlateauDatasetContentSourceFactory(new RemoteArchiveDistributionPolicy(), new ArchiveFileLayoutPolicy()),
             new CityGmlAppearanceStoreFactory(),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -350,7 +350,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 Projection: ResoniteMaterialProjection.Uv,
                 DepthOffset: terrainAlignedDepthOffset,
                 SubmeshIndices: [0],
-                AssetScope: ResoniteMaterialAssetScope.Common));
+                AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv()));
         bool terrainAlignedGenericSlotExistedWhenSendWorkersStarted = false;
         ResoniteMaterialPlanning materialPlanning = new(CreateBundledDefaultMaterialAssetStore());
         await using ResoniteLiveSceneImportTarget importTarget = new(
@@ -422,7 +422,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 Projection: ResoniteMaterialProjection.Uv,
                 DepthOffset: new ResoniteMaterialDepthOffset(-10.0, -10.0),
                 SubmeshIndices: [0],
-                AssetScope: ResoniteMaterialAssetScope.Common));
+                AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv()));
         bool materialSlotExistedWhenSendWorkersStarted = false;
         await using ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(
             routedClient,
@@ -535,7 +535,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             [
                 demObject.Materials[0] with
                 {
-                    CommonMaterial = CommonMaterialCatalog.Create().Generic.Uv,
+                AssetBinding = ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv),
                 },
             ],
         };
@@ -1094,7 +1094,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     ResoniteTextureSourceKind.Dataset,
                     ResoniteMaterialProjection.Uv,
                     null,
-                    [0]),
+                    [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             CollisionEnabled: true,
             SourceFileRelativePath: sourceFileRelativePath);
@@ -1121,7 +1122,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     ResoniteMaterialProjection.Uv,
                     null,
                     [0],
-                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay)),
+                    AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay)),
             ],
             CollisionEnabled: true,
             SourceFileRelativePath: sourceFileRelativePath);
@@ -1153,9 +1155,8 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     TextureScale: textureScale,
                     Family: family,
                     TextureOffset: textureOffset,
-                    AssetScope: ResoniteMaterialAssetScope.Common,
                     BundledVariantIndex: variantIndex,
-                    CommonMaterial: CommonMaterialCatalog.Create().FacadeHighriseGlass.Facade001),
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(CommonMaterialCatalog.Create().FacadeHighriseGlass.Facade001)),
             ],
             CollisionEnabled: true,
             SourceFileRelativePath: "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml");
@@ -1183,10 +1184,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: depthOffset,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.Common,
-                    CommonMaterial: depthOffset is null
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(depthOffset is null
                         ? CommonMaterialCatalog.Create().VertexColor.Uv
-                        : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv),
+                        : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv)),
             ],
             CollisionEnabled: true,
             SourceFileRelativePath: "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml");
@@ -1214,10 +1214,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: payloadDepthOffset,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.Common,
-                    CommonMaterial: payloadDepthOffset is null
+                    AssetBinding: ResoniteMaterialAssetBinding.SharedCommon(payloadDepthOffset is null
                         ? CommonMaterialCatalog.Create().VertexColor.Uv
-                        : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv),
+                        : CommonMaterialCatalog.Create().VertexColor.TerrainAlignedUv)),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1230,7 +1229,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [1],
-                    CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv),
+                    AssetBinding: ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv)),
             ],
             CollisionEnabled: true,
             SourceFileRelativePath: "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml");

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -704,7 +704,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             .ToArray();
         Assert.Contains(creditStrings, static creditString => creditString.Contains("GSI Maps Terms", StringComparison.Ordinal));
         Assert.Contains(creditStrings, static creditString => !creditString.Contains("GSI Maps Terms", StringComparison.Ordinal));
-        ImportDataSourceUsage demSourceUsage = Assert.Single(executionResult.DataSourceUsages ?? []);
+        ImportDataSourceUsage demSourceUsage = Assert.Single(executionResult.DataSourceUsages);
         Assert.Equal(ImportDataSourceCategory.DemTextureSource, demSourceUsage.Category);
         Assert.Equal(
             new TerrainTextureTileSource(
@@ -772,10 +772,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             CreateImportedObjectUnits(
                 CreateDemCityObject("dem-mixed", "udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml", overlay)));
 
-        ImportDataSourceUsage[] usages = executionResult.DataSourceUsages?
+        ImportDataSourceUsage[] usages = executionResult.DataSourceUsages
             .OrderBy(static usage => usage.Identity, StringComparer.Ordinal)
-            .ToArray()
-            ?? [];
+            .ToArray();
         Assert.Equal(2, usages.Length);
         Assert.Contains(
             usages,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -160,22 +160,20 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         PlateauImportRequest? normalizedRequest = null,
         CommonMaterialCatalog<DefaultCommonMaterialMember>? commonMaterials = null)
     {
-        PlateauImportRequest effectiveNormalizedRequest = normalizedRequest ?? metadata.Request;
-        PlateauImportRequest resolvedRequest = CreateResolvedRequest(
+        ValidatedPlateauImportRequest effectiveNormalizedRequest = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+            normalizedRequest ?? metadata.Request);
+        ResolvedLocalPlateauImportRequest resolvedRequest = CreateResolvedRequest(
             effectiveNormalizedRequest,
             metadata.Request,
             workDirectory);
-        PlateauImportRequest importRequest = CreateImportRequest(effectiveNormalizedRequest, resolvedRequest);
         ImportedSceneMetadata effectiveMetadata = metadata with
         {
-            Request = importRequest,
+            Request = resolvedRequest.ToImportRequest(),
         };
 
         return SceneImportExecutionPlan.Create(
-            effectiveNormalizedRequest,
             resolvedRequest,
             effectiveMetadata,
-            GetRequiredResolvedLocalSourcePath(resolvedRequest),
             workDirectory,
             commonMaterials ?? CreateReferencedCommonMaterials([], enableMeshBake: false));
     }
@@ -204,49 +202,35 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         return catalog.FilterToDefinitions(definitions);
     }
 
-    private static PlateauImportRequest CreateImportRequest(
-        PlateauImportRequest normalizedRequest,
-        PlateauImportRequest resolvedRequest)
-    {
-        return normalizedRequest with
-        {
-            CityGmlSource = resolvedRequest.CityGmlSource,
-            DemTextureSource = resolvedRequest.DemTextureSource,
-        };
-    }
-
-    private static PlateauImportRequest CreateResolvedRequest(
-        PlateauImportRequest normalizedRequest,
+    private static ResolvedLocalPlateauImportRequest CreateResolvedRequest(
+        ValidatedPlateauImportRequest normalizedRequest,
         PlateauImportRequest metadataRequest,
         string workDirectory)
     {
-        string? resolvedSourcePath = ResolveLocalPath(normalizedRequest.CityGmlSource, workDirectory, "source-archive")
+        string? resolvedSourcePath = ResolveLocalPath(normalizedRequest.CityGmlSource.ToDatasetLocation(), workDirectory, "source-archive")
             ?? metadataRequest.CityGmlLocalSourcePath;
         if (string.IsNullOrWhiteSpace(resolvedSourcePath))
         {
             throw new ArgumentException("Metadata request must include a local CityGML source path.", nameof(metadataRequest));
         }
 
-        DatasetLocation? resolvedDemTextureSource = metadataRequest.DemTextureSource;
+        ValidatedLocalDatasetLocation? resolvedDemTextureSource = metadataRequest.DemTextureLocalSourcePath is { } metadataDemTexturePath
+            ? new ValidatedLocalDatasetLocation(metadataDemTexturePath)
+            : null;
         if (normalizedRequest.DemTextureSource is not null)
         {
-            string? resolvedDemTexturePath = ResolveLocalPath(normalizedRequest.DemTextureSource, workDirectory, "source-ortho");
-            resolvedDemTextureSource = resolvedDemTexturePath is null
-                ? metadataRequest.DemTextureSource
-                : DatasetLocation.Local(resolvedDemTexturePath);
+            string? resolvedDemTexturePath = ResolveLocalPath(normalizedRequest.DemTextureSource.ToDatasetLocation(), workDirectory, "source-ortho");
+            if (resolvedDemTexturePath is not null)
+            {
+                resolvedDemTextureSource = new ValidatedLocalDatasetLocation(resolvedDemTexturePath);
+            }
         }
 
-        return normalizedRequest with
-        {
-            CityGmlSource = DatasetLocation.Local(resolvedSourcePath),
-            DemTextureSource = resolvedDemTextureSource,
-        };
-    }
-
-    private static string GetRequiredResolvedLocalSourcePath(PlateauImportRequest resolvedRequest)
-    {
-        return resolvedRequest.CityGmlLocalSourcePath
-            ?? throw new ArgumentException("Resolved request must include a local CityGML source path.", nameof(resolvedRequest));
+        return ResolvedLocalPlateauImportRequest.Create(
+            normalizedRequest,
+            new ValidatedLocalDatasetLocation(resolvedSourcePath),
+            resolvedDemTextureSource,
+            workDirectory);
     }
 
     private static string? ResolveLocalPath(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -71,7 +71,7 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
             r, g, b, 255,
             r, g, b, 255,
         ];
-        return new ResoniteTexturePayload(2, 2, ResoniteTextureColorProfiles.Srgb, rawBytes, identity);
+        return new RawRgba32ResoniteTexturePayload(2, 2, ResoniteTextureColorProfiles.Srgb, rawBytes, identity);
     }
 
     public static ImportedSceneMetadata CreateMetadata(
@@ -525,13 +525,22 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
         => Enumerable.Repeat(TerrainGridSampleCoverage.Measured, count).ToArray();
 
     private static TexturePayload ToContractTexturePayload(ResoniteTexturePayload payload)
-        => new(
-            payload.Width,
-            payload.Height,
-            payload.ColorProfile,
-            payload.BinaryPayload.AsSpan().ToArray(),
-            payload.Identity,
-            (TexturePayloadFormat)payload.Format);
+        => payload switch
+        {
+            RawRgba32ResoniteTexturePayload raw => new RawRgba32TexturePayload(
+                raw.Width,
+                raw.Height,
+                raw.ColorProfile,
+                raw.BinaryPayload.AsSpan().ToArray(),
+                raw.Identity),
+            EncodedImageResoniteTexturePayload encoded => new EncodedImageTexturePayload(
+                encoded.Width,
+                encoded.Height,
+                encoded.ColorProfile,
+                encoded.Source,
+                encoded.Identity),
+            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.GetType(), "Unsupported texture payload type."),
+        };
 
 }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -64,11 +64,12 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TexturePayload: null,
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
-                    TextureScale: null,
-                    TextureOffset: null,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(MeshCode), overlay)),
+                    AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                    TextureScale: null,
+                    TextureOffset: null,
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay)),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -453,7 +454,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(MeshCode), overlay)),
+                    AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay)),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -523,7 +525,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -686,7 +689,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -836,7 +840,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(MeshCode), overlay)),
+                    AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay)),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -900,7 +905,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             CollisionEnabled: false,
             SourceFileRelativePath: $"udx/bldg/{MeshCode}/plateau_{DatasetName}_bldg_{MeshCode}.gml");
@@ -947,7 +953,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(MeshCode), overlay)),
+                    AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                    TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay)),
             ]
         );
         ResoniteConstructionCityObject withoutOverlay = withOverlay with
@@ -998,9 +1005,10 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     TextureScale: null,
-                    TextureOffset: null,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped),
+                    TextureOffset: null
+                    ),
             ]
         );
         ResoniteConstructionCityObject withBake = baseline with
@@ -1054,7 +1062,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     Family: BundledDefaultMaterialFamilies.RoadUv),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
@@ -1063,7 +1071,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [1]),
+                    SubmeshIndices: [1],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: sourceFile);
 
@@ -1103,7 +1112,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: sourceFile);
 
@@ -1149,7 +1159,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: sourceFile);
 
@@ -1202,7 +1213,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: sourceFile);
 
@@ -1254,9 +1266,9 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     TextureScale: new ResoniteFloat2(0.5, 0.5),
                     Family: BundledDefaultMaterialFamilies.Facade,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
                     BundledVariantIndex: 0),
             ],
             SourceFileRelativePath: sourceFile);
@@ -1328,10 +1340,10 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     TextureScale: new ResoniteFloat2(0.5, 0.5),
                     TextureOffset: new ResoniteFloat2(0.125, 0.25),
                     Family: BundledDefaultMaterialFamilies.Facade,
-                    AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped,
                     BundledVariantIndex: 0),
             ],
             SourceFileRelativePath: sourceFile);
@@ -1394,7 +1406,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [1]),
+                    SubmeshIndices: [1],
+                    ResoniteMaterialAssetBinding.Presentation),
             ]
         );
 
@@ -1432,7 +1445,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [1]),
+                    SubmeshIndices: [1],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
 
@@ -1462,7 +1476,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
@@ -1470,7 +1485,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0, 1]),
+                    SubmeshIndices: [0, 1],
+                    ResoniteMaterialAssetBinding.Presentation),
             ]
         );
 
@@ -1513,6 +1529,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                                        AssetBinding: ResoniteMaterialAssetBinding.Presentation,
                     TextureScale: new ResoniteFloat2(2.0, 0.5),
                     TextureOffset: new ResoniteFloat2(0.25, 0.75)),
                 new ResoniteMaterialBinding(
@@ -1522,7 +1539,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0, 1]),
+                    SubmeshIndices: [0, 1],
+                    ResoniteMaterialAssetBinding.Presentation),
             ]
         );
 
@@ -1553,7 +1571,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ]
         );
 
@@ -1599,7 +1618,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ]
         );
 
@@ -1666,7 +1686,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,
-                    SubmeshIndices: [0]),
+                    SubmeshIndices: [0],
+                    ResoniteMaterialAssetBinding.Presentation),
             ],
             SourceFileRelativePath: $"udx/dem/533945/plateau_{DatasetName}_dem_533945.gml");
     }
@@ -1694,10 +1715,11 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     TexturePayload: null,
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
-                    TextureScale: null,
-                    TextureOffset: null,
                     DepthOffset: null,
                     SubmeshIndices: [0],
+                    AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                    TextureScale: null,
+                    TextureOffset: null,
                     TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse(meshCode), overlay)),
             ],
             SourceFileRelativePath: $"udx/{packageName}/{meshCode}/plateau_{DatasetName}_{packageName}_{meshCode}.gml");
@@ -1710,7 +1732,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
             Materials = cityObject.Materials
                 .Select(static material => material with
                 {
-                    CommonMaterial = CommonMaterialCatalog.Create().Generic.Uv,
+                    AssetBinding = ResoniteMaterialAssetBinding.PresentationCommon(CommonMaterialCatalog.Create().Generic.Uv),
                 })
                 .ToArray(),
         };

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -146,10 +146,11 @@ public sealed class ResoniteLiveSceneImportTargetTests
         TerrainTextureOverlay demOverlay = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/dem/{z}/{x}/{y}.png");
         TerrainTextureOverlay roofOverlayWithDifferentUri = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/roof/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
-            _ => new GeneratedTerrainTexture(
+            requestedOverlay => new GeneratedTerrainTexture(
                 CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
-                new ResoniteFloat2(0.0, 0.0)));
+                new ResoniteFloat2(0.0, 0.0),
+                requestedOverlay.PrimarySource));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
             MeshCode,
@@ -226,10 +227,11 @@ public sealed class ResoniteLiveSceneImportTargetTests
         TerrainTextureOverlay firstOverlay = CreateThirdMeshOverlay("53394525", "https://tiles.example/{z}/{x}/{y}.png");
         TerrainTextureOverlay secondOverlay = CreateThirdMeshOverlay("53394526", "https://tiles.example/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
-            _ => new GeneratedTerrainTexture(
+            requestedOverlay => new GeneratedTerrainTexture(
                 CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
-                new ResoniteFloat2(0.0, 0.0)));
+                new ResoniteFloat2(0.0, 0.0),
+                requestedOverlay.PrimarySource));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
             MeshCode,
@@ -276,10 +278,11 @@ public sealed class ResoniteLiveSceneImportTargetTests
         using SceneSinkRecordingClient client = new();
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://tiles.example/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
-            _ => new GeneratedTerrainTexture(
+            requestedOverlay => new GeneratedTerrainTexture(
                 CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
-                new ResoniteFloat2(0.0, 0.0)));
+                new ResoniteFloat2(0.0, 0.0),
+                requestedOverlay.PrimarySource));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
             MeshCode,
@@ -366,10 +369,11 @@ public sealed class ResoniteLiveSceneImportTargetTests
         using SceneSinkRecordingClient client = new();
         TerrainTextureOverlay mismatchedOverlay = CreateThirdMeshOverlay("53394526", "https://tiles.example/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
-            _ => new GeneratedTerrainTexture(
+            requestedOverlay => new GeneratedTerrainTexture(
                 CreateRawTextureSource(2, 2, ResoniteTextureColorProfiles.Srgb, new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
-                new ResoniteFloat2(0.0, 0.0)));
+                new ResoniteFloat2(0.0, 0.0),
+                requestedOverlay.PrimarySource));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
             MeshCode,
@@ -414,7 +418,8 @@ public sealed class ResoniteLiveSceneImportTargetTests
                     ResoniteTextureColorProfiles.Srgb,
                     new byte[16]),
                 new ResoniteFloat2(1.0, 1.0),
-                new ResoniteFloat2(0.125, 0.375)));
+                new ResoniteFloat2(0.125, 0.375),
+                requestedOverlay.PrimarySource));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
             MeshCode,
@@ -786,14 +791,15 @@ public sealed class ResoniteLiveSceneImportTargetTests
         using SceneSinkRecordingClient client = new();
         TerrainTextureOverlay overlay = CreateThirdMeshOverlay(MeshCode, "https://example.invalid/{z}/{x}/{y}.png");
         RecordingTerrainTextureAssetGenerator terrainTextureGenerator = new(
-            _ => new GeneratedTerrainTexture(
+            requestedOverlay => new GeneratedTerrainTexture(
                 CreateRawTextureSource(
                     2,
                     2,
                     ResoniteTextureColorProfiles.Srgb,
                     new byte[16]),
                 new ResoniteFloat2(0.5, 0.25),
-                new ResoniteFloat2(0.125, 0.375)));
+                new ResoniteFloat2(0.125, 0.375),
+                requestedOverlay.PrimarySource));
         ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
             DatasetName,
             MeshCode,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -1000,7 +1000,7 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 new ResoniteMaterialBinding(
                     BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
                     MaterialType: ResoniteMaterialType.Standard,
-                    TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/uv-bake-budget.png"),
+                    TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/uv-bake-budget.png"),
                     TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                     Projection: ResoniteMaterialProjection.Uv,
                     DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetYOffsetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetYOffsetTests.cs
@@ -82,7 +82,8 @@ public sealed class ResoniteLiveSceneImportTargetYOffsetTests
             TextureSourceKind: ResoniteTextureSourceKind.Bundled,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
-            SubmeshIndices: [0]);
+            SubmeshIndices: [0],
+            ResoniteMaterialAssetBinding.Presentation);
     }
 
     private static double GetSlotY(Slot slot)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialAssetBindingTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialAssetBindingTestFactory.cs
@@ -1,0 +1,90 @@
+using System;
+
+using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+internal static class ResoniteMaterialAssetBindingTestFactory
+{
+    internal static ResoniteMaterialAssetBinding SharedBundled(string family, int variantIndex)
+    {
+        return ResoniteMaterialAssetBinding.SharedCommon(SelectBundledMember(family, variantIndex));
+    }
+
+    internal static ResoniteMaterialAssetBinding SharedGenericUv()
+    {
+        return ResoniteMaterialAssetBinding.SharedCommon(CommonMaterialCatalog.Create().Generic.Uv);
+    }
+
+    internal static DefaultCommonMaterialMember SelectBundledMember(string family, int variantIndex)
+    {
+        CommonMaterialCatalog<DefaultCommonMaterialMember> commonMaterials = CommonMaterialCatalog.Create();
+        return family switch
+        {
+            BundledDefaultMaterialFamilies.CityFurniture => variantIndex switch
+            {
+                0 => commonMaterials.CityFurniture.Plaster002,
+                1 => commonMaterials.CityFurniture.Plaster001,
+                2 => commonMaterials.CityFurniture.Plaster003,
+                3 => commonMaterials.CityFurniture.Plaster004,
+                4 => commonMaterials.CityFurniture.Plaster005,
+                _ => commonMaterials.CityFurniture.Plaster006,
+            },
+            BundledDefaultMaterialFamilies.FacadeHighriseGlass => variantIndex switch
+            {
+                0 => commonMaterials.FacadeHighriseGlass.Facade001,
+                1 => commonMaterials.FacadeHighriseGlass.Facade005,
+                _ => commonMaterials.FacadeHighriseGlass.Facade006,
+            },
+            BundledDefaultMaterialFamilies.FacadeHighriseNightLow => variantIndex == 0
+                ? commonMaterials.FacadeHighriseNightLow.Facade002
+                : commonMaterials.FacadeHighriseNightLow.Facade011,
+            BundledDefaultMaterialFamilies.FacadeMidriseGrid => variantIndex == 0
+                ? commonMaterials.FacadeMidriseGrid.Facade014
+                : commonMaterials.FacadeMidriseGrid.Facade015,
+            BundledDefaultMaterialFamilies.Other => variantIndex switch
+            {
+                0 => commonMaterials.Other.Concrete012,
+                1 => commonMaterials.Other.Ground054,
+                2 => commonMaterials.Other.Plaster002,
+                3 => commonMaterials.Other.Plaster001,
+                4 => commonMaterials.Other.Plaster003,
+                5 => commonMaterials.Other.Plaster004,
+                6 => commonMaterials.Other.Plaster005,
+                7 => commonMaterials.Other.Plaster006,
+                _ => commonMaterials.Other.TextureCanFacade0022,
+            },
+            BundledDefaultMaterialFamilies.RoadTriplanar => variantIndex switch
+            {
+                0 => commonMaterials.RoadTriplanar.Road012A,
+                1 => commonMaterials.RoadTriplanar.Road013A,
+                2 => commonMaterials.RoadTriplanar.Road014A,
+                _ => commonMaterials.RoadTriplanar.Road015A,
+            },
+            BundledDefaultMaterialFamilies.RoadUv => variantIndex switch
+            {
+                0 => commonMaterials.RoadUv.Road012A,
+                1 => commonMaterials.RoadUv.Road013A,
+                2 => commonMaterials.RoadUv.Road014A,
+                _ => commonMaterials.RoadUv.Road015A,
+            },
+            BundledDefaultMaterialFamilies.Roof => variantIndex switch
+            {
+                0 => commonMaterials.Roof.Concrete012,
+                1 => commonMaterials.Roof.Concrete033,
+                2 => commonMaterials.Roof.RoofingTiles012A,
+                _ => commonMaterials.Roof.RoofingTiles014B,
+            },
+            BundledDefaultMaterialFamilies.Vegetation => variantIndex == 0
+                ? commonMaterials.Vegetation.Ground054
+                : commonMaterials.Vegetation.Concrete012,
+            BundledDefaultMaterialFamilies.WallResidentialPlasterLow => variantIndex == 0
+                ? commonMaterials.WallResidentialPlasterLow.ResidentialPlasterLow
+                : commonMaterials.WallResidentialPlasterLow.ResidentialPlasterDark,
+            _ => throw new InvalidOperationException(
+                $"Bundled family '{family}' variant {variantIndex} is not represented by this test factory."),
+        };
+    }
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
@@ -29,8 +29,8 @@ public sealed class ResoniteMaterialComponentPolicyTests
             SubmeshIndices: [0],
             TextureScale: new ResoniteFloat2(0.5, 0.25),
             TextureOffset: new ResoniteFloat2(0.125, 0.75),
-            Family: BundledDefaultMaterialFamilies.Facade,
-            AssetScope: ResoniteMaterialAssetScope.Common,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0),
             BundledVariantIndex: 0);
 
         string componentType = ResoniteMaterialComponentPolicy.GetComponentType(material);
@@ -69,8 +69,8 @@ public sealed class ResoniteMaterialComponentPolicyTests
             SubmeshIndices: [0],
             TextureScale: new ResoniteFloat2(1.0, 1.0),
             TextureOffset: new ResoniteFloat2(0.0, 0.0),
-            Family: BundledDefaultMaterialFamilies.Facade,
-            AssetScope: ResoniteMaterialAssetScope.Common,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0),
             BundledVariantIndex: 0);
 
         Dictionary<string, Member> members = ResoniteMaterialComponentPolicy.CreateMembers(material);
@@ -90,7 +90,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         Dictionary<string, Member> members = ResoniteMaterialComponentPolicy.CreateMembers(material);
 
@@ -109,9 +109,9 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: new ResoniteFloat2(0.5, 0.25),
-            TextureOffset: new ResoniteFloat2(0.125, 0.75),
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+            TextureOffset: new ResoniteFloat2(0.125, 0.75));
 
         InvalidOperationException error = Assert.Throws<InvalidOperationException>(
             () => ResoniteMaterialComponentPolicy.CreateMembers(material));
@@ -131,6 +131,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Triplanar,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: new ResoniteFloat2(0.25, 0.125),
             Family: BundledDefaultMaterialFamilies.RoadTriplanar,
             BundledVariantIndex: 0);
@@ -141,7 +142,8 @@ public sealed class ResoniteMaterialComponentPolicyTests
             TextureSourceKind: ResoniteTextureSourceKind.Bundled,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
-            SubmeshIndices: [0]);
+            SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation);
 
         Dictionary<string, Member> triplanarMembers = ResoniteMaterialComponentPolicy.CreateMembers(triplanarMaterial);
         Dictionary<string, Member> wireframeMembers = ResoniteMaterialComponentPolicy.CreateMembers(wireframeMaterial);
@@ -175,9 +177,9 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: new ResoniteFloat2(1.0, 1.0),
-            TextureOffset: new ResoniteFloat2(0.125, 0.75),
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+            TextureOffset: new ResoniteFloat2(0.125, 0.75));
 
         ResoniteMaterialBinding normalized = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
 
@@ -198,17 +200,17 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureOffset: new ResoniteFloat2(0.125, 0.75),
             TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(
                 ThirdRegionalMeshCode.Parse("53394525"),
                 new TerrainTextureOverlay(
-                PackageName: "dem",
-            MeshCode: ThirdRegionalMeshCode.Parse("53394525"),
-                UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
-                ZoomLevel: 17,
-                GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
-                    MaxTextureSize: 512)),
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+                    PackageName: "dem",
+                    MeshCode: ThirdRegionalMeshCode.Parse("53394525"),
+                    UrlTemplate: "https://example.invalid/{z}/{x}/{y}.png",
+                    ZoomLevel: 17,
+                    GeographicBounds: new GeographicRectangle(35.68, 35.69, 139.69, 139.70),
+                    MaxTextureSize: 512)));
 
         InvalidOperationException error = Assert.Throws<InvalidOperationException>(
             () => ResoniteMaterialComponentPolicy.CreateMembers(material));
@@ -227,7 +229,8 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
-            Family: BundledDefaultMaterialFamilies.Facade,
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
             BundledVariantIndex: 0);
 
         bool resolved = ResoniteMaterialComponentPolicy.TryGetBundledCompanionTextureSet(
@@ -284,7 +287,8 @@ public sealed class ResoniteMaterialComponentPolicyTests
                 Projection: ResoniteMaterialProjection.Uv,
                 DepthOffset: null,
                 SubmeshIndices: [0],
-                Family: BundledDefaultMaterialFamilies.Facade,
+                AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+                Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
                 BundledVariantIndex: variantIndex);
 
             bool resolved = ResoniteMaterialComponentPolicy.TryGetBundledCompanionTextureSet(
@@ -311,6 +315,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Projection: ResoniteMaterialProjection.Triplanar,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             Family: BundledDefaultMaterialFamilies.CityFurniture,
             BundledVariantIndex: 0);
 
@@ -353,7 +358,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Family: BundledDefaultMaterialFamilies.WallResidentialPlasterLow,
             BundledVariantIndex: 0,
             TextureScale: new ResoniteFloat2(1.0 / 3.0, 1.0 / 3.0),
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.WallResidentialPlasterLow, 0));
 
         bool resolved = ResoniteMaterialComponentPolicy.TryGetBundledCompanionTextureSet(
             new BundledDefaultMaterialAssetStore(),
@@ -390,7 +395,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
             Family: BundledDefaultMaterialFamilies.WallResidentialPlasterLow,
             BundledVariantIndex: 1,
             TextureScale: new ResoniteFloat2(1.0 / 3.0, 1.0 / 3.0),
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.WallResidentialPlasterLow, 1));
 
         bool resolved = ResoniteMaterialComponentPolicy.TryGetBundledCompanionTextureSet(
             new BundledDefaultMaterialAssetStore(),
@@ -422,7 +427,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
             SubmeshIndices: [0],
             Family: BundledDefaultMaterialFamilies.FacadeHighriseNightLow,
             BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseNightLow, 0));
 
         bool resolved = ResoniteMaterialComponentPolicy.TryGetBundledCompanionTextureSet(
             new BundledDefaultMaterialAssetStore(),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
@@ -104,7 +104,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
         ResoniteMaterialBinding material = new(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic.png"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/dynamic.png"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
@@ -172,7 +172,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
         ResoniteMaterialBinding material = new(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/direct-terrain-grid-style.png"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/direct-terrain-grid-style.png"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -357,7 +357,7 @@ public sealed class ResoniteMaterialPlanningTests
         ResoniteMaterialBinding firstMaterial = new(
             BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], identity: "payload-a"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], identity: "payload-a"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -123,20 +123,20 @@ public sealed class ResoniteMaterialPlanningTests
 
         Assert.Equal(importCountAfterBase + 3, ImportedRgba32Textures(client).Count);
         Assert.NotEqual(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Albedo));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo));
         Assert.NotEqual(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Normal),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Normal));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Normal),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Normal));
         Assert.NotEqual(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Height),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Height));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Height),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Height));
         Assert.Equal(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Metallic),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Metallic));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic));
         Assert.Equal(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Emission),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Emission));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Emission),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Emission));
     }
 
     [Fact]
@@ -163,23 +163,23 @@ public sealed class ResoniteMaterialPlanningTests
 
         Assert.Equal(importCountAfterBase + 2, ImportedRgba32Textures(client).Count);
         Assert.NotEqual(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Albedo));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo));
         Assert.Equal(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Normal),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Normal));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Normal),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Normal));
         Assert.Equal(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Height),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Height));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Height),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Height));
         Assert.Equal(
-            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Metallic),
-            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.TextureMemberRole.Metallic));
+            GetTextureUri(basePlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic),
+            GetTextureUri(colorVariantPlannedAsset, ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic));
         Assert.Null(ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             basePlannedAsset.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Emission));
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Emission));
         Assert.NotNull(ResoniteMaterialPlanning.TryGetPlannedTextureUri(
             colorVariantPlannedAsset.Textures,
-            ResoniteSceneMaterialConventions.TextureMemberRole.Emission));
+            ResoniteSceneMaterialConventions.PlannedTextureRole.Emission));
     }
 
     [Fact]
@@ -269,7 +269,7 @@ public sealed class ResoniteMaterialPlanningTests
             material,
             [
                 new PlannedTextureAsset(
-                    ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
+                    ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo),
                     new Uri("resdb:///texture/albedo", UriKind.Absolute)),
             ],
             PreserveDedicatedMaterialSlot: false);
@@ -292,10 +292,10 @@ public sealed class ResoniteMaterialPlanningTests
             material,
             [
                 new PlannedTextureAsset(
-                    ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.TextureMemberRole.Albedo),
+                    ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo),
                     new Uri("resdb:///texture/albedo", UriKind.Absolute)),
                 new PlannedTextureAsset(
-                    ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.TextureMemberRole.Emission),
+                    ResoniteSceneMaterialConventions.CreateTextureIdentity(ResoniteSceneMaterialConventions.PlannedTextureRole.Emission),
                     new Uri("resdb:///texture/emission", UriKind.Absolute)),
             ],
             PreserveDedicatedMaterialSlot: false);
@@ -435,7 +435,7 @@ public sealed class ResoniteMaterialPlanningTests
 
     private static Uri GetTextureUri(
         PlannedDedicatedMaterialAsset plannedAsset,
-        ResoniteSceneMaterialConventions.TextureMemberRole role)
+        ResoniteSceneMaterialConventions.PlannedTextureRole role)
     {
         return ResoniteMaterialPlanning.TryGetPlannedTextureUri(plannedAsset.Textures, role)
             ?? throw new InvalidOperationException($"Missing planned texture role '{role}'.");

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -46,8 +46,8 @@ public sealed class ResoniteMaterialPlanningTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
-            Family: BundledDefaultMaterialFamilies.Facade,
-            AssetScope: ResoniteMaterialAssetScope.Common,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0),
             BundledVariantIndex: 0);
         _ = ResoniteMaterialComponentPolicy.TryGetBundledCompanionTextureSet(
             new BundledDefaultMaterialAssetStore(),
@@ -194,7 +194,8 @@ public sealed class ResoniteMaterialPlanningTests
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
-            SubmeshIndices: [0]);
+            SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation);
 
         PlannedDedicatedMaterialAsset preserved = await planning.PlanDedicatedMaterialAssetAsync(
             client,
@@ -240,6 +241,7 @@ public sealed class ResoniteMaterialPlanningTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: new ResoniteFloat2(0.4, 0.8),
             TextureOffset: new ResoniteFloat2(0.1, 0.2),
             TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay));
@@ -264,7 +266,7 @@ public sealed class ResoniteMaterialPlanningTests
     public void AddCommonMaterialComponentsDoesNotCreateEmissionMembersWithoutEmissionSource()
     {
         ResoniteBatchOperations.BatchActionBuilder batchBuilder = new();
-        ResoniteMaterialBinding material = CreateBundledMaterial(BundledDefaultMaterialFamilies.Facade, 0);
+        ResoniteMaterialBinding material = CreateBundledMaterial(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0);
         PlannedDedicatedMaterialAsset plannedMaterial = new(
             material,
             [
@@ -330,7 +332,8 @@ public sealed class ResoniteMaterialPlanningTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
-            TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay));
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
+            TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(overlay.MeshCode, overlay));
         Dictionary<TerrainTextureOverlay, GeneratedTerrainTexture> preparedTerrainTextures = new()
         {
             [overlay] = new GeneratedTerrainTexture(
@@ -358,7 +361,8 @@ public sealed class ResoniteMaterialPlanningTests
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
-            SubmeshIndices: [0]);
+            SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation);
         ResoniteMaterialBinding secondMaterial = firstMaterial with
         {
         };
@@ -414,7 +418,11 @@ public sealed class ResoniteMaterialPlanningTests
             Family: projection == ResoniteMaterialProjection.Uv
                 ? BundledDefaultMaterialFamilies.RoadUv
                 : BundledDefaultMaterialFamilies.RoadTriplanar,
-            AssetScope: ResoniteMaterialAssetScope.Common,
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(
+                projection == ResoniteMaterialProjection.Uv
+                    ? BundledDefaultMaterialFamilies.RoadUv
+                    : BundledDefaultMaterialFamilies.RoadTriplanar,
+                0),
             BundledVariantIndex: 0);
     }
 
@@ -429,7 +437,7 @@ public sealed class ResoniteMaterialPlanningTests
             DepthOffset: null,
             SubmeshIndices: [0],
             Family: family,
-            AssetScope: ResoniteMaterialAssetScope.Common,
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(family, variantIndex),
             BundledVariantIndex: variantIndex);
     }
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -248,7 +248,8 @@ public sealed class ResoniteMaterialPlanningTests
             [overlay] = new GeneratedTerrainTexture(
                 CreateRawTextureSource(512, 256, ResoniteTextureColorProfiles.Srgb, new byte[512 * 256 * 4]),
                 new ResoniteFloat2(0.5, 0.25),
-                new ResoniteFloat2(0.0, 0.0)),
+                new ResoniteFloat2(0.0, 0.0),
+                overlay.PrimarySource),
         };
 
         ResoniteMaterialBinding effectiveMaterial = ResoniteMaterialPlanning.ResolveTerrainTextureCanvasMaterial(
@@ -335,7 +336,8 @@ public sealed class ResoniteMaterialPlanningTests
             [overlay] = new GeneratedTerrainTexture(
                 CreateRawTextureSource(512, 256, ResoniteTextureColorProfiles.Srgb, new byte[512 * 256 * 4]),
                 new ResoniteFloat2(0.5, 0.25),
-                new ResoniteFloat2(0.0, 0.0)),
+                new ResoniteFloat2(0.0, 0.0),
+                overlay.PrimarySource),
         };
 
         ResoniteMaterialBinding effectiveMaterial = ResoniteMaterialPlanning.ResolveTerrainTextureCanvasMaterial(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -343,7 +343,8 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 TextureSourceKind: ResoniteTextureSourceKind.Dataset,
                 Projection: ResoniteMaterialProjection.Uv,
                 DepthOffset: null,
-                SubmeshIndices: [0]),
+                SubmeshIndices: [0],
+                ResoniteMaterialAssetBinding.Presentation),
             [new PlannedTextureAsset(new TextureIdentity("albedo"), new Uri("resdb:///texture/albedo"))],
             PreserveDedicatedMaterialSlot: true,
             DedicatedMaterialSlotName: "material-000-pbs-uv-uv");
@@ -411,7 +412,8 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 TextureSourceKind: ResoniteTextureSourceKind.Bundled,
                 Projection: ResoniteMaterialProjection.Uv,
                 DepthOffset: null,
-                SubmeshIndices: [0]),
+                SubmeshIndices: [0],
+                ResoniteMaterialAssetBinding.Presentation),
             [
                 new PlannedTextureAsset(new TextureIdentity("albedo"), new Uri("resdb:///texture/albedo")),
                 new PlannedTextureAsset(new TextureIdentity("normal"), new Uri("resdb:///texture/normal")),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -136,11 +136,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchSlotEmission meshAssetSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object", StringComparison.Ordinal)
-                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
+                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         PlannedBatchSlotEmission presentationSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object", StringComparison.Ordinal)
-                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("lod-slot")));
+                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("lod-slot")));
         PlannedBatchSlotEmission heightMapSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object_terrain-grid", StringComparison.Ordinal));
@@ -164,26 +164,23 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshCollider", StringComparison.Ordinal));
 
         Assert.Equal(new ResoniteSlotLocator("asset-lod-slot"), AssertCanonical(meshAssetSlot.ParentTarget));
-        Assert.False(IsPlanned(meshAssetSlot.ParentTarget));
         Assert.Equal(new ResoniteSlotLocator("asset-lod-slot"), AssertCanonical(heightMapSlot.ParentTarget));
-        Assert.False(IsPlanned(heightMapSlot.ParentTarget));
         Assert.Equal(presentationSlot.Identity, AssertPlanned(gridMesh.ContainerTarget));
         Assert.Equal(presentationSlot.Identity, AssertPlanned(pointsGradientDriver.ContainerTarget));
         Assert.Equal(presentationSlot.Identity, AssertPlanned(pointsProgressDriver.ContainerTarget));
         Assert.Equal(heightMapSlot.Identity, AssertPlanned(heightTexture.ContainerTarget));
-        Assert.True(IsPlanned(heightTexture.ContainerTarget));
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(heightTexture.Members["WrapModeU"])).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(heightTexture.Members["WrapModeV"])).Value);
         Assert.Equal("Point", Assert.IsType<Field_Nullable_Enum>(ToMember(heightTexture.Members["FilterMode"])).Value);
         Assert.False(Assert.IsType<Field_bool>(ToMember(heightTexture.Members["MipMaps"])).Value);
         Reference displacementTexture = Assert.IsType<Reference>(ToMember(gridMesh.Members["DisplacementTexture"]));
         Assert.Equal(ToPlannedTargetId(heightTexture.Identity), displacementTexture.TargetID);
-        PlannedAddressableFieldMember gridPointsMember = Assert.IsType<PlannedAddressableFieldMember>(gridMesh.Members["Points"]);
+        PlannedAddressableFieldMember gridPointsMember = Assert.IsType<PlannedAddressableFieldMember.Int2>(gridMesh.Members["Points"]);
         Field_int2 gridPoints = Assert.IsType<Field_int2>(gridPointsMember.Value);
         Assert.Equal(2, gridPoints.Value.x);
         Assert.Equal(3, gridPoints.Value.y);
         Assert.True(string.IsNullOrWhiteSpace(gridPoints.ID));
-        PlannedAddressableFieldMember progress = Assert.IsType<PlannedAddressableFieldMember>(pointsGradientDriver.Members["Progress"]);
+        PlannedAddressableFieldMember progress = Assert.IsType<PlannedAddressableFieldMember.Float>(pointsGradientDriver.Members["Progress"]);
         Assert.Equal(1.0f, Assert.IsType<Field_float>(progress.Value).Value);
         PlannedElementReferenceMember pointsTarget = Assert.IsType<PlannedElementReferenceMember>(pointsGradientDriver.Members["Target"]);
         Assert.Equal(gridPointsMember.Identity, AssertPlannedField(pointsTarget.Target));
@@ -260,7 +257,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(colliderMesh)).TargetID);
         foreach (PlannedBatchComponentEmission meshSwitch in meshSwitches)
         {
-            PlannedAddressableFieldMember state = Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]);
+            PlannedAddressableFieldMember state = Assert.IsType<PlannedAddressableFieldMember.Bool>(meshSwitch.Members["State"]);
             PlannedElementReferenceMember target = Assert.IsType<PlannedElementReferenceMember>(meshSwitch.Members["Target"]);
             Assert.True(
                 AssertPlannedField(target.Target) is BatchPlanFieldLocator plannedTarget
@@ -276,7 +273,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             Assert.True(
                 AssertPlannedField(target.Target) is BatchPlanFieldLocator plannedStateTarget
                 && meshSwitches
-                    .Select(meshSwitch => Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]).Identity)
+                    .Select(meshSwitch => Assert.IsType<PlannedAddressableFieldMember.Bool>(meshSwitch.Members["State"]).Identity)
                     .Contains(plannedStateTarget));
             Assert.Equal("PLATEAU.Terrain.Static.Enabled", Assert.IsType<Field_string>(ToMember(boolDriver.Members["VariableName"])).Value);
             Assert.False(Assert.IsType<Field_bool>(ToMember(boolDriver.Members["DefaultValue"])).Value);
@@ -380,14 +377,14 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Reference dedicatedMaterialReference = Assert.IsType<Reference>(materials.Elements[1]);
         PlannedBatchSlotEmission dedicatedMaterialSlot = Assert.Single(
             batchPlan.SlotEmissions,
-            slot => IsPlanned(slot.ParentTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object"))
+            slot => IsBatchSlotTarget(slot.ParentTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object"))
                 && string.Equals(slot.SlotName, "material-000-pbs-uv-uv", StringComparison.Ordinal));
         PlannedBatchComponentEmission dedicatedMaterialComponent = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal));
         PlannedBatchComponentEmission albedoTexture = Assert.Single(
             batchPlan.ComponentEmissions,
-            component => IsPlanned(component.ContainerTarget, dedicatedMaterialSlot.Identity)
+            component => IsBatchSlotTarget(component.ContainerTarget, dedicatedMaterialSlot.Identity)
                 && string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
 
         Assert.Equal("existing-material-id", reusableMaterialReference.TargetID);
@@ -441,10 +438,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchSlotEmission meshAssetSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal)
-                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
+                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         Assert.DoesNotContain(
             batchPlan.SlotEmissions,
-            slot => IsPlanned(slot.ParentTarget, meshAssetSlot.Identity)
+            slot => IsBatchSlotTarget(slot.ParentTarget, meshAssetSlot.Identity)
                 && !string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal));
 
         PlannedBatchComponentEmission materialComponent = Assert.Single(
@@ -526,11 +523,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchSlotEmission assetSlot = Assert.Single(
             batchPlan.SlotEmissions,
             slot => string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal)
-                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
+                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         PlannedBatchComponentEmission overrideTexture = Assert.Single(
             batchPlan.ComponentEmissions,
             component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && IsPlanned(component.ContainerTarget, assetSlot.Identity));
+                && IsBatchSlotTarget(component.ContainerTarget, assetSlot.Identity));
 
         Assert.Equal("shared-material-id", materialReference.TargetID);
         Assert.Equal(ToPlannedTargetId(propertyBlockComponent.Identity), propertyBlockReference.TargetID);
@@ -573,7 +570,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchComponentEmission overrideTexture = Assert.Single(
             batchPlan.ComponentEmissions,
             component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && IsPlanned(component.ContainerTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object")));
+                && IsBatchSlotTarget(component.ContainerTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object")));
 
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(overrideTexture.Members["WrapModeU"])).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(overrideTexture.Members["WrapModeV"])).Value);
@@ -684,29 +681,24 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
     private static BatchPlanSlotLocator AssertPlanned(PlannedSlotTargetReference target)
     {
-        return Assert.IsType<PlannedSlotTargetReference.PlannedSlotTarget>(target).Locator;
+        return Assert.IsType<PlannedSlotTargetReference.BatchSlotTarget>(target).Locator;
+    }
+
+    private static bool IsCanonicalSlotTarget(PlannedSlotTargetReference target, ResoniteSlotLocator expected)
+    {
+        return target is PlannedSlotTargetReference.CanonicalSlotTarget canonicalSlot
+            && canonicalSlot.Locator == expected;
+    }
+
+    private static bool IsBatchSlotTarget(PlannedSlotTargetReference target, BatchPlanSlotLocator expected)
+    {
+        return target is PlannedSlotTargetReference.BatchSlotTarget plannedSlot
+            && plannedSlot.Locator == expected;
     }
 
     private static BatchPlanFieldLocator AssertPlannedField(PlannedWorldElementReference target)
     {
-        return Assert.IsType<PlannedWorldElementReference.PlannedFieldElement>(target).Locator;
-    }
-
-    private static bool IsCanonical(PlannedSlotTargetReference target, ResoniteSlotLocator locator)
-    {
-        return target is PlannedSlotTargetReference.CanonicalSlotTarget canonicalSlot
-            && canonicalSlot.Locator == locator;
-    }
-
-    private static bool IsPlanned(PlannedSlotTargetReference target)
-    {
-        return target is PlannedSlotTargetReference.PlannedSlotTarget;
-    }
-
-    private static bool IsPlanned(PlannedSlotTargetReference target, BatchPlanSlotLocator locator)
-    {
-        return target is PlannedSlotTargetReference.PlannedSlotTarget plannedSlot
-            && plannedSlot.Locator == locator;
+        return Assert.IsType<PlannedWorldElementReference.BatchFieldElement>(target).Locator;
     }
 
     private static void AssertGradientPoint(Member member, float expectedPosition, int expectedX, int expectedY)
@@ -720,25 +712,22 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
     private static Member ToMember(PlannedMember member)
     {
-        return member switch
-        {
-            PlannedLiteralMember literal => literal.Value,
-            PlannedElementReferenceMember reference => new Reference
+        return member.Match(
+            literal: static literal => literal,
+            reference: reference => new Reference
             {
-                TargetID = ResolveTargetId(reference.Target),
+                TargetID = ResolveTargetId(reference),
             },
-            PlannedAddressableFieldMember field => field.Value,
-            PlannedAddressableReferenceMember reference => new Reference
+            addressableField: static field => field.Value,
+            addressableReference: (identity, target) => new Reference
             {
-                ID = ToPlannedTargetId(reference.Identity),
-                TargetID = ResolveTargetId(reference.Target),
+                ID = ToPlannedTargetId(identity),
+                TargetID = ResolveTargetId(target),
             },
-            PlannedSyncListMember syncList => new SyncList
+            list: elements => new SyncList
             {
-                Elements = syncList.Elements.Select(ToMember).ToList(),
-            },
-            _ => throw new InvalidOperationException($"Unsupported planned member type '{member.GetType().Name}'."),
-        };
+                Elements = elements.Select(ToMember).ToList(),
+            });
     }
 
     private static BatchPlanSlotLocator FindAssetSlotIdentity(PlannedBatchEmission batchPlan, string slotName)
@@ -746,20 +735,17 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         return Assert.Single(
             batchPlan.SlotEmissions,
             slot => string.Equals(slot.SlotName, slotName, StringComparison.Ordinal)
-                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot"))).Identity;
+                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot"))).Identity;
     }
 
     private static string? ResolveTargetId(PlannedWorldElementReference target)
     {
-        return target switch
-        {
-            PlannedWorldElementReference.CanonicalSlotElement canonicalSlot => canonicalSlot.Locator.Value,
-            PlannedWorldElementReference.CanonicalComponentElement canonicalComponent => canonicalComponent.Locator.Value,
-            PlannedWorldElementReference.PlannedSlotElement plannedSlot => ToPlannedTargetId(plannedSlot.Locator),
-            PlannedWorldElementReference.PlannedComponentElement plannedComponent => ToPlannedTargetId(plannedComponent.Locator),
-            PlannedWorldElementReference.PlannedFieldElement plannedField => ToPlannedTargetId(plannedField.Locator),
-            _ => throw new InvalidOperationException("Unsupported planned world element reference."),
-        };
+        return target.Match(
+            static canonicalSlot => canonicalSlot.Value,
+            static canonicalComponent => canonicalComponent.Value,
+            static plannedSlot => ToPlannedTargetId(plannedSlot),
+            static plannedComponent => ToPlannedTargetId(plannedComponent),
+            static plannedField => ToPlannedTargetId(plannedField));
     }
 
     private static string ToPlannedTargetId(BatchPlanSlotLocator locator)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -28,10 +28,77 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             });
 
         Assert.Equal(fieldIdentity, bundle.Field.Identity);
-        Assert.Equal(fieldIdentity, bundle.Target.Target.PlannedField);
+        Assert.Equal(fieldIdentity, AssertPlannedField(bundle.Target.Target));
         Assert.False(Assert.IsType<Field_bool>(bundle.Field.Value).Value);
         Assert.False(Assert.IsType<Field_bool>(bundle.DefaultValue.Value).Value);
         Assert.NotSame(bundle.Field.Value, bundle.DefaultValue.Value);
+    }
+
+    [Fact]
+    public void PlannedBatchEmissionCreateRejectsForwardPlannedSlotParentReference()
+    {
+        BatchPlanSlotLocator child = new(1);
+        BatchPlanSlotLocator parent = new(2);
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => PlannedBatchEmission.Create(
+                [
+                    new PlannedBatchSlotEmission(
+                        child,
+                        PlannedSlotTargetReference.PlannedSlot(parent),
+                        "child",
+                        null,
+                        null),
+                    new PlannedBatchSlotEmission(
+                        parent,
+                        PlannedSlotTargetReference.CanonicalSlot(new ResoniteSlotLocator("root")),
+                        "parent",
+                        null,
+                        null),
+                ],
+                [],
+                [child, parent],
+                []));
+
+        Assert.Equal("Planned slot parent target must reference an earlier planned slot.", error.Message);
+    }
+
+    [Fact]
+    public void PlannedBatchEmissionCreateRejectsForwardPlannedComponentMemberReference()
+    {
+        BatchPlanSlotLocator container = new(1);
+        BatchPlanComponentLocator source = new(1);
+        BatchPlanComponentLocator target = new(2);
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => PlannedBatchEmission.Create(
+                [
+                    new PlannedBatchSlotEmission(
+                        container,
+                        PlannedSlotTargetReference.CanonicalSlot(new ResoniteSlotLocator("root")),
+                        "container",
+                        null,
+                        null),
+                ],
+                [
+                    new PlannedBatchComponentEmission(
+                        source,
+                        PlannedSlotTargetReference.PlannedSlot(container),
+                        "[FrooxEngine]FrooxEngine.Source",
+                        new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
+                        {
+                            ["Target"] = PlannedMembers.Reference(PlannedWorldElementReference.Planned(target)),
+                        }),
+                    new PlannedBatchComponentEmission(
+                        target,
+                        PlannedSlotTargetReference.PlannedSlot(container),
+                        "[FrooxEngine]FrooxEngine.Target",
+                        new Dictionary<string, PlannedMember>(StringComparer.Ordinal)),
+                ],
+                [container],
+                [source, target]));
+
+        Assert.Equal("Planned world element target must reference an earlier planned component.", error.Message);
     }
 
     [Fact]
@@ -69,11 +136,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchSlotEmission meshAssetSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object", StringComparison.Ordinal)
-                && slot.ParentTarget.Canonical == new ResoniteSlotLocator("asset-lod-slot"));
+                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         PlannedBatchSlotEmission presentationSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object", StringComparison.Ordinal)
-                && slot.ParentTarget.Canonical == new ResoniteSlotLocator("lod-slot"));
+                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("lod-slot")));
         PlannedBatchSlotEmission heightMapSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Terrain Grid Object_terrain-grid", StringComparison.Ordinal));
@@ -97,14 +164,14 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshCollider", StringComparison.Ordinal));
 
         Assert.Equal(new ResoniteSlotLocator("asset-lod-slot"), AssertCanonical(meshAssetSlot.ParentTarget));
-        Assert.False(meshAssetSlot.ParentTarget.IsPlanned);
+        Assert.False(IsPlanned(meshAssetSlot.ParentTarget));
         Assert.Equal(new ResoniteSlotLocator("asset-lod-slot"), AssertCanonical(heightMapSlot.ParentTarget));
-        Assert.False(heightMapSlot.ParentTarget.IsPlanned);
+        Assert.False(IsPlanned(heightMapSlot.ParentTarget));
         Assert.Equal(presentationSlot.Identity, AssertPlanned(gridMesh.ContainerTarget));
         Assert.Equal(presentationSlot.Identity, AssertPlanned(pointsGradientDriver.ContainerTarget));
         Assert.Equal(presentationSlot.Identity, AssertPlanned(pointsProgressDriver.ContainerTarget));
         Assert.Equal(heightMapSlot.Identity, AssertPlanned(heightTexture.ContainerTarget));
-        Assert.True(heightTexture.ContainerTarget.IsPlanned);
+        Assert.True(IsPlanned(heightTexture.ContainerTarget));
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(heightTexture.Members["WrapModeU"])).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(heightTexture.Members["WrapModeV"])).Value);
         Assert.Equal("Point", Assert.IsType<Field_Nullable_Enum>(ToMember(heightTexture.Members["FilterMode"])).Value);
@@ -119,14 +186,14 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedAddressableFieldMember progress = Assert.IsType<PlannedAddressableFieldMember>(pointsGradientDriver.Members["Progress"]);
         Assert.Equal(1.0f, Assert.IsType<Field_float>(progress.Value).Value);
         PlannedElementReferenceMember pointsTarget = Assert.IsType<PlannedElementReferenceMember>(pointsGradientDriver.Members["Target"]);
-        Assert.Equal(gridPointsMember.Identity, pointsTarget.Target.PlannedField);
+        Assert.Equal(gridPointsMember.Identity, AssertPlannedField(pointsTarget.Target));
         SyncList gradientPoints = Assert.IsType<SyncList>(ToMember(pointsGradientDriver.Members["Points"]));
         Assert.Equal(2, gradientPoints.Elements.Count);
         AssertGradientPoint(gradientPoints.Elements[0], 0.0f, 2, 2);
         AssertGradientPoint(gradientPoints.Elements[1], 1.0f, 2, 3);
         Assert.Equal("PLATEAU.Terrain.Grid.Detail", Assert.IsType<Field_string>(ToMember(pointsProgressDriver.Members["VariableName"])).Value);
         PlannedElementReferenceMember progressTarget = Assert.IsType<PlannedElementReferenceMember>(pointsProgressDriver.Members["Target"]);
-        Assert.Equal(progress.Identity, progressTarget.Target.PlannedField);
+        Assert.Equal(progress.Identity, AssertPlannedField(progressTarget.Target));
         Assert.Equal(1.0f, Assert.IsType<Field_float>(ToMember(pointsProgressDriver.Members["DefaultValue"])).Value);
         Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(meshRenderer.Members["Mesh"])).TargetID);
         Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(meshCollider.Members["Mesh"])).TargetID);
@@ -196,7 +263,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             PlannedAddressableFieldMember state = Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]);
             PlannedElementReferenceMember target = Assert.IsType<PlannedElementReferenceMember>(meshSwitch.Members["Target"]);
             Assert.True(
-                target.Target.PlannedField is BatchPlanFieldLocator plannedTarget
+                AssertPlannedField(target.Target) is BatchPlanFieldLocator plannedTarget
                 && new[] { rendererMesh.Identity, colliderMesh.Identity }.Contains(plannedTarget));
             Assert.False(Assert.IsType<Field_bool>(state.Value).Value);
             Assert.Equal(ToPlannedTargetId(gridMesh.Identity), Assert.IsType<Reference>(ToMember(meshSwitch.Members["FalseTarget"])).TargetID);
@@ -207,7 +274,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         {
             PlannedElementReferenceMember target = Assert.IsType<PlannedElementReferenceMember>(boolDriver.Members["Target"]);
             Assert.True(
-                target.Target.PlannedField is BatchPlanFieldLocator plannedStateTarget
+                AssertPlannedField(target.Target) is BatchPlanFieldLocator plannedStateTarget
                 && meshSwitches
                     .Select(meshSwitch => Assert.IsType<PlannedAddressableFieldMember>(meshSwitch.Members["State"]).Identity)
                     .Contains(plannedStateTarget));
@@ -313,14 +380,14 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Reference dedicatedMaterialReference = Assert.IsType<Reference>(materials.Elements[1]);
         PlannedBatchSlotEmission dedicatedMaterialSlot = Assert.Single(
             batchPlan.SlotEmissions,
-            slot => slot.ParentTarget.Planned == FindAssetSlotIdentity(batchPlan, "Triangle Object")
+            slot => IsPlanned(slot.ParentTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object"))
                 && string.Equals(slot.SlotName, "material-000-pbs-uv-uv", StringComparison.Ordinal));
         PlannedBatchComponentEmission dedicatedMaterialComponent = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal));
         PlannedBatchComponentEmission albedoTexture = Assert.Single(
             batchPlan.ComponentEmissions,
-            component => component.ContainerTarget.Planned == dedicatedMaterialSlot.Identity
+            component => IsPlanned(component.ContainerTarget, dedicatedMaterialSlot.Identity)
                 && string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
 
         Assert.Equal("existing-material-id", reusableMaterialReference.TargetID);
@@ -374,10 +441,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchSlotEmission meshAssetSlot = Assert.Single(
             batchPlan.SlotEmissions,
             static slot => string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal)
-                && slot.ParentTarget.Canonical == new ResoniteSlotLocator("asset-lod-slot"));
+                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         Assert.DoesNotContain(
             batchPlan.SlotEmissions,
-            slot => slot.ParentTarget.Planned == meshAssetSlot.Identity
+            slot => IsPlanned(slot.ParentTarget, meshAssetSlot.Identity)
                 && !string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal));
 
         PlannedBatchComponentEmission materialComponent = Assert.Single(
@@ -459,11 +526,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchSlotEmission assetSlot = Assert.Single(
             batchPlan.SlotEmissions,
             slot => string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal)
-                && slot.ParentTarget.Canonical == new ResoniteSlotLocator("asset-lod-slot"));
+                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         PlannedBatchComponentEmission overrideTexture = Assert.Single(
             batchPlan.ComponentEmissions,
             component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && component.ContainerTarget.Planned == assetSlot.Identity);
+                && IsPlanned(component.ContainerTarget, assetSlot.Identity));
 
         Assert.Equal("shared-material-id", materialReference.TargetID);
         Assert.Equal(ToPlannedTargetId(propertyBlockComponent.Identity), propertyBlockReference.TargetID);
@@ -506,7 +573,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchComponentEmission overrideTexture = Assert.Single(
             batchPlan.ComponentEmissions,
             component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && component.ContainerTarget.Planned == FindAssetSlotIdentity(batchPlan, "Triangle Object"));
+                && IsPlanned(component.ContainerTarget, FindAssetSlotIdentity(batchPlan, "Triangle Object")));
 
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(overrideTexture.Members["WrapModeU"])).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(overrideTexture.Members["WrapModeV"])).Value);
@@ -612,16 +679,34 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
     private static ResoniteSlotLocator AssertCanonical(PlannedSlotTargetReference target)
     {
-        Assert.NotNull(target.Canonical);
-        Assert.Null(target.Planned);
-        return target.Canonical.Value;
+        return Assert.IsType<PlannedSlotTargetReference.CanonicalSlotTarget>(target).Locator;
     }
 
     private static BatchPlanSlotLocator AssertPlanned(PlannedSlotTargetReference target)
     {
-        Assert.NotNull(target.Planned);
-        Assert.Null(target.Canonical);
-        return target.Planned.Value;
+        return Assert.IsType<PlannedSlotTargetReference.PlannedSlotTarget>(target).Locator;
+    }
+
+    private static BatchPlanFieldLocator AssertPlannedField(PlannedWorldElementReference target)
+    {
+        return Assert.IsType<PlannedWorldElementReference.PlannedFieldElement>(target).Locator;
+    }
+
+    private static bool IsCanonical(PlannedSlotTargetReference target, ResoniteSlotLocator locator)
+    {
+        return target is PlannedSlotTargetReference.CanonicalSlotTarget canonicalSlot
+            && canonicalSlot.Locator == locator;
+    }
+
+    private static bool IsPlanned(PlannedSlotTargetReference target)
+    {
+        return target is PlannedSlotTargetReference.PlannedSlotTarget;
+    }
+
+    private static bool IsPlanned(PlannedSlotTargetReference target, BatchPlanSlotLocator locator)
+    {
+        return target is PlannedSlotTargetReference.PlannedSlotTarget plannedSlot
+            && plannedSlot.Locator == locator;
     }
 
     private static void AssertGradientPoint(Member member, float expectedPosition, int expectedX, int expectedY)
@@ -661,34 +746,20 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         return Assert.Single(
             batchPlan.SlotEmissions,
             slot => string.Equals(slot.SlotName, slotName, StringComparison.Ordinal)
-                && slot.ParentTarget.Canonical == new ResoniteSlotLocator("asset-lod-slot")).Identity;
+                && IsCanonical(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot"))).Identity;
     }
 
     private static string? ResolveTargetId(PlannedWorldElementReference target)
     {
-        if (target.CanonicalSlot is ResoniteSlotLocator canonicalSlot)
+        return target switch
         {
-            return canonicalSlot.Value;
-        }
-
-        if (target.CanonicalComponent is ResoniteComponentLocator canonicalComponent)
-        {
-            return canonicalComponent.Value;
-        }
-
-        if (target.PlannedSlot is BatchPlanSlotLocator plannedSlot)
-        {
-            return ToPlannedTargetId(plannedSlot);
-        }
-
-        if (target.PlannedComponent is BatchPlanComponentLocator plannedComponent)
-        {
-            return ToPlannedTargetId(plannedComponent);
-        }
-
-        return target.PlannedField is BatchPlanFieldLocator plannedField
-            ? ToPlannedTargetId(plannedField)
-            : null;
+            PlannedWorldElementReference.CanonicalSlotElement canonicalSlot => canonicalSlot.Locator.Value,
+            PlannedWorldElementReference.CanonicalComponentElement canonicalComponent => canonicalComponent.Locator.Value,
+            PlannedWorldElementReference.PlannedSlotElement plannedSlot => ToPlannedTargetId(plannedSlot.Locator),
+            PlannedWorldElementReference.PlannedComponentElement plannedComponent => ToPlannedTargetId(plannedComponent.Locator),
+            PlannedWorldElementReference.PlannedFieldElement plannedField => ToPlannedTargetId(plannedField.Locator),
+            _ => throw new InvalidOperationException("Unsupported planned world element reference."),
+        };
     }
 
     private static string ToPlannedTargetId(BatchPlanSlotLocator locator)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -151,7 +151,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
         ResoniteMaterialBinding material = new(
             BaseColor: new ResoniteColor(0.1, 0.2, 0.3, 1.0),
             MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/payload-a.png"),
+            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/payload-a.png"),
             TextureSourceKind: ResoniteTextureSourceKind.Dataset,
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: new ResoniteMaterialDepthOffset(2.0, 3.0),

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -57,23 +57,23 @@ public sealed class ResoniteSceneMaterialConventionsTests
         Assert.Equal(
             new TextureIdentity("albedo"),
             ResoniteSceneMaterialConventions.CreateTextureIdentity(
-                ResoniteSceneMaterialConventions.TextureMemberRole.Albedo));
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo));
         Assert.Equal(
             new TextureIdentity("normal"),
             ResoniteSceneMaterialConventions.CreateTextureIdentity(
-                ResoniteSceneMaterialConventions.TextureMemberRole.Normal));
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Normal));
         Assert.Equal(
             new TextureIdentity("height"),
             ResoniteSceneMaterialConventions.CreateTextureIdentity(
-                ResoniteSceneMaterialConventions.TextureMemberRole.Height));
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Height));
         Assert.Equal(
             new TextureIdentity("metallic"),
             ResoniteSceneMaterialConventions.CreateTextureIdentity(
-                ResoniteSceneMaterialConventions.TextureMemberRole.Metallic));
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic));
         Assert.Equal(
             new TextureIdentity("emission"),
             ResoniteSceneMaterialConventions.CreateTextureIdentity(
-                ResoniteSceneMaterialConventions.TextureMemberRole.Emission));
+                ResoniteSceneMaterialConventions.PlannedTextureRole.Emission));
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -89,9 +89,9 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             TextureScale: FacadeDefaultTilesPerMeter(),
             TextureOffset: new ResoniteFloat2(0.0, 0.5 / 6.0),
-            Family: BundledDefaultMaterialFamilies.Facade,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
             BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0));
 
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
@@ -111,9 +111,9 @@ public sealed class ResoniteSceneMaterialConventionsTests
             DepthOffset: null,
             SubmeshIndices: [0],
             TextureScale: new ResoniteFloat2(0.5, 0.5),
-            Family: BundledDefaultMaterialFamilies.Facade,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
             BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0));
 
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
@@ -134,9 +134,9 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             TextureScale: new ResoniteFloat2(1.0 / 6.0, 1.0 / 6.0),
             TextureOffset: new ResoniteFloat2(0.0, 0.5 / 6.0),
-            Family: BundledDefaultMaterialFamilies.Facade,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
             BundledVariantIndex: 1,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 1));
 
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
@@ -156,11 +156,11 @@ public sealed class ResoniteSceneMaterialConventionsTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: new ResoniteMaterialDepthOffset(2.0, 3.0),
             SubmeshIndices: [0],
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
             TextureScale: new ResoniteFloat2(0.5, 0.25),
             TextureOffset: new ResoniteFloat2(0.125, 0.75),
-            Family: BundledDefaultMaterialFamilies.Facade,
-            BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
+            BundledVariantIndex: 0);
 
         string slotName = ResoniteSceneMaterialConventions.CreateDedicatedMaterialSlotName(material, materialIndex: 0);
 
@@ -182,7 +182,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0],
-            AssetScope: ResoniteMaterialAssetScope.PresentationSlotScoped);
+            AssetBinding: ResoniteMaterialAssetBinding.Presentation);
 
         Assert.Throws<ArgumentOutOfRangeException>(
             () => ResoniteSceneMaterialConventions.CreateDedicatedMaterialSlotName(material, materialIndex: -1));
@@ -203,7 +203,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             TextureOffset: new ResoniteFloat2(0.25, 0.75),
             Family: null,
             BundledVariantIndex: null,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
@@ -226,7 +226,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             TextureOffset: new ResoniteFloat2(0.0, 0.0),
             Family: null,
             BundledVariantIndex: null,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
@@ -248,7 +248,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             Family: null,
             TextureOffset: null,
             BundledVariantIndex: null,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         IReadOnlyList<string> slotLookupNames = ResoniteSceneMaterialConventions.CreateCommonMaterialSlotLookupNames(material);
 
@@ -268,7 +268,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             TextureScale: null,
             TextureOffset: new ResoniteFloat2(0.25, 0.75),
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         IReadOnlyList<string> slotLookupNames = ResoniteSceneMaterialConventions.CreateCommonMaterialSlotLookupNames(material);
 
@@ -290,7 +290,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             TextureScale: null,
             Family: null,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         string slotName = ResoniteSceneMaterialConventions.CreateMaterialSlotName(material);
 
@@ -313,8 +313,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             TerrainOverlayMaterial: new TerrainOverlayMaterialBinding(ThirdRegionalMeshCode.Parse("53394525"), overlay),
             Family: null,
-            AssetScope: ResoniteMaterialAssetScope.Common,
-            CommonMaterial: CommonMaterialCatalog.Create().Generic.Uv);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
 
         ResoniteMaterialBinding normalized = ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
 
@@ -356,14 +355,16 @@ public sealed class ResoniteSceneMaterialConventionsTests
             DepthOffset: null,
             SubmeshIndices: [0],
             TextureScale: FacadeDefaultTilesPerMeter(),
-            Family: BundledDefaultMaterialFamilies.Facade,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
             BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0));
 
         ResoniteMaterialBinding normalized = ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
 
         Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, normalized.AssetScope);
         Assert.Equal(new ResoniteColor(0.8, 0.7, 0.6, 1.0), normalized.BaseColor);
+        Assert.Null(normalized.TextureScale);
+        Assert.Null(normalized.TextureOffset);
     }
 
     [Fact]
@@ -379,15 +380,16 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             TextureScale: FacadeDefaultTilesPerMeter(),
             TextureOffset: new ResoniteFloat2(0.125, 0.25),
-            Family: BundledDefaultMaterialFamilies.Facade,
+            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
             BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(BundledDefaultMaterialFamilies.FacadeHighriseGlass, 0));
 
         ResoniteMaterialBinding normalized = ResoniteSceneMaterialConventions.NormalizeBatchGroupedMaterialBinding(material);
 
         Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, normalized.AssetScope);
         Assert.Equal(new ResoniteMaterialDepthOffset(1.0, 1.0), normalized.DepthOffset);
-        Assert.Equal(new ResoniteFloat2(0.125, 0.25), normalized.TextureOffset);
+        Assert.Null(normalized.TextureScale);
+        Assert.Null(normalized.TextureOffset);
     }
 
 
@@ -427,7 +429,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             SubmeshIndices: [0],
             Family: family,
             BundledVariantIndex: 0,
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedBundled(family, 0));
     }
 
     private static ResoniteMaterialBinding CreateGenericCommonMaterial(ResoniteMaterialDepthOffset? depthOffset)
@@ -440,7 +442,7 @@ public sealed class ResoniteSceneMaterialConventionsTests
             Projection: ResoniteMaterialProjection.Uv,
             DepthOffset: depthOffset,
             SubmeshIndices: [0],
-            AssetScope: ResoniteMaterialAssetScope.Common);
+            AssetBinding: ResoniteMaterialAssetBindingTestFactory.SharedGenericUv());
     }
 
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteTexturePayloadTests.cs
@@ -9,7 +9,7 @@ public sealed class ResoniteTexturePayloadTests
     {
         byte[] source = [4, 3, 2, 1];
 
-        ResoniteTexturePayload payload = new(1, 1, "sRGB", source, "dataset:texture");
+        RawRgba32ResoniteTexturePayload payload = new(1, 1, "sRGB", source, "dataset:texture");
         source[0] = 9;
 
         Assert.Equal<byte>([4, 3, 2, 1], payload.BinaryPayload);

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -77,6 +77,43 @@ public sealed class SceneImportContractMapperTests
     }
 
     [Fact]
+    public void CommonMaterialMemberCreatesTypedSharedCommonBinding()
+    {
+        DefaultCommonMaterialMember commonMaterial = CommonMaterialCatalog.Create().Generic.Uv;
+
+        MaterialBinding binding = commonMaterial.CreateBinding([0]);
+        ResoniteMaterialBinding mapped = SceneImportContractMapper.ToInternal(binding);
+
+        Assert.IsType<SharedCommonMaterialBinding>(binding);
+        Assert.Equal(MaterialReuseScope.Shared, binding.ReuseScope);
+        Assert.Equal(commonMaterial, binding.CommonMaterial);
+        Assert.Equal(ResoniteMaterialAssetScope.Common, mapped.AssetScope);
+        Assert.Equal(commonMaterial, mapped.CommonMaterial);
+    }
+
+    [Fact]
+    public void PresentationCommonBindingKeepsPresentationScope()
+    {
+        DefaultCommonMaterialMember commonMaterial = CommonMaterialCatalog.Create().Generic.Uv;
+        MaterialBinding binding = new PresentationCommonMaterialBinding(
+            BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+            MaterialType: MaterialType.Standard,
+            TexturePayload: null,
+            TextureSourceKind: TextureSourceKind.Dataset,
+            Projection: MaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0],
+            commonMaterial: commonMaterial);
+
+        ResoniteMaterialBinding mapped = SceneImportContractMapper.ToInternal(binding);
+
+        Assert.Equal(MaterialReuseScope.PerObject, binding.ReuseScope);
+        Assert.Equal(commonMaterial, binding.CommonMaterial);
+        Assert.Equal(ResoniteMaterialAssetScope.PresentationSlotScoped, mapped.AssetScope);
+        Assert.Equal(commonMaterial, mapped.CommonMaterial);
+    }
+
+    [Fact]
     public void ToInternalMaterialBindingsKeepsSharedTerrainOverlayWithoutCommonMaterialPresentationScoped()
     {
         TerrainTextureOverlay overlay = new(

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
@@ -38,6 +40,26 @@ public sealed class SceneImportContractMapperTests
         Assert.Equal(0.125, mapped.TextureOffset!.Y, 9);
         Assert.Equal(ResoniteMaterialAssetScope.Common, mapped.AssetScope);
         Assert.Equal(3, mapped.BundledVariantIndex);
+    }
+
+    [Theory]
+    [InlineData(nameof(MaterialBinding.MaterialType))]
+    [InlineData(nameof(MaterialBinding.TextureSourceKind))]
+    [InlineData(nameof(MaterialBinding.Projection))]
+    [InlineData(nameof(TexturePayload.Format))]
+    public void ToInternalMaterialBindingsRejectsUnsupportedContractEnumValues(string invalidField)
+    {
+        MaterialBinding binding = CreateValidBinding() with
+        {
+            MaterialType = invalidField == nameof(MaterialBinding.MaterialType) ? (MaterialType)999 : MaterialType.Standard,
+            TextureSourceKind = invalidField == nameof(MaterialBinding.TextureSourceKind) ? (TextureSourceKind)999 : TextureSourceKind.Dataset,
+            Projection = invalidField == nameof(MaterialBinding.Projection) ? (MaterialProjection)999 : MaterialProjection.Uv,
+            TexturePayload = invalidField == nameof(TexturePayload.Format)
+                ? new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", (TexturePayloadFormat)999)
+                : new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => SceneImportContractMapper.ToInternal(binding));
     }
 
     [Fact]
@@ -145,5 +167,17 @@ public sealed class SceneImportContractMapperTests
         Assert.Same(overlay, mapped.TerrainOverlay);
         Assert.Equal("53394525", mapped.TerrainMeshCode);
         Assert.Null(mapped.CommonMaterial);
+    }
+
+    private static MaterialBinding CreateValidBinding()
+    {
+        return new MaterialBinding(
+            BaseColor: new ColorRgba(0.1, 0.2, 0.3, 0.4),
+            MaterialType: MaterialType.Standard,
+            TexturePayload: new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
+            TextureSourceKind: TextureSourceKind.Dataset,
+            Projection: MaterialProjection.Uv,
+            DepthOffset: null,
+            SubmeshIndices: [0]);
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SceneImportContractMapperTests.cs
@@ -16,7 +16,7 @@ public sealed class SceneImportContractMapperTests
             new(
                 BaseColor: new ColorRgba(0.1, 0.2, 0.3, 0.4),
                 MaterialType: MaterialType.Standard,
-                TexturePayload: new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
+                TexturePayload: CreateEncodedTexturePayload(),
                 TextureSourceKind: TextureSourceKind.Dataset,
                 Projection: MaterialProjection.Uv,
                 DepthOffset: new MaterialDepthOffset(-1.5, 2.5),
@@ -32,8 +32,8 @@ public sealed class SceneImportContractMapperTests
 
         Assert.Equal(0.1, mapped.BaseColor.R, 9);
         Assert.Equal(0.2, mapped.BaseColor.G, 9);
-        Assert.Equal("dataset:texture", mapped.TexturePayload!.Identity);
-        Assert.Equal(ResoniteTexturePayloadFormat.EncodedImage, mapped.TexturePayload.Format);
+        EncodedImageResoniteTexturePayload encodedPayload = Assert.IsType<EncodedImageResoniteTexturePayload>(mapped.TexturePayload);
+        Assert.Equal("dataset:texture", encodedPayload.Identity);
         Assert.Equal(-1.5, mapped.DepthOffset!.Factor, 9);
         Assert.Equal(2.5, mapped.DepthOffset.Units, 9);
         Assert.Equal(0.25, mapped.TextureScale!.X, 9);
@@ -42,11 +42,39 @@ public sealed class SceneImportContractMapperTests
         Assert.Equal(3, mapped.BundledVariantIndex);
     }
 
+    [Fact]
+    public void ToInternalMaterialBindingsMapsRawTextureDimensionsWithoutNullableGuards()
+    {
+        MaterialBinding[] bindings =
+        [
+            new PresentationMaterialBinding(
+                BaseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0),
+                MaterialType: MaterialType.Standard,
+                TexturePayload: new RawRgba32TexturePayload(
+                    width: 2,
+                    height: 1,
+                    colorProfile: "sRGB",
+                    binaryPayload: [1, 2, 3, 4, 5, 6, 7, 8],
+                    identity: "raw:texture"),
+                TextureSourceKind: TextureSourceKind.Dataset,
+                Projection: MaterialProjection.Uv,
+                DepthOffset: null,
+                SubmeshIndices: [0]),
+        ];
+
+        ResoniteMaterialBinding mapped = Assert.Single(SceneImportContractMapper.ToInternal(bindings));
+
+        RawRgba32ResoniteTexturePayload rawPayload = Assert.IsType<RawRgba32ResoniteTexturePayload>(mapped.TexturePayload);
+        Assert.Equal(2, rawPayload.Width);
+        Assert.Equal(1, rawPayload.Height);
+        Assert.Equal("raw:texture", rawPayload.Identity);
+        Assert.Equal<byte>([1, 2, 3, 4, 5, 6, 7, 8], rawPayload.BinaryPayload);
+    }
+
     [Theory]
     [InlineData(nameof(MaterialBinding.MaterialType))]
     [InlineData(nameof(MaterialBinding.TextureSourceKind))]
     [InlineData(nameof(MaterialBinding.Projection))]
-    [InlineData(nameof(TexturePayload.Format))]
     public void ToInternalMaterialBindingsRejectsUnsupportedContractEnumValues(string invalidField)
     {
         MaterialBinding binding = CreateValidBinding() with
@@ -54,9 +82,6 @@ public sealed class SceneImportContractMapperTests
             MaterialType = invalidField == nameof(MaterialBinding.MaterialType) ? (MaterialType)999 : MaterialType.Standard,
             TextureSourceKind = invalidField == nameof(MaterialBinding.TextureSourceKind) ? (TextureSourceKind)999 : TextureSourceKind.Dataset,
             Projection = invalidField == nameof(MaterialBinding.Projection) ? (MaterialProjection)999 : MaterialProjection.Uv,
-            TexturePayload = invalidField == nameof(TexturePayload.Format)
-                ? new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", (TexturePayloadFormat)999)
-                : new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
         };
 
         Assert.Throws<ArgumentOutOfRangeException>(() => SceneImportContractMapper.ToInternal(binding));
@@ -174,10 +199,22 @@ public sealed class SceneImportContractMapperTests
         return new MaterialBinding(
             BaseColor: new ColorRgba(0.1, 0.2, 0.3, 0.4),
             MaterialType: MaterialType.Standard,
-            TexturePayload: new TexturePayload(2, 2, "sRGB", [1, 2, 3, 4], "dataset:texture", TexturePayloadFormat.EncodedImage),
+            TexturePayload: CreateEncodedTexturePayload(),
             TextureSourceKind: TextureSourceKind.Dataset,
             Projection: MaterialProjection.Uv,
             DepthOffset: null,
             SubmeshIndices: [0]);
+    }
+
+    private static TexturePayload CreateEncodedTexturePayload()
+    {
+        return new EncodedImageTexturePayload(
+            width: 2,
+            height: 2,
+            colorProfile: "sRGB",
+            source: TextureImportSourceFactory.CreateInMemoryEncodedImage(
+                colorProfile: "sRGB",
+                bytes: [1, 2, 3, 4],
+                identity: "dataset:texture"));
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureAssetGeneratorTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
+using PlateauResoniteLink.Transport.ResoniteLink;
 
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -37,6 +38,97 @@ public sealed class TerrainTextureAssetGeneratorTests
         Assert.Equal(WebMercatorTileMath.MaxZoomLevel, source.ZoomLevel);
         Assert.Throws<ArgumentOutOfRangeException>(
             static () => new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", WebMercatorTileMath.MaxZoomLevel + 1));
+    }
+
+    [Fact]
+    public void GeneratedTerrainTextureRequiresTrackedSources()
+    {
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            new GeneratedTerrainTexture(
+                TextureImportSourceTestFactory.CreateRawTextureSource(
+                    1,
+                    1,
+                    ResoniteTextureColorProfiles.Srgb,
+                    [255, 255, 255, 255]),
+                TextureUvRect.Identity,
+                []));
+
+        Assert.Contains("at least one source", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GeneratedTerrainTextureRejectsNullTrackedSources()
+    {
+        ITextureImportSource textureSource = TextureImportSourceTestFactory.CreateRawTextureSource(
+            1,
+            1,
+            ResoniteTextureColorProfiles.Srgb,
+            [255, 255, 255, 255]);
+
+        Assert.Throws<ArgumentNullException>(() =>
+            new GeneratedTerrainTexture(
+                textureSource,
+                new ResoniteFloat2(1.0, 1.0),
+                new ResoniteFloat2(0.0, 0.0),
+                (TerrainTextureSource)null!));
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            new GeneratedTerrainTexture(
+                textureSource,
+                TextureUvRect.Identity,
+                [new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", 17), null!]));
+
+        Assert.Contains("cannot contain null", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TerrainTextureOverlayRejectsNullSourcesFromConstructionAndWithExpressions()
+    {
+        TerrainTextureOverlay overlay = CreateFullCoverageOverlay("https://tiles.example/{z}/{x}/{y}.png");
+
+        Assert.Throws<ArgumentNullException>(() =>
+            new TerrainTextureOverlay(
+                PackageName: "dem",
+                MeshCode: ThirdRegionalMeshCode.Parse("53395325"),
+                GeographicBounds: overlay.GeographicBounds,
+                MaxTextureSize: 512,
+                Sources: null!));
+
+        ArgumentException constructionException = Assert.Throws<ArgumentException>(() =>
+            new TerrainTextureOverlay(
+                PackageName: "dem",
+                MeshCode: ThirdRegionalMeshCode.Parse("53395325"),
+                GeographicBounds: overlay.GeographicBounds,
+                MaxTextureSize: 512,
+                Sources: [null!]));
+
+        ArgumentException withExpressionException = Assert.Throws<ArgumentException>(() =>
+            overlay with { Sources = [null!] });
+
+        Assert.Contains("cannot contain null", constructionException.Message, StringComparison.Ordinal);
+        Assert.Contains("cannot contain null", withExpressionException.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GeneratedTerrainTextureDerivesIdentityFromFirstTrackedSourceAndExposesReadOnlyState()
+    {
+        TerrainTextureTileSource usedSource = new("https://used.example/{z}/{x}/{y}.png", 17);
+        TerrainTextureTileSource otherSource = new("https://other.example/{z}/{x}/{y}.png", 17);
+        List<TerrainTextureSource> trackedSources = [usedSource, otherSource];
+        GeneratedTerrainTexture texture = new(
+            TextureImportSourceTestFactory.CreateRawTextureSource(
+                1,
+                1,
+                ResoniteTextureColorProfiles.Srgb,
+                [255, 255, 255, 255]),
+            TextureUvRect.Identity,
+            trackedSources);
+
+        trackedSources.Clear();
+
+        Assert.Equal(usedSource, texture.UsedSource);
+        Assert.Equal([usedSource, otherSource], texture.UsedSources);
+        Assert.IsNotType<TerrainTextureSource[]>(texture.UsedSources);
     }
 
     [Fact]
@@ -492,7 +584,7 @@ public sealed class TerrainTextureAssetGeneratorTests
 
         Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
         Assert.Contains(
-            texture.UsedSources ?? [],
+            texture.UsedSources,
             static source => source is TerrainTextureTileSource tileSource
                 && tileSource.UrlTemplate == "https://primary.example/{z}/{x}/{y}.png");
         Assert.Contains("primary.example", handler.RequestedHosts);

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
@@ -38,7 +38,6 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             geoAsciiParams: null);
 
         Assert.NotNull(metadata);
-        Assert.True(metadata.IsUsable);
         Assert.Equal("EPSG:6676", metadata.CoordinateSystemIdentifier);
         Assert.Equal(1.0, metadata.PixelWidthMeters);
         Assert.Equal(1.0, metadata.PixelHeightMeters);
@@ -49,7 +48,7 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
     }
 
     [Fact]
-    public void TryCreateMetadataReturnsUnusableMetadataWhenCoordinateSystemIsMissing()
+    public void TryCreateMetadataReturnsNullWhenCoordinateSystemIsMissing()
     {
         GeoReferencedRasterMetadata? metadata = TerrainTextureGeoReferencedRasterMetadataReader.TryCreateMetadata(
             pixelWidth: 10,
@@ -61,9 +60,26 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             geoDoubleParams: null,
             geoAsciiParams: null);
 
-        Assert.NotNull(metadata);
-        Assert.False(metadata.IsUsable);
-        Assert.Null(metadata.CoordinateSystemIdentifier);
+        Assert.Null(metadata);
+    }
+
+    [Fact]
+    public async Task TryReadMetadataAsyncReturnsNullWhenRasterContentSourceCannotOpen()
+    {
+        GeoReferencedRasterMetadata? metadata = await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(
+            new ThrowingRasterContentSource(new IOException("candidate raster unavailable")),
+            CancellationToken.None);
+
+        Assert.Null(metadata);
+    }
+
+    [Fact]
+    public async Task TryReadMetadataAsyncPropagatesCancellationFromRasterContentSource()
+    {
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            async () => await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(
+                new ThrowingRasterContentSource(new OperationCanceledException("cancelled")),
+                CancellationToken.None));
     }
 
     [Fact]
@@ -92,7 +108,6 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             geoAsciiParams: "WGS 84 / Pseudo-Mercator|WGS 84|");
 
         Assert.NotNull(metadata);
-        Assert.True(metadata.IsUsable);
         Assert.Equal("EPSG:3857", metadata.CoordinateSystemIdentifier);
         Assert.InRange(metadata.GeographicBounds.MinLatitude, 35.76, 35.77);
         Assert.InRange(metadata.GeographicBounds.MaxLatitude, 35.77, 35.78);
@@ -126,7 +141,6 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
                 geoDoubleParams: snapshot.GeoDoubleParams,
                 geoAsciiParams: snapshot.GeoAsciiParams));
 
-        Assert.True(metadata.IsUsable);
         Assert.Equal("EPSG:4326", metadata.CoordinateSystemIdentifier);
         Assert.InRange(metadata.GeographicBounds.MinLatitude, 34.9989, 34.9991);
         Assert.InRange(metadata.GeographicBounds.MaxLongitude, 139.0009, 139.0011);
@@ -152,7 +166,6 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             geoAsciiParams: "WGS 84 / Pseudo-Mercator|WGS 84|");
 
         Assert.NotNull(metadata);
-        Assert.True(metadata.IsUsable);
         Assert.Equal("EPSG:3857", metadata.CoordinateSystemIdentifier);
     }
 
@@ -170,7 +183,6 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             geoAsciiParams: "WGS 84 / Pseudo-Mercator|WGS 84|");
 
         Assert.NotNull(metadata);
-        Assert.True(metadata.IsUsable);
         Assert.Equal("EPSG:3857", metadata.CoordinateSystemIdentifier);
     }
 
@@ -531,7 +543,7 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
     }
 
     [Fact]
-    public async Task EnsureTextureAsyncSkipsUnsupportedGeoReferencedRasterSource()
+    public async Task EnsureTextureAsyncSkipsUnavailableGeoReferencedRasterSourceBeforeTileFallback()
     {
         GeographicRectangle bounds = new(0.0, WebMercatorTileMath.MaxLatitude, -180.0, 180.0);
         TerrainTextureOverlay overlay = new(
@@ -541,7 +553,9 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             MaxTextureSize: 1024,
             Sources:
             [
-                new TerrainTextureGeoReferencedRasterSource("missing.tif"),
+                new TerrainTextureGeoReferencedRasterSource(
+                    "missing.tif",
+                    new GeoReferencedRasterMetadata(bounds, "EPSG:4326", 1.0, 1.0)),
                 new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", 1),
             ]);
 
@@ -551,9 +565,61 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
 
         GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
 
-        Assert.Equal(4, handler.RequestCount);
-        Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
         Assert.IsType<TerrainTextureTileSource>(texture.UsedSource);
+        Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
+        Assert.True(handler.RequestCount > 0);
+    }
+
+    [Fact]
+    public async Task EnsureTextureAsyncSkipsNonOverlappingGeoReferencedRasterSourceBeforeTileFallback()
+    {
+        using TemporaryDirectory workDirectory = new();
+        string rasterPath = Path.Combine(workDirectory.Path, "terrain.png");
+        using (Image<Rgba32> rasterImage = new(2, 2, new Rgba32(12, 34, 56, 255)))
+        {
+            await rasterImage.SaveAsPngAsync(rasterPath);
+        }
+
+        GeographicRectangle requestedBounds = new(35.0, 35.001, 139.0, 139.001);
+        TerrainTextureOverlay overlay = new(
+            PackageName: "dem",
+            MeshCode: ThirdRegionalMeshCode.Parse("53394525"),
+            GeographicBounds: requestedBounds,
+            MaxTextureSize: 1024,
+            Sources:
+            [
+                new TerrainTextureGeoReferencedRasterSource(
+                    rasterPath,
+                    new GeoReferencedRasterMetadata(
+                        new GeographicRectangle(36.0, 36.001, 140.0, 140.001),
+                        "EPSG:4326",
+                        1.0,
+                        1.0)),
+                new TerrainTextureTileSource("https://tiles.example/{z}/{x}/{y}.png", 1),
+            ]);
+
+        using TerrainTextureAssetGeneratorTestsProxyMapTileHandler handler = new();
+        using HttpClient httpClient = new(handler);
+        TerrainTextureAssetGenerator generator = new(httpClient, disablePersistentCache: true);
+
+        GeneratedTerrainTexture texture = await generator.EnsureTextureAsync(overlay, CancellationToken.None);
+
+        Assert.IsType<TerrainTextureTileSource>(texture.UsedSource);
+        Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
+        Assert.True(handler.RequestCount > 0);
+    }
+
+    private sealed class ThrowingRasterContentSource(Exception exception) : ITerrainTextureRasterContentSource
+    {
+        public string IdentityKey => "throwing-raster";
+
+        public string Description => "throwing-raster";
+
+        public ValueTask<Stream> OpenReadAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            throw exception;
+        }
     }
 
     private sealed class NeverCalledMapTileHandler : HttpMessageHandler

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
@@ -199,6 +199,34 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
     }
 
     [Fact]
+    public async Task TryReadMetadataAsyncReturnsNullWhenFileCannotBeIdentifiedAsRaster()
+    {
+        using TemporaryDirectory workDirectory = new();
+        string rasterPath = Path.Combine(workDirectory.Path, "not-a-raster.tif");
+        await File.WriteAllTextAsync(rasterPath, "not a raster");
+
+        GeoReferencedRasterMetadata? metadata =
+            await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(
+                rasterPath,
+                CancellationToken.None);
+
+        Assert.Null(metadata);
+    }
+
+    [Fact]
+    public async Task TryReadMetadataAsyncReturnsNullWhenStreamCannotBeIdentifiedAsRaster()
+    {
+        using MemoryStream stream = new("not a raster"u8.ToArray());
+
+        GeoReferencedRasterMetadata? metadata =
+            await TerrainTextureGeoReferencedRasterMetadataReader.TryReadMetadataAsync(
+                stream,
+                CancellationToken.None);
+
+        Assert.Null(metadata);
+    }
+
+    [Fact]
     public void TryCropUsesMercatorVerticalInterpolationForEpsg3857()
     {
         using Image<Rgba32> sourceImage = new(4, 4);

--- a/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/TerrainTextureGeoReferencedRasterSupportTests.cs
@@ -370,8 +370,8 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
         Assert.NotEqual(Materialize(tileOnlyTexture.TextureSource).Bytes, Materialize(rasterOnlyTexture.TextureSource).Bytes);
         Assert.NotEqual(Materialize(tileOnlyTexture.TextureSource).Bytes, Materialize(mixedTexture.TextureSource).Bytes);
         Assert.NotEqual(Materialize(rasterOnlyTexture.TextureSource).Bytes, Materialize(mixedTexture.TextureSource).Bytes);
-        Assert.Single(rasterOnlyTexture.UsedSources ?? []);
-        Assert.Equal(2, (mixedTexture.UsedSources ?? []).Count);
+        Assert.Single(rasterOnlyTexture.UsedSources);
+        Assert.Equal(2, mixedTexture.UsedSources.Count);
     }
 
     [Fact]
@@ -522,9 +522,9 @@ public sealed class TerrainTextureGeoReferencedRasterSupportTests
             new Rgba32(12, 34, 56, 255),
             outputImage[(layout.CropWidth * 3) / 4, occupiedTop + (layout.CropHeight / 2)]);
         Assert.NotEmpty(Materialize(texture.TextureSource).Bytes);
-        Assert.Contains(texture.UsedSources ?? [], static source => source is TerrainTextureGeoReferencedRasterSource);
+        Assert.Contains(texture.UsedSources, static source => source is TerrainTextureGeoReferencedRasterSource);
         Assert.Contains(
-            texture.UsedSources ?? [],
+            texture.UsedSources,
             static source => source is TerrainTextureTileSource tileSource
                 && tileSource.UrlTemplate == "https://tiles.example/{z}/{x}/{y}.png");
         Assert.IsType<TerrainTextureTileSource>(texture.UsedSource);

--- a/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/TextureImportSourceTestFactory.cs
@@ -16,34 +16,32 @@ internal static class TextureImportSourceTestFactory
         byte[] rawRgba32Bytes,
         string? identity = null)
     {
-        return TextureImportSourceFactory.CreateInMemory(
+        return TextureImportSourceFactory.CreateInMemoryRaw(
             width,
             height,
             colorProfile,
             rawRgba32Bytes,
-            identity ?? $"test-rgba32:{width}:{height}:{Guid.NewGuid():N}",
-            TexturePayloadFormat.RawRgba32);
+            identity ?? $"test-rgba32:{width}:{height}:{Guid.NewGuid():N}");
     }
 
-    public static IReadOnlyList<RawTexturePayload> ImportedRgba32Textures(SceneSinkRecordingClient client)
+    public static IReadOnlyList<Rgba32RawTexturePayload> ImportedRgba32Textures(SceneSinkRecordingClient client)
     {
         return client.ImportedTexturePayloads
-            .Where(static payload => payload.Format == RawTexturePayloadFormat.Rgba32)
+            .OfType<Rgba32RawTexturePayload>()
             .ToArray();
     }
 
-    public static IReadOnlyList<RawTexturePayload> ImportedHdrTextures(SceneSinkRecordingClient client)
+    public static IReadOnlyList<RgbaFloat32RawTexturePayload> ImportedHdrTextures(SceneSinkRecordingClient client)
     {
         return client.ImportedTexturePayloads
-            .Where(static payload => payload.Format == RawTexturePayloadFormat.RgbaFloat32)
+            .OfType<RgbaFloat32RawTexturePayload>()
             .ToArray();
     }
 
-    public static bool IsSolidColorTexture(RawTexturePayload texture, byte r, byte g, byte b)
+    public static bool IsSolidColorTexture(Rgba32RawTexturePayload texture, byte r, byte g, byte b)
     {
         byte[] expectedPixel = [r, g, b, 255];
-        return texture.Format == RawTexturePayloadFormat.Rgba32
-            && texture.Width == 2
+        return texture.Width == 2
             && texture.Height == 2
             && texture.Bytes.Chunk(4).All(pixel => pixel.SequenceEqual(expectedPixel));
     }

--- a/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Transport/ResoniteLinkClientTests.cs
@@ -378,7 +378,7 @@ public sealed class ResoniteLinkClientTests
         }
     }
 
-    private sealed class InstrumentedTextureImportSource : IRawTexturePayloadSource
+    private sealed class InstrumentedTextureImportSource : IRgba32RawTexturePayloadSource
     {
         public int MaterializeCallCount { get; private set; }
 
@@ -390,11 +390,11 @@ public sealed class ResoniteLinkClientTests
 
         public long? EstimatedByteLength => 4;
 
-        public ValueTask<RawTexturePayload> MaterializeRawAsync(CancellationToken cancellationToken)
+        public ValueTask<Rgba32RawTexturePayload> MaterializeRgba32Async(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             MaterializeCallCount++;
-            return ValueTask.FromResult(new RawTexturePayload(
+            return ValueTask.FromResult(new Rgba32RawTexturePayload(
                 1,
                 1,
                 ResoniteTextureColorProfiles.Srgb,

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceCollectionExtensionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceCollectionExtensionsTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Tests.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.UseCases;
 
@@ -16,10 +17,8 @@ public sealed class PlateauImportServiceCollectionExtensionsTests
     [Fact]
     public async Task AddImportedSceneSourceServicesUsesCustomComposerWhenFactoryCreatesSourceFromReader()
     {
-        ResolvedLocalPlateauImportRequest request = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDataset"));
+        ResolvedLocalPlateauImportRequest request = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            cityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDataset"));
         ImportedSceneSourceSnapshot expectedReadResult = new(
             new ImportedSceneSourceDataset(
                 new StubDatasetContentSource(request.CityGmlLocalSourcePath),

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceCollectionExtensionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceCollectionExtensionsTests.cs
@@ -16,13 +16,13 @@ public sealed class PlateauImportServiceCollectionExtensionsTests
     [Fact]
     public async Task AddImportedSceneSourceServicesUsesCustomComposerWhenFactoryCreatesSourceFromReader()
     {
-        PlateauImportRequest request = new(
+        ResolvedLocalPlateauImportRequest request = new(
             Dataset: "tokyo23ku",
             MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local(TestData.GetFixturePath("LocalPlateauDataset")));
+            CityGmlLocalSourcePath: TestData.GetFixturePath("LocalPlateauDataset"));
         ImportedSceneSourceSnapshot expectedReadResult = new(
             new ImportedSceneSourceDataset(
-                new StubDatasetContentSource(request.CityGmlLocalSourcePath!),
+                new StubDatasetContentSource(request.CityGmlLocalSourcePath),
                 [],
                 ["bldg"],
                 [],
@@ -108,10 +108,10 @@ public sealed class PlateauImportServiceCollectionExtensionsTests
 
     private sealed class CustomCityGmlDocumentReader(ImportedSceneSourceSnapshot? readResult = null) : ICityGmlDocumentReader
     {
-        public PlateauImportRequest? LastRequest { get; private set; }
+        public ResolvedLocalPlateauImportRequest? LastRequest { get; private set; }
 
         public Task<ImportedSceneSourceSnapshot> ReadAsync(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             Action<string>? progressReporter = null,
             CancellationToken cancellationToken = default)
         {
@@ -123,7 +123,7 @@ public sealed class PlateauImportServiceCollectionExtensionsTests
     private sealed class CustomImportedSceneSourceFactory : IImportedSceneSourceFactory
     {
         public Task<IImportedSceneSource> CreateAsync(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             Action<string>? progressReporter = null,
             CancellationToken cancellationToken = default)
         {
@@ -151,12 +151,12 @@ public sealed class PlateauImportServiceCollectionExtensionsTests
 
     private sealed class RecordingConstructionComposer(IImportedSceneSource source) : IImportedSceneSourceComposer
     {
-        public PlateauImportRequest? LastRequest { get; private set; }
+        public ResolvedLocalPlateauImportRequest? LastRequest { get; private set; }
 
         public ImportedSceneSourceSnapshot? LastReadResult { get; private set; }
 
         public IImportedSceneSource Compose(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             ImportedSceneSourceSnapshot readResult,
             IImportedObjectUnitOptimizer objectUnitOptimizer,
             Action<string>? progressReporter = null)

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
@@ -61,11 +61,8 @@ public sealed class PlateauImportServiceTests
         ImportExecutionResult result = await service.ExecuteAsync(rawRequest, workRoot.Path);
 
         Assert.Equal(Path.Combine(workRoot.Path, "tokyo23ku"), datasetSourceResolver.LastWorkRoot);
-        Assert.NotNull(sceneSink.ConnectedRequest);
-        Assert.Equal("tokyo23ku", sceneSink.ConnectedRequest!.Dataset);
-        Assert.Equal("53394525", sceneSink.ConnectedRequest.MeshCode);
-        Assert.Equal(rawSourceUri, sceneSink.ConnectedRequest.CityGmlServerUri);
-        Assert.Equal(["bldg"], sceneSink.ConnectedRequest.PackageNames);
+        Assert.Equal("tokyo23ku", sceneSink.ConnectedDataset);
+        Assert.Equal("53394525", sceneSink.ConnectedMeshCode);
         Assert.NotNull(importedSceneSourceFactory.LastRequest);
         Assert.Equal("tokyo23ku", importedSceneSourceFactory.LastRequest!.Dataset);
         Assert.Equal("53394525", importedSceneSourceFactory.LastRequest.MeshCode);
@@ -73,7 +70,6 @@ public sealed class PlateauImportServiceTests
         Assert.Equal(["bldg"], importedSceneSourceFactory.LastRequest.PackageNames);
         Assert.NotNull(sceneSink.BeginRequest);
         Assert.Equal(resolvedSourcePath, sceneSink.BeginRequest!.Metadata.Request.CityGmlLocalSourcePath);
-        Assert.Equal(resolvedSourcePath, sceneSink.BeginRequest.ResolvedSourcePath);
         Assert.Equal(Path.Combine(workRoot.Path, "tokyo23ku"), sceneSink.BeginRequest.WorkRoot);
         Assert.Equal(["bldg"], sceneSink.BeginRequest.Metadata.SourceDataset.PackageNames);
         Assert.Equal(readResult.DocumentSet.RelativeSourceFiles, sceneSink.BeginRequest.Metadata.SourceDataset.SourceFiles);
@@ -541,7 +537,9 @@ public sealed class PlateauImportServiceTests
     {
         public int ExecuteCallCount { get; private set; }
 
-        public PlateauImportRequest? ConnectedRequest { get; private set; }
+        public string? ConnectedDataset { get; private set; }
+
+        public string? ConnectedMeshCode { get; private set; }
 
         public SceneImportRequest? BeginRequest { get; private set; }
 
@@ -561,7 +559,8 @@ public sealed class PlateauImportServiceTests
             CancellationToken cancellationToken = default)
         {
             ExecuteCallCount++;
-            ConnectedRequest = plan.NormalizedRequest;
+            ConnectedDataset = plan.SceneImportRequest.Metadata.Request.Dataset;
+            ConnectedMeshCode = plan.SceneImportRequest.Metadata.Request.MeshCode;
             BeginRequest = plan.SceneImportRequest;
             OnExecuteBeforeRead?.Invoke(plan);
             await foreach (ImportedObjectUnit objectUnit in objectUnits.WithCancellation(cancellationToken))
@@ -614,9 +613,9 @@ public sealed class PlateauImportServiceTests
                 : Assert.IsType<ValidatedLocalDatasetLocation>(resolvedRequest.DemTextureSource);
             return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(
                 request,
-                workRoot,
                 localSource,
-                localDemTextureSource));
+                localDemTextureSource,
+                workRoot));
         }
     }
 

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
@@ -90,14 +90,14 @@ public sealed class PlateauImportServiceTests
         Assert.Equal(source.Metadata.SceneName, result.Metadata.SceneName);
         Assert.Equal(source.Metadata.SourceDataset.PackageNames, result.Metadata.SourceDataset.PackageNames);
         Assert.Equal(["stub://destination"], result.Destinations);
-        Assert.Equal(1 + readResult.DocumentSet.RelativeSourceFiles.Count, result.DataSourceUsages?.Count);
+        Assert.Equal(1 + readResult.DocumentSet.RelativeSourceFiles.Count, result.DataSourceUsages.Count);
         Assert.Contains(
-            result.DataSourceUsages ?? [],
+            result.DataSourceUsages,
             static usage => usage.Category == ImportDataSourceCategory.CityGmlSourceFile
                 && string.Equals(usage.Identity, "udx/bldg/53394525/building.gml", StringComparison.Ordinal)
                 && usage.UsedCount == 1);
         Assert.Contains(
-            result.DataSourceUsages ?? [],
+            result.DataSourceUsages,
             static usage => usage.Category == ImportDataSourceCategory.DemTextureSource
                 && string.Equals(usage.Identity, "terrain://ortho-primary", StringComparison.Ordinal)
                 && usage.UsedCount == 2);

--- a/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/PlateauImportServiceTests.cs
@@ -601,14 +601,22 @@ public sealed class PlateauImportServiceTests
 
         public string? LastWorkRoot { get; private set; }
 
-        public Task<ValidatedPlateauImportRequest> ResolveAsync(
+        public Task<ResolvedLocalPlateauImportRequest> ResolveAsync(
             ValidatedPlateauImportRequest request,
             string workRoot,
             CancellationToken cancellationToken = default)
         {
             ResolveCallCount++;
             LastWorkRoot = workRoot;
-            return Task.FromResult(resolvedRequest);
+            ValidatedLocalDatasetLocation localSource = Assert.IsType<ValidatedLocalDatasetLocation>(resolvedRequest.CityGmlSource);
+            ValidatedLocalDatasetLocation? localDemTextureSource = resolvedRequest.DemTextureSource is null
+                ? null
+                : Assert.IsType<ValidatedLocalDatasetLocation>(resolvedRequest.DemTextureSource);
+            return Task.FromResult(ResolvedLocalPlateauImportRequest.Create(
+                request,
+                workRoot,
+                localSource,
+                localDemTextureSource));
         }
     }
 
@@ -616,7 +624,7 @@ public sealed class PlateauImportServiceTests
     {
         public int ResolveCallCount { get; private set; }
 
-        public Task<ValidatedPlateauImportRequest> ResolveAsync(
+        public Task<ResolvedLocalPlateauImportRequest> ResolveAsync(
             ValidatedPlateauImportRequest request,
             string workRoot,
             CancellationToken cancellationToken = default)
@@ -632,10 +640,10 @@ public sealed class PlateauImportServiceTests
     {
         public int CreateCallCount { get; private set; }
 
-        public PlateauImportRequest? LastRequest { get; private set; }
+        public ResolvedLocalPlateauImportRequest? LastRequest { get; private set; }
 
         public Task<IImportedSceneSource> CreateAsync(
-            PlateauImportRequest request,
+            ResolvedLocalPlateauImportRequest request,
             Action<string>? progressReporter = null,
             CancellationToken cancellationToken = default)
         {

--- a/tests/PlateauResoniteLink.Tests/UseCases/SceneImportExecutionPlanTests.cs
+++ b/tests/PlateauResoniteLink.Tests/UseCases/SceneImportExecutionPlanTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
+using PlateauResoniteLink.Tests.Application.Importing;
 
 namespace PlateauResoniteLink.Tests.UseCases;
 
@@ -11,141 +12,59 @@ namespace PlateauResoniteLink.Tests.UseCases;
 public sealed class SceneImportExecutionPlanTests
 {
     [Fact]
-    public void Constructor_AllowsResolvedLocalCityGmlSourceForRemoteInput()
+    public void CreateCarriesResolvedLocalRequest()
     {
         string workRoot = "work";
         Uri remoteCityGmlUri = new("https://example.test/tokyo23ku.zip");
-        PlateauImportRequest normalizedRequest = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Remote(remoteCityGmlUri),
-            PackageNames: ["bldg"]);
-        PlateauImportRequest resolvedRequest = normalizedRequest with
-        {
-            CityGmlSource = DatasetLocation.Local(
-                RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, remoteCityGmlUri, "source-archive")),
-        };
+        ValidatedPlateauImportRequest validatedRequest = PlateauImportRequestValidator.NormalizeAndValidateOrThrow(
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: "53394525",
+                CityGmlSource: DatasetLocation.Remote(remoteCityGmlUri),
+                PackageNames: ["bldg"]));
+        string resolvedSourcePath = RemoteDatasetResourceLayout.GetRemoteResourcePath(
+            workRoot,
+            remoteCityGmlUri,
+            ResolvedLocalPlateauImportRequest.RemoteCityGmlResourcePrefix);
+        ResolvedLocalPlateauImportRequest resolvedRequest = ResolvedLocalPlateauImportRequest.Create(
+            validatedRequest,
+            new ValidatedLocalDatasetLocation(resolvedSourcePath),
+            demTextureSource: null,
+            workRoot);
+        ImportedSceneMetadata metadata = CreateMetadata(resolvedRequest.ToImportRequest());
 
-        SceneImportExecutionPlan plan = new(
-            normalizedRequest,
+        SceneImportExecutionPlan plan = SceneImportExecutionPlan.Create(
             resolvedRequest,
-            new SceneImportRequest(CreateMetadata(resolvedRequest), "resolved-source", workRoot, CommonMaterialCatalog.Create()));
+            metadata,
+            workRoot,
+            CommonMaterialCatalog.Create());
 
-        Assert.Equal(normalizedRequest, plan.NormalizedRequest);
-        Assert.Equal(resolvedRequest, plan.ResolvedRequest);
-        Assert.Equal(resolvedRequest.CityGmlLocalSourcePath, plan.SceneImportRequest.Metadata.Request.CityGmlLocalSourcePath);
+        Assert.Equal(metadata.SourceDataset, plan.SceneImportRequest.Metadata.SourceDataset);
+        Assert.Equal(resolvedSourcePath, plan.SceneImportRequest.Metadata.Request.CityGmlLocalSourcePath);
     }
 
     [Fact]
-    public void Constructor_RejectsDifferentRemoteCityGmlSource()
-    {
-        PlateauImportRequest normalizedRequest = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Remote(new Uri("https://example.test/tokyo23ku.zip")),
-            PackageNames: ["bldg"]);
-        PlateauImportRequest mismatchedRequest = normalizedRequest with
-        {
-            CityGmlSource = DatasetLocation.Remote(new Uri("https://example.test/other.zip")),
-        };
-
-        Assert.Throws<ArgumentException>(
-            () => new SceneImportExecutionPlan(
-                normalizedRequest,
-                mismatchedRequest,
-                new SceneImportRequest(CreateMetadata(mismatchedRequest), "resolved-source", "work", CommonMaterialCatalog.Create())));
-    }
-
-    [Fact]
-    public void Constructor_RejectsDifferentLocalDemTextureSource()
-    {
-        PlateauImportRequest normalizedRequest = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("raw-source"),
-            DemTextureSource: DatasetLocation.Local("ortho-a.tif"),
-            PackageNames: ["bldg"]);
-        PlateauImportRequest mismatchedRequest = normalizedRequest with
-        {
-            DemTextureSource = DatasetLocation.Local("ortho-b.tif"),
-        };
-
-        Assert.Throws<ArgumentException>(
-            () => new SceneImportExecutionPlan(
-                normalizedRequest,
-                mismatchedRequest,
-                new SceneImportRequest(CreateMetadata(mismatchedRequest), "resolved-source", "work", CommonMaterialCatalog.Create())));
-    }
-
-    [Fact]
-    public void Constructor_RejectsDifferentTerrainMeshMode()
-    {
-        PlateauImportRequest normalizedRequest = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("raw-source"),
-            TerrainMeshMode: TerrainMeshMode.Static,
-            PackageNames: ["bldg"]);
-        PlateauImportRequest mismatchedRequest = normalizedRequest with
-        {
-            TerrainMeshMode = TerrainMeshMode.Dynamic,
-        };
-
-        Assert.Throws<ArgumentException>(
-            () => new SceneImportExecutionPlan(
-                normalizedRequest,
-                mismatchedRequest,
-                new SceneImportRequest(CreateMetadata(mismatchedRequest), "resolved-source", "work", CommonMaterialCatalog.Create())));
-    }
-
-    [Fact]
-    public void Constructor_AllowsResolvedLocalDemTextureSourceForRemoteInput()
+    public void CreateRejectsMetadataRequestThatDoesNotMatchResolvedLocalRequest()
     {
         string workRoot = "work";
-        Uri remoteDemTextureUri = new("https://example.test/ortho-a.tif");
-        PlateauImportRequest normalizedRequest = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("raw-source"),
-            DemTextureSource: DatasetLocation.Remote(remoteDemTextureUri),
-            PackageNames: ["bldg"]);
-        PlateauImportRequest resolvedRequest = normalizedRequest with
-        {
-            DemTextureSource = DatasetLocation.Local(
-                RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, remoteDemTextureUri, "source-ortho")),
-        };
+        ResolvedLocalPlateauImportRequest resolvedRequest = ResolvedLocalPlateauImportRequestTestFactory.Create(
+            dataset: "tokyo23ku",
+            meshCode: "53394525",
+            cityGmlLocalSourcePath: "/tmp/plateau");
+        ImportedSceneMetadata metadata = CreateMetadata(
+            resolvedRequest.ToImportRequest() with
+            {
+                MeshCode = "53394526",
+            });
 
-        SceneImportExecutionPlan plan = new(
-            normalizedRequest,
-            resolvedRequest,
-            new SceneImportRequest(CreateMetadata(resolvedRequest), "resolved-source", workRoot, CommonMaterialCatalog.Create()));
-
-        Assert.Equal(
-            RemoteDatasetResourceLayout.GetRemoteResourcePath(workRoot, remoteDemTextureUri, "source-ortho"),
-            plan.SceneImportRequest.Metadata.Request.DemTextureLocalSourcePath);
-    }
-
-    [Fact]
-    public void Constructor_RejectsResolvedLocalDemTextureSourceThatDoesNotMatchExpectedRemoteMaterializationPath()
-    {
-        string workRoot = "work";
-        Uri remoteDemTextureUri = new("https://example.test/ortho-a.tif");
-        PlateauImportRequest normalizedRequest = new(
-            Dataset: "tokyo23ku",
-            MeshCode: "53394525",
-            CityGmlSource: DatasetLocation.Local("raw-source"),
-            DemTextureSource: DatasetLocation.Remote(remoteDemTextureUri),
-            PackageNames: ["bldg"]);
-        PlateauImportRequest resolvedRequest = normalizedRequest with
-        {
-            DemTextureSource = DatasetLocation.Local("unexpected-local-ortho.tif"),
-        };
-
-        Assert.Throws<ArgumentException>(
-            () => new SceneImportExecutionPlan(
-                normalizedRequest,
+        ArgumentException exception = Assert.Throws<ArgumentException>(
+            () => SceneImportExecutionPlan.Create(
                 resolvedRequest,
-                new SceneImportRequest(CreateMetadata(resolvedRequest), "resolved-source", workRoot, CommonMaterialCatalog.Create())));
+                metadata,
+                workRoot,
+                CommonMaterialCatalog.Create()));
+
+        Assert.Equal("metadataRequest", exception.ParamName);
     }
 
     private static ImportedSceneMetadata CreateMetadata(PlateauImportRequest request)


### PR DESCRIPTION
## Summary

- Rescues the rollbacked type-refactor stack that can be proven regression-free against the Kawasaki 2022 `53392582` default fake sink dump baseline.
- Keeps the original material grouping contract: texture payload identity remains the grouping identity; `TexturePayload.Source.Identity` is not used for material grouping.
- Keeps presentation-common materials on the shared common material / `MainTexturePropertyBlock` path by preserving the pre-regression `CommonMaterial != null` planner behavior.
- Excludes the changes that are now proven or still unproven unsafe: #339, #340 `cb62313f`, and #351 `4f5a3740`.

## Confirmed Regressions

The rollback investigation found these concrete regression sources:

- #340 / `cb62313f Use texture source as payload identity carrier`: changed material grouping from `material.TexturePayload?.Identity` to `material.TexturePayload?.Source.Identity`. That is a semantic change, because payload identity is the material grouping identity. Source identity can split visually equivalent texture/material payloads and can split baked LOD meshes.
- #351 / `4f5a3740 Preserve presentation common material assets`: narrowed presentation-common handling from `CommonMaterial != null` to `AssetBinding.IsSharedCommon`. That skips the shared common material planner path for presentation-common albedo-texture-only materials, so the `MainTexturePropertyBlock` override path is lost.
- #339 / terrain overlay material source changes: when applied to the standard Kawasaki 2022 `53392582` fake sink dump, LOD1 changed from `mesh:151368:18:188e...` to `mesh:151368:19:b28f...`. This was reproduced, then the #339 rescue commits were reverted.

## Non-regression Finding

Kawasaki 2022 `53392582` LOD2 buildings contain mixed textured and untextured wall surfaces in the source CityGML itself. In `udx/bldg/53392582_bldg_6697_op.gml`, counting `bldg:WallSurface` descendants against `app:ParameterizedTexture` targets shows:

```text
LOD2 wall surfaces:                         1644
LOD2 wall surfaces with texture target:     1502
LOD2 wall surfaces without texture target:  142
Buildings mixing textured/untextured walls: 30
X3DMaterial targets in the file:            0
```

Therefore, shared/common wall material appearing alongside textured LOD2 walls in this mesh is not by itself evidence that importer output lost texture. The confirmed regression is the missing `MainTexturePropertyBlock` path from #351, not source texture target loss for those untextured walls.

## Rescued Scope

The branch now rescues safe changes from the rollback range covering #308, #309, #311, #312, #313, #316, #318, #319, #322, #323, #324, #325, #326, #335, #336, #337, #340, #343, #345, #346, #347, #348, #349, #350, and the safe parts of #351.

#340 was rescued with payload/source/raw texture variant typing and HDR raw payload length validation, but without `cb62313f Use texture source as payload identity carrier`. Code check: `MaterialGroupingPolicy` still uses `material.TexturePayload?.Identity`, and both application/Resonite texture payloads still expose their own `Identity`.

#351 was rescued with typed common material bindings, target-side typed material asset bindings, typed common material planner handoff, and demoted common material UV normalization. The regressive `4f5a3740 Preserve presentation common material assets` classifier/planner narrowing to `AssetBinding.IsSharedCommon` is not included.

#339 was attempted and then reverted because the standard Kawasaki dump changed: LOD1 changed from 18 to 19 submeshes and the mesh hash changed. This is a third regression source beyond the two externally reported roots.

## Regression Guard

The lesson applied here is that real-data fake sink dump comparison must use the standard import settings, not a narrowed `--packages bldg` run and not only tracked synthetic fixtures.

Validated Kawasaki 2022 mesh `53392582` with default package settings after the final rescue commit:

```text
rollback baseline SHA-256: 0da3ad9f53aa2b07441dea4cdb5ba9c681a9131c6603edf7038408144d6ccfeb
rescued branch SHA-256:   0da3ad9f53aa2b07441dea4cdb5ba9c681a9131c6603edf7038408144d6ccfeb
no-index diff/stat:       empty
slots:                    103 -> 103
components:               279 -> 279
MainTexturePropertyBlock:  3 -> 3
PBS_Metallic:             31 -> 31
StaticTexture2D:           205 -> 205
LOD1 mesh:                 mesh:151368:18:188e3cce8577d1fcdedc3148facc9ae026d900ac167721557358894cd68ac539
```

Additional unsafe evidence:

```text
#339 attempted dump SHA-256: 25947d63d088e09653aece529af8bf61964ae98eb067a98e566911eddb940291
baseline SHA-256:          0da3ad9f53aa2b07441dea4cdb5ba9c681a9131c6603edf7038408144d6ccfeb
observed LOD1 regression:  mesh:151368:18:188e... -> mesh:151368:19:b28f...
```

## Verification

```text
dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
dotnet format whitespace . --folder --verify-no-changes
dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
```

Full test result: 1038 passed.
