### PR TITLE
[codex] Fix append placement origin recovery

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootPlacementResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootPlacementResolver.cs
@@ -53,9 +53,7 @@ internal static class ObservedSourceRootPlacementResolver
                     : default)
                 .Where(static candidate => candidate.Slot is not null)
                 .Select(candidate => new ObservedSourceRootPlacement(
-                    ResonitePlacementPolicy.Add(
-                        GetRequiredSourceRootPosition(candidate.Slot),
-                        ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
+                    ResolvePositionFromObservedRootOrigin(candidate.MeshCode, rootMeshCode, GetRequiredSourceRootPosition(candidate.Slot)),
                     ReferenceMeshCode: candidate.MeshCode,
                     SlotId: candidate.Slot.ID ?? string.Empty))
                 .ToArray();
@@ -99,6 +97,21 @@ internal static class ObservedSourceRootPlacementResolver
         return Math.Abs(left.X - right.X) <= tolerance
             && Math.Abs(left.Y - right.Y) <= tolerance
             && Math.Abs(left.Z - right.Z) <= tolerance;
+    }
+
+    private static ResoniteFloat3 ResolvePositionFromObservedRootOrigin(
+        string observedMeshCode,
+        string rootMeshCode,
+        ResoniteFloat3 observedRootPosition)
+    {
+        ResoniteLocalOrigin observedParentOrigin = ResonitePlacementPolicy.ResolveParentOriginFromMeshRootPosition(
+            observedMeshCode,
+            observedRootPosition);
+        ResoniteFloat3 rootPosition = ResonitePlacementPolicy.ResolveMeshRootPosition(
+            observedParentOrigin,
+            rootMeshCode,
+            observedRootHeight: observedRootPosition.Y);
+        return rootPosition;
     }
 
     private static ResoniteFloat3 GetRequiredSourceRootPosition(Slot slot)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePlacementPolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePlacementPolicy.cs
@@ -160,6 +160,38 @@ internal static class ResonitePlacementPolicy
             rootOffsetFromRequest.Z);
     }
 
+    public static ResoniteLocalOrigin ResolveParentOriginFromMeshRootPosition(
+        string meshCode,
+        ResoniteFloat3 rootPosition)
+    {
+        if (!PlateauMeshCode.TryGetGeodeticCenter(meshCode, out GeodeticCoordinate meshCenter))
+        {
+            return new ResoniteLocalOrigin(0.0, 0.0, 0.0);
+        }
+
+        ResoniteLocalOrigin origin = MoveOrigin(
+            new ResoniteLocalOrigin(meshCenter.Latitude, meshCenter.Longitude, meshCenter.Altitude),
+            -rootPosition.X,
+            -rootPosition.Z);
+
+        for (int iteration = 0; iteration < 6; iteration++)
+        {
+            ResoniteFloat3 projectedPosition = ComputeOriginOffset(
+                origin,
+                new ResoniteLocalOrigin(meshCenter.Latitude, meshCenter.Longitude, meshCenter.Altitude));
+            double errorX = projectedPosition.X - rootPosition.X;
+            double errorZ = projectedPosition.Z - rootPosition.Z;
+            if (Math.Abs(errorX) <= 0.001 && Math.Abs(errorZ) <= 0.001)
+            {
+                break;
+            }
+
+            origin = MoveOrigin(origin, errorX, errorZ);
+        }
+
+        return origin;
+    }
+
     public static ResonitePlacementCorrectionResult EvaluateRootPlacementCorrection(
         ResoniteLocalOrigin requestOrigin,
         string rootMeshCode,
@@ -259,6 +291,23 @@ internal static class ResonitePlacementPolicy
             currentCenter.Longitude,
             currentCenter.Altitude);
         return new ResoniteFloat3(X: eun.x, Y: 0.0, Z: eun.y);
