### PR TITLE
[codex] Remove bundled material temp extraction

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/BundledDefaultMaterialAssetStore.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/BundledDefaultMaterialAssetStore.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 
 using PlateauResoniteLink.Domain.Importing;
 
@@ -16,94 +15,42 @@ namespace PlateauResoniteLink.Targets.Resonite;
 internal sealed class BundledDefaultMaterialAssetStore
 {
     private const string ResourceRoot = "PlateauResoniteLink.Assets.DefaultMaterials.";
-    private static readonly object SyncRoot = new();
     private static readonly Assembly Assembly = typeof(BundledDefaultMaterialAssetStore).Assembly;
     private static readonly HashSet<string> ResourceNames = Assembly
         .GetManifestResourceNames()
         .ToHashSet(StringComparer.Ordinal);
-    private static readonly Dictionary<string, long> ResourceLengths = new(StringComparer.Ordinal);
-    private static readonly AsyncLocal<string?> ExtractionRootOverride = new();
-    private static readonly string DefaultExtractionRoot = Path.Combine(
-        Path.GetTempPath(),
-        "PlateauResoniteLink",
-        "default-materials",
-        Assembly.ManifestModule.ModuleVersionId.ToString("N"));
 
-    public string GetAbsolutePath(string logicalPath)
+    public Stream OpenRead(string logicalPath)
     {
-        const string logicalPrefix = "default-materials/";
-        if (!logicalPath.StartsWith(logicalPrefix, StringComparison.Ordinal))
-        {
-            throw new InvalidOperationException($"Bundled material path must start with '{logicalPrefix}', but was '{logicalPath}'.");
-        }
-
         string resourceName = GetResourceName(logicalPath);
-
-        string absolutePath = Path.Combine(
-            GetExtractionRoot(),
-            logicalPath.Replace('/', Path.DirectorySeparatorChar));
-        string? directory = Path.GetDirectoryName(absolutePath);
-        if (directory is null)
-        {
-            throw new InvalidOperationException($"Could not determine extraction directory for '{logicalPath}'.");
-        }
-
-        lock (SyncRoot)
-        {
-            if (ResourceLengths.TryGetValue(resourceName, out long expectedLength)
-                && TryGetExistingFileLength(absolutePath, out long existingLength)
-                && existingLength == expectedLength)
-            {
-                return absolutePath;
-            }
-
-            using Stream resourceStream = Assembly.GetManifestResourceStream(resourceName)
-                ?? throw new InvalidOperationException($"Embedded resource '{resourceName}' was not found.");
-            ResourceLengths[resourceName] = resourceStream.Length;
-            if (TryGetExistingFileLength(absolutePath, out existingLength)
-                && existingLength == resourceStream.Length)
-            {
-                return absolutePath;
-            }
-
-            Directory.CreateDirectory(directory);
-            WriteResourceAtomically(absolutePath, resourceStream);
-        }
-
-        return absolutePath;
+        return Assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded resource '{resourceName}' was not found.");
     }
 
-    public string GetAbsolutePath(BundledDefaultTextureAsset asset)
+    public Stream OpenRead(BundledDefaultTextureAsset asset)
     {
         ArgumentNullException.ThrowIfNull(asset);
-        return GetAbsolutePath(asset.LogicalPath);
+        return OpenRead(asset.LogicalPath);
     }
 
-    public bool TryGetAbsolutePath(string logicalPath, out string absolutePath)
-    {
-        if (!TryGetResourceName(logicalPath, out _))
-        {
-            absolutePath = string.Empty;
-            return false;
-        }
-
-        absolutePath = GetAbsolutePath(logicalPath);
-        return true;
-    }
-
-    public bool TryGetAbsolutePath(BundledDefaultTextureAsset asset, out string absolutePath)
+    public byte[] ReadAllBytes(BundledDefaultTextureAsset asset)
     {
         ArgumentNullException.ThrowIfNull(asset);
-        return TryGetAbsolutePath(asset.LogicalPath, out absolutePath);
+        using Stream stream = OpenRead(asset);
+        using MemoryStream buffer = new();
+        stream.CopyTo(buffer);
+        return buffer.ToArray();
     }
 
-    internal IDisposable PushExtractionRootOverride(string extractionRoot)
+    public bool Contains(string logicalPath)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(extractionRoot);
+        return TryGetResourceName(logicalPath, out _);
+    }
 
