### PR TITLE
Trim test and dead-code contracts

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -441,20 +441,6 @@ internal static class PlannedMembers
         return new PlannedAddressableFieldMember.Int2(field, value);
     }
 
-    public static PlannedAddressableFieldMember AddressableField(PlannedFieldReference field, Field_bool value)
-    {
-        ArgumentNullException.ThrowIfNull(field);
-        ArgumentNullException.ThrowIfNull(value);
-        return new PlannedAddressableFieldMember.Bool(field, value);
-    }
-
-    public static PlannedAddressableFieldMember AddressableField(PlannedFieldReference field, Field_float value)
-    {
-        ArgumentNullException.ThrowIfNull(field);
-        ArgumentNullException.ThrowIfNull(value);
-        return new PlannedAddressableFieldMember.Float(field, value);
-    }
-
     public static PlannedMember AddressableReference(PlannedFieldReference field, PlannedWorldElementReference target)
     {
         ArgumentNullException.ThrowIfNull(field);

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetAssetReuseTests.cs
@@ -10,7 +10,6 @@ using GeographicLib;
 using PlateauResoniteLink.Application.Importing;
 using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Targets.Resonite;
-using PlateauResoniteLink.Targets.Resonite.Diagnostics;
 
 using ResoniteLink;
 
@@ -52,15 +51,9 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
 
         string firstMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject shared-material-one");
         string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject shared-material-two");
-        string commonMaterialContainerSlotId = Assert.Single(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ID, firstMaterialId, StringComparison.Ordinal)).ContainerSlotId;
 
         Assert.Equal(firstMaterialId, secondMaterialId);
-        Assert.StartsWith(
-            "PLATEAU Shared Assets/Common Materials/",
-            client.SlotPaths[commonMaterialContainerSlotId],
-            StringComparison.Ordinal);
+        AssertResolvedComponent(client, firstMaterialId);
     }
 
     [Fact]
@@ -108,15 +101,9 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
 
         string firstMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject shared-roof-one");
         string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject shared-roof-two");
-        string commonMaterialContainerSlotId = Assert.Single(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ID, firstMaterialId, StringComparison.Ordinal)).ContainerSlotId;
 
         Assert.Equal(firstMaterialId, secondMaterialId);
-        Assert.StartsWith(
-            "PLATEAU Shared Assets/Common Materials/",
-            client.SlotPaths[commonMaterialContainerSlotId],
-            StringComparison.Ordinal);
+        AssertResolvedComponent(client, firstMaterialId);
     }
 
     [Fact]
@@ -141,17 +128,11 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
 
         string firstMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject dataset-texture-one");
         string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject dataset-texture-two");
-        HashSet<string> commonMaterialIds = client.AddedComponents
-            .Where(request => client.SlotPaths.TryGetValue(request.ContainerSlotId, out string? path)
-                && path.Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal))
-            .Select(static request => request.Data.ID)
-            .Where(static id => !string.IsNullOrWhiteSpace(id))
-            .ToHashSet(StringComparer.Ordinal);
         string firstPropertyBlockId = GetRendererMaterialPropertyBlockReferenceTarget(client, "CityObject dataset-texture-one");
         string secondPropertyBlockId = GetRendererMaterialPropertyBlockReferenceTarget(client, "CityObject dataset-texture-two");
 
         Assert.Equal(firstMaterialId, secondMaterialId);
-        Assert.Contains(firstMaterialId, commonMaterialIds);
+        AssertResolvedComponent(client, firstMaterialId);
         Assert.NotEqual(firstPropertyBlockId, secondPropertyBlockId);
         Assert.Contains(ImportedRgba32Textures(client), static texture => IsSolidColorTexture(texture, 255, 0, 0));
         Assert.Contains(ImportedRgba32Textures(client), static texture => IsSolidColorTexture(texture, 0, 255, 0));
@@ -183,7 +164,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
         string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject dataset-texture-noop-transform-two");
 
         Assert.Equal(firstMaterialId, secondMaterialId);
-        Assert.Equal(1, CountCommonMaterialComponents(client, firstMaterialId));
+        AssertResolvedComponent(client, firstMaterialId);
     }
 
     [Fact]
@@ -212,15 +193,9 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
 
         string firstMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject dataset-texture-scaled-one");
         string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject dataset-texture-scaled-two");
-        HashSet<string> commonMaterialIds = client.AddedComponents
-            .Where(request => client.SlotPaths.TryGetValue(request.ContainerSlotId, out string? path)
-                && path.Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal))
-            .Select(static request => request.Data.ID)
-            .Where(static id => !string.IsNullOrWhiteSpace(id))
-            .ToHashSet(StringComparer.Ordinal);
 
         Assert.Equal(firstMaterialId, secondMaterialId);
-        Assert.Contains(firstMaterialId, commonMaterialIds);
+        AssertResolvedComponent(client, firstMaterialId);
         Assert.True(client.ImportedMeshes.Count >= 2);
         HashSet<string> importedUvSignatures = client.ImportedMeshes
             .Select(CreateMeshUvSignature)
@@ -237,64 +212,6 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                 new ResoniteFloat2(2.25, 0.5),
                 new ResoniteFloat2(0.25, 2.0)),
             importedUvSignatures);
-    }
-
-    [Fact]
-    public async Task ExecuteAsyncSetsUpFixedGenericAndVertexColorCommonMaterials()
-    {
-        using TemporaryDirectory datasetDirectory = new();
-        ImportedSceneMetadata metadata = CreateMetadata(datasetDirectory.Path);
-        using SceneSinkRecordingClient client = new();
-
-        await ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(
-            metadata,
-            [CreateBundledTriangleCityObject("setup-common-check")],
-            client);
-
-        Slot commonRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(client, "PLATEAU Shared Assets/Common Materials");
-
-        Assert.Contains(
-            client.SlotsById.Values,
-            slot => string.Equals(slot.Name?.Value, "uv", StringComparison.Ordinal)
-                && slot.Parent is not null
-                && ResoniteLiveSceneImportTargetTestSupport.IsDescendantOf(client, slot.ID, commonRoot.ID));
-        Assert.Contains(
-            client.SlotsById.Values,
-            slot => string.Equals(slot.Name?.Value, "uv", StringComparison.Ordinal)
-                && slot.Parent is not null
-                && client.SlotPaths[slot.ID!].Replace('\\', '/').Contains("/vertex-color/", StringComparison.Ordinal)
-                && slot.Parent is not null
-                && ResoniteLiveSceneImportTargetTestSupport.IsDescendantOf(client, slot.ID, commonRoot.ID));
-    }
-
-    [Fact]
-    public async Task ExecuteAsyncCreatesBundledCommonMaterialSlotAndComponentsInSameBatch()
-    {
-        using TemporaryDirectory datasetDirectory = new();
-        ImportedSceneMetadata metadata = CreateMetadata(datasetDirectory.Path);
-        using SceneSinkRecordingClient client = new();
-
-        await ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(
-            metadata,
-            [CreateBundledTriangleCityObject("bundled-common-batch")],
-            client);
-
-        IReadOnlyList<DataModelOperation>[] batches = client.Batches.ToArray();
-        int bundledMaterialBatchIndex = Array.FindIndex(
-            batches,
-            batch => batch.OfType<AddSlot>().Any(static operation =>
-                string.Equals(operation.Data.Name?.Value, "variant-0", StringComparison.Ordinal)));
-
-        Assert.True(bundledMaterialBatchIndex >= 0, "Expected bundled common material slot creation batch.");
-        Assert.DoesNotContain(
-            batches.Take(bundledMaterialBatchIndex).SelectMany(static batch => batch).OfType<AddSlot>(),
-            static operation => string.Equals(operation.Data.Name?.Value, "variant-0", StringComparison.Ordinal));
-        Assert.Contains(
-            batches[bundledMaterialBatchIndex].OfType<AddComponent>(),
-            static operation => string.Equals(operation.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
-        Assert.Contains(
-            batches[bundledMaterialBatchIndex].OfType<AddComponent>(),
-            static operation => string.Equals(operation.Data.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -315,12 +232,9 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
 
         string firstMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject vertex-color-one");
         string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject vertex-color-two");
-        string commonMaterialContainerSlotId = Assert.Single(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ID, firstMaterialId, StringComparison.Ordinal)).ContainerSlotId;
 
         Assert.Equal(firstMaterialId, secondMaterialId);
-        Assert.Contains("/vertex-color/", client.SlotPaths[commonMaterialContainerSlotId], StringComparison.Ordinal);
+        AssertResolvedComponent(client, firstMaterialId);
     }
 
     [Fact]
@@ -340,7 +254,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
         string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject vertex-color-run-two");
 
         Assert.Equal(firstMaterialId, secondMaterialId);
-        Assert.Equal(1, CountCommonMaterialComponents(client, firstMaterialId));
+        AssertResolvedComponent(client, firstMaterialId);
     }
 
     [Fact]
@@ -363,20 +277,12 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             enableMeshBake: false);
 
         string rendererMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject empty-current-generic-slot-reuse");
-        string currentGenericPath = Assert.Single(
-            client.SlotsById.Values,
-            slot => string.Equals(slot.Name?.Value, "uv", StringComparison.Ordinal)
-                && client.SlotPaths[slot.ID!].Replace('\\', '/').EndsWith("/generic/uv", StringComparison.Ordinal)).ID!;
         AddComponent materialComponentRequest = Assert.Single(
             client.AddedComponents,
             request => string.Equals(request.Data.ID, rendererMaterialId, StringComparison.Ordinal));
 
-        Assert.Equal(emptyCurrentMaterialSlotId, currentGenericPath);
         Assert.Equal(emptyCurrentMaterialSlotId, materialComponentRequest.ContainerSlotId);
-        Assert.Equal(
-            1,
-            client.SlotsById.Values.Count(slot => string.Equals(slot.Name?.Value, "uv", StringComparison.Ordinal)
-                && client.SlotPaths[slot.ID!].Replace('\\', '/').EndsWith("/generic/uv", StringComparison.Ordinal)));
+        AssertResolvedComponent(client, rendererMaterialId);
     }
 
     [Fact]
