### PR TITLE
Fix DEM GridMesh thin boundary fallback

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridSampler.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridSampler.cs
@@ -60,6 +60,7 @@ internal static class CityGmlDemTerrainGridSampler
         }
 
         cancellationToken.ThrowIfCancellationRequested();
+        ExtendThinBoundaryMissingSamples(localHeights, sampleCoverage, width, height);
         return new DemTerrainGridHeightSamples(width, height, localHeights, sampleCoverage);
     }
 
@@ -86,6 +87,161 @@ internal static class CityGmlDemTerrainGridSampler
     private static double ResolveGridCoordinateRatio(int index, int count)
     {
         return count <= 1 ? 0.0 : (double)index / (count - 1);
+    }
+
+    private static void ExtendThinBoundaryMissingSamples(
+        double[] localHeights,
+        TerrainGridSampleCoverage[] sampleCoverage,
+        int width,
+        int height)
+    {
+        bool[] visited = new bool[width * height];
+        for (int row = 0; row < height; row++)
+        {
+            for (int column = 0; column < width; column++)
+            {
+                int sampleIndex = (row * width) + column;
+                if (visited[sampleIndex]
+                    || sampleCoverage[sampleIndex] != TerrainGridSampleCoverage.NoSurface
+                    || !IsBoundarySample(row, column, width, height))
+                {
+                    continue;
+                }
+
+                FillThinBoundaryComponent(
+                    localHeights,
+                    sampleCoverage,
+                    visited,
+                    width,
+                    height,
+                    row,
+                    column);
+            }
+        }
+    }
+
+    private static void FillThinBoundaryComponent(
+        double[] localHeights,
+        TerrainGridSampleCoverage[] sampleCoverage,
+        bool[] visited,
+        int width,
+        int height,
+        int startRow,
+        int startColumn)
+    {
+        List<int> componentIndices = [];
+        Queue<(int Row, int Column)> frontier = [];
+        int firstRow = startRow;
+        int firstColumn = startColumn;
+        bool sameRow = true;
+        bool sameColumn = true;
+
+        MarkVisited(startRow, startColumn);
+        while (frontier.Count > 0)
+        {
+            (int row, int column) = frontier.Dequeue();
+            int sampleIndex = (row * width) + column;
+            componentIndices.Add(sampleIndex);
+            sameRow &= row == firstRow;
+            sameColumn &= column == firstColumn;
+
+            TryVisit(row - 1, column);
+            TryVisit(row + 1, column);
+            TryVisit(row, column - 1);
+            TryVisit(row, column + 1);
+        }
+
+        if (!sameRow && !sameColumn)
+        {
+            return;
+        }
+
+        List<(int SampleIndex, double Height)> fills = [];
+        foreach (int sampleIndex in componentIndices)
+        {
+            int row = sampleIndex / width;
+            int column = sampleIndex % width;
+            if (TryResolveMeasuredNeighborHeight(localHeights, sampleCoverage, width, height, row, column, out double heightValue))
+            {
+                fills.Add((sampleIndex, heightValue));
+            }
+        }
+
+        foreach ((int sampleIndex, double heightValue) in fills)
+        {
+            localHeights[sampleIndex] = heightValue;
+            sampleCoverage[sampleIndex] = TerrainGridSampleCoverage.Measured;
+        }
+
+        void TryVisit(int row, int column)
+        {
+            if ((uint)row >= (uint)height || (uint)column >= (uint)width)
+            {
+                return;
+            }
+
+            int sampleIndex = (row * width) + column;
+            if (visited[sampleIndex] || sampleCoverage[sampleIndex] != TerrainGridSampleCoverage.NoSurface)
+            {
+                return;
+            }
+
+            MarkVisited(row, column);
+        }
+
+        void MarkVisited(int row, int column)
+        {
+            int sampleIndex = (row * width) + column;
+            visited[sampleIndex] = true;
+            frontier.Enqueue((row, column));
+        }
+    }
+
+    private static bool TryResolveMeasuredNeighborHeight(
+        double[] localHeights,
+        TerrainGridSampleCoverage[] sampleCoverage,
+        int width,
+        int height,
+        int row,
+        int column,
+        out double heightValue)
+    {
+        double sum = 0.0;
+        int count = 0;
+        TryAdd(row - 1, column);
+        TryAdd(row + 1, column);
+        TryAdd(row, column - 1);
+        TryAdd(row, column + 1);
+        if (count == 0)
+        {
+            heightValue = 0.0;
+            return false;
+        }
+
+        heightValue = sum / count;
+        return true;
+
+        void TryAdd(int neighborRow, int neighborColumn)
+        {
+            if ((uint)neighborRow >= (uint)height || (uint)neighborColumn >= (uint)width)
+            {
+                return;
+            }
+
+            int neighborIndex = (neighborRow * width) + neighborColumn;
+            if (sampleCoverage[neighborIndex] != TerrainGridSampleCoverage.Measured)
+            {
+                return;
+            }
+
+            sum += localHeights[neighborIndex];
+            count++;
+        }
+    }
+
+    private static bool IsBoundarySample(int row, int column, int width, int height)
+    {
+        return row == 0 || row == height - 1 || column == 0 || column == width - 1;
     }
 
     private static bool TryInterpolateLocalTriangleHeight(

--- a/tests/PlateauResoniteLink.Tests/Profiles/CityGmlDemTerrainGridSamplerTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CityGmlDemTerrainGridSamplerTests.cs
@@ -111,6 +111,39 @@ public sealed class CityGmlDemTerrainGridSamplerTests
     }
 
     [Fact]
