### PR TITLE
Sample DEM GridMesh from source surfaces

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -136,6 +136,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             cityObjectOrigin,
             cityObjectCartesian,
             demTerrainTextureOverlay,
+            heightMapBounds.GeographicBounds,
             materialResolver);
         Float2? heightMapUvScale = heightMapOccupiedUvRect.HasValue
             ? ToContractFloat2(heightMapOccupiedUvRect.Value.ScaleValue)
@@ -182,6 +183,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         GeodeticPoint cityObjectOrigin,
         LocalCartesian? cityObjectCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
+        GeographicRectangle terrainGridGeographicBounds,
         IDefaultMaterialResolver materialResolver)
     {
         if (demTerrainTextureOverlay is null)
@@ -189,7 +191,6 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             return null;
         }
 
-        GeographicRectangle? demObjectBounds = TryGetDemObjectGeographicBounds(cityObject.Source, demTerrainTextureOverlay);
         ResolvedSurfaceMaterial? representativeSurface = CityGmlSurfaceMaterialResolver.EnumerateSurfaces(
                 cityObject,
                 cityObjectOrigin,
@@ -206,21 +207,8 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             cityObject.Source,
             representativeSurface,
             demTerrainTextureOverlay,
-            demObjectBounds);
+            terrainGridGeographicBounds);
         return occupiedUvRect is { IsIdentity: true } ? null : occupiedUvRect;
-    }
-
-    private static GeographicRectangle? TryGetDemObjectGeographicBounds(
-        ParsedCityObject cityObject,
-        TerrainTextureOverlay? demTerrainTextureOverlay)
-    {
-        if (demTerrainTextureOverlay is null
-            || !string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
-
-        return ResolveCityObjectGeographicBounds(cityObject);
     }
 
     private static DemTerrainGridBounds CreateDemTerrainGridBounds(
@@ -259,10 +247,10 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
 
         if ((clippedMaxX - clippedMinX) <= 1e-6 || (clippedMaxZ - clippedMinZ) <= 1e-6)
         {
-            return new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
+            return new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ, clippedBounds);
         }
 
-        return new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ);
+        return new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ, clippedBounds);
     }
 
     private static GeographicRectangle ResolveDemTerrainGridGeographicBounds(
@@ -457,7 +445,8 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         double MinX,
         double MaxX,
         double MinZ,
-        double MaxZ);
+        double MaxZ,
+        GeographicRectangle GeographicBounds);
 }
 
 internal sealed record TerrainGridProjectedCityObject(

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -29,9 +29,11 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         IDefaultMaterialResolver materialResolver,
         Action<string>? progressReporter,
         CancellationToken cancellationToken,
+        out bool outsideSamplingBounds,
         out TerrainGridProjectedCityObject? heightMapCityObject)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        outsideSamplingBounds = false;
         heightMapCityObject = null;
 
         if (terrainGridSamplingSource.Surfaces.SelectMany(static surface => surface.Vertices).Take(3).Count() < 3)
@@ -68,14 +70,21 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             return false;
         }
 
-        DemTerrainGridBounds heightMapBounds = CreateDemTerrainGridBounds(
+        if (!TryCreateDemTerrainGridBounds(
             cityObject,
             slotPosition,
             globalOriginPoint,
             globalCartesian,
             demTerrainTextureOverlay,
             requestedMeshCodeBounds,
-            positions);
+            positions,
+            out DemTerrainGridBounds? heightMapBounds)
+            || heightMapBounds is null)
+        {
+            outsideSamplingBounds = true;
+            return false;
+        }
+
         double minX = heightMapBounds.MinX;
         double maxX = heightMapBounds.MaxX;
         double minZ = heightMapBounds.MinZ;
@@ -211,15 +220,17 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         return occupiedUvRect is { IsIdentity: true } ? null : occupiedUvRect;
     }
 
-    private static DemTerrainGridBounds CreateDemTerrainGridBounds(
+    private static bool TryCreateDemTerrainGridBounds(
         ConstructionCityObjectDraft cityObject,
         Float3 slotPosition,
         GeodeticPoint globalOriginPoint,
         LocalCartesian? globalCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
-        IReadOnlyList<Float3> positions)
+        IReadOnlyList<Float3> positions,
+        out DemTerrainGridBounds? bounds)
     {
+        bounds = null;
         double rawMinX = positions.Min(static position => position.X);
         double rawMaxX = positions.Max(static position => position.X);
         double rawMinZ = positions.Min(static position => position.Z);
@@ -247,10 +258,17 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
 
         if ((clippedMaxX - clippedMinX) <= 1e-6 || (clippedMaxZ - clippedMinZ) <= 1e-6)
         {
-            return new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ, clippedBounds);
+            if (cityObject.Source.SharedAcrossMeshCodes)
+            {
+                return false;
+            }
+
+            bounds = new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ, clippedBounds);
+            return true;
         }
 
-        return new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ, clippedBounds);
+        bounds = new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ, clippedBounds);
+        return true;
     }
 
     private static GeographicRectangle ResolveDemTerrainGridGeographicBounds(

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -20,6 +20,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
 
     internal static bool TryProject(
         ConstructionCityObjectDraft cityObject,
+        ConstructionCityObjectDraft terrainGridSamplingSource,
         GeodeticPoint globalOriginPoint,
         LocalCartesian? globalCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
@@ -33,7 +34,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         cancellationToken.ThrowIfCancellationRequested();
         heightMapCityObject = null;
 
-        if (cityObject.Surfaces.SelectMany(static surface => surface.Vertices).Take(3).Count() < 3)
+        if (terrainGridSamplingSource.Surfaces.SelectMany(static surface => surface.Vertices).Take(3).Count() < 3)
         {
             return false;
         }
@@ -52,11 +53,11 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         }
 
         Float3 slotPosition = CreateScenePosition(cityObjectOrigin, globalOriginPoint, globalCartesian);
-        Float3[] positions = cityObject.Surfaces
+        Float3[] positions = terrainGridSamplingSource.Surfaces
             .SelectMany(static surface => surface.Vertices)
             .Select(point => CreateGlobalTerrainGridLocalPosition(point, slotPosition, globalOriginPoint, globalCartesian))
             .ToArray();
-        TerrainGridTriangle[] triangles = CreateDemTerrainGridTriangles(cityObject, slotPosition, globalOriginPoint, globalCartesian);
+        TerrainGridTriangle[] triangles = CreateDemTerrainGridTriangles(terrainGridSamplingSource, slotPosition, globalOriginPoint, globalCartesian);
         double seaLevelLocalHeight = CreateGlobalTerrainGridLocalPosition(
             new GeodeticPoint(cityObjectOrigin.Latitude, cityObjectOrigin.Longitude, 0.0),
             slotPosition,
@@ -73,6 +74,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             globalOriginPoint,
             globalCartesian,
             demTerrainTextureOverlay,
+            requestedMeshCodeBounds,
             positions);
         double minX = heightMapBounds.MinX;
         double maxX = heightMapBounds.MaxX;
@@ -227,6 +229,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         GeodeticPoint globalOriginPoint,
         LocalCartesian? globalCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
         IReadOnlyList<Float3> positions)
     {
         double rawMinX = positions.Min(static position => position.X);
@@ -234,14 +237,10 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         double rawMinZ = positions.Min(static position => position.Z);
         double rawMaxZ = positions.Max(static position => position.Z);
 
-        if (demTerrainTextureOverlay is null)
-        {
-            return new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ);
-        }
-
-        GeographicRectangle clippedBounds = IntersectGeographicBounds(
-            ResolveCityObjectGeographicBounds(cityObject.Source),
-            demTerrainTextureOverlay.GeographicBounds);
+        GeographicRectangle clippedBounds = ResolveDemTerrainGridGeographicBounds(
+            cityObject,
+            demTerrainTextureOverlay,
+            requestedMeshCodeBounds);
         Float3[] clippedAxisPositions = CreateClippedAxisPositions(
             clippedBounds,
             slotPosition,
@@ -264,6 +263,66 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         }
 
         return new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ);