-        string? previousRoot = ExtractionRootOverride.Value;
-        ExtractionRootOverride.Value = extractionRoot;
-        return new ExtractionRootOverrideScope(previousRoot);
+    public bool Contains(BundledDefaultTextureAsset asset)
+    {
+        ArgumentNullException.ThrowIfNull(asset);
+        return Contains(asset.LogicalPath);
     }
 
     private static string GetResourceName(string logicalPath)
@@ -149,31 +96,6 @@ internal sealed class BundledDefaultMaterialAssetStore
         return false;
     }
 
-    internal static bool TryGetExistingFileLength(string path, out long length)
-    {
-        try
-        {
-            if (!File.Exists(path))
-            {
-                length = 0;
-                return false;
-            }
-
-            length = new FileInfo(path).Length;
-            return true;
-        }
-        catch (IOException)
-        {
-            length = 0;
-            return false;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            length = 0;
-            return false;
-        }
-    }
-
     private static string CreateNormalizedResourceSuffix(string relativePath)
     {
         string[] segments = relativePath.Split('/');
@@ -188,52 +110,5 @@ internal sealed class BundledDefaultMaterialAssetStore
         }
 
         return string.Join('.', segments);
-    }
-
-    private static string GetExtractionRoot()
-    {
-        return ExtractionRootOverride.Value ?? DefaultExtractionRoot;
-    }
-
-    private static void WriteResourceAtomically(string absolutePath, Stream resourceStream)
-    {
-        string temporaryPath = $"{absolutePath}.{Guid.NewGuid():N}.tmp";
-        try
-        {
-            using (FileStream fileStream = new(
-                temporaryPath,
-                FileMode.CreateNew,
-                FileAccess.Write,
-                FileShare.None))
-            {
-                resourceStream.CopyTo(fileStream);
-            }
-
-            File.Move(temporaryPath, absolutePath, overwrite: true);
-        }
-        finally
-        {
-            if (File.Exists(temporaryPath))
-            {
-                File.Delete(temporaryPath);
-            }
-        }
-    }
-
-    private sealed class ExtractionRootOverrideScope(string? previousRoot) : IDisposable
-    {
-        private readonly string? previousRoot = previousRoot;
-        private bool disposed;
-
-        public void Dispose()
-        {
-            if (disposed)
-            {
-                return;
-            }
-
-            ExtractionRootOverride.Value = previousRoot;
-            disposed = true;
-        }
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -451,10 +451,11 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         string colorProfile,
         CancellationToken cancellationToken)
     {
-        string absolutePath = bundledDefaultMaterialAssetStore.GetAbsolutePath(asset);
-        ITextureImportSource textureSource = ResoniteTextureImportFactory.CreateSourceFromFile(
-            absolutePath,
-            colorProfile);
+        byte[] encodedBytes = bundledDefaultMaterialAssetStore.ReadAllBytes(asset);
+        ITextureImportSource textureSource = TextureImportSourceFactory.CreateInMemoryEncodedImage(
+            colorProfile,
+            encodedBytes,
+            $"bundled:{asset.LogicalPath}");
         return await importClient.ImportTextureAsync(textureSource, cancellationToken);
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialComponentPolicy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialComponentPolicy.cs
@@ -219,7 +219,7 @@ internal static class ResoniteMaterialComponentPolicy
         int variantIndex)
         where TRole : IBundledDefaultTextureRole
     {
-        if (!bundledDefaultMaterialAssetStore.TryGetAbsolutePath(asset, out _))
+        if (!bundledDefaultMaterialAssetStore.Contains(asset))
         {
             throw new InvalidOperationException(
                 $"Could not resolve bundled texture source '{asset.LogicalPath}' "

--- a/tests/PlateauResoniteLink.Tests/Domain/BundledDefaultMaterialVariantTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Domain/BundledDefaultMaterialVariantTests.cs
@@ -197,36 +197,16 @@ public sealed class BundledDefaultMaterialVariantTests
     }
 
     [Fact]
-    public void BundledDefaultMaterialAssetStoreRepairsTruncatedExtractedFile()
+    public void BundledDefaultMaterialAssetStoreReadsBundledResourceWithoutFileMaterialization()
     {
         string logicalPath = BundledDefaultMaterialFamilies.GetVariant(BundledDefaultMaterialFamilies.CityFurniture, 0);
-        using TemporaryDirectory extractionRoot = new();
         BundledDefaultMaterialAssetStore assetStore = new();
-        using IDisposable _ = assetStore.PushExtractionRootOverride(extractionRoot.Path);
-        string extractedPath = Path.Combine(
-            extractionRoot.Path,
-            logicalPath.Replace('/', Path.DirectorySeparatorChar));
-        Directory.CreateDirectory(Path.GetDirectoryName(extractedPath)!);
-        File.WriteAllBytes(extractedPath, [1, 2, 3]);
 
-        string repairedPath = assetStore.GetAbsolutePath(logicalPath);
+        using Stream stream = assetStore.OpenRead(logicalPath);
 
-        Assert.Equal(extractedPath, repairedPath);
-        Assert.True(new FileInfo(repairedPath).Length > 3);
-        using Image image = Image.Load(repairedPath);
+        using Image image = Image.Load(stream);
         Assert.True(image.Width > 0);
         Assert.True(image.Height > 0);
-    }
-
-    [Fact]
-    public void BundledDefaultMaterialAssetStoreTreatsMissingCachedFileLengthAsCacheMiss()
-    {
-        string missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "missing.png");
-
-        bool resolved = BundledDefaultMaterialAssetStore.TryGetExistingFileLength(missingPath, out long length);
-
-        Assert.False(resolved);
-        Assert.Equal(0, length);
     }
 
     [Theory]
@@ -246,7 +226,7 @@ public sealed class BundledDefaultMaterialVariantTests
     [InlineData("default-materials/wallskins/wall_school_public_dark/emission.png")]
     public void KnownBlackEmissionImagesAreNotBundledSources(string logicalPath)
     {
-        Assert.False(new BundledDefaultMaterialAssetStore().TryGetAbsolutePath(logicalPath, out _));
+        Assert.False(new BundledDefaultMaterialAssetStore().Contains(logicalPath));
     }
 
     [Theory]
@@ -271,7 +251,7 @@ public sealed class BundledDefaultMaterialVariantTests
     [InlineData("default-materials/ambientcg/roof/Asphalt025C_2K-JPG_NormalGL.jpg")]
     public void SharedDuplicateTextureImagesAreNotBundledSources(string logicalPath)
     {
-        Assert.False(new BundledDefaultMaterialAssetStore().TryGetAbsolutePath(logicalPath, out _));
+        Assert.False(new BundledDefaultMaterialAssetStore().Contains(logicalPath));
     }
 
     [Theory]
@@ -282,7 +262,7 @@ public sealed class BundledDefaultMaterialVariantTests
     [InlineData("default-materials/texturecan/facade/Others0029_2K_Height.png")]
     public void FlatWhiteTextureCanHeightMapsAreNotBundledSources(string logicalPath)
     {
-        Assert.False(new BundledDefaultMaterialAssetStore().TryGetAbsolutePath(logicalPath, out _));
+        Assert.False(new BundledDefaultMaterialAssetStore().Contains(logicalPath));
     }
 
     private static bool TryGetWallSkinEmissionPath(string texturePath, out string? emissionPath)
@@ -293,7 +273,7 @@ public sealed class BundledDefaultMaterialVariantTests
         Assert.EndsWith(suffix, texturePath, StringComparison.Ordinal);
         string materialName = texturePath[prefix.Length..^suffix.Length];
         string logicalPath = $"default-materials/wallskins/{materialName}/emission.png";
-        if (!new BundledDefaultMaterialAssetStore().TryGetAbsolutePath(logicalPath, out _))
+        if (!new BundledDefaultMaterialAssetStore().Contains(logicalPath))
         {
             emissionPath = null;
             return false;

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialComponentPolicyTests.cs
@@ -298,9 +298,16 @@ public sealed class ResoniteMaterialComponentPolicyTests
 
             Assert.True(resolved);
             Assert.NotNull(textureSet);
-            Assert.True(GetPath(textureSet.Height) is not null && File.Exists(GetPath(textureSet.Height)), $"Missing height companion for facade variant '{variants[variantIndex]}'.");
-            Assert.True(GetPath(textureSet.Metallic) is not null && File.Exists(GetPath(textureSet.Metallic)), $"Missing packed metallic companion for facade variant '{variants[variantIndex]}'.");
-            Assert.True(GetPath(textureSet.Normal) is not null && File.Exists(GetPath(textureSet.Normal)), $"Missing normal companion for facade variant '{variants[variantIndex]}'.");
+            BundledDefaultMaterialAssetStore assetStore = new();
+            Assert.True(
+                textureSet.Height is not null && assetStore.Contains(textureSet.Height),
+                $"Missing height companion for facade variant '{variants[variantIndex]}'.");
+            Assert.True(
+                textureSet.Metallic is not null && assetStore.Contains(textureSet.Metallic),
+                $"Missing packed metallic companion for facade variant '{variants[variantIndex]}'.");
+            Assert.True(
+                textureSet.Normal is not null && assetStore.Contains(textureSet.Normal),
+                $"Missing normal companion for facade variant '{variants[variantIndex]}'.");
         }
     }
 