+    }
+
+    private static ResoniteLocalOrigin MoveOrigin(
+        ResoniteLocalOrigin origin,
+        double eastMeters,
+        double northMeters)
+    {
+        LocalCartesian cartesian = new(
+            origin.Latitude,
+            origin.Longitude,
+            origin.Altitude,
+            Geocentric.WGS84);
+        (double movedLatitude, double movedLongitude, double movedAltitude) = cartesian.Reverse(
+            eastMeters,
+            northMeters,
+            0.0);
+        return new ResoniteLocalOrigin(movedLatitude, movedLongitude, movedAltitude);
     }
 
     private static string ComputeStableHashSuffix(string value)

--- a/tests/PlateauResoniteLink.Tests/Targets/ObservedSourceRootPlacementResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ObservedSourceRootPlacementResolverTests.cs
@@ -51,13 +51,35 @@ public sealed class ObservedSourceRootPlacementResolverTests
             [
                 CreateSlot("sibling-root", "plateau_tokyo23ku_bldg_53394525", new ResoniteFloat3(20.0, 1.0, 30.0)),
             ]);
-        ResoniteFloat3 expected = ResonitePlacementPolicy.Add(
-            new ResoniteFloat3(20.0, 1.0, 30.0),
-            ResonitePlacementPolicy.ComputeMeshCodeOffset("53394525", "53394527"));
+        ResoniteFloat3 expected = ResonitePlacementPolicy.ResolveMeshRootPosition(
+            ResonitePlacementPolicy.ResolveParentOriginFromMeshRootPosition("53394525", new ResoniteFloat3(20.0, 1.0, 30.0)),
+            "53394527",
+            observedRootHeight: 1.0);
 
         Assert.Equal(expected, placement?.Position);
         Assert.Equal("53394525", placement?.ReferenceMeshCode);
         Assert.Equal("sibling-root", placement?.SlotId);
+    }
+
+    [Fact]
+    public void TryResolveProjectsSiblingSourceRootsThroughRecoveredParentOrigin()
+    {
+        ResoniteLocalOrigin parentOrigin = new(35.6875, 139.69375, 0.0);
+        ResoniteFloat3 firstRootPosition = ResonitePlacementPolicy.ResolveMeshRootPosition(parentOrigin, "53394525");
+        ResoniteFloat3 secondRootPosition = ResonitePlacementPolicy.ResolveMeshRootPosition(parentOrigin, "53394526");
+
+        ObservedSourceRootPlacement? placement = ObservedSourceRootPlacementResolver.TryResolve(
+            "plateau_tokyo23ku_bldg_53394527",
+            "53394527",
+            [
+                CreateSlot("first-sibling-root", "plateau_tokyo23ku_bldg_53394525", firstRootPosition),
+                CreateSlot("second-sibling-root", "plateau_tokyo23ku_bldg_53394526", secondRootPosition),
+            ]);
+        ResoniteFloat3 expected = ResonitePlacementPolicy.ResolveMeshRootPosition(parentOrigin, "53394527");
+
+        Assert.NotNull(placement);
+        Assert.Equal(expected.X, placement.Value.Position.X, 3);
+        Assert.Equal(expected.Z, placement.Value.Position.Z, 3);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResonitePlacementPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResonitePlacementPolicyTests.cs
@@ -109,6 +109,32 @@ public sealed class ResonitePlacementPolicyTests
     }
 
     [Fact]