+    }
+
+    private static GeographicRectangle ResolveDemTerrainGridGeographicBounds(
+        ConstructionCityObjectDraft cityObject,
+        TerrainTextureOverlay? demTerrainTextureOverlay,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds)
+    {
+        GeographicRectangle bounds = TryCreateThirdMeshGeographicBounds(cityObject.ActualMeshCode, out GeographicRectangle thirdMeshBounds)
+            ? thirdMeshBounds
+            : ResolveCityObjectGeographicBounds(cityObject.Source);
+
+        if (requestedMeshCodeBounds.Count > 0)
+        {
+            bounds = IntersectRequestedMeshBounds(bounds, requestedMeshCodeBounds)
+                ?? bounds;
+        }
+
+        return demTerrainTextureOverlay is null
+            ? bounds
+            : IntersectGeographicBounds(bounds, demTerrainTextureOverlay.GeographicBounds);
+    }
+
+    private static GeographicRectangle? IntersectRequestedMeshBounds(
+        GeographicRectangle bounds,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds)
+    {
+        GeographicRectangle[] intersections = requestedMeshCodeBounds
+            .Select(requested => IntersectGeographicBounds(bounds, new GeographicRectangle(
+                requested.SouthLatitude,
+                requested.NorthLatitude,
+                requested.WestLongitude,
+                requested.EastLongitude)))
+            .Where(static intersection => IsUsableGeographicBounds(intersection))
+            .ToArray();
+        return intersections.Length == 0
+            ? null
+            : new GeographicRectangle(
+                intersections.Min(static intersection => intersection.MinLatitude),
+                intersections.Max(static intersection => intersection.MaxLatitude),
+                intersections.Min(static intersection => intersection.MinLongitude),
+                intersections.Max(static intersection => intersection.MaxLongitude));
+    }
+
+    private static bool TryCreateThirdMeshGeographicBounds(
+        string actualMeshCode,
+        out GeographicRectangle bounds)
+    {
+        if (ThirdRegionalMeshCode.TryParse(actualMeshCode, out ThirdRegionalMeshCode thirdMeshCode))
+        {
+            JisRegionalMeshBounds meshBounds = thirdMeshCode.Bounds;
+            bounds = new GeographicRectangle(
+                meshBounds.SouthLatitude,
+                meshBounds.NorthLatitude,
+                meshBounds.WestLongitude,
+                meshBounds.EastLongitude);
+            return true;
+        }
+
+        bounds = new GeographicRectangle(0.0, 0.0, 0.0, 0.0);
+        return false;
     }
 
     private static Float3[] CreateClippedAxisPositions(
@@ -318,6 +377,12 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             MaxLatitude: Math.Min(left.MaxLatitude, right.MaxLatitude),
             MinLongitude: Math.Max(left.MinLongitude, right.MinLongitude),
             MaxLongitude: Math.Min(left.MaxLongitude, right.MaxLongitude));
+    }
+
+    private static bool IsUsableGeographicBounds(GeographicRectangle bounds)
+    {
+        return (bounds.MaxLatitude - bounds.MinLatitude) > 1e-12
+            && (bounds.MaxLongitude - bounds.MinLongitude) > 1e-12;
     }
 
     private static TerrainGridTriangle[] CreateDemTerrainGridTriangles(

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -72,6 +72,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
 
         if (!TryCreateDemTerrainGridBounds(
             cityObject,
+            terrainGridSamplingSource,
             slotPosition,
             globalOriginPoint,
             globalCartesian,
@@ -222,6 +223,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
 
     private static bool TryCreateDemTerrainGridBounds(
         ConstructionCityObjectDraft cityObject,
+        ConstructionCityObjectDraft terrainGridSamplingSource,
         Float3 slotPosition,
         GeodeticPoint globalOriginPoint,
         LocalCartesian? globalCartesian,
@@ -240,6 +242,18 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             cityObject,
             demTerrainTextureOverlay,
             requestedMeshCodeBounds);
+        GeographicRectangle rawGeographicBounds = ResolveCityObjectGeographicBounds(terrainGridSamplingSource.Source);
+        GeographicRectangle clampedGeographicBounds = IntersectGeographicBounds(clippedBounds, rawGeographicBounds);
+        if (NearlyCoversGeographicBounds(rawGeographicBounds, clippedBounds))
+        {
+            clampedGeographicBounds = clippedBounds;
+        }
+
+        if (!IsUsableGeographicBounds(clampedGeographicBounds))
+        {
+            clampedGeographicBounds = rawGeographicBounds;
+        }
+
         Float3[] clippedAxisPositions = CreateClippedAxisPositions(
             clippedBounds,
             slotPosition,
@@ -263,11 +277,11 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
                 return false;
             }
 
-            bounds = new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ, clippedBounds);
+            bounds = new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ, clampedGeographicBounds);
             return true;
         }
 
-        bounds = new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ, clippedBounds);
+        bounds = new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ, clampedGeographicBounds);
         return true;
     }
 
@@ -389,6 +403,19 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
     {
         return (bounds.MaxLatitude - bounds.MinLatitude) > 1e-12
             && (bounds.MaxLongitude - bounds.MinLongitude) > 1e-12;
+    }
+
+    private static bool NearlyCoversGeographicBounds(
+        GeographicRectangle candidate,
+        GeographicRectangle bounds)
+    {
+        const double relativeTolerance = 1e-3;
+        double latitudeTolerance = Math.Max(bounds.MaxLatitude - bounds.MinLatitude, 0.0) * relativeTolerance;
+        double longitudeTolerance = Math.Max(bounds.MaxLongitude - bounds.MinLongitude, 0.0) * relativeTolerance;
+        return candidate.MinLatitude <= bounds.MinLatitude + latitudeTolerance
+            && candidate.MaxLatitude >= bounds.MaxLatitude - latitudeTolerance
+            && candidate.MinLongitude <= bounds.MinLongitude + longitudeTolerance
+            && candidate.MaxLongitude >= bounds.MaxLongitude - longitudeTolerance;
     }
 
     private static TerrainGridTriangle[] CreateDemTerrainGridTriangles(

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -90,6 +90,7 @@ internal static class CityGmlParsedCityObjectProjection
             GeometryHeightMeters = geometryHeightMeters,
         };
         ConstructionCityObjectDraft constructionDraft = GeneratedLod1RoofCityObjectFactory.CreateDraft(terrainAlignedParsedCityObject);
+        ConstructionCityObjectDraft terrainGridSamplingDraft = constructionDraft;
         List<ImportedCityObject> projectedCityObjects = [];
         List<ImportedCityObject> generatedRoadMarkings = [];
 
