### PR TITLE
Normalize DEM parent mesh discovery to third meshes

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/DemCityObjectAggregation.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemCityObjectAggregation.cs
@@ -97,8 +97,7 @@ internal static class DemCityObjectAggregation
         SourceFileDescriptor sourceFile,
         IReadOnlyList<string>? selectedMeshCodes)
     {
-        if (!sourceFile.RequiresMeshCodeBoundsFilter
-            || selectedMeshCodes is null
+        if (selectedMeshCodes is null
             || sourceFile.MatchedMeshCode.Length != 6)
         {
             return [];

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
@@ -75,9 +75,9 @@ internal static class LocalCityGmlSourceFileDiscovery
     {
         string[] selectedMeshCodes = candidates
             .Where(static candidate => candidate.IsRequestedPackage)
-            .SelectMany(static candidate => candidate.FileMeshCodes.Concat(candidate.DirectoryMeshCodes))
-            .Distinct(StringComparer.Ordinal)
-            .SelectMany(matcher.GetSelectedMeshCodes)
+            .SelectMany(candidate => candidate.FileMeshCodes
+                .Concat(candidate.DirectoryMeshCodes)
+                .SelectMany(meshCode => matcher.GetSelectedMeshCodes(meshCode, candidate.PackageName)))
             .Distinct(StringComparer.Ordinal)
             .OrderBy(static meshCode => meshCode, StringComparer.Ordinal)
             .ToArray();
@@ -174,7 +174,8 @@ internal static class LocalCityGmlSourceFileDiscovery
                 candidate.RelativePath,
                 candidate.PackageName,
                 matchedMeshCode,
-                matcher.RequiresMeshCodeBoundsFilter(matchedMeshCode));
+                matcher.RequiresMeshCodeBoundsFilter(matchedMeshCode)
+                || RequiresParentDemMeshCodeBoundsFilter(candidate.PackageName, matchedMeshCode, requestedMeshCodes));
         }
 
         string? parentMeshCode = candidate.FileMeshCodes
@@ -194,6 +195,17 @@ internal static class LocalCityGmlSourceFileDiscovery
             candidate.PackageName,
             parentMeshCode,
             RequiresMeshCodeBoundsFilter: true);
+    }
+
+    private static bool RequiresParentDemMeshCodeBoundsFilter(
+        string packageName,
+        string matchedMeshCode,
+        IReadOnlySet<string> requestedMeshCodes)
+    {
+        return string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase)
+            && matchedMeshCode.Length == 6
+            && requestedMeshCodes.Any(meshCode => meshCode.Length >= 8
+                && meshCode.StartsWith(matchedMeshCode, StringComparison.Ordinal));
     }
 
     private static string[] ExtractMeshCodes(string value)
@@ -298,10 +310,33 @@ internal static class LocalCityGmlSourceFileDiscovery
             return new MeshCodeSelectionMatcher(requestedValue, [], regex);
         }
 