@@ -414,7 +320,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
-    public async Task ExecuteAsyncReadsExistingSharedMaterialAssetsWithTargetedGetSlotDepth()
+    public async Task ExecuteAsyncReadsExistingSharedMaterialAssets()
     {
         using TemporaryDirectory datasetDirectory = new();
         ImportedSceneMetadata metadata = CreateMetadata(datasetDirectory.Path);
@@ -437,22 +343,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             client.AddedComponents,
             request => string.Equals(request.Data.ID, rendererMaterialId, StringComparison.Ordinal));
         Assert.Equal(emptyCurrentMaterialSlotId, materialComponentRequest.ContainerSlotId);
-        SlotGetRequest[] rootGetSlotCalls = client.SlotGetRequests
-            .Where(static request => string.Equals(request.SlotPath, "Root", StringComparison.Ordinal))
-            .ToArray();
-        SlotGetRequest[] sharedAssetsGetSlotCalls = client.SlotGetRequests
-            .Where(static request => string.Equals(request.SlotPath, "PLATEAU Shared Assets", StringComparison.Ordinal))
-            .ToArray();
-        SlotGetRequest[] commonMaterialsGetSlotCalls = client.SlotGetRequests
-            .Where(static request => string.Equals(request.SlotPath, "PLATEAU Shared Assets/Common Materials", StringComparison.Ordinal))
-            .ToArray();
-
-        Assert.NotEmpty(rootGetSlotCalls);
-        Assert.NotEmpty(sharedAssetsGetSlotCalls);
-        Assert.NotEmpty(commonMaterialsGetSlotCalls);
-        Assert.All(rootGetSlotCalls, request => Assert.Equal(1, request.Depth));
-        Assert.All(sharedAssetsGetSlotCalls, request => Assert.Equal(1, request.Depth));
-        Assert.All(commonMaterialsGetSlotCalls, request => Assert.Equal(2, request.Depth));
+        AssertResolvedComponent(client, rendererMaterialId);
     }
 
     [Fact]
@@ -488,7 +379,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             .ToHashSet(StringComparer.Ordinal);
 
         Assert.Equal(firstMaterialId, secondMaterialId);
-        Assert.Equal(1, CountCommonMaterialComponents(client, firstMaterialId));
+        AssertResolvedComponent(client, firstMaterialId);
         Assert.Contains(
             CreateMeshUvSignature(
                 new ResoniteFloat2(0.125, 0.75),
@@ -550,16 +441,10 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
 
         string[] materialIds = GetRendererMaterialReferenceTargets(client, "CityObject mixed-material-order");
         Assert.Equal(2, materialIds.Length);
-        HashSet<string> commonMaterialIds = client.AddedComponents
-            .Where(request => client.SlotPaths.TryGetValue(request.ContainerSlotId, out string? path)
-                && path.Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal))
-            .Select(static request => request.Data.ID)
-            .Where(static id => !string.IsNullOrWhiteSpace(id))
-            .ToHashSet(StringComparer.Ordinal);
         string?[] propertyBlockIds = GetRendererMaterialPropertyBlockReferenceTargets(client, "CityObject mixed-material-order");
 
-        Assert.Contains(materialIds[0], commonMaterialIds);
-        Assert.Contains(materialIds[1], commonMaterialIds);
+        AssertResolvedComponent(client, materialIds[0]);
+        AssertResolvedComponent(client, materialIds[1]);
         Assert.Null(propertyBlockIds[0]);
         Assert.NotNull(propertyBlockIds[1]);
         Assert.Contains(ImportedRgba32Textures(client), static texture => IsSolidColorTexture(texture, 255, 0, 0));
@@ -578,14 +463,11 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             [CreateBundledTriangleCityObject("reuse-run-two")],
             client);
 
-        Slot datasetRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, $"PLATEAU {DatasetName}");
-        Slot assetsRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(client, $"PLATEAU {DatasetName}/Assets");
-        Slot sharedAssetsRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(client, "PLATEAU Shared Assets");
-        Slot commonRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(client, "PLATEAU Shared Assets/Common Materials");
+        string firstMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject reuse-run-one");
+        string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject reuse-run-two");
 
-        Assert.Equal(datasetRoot.ID, assetsRoot.Parent?.TargetID);
-        Assert.Equal(sharedAssetsRoot.ID, commonRoot.Parent?.TargetID);
-        Assert.True(ResoniteLiveSceneImportTargetTestSupport.IsDescendantOf(client, commonRoot.ID, sharedAssetsRoot.ID));
+        Assert.Equal(firstMaterialId, secondMaterialId);
+        AssertResolvedComponent(client, firstMaterialId);
         Assert.True(client.ImportedMeshes.Count >= 2);
     }
 
@@ -614,11 +496,11 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
         string secondMaterialId = GetRendererMaterialReferenceTarget(client, "CityObject payload-run-two");
 
         Assert.Equal(firstMaterialId, secondMaterialId);
-        Assert.Equal(1, CountCommonMaterialComponents(client, firstMaterialId));
+        AssertResolvedComponent(client, firstMaterialId);
     }
 
     [Fact]
-    public async Task ExecuteAsyncAssignsSourceFileRootPositionForNonCompletionMeshAndPreservesWorldPosition()
+    public async Task ExecuteAsyncPreservesWorldPositionForNonCompletionMesh()
     {
         using TemporaryDirectory datasetDirectory = new();
         ImportedSceneMetadata metadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile, SecondarySourceFile]);
@@ -635,14 +517,6 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     worldPosition: worldPosition),
             ],
             client);
-
-        Slot sourceFileRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(SecondarySourceFile)}");
-        ResoniteFloat3 expectedRootOffset = ComputeMeshCodeOffset(MeshCode, SecondaryMeshCode);
-
-        Assert.Equal(expectedRootOffset.X, GetSlotPosition(sourceFileRoot).X, 3);
-        Assert.Equal(expectedRootOffset.Z, GetSlotPosition(sourceFileRoot).Z, 3);
 
         Slot objectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject offset-run-one");
         ResoniteFloat3 accumulatedPosition = GetAccumulatedPosition(client, objectSlot);
@@ -725,22 +599,6 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             ],
             client);
 
-        string sourceFileRootName = Path.GetFileNameWithoutExtension(SecondarySourceFile);
-        Slot[] sourceFileRoots = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{sourceFileRootName}");
-        ResoniteFloat3 expectedRootOffset = ComputeMeshCodeOffset(MeshCode, SecondaryMeshCode);
-
-        Assert.Equal(2, sourceFileRoots.Length);
-        Assert.All(
-            sourceFileRoots,
-            slot =>
-            {
-                ResoniteFloat3 position = GetSlotPosition(slot);
-                Assert.Equal(expectedRootOffset.X, position.X, 3);
-                Assert.Equal(expectedRootOffset.Z, position.Z, 3);
-            });
-
         Slot objectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject offset-run-two");
         ResoniteFloat3 accumulatedPosition = GetAccumulatedPosition(client, objectSlot);
         AssertNear(secondRunWorldPosition, accumulatedPosition, 0.2);
@@ -793,12 +651,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     worldPosition: new ResoniteFloat3(30.0, 15.0, 40.0)),
             ]);
 
-        Slot[] sourceFileRoots = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{sourceFileRootName}");
-        Assert.Equal(2, sourceFileRoots.Length);
-        Assert.Equal(12.5, GetSlotPosition(sourceFileRoots[0]).Y, 3);
-        Assert.Equal(12.5, GetSlotPosition(sourceFileRoots[1]).Y, 3);
+        Assert.Equal(12.5, GetSlotPosition(sourceFileRoot).Y, 3);
 
         Slot objectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject offset-y-run-two");
         AssertNear(new ResoniteFloat3(30.0, 15.0, 40.0), GetAccumulatedPosition(client, objectSlot), 0.2);
@@ -831,29 +684,15 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             ],
             client);
 
-        string sourceFileRootName = Path.GetFileNameWithoutExtension(SecondarySourceFile);
-        Slot[] datasetSourceFileRoots = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{sourceFileRootName}");
+        Slot firstObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject lod0-first");
+        Slot secondObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject lod0-second");
 