@@ -105,6 +106,7 @@ internal static class CityGmlParsedCityObjectProjection
             cancellationToken.ThrowIfCancellationRequested();
             ImportedCityObject cityObject = ProjectTerrainMeshModeCityObject(
                 partitionedCityObject.CityObject,
+                terrainGridSamplingDraft,
                 globalOriginPoint,
                 globalCartesian,
                 partitionedCityObject.Overlay,
@@ -228,6 +230,7 @@ internal static class CityGmlParsedCityObjectProjection
 
     internal static ImportedCityObject ProjectTerrainMeshModeCityObject(
         ConstructionCityObjectDraft cityObject,
+        ConstructionCityObjectDraft? demTerrainGridSamplingSource,
         GeodeticPoint globalOriginPoint,
         LocalCartesian? globalCartesian,
         TerrainTextureOverlay? demTerrainTextureOverlay,
@@ -245,6 +248,7 @@ internal static class CityGmlParsedCityObjectProjection
 
         bool hasGrid = CityGmlDemTerrainGridCityObjectProjection.TryProject(
             cityObject,
+            demTerrainGridSamplingSource ?? cityObject,
             globalOriginPoint,
             globalCartesian,
             demTerrainTextureOverlay,

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -257,9 +257,15 @@ internal static class CityGmlParsedCityObjectProjection
             materialResolver,
             progressReporter,
             cancellationToken,
+            out bool outsideTerrainGridSamplingBounds,
             out TerrainGridProjectedCityObject? heightMapCityObject);
         if (!hasGrid)
         {
+            if (outsideTerrainGridSamplingBounds)
+            {
+                return CreateNonRenderableCityObject(cityObject);
+            }
+
             return request.TerrainMeshMode == TerrainMeshMode.Dynamic
                 ? CreateNonRenderableCityObject(cityObject)
                 : CityGmlTriangleMeshCityObjectProjection.Project(cityObject, globalOriginPoint, globalCartesian, demTerrainTextureOverlay, materialResolver);

--- a/src/PlateauResoniteLink/Application/Importing/DemCityObjectAggregation.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemCityObjectAggregation.cs
@@ -97,8 +97,7 @@ internal static class DemCityObjectAggregation
         SourceFileDescriptor sourceFile,
         IReadOnlyList<string>? selectedMeshCodes)
     {
-        if (!sourceFile.RequiresMeshCodeBoundsFilter
-            || selectedMeshCodes is null
+        if (selectedMeshCodes is null
             || sourceFile.MatchedMeshCode.Length != 6)
         {
             return [];

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
@@ -178,6 +178,17 @@ internal static class LocalCityGmlSourceFileDiscovery
                 || RequiresParentDemMeshCodeBoundsFilter(candidate.PackageName, matchedMeshCode, requestedMeshCodes));
         }
 
+        string? requestedDemDetailedMeshCode = TryMatchRequestedDemDetailedMeshCode(candidate, requestedMeshCodes);
+        if (requestedDemDetailedMeshCode is not null)
+        {
+            return new LocalCityGmlSourceFileDescriptor(
+                candidate.AbsolutePath,
+                candidate.RelativePath,
+                candidate.PackageName,
+                requestedDemDetailedMeshCode,
+                RequiresMeshCodeBoundsFilter: false);
+        }
+
         string? parentMeshCode = candidate.FileMeshCodes
             .Concat(candidate.DirectoryMeshCodes)
             .Where(static meshCode => meshCode.Length == 6)
@@ -206,6 +217,23 @@ internal static class LocalCityGmlSourceFileDiscovery
             && matchedMeshCode.Length == 6
             && requestedMeshCodes.Any(meshCode => meshCode.Length >= 8
                 && meshCode.StartsWith(matchedMeshCode, StringComparison.Ordinal));
+    }
+
+    private static string? TryMatchRequestedDemDetailedMeshCode(
+        LocalCityGmlDatasetSourceFileCandidate candidate,
+        IReadOnlySet<string> requestedMeshCodes)
+    {
+        if (!string.Equals(candidate.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return candidate.FileMeshCodes
+            .Concat(candidate.DirectoryMeshCodes)
+            .Where(static meshCode => meshCode.Length == 8)
+            .Where(requestedMeshCodes.Contains)
+            .OrderBy(static meshCode => meshCode, StringComparer.Ordinal)
+            .FirstOrDefault();
     }
 
     private static string[] ExtractMeshCodes(string value)

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
@@ -75,9 +75,9 @@ internal static class LocalCityGmlSourceFileDiscovery
     {
         string[] selectedMeshCodes = candidates
             .Where(static candidate => candidate.IsRequestedPackage)
-            .SelectMany(static candidate => candidate.FileMeshCodes.Concat(candidate.DirectoryMeshCodes))
-            .Distinct(StringComparer.Ordinal)
-            .SelectMany(matcher.GetSelectedMeshCodes)
+            .SelectMany(candidate => candidate.FileMeshCodes
+                .Concat(candidate.DirectoryMeshCodes)
+                .SelectMany(meshCode => matcher.GetSelectedMeshCodes(meshCode, candidate.PackageName)))
             .Distinct(StringComparer.Ordinal)
             .OrderBy(static meshCode => meshCode, StringComparer.Ordinal)
             .ToArray();
@@ -174,7 +174,8 @@ internal static class LocalCityGmlSourceFileDiscovery
                 candidate.RelativePath,
                 candidate.PackageName,
                 matchedMeshCode,
-                matcher.RequiresMeshCodeBoundsFilter(matchedMeshCode));
+                matcher.RequiresMeshCodeBoundsFilter(matchedMeshCode)
+                || RequiresParentDemMeshCodeBoundsFilter(candidate.PackageName, matchedMeshCode, requestedMeshCodes));
         }
 
         string? parentMeshCode = candidate.FileMeshCodes
@@ -194,6 +195,17 @@ internal static class LocalCityGmlSourceFileDiscovery
             candidate.PackageName,
             parentMeshCode,
             RequiresMeshCodeBoundsFilter: true);
+    }
+
+    private static bool RequiresParentDemMeshCodeBoundsFilter(
+        string packageName,
+        string matchedMeshCode,
+        IReadOnlySet<string> requestedMeshCodes)
+    {
+        return string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase)
+            && matchedMeshCode.Length == 6
+            && requestedMeshCodes.Any(meshCode => meshCode.Length >= 8
+                && meshCode.StartsWith(matchedMeshCode, StringComparison.Ordinal));
     }
 
     private static string[] ExtractMeshCodes(string value)
@@ -298,10 +310,33 @@ internal static class LocalCityGmlSourceFileDiscovery
             return new MeshCodeSelectionMatcher(requestedValue, [], regex);
         }
 