-        public IEnumerable<string> GetSelectedMeshCodes(string candidateMeshCode)
+        public IEnumerable<string> GetSelectedMeshCodes(string candidateMeshCode, string packageName)
         {
+            bool isDem = string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase);
             if (IsLiteral)
             {
+                if (isDem
+                    && RequestedValue.Length == 6
+                    && candidateMeshCode.Length == 6
+                    && exactCodes.Contains(candidateMeshCode, StringComparer.Ordinal))
+                {
+                    foreach (string detailedMeshCode in EnumerateDetailedMeshCodes(candidateMeshCode))
+                    {
+                        yield return detailedMeshCode;
+                    }
+
+                    yield break;
+                }
+
+                if (isDem
+                    && RequestedValue.Length == 6
+                    && candidateMeshCode.Length == 8
+                    && candidateMeshCode.StartsWith(RequestedValue, StringComparison.Ordinal))
+                {
+                    yield return candidateMeshCode;
+                    yield break;
+                }
+
                 if (candidateMeshCode.Length == RequestedValue.Length
                     && exactCodes.Contains(candidateMeshCode, StringComparer.Ordinal))
                 {
@@ -317,23 +352,25 @@ internal static class LocalCityGmlSourceFileDiscovery
                 yield break;
             }
 
+            if (candidateMeshCode.Length == 6)
+            {
+                string[] detailedMeshCodes = EnumerateDetailedMeshCodes(candidateMeshCode)
+                    .Where(meshCode => regex!.IsMatch(meshCode))
+                    .ToArray();
+                if (detailedMeshCodes.Length > 0)
+                {
+                    foreach (string detailedMeshCode in detailedMeshCodes)
+                    {
+                        yield return detailedMeshCode;
+                    }
+
+                    yield break;
+                }
+            }
+
             if (regex!.IsMatch(candidateMeshCode))
             {
                 yield return candidateMeshCode;
-                yield break;
-            }
-
-            if (candidateMeshCode.Length != 6)
-            {
-                yield break;
-            }
-
-            foreach (string detailedMeshCode in EnumerateDetailedMeshCodes(candidateMeshCode))
-            {
-                if (regex.IsMatch(detailedMeshCode))
-                {
-                    yield return detailedMeshCode;
-                }
             }
         }
 

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
@@ -352,12 +352,12 @@ internal static class LocalCityGmlSourceFileDiscovery
                 yield break;
             }
 
-            if (isDem && candidateMeshCode.Length == 6)
+            if (candidateMeshCode.Length == 6)
             {
                 string[] detailedMeshCodes = EnumerateDetailedMeshCodes(candidateMeshCode)
                     .Where(meshCode => regex!.IsMatch(meshCode))
                     .ToArray();
-                if (detailedMeshCodes.Length > 0)
+                if (isDem && detailedMeshCodes.Length > 0)
                 {
                     foreach (string detailedMeshCode in detailedMeshCodes)
                     {
@@ -366,6 +366,19 @@ internal static class LocalCityGmlSourceFileDiscovery
 
                     yield break;
                 }
+
+                if (regex!.IsMatch(candidateMeshCode))
+                {
+                    yield return candidateMeshCode;
+                    yield break;
+                }
+
+                foreach (string detailedMeshCode in detailedMeshCodes)
+                {
+                    yield return detailedMeshCode;
+                }
+
+                yield break;
             }
 
             if (regex!.IsMatch(candidateMeshCode))

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
@@ -352,7 +352,7 @@ internal static class LocalCityGmlSourceFileDiscovery
                 yield break;
             }
 
-            if (candidateMeshCode.Length == 6)
+            if (isDem && candidateMeshCode.Length == 6)
             {
                 string[] detailedMeshCodes = EnumerateDetailedMeshCodes(candidateMeshCode)
                     .Where(meshCode => regex!.IsMatch(meshCode))

--- a/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
@@ -596,6 +596,23 @@ public sealed class DatasetInspectionServiceTests
         Assert.Equal(CreateThirdMeshCodes("533914"), parentRegexResult.SelectedMeshCodes);
     }
 