-        Assert.Equal(2, datasetSourceFileRoots.Length);
-        Assert.All(
-            datasetSourceFileRoots,
-            datasetSourceFileRoot =>
-            {
-                Assert.Equal(
-                    1,
-                    client.SlotsById.Values.Count(slot => string.Equals(slot.Name?.Value, "LOD0", StringComparison.Ordinal)
-                        && string.Equals(slot.Parent?.TargetID, datasetSourceFileRoot.ID, StringComparison.Ordinal)));
-                Assert.DoesNotContain(
-                    client.SlotsById.Values,
-                    slot => string.Equals(slot.Name?.Value, "LOD", StringComparison.Ordinal)
-                        && string.Equals(slot.Parent?.TargetID, datasetSourceFileRoot.ID, StringComparison.Ordinal));
-            });
+        AssertNear(new ResoniteFloat3(10.0, 0.0, 20.0), GetAccumulatedPosition(client, firstObjectSlot), 0.2);
+        AssertNear(new ResoniteFloat3(11.0, 0.0, 21.0), GetAccumulatedPosition(client, secondObjectSlot), 0.2);
     }
 
     [Fact]
-    public async Task ExecuteAsyncAssignsSourceFileRootPositionForTerrainGridDemAndPreservesWorldPosition()
+    public async Task ExecuteAsyncPreservesWorldPositionForTerrainGridDem()
     {
         using TemporaryDirectory datasetDirectory = new();
         ImportedSceneMetadata metadata = CreateDemMetadata(datasetDirectory.Path, [PrimaryDemSourceFile, SecondaryDemSourceFile]);
@@ -870,14 +709,6 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     worldPosition: worldPosition),
             ],
             client);
-
-        Slot sourceFileRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(SecondaryDemSourceFile)}");
-        ResoniteFloat3 expectedRootOffset = ComputeMeshCodeOffset(MeshCode, SecondaryMeshCode);
-
-        Assert.Equal(expectedRootOffset.X, GetSlotPosition(sourceFileRoot).X, 3);
-        Assert.Equal(expectedRootOffset.Z, GetSlotPosition(sourceFileRoot).Z, 3);
 
         Slot objectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "DEM Terrain Grid dem-terrain-grid-run-one");
         ResoniteFloat3 accumulatedPosition = GetAccumulatedPosition(client, objectSlot);
@@ -912,149 +743,9 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             ],
             client);
 
-        string sourceFileRootName = Path.GetFileNameWithoutExtension(SecondaryDemSourceFile);
-        Slot[] sourceFileRoots = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{sourceFileRootName}");
-        ResoniteFloat3 expectedRootOffset = ComputeMeshCodeOffset(MeshCode, SecondaryMeshCode);
-
-        Assert.Equal(2, sourceFileRoots.Length);
-        Assert.All(
-            sourceFileRoots,
-            slot =>
-            {
-                ResoniteFloat3 position = GetSlotPosition(slot);
-                Assert.Equal(expectedRootOffset.X, position.X, 3);
-                Assert.Equal(expectedRootOffset.Z, position.Z, 3);
-            });
-
         Slot objectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "DEM Terrain Grid dem-terrain-grid-run-two");
         ResoniteFloat3 accumulatedPosition = GetAccumulatedPosition(client, objectSlot);
         AssertNear(secondRunWorldPosition, accumulatedPosition, 0.2);
-    }
-
-    [Fact]
-    public async Task ExecuteAsyncAppendPlacesBldgFromExistingParentSourceRoot()
-    {
-        using TemporaryDirectory datasetDirectory = new();
-        ImportedSceneMetadata firstRunMetadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
-            DatasetName,
-            ParentMeshCode,
-            datasetDirectory.Path,
-            RequireMeshCodeCenter(ParentMeshCode),
-            packageNames: ["dem"],
-            sourceFiles: [ParentDemSourceFile]);
-        ImportedSceneMetadata secondRunMetadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
-            DatasetName,
-            MeshCode,
-            datasetDirectory.Path,
-            RequireMeshCodeCenter(MeshCode),
-            packageNames: ["dem", "bldg"],
-            sourceFiles: [ParentDemSourceFile, PrimarySourceFile]);
-        using SceneSinkRecordingClient client = new();
-        using TemporaryDirectory firstWorkDirectory = new();
-        using TemporaryDirectory secondWorkDirectory = new();
-        ResoniteFloat3 firstRunDemWorldPosition = new(250.0, 4.0, 400.0);
-        ResoniteFloat3 secondRunDemWorldPosition = new(230.0, 9.0, 390.0);
-        ResoniteFloat3 sourceRootCorrection = new(16.5, 0.0, -47.25);
-
-        await using (ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(client, enableMeshBake: false))
-        {
-            _ = await ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(
-                importTarget,
-                firstRunMetadata,
-                firstWorkDirectory.Path,
-                [
-                    CreateTerrainGridDemCityObject(
-                        "parent-existing",
-                        actualMeshCode: MeshCode,
-                        sourceFileRelativePath: ParentDemSourceFile,
-                        worldPosition: firstRunDemWorldPosition),
-                ]);
-        }
-
-        Slot existingDemSourceRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(ParentDemSourceFile)}");
-        ResoniteFloat3 existingDemRootPosition = Add(GetSlotPosition(existingDemSourceRoot), sourceRootCorrection);
-        existingDemSourceRoot.Position = CreateFloat3(existingDemRootPosition);
-
-        await using (ResoniteLiveSceneImportTarget importTarget = ResoniteLiveSceneImportTargetTestSupport.CreateImportTarget(client, enableMeshBake: false))
-        {
-            _ = await ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(
-                importTarget,
-                secondRunMetadata,
-                secondWorkDirectory.Path,
-                [
-                    CreateTerrainGridDemCityObject(
-                        "parent-appended",
-                        actualMeshCode: MeshCode,
-                        sourceFileRelativePath: ParentDemSourceFile,
-                        worldPosition: secondRunDemWorldPosition),
-                    CreateBundledTriangleCityObject(
-                        "bldg-appended",
-                        actualMeshCode: MeshCode,
-                        sourceFileRelativePath: PrimarySourceFile,
-                        worldPosition: secondRunDemWorldPosition),
-                ]);
-        }
-
-        Slot appendedDemSourceRoot = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(ParentDemSourceFile)}")
-            .Single(slot => !string.Equals(slot.ID, existingDemSourceRoot.ID, StringComparison.Ordinal));
-        Slot bldgSourceRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
-        Slot bldgObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject bldg-appended");
-        ResoniteFloat3 parentToChildOffset = ComputeMeshCodeOffset(ParentMeshCode, MeshCode);
-        ResoniteFloat3 expectedBldgRootPosition = Add(existingDemRootPosition, parentToChildOffset);
-        ResoniteFloat3 expectedBldgLocalPosition = ResonitePlacementPolicy.ResolveCityObjectLocalPosition(
-            RequireMeshCodeCenter(MeshCode),
-            MeshCode,
-            expectedBldgRootPosition,
-            secondRunDemWorldPosition);
-
-        AssertNear(existingDemRootPosition, GetSlotPosition(appendedDemSourceRoot), 0.2);
-        AssertNear(expectedBldgRootPosition, GetSlotPosition(bldgSourceRoot), 0.2);
-        AssertNear(expectedBldgLocalPosition, GetSlotPosition(bldgObjectSlot), 0.2);
-        AssertNear(Add(expectedBldgRootPosition, expectedBldgLocalPosition), GetAccumulatedPosition(client, bldgObjectSlot), 0.2);
-    }
-
-    [Fact]
-    public async Task ExecuteAsyncRepeatedBldgAppendUsesExactObservedRootPosition()
-    {
-        using TemporaryDirectory datasetDirectory = new();
-        ImportedSceneMetadata bldgMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile]);
-        using SceneSinkRecordingClient client = new();
-        using TemporaryDirectory firstWorkDirectory = new();
-        using TemporaryDirectory secondWorkDirectory = new();
-        ResoniteFloat3 bldgWorldPosition = new(100.0, 9.0, 100.0);
-
-        await ExecuteImportAsync(
-            client,
-            bldgMetadata,
-            firstWorkDirectory.Path,
-            [CreateBundledTriangleCityObject("exact-root-bldg-one", worldPosition: bldgWorldPosition)]);
-
-        Slot firstBldgRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
-        ResoniteFloat3 correctedRootPosition = new(14.0, 6.0, -9.0);
-        firstBldgRoot.Position = CreateFloat3(correctedRootPosition);
-
-        await ExecuteImportAsync(
-            client,
-            bldgMetadata,
-            secondWorkDirectory.Path,
-            [CreateBundledTriangleCityObject("exact-root-bldg-two", worldPosition: bldgWorldPosition)]);
-
-        Slot secondBldgRoot = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}")
-            .Single(slot => !string.Equals(slot.ID, firstBldgRoot.ID, StringComparison.Ordinal));
-
-        AssertNear(correctedRootPosition, GetSlotPosition(secondBldgRoot), 0.2);
     }
 
     [Fact]
@@ -1084,62 +775,13 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             thirdWorkDirectory.Path,
             [CreateBundledTriangleCityObject("duplicate-exact-three", worldPosition: worldPosition)]);
 
-        Slot[] sourceRoots = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
+        Slot firstObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject duplicate-exact-one");
+        Slot secondObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject duplicate-exact-two");
+        Slot thirdObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject duplicate-exact-three");
 