-        public IEnumerable<string> GetSelectedMeshCodes(string candidateMeshCode)
+        public IEnumerable<string> GetSelectedMeshCodes(string candidateMeshCode, string packageName)
         {
+            bool isDem = string.Equals(packageName, "dem", StringComparison.OrdinalIgnoreCase);
             if (IsLiteral)
             {
+                if (isDem
+                    && RequestedValue.Length == 6
+                    && candidateMeshCode.Length == 6
+                    && exactCodes.Contains(candidateMeshCode, StringComparer.Ordinal))
+                {
+                    foreach (string detailedMeshCode in EnumerateDetailedMeshCodes(candidateMeshCode))
+                    {
+                        yield return detailedMeshCode;
+                    }
+
+                    yield break;
+                }
+
+                if (isDem
+                    && RequestedValue.Length == 6
+                    && candidateMeshCode.Length == 8
+                    && candidateMeshCode.StartsWith(RequestedValue, StringComparison.Ordinal))
+                {
+                    yield return candidateMeshCode;
+                    yield break;
+                }
+
                 if (candidateMeshCode.Length == RequestedValue.Length
                     && exactCodes.Contains(candidateMeshCode, StringComparer.Ordinal))
                 {
@@ -317,23 +352,25 @@ internal static class LocalCityGmlSourceFileDiscovery
                 yield break;
             }
 
+            if (candidateMeshCode.Length == 6)
+            {
+                string[] detailedMeshCodes = EnumerateDetailedMeshCodes(candidateMeshCode)
+                    .Where(meshCode => regex!.IsMatch(meshCode))
+                    .ToArray();
+                if (detailedMeshCodes.Length > 0)
+                {
+                    foreach (string detailedMeshCode in detailedMeshCodes)
+                    {
+                        yield return detailedMeshCode;
+                    }
+
+                    yield break;
+                }
+            }
+
             if (regex!.IsMatch(candidateMeshCode))
             {
                 yield return candidateMeshCode;
-                yield break;
-            }
-
-            if (candidateMeshCode.Length != 6)
-            {
-                yield break;
-            }
-
-            foreach (string detailedMeshCode in EnumerateDetailedMeshCodes(candidateMeshCode))
-            {
-                if (regex.IsMatch(detailedMeshCode))
-                {
-                    yield return detailedMeshCode;
-                }
             }
         }
 

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
@@ -75,8 +75,7 @@ internal static class LocalCityGmlSourceFileDiscovery
     {
         string[] selectedMeshCodes = candidates
             .Where(static candidate => candidate.IsRequestedPackage)
-            .SelectMany(candidate => candidate.FileMeshCodes
-                .Concat(candidate.DirectoryMeshCodes)
+            .SelectMany(candidate => EnumerateCandidateMeshCodesForSelection(candidate)
                 .SelectMany(meshCode => matcher.GetSelectedMeshCodes(meshCode, candidate.PackageName)))
             .Distinct(StringComparer.Ordinal)
             .OrderBy(static meshCode => meshCode, StringComparer.Ordinal)
@@ -97,6 +96,25 @@ internal static class LocalCityGmlSourceFileDiscovery
             .ToArray();
 
         return new LocalCityGmlSourceFileDiscoveryResult(sourceFiles, selectedMeshCodes);
+    }
+
+    private static IEnumerable<string> EnumerateCandidateMeshCodesForSelection(
+        LocalCityGmlDatasetSourceFileCandidate candidate)
+    {
+        if (string.Equals(candidate.PackageName, "dem", StringComparison.OrdinalIgnoreCase))
+        {
+            string[] detailedMeshCodes = candidate.FileMeshCodes
+                .Concat(candidate.DirectoryMeshCodes)
+                .Where(static meshCode => meshCode.Length == 8)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            if (detailedMeshCodes.Length > 0)
+            {
+                return detailedMeshCodes;
+            }
+        }
+
+        return candidate.FileMeshCodes.Concat(candidate.DirectoryMeshCodes);
     }
 
     private static LocalCityGmlDatasetSourceFileCandidate? CreateCandidateSourceFile(
@@ -165,17 +183,16 @@ internal static class LocalCityGmlSourceFileDiscovery
             return null;
         }
 
-        string? matchedMeshCode = matcher.Match(candidate.FileMeshCodes, requestedMeshCodes)
-            ?? matcher.Match(candidate.DirectoryMeshCodes, requestedMeshCodes);
-        if (matchedMeshCode is not null)
+        string? matchedFileMeshCode = matcher.Match(candidate.FileMeshCodes, requestedMeshCodes);
+        if (matchedFileMeshCode is not null)
         {
             return new LocalCityGmlSourceFileDescriptor(
                 candidate.AbsolutePath,
                 candidate.RelativePath,
                 candidate.PackageName,
-                matchedMeshCode,
-                matcher.RequiresMeshCodeBoundsFilter(matchedMeshCode)
-                || RequiresParentDemMeshCodeBoundsFilter(candidate.PackageName, matchedMeshCode, requestedMeshCodes));
+                matchedFileMeshCode,
+                matcher.RequiresMeshCodeBoundsFilter(matchedFileMeshCode)
+                || RequiresParentDemMeshCodeBoundsFilter(candidate.PackageName, matchedFileMeshCode, requestedMeshCodes));
         }
 
         string? requestedDemDetailedMeshCode = TryMatchRequestedDemDetailedMeshCode(candidate, requestedMeshCodes);
@@ -187,6 +204,18 @@ internal static class LocalCityGmlSourceFileDiscovery
                 candidate.PackageName,
                 requestedDemDetailedMeshCode,
                 RequiresMeshCodeBoundsFilter: false);
+        }
+
+        string? matchedDirectoryMeshCode = matcher.Match(candidate.DirectoryMeshCodes, requestedMeshCodes);
+        if (matchedDirectoryMeshCode is not null)
+        {
+            return new LocalCityGmlSourceFileDescriptor(
+                candidate.AbsolutePath,
+                candidate.RelativePath,
+                candidate.PackageName,
+                matchedDirectoryMeshCode,
+                matcher.RequiresMeshCodeBoundsFilter(matchedDirectoryMeshCode)
+                || RequiresParentDemMeshCodeBoundsFilter(candidate.PackageName, matchedDirectoryMeshCode, requestedMeshCodes));
         }
 
         string? parentMeshCode = candidate.FileMeshCodes

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
@@ -352,12 +352,12 @@ internal static class LocalCityGmlSourceFileDiscovery
                 yield break;
             }
 
-            if (isDem && candidateMeshCode.Length == 6)
+            if (candidateMeshCode.Length == 6)
             {
                 string[] detailedMeshCodes = EnumerateDetailedMeshCodes(candidateMeshCode)
                     .Where(meshCode => regex!.IsMatch(meshCode))
                     .ToArray();
-                if (detailedMeshCodes.Length > 0)
+                if (isDem && detailedMeshCodes.Length > 0)
                 {
                     foreach (string detailedMeshCode in detailedMeshCodes)
                     {
@@ -366,6 +366,19 @@ internal static class LocalCityGmlSourceFileDiscovery
 
                     yield break;
                 }
+
+                if (regex!.IsMatch(candidateMeshCode))
+                {
+                    yield return candidateMeshCode;
+                    yield break;
+                }
+
+                foreach (string detailedMeshCode in detailedMeshCodes)
+                {
+                    yield return detailedMeshCode;
+                }
+
+                yield break;
             }
 
             if (regex!.IsMatch(candidateMeshCode))

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlSourceFileDiscovery.cs
@@ -352,7 +352,7 @@ internal static class LocalCityGmlSourceFileDiscovery
                 yield break;
             }
 
-            if (candidateMeshCode.Length == 6)
+            if (isDem && candidateMeshCode.Length == 6)
             {
                 string[] detailedMeshCodes = EnumerateDetailedMeshCodes(candidateMeshCode)
                     .Where(meshCode => regex!.IsMatch(meshCode))

--- a/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
@@ -596,6 +596,23 @@ public sealed class DatasetInspectionServiceTests
         Assert.Equal(CreateThirdMeshCodes("533914"), parentRegexResult.SelectedMeshCodes);
     }
 