+    [Fact]
+    public async Task SearchAsyncKeepsRegexParentNonDemMatchAsParentMeshCode()
+    {
+        byte[] archiveBytes = CreateZipArchive(
+            ("udx/tran/533914/plateau_yokohama_tran_533914.gml", "<tran:CityModel />"));
+        using TemporaryDirectory workRoot = new();
+        string archivePath = Path.Combine(workRoot.Path, "dataset.zip");
+        await File.WriteAllBytesAsync(archivePath, archiveBytes);
+
+        DatasetSearchResult result = await service.SearchAsync(archivePath, "53391[4].*", ["tran"]);
+
+        Assert.Equal(["533914"], result.SelectedMeshCodes);
+        DatasetSearchEntry entry = Assert.Single(result.SourceFiles);
+        Assert.Equal("533914", entry.MatchedMeshCode);
+        Assert.False(entry.RequiresMeshCodeBoundsFilter);
+    }
+
     private static void WriteDatasetFile(string datasetRoot, string relativePath, string content)
     {
         string absolutePath = Path.Combine(

--- a/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
@@ -613,6 +613,23 @@ public sealed class DatasetInspectionServiceTests
         Assert.False(entry.RequiresMeshCodeBoundsFilter);
     }
 
+    [Fact]
+    public async Task SearchAsyncKeepsChildRegexParentNonDemMatchBoundsFiltered()
+    {
+        byte[] archiveBytes = CreateZipArchive(
+            ("udx/tran/533914/plateau_yokohama_tran_533914.gml", "<tran:CityModel />"));
+        using TemporaryDirectory workRoot = new();
+        string archivePath = Path.Combine(workRoot.Path, "dataset.zip");
+        await File.WriteAllBytesAsync(archivePath, archiveBytes);
+
+        DatasetSearchResult result = await service.SearchAsync(archivePath, "5339142.", ["tran"]);
+
+        Assert.Equal(CreateThirdMeshCodes("533914").Where(static meshCode => meshCode.StartsWith("5339142", StringComparison.Ordinal)).ToArray(), result.SelectedMeshCodes);
+        DatasetSearchEntry entry = Assert.Single(result.SourceFiles);
+        Assert.Equal("533914", entry.MatchedMeshCode);
+        Assert.True(entry.RequiresMeshCodeBoundsFilter);
+    }
+
     private static void WriteDatasetFile(string datasetRoot, string relativePath, string content)
     {
         string absolutePath = Path.Combine(

--- a/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
@@ -536,6 +536,66 @@ public sealed class DatasetInspectionServiceTests
             result.SourceFiles.Select(static entry => entry.RelativePath).ToArray());
     }
 
+    [Fact]
+    public async Task SearchAsyncExpandsRegexParentDemSourceMatchToThirdMeshCodes()
+    {
+        byte[] archiveBytes = CreateZipArchive(
+            ("udx/dem/533914_dem_6697_00_op.gml", "<dem:CityModel />"),
+            ("udx/dem/533914_dem_6697_05_op.gml", "<dem:CityModel />"));
+        using TemporaryDirectory workRoot = new();
+        string archivePath = Path.Combine(workRoot.Path, "dataset.zip");
+        await File.WriteAllBytesAsync(archivePath, archiveBytes);
+
+        DatasetSearchResult result = await service.SearchAsync(archivePath, "53391[4].*", ["dem"]);
+
+        Assert.Equal(CreateThirdMeshCodes("533914"), result.SelectedMeshCodes);
+        Assert.Equal(
+            [
+                "udx/dem/533914_dem_6697_00_op.gml",
+                "udx/dem/533914_dem_6697_05_op.gml",
+            ],
+            result.SourceFiles.Select(static entry => entry.RelativePath).ToArray());
+        Assert.All(result.SourceFiles, static entry =>
+        {
+            Assert.Equal("533914", entry.MatchedMeshCode);
+            Assert.True(entry.RequiresMeshCodeBoundsFilter);
+        });
+    }
+
+    [Fact]
+    public async Task SearchAsyncExpandsExactParentDemSourceMatchToThirdMeshCodes()
+    {
+        byte[] archiveBytes = CreateZipArchive(
+            ("udx/dem/533914_dem_6697_00_op.gml", "<dem:CityModel />"));
+        using TemporaryDirectory workRoot = new();
+        string archivePath = Path.Combine(workRoot.Path, "dataset.zip");
+        await File.WriteAllBytesAsync(archivePath, archiveBytes);
+
+        DatasetSearchResult result = await service.SearchAsync(archivePath, "533914", ["dem"]);
+
+        Assert.Equal(CreateThirdMeshCodes("533914"), result.SelectedMeshCodes);
+        DatasetSearchEntry entry = Assert.Single(result.SourceFiles);
+        Assert.Equal("533914", entry.MatchedMeshCode);
+        Assert.True(entry.RequiresMeshCodeBoundsFilter);
+    }
+
+    [Fact]
+    public async Task SearchAsyncTreatsRegexParentDemMatchLikeExplicitThirdMeshRegex()
+    {
+        byte[] archiveBytes = CreateZipArchive(
+            ("udx/dem/533914_dem_6697_00_op.gml", "<dem:CityModel />"),
+            ("udx/dem/533914_dem_6697_05_op.gml", "<dem:CityModel />"));
+        using TemporaryDirectory workRoot = new();
+        string archivePath = Path.Combine(workRoot.Path, "dataset.zip");
+        await File.WriteAllBytesAsync(archivePath, archiveBytes);
+
+        DatasetSearchResult parentRegexResult = await service.SearchAsync(archivePath, "53391[4].*", ["dem"]);
+        DatasetSearchResult thirdRegexResult = await service.SearchAsync(archivePath, "533914..", ["dem"]);
+
+        Assert.Equal(thirdRegexResult.SelectedMeshCodes, parentRegexResult.SelectedMeshCodes);
+        Assert.Equal(CreateThirdMeshCodes("533914"), parentRegexResult.SelectedMeshCodes);
+    }
+
     private static void WriteDatasetFile(string datasetRoot, string relativePath, string content)
     {
         string absolutePath = Path.Combine(
@@ -582,5 +642,12 @@ public sealed class DatasetInspectionServiceTests
         }
 
         return stream.ToArray();
+    }
+
+    private static string[] CreateThirdMeshCodes(string parentMeshCode)
+    {
+        return Enumerable.Range(0, 100)
+            .Select(index => $"{parentMeshCode}{index / 10}{index % 10}")
+            .ToArray();
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemCityObjectAggregationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemCityObjectAggregationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 
 using PlateauResoniteLink.Application.Importing;
@@ -78,6 +79,30 @@ public sealed class DemCityObjectAggregationTests
         Assert.Equal("dem_plateau_fukuoka_dem_503033_50303312", result.SlotKey);
         Assert.Equal("DEM 50303312", result.DisplayName);
         Assert.Equal("50303312", result.ActualMeshCode);
+    }
+
+    [Fact]
+    public void AggregateBySourceFileAndThirdMeshUsesSelectedThirdMeshWithoutDependingOnBoundsFilterFlag()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("EPSG:4326");
+        SourceFileDescriptor sourceFile = new(
+            "udx/dem/533914_dem_6697_00_op.gml",
+            "dem",
+            "533914",
+            RequiresMeshCodeBoundsFilter: false);
+        ParsedCityObject[] cityObjects =
+        [
+            CreateCityObject("dem-parent", "polygon-parent", "533914", sourceFile.RelativePath, referenceSystem),
+        ];
+
+        ParsedCityObject[] results = DemCityObjectAggregation.AggregateBySourceFileAndThirdMesh(
+            sourceFile,
+            cityObjects,
+            ["53391400", "53391401"]);
+
+        Assert.Equal(["53391400", "53391401"], results.Select(static result => result.ActualMeshCode).ToArray());
+        Assert.All(results, static result => Assert.StartsWith("DEM 533914", result.DisplayName, StringComparison.Ordinal));
+        Assert.DoesNotContain(results, static result => string.Equals(result.ActualMeshCode, "533914", StringComparison.Ordinal));
     }
 
     private static ParsedCityObject CreateCityObject(


### PR DESCRIPTION
## Summary
- Normalize DEM parent mesh discovery so second-level DEM source matches expand to third regional mesh codes before import/projection.
- Keep the 6-digit DEM source mesh only as a discovery descriptor key with bounds filtering enabled.
- Add aggregation-side defense so selected third meshes are used even if an older descriptor reaches DEM aggregation with the wrong filter flag.

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~DatasetInspectionServiceTests|FullyQualifiedName~DemCityObjectAggregationTests"`
- Yokohama real-data search: `--mesh-code '53391[4].*' --packages dem` now returns `selectedMeshCodes=53391400..53391499`, while source descriptors keep `matchedMeshCode=533914` and `requiresMeshCodeBoundsFilter=true`.
- Yokohama real-data dynamic canonical dump: `--mesh-code '53391[4].*' --terrain-mesh dynamic --terrain-grid-max-resolution 256 --packages dem` produced 100 DEM objects, no 6-digit `DEM 533914`, duplicate 0, tiny/degenerate 0, `Aspect > 10` 0, and matched the `533914..` mesh code set.
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (1050 passed)