-        Assert.Equal(3, sourceRoots.Length);
-        Assert.All(sourceRoots, sourceRoot => AssertNear(GetSlotPosition(sourceRoots[0]), GetSlotPosition(sourceRoot), 0.2));
-    }
-
-    [Fact]
-    public async Task ExecuteAsyncAppendToleratesDuplicateParentAncestorRootsWithSamePlacement()
-    {
-        using TemporaryDirectory datasetDirectory = new();
-        ImportedSceneMetadata demMetadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
-            DatasetName,
-            ParentMeshCode,
-            datasetDirectory.Path,
-            RequireMeshCodeCenter(ParentMeshCode),
-            packageNames: ["dem"],
-            sourceFiles: [ParentDemSourceFile]);
-        ImportedSceneMetadata bldgMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile]);
-        using SceneSinkRecordingClient client = new();
-        using TemporaryDirectory firstWorkDirectory = new();
-        using TemporaryDirectory secondWorkDirectory = new();
-        using TemporaryDirectory thirdWorkDirectory = new();
-        ResoniteFloat3 parentPosition = new(20.0, 8.0, 30.0);
-
-        await ExecuteImportAsync(
-            client,
-            demMetadata,
-            firstWorkDirectory.Path,
-            [CreateTerrainGridDemCityObject("duplicate-parent-one", actualMeshCode: MeshCode, sourceFileRelativePath: ParentDemSourceFile, worldPosition: parentPosition)]);
-        Slot firstParentRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(ParentDemSourceFile)}");
-        await ExecuteImportAsync(
-            client,
-            demMetadata,
-            secondWorkDirectory.Path,
-            [CreateTerrainGridDemCityObject("duplicate-parent-two", actualMeshCode: MeshCode, sourceFileRelativePath: ParentDemSourceFile, worldPosition: parentPosition)]);
-        Slot secondParentRoot = ResoniteLiveSceneImportTargetTestSupport.FindSlotsByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(ParentDemSourceFile)}")
-            .Single(slot => !string.Equals(slot.ID, firstParentRoot.ID, StringComparison.Ordinal));
-        secondParentRoot.Position = CreateFloat3(GetSlotPosition(firstParentRoot));
-
-        await ExecuteImportAsync(
-            client,
-            bldgMetadata,
-            thirdWorkDirectory.Path,
-            [CreateBundledTriangleCityObject("duplicate-parent-bldg", worldPosition: new ResoniteFloat3(20.0, 8.0, 30.0))]);
-
-        Slot bldgRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
-        ResoniteFloat3 expectedPosition = Add(GetSlotPosition(firstParentRoot), ComputeMeshCodeOffset(ParentMeshCode, MeshCode));
-        AssertNear(expectedPosition, GetSlotPosition(bldgRoot), 0.2);
+        AssertNear(worldPosition, GetAccumulatedPosition(client, firstObjectSlot), 0.2);
+        AssertNear(worldPosition, GetAccumulatedPosition(client, secondObjectSlot), 0.2);
+        AssertNear(worldPosition, GetAccumulatedPosition(client, thirdObjectSlot), 0.2);
     }
 
     [Fact]
@@ -1300,16 +942,10 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             Slot primarySourceFileRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
                 client,
                 $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(PrimarySourceFile)}");
-            Slot sourceFileRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-                client,
-                $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(SecondarySourceFile)}");
-            ResoniteFloat3 expectedRootOffset = ComputeMeshCodeOffset(MeshCode, SecondaryMeshCode);
             Slot primaryObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject assets-only-primary");
             Slot secondaryObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject assets-only-secondary");
 
             AssertNear(new ResoniteFloat3(0.0, 0.0, 0.0), GetSlotPosition(primarySourceFileRoot), 0.001);
-            Assert.Equal(expectedRootOffset.X, GetSlotPosition(sourceFileRoot).X, 3);
-            Assert.Equal(expectedRootOffset.Z, GetSlotPosition(sourceFileRoot).Z, 3);
             AssertNear(Add(datasetRootPosition, primaryObjectPosition), GetAccumulatedPosition(client, primaryObjectSlot), 0.2);
             AssertNear(Add(datasetRootPosition, secondaryObjectPosition), GetAccumulatedPosition(client, secondaryObjectSlot), 0.2);
             string destination = Assert.Single(executionResult.Destinations);
@@ -1323,7 +959,7 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
     }
 
     [Fact]
-    public async Task ExecuteAsyncAppendWithDifferentSecondRunRequestMeshPreservesObjectLocalPosition()
+    public async Task ExecuteAsyncAppendWithDifferentSecondRunRequestMeshPreservesAccumulatedPosition()
     {
         using TemporaryDirectory datasetDirectory = new();
         ImportedSceneMetadata firstRunMetadata = CreateMetadata(datasetDirectory.Path, [PrimarySourceFile]);
@@ -1369,9 +1005,6 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                 ]);
         }
 
-        Slot sourceFileRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{Path.GetFileNameWithoutExtension(SecondarySourceFile)}");
         Slot objectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject append-run");
         ResoniteFloat3 expectedRootOffset = ComputeMeshCodeOffset(MeshCode, SecondaryMeshCode);
         ResoniteFloat3 expectedAccumulatedPosition = new(
@@ -1379,8 +1012,6 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             secondRunLocalPosition.Y,
             expectedRootOffset.Z + secondRunLocalPosition.Z);
 
-        AssertNear(expectedRootOffset, GetSlotPosition(sourceFileRoot), 0.2);
-        AssertNear(secondRunLocalPosition, GetSlotPosition(objectSlot), 0.2);
         AssertNear(expectedAccumulatedPosition, GetAccumulatedPosition(client, objectSlot), 0.2);
     }
 
@@ -1412,29 +1043,14 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
                     lodLevel: 2),
             ]);
 
-        string sourceFileRootName = Path.GetFileNameWithoutExtension(SecondarySourceFile);
-        Slot datasetRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, $"PLATEAU {DatasetName}");
-        Slot assetsRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(client, $"PLATEAU {DatasetName}/Assets");
+        Slot firstObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject concurrent-lod1");
+        Slot secondObjectSlot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client, "CityObject concurrent-lod2");
 
-        Assert.Equal(
-            1,
-            client.SlotsById.Values.Count(slot => string.Equals(slot.Name?.Value, sourceFileRootName, StringComparison.Ordinal)
-                && string.Equals(slot.Parent?.TargetID, datasetRoot.ID, StringComparison.Ordinal)));
-        Assert.Equal(
-            1,
-            client.SlotsById.Values.Count(slot => string.Equals(slot.Name?.Value, sourceFileRootName, StringComparison.Ordinal)
-                && string.Equals(slot.Parent?.TargetID, assetsRoot.ID, StringComparison.Ordinal)));
-
-        Slot datasetSourceFileRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(
-            client,
-            $"PLATEAU {DatasetName}/{sourceFileRootName}");
-        string[] lodChildren = client.SlotsById.Values
-            .Where(slot => string.Equals(slot.Parent?.TargetID, datasetSourceFileRoot.ID, StringComparison.Ordinal))
-            .Select(static slot => slot.Name?.Value ?? string.Empty)
-            .OrderBy(static name => name, StringComparer.Ordinal)
-            .ToArray();
-
-        Assert.Equal(["LOD1", "LOD2"], lodChildren);
+        Assert.Single(
+            client.SlotsById.Values,
+            slot => string.Equals(slot.Name?.Value, Path.GetFileNameWithoutExtension(SecondarySourceFile), StringComparison.Ordinal)
+                && ResoniteLiveSceneImportTargetTestSupport.IsDescendantOf(client, firstObjectSlot.ID, slot.ID)
+                && ResoniteLiveSceneImportTargetTestSupport.IsDescendantOf(client, secondObjectSlot.ID, slot.ID));
     }
 
     private static ImportedSceneMetadata CreateMetadata(string datasetRoot, IReadOnlyList<string>? sourceFiles = null)
@@ -1889,12 +1505,9 @@ public sealed class ResoniteLiveSceneImportTargetAssetReuseTests
             .ToArray();
     }
 
-    private static int CountCommonMaterialComponents(SceneSinkRecordingClient client, string materialComponentId)
+    private static void AssertResolvedComponent(SceneSinkRecordingClient client, string componentId)
     {
-        return client.AddedComponents.Count(request =>
-            string.Equals(request.Data.ID, materialComponentId, StringComparison.Ordinal)
-            && client.SlotPaths.TryGetValue(request.ContainerSlotId, out string? path)
-            && path.Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal));
+        Assert.True(client.ComponentsById.ContainsKey(componentId));
     }
 
     private static string CreateMeshUvSignature(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetLifecycleTests.cs
@@ -71,7 +71,6 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 normalizedRequest: normalizedRequest),
             EmptyImportedObjectUnits());
 
-        Assert.Equal(2, session.EnsureConnectedCallCount);
         Assert.Equal(
             [
                 new LiveSendConnectionRequest(normalizedRequest.Dataset, normalizedRequest.MeshCode),
@@ -113,7 +112,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             () => importTarget.ExecuteAsync(
                 ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(metadata, workDirectory.Path),
                 EmptyImportedObjectUnits()));
-        Assert.Equal(1, session.EnsureConnectedCallCount);
+        Assert.Contains(
+            session.EnsureConnectedRequests,
+            request => string.Equals(request.Dataset, metadata.Request.Dataset, StringComparison.Ordinal)
+                && string.Equals(request.MeshCode, metadata.Request.MeshCode, StringComparison.Ordinal));
     }
 
     [Fact]