+    [Fact]
+    public async Task SearchAsyncKeepsRegexParentNonDemMatchAsParentMeshCode()
+    {
+        byte[] archiveBytes = CreateZipArchive(
+            ("udx/tran/533914/plateau_yokohama_tran_533914.gml", "<tran:CityModel />"));
+        using TemporaryDirectory workRoot = new();
+        string archivePath = Path.Combine(workRoot.Path, "dataset.zip");
+        await File.WriteAllBytesAsync(archivePath, archiveBytes);
+
+        DatasetSearchResult result = await service.SearchAsync(archivePath, "53391[4].*", ["tran"]);
+
+        Assert.Equal(["533914"], result.SelectedMeshCodes);
+        DatasetSearchEntry entry = Assert.Single(result.SourceFiles);
+        Assert.Equal("533914", entry.MatchedMeshCode);
+        Assert.False(entry.RequiresMeshCodeBoundsFilter);
+    }
+
     private static void WriteDatasetFile(string datasetRoot, string relativePath, string content)
     {
         string absolutePath = Path.Combine(

--- a/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
@@ -613,6 +613,23 @@ public sealed class DatasetInspectionServiceTests
         Assert.False(entry.RequiresMeshCodeBoundsFilter);
     }
 
+    [Fact]
+    public async Task SearchAsyncKeepsChildRegexParentNonDemMatchBoundsFiltered()
+    {
+        byte[] archiveBytes = CreateZipArchive(
+            ("udx/tran/533914/plateau_yokohama_tran_533914.gml", "<tran:CityModel />"));
+        using TemporaryDirectory workRoot = new();
+        string archivePath = Path.Combine(workRoot.Path, "dataset.zip");
+        await File.WriteAllBytesAsync(archivePath, archiveBytes);
+
+        DatasetSearchResult result = await service.SearchAsync(archivePath, "5339142.", ["tran"]);
+
+        Assert.Equal(CreateThirdMeshCodes("533914").Where(static meshCode => meshCode.StartsWith("5339142", StringComparison.Ordinal)).ToArray(), result.SelectedMeshCodes);
+        DatasetSearchEntry entry = Assert.Single(result.SourceFiles);
+        Assert.Equal("533914", entry.MatchedMeshCode);
+        Assert.True(entry.RequiresMeshCodeBoundsFilter);
+    }
+
     private static void WriteDatasetFile(string datasetRoot, string relativePath, string content)
     {
         string absolutePath = Path.Combine(

--- a/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Application/DatasetInspectionServiceTests.cs
@@ -536,6 +536,66 @@ public sealed class DatasetInspectionServiceTests
             result.SourceFiles.Select(static entry => entry.RelativePath).ToArray());
     }
 
+    [Fact]
+    public async Task SearchAsyncExpandsRegexParentDemSourceMatchToThirdMeshCodes()
+    {
+        byte[] archiveBytes = CreateZipArchive(
+            ("udx/dem/533914_dem_6697_00_op.gml", "<dem:CityModel />"),
+            ("udx/dem/533914_dem_6697_05_op.gml", "<dem:CityModel />"));
+        using TemporaryDirectory workRoot = new();
+        string archivePath = Path.Combine(workRoot.Path, "dataset.zip");
+        await File.WriteAllBytesAsync(archivePath, archiveBytes);
+
+        DatasetSearchResult result = await service.SearchAsync(archivePath, "53391[4].*", ["dem"]);
+
+        Assert.Equal(CreateThirdMeshCodes("533914"), result.SelectedMeshCodes);
+        Assert.Equal(
+            [
+                "udx/dem/533914_dem_6697_00_op.gml",
+                "udx/dem/533914_dem_6697_05_op.gml",
+            ],
+            result.SourceFiles.Select(static entry => entry.RelativePath).ToArray());
+        Assert.All(result.SourceFiles, static entry =>
+        {
+            Assert.Equal("533914", entry.MatchedMeshCode);
+            Assert.True(entry.RequiresMeshCodeBoundsFilter);
+        });
+    }
+
+    [Fact]
+    public async Task SearchAsyncExpandsExactParentDemSourceMatchToThirdMeshCodes()
+    {
+        byte[] archiveBytes = CreateZipArchive(
+            ("udx/dem/533914_dem_6697_00_op.gml", "<dem:CityModel />"));
+        using TemporaryDirectory workRoot = new();
+        string archivePath = Path.Combine(workRoot.Path, "dataset.zip");
+        await File.WriteAllBytesAsync(archivePath, archiveBytes);
+
+        DatasetSearchResult result = await service.SearchAsync(archivePath, "533914", ["dem"]);
+
+        Assert.Equal(CreateThirdMeshCodes("533914"), result.SelectedMeshCodes);
+        DatasetSearchEntry entry = Assert.Single(result.SourceFiles);
+        Assert.Equal("533914", entry.MatchedMeshCode);
+        Assert.True(entry.RequiresMeshCodeBoundsFilter);
+    }
+
+    [Fact]
+    public async Task SearchAsyncTreatsRegexParentDemMatchLikeExplicitThirdMeshRegex()
+    {
+        byte[] archiveBytes = CreateZipArchive(
+            ("udx/dem/533914_dem_6697_00_op.gml", "<dem:CityModel />"),
+            ("udx/dem/533914_dem_6697_05_op.gml", "<dem:CityModel />"));
+        using TemporaryDirectory workRoot = new();
+        string archivePath = Path.Combine(workRoot.Path, "dataset.zip");
+        await File.WriteAllBytesAsync(archivePath, archiveBytes);
+
+        DatasetSearchResult parentRegexResult = await service.SearchAsync(archivePath, "53391[4].*", ["dem"]);
+        DatasetSearchResult thirdRegexResult = await service.SearchAsync(archivePath, "533914..", ["dem"]);
+
+        Assert.Equal(thirdRegexResult.SelectedMeshCodes, parentRegexResult.SelectedMeshCodes);
+        Assert.Equal(CreateThirdMeshCodes("533914"), parentRegexResult.SelectedMeshCodes);
+    }
+
     private static void WriteDatasetFile(string datasetRoot, string relativePath, string content)
     {
         string absolutePath = Path.Combine(
@@ -582,5 +642,12 @@ public sealed class DatasetInspectionServiceTests
         }
 
         return stream.ToArray();
+    }
+
+    private static string[] CreateThirdMeshCodes(string parentMeshCode)
+    {
+        return Enumerable.Range(0, 100)
+            .Select(index => $"{parentMeshCode}{index / 10}{index % 10}")
+            .ToArray();
     }
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/DemCityObjectAggregationTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DemCityObjectAggregationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 
 using PlateauResoniteLink.Application.Importing;
@@ -78,6 +79,30 @@ public sealed class DemCityObjectAggregationTests
         Assert.Equal("dem_plateau_fukuoka_dem_503033_50303312", result.SlotKey);
         Assert.Equal("DEM 50303312", result.DisplayName);
         Assert.Equal("50303312", result.ActualMeshCode);
+    }
+
+    [Fact]
+    public void AggregateBySourceFileAndThirdMeshUsesSelectedThirdMeshWithoutDependingOnBoundsFilterFlag()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("EPSG:4326");
+        SourceFileDescriptor sourceFile = new(
+            "udx/dem/533914_dem_6697_00_op.gml",
+            "dem",
+            "533914",
+            RequiresMeshCodeBoundsFilter: false);
+        ParsedCityObject[] cityObjects =
+        [
+            CreateCityObject("dem-parent", "polygon-parent", "533914", sourceFile.RelativePath, referenceSystem),
+        ];
+
+        ParsedCityObject[] results = DemCityObjectAggregation.AggregateBySourceFileAndThirdMesh(
+            sourceFile,
+            cityObjects,
+            ["53391400", "53391401"]);
+
+        Assert.Equal(["53391400", "53391401"], results.Select(static result => result.ActualMeshCode).ToArray());
+        Assert.All(results, static result => Assert.StartsWith("DEM 533914", result.DisplayName, StringComparison.Ordinal));
+        Assert.DoesNotContain(results, static result => string.Equals(result.ActualMeshCode, "533914", StringComparison.Ordinal));
     }
 
     private static ParsedCityObject CreateCityObject(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -2650,7 +2650,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public async Task DemTerrainGridModeCarriesGeneratedTextureUvTransformOnGeometryInsteadOfMaterial()
+    public async Task DemTerrainGridModeOmitsGeneratedTextureUvTransformWhenGridCoversOverlayMesh()
     {
         using TemporaryDirectory datasetRoot = new();
         CreateRuntimeDemChunkFixture(datasetRoot.Path);
@@ -2676,12 +2676,8 @@ public sealed class LocalCityGmlObjectProjectionTests
         TerrainGridGeometry geometry = Assert.IsType<TerrainGridGeometry>(demCityObject.Geometry);
         MaterialBinding material = Assert.Single(demCityObject.Materials);
 
-        Assert.NotNull(geometry.UvScale);
-        Assert.NotNull(geometry.UvOffset);
-        Assert.InRange(geometry.UvOffset!.X, 0.07, 0.11);
-        Assert.InRange(geometry.UvOffset.Y, 0.09, 0.11);
-        Assert.InRange(geometry.UvOffset.X + geometry.UvScale!.X, 0.91, 0.93);
-        Assert.InRange(geometry.UvOffset.Y + geometry.UvScale.Y, 0.91, 0.93);
+        Assert.Null(geometry.UvScale);
+        Assert.Null(geometry.UvOffset);
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
     }
@@ -2717,8 +2713,8 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.NotEmpty(geometry.StaticMesh.Mesh.Submeshes);
         Assert.True(geometry.GridMesh.Width > 1);
         Assert.True(geometry.GridMesh.Height > 1);
-        Assert.NotNull(geometry.GridMesh.UvScale);
-        Assert.NotNull(geometry.GridMesh.UvOffset);
+        Assert.Null(geometry.GridMesh.UvScale);
+        Assert.Null(geometry.GridMesh.UvOffset);
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
     }