@@ -336,12 +343,15 @@ public sealed class ResoniteMaterialComponentPolicyTests
     public void BundledDefaultMaterialAssetStoreResolvesCityFurnitureAsset()
     {
         string logicalPath = BundledDefaultMaterialFamilies.GetVariant(BundledDefaultMaterialFamilies.CityFurniture, 0);
+        BundledDefaultMaterialAssetStore assetStore = new();
 
-        bool resolved = new BundledDefaultMaterialAssetStore().TryGetAbsolutePath(logicalPath, out string absolutePath);
+        bool resolved = assetStore.Contains(logicalPath);
 
         Assert.True(resolved);
-        Assert.EndsWith("Plaster002_2K-JPG_Color.jpg", absolutePath, StringComparison.Ordinal);
-        Assert.True(File.Exists(absolutePath));
+        using Stream stream = assetStore.OpenRead(logicalPath);
+        using Image image = Image.Load(stream);
+        Assert.True(image.Width > 0);
+        Assert.True(image.Height > 0);
     }
 
     [Fact]
@@ -371,10 +381,10 @@ public sealed class ResoniteMaterialComponentPolicyTests
         string normalizedHeightPath = GetPath(textureSet.Height)!.Replace('\\', '/');
         string normalizedMetallicPath = GetPath(textureSet.Metallic)!.Replace('\\', '/');
         string normalizedNormalPath = GetPath(textureSet.Normal)!.Replace('\\', '/');