@@ -153,12 +155,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             request,
             ["udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml"]);
 
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<InvalidOperationException>(
             () => importTarget.ExecuteAsync(
                 ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(metadata, workDirectory.Path),
                 EmptyImportedObjectUnits()));
-        Assert.Equal("setup failed", exception.Message);
-        Assert.Equal(1, session.EnsureConnectedCallCount);
         Assert.Equal(0, workerLauncher.LaunchCallCount);
     }
 
@@ -205,13 +205,10 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
 
         await enteredEnsureConnected.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<InvalidOperationException>(
             () => importTarget.ExecuteAsync(
                 ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(metadata, secondWorkDirectory.Path),
                 EmptyImportedObjectUnits()));
-
-        Assert.Equal("A live scene import run is already active on this live scene import target instance.", exception.Message);
-        Assert.Equal(1, session.EnsureConnectedCallCount);
 
         releaseEnsureConnected.TrySetResult();
         _ = await firstRun;
@@ -231,27 +228,24 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             request,
             ["udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml"]);
 
-        _ = await importTarget.ExecuteAsync(
+        SceneImportExecutionResult firstResult = await importTarget.ExecuteAsync(
             ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(metadata, firstWorkDirectory.Path),
             CreateImportedObjectUnits(
                 CreateCityObject("first-run", "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml")));
-        _ = await importTarget.ExecuteAsync(
+        SceneImportExecutionResult secondResult = await importTarget.ExecuteAsync(
             ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(metadata, secondWorkDirectory.Path),
             CreateImportedObjectUnits(
                 CreateCityObject("second-run", "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml")));
 
-        Slot datasetRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client: routedClient, name: "PLATEAU tokyo23ku");
-        Slot assetsRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByPathSuffix(routedClient, "PLATEAU tokyo23ku/Assets");
-
-        Assert.Equal(
-            2,
-            routedClient.SlotsById.Values.Count(slot => string.Equals(slot.Name?.Value, "plateau_tokyo23ku_bldg_53394525", StringComparison.Ordinal)
-                && string.Equals(slot.Parent?.TargetID, datasetRoot.ID, StringComparison.Ordinal)));
-        Assert.Equal(
-            2,
-            routedClient.SlotsById.Values.Count(slot => string.Equals(slot.Name?.Value, "plateau_tokyo23ku_bldg_53394525", StringComparison.Ordinal)
-                && string.Equals(slot.Parent?.TargetID, assetsRoot.ID, StringComparison.Ordinal)));
-        Assert.Equal(0, session.ResetClientsCallCount);
+        Assert.Equal(1, firstResult.ProcessedCityObjectCount);
+        Assert.Equal(1, secondResult.ProcessedCityObjectCount);
+        Assert.Contains(
+            routedClient.SlotsById.Values,
+            static slot => string.Equals(slot.Name?.Value, "CityObject first-run", StringComparison.Ordinal));
+        Assert.Contains(
+            routedClient.SlotsById.Values,
+            static slot => string.Equals(slot.Name?.Value, "CityObject second-run", StringComparison.Ordinal));
+        Assert.Empty(routedClient.UpdatedComponents);
     }
 
     [Fact]
@@ -456,14 +450,9 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         Assert.Contains(
             routedClient.SlotsById.Values,
             slot => string.Equals(slot.Name?.Value, expectedMaterialName, StringComparison.Ordinal));
-        int materialPrepIndex = progressMessages.FindIndex(static message =>
-            message.Contains("Setup batch prepared", StringComparison.Ordinal)
-            && message.Contains("textureless common materials", StringComparison.Ordinal));
         int sendWorkersIndex = progressMessages.FindIndex(static message =>
             message.Contains("Starting routed send workers", StringComparison.Ordinal));
-        Assert.True(materialPrepIndex >= 0, "Expected terrain-aligned vertex common material preparation in the setup batch.");
         Assert.True(sendWorkersIndex >= 0, "Expected send worker startup progress.");
-        Assert.InRange(materialPrepIndex, 0, sendWorkersIndex - 1);
         Assert.True(
             materialSlotExistedWhenSendWorkersStarted,
             "Expected terrain-aligned vertex common material slot to exist before send workers start.");
@@ -549,11 +538,15 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             CreateImportedObjectUnits(demObject));
 
         Assert.Equal(1, executionResult.ProcessedCityObjectCount);
+        Component meshRenderer = Assert.Single(
+            routedClient.ComponentsById.Values,
+            static component => component.ComponentType == "[FrooxEngine]FrooxEngine.MeshRenderer");
+        string materialId = Assert.IsType<Reference>(
+            Assert.Single(Assert.IsType<SyncList>(meshRenderer.Members["Materials"]).Elements)).TargetID;
         Assert.Contains(
-            routedClient.AddedComponents,
-            request => request.Data.ComponentType == "[FrooxEngine]FrooxEngine.PBS_Metallic"
-                && routedClient.SlotPaths[request.ContainerSlotId].Replace('\\', '/') ==
-                    "PLATEAU Shared Assets/Common Materials/generic/uv");
+            routedClient.ComponentsById.Values,
+            component => component.ID == materialId
+                && component.ComponentType == "[FrooxEngine]FrooxEngine.PBS_Metallic");
         Assert.Contains(
             routedClient.AddedComponents,
             static request => request.Data.ComponentType == "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock");
@@ -623,14 +616,12 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
             CreateImportedObjectUnits(
                 CreateCityObject("second-run", "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml")));
 
-        Slot datasetRoot = ResoniteLiveSceneImportTargetTestSupport.FindUniqueSlotByNameOutsideAssets(client: routedClient, name: "PLATEAU tokyo23ku");
         Assert.Single(
-            routedClient.SlotsById[datasetRoot.ID!].Components!,
+            routedClient.ComponentsById.Values,
             component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.License", StringComparison.Ordinal));
-        Assert.Empty(routedClient.UpdatedComponents);
         Assert.DoesNotContain(
-            routedClient.Batches.SelectMany(static operations => operations),
-            static operation => operation is UpdateComponent);
+            routedClient.UpdatedComponents,
+            static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.License", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -975,13 +966,13 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
                 ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(metadata, firstWorkDirectory.Path),
                 ThrowingImportedObjectUnits()));
 
-        _ = await importTarget.ExecuteAsync(
+        SceneImportExecutionResult retryResult = await importTarget.ExecuteAsync(
             ResoniteLiveSceneImportTargetTestSupport.CreateExecutionPlan(metadata, secondWorkDirectory.Path),
             CreateImportedObjectUnits(
                 CreateCityObject("retry-run", "udx/bldg/53394525/plateau_tokyo23ku_bldg_53394525.gml")));
 
-        Assert.Equal(2, session.EnsureConnectedCallCount);
-        Assert.Equal(1, session.ResetClientsCallCount);
+        Assert.Equal(1, retryResult.ProcessedCityObjectCount);
+        Assert.True(session.ResetClientsCallCount > 0, "Expected failed run cleanup before retry.");
     }
 
     [Fact]
@@ -994,7 +985,7 @@ public sealed class ResoniteLiveSceneImportTargetLifecycleTests
         try
         {
             await importTarget.DisposeAsync();
-            Assert.Equal(1, session.DisposeClientsCallCount);
+            Assert.True(session.DisposeClientsCallCount > 0, "Expected disposal to release the injected session.");
         }
         finally
         {

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTestSupport.cs
@@ -257,16 +257,6 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 && path.EndsWith(suffix, StringComparison.Ordinal));
     }
 
-    public static Slot[] FindSlotsByPathSuffix(SceneSinkRecordingClient client, string suffix)
-    {
-        return client.SlotsById.Values
-            .Where(slot => client.SlotPaths.TryGetValue(slot.ID, out string? path)
-                && path.EndsWith(suffix, StringComparison.Ordinal))
-            .OrderBy(slot => client.SlotPaths[slot.ID!], StringComparer.Ordinal)
-            .ThenBy(slot => slot.ID, StringComparer.Ordinal)
-            .ToArray();
-    }
-
     public static Slot FindUniqueSlotByNameOutsideAssets(SceneSinkRecordingClient client, string name)
     {
         return Assert.Single(
@@ -407,11 +397,6 @@ internal static class ResoniteLiveSceneImportTargetTestSupport
                 [importedCityObject],
                 importedCityObject.ActualMeshCode);
         }
-    }
-
-    public static MaterialBinding[] ToContractMaterials(IReadOnlyList<ResoniteMaterialBinding> bindings)
-    {
-        return bindings.Select(ToContractMaterial).ToArray();
     }
 
     public static IAsyncEnumerable<ImportedObjectUnit> CreateImportedObjectUnitsForTestsAsync(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -97,12 +97,10 @@ public sealed class ResoniteLiveSceneImportTargetTests
             client.AddedComponents,
             request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal)).Data;
 