@@ -2776,6 +2772,7 @@ public sealed class LocalCityGmlObjectProjectionTests
             CancellationToken.None);
 
         TerrainGridGeometry geometry = Assert.IsType<TerrainGridGeometry>(projected.Geometry);
+        MaterialBinding material = Assert.Single(projected.Materials);
         Assert.All(EnumerateBoundaryCoverage(geometry), static coverage => Assert.Equal(TerrainGridSampleCoverage.Measured, coverage));
         Assert.True(geometry.Size.X > 0.0);
         Assert.True(geometry.Size.Y > 0.0);
@@ -2787,6 +2784,9 @@ public sealed class LocalCityGmlObjectProjectionTests
             geometry.Size.Y / EstimateProjectedLatitudeSpanMeters(south, north, west, east, origin, cartesian),
             0.99,
             1.01);
+        Assert.Null(geometry.UvScale);
+        Assert.Null(geometry.UvOffset);
+        Assert.NotNull(material.TerrainOverlay);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -2724,6 +2724,72 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
+    public void DemTerrainGridModeSamplesRawDemSourceAcrossThirdMeshBounds()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        const string meshCode = "53394525";
+        (double south, double north, double west, double east) = GetMeshBounds(meshCode);
+        ParsedSurface rawSurface = CreateParsedSurface(
+            "raw-dem",
+            ParsedSurfaceSemantic.Ground,
+            CreateBoundsQuadVertices(
+                south - ((north - south) * 0.05),
+                north + ((north - south) * 0.05),
+                west - ((east - west) * 0.05),
+                east + ((east - west) * 0.05),
+                20.0),
+            texturePayload: null,
+            baseColor: new ColorRgba(0.4, 0.5, 0.3, 1.0));
+        ParsedSurface clippedVisualSurface = CreateParsedSurface(
+            "clipped-dem",
+            ParsedSurfaceSemantic.Ground,
+            CreateBoundsQuadVertices(
+                south + ((north - south) * 0.05),
+                north - ((north - south) * 0.05),
+                west + ((east - west) * 0.05),
+                east - ((east - west) * 0.05),
+                20.0),
+            texturePayload: null,
+            baseColor: new ColorRgba(0.4, 0.5, 0.3, 1.0));
+        ParsedCityObject visualCityObject = CreateParsedCityObject("dem", [clippedVisualSurface], referenceSystem);
+        ParsedCityObject rawCityObject = visualCityObject with { Surfaces = [rawSurface] };
+        GeodeticPoint origin = CreateMeshCenterPoint(meshCode, 0.0);
+        GeographicLib.LocalCartesian cartesian = new(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric);
+
+        ImportedCityObject projected = CityGmlParsedCityObjectProjection.ProjectTerrainMeshModeCityObject(
+            GeneratedLod1RoofCityObjectFactory.CreateDraft(visualCityObject),
+            GeneratedLod1RoofCityObjectFactory.CreateDraft(rawCityObject),
+            origin,
+            cartesian,
+            CreateThirdMeshOverlay(meshCode),
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: meshCode,
+                CityGmlSource: DatasetLocation.Local("dataset"),
+                PackageNames: ["dem"],
+                TerrainMeshMode: TerrainMeshMode.Grid,
+                TerrainGridMetersPerVertex: 100.0,
+                TerrainGridMaxResolution: 8),
+            [MeshCodeBounds.Parse(meshCode)],
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create()),
+            progressReporter: null,
+            CancellationToken.None);
+
+        TerrainGridGeometry geometry = Assert.IsType<TerrainGridGeometry>(projected.Geometry);
+        Assert.All(EnumerateBoundaryCoverage(geometry), static coverage => Assert.Equal(TerrainGridSampleCoverage.Measured, coverage));
+        Assert.True(geometry.Size.X > 0.0);
+        Assert.True(geometry.Size.Y > 0.0);
+        Assert.InRange(
+            geometry.Size.X / EstimateProjectedLongitudeSpanMeters(south, north, west, east, origin, cartesian),
+            0.99,
+            1.01);
+        Assert.InRange(
+            geometry.Size.Y / EstimateProjectedLatitudeSpanMeters(south, north, west, east, origin, cartesian),
+            0.99,
+            1.01);
+    }
+
+    [Fact]
     public void DemTerrainDynamicModeKeepsMaterialBindingsCompatibleWithStaticMesh()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
@@ -3784,6 +3850,81 @@ public sealed class LocalCityGmlObjectProjectionTests
         return new GeodeticPoint((south + north) / 2.0, (west + east) / 2.0, altitudeMeters);
     }
 