-        Assert.Contains("/default-materials/wallskins/wall_res_plaster_low/", normalizedEmissionPath, StringComparison.Ordinal);
-        Assert.Contains("/default-materials/wallskins/wall_res_plaster_low/", normalizedHeightPath, StringComparison.Ordinal);
-        Assert.Contains("/default-materials/wallskins/wall_res_plaster_low/", normalizedMetallicPath, StringComparison.Ordinal);
-        Assert.Contains("/default-materials/wallskins/wall_res_plaster_low/", normalizedNormalPath, StringComparison.Ordinal);
+        Assert.Contains("default-materials/wallskins/wall_res_plaster_low/", normalizedEmissionPath, StringComparison.Ordinal);
+        Assert.Contains("default-materials/wallskins/wall_res_plaster_low/", normalizedHeightPath, StringComparison.Ordinal);
+        Assert.Contains("default-materials/wallskins/wall_res_plaster_low/", normalizedMetallicPath, StringComparison.Ordinal);
+        Assert.Contains("default-materials/wallskins/wall_res_plaster_low/", normalizedNormalPath, StringComparison.Ordinal);
         Assert.EndsWith("emission.png", GetPath(textureSet.Emission), StringComparison.Ordinal);
         Assert.EndsWith("height.png", GetPath(textureSet.Height), StringComparison.Ordinal);
         Assert.EndsWith("metallic_ao_smoothness.png", GetPath(textureSet.Metallic), StringComparison.Ordinal);