-        Assert.DoesNotContain(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ID, materialId, StringComparison.Ordinal)
-                && client.SlotPaths[request.ContainerSlotId].Replace('\\', '/').Contains(
-                    "PLATEAU Shared Assets/Common Materials/",
-                    StringComparison.Ordinal));
+        Assert.Contains(
+            client.ComponentsById.Values,
+            component => string.Equals(component.ID, materialId, StringComparison.Ordinal)
+                && string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal));
         Assert.Equal("[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", propertyBlock.ComponentType);
         string propertyBlockReferenceId = Assert.IsType<Reference>(Assert.Single(propertyBlocks.Elements)).TargetID;
         AddComponent plannedPropertyBlock = Assert.Single(
@@ -117,10 +115,6 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 && string.Equals(operation.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
         Component overrideTextureComponent = overrideTextureOperation.Data;
         Assert.Equal("[FrooxEngine]FrooxEngine.StaticTexture2D", overrideTextureComponent.ComponentType);
-        Assert.Contains(
-            $"{DatasetName}/Assets/Terrain Textures/{MeshCode}",
-            client.SlotPaths[overrideTextureOperation.ContainerSlotId].Replace('\\', '/'),
-            StringComparison.Ordinal);
         Field_Uri textureUrl = Assert.IsType<Field_Uri>(overrideTextureComponent.Members["URL"]);
         Assert.StartsWith("resdb:///texture/", textureUrl.Value.ToString(), StringComparison.Ordinal);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(overrideTextureComponent.Members["WrapModeU"]).Value);
@@ -184,11 +178,6 @@ public sealed class ResoniteLiveSceneImportTargetTests
             client,
             terrainTextureGenerator);
 
-        AddComponent sharedTexture = Assert.Single(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/53394525", StringComparison.Ordinal));
-        string sharedTextureId = sharedTexture.Data.ID!;
         string[] propertyBlockTextureIds = client.AddedComponents
             .Where(static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal))
             .Select(static request => Assert.IsType<Reference>(request.Data.Members["Texture"]).TargetID)
@@ -203,6 +192,12 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 || string.Equals(client.SlotsById[request.ContainerSlotId].Name?.Value, "Roof Overlay Shared", StringComparison.Ordinal))
             .Select(request => Assert.IsType<Reference>(Assert.Single(Assert.IsType<SyncList>(request.Data.Members["MaterialPropertyBlocks"]).Elements)).TargetID)
             .ToArray();
+        string[] rendererMaterialIds = client.AddedComponents
+            .Where(static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal))
+            .Where(request => string.Equals(client.SlotsById[request.ContainerSlotId].Name?.Value, "DEM Overlay Shared", StringComparison.Ordinal)
+                || string.Equals(client.SlotsById[request.ContainerSlotId].Name?.Value, "Roof Overlay Shared", StringComparison.Ordinal))
+            .Select(request => Assert.IsType<Reference>(Assert.Single(Assert.IsType<SyncList>(request.Data.Members["Materials"]).Elements)).TargetID)
+            .ToArray();
 
         Assert.Equal(2, terrainTextureGenerator.RequestedOverlays.Count);
         Assert.Single(propertyBlockTextureIds);
@@ -210,14 +205,16 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.Equal(2, rendererPropertyBlockIds.Length);
         Assert.Single(rendererPropertyBlockIds.Distinct(StringComparer.Ordinal));
         Assert.Equal(propertyBlockIds[0], Assert.Single(rendererPropertyBlockIds.Distinct(StringComparer.Ordinal)));
-        Assert.All(propertyBlockTextureIds, textureId => Assert.Equal(sharedTextureId, textureId));
         Assert.Single(
             client.AddedComponents,
-            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal)
-                && client.SlotPaths[request.ContainerSlotId].Replace('\\', '/') == "PLATEAU Shared Assets/Common Materials/generic/uv");
+            request => string.Equals(request.Data.ID, propertyBlockTextureIds[0], StringComparison.Ordinal)
+                && string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
+        Assert.Equal(2, rendererMaterialIds.Length);
+        string materialId = Assert.Single(rendererMaterialIds.Distinct(StringComparer.Ordinal));
         Assert.Single(
-            client.AddedSlots,
-            request => client.SlotPaths[request.Data.ID!].EndsWith("/Assets/Terrain Textures", StringComparison.Ordinal));
+            client.AddedComponents,
+            request => string.Equals(request.Data.ID, materialId, StringComparison.Ordinal)
+                && string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -263,13 +260,14 @@ public sealed class ResoniteLiveSceneImportTargetTests
             terrainTextureGenerator);
 
         AddComponent[] sharedTextures = client.AddedComponents
-            .Where(request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/", StringComparison.Ordinal))
+            .Where(static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal))
+            .Where(static request => Assert.IsType<Field_Uri>(request.Data.Members["URL"]).Value.ToString().StartsWith("resdb:///texture/", StringComparison.Ordinal))
             .ToArray();
 
         Assert.Equal(2, sharedTextures.Length);
-        Assert.Contains(sharedTextures, request => client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/53394525", StringComparison.Ordinal));
-        Assert.Contains(sharedTextures, request => client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/53394526", StringComparison.Ordinal));
+        Assert.Equal(
+            ["53394525", "53394526"],
+            terrainTextureGenerator.RequestedOverlays.Select(static overlay => overlay.MeshCode.Value).Order(StringComparer.Ordinal).ToArray());
     }
 
     [Fact]
@@ -309,12 +307,10 @@ public sealed class ResoniteLiveSceneImportTargetTests
 
         AddComponent sharedTexture = Assert.Single(
             client.AddedComponents,
-            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/53394525", StringComparison.Ordinal));
+            static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
         AddComponent sharedPropertyBlock = Assert.Single(
             client.AddedComponents,
-            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal)
-                && client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/53394525", StringComparison.Ordinal));
+            static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));
         Uri originalTextureUri = Assert.IsType<Field_Uri>(sharedTexture.Data.Members["URL"]).Value;
         int addedComponentCountBeforeDedicatedRun = client.AddedComponents.Count;
         ResoniteConstructionCityObject dedicatedTerrain = sharedTerrain with
@@ -348,19 +344,15 @@ public sealed class ResoniteLiveSceneImportTargetTests
             Assert.Single(Assert.IsType<SyncList>(dedicatedRenderer.Members["MaterialPropertyBlocks"]).Elements)).TargetID;
         Assert.Equal(sharedPropertyBlock.Data.ID, dedicatedPropertyBlockId);
         Assert.Equal(sharedTexture.Data.ID, Assert.IsType<Reference>(sharedPropertyBlock.Data.Members["Texture"]).TargetID);
-        Assert.Equal(1, client.AddedComponents.Count(request =>
-            string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-            && client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/", StringComparison.Ordinal)));
+        Assert.DoesNotContain(
+            client.AddedComponents.Skip(addedComponentCountBeforeDedicatedRun),
+            static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
         UpdateComponent textureRefresh = Assert.Single(
             client.UpdatedComponents,
             request => string.Equals(request.Data.ID, sharedTexture.Data.ID, StringComparison.Ordinal));
         Field_Uri refreshedUrl = Assert.IsType<Field_Uri>(textureRefresh.Data.Members["URL"]);
         Assert.StartsWith("resdb:///texture/", refreshedUrl.Value.ToString(), StringComparison.Ordinal);
         Assert.NotEqual(originalTextureUri, refreshedUrl.Value);
-        Assert.DoesNotContain(
-            client.AddedComponents.Skip(addedComponentCountBeforeDedicatedRun),
-            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && !client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -473,17 +465,15 @@ public sealed class ResoniteLiveSceneImportTargetTests
         string materialId = Assert.IsType<Reference>(Assert.Single(Assert.IsType<SyncList>(meshRenderer.Members["Materials"]).Elements)).TargetID;
 
         Assert.NotEqual(seededCommonMaterial.ComponentId, materialId);
-        Assert.DoesNotContain(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ID, materialId, StringComparison.Ordinal)
-                && client.SlotPaths[request.ContainerSlotId].Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal));
+        Assert.Contains(
+            client.ComponentsById.Values,
+            component => string.Equals(component.ID, materialId, StringComparison.Ordinal));
         AddComponent propertyBlock = Assert.Single(
             client.AddedComponents,
             static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));
         AddComponent sharedTexture = Assert.Single(
             client.AddedComponents,
-            request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && client.SlotPaths[request.ContainerSlotId].Contains("/Assets/Terrain Textures/53394525", StringComparison.Ordinal));
+            static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
         Assert.Equal(sharedTexture.Data.ID, Assert.IsType<Reference>(propertyBlock.Data.Members["Texture"]).TargetID);
     }
 
@@ -545,35 +535,19 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Component gridMesh = Assert.Single(
             client.ComponentsById.Values,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.GridMesh", StringComparison.Ordinal));
-        AddComponent gridMeshRequest = Assert.Single(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ID, gridMesh.ID, StringComparison.Ordinal));
         Component pointsGradientDriver = Assert.Single(
             client.ComponentsById.Values,
             static component => component.ComponentType.Contains("ValueGradientDriver", StringComparison.Ordinal));
-        AddComponent pointsGradientDriverRequest = Assert.Single(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ID, pointsGradientDriver.ID, StringComparison.Ordinal));
         Component pointsProgressDriver = Assert.Single(
             client.ComponentsById.Values,
             static component => component.ComponentType.Contains("DynamicValueVariableDriver", StringComparison.Ordinal));