+    private static IReadOnlyList<GeodeticPoint> CreateBoundsQuadVertices(
+        double south,
+        double north,
+        double west,
+        double east,
+        double altitudeMeters)
+    {
+        return
+        [
+            new(south, west, altitudeMeters),
+            new(south, east, altitudeMeters),
+            new(north, east, altitudeMeters),
+            new(north, west, altitudeMeters),
+            new(south, west, altitudeMeters),
+        ];
+    }
+
+    private static IEnumerable<TerrainGridSampleCoverage> EnumerateBoundaryCoverage(TerrainGridGeometry geometry)
+    {
+        for (int column = 0; column < geometry.Width; column++)
+        {
+            yield return geometry.SampleCoverage[column];
+            yield return geometry.SampleCoverage[((geometry.Height - 1) * geometry.Width) + column];
+        }
+
+        for (int row = 0; row < geometry.Height; row++)
+        {
+            yield return geometry.SampleCoverage[row * geometry.Width];
+            yield return geometry.SampleCoverage[(row * geometry.Width) + geometry.Width - 1];
+        }
+    }
+
+    private static double EstimateProjectedLongitudeSpanMeters(
+        double south,
+        double north,
+        double west,
+        double east,
+        GeodeticPoint origin,
+        GeographicLib.LocalCartesian cartesian)
+    {
+        double latitude = (south + north) / 2.0;
+        Float3 westPosition = CreateScenePosition(new GeodeticPoint(latitude, west, origin.Altitude), origin, cartesian);
+        Float3 eastPosition = CreateScenePosition(new GeodeticPoint(latitude, east, origin.Altitude), origin, cartesian);
+        return Math.Abs(eastPosition.X - westPosition.X);
+    }
+
+    private static double EstimateProjectedLatitudeSpanMeters(
+        double south,
+        double north,
+        double west,
+        double east,
+        GeodeticPoint origin,
+        GeographicLib.LocalCartesian cartesian)
+    {
+        double longitude = (west + east) / 2.0;
+        Float3 southPosition = CreateScenePosition(new GeodeticPoint(south, longitude, origin.Altitude), origin, cartesian);
+        Float3 northPosition = CreateScenePosition(new GeodeticPoint(north, longitude, origin.Altitude), origin, cartesian);
+        return Math.Abs(northPosition.Z - southPosition.Z);
+    }
+
+    private static Float3 CreateScenePosition(
+        GeodeticPoint point,
+        GeodeticPoint origin,
+        GeographicLib.LocalCartesian cartesian)
+    {
+        return SceneAxisMapper.CreatePosition(
+            point.Latitude,
+            point.Longitude,
+            point.Altitude,
+            origin.Latitude,
+            origin.Longitude,
+            origin.Altitude,
+            cartesian);
+    }
+
     private static TerrainTextureOverlay CreateThirdMeshOverlay(string meshCode)
     {
         (double south, double north, double west, double east) = GetMeshBounds(meshCode);
@@ -3866,6 +4007,7 @@ public sealed class LocalCityGmlObjectProjectionTests
 
         return CityGmlParsedCityObjectProjection.ProjectTerrainMeshModeCityObject(
             GeneratedLod1RoofCityObjectFactory.CreateDraft(cityObject),
+            demTerrainGridSamplingSource: null,
             globalOriginPoint,
             globalCartesian: null,
             demTerrainTextureOverlay: null,

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -2790,14 +2790,51 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
+    public void DemTerrainGridModeSkipsSourceSurfaceOutsideActualThirdMeshBounds()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        ParsedSurface rawSurface = CreateParsedSurface(
+            "raw-dem-outside-actual-mesh",
+            ParsedSurfaceSemantic.Ground,
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 20.0, minRatio: 0.1, maxRatio: 0.9, reverseWinding: false),
+            texturePayload: null,
+            baseColor: new ColorRgba(0.4, 0.5, 0.3, 1.0));
+        ParsedCityObject cityObject = CreateParsedCityObject("dem", [rawSurface], referenceSystem) with
+        {
+            ActualMeshCode = "53394526",
+            SharedAcrossMeshCodes = true,
+        };
+        PlateauImportRequest request = new(
+            Dataset: "tokyo23ku",
+            MeshCode: "53394526",
+            CityGmlSource: DatasetLocation.Local("/tmp/plateau"),
+            PackageNames: ["dem"],
+            TerrainMeshMode: TerrainMeshMode.Grid,
+            TerrainGridMetersPerVertex: 100.0,
+            TerrainGridMaxResolution: 8);
+
+        ImportedCityObject[] projected = LocalCityGmlObjectProjection.ProjectParsedCityObject(
+            cityObject,
+            CreateMeshCenterPoint("53394526", altitudeMeters: 0.0),
+            globalCartesian: null,
+            demTerrainTextureOverlays: [],
+            requestedMeshCodeBounds: [MeshCodeBounds.Parse("53394526")],
+            terrainHeightSampler: null,
+            request,
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create())).ToArray();
+
+        Assert.Empty(projected);
+    }
+
+    [Fact]
     public void DemTerrainDynamicModeKeepsMaterialBindingsCompatibleWithStaticMesh()
     {
         CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
-        GeodeticPoint origin = new(35.0, 139.0, 10.0);
+        GeodeticPoint origin = CreateMeshCenterPoint("53394525", 10.0);
         ParsedSurface validSurface = CreateParsedSurface(
             "valid-dem",
             ParsedSurfaceSemantic.Ground,
-            CreateHorizontalQuadVertices(origin, origin.Altitude, 10.0, reverseWinding: false),
+            CreateMeshRelativeQuadVertices("53394525", altitudeMeters: 10.0, minRatio: 0.45, maxRatio: 0.55, reverseWinding: false),
             texturePayload: null,
             baseColor: new ColorRgba(1.0, 1.0, 1.0, 1.0));
         ParsedSurface degenerateSurface = CreateParsedSurface(

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlObjectProjectionTests.cs
@@ -2650,7 +2650,7 @@ public sealed class LocalCityGmlObjectProjectionTests
     }
 
     [Fact]
-    public async Task DemTerrainGridModeOmitsGeneratedTextureUvTransformWhenGridCoversOverlayMesh()
+    public async Task DemTerrainGridModeKeepsGeneratedTextureUvTransformOnGridMeshWhenGridCoversPartialOverlayMesh()
     {
         using TemporaryDirectory datasetRoot = new();
         CreateRuntimeDemChunkFixture(datasetRoot.Path);
@@ -2676,10 +2676,54 @@ public sealed class LocalCityGmlObjectProjectionTests
         TerrainGridGeometry geometry = Assert.IsType<TerrainGridGeometry>(demCityObject.Geometry);
         MaterialBinding material = Assert.Single(demCityObject.Materials);
 
-        Assert.Null(geometry.UvScale);
-        Assert.Null(geometry.UvOffset);
+        Assert.NotNull(geometry.UvScale);
+        Assert.NotNull(geometry.UvOffset);
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
+    }
+
+    [Fact]
+    public void DemTerrainGridModeKeepsGeneratedTextureUvTransformWhenGridCoversPartialOverlayMesh()
+    {
+        CoordinateReferenceSystem referenceSystem = CoordinateReferenceSystem.Parse("http://www.opengis.net/def/crs/EPSG/0/6697");
+        const string meshCode = "53394525";
+        ParsedSurface partialSurface = CreateParsedSurface(
+            "partial-dem",
+            ParsedSurfaceSemantic.Ground,
+            CreateMeshRelativeQuadVertices(meshCode, altitudeMeters: 20.0, minRatio: 0.2, maxRatio: 0.8, reverseWinding: false),
+            texturePayload: null,
+            baseColor: new ColorRgba(0.4, 0.5, 0.3, 1.0));
+        ParsedCityObject cityObject = CreateParsedCityObject("dem", [partialSurface], referenceSystem);
+        GeodeticPoint origin = CreateMeshCenterPoint(meshCode, 0.0);
+        GeographicLib.LocalCartesian cartesian = new(origin.Latitude, origin.Longitude, origin.Altitude, referenceSystem.Geocentric);
+
+        ImportedCityObject projected = CityGmlParsedCityObjectProjection.ProjectTerrainMeshModeCityObject(
+            GeneratedLod1RoofCityObjectFactory.CreateDraft(cityObject),
+            GeneratedLod1RoofCityObjectFactory.CreateDraft(cityObject),
+            origin,
+            cartesian,
+            CreateThirdMeshOverlay(meshCode),
+            new PlateauImportRequest(
+                Dataset: "tokyo23ku",
+                MeshCode: meshCode,
+                CityGmlSource: DatasetLocation.Local("dataset"),
+                PackageNames: ["dem"],
+                TerrainMeshMode: TerrainMeshMode.Grid,
+                TerrainGridMetersPerVertex: 100.0,
+                TerrainGridMaxResolution: 8),
+            [MeshCodeBounds.Parse(meshCode)],
+            new DefaultMaterialResolver(CommonMaterialCatalog.Create()),
+            progressReporter: null,
+            CancellationToken.None);
+
+        TerrainGridGeometry geometry = Assert.IsType<TerrainGridGeometry>(projected.Geometry);
+        Float2 uvScale = Assert.IsType<Float2>(geometry.UvScale);
+        Float2 uvOffset = Assert.IsType<Float2>(geometry.UvOffset);
+
+        Assert.InRange(uvScale.X, 0.0, 1.0);
+        Assert.InRange(uvScale.Y, 0.0, 1.0);
+        Assert.InRange(uvOffset.X, 0.0, 1.0);
+        Assert.InRange(uvOffset.Y, 0.0, 1.0);
     }
 
     [Fact]
@@ -2713,8 +2757,8 @@ public sealed class LocalCityGmlObjectProjectionTests
         Assert.NotEmpty(geometry.StaticMesh.Mesh.Submeshes);
         Assert.True(geometry.GridMesh.Width > 1);
         Assert.True(geometry.GridMesh.Height > 1);
-        Assert.Null(geometry.GridMesh.UvScale);
-        Assert.Null(geometry.GridMesh.UvOffset);
+        Assert.NotNull(geometry.GridMesh.UvScale);
+        Assert.NotNull(geometry.GridMesh.UvOffset);
         Assert.Null(material.TextureScale);
         Assert.Null(material.TextureOffset);
     }

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileDiscoveryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileDiscoveryTests.cs
@@ -66,17 +66,23 @@ public sealed class LocalCityGmlSourceFileDiscoveryTests
         LocalCityGmlSourceFileDiscoveryResult discoveryResult = LocalCityGmlSourceFileDiscovery.Discover(
             [
                 "udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml",
+                "udx/dem/533945/plateau_tokyo23ku_dem_53394526.gml",
                 "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml",
             ],
             "533945",
             packageNames: null);