+    public void ResolveParentOriginFromMeshRootPosition_RestoresOriginFromMeshCodeAndHorizontalPosition()
+    {
+        PlateauResoniteLink.Targets.Resonite.ResoniteLocalOrigin parentOrigin = new(35.6875, 139.69375, 0.0);
+        PlateauResoniteLink.Targets.Resonite.ResoniteFloat3 firstRootPosition =
+            PlateauResoniteLink.Targets.Resonite.ResonitePlacementPolicy.ResolveMeshRootPosition(parentOrigin, "53394525");
+        PlateauResoniteLink.Targets.Resonite.ResoniteFloat3 secondRootPosition =
+            PlateauResoniteLink.Targets.Resonite.ResonitePlacementPolicy.ResolveMeshRootPosition(parentOrigin, "53394526");
+
+        PlateauResoniteLink.Targets.Resonite.ResoniteLocalOrigin firstRecovered =
+            PlateauResoniteLink.Targets.Resonite.ResonitePlacementPolicy.ResolveParentOriginFromMeshRootPosition("53394525", firstRootPosition);
+        PlateauResoniteLink.Targets.Resonite.ResoniteLocalOrigin secondRecovered =
+            PlateauResoniteLink.Targets.Resonite.ResonitePlacementPolicy.ResolveParentOriginFromMeshRootPosition("53394526", secondRootPosition);
+        PlateauResoniteLink.Targets.Resonite.ResoniteFloat3 projectedFromFirst =
+            PlateauResoniteLink.Targets.Resonite.ResonitePlacementPolicy.ResolveMeshRootPosition(firstRecovered, "53394527");
+        PlateauResoniteLink.Targets.Resonite.ResoniteFloat3 projectedFromSecond =
+            PlateauResoniteLink.Targets.Resonite.ResonitePlacementPolicy.ResolveMeshRootPosition(secondRecovered, "53394527");
+        PlateauResoniteLink.Targets.Resonite.ResoniteFloat3 expected =
+            PlateauResoniteLink.Targets.Resonite.ResonitePlacementPolicy.ResolveMeshRootPosition(parentOrigin, "53394527");
+
+        Assert.Equal(expected.X, projectedFromFirst.X, 3);
+        Assert.Equal(expected.Z, projectedFromFirst.Z, 3);
+        Assert.Equal(expected.X, projectedFromSecond.X, 3);
+        Assert.Equal(expected.Z, projectedFromSecond.Z, 3);
+    }
+
+    [Fact]
     public void FormatLodSlotName_UsesLod0ForNullLod()
     {
         string slotName = PlateauResoniteLink.Targets.Resonite.ResonitePlacementPolicy.FormatLodSlotName(null);


### PR DESCRIPTION
## Summary

- recover the append parent origin from observed source-root mesh-code plus X/Z position
- use that recovered origin when projecting sibling source roots for new mesh roots
- keep true coordinate-frame disagreement as an ambiguous append error

## Root Cause

The sibling append fallback projected a new mesh root by adding a mesh-to-mesh offset to an observed root position. That offset is computed in the observed mesh's local frame, so it does not reliably preserve the parent-origin coordinate frame across different third mesh roots.

## Validation

- `dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --filter "FullyQualifiedName~ObservedSourceRootPlacementResolverTests|FullyQualifiedName~ResonitePlacementPolicyTests|FullyQualifiedName~ExecuteAsyncSiblingAppend"`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
- Live send on `Esnya Headless2 Workspace3` / `ws://localhost:19100/` with DEM present:
  - removed only `PLATEAU plateau-14130-kawasaki-shi-2022`, then verified no stale target root in `runtime/windows/resonite/root-dumps/kawasaki-dem-post-removal-pre-send.json`
  - base: dataset `plateau-14130-kawasaki-shi-2022`, mesh `5339253[46]`, packages `dem,bldg`, source `source-archive-bab804e17464.zip`, exit 0, `Send summary: attempted=5 sent=5 failed=0`
  - append: mesh `53392535`, packages `dem,bldg`, source file `udx/bldg/53392535_bldg_6697_op.gml`, exit 0, `Send summary: attempted=3 sent=3 failed=0`
  - append sent `DEM 53392535`, so placement was validated with terrain present, not bldg-only
  - post-append dump `runtime/windows/resonite/root-dumps/kawasaki-dem-append-53392535-after-send.json` confirmed source roots: `53392534_bldg_6697_op X=-1133.7073 Z=0.071865775`, `53392536_bldg_6697_op X=1133.7073 Z=0.071865775`, appended `53392535_bldg_6697_op X=0.08794936 Z=0.03590375`, and `533925_dem_6697_05_op` roots carrying `DEM 53392535`.