+    public void SampleExtendsThinBoundaryMissingStripFromMeasuredTerrain()
+    {
+        TerrainGridTriangle[] triangles =
+        [
+            new(
+                new Float3(0.01, 10.0, 0.0),
+                new Float3(2.0, 20.0, 0.0),
+                new Float3(0.01, 30.0, 2.0)),
+            new(
+                new Float3(2.0, 20.0, 0.0),
+                new Float3(2.0, 40.0, 2.0),
+                new Float3(0.01, 30.0, 2.0)),
+        ];
+
+        DemTerrainGridHeightSamples samples = CityGmlDemTerrainGridSampler.Sample(
+            minX: 0.0,
+            maxX: 2.0,
+            minZ: 0.0,
+            maxZ: 2.0,
+            metersPerVertex: 1.0,
+            maxResolution: 3,
+            fallbackHeight: -100.0,
+            triangles);
+
+        Assert.NotEqual(-100.0, samples.LocalHeights[0], precision: 6);
+        Assert.NotEqual(-100.0, samples.LocalHeights[3], precision: 6);
+        Assert.NotEqual(-100.0, samples.LocalHeights[6], precision: 6);
+        Assert.Equal(TerrainGridSampleCoverage.Measured, samples.SampleCoverage[0]);
+        Assert.Equal(TerrainGridSampleCoverage.Measured, samples.SampleCoverage[3]);
+        Assert.Equal(TerrainGridSampleCoverage.Measured, samples.SampleCoverage[6]);
+    }
+
+    [Fact]
     public void SampleSeparatesMeasuredSeaLevelFromNoSurfaceSeaLevel()
     {
         TerrainGridTriangle[] triangles =


### PR DESCRIPTION
## Summary
- Fixes a GridMesh/HeightMap regression where a thin boundary strip can fall back to sea level after DEM clipping and boundary sampling.
- Extends only boundary-connected NoSurface components that are a single row or a single column, using adjacent measured terrain samples.
- Keeps real surface gaps/coastline-style NoSurface samples as fallback sea level.

## Root Cause
`Fix DEM grid boundary precision` restored GridMesh sampling to exact grid boundaries. When clipped DEM surfaces end slightly inside the requested mesh boundary, the boundary row/column can miss triangle interpolation and become fallback sea level. The previous broad boundary fill had been removed during pixel-center sampling, and the current coverage-aware sampler had no narrow boundary-strip repair.

## Validation
- Real Yokohama dump under `.tmp`: `53391[4].*`, `--terrain-mesh grid`, `--terrain-grid-max-resolution 256`, `--packages dem`
  - `grid_count=100`
  - `mesh_min=DEM 53391400 mesh_max=DEM 53391499`
  - `duplicates=0`, `six_digit_dem=0`, `tiny=0`, `skinny=0`
  - `sizes=256x256:100`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~CityGmlDemTerrainGridSamplerTests|FullyQualifiedName~DemTerrainGridChunkBoundaryAlignmentPolicyTests|FullyQualifiedName~LocalCityGmlObjectProjectionTests"`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`