-        LocalCityGmlSourceFileDescriptor descriptor = Assert.Single(discoveryResult.SourceFiles);
+        LocalCityGmlSourceFileDescriptor[] descriptors = discoveryResult.SourceFiles.ToArray();
 
-        Assert.Equal(["53394525"], discoveryResult.SelectedMeshCodes);
-        Assert.Equal("udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml", descriptor.RelativePath);
-        Assert.Equal("dem", descriptor.PackageName);
-        Assert.Equal("53394525", descriptor.MatchedMeshCode);
-        Assert.False(descriptor.RequiresMeshCodeBoundsFilter);
+        Assert.Equal(["53394525", "53394526"], discoveryResult.SelectedMeshCodes);
+        Assert.Equal(
+            [
+                "udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml",
+                "udx/dem/533945/plateau_tokyo23ku_dem_53394526.gml",
+            ],
+            descriptors.Select(static descriptor => descriptor.RelativePath).ToArray());
+        Assert.All(descriptors, static descriptor => Assert.Equal("dem", descriptor.PackageName));
+        Assert.Equal(["53394525", "53394526"], descriptors.Select(static descriptor => descriptor.MatchedMeshCode).ToArray());
+        Assert.All(descriptors, static descriptor => Assert.False(descriptor.RequiresMeshCodeBoundsFilter));
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileDiscoveryTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/LocalCityGmlSourceFileDiscoveryTests.cs
@@ -61,6 +61,25 @@ public sealed class LocalCityGmlSourceFileDiscoveryTests
     }
 
     [Fact]
+    public void DiscoverParentDemRequestIncludesRequestedDetailedDemFiles()
+    {
+        LocalCityGmlSourceFileDiscoveryResult discoveryResult = LocalCityGmlSourceFileDiscovery.Discover(
+            [
+                "udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml",
+                "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml",
+            ],
+            "533945",
+            packageNames: null);
+        LocalCityGmlSourceFileDescriptor descriptor = Assert.Single(discoveryResult.SourceFiles);
+
+        Assert.Equal(["53394525"], discoveryResult.SelectedMeshCodes);
+        Assert.Equal("udx/dem/53394525/plateau_tokyo23ku_dem_53394525.gml", descriptor.RelativePath);
+        Assert.Equal("dem", descriptor.PackageName);
+        Assert.Equal("53394525", descriptor.MatchedMeshCode);
+        Assert.False(descriptor.RequiresMeshCodeBoundsFilter);
+    }
+
+    [Fact]
     public void DiscoverMatchesRegexMeshCodesFromFileNamesAndDirectories()
     {
         LocalCityGmlSourceFileDescriptor[] result = LocalCityGmlSourceFileDiscovery.Discover(


### PR DESCRIPTION
## Summary
- Replaces the DEM GridMesh/HeightMap path so sampling uses the pre-partition DEM source surfaces instead of the visual/material-partitioned DEM mesh.
- Keeps the DEM GridMesh domain tied to the third regional mesh code, intersected with requested mesh bounds and terrain overlay bounds.
- Adds a regression test proving an inset visual DEM surface cannot shrink or hollow the GridMesh sampling domain when the raw DEM source covers the third mesh.

This supersedes #362 and #364. #364's boundary-fill fallback is intentionally not used here.

## Real-data dump
Dataset: `14100_yokohama-shi_city_2024`
Command shape:
`--mesh-code "53391[4].*" --terrain-mesh dynamic --terrain-grid-max-resolution 256 --packages dem`

Dumps are under `.tmp/dem-heightmap-source-fix/` and are untracked.

- before normalized: `.tmp/dem-heightmap-source-fix/before-normalized/dump.json`
- after: `.tmp/dem-heightmap-source-fix/after/dump.json`

Comparison:
- before DEM GridMesh count: 100
- after DEM GridMesh count: 100
- before tiny/skinny (`width == 2 || height == 2`): 0
- after tiny/skinny (`width == 2 || height == 2`): 0
- before sizes: `256x256:100`
- after sizes: `256x256:100`
- 99 DEM grids changed size/magnitude slightly, confirming the source-surface sampling path affects the real output.

## Verification
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~LocalCityGmlObjectProjectionTests|FullyQualifiedName~CityGmlDemTerrainGridSamplerTests|FullyQualifiedName~DemTerrainGridChunkBoundaryAlignmentPolicyTests"` => 93 passed
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` => 1053 passed