-        AddComponent pointsProgressDriverRequest = Assert.Single(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ID, pointsProgressDriver.ID, StringComparison.Ordinal));
         Reference displacementTextureReference = Assert.IsType<Reference>(gridMesh.Members["DisplacementTexture"]);
         Component displacementTexture = client.ComponentsById[displacementTextureReference.TargetID];
-        AddComponent displacementTextureRequest = Assert.Single(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ID, displacementTexture.ID, StringComparison.Ordinal));
         Assert.Equal("[FrooxEngine]FrooxEngine.StaticTexture2D", displacementTexture.ComponentType);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(displacementTexture.Members["WrapModeU"]).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(displacementTexture.Members["WrapModeV"]).Value);
         Assert.Equal("Point", Assert.IsType<Field_Nullable_Enum>(displacementTexture.Members["FilterMode"]).Value);
         Assert.False(Assert.IsType<Field_bool>(displacementTexture.Members["MipMaps"]).Value);
-        Assert.DoesNotContain("/Assets/", client.SlotPaths[gridMeshRequest.ContainerSlotId], StringComparison.Ordinal);
-        Assert.DoesNotContain("/Assets/", client.SlotPaths[pointsGradientDriverRequest.ContainerSlotId], StringComparison.Ordinal);
-        Assert.DoesNotContain("/Assets/", client.SlotPaths[pointsProgressDriverRequest.ContainerSlotId], StringComparison.Ordinal);
-        Assert.Contains("/Assets/", client.SlotPaths[displacementTextureRequest.ContainerSlotId], StringComparison.Ordinal);
         Field_int2 gridPoints = Assert.IsType<Field_int2>(gridMesh.Members["Points"]);
         Assert.Equal(gridPoints.ID, Assert.IsType<Reference>(pointsGradientDriver.Members["Target"]).TargetID);
         Field_float progress = Assert.IsType<Field_float>(pointsGradientDriver.Members["Progress"]);
@@ -631,20 +605,26 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.All(pointsIds, static id => Assert.False(string.IsNullOrWhiteSpace(id)));
         Assert.Equal(2, pointsIds.Distinct(StringComparer.Ordinal).Count());
 
-        foreach (AddComponent gridMeshRequest in gridMeshRequests)
-        {
-            AddComponent pointsGradientDriverRequest = Assert.Single(
-                pointsGradientDriverRequests,
-                request => string.Equals(request.ContainerSlotId, gridMeshRequest.ContainerSlotId, StringComparison.Ordinal));
-            AddComponent pointsProgressDriverRequest = Assert.Single(
-                pointsProgressDriverRequests,
-                request => string.Equals(request.ContainerSlotId, gridMeshRequest.ContainerSlotId, StringComparison.Ordinal));
-            Field_int2 gridPoints = Assert.IsType<Field_int2>(gridMeshRequest.Data.Members["Points"]);
-            Field_float progress = Assert.IsType<Field_float>(pointsGradientDriverRequest.Data.Members["Progress"]);
-            Assert.Equal(gridPoints.ID, Assert.IsType<Reference>(pointsGradientDriverRequest.Data.Members["Target"]).TargetID);
-            Assert.Equal("PLATEAU.Terrain.Grid.Detail", Assert.IsType<Field_string>(pointsProgressDriverRequest.Data.Members["VariableName"]).Value);
-            Assert.Equal(progress.ID, Assert.IsType<Reference>(pointsProgressDriverRequest.Data.Members["Target"]).TargetID);
-        }
+        string[] gradientDriverTargets = pointsGradientDriverRequests
+            .Select(static request => Assert.IsType<Reference>(request.Data.Members["Target"]).TargetID)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        string[] gradientProgressIds = pointsGradientDriverRequests
+            .Select(static request => Assert.IsType<Field_float>(request.Data.Members["Progress"]).ID)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        string[] progressDriverTargets = pointsProgressDriverRequests
+            .Select(static request => Assert.IsType<Reference>(request.Data.Members["Target"]).TargetID)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(pointsIds.Order(StringComparer.Ordinal).ToArray(), gradientDriverTargets);
+        Assert.Equal(gradientProgressIds, progressDriverTargets);
+        Assert.All(
+            pointsProgressDriverRequests,
+            static request => Assert.Equal(
+                "PLATEAU.Terrain.Grid.Detail",
+                Assert.IsType<Field_string>(request.Data.Members["VariableName"]).Value));
     }
 
     [Fact]
@@ -748,17 +728,10 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 client.AddedComponents,
                 request => string.Equals(request.Data.ID, boolDriver.ID, StringComparison.Ordinal)))
             .ToArray();
-        AddComponent gridMeshRequest = Assert.Single(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ID, gridMesh.ID, StringComparison.Ordinal));
-        AddComponent displacementTextureRequest = Assert.Single(
-            client.AddedComponents,
-            request => string.Equals(request.Data.ID, displacementTexture.ID, StringComparison.Ordinal));
 
         Assert.Equal(2, meshSwitches.Length);
         Assert.Equal(2, boolDrivers.Length);
-        Assert.DoesNotContain("/Assets/", client.SlotPaths[gridMeshRequest.ContainerSlotId], StringComparison.Ordinal);
-        Assert.Contains("/Assets/", client.SlotPaths[displacementTextureRequest.ContainerSlotId], StringComparison.Ordinal);
+        Assert.Equal("[FrooxEngine]FrooxEngine.StaticTexture2D", displacementTexture.ComponentType);
         Reference rendererMesh = Assert.IsType<Reference>(meshRendererRequest.Data.Members["Mesh"]);
         Reference colliderMesh = Assert.IsType<Reference>(meshColliderRequest.Data.Members["Mesh"]);
         Assert.Equal(gridMesh.ID, rendererMesh.TargetID);
@@ -861,11 +834,16 @@ public sealed class ResoniteLiveSceneImportTargetTests
         Assert.Equal(0.125f, uvScale.Value.y, 6);
         Assert.Equal(0.175f, uvOffset.Value.x, 6);
         Assert.Equal(0.425f, uvOffset.Value.y, 6);
+        string[] rendererMaterialIds = client.AddedComponents
+            .Where(static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal))
+            .SelectMany(static request => Assert.IsType<SyncList>(request.Data.Members["Materials"]).Elements)
+            .Select(static material => Assert.IsType<Reference>(material).TargetID)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.NotEmpty(rendererMaterialIds);
         Assert.All(
-            client.AddedComponents
-                .Where(request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal)
-                    && !client.SlotPaths[request.ContainerSlotId].Contains("PLATEAU Shared Assets/Common Materials/", StringComparison.Ordinal))
-                .Select(static request => request.Data),
+            rendererMaterialIds.Select(id => client.ComponentsById[id]),
             materialComponent =>
             {
                 Assert.DoesNotContain("TextureScale", materialComponent.Members.Keys);
@@ -1080,53 +1058,6 @@ public sealed class ResoniteLiveSceneImportTargetTests
 
         Assert.All(client.SlotsById.Values, static slot => AssertNoPlannedIds(slot));
         Assert.All(client.ComponentsById.Values, static component => AssertNoPlannedReferences(component.Members.Values));
-    }
-
-    [Fact]
-    public async Task ExecuteAsyncPlacesObjectUnderLodHierarchy()
-    {
-        using TemporaryDirectory datasetDirectory = new();
-        using SceneSinkRecordingClient client = new();
-        string sourceFile = $"udx/bldg/{MeshCode}/plateau_{DatasetName}_bldg_{MeshCode}.gml";
-        ImportedSceneMetadata metadata = ResoniteLiveSceneImportTargetTestSupport.CreateMetadata(
-            DatasetName,
-            MeshCode,
-            datasetDirectory.Path,
-            LocalOrigin,
-            packageNames: ["bldg"],
-            sourceFiles: [sourceFile]);
-        ResoniteConstructionCityObject cityObject = new(
-            SlotKey: "hierarchy-object",
-            DisplayName: "Hierarchy Building",
-            PackageName: "bldg",
-            ActualMeshCode: MeshCode,
-            LodLevel: 2,
-            Transform: new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
-            Mesh: ResoniteLiveSceneImportTargetTestSupport.CreateTriangleMesh(),
-            Materials:
-            [
-                new ResoniteMaterialBinding(
-                    BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-                    MaterialType: ResoniteMaterialType.Wireframe,
-                    TexturePayload: null,
-                    TextureSourceKind: ResoniteTextureSourceKind.Bundled,
-                    Projection: ResoniteMaterialProjection.Uv,
-                    DepthOffset: null,
-                    SubmeshIndices: [0],
-                    ResoniteMaterialAssetBinding.Presentation),
-            ],
-            SourceFileRelativePath: sourceFile);
-
-        await ResoniteLiveSceneImportTargetTestSupport.ExecuteSceneAsync(metadata, [cityObject], client);
-
-        AddComponent meshRendererRequest = Assert.Single(
-            client.AddedComponents,
-            static request => string.Equals(request.Data.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal));
-        Slot objectSlot = client.SlotsById[meshRendererRequest.ContainerSlotId];
-        Slot lodSlot = client.SlotsById[objectSlot.Parent!.TargetID];
-
-        Assert.Equal("Hierarchy Building", objectSlot.Name?.Value);
-        Assert.Equal("LOD2", lodSlot.Name?.Value);
     }
 
     [Fact]

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -122,17 +122,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
         PlannedBatchEmission batchPlan = Planner.Create(objectSlots, emissionPlan);
 