@@ -408,10 +418,10 @@ public sealed class ResoniteMaterialComponentPolicyTests
         string normalizedHeightPath = GetPath(textureSet.Height)!.Replace('\\', '/');
         string normalizedMetallicPath = GetPath(textureSet.Metallic)!.Replace('\\', '/');
         string normalizedNormalPath = GetPath(textureSet.Normal)!.Replace('\\', '/');
-        Assert.Contains("/default-materials/wallskins/wall_res_plaster_low/", normalizedEmissionPath, StringComparison.Ordinal);
-        Assert.Contains("/default-materials/wallskins/wall_res_plaster_dark/", normalizedHeightPath, StringComparison.Ordinal);
-        Assert.Contains("/default-materials/wallskins/wall_res_plaster_low/", normalizedMetallicPath, StringComparison.Ordinal);
-        Assert.Contains("/default-materials/wallskins/wall_res_plaster_dark/", normalizedNormalPath, StringComparison.Ordinal);
+        Assert.Contains("default-materials/wallskins/wall_res_plaster_low/", normalizedEmissionPath, StringComparison.Ordinal);
+        Assert.Contains("default-materials/wallskins/wall_res_plaster_dark/", normalizedHeightPath, StringComparison.Ordinal);
+        Assert.Contains("default-materials/wallskins/wall_res_plaster_low/", normalizedMetallicPath, StringComparison.Ordinal);
+        Assert.Contains("default-materials/wallskins/wall_res_plaster_dark/", normalizedNormalPath, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -440,19 +450,21 @@ public sealed class ResoniteMaterialComponentPolicyTests
         string normalizedHeightPath = GetPath(textureSet.Height)!.Replace('\\', '/');
         string normalizedMetallicPath = GetPath(textureSet.Metallic)!.Replace('\\', '/');
         string normalizedNormalPath = GetPath(textureSet.Normal)!.Replace('\\', '/');
-        Assert.Contains("/default-materials/ambientcg/facade/Facade002_2K-JPG_Emission.jpg", normalizedEmissionPath, StringComparison.Ordinal);
-        Assert.Contains("/default-materials/ambientcg/facade/Facade001_2K-JPG_Height.jpg", normalizedHeightPath, StringComparison.Ordinal);
-        Assert.Contains("/default-materials/ambientcg/facade/Facade001_2K-JPG_Metallic.png", normalizedMetallicPath, StringComparison.Ordinal);
-        Assert.Contains("/default-materials/ambientcg/facade/Facade001_2K-JPG_NormalGL.jpg", normalizedNormalPath, StringComparison.Ordinal);
+        Assert.Contains("default-materials/ambientcg/facade/Facade002_2K-JPG_Emission.jpg", normalizedEmissionPath, StringComparison.Ordinal);
+        Assert.Contains("default-materials/ambientcg/facade/Facade001_2K-JPG_Height.jpg", normalizedHeightPath, StringComparison.Ordinal);
+        Assert.Contains("default-materials/ambientcg/facade/Facade001_2K-JPG_Metallic.png", normalizedMetallicPath, StringComparison.Ordinal);
+        Assert.Contains("default-materials/ambientcg/facade/Facade001_2K-JPG_NormalGL.jpg", normalizedNormalPath, StringComparison.Ordinal);
     }
 
     [Fact]
     public void BundledDefaultCityFurnitureAlbedoStaysNearNeutralWhite()
     {
         string logicalPath = BundledDefaultMaterialFamilies.GetVariant(BundledDefaultMaterialFamilies.CityFurniture, 0);
-        Assert.True(new BundledDefaultMaterialAssetStore().TryGetAbsolutePath(logicalPath, out string absolutePath));
+        BundledDefaultMaterialAssetStore assetStore = new();
+        Assert.True(assetStore.Contains(logicalPath));
 
-        using Image<Rgba32> image = Image.Load<Rgba32>(absolutePath);
+        using Stream stream = assetStore.OpenRead(logicalPath);
+        using Image<Rgba32> image = Image.Load<Rgba32>(stream);
         double totalR = 0.0;
         double totalG = 0.0;
         double totalB = 0.0;
@@ -491,11 +503,11 @@ public sealed class ResoniteMaterialComponentPolicyTests
             string stem = Path.GetFileNameWithoutExtension(logicalPath);
             string metallicLogicalPath = $"{directory}/{stem[..^"_Color".Length]}_Metallic.png";
 
-            Assert.True(
-                new BundledDefaultMaterialAssetStore().TryGetAbsolutePath(metallicLogicalPath, out string absolutePath),
-                $"Missing packed metallic map: {metallicLogicalPath}");
+            BundledDefaultMaterialAssetStore assetStore = new();
+            Assert.True(assetStore.Contains(metallicLogicalPath), $"Missing packed metallic map: {metallicLogicalPath}");
 
-            using Image<Rgba32> image = Image.Load<Rgba32>(absolutePath);
+            using Stream stream = assetStore.OpenRead(metallicLogicalPath);
+            using Image<Rgba32> image = Image.Load<Rgba32>(stream);
             for (int y = 0; y < image.Height; y += 32)
             {
                 for (int x = 0; x < image.Width; x += 32)
@@ -527,7 +539,7 @@ public sealed class ResoniteMaterialComponentPolicyTests
     {
         return asset is null
             ? null
-            : new BundledDefaultMaterialAssetStore().GetAbsolutePath(asset);
+            : asset.LogicalPath;
     }
 
     private static IEnumerable<string> EnumerateBundledDefaultMaterialVariants()


### PR DESCRIPTION
## Summary

- Stop extracting bundled default material resources under `%TEMP%\PlateauResoniteLink\default-materials`.
- Read bundled resources directly as streams/bytes and pass them through the existing in-memory encoded texture path.
- Update bundled material tests so they assert resource availability and image readability instead of materialized temp files.

## Root Cause

Bundled default materials were embedded resources, but `BundledDefaultMaterialAssetStore` materialized them to a temp cache and returned absolute file paths. The live texture import path already converts texture sources into raw payloads before calling ResoniteLink, so the file materialization was not a transport requirement and could accumulate hundreds of MB per build/module version.

## Validation

- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --no-build --verbosity minimal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "FullyQualifiedName~BundledDefaultMaterialVariantTests|FullyQualifiedName~ResoniteMaterialComponentPolicyTests|FullyQualifiedName~ResoniteLinkClientTests"`
- Verified no new `%TEMP%\PlateauResoniteLink\default-materials` directory was created by the targeted test run.
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity minimal -m:1 --disable-build-servers -p:UseSharedCompilation=false`