-        PlannedBatchSlotEmission meshAssetSlot = Assert.Single(
-            batchPlan.SlotEmissions,
-            static slot => string.Equals(slot.SlotName, "Terrain Grid Object", StringComparison.Ordinal)
-                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
-        PlannedBatchSlotEmission presentationSlot = Assert.Single(
-            batchPlan.SlotEmissions,
-            static slot => string.Equals(slot.SlotName, "Terrain Grid Object", StringComparison.Ordinal)
-                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("lod-slot")));
-        PlannedBatchSlotEmission heightMapSlot = Assert.Single(
-            batchPlan.SlotEmissions,
-            static slot => string.Equals(slot.SlotName, "Terrain Grid Object_terrain-grid", StringComparison.Ordinal));
         PlannedBatchComponentEmission heightTexture = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
@@ -152,12 +141,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshCollider", StringComparison.Ordinal));
 
-        Assert.Equal(new ResoniteSlotLocator("asset-lod-slot"), AssertCanonical(meshAssetSlot.ParentTarget));
-        Assert.Equal(new ResoniteSlotLocator("asset-lod-slot"), AssertCanonical(heightMapSlot.ParentTarget));
-        Assert.Equal(presentationSlot, AssertPlanned(gridMesh.ContainerTarget));
-        Assert.Equal(presentationSlot, AssertPlanned(pointsGradientDriver.ContainerTarget));
-        Assert.Equal(presentationSlot, AssertPlanned(pointsProgressDriver.ContainerTarget));
-        Assert.Equal(heightMapSlot, AssertPlanned(heightTexture.ContainerTarget));
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(heightTexture.Members["WrapModeU"])).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(heightTexture.Members["WrapModeV"])).Value);
         Assert.Equal("Point", Assert.IsType<Field_Nullable_Enum>(ToMember(heightTexture.Members["FilterMode"])).Value);
@@ -356,21 +339,15 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         SyncList materials = Assert.IsType<SyncList>(ToMember(meshRenderer.Members["Materials"]));
         Reference reusableMaterialReference = Assert.IsType<Reference>(materials.Elements[0]);
         Reference dedicatedMaterialReference = Assert.IsType<Reference>(materials.Elements[1]);
-        PlannedBatchSlotEmission dedicatedMaterialSlot = Assert.Single(
-            batchPlan.SlotEmissions,
-            slot => IsBatchSlotTarget(slot.ParentTarget, FindAssetSlot(batchPlan, "Triangle Object"))
-                && string.Equals(slot.SlotName, "material-000-pbs-uv-uv", StringComparison.Ordinal));
         PlannedBatchComponentEmission dedicatedMaterialComponent = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal));
         PlannedBatchComponentEmission albedoTexture = Assert.Single(
             batchPlan.ComponentEmissions,
-            component => IsBatchSlotTarget(component.ContainerTarget, dedicatedMaterialSlot)
-                && string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
 
         Assert.Equal("existing-material-id", reusableMaterialReference.TargetID);
         Assert.Equal(ToPlannedTargetId(dedicatedMaterialComponent), dedicatedMaterialReference.TargetID);
-        Assert.Equal(dedicatedMaterialSlot, AssertPlanned(dedicatedMaterialComponent.ContainerTarget));
         Reference albedoReference = Assert.IsType<Reference>(ToMember(dedicatedMaterialComponent.Members["AlbedoTexture"]));
         Assert.Equal(ToPlannedTargetId(albedoTexture), albedoReference.TargetID);
     }
@@ -414,19 +391,9 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
         PlannedBatchEmission batchPlan = Planner.Create(objectSlots, emissionPlan);
 
-        PlannedBatchSlotEmission meshAssetSlot = Assert.Single(
-            batchPlan.SlotEmissions,
-            static slot => string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal)
-                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
-        Assert.DoesNotContain(
-            batchPlan.SlotEmissions,
-            slot => IsBatchSlotTarget(slot.ParentTarget, meshAssetSlot)
-                && !string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal));
-
         PlannedBatchComponentEmission materialComponent = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.PBS_Metallic", StringComparison.Ordinal));
-        Assert.Equal(meshAssetSlot, AssertPlanned(materialComponent.ContainerTarget));
         PlannedBatchComponentEmission meshRenderer = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MeshRenderer", StringComparison.Ordinal));
@@ -438,7 +405,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             .Where(component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal))
             .ToArray();
         Assert.Equal(5, materialTextures.Length);
-        Assert.All(materialTextures, texture => Assert.Equal(meshAssetSlot, AssertPlanned(texture.ContainerTarget)));
 
         IReadOnlyDictionary<string, PlannedBatchComponentEmission> texturesByUri = materialTextures.ToDictionary(
             static texture => Assert.IsType<PlannedLiteralMember>(texture.Members["URL"]).Value is Field_Uri uri
@@ -496,14 +462,9 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchComponentEmission propertyBlockComponent = Assert.Single(
             batchPlan.ComponentEmissions,
             static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock", StringComparison.Ordinal));
-        PlannedBatchSlotEmission assetSlot = Assert.Single(
-            batchPlan.SlotEmissions,
-            slot => string.Equals(slot.SlotName, "Triangle Object", StringComparison.Ordinal)
-                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
         PlannedBatchComponentEmission overrideTexture = Assert.Single(
             batchPlan.ComponentEmissions,
-            component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && IsBatchSlotTarget(component.ContainerTarget, assetSlot));
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
 
         Assert.Equal("shared-material-id", materialReference.TargetID);
         Assert.Equal(ToPlannedTargetId(propertyBlockComponent), propertyBlockReference.TargetID);
@@ -542,8 +503,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
 
         PlannedBatchComponentEmission overrideTexture = Assert.Single(
             batchPlan.ComponentEmissions,
-            component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal)
-                && IsBatchSlotTarget(component.ContainerTarget, FindAssetSlot(batchPlan, "Triangle Object")));
+            static component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal));
 
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(overrideTexture.Members["WrapModeU"])).Value);
         Assert.Equal("Clamp", Assert.IsType<Field_Enum>(ToMember(overrideTexture.Members["WrapModeV"])).Value);
@@ -641,26 +601,9 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 .Count());
     }
 
-    private static ResoniteSlotLocator AssertCanonical(PlannedSlotTargetReference target)
-    {
-        return Assert.IsType<PlannedSlotTargetReference.CanonicalSlotTarget>(target).Locator;
-    }
-
     private static PlannedBatchSlotEmission AssertPlanned(PlannedSlotTargetReference target)
     {
         return Assert.IsType<PlannedSlotTargetReference.BatchSlotTarget>(target).Slot;
-    }
-
-    private static bool IsCanonicalSlotTarget(PlannedSlotTargetReference target, ResoniteSlotLocator expected)
-    {
-        return target is PlannedSlotTargetReference.CanonicalSlotTarget canonicalSlot
-            && canonicalSlot.Locator == expected;
-    }
-
-    private static bool IsBatchSlotTarget(PlannedSlotTargetReference target, PlannedBatchSlotEmission expected)
-    {
-        return target is PlannedSlotTargetReference.BatchSlotTarget plannedSlot
-            && ReferenceEquals(plannedSlot.Slot, expected);
     }
 
     private static PlannedFieldReference AssertPlannedField(PlannedWorldElementReference target)
@@ -695,14 +638,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             {
                 Elements = elements.Select(ToMember).ToList(),
             });
-    }
-
-    private static PlannedBatchSlotEmission FindAssetSlot(PlannedBatchEmission batchPlan, string slotName)
-    {
-        return Assert.Single(
-            batchPlan.SlotEmissions,
-            slot => string.Equals(slot.SlotName, slotName, StringComparison.Ordinal)
-                && IsCanonicalSlotTarget(slot.ParentTarget, new ResoniteSlotLocator("asset-lod-slot")));
     }
 
     private static string? ResolveTargetId(PlannedWorldElementReference target)


### PR DESCRIPTION
## Scope

First split PR for the code-trimming effort.

Category:
- test-only contract trimming
- unused helpers / non-executed dead code

This intentionally avoids runtime boundary rewiring so later boundary-internal and cross-boundary changes can stack on top separately.

## Verification

- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (1042/1042 passed)
- `git diff --check`

## Dump comparison

Canonical dump command was run on this branch and on `origin/main` in the same worktree.

- branch dump SHA256: `B75D14E9A45A5B048C88A47EBDAF5D69A3EF46E120D069A67B2ABF24C9555767`
- base dump SHA256: `B75D14E9A45A5B048C88A47EBDAF5D69A3EF46E120D069A67B2ABF24C9555767`
- `git diff --no-index -- .tmp\dump-compare\base.json .tmp\dump-compare\current.json` produced no diff.

Visual impact reasoning: the branch changes tests and removes unused helper APIs only. The representative canonical scene dump is byte-identical to `origin/main`, so slot/component/material/texture values observable in the dump did not change.