### PR TITLE
[codex] Refine progress log levels

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -84,7 +84,7 @@ dotnet run --project src/PlateauResoniteLink.Cli -- \
 
 `search` と `stats` は、ローカルの dataset directory とローカル `.zip` / `.7z` archive を inspection します。remote import 自体は引き続き explicit な direct archive URL が必要です。
 
-CLI は既定で timestamp、level、category、message を含む短い .NET 風の console log を出力します。Information レベルの出力には、`Processing CityGML source file 3/18 (17%)` のような粗い import 進捗、live-send counter summary、material setup、最終 send summary が含まれます。file ごと、object ごと、RPC diagnostic、ResoniteLink transport の debug 詳細が必要なときは `--verbose` を付けてください。
+CLI は既定で timestamp、level、category、message を含む短い .NET 風の console log を出力します。Information レベルの出力は phase-oriented で、source discovery、source-scan aggregate progress、live-send ingest / sending counter、setup summary、datasource decision、最終 send summary を表示します。file ごと、object ごと、lane ごと、RPC breakdown、elapsed-time statistics、ResoniteLink transport の詳細は Debug レベルです。必要なときは `--verbose` を付けてください。
 
 `--work-root` を省略した場合、CLI は dataset ごとの archive と live temporary file を `local/<dataset>/` 配下に置きます。terrain tile download は別に local app-data 配下へ既定 cache され、`--terrain-tile-cache-root` で上書き、`--disable-terrain-tile-cache` で cross-run cache を無効化できます。DEM terrain texture source は既定では PLATEAU Ortho から GSI seamless photo tile に fallback できますが、`--exclude-gsi-terrain-tiles` を指定すると GeoTIFF と PLATEAU Ortho のみに限定します。
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ dotnet run --project src/PlateauResoniteLink.Cli -- \
 
 `search` and `stats` inspect local dataset directories and local `.zip` / `.7z` archives. Remote import still requires an explicit direct archive URL.
 
-By default, the CLI writes short .NET-style console log lines with a timestamp, level, category, and message. Information-level output includes coarse import progress such as `Processing CityGML source file 3/18 (17%)`, live-send counter summaries, material setup, and final send summaries. Add `--verbose` when you need debug-level per-file, per-object, RPC diagnostic, and ResoniteLink transport details.
+By default, the CLI writes short .NET-style console log lines with a timestamp, level, category, and message. Information-level output is phase-oriented: source discovery, source-scan aggregate progress, live-send ingest/sending counters, setup summaries, datasource decisions, and final send summaries. Per-file, per-object, per-lane, RPC breakdown, elapsed-time statistics, and transport details are debug-level output; add `--verbose` when you need them.
 
 When `--work-root` is omitted, the CLI stores dataset-local archives and live temporary files under `local/<dataset>/`. Terrain tile downloads are cached separately under the local app-data cache root by default; override that path with `--terrain-tile-cache-root` or disable cross-run tile caching with `--disable-terrain-tile-cache`. By default, DEM terrain texture sources can fall back from PLATEAU Ortho to GSI seamless photo tiles; specify `--exclude-gsi-terrain-tiles` to keep terrain texture sources to GeoTIFF and PLATEAU Ortho only.
 

--- a/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
+++ b/src/PlateauResoniteLink/Application/Importing/PlateauImportService.cs
@@ -70,7 +70,9 @@ internal sealed class PlateauImportService(
 
             ImportedSceneMetadata metadata = importedSceneSource.Metadata;
             logger.WriteInformation(
-                "Setup will use {CommonMaterialCount} codebase-reachable common materials.",
+                "Import source prepared for live send (dataset='{Dataset}', mesh='{MeshCode}', common_materials={CommonMaterialCount}).",
+                resolvedRequest.Dataset,
+                resolvedRequest.MeshCode,
                 commonMaterials.Count);
 
             SceneImportExecutionPlan executionPlan = SceneImportExecutionPlan.Create(
@@ -84,11 +86,11 @@ internal sealed class PlateauImportService(
                 await preflight.ValidateBeforeSinkSetupAsync(cancellationToken);
             }
 
-            logger.WriteInformation("Starting live scene initialization with codebase-reachable common materials.");
+            logger.WriteInformation("Starting live scene initialization.");
 
             int sourceCityObjectCount = 0;
             Stopwatch cityObjectStopwatch = Stopwatch.StartNew();
-            logger.WriteInformation("Handing object unit stream to sink.");
+            logger.WriteDebug("Handing object unit stream to sink.");
             CountingImportedObjectUnitStream countedObjectUnits = new(
                 importedSceneSource.ReadObjectUnitsAsync(cancellationToken),
                 cityObjectCount => sourceCityObjectCount += cityObjectCount);
@@ -98,7 +100,7 @@ internal sealed class PlateauImportService(
                 cancellationToken);
 
             cityObjectStopwatch.Stop();
-            logger.WriteInformation(
+            logger.WriteDebug(
                 "Streamed {CityObjectCount} city objects in {ElapsedSeconds:F3}s.",
                 sourceCityObjectCount,
                 cityObjectStopwatch.Elapsed.TotalSeconds);

--- a/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
@@ -92,6 +92,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
         int producerConcurrency = Math.Min(sourceFiles.Length, MaxConcurrentCityObjectProducers);
         ConcurrentQueue<(SourceFilePipeline SourceFile, int Index)> pendingSourceFiles = new(
             sourceFiles.Select((sourceFile, index) => (sourceFile, index + 1)));
+        SourceScanProgress sourceScanProgress = new();
 
         logger.WriteInformation(
             "City object unit producers launched: {ProducerConcurrency} worker(s) for {SourceFileCount} file-scoped streams.",
@@ -103,6 +104,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
                 () => ProduceCityObjectsUntilDrainedAsync(
                     channel.Writer,
                     pendingSourceFiles,
+                    sourceScanProgress,
                     sourceFiles.Length,
                     cancellationToken),
                 cancellationToken))
@@ -133,12 +135,13 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
         ChannelWriter<ImportedObjectUnit> writer,
         SourceFilePipeline sourceFile,
         int fileIndex,
+        SourceScanProgress sourceScanProgress,
         int totalFiles,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         int percent = totalFiles == 0 ? 100 : (int)Math.Floor((fileIndex / (double)totalFiles) * 100.0);
-        logger.WriteInformation(
+        logger.WriteDebug(
             "Processing CityGML source file {FileIndex}/{TotalFiles} ({Percent}%). Source='{SourceFile}'.",
             fileIndex,
             totalFiles,
@@ -156,18 +159,46 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
             await writer.WriteAsync(objectUnit, cancellationToken);
         }
 
-        logger.WriteInformation(
+        logger.WriteDebug(
             "Finished CityGML source file {FileIndex}/{TotalFiles}. Source='{SourceFile}', yielded_units={YieldedUnitCount}, yielded_city_objects={YieldedCityObjectCount}.",
             fileIndex,
             totalFiles,
             sourceFile.SourceFile.RelativePath,
             yieldedUnitCount,
             yieldedCount);
+
+        int completedSourceFiles = Interlocked.Increment(ref sourceScanProgress.CompletedSourceFileCount);
+        int producedCityObjects = Interlocked.Add(ref sourceScanProgress.ProducedCityObjectCount, yieldedCount);
+        int producedObjectUnits = Interlocked.Add(ref sourceScanProgress.ProducedObjectUnitCount, yieldedUnitCount);
+        if (completedSourceFiles == totalFiles || completedSourceFiles % 25 == 0)
+        {
+            int completedPercent = totalFiles == 0 ? 100 : (int)Math.Floor((completedSourceFiles / (double)totalFiles) * 100.0);
+            if (completedSourceFiles == totalFiles)
+            {
+                logger.WriteInformation(
+                    "Import source scan completed: source_files={CompletedSourceFileCount}/{TotalFiles}, produced_units={ProducedObjectUnitCount}, produced_city_objects={ProducedCityObjectCount}. Live send may still be draining queued objects.",
+                    completedSourceFiles,
+                    totalFiles,
+                    producedObjectUnits,
+                    producedCityObjects);
+            }
+            else
+            {
+                logger.WriteInformation(
+                    "Import source scan progress: source_files={CompletedSourceFileCount}/{TotalFiles} ({CompletedPercent}%), produced_units={ProducedObjectUnitCount}, produced_city_objects={ProducedCityObjectCount}.",
+                    completedSourceFiles,
+                    totalFiles,
+                    completedPercent,
+                    producedObjectUnits,
+                    producedCityObjects);
+            }
+        }
     }
 
     private async Task ProduceCityObjectsUntilDrainedAsync(
         ChannelWriter<ImportedObjectUnit> writer,
         ConcurrentQueue<(SourceFilePipeline SourceFile, int Index)> pendingSourceFiles,
+        SourceScanProgress sourceScanProgress,
         int totalFiles,
         CancellationToken cancellationToken)
     {
@@ -177,6 +208,7 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
                 writer,
                 nextSourceFile.SourceFile,
                 nextSourceFile.Index,
+                sourceScanProgress,
                 totalFiles,
                 cancellationToken);
         }
@@ -287,12 +319,21 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
 
         fileStopwatch.Stop();
         fileWarningStatistics.ReportFile(sourceFile.SourceFile.RelativePath, logger);
-        logger.WriteInformation(
+        logger.WriteDebug(
             "City object producer projected '{SourceFile}' (parsed_city_objects={ParsedCityObjectCount}, yielded={YieldedCityObjectCount}, elapsed_s={ElapsedSeconds:F3}).",
             sourceFile.SourceFile.RelativePath,
             parsedCount,
             yieldedCount,
             fileStopwatch.Elapsed.TotalSeconds);
+    }
+
+    private sealed class SourceScanProgress
+    {
+        public int CompletedSourceFileCount;
+
+        public int ProducedCityObjectCount;
+
+        public int ProducedObjectUnitCount;
     }
 
     private sealed class StreamingDemProjectionSource(SourceFileDescriptor sourceFile)

--- a/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/LiveSendExecutionState.cs
@@ -18,6 +18,10 @@ internal sealed class LiveSendProgressSink
 
     public int QueuedCityObjectCount;
 
+    public int SourceObjectUnitCount;
+
+    public int SourceCityObjectCount;
+
     public int FirstQueuedCityObjectLogged;
 
     public int FirstPreparedCityObjectLogged;
@@ -36,6 +40,8 @@ internal sealed class LiveSendProgressSink
         ProcessedCityObjectCount = 0;
         FailedCityObjectCount = 0;
         QueuedCityObjectCount = 0;
+        SourceObjectUnitCount = 0;
+        SourceCityObjectCount = 0;
         FirstQueuedCityObjectLogged = 0;
         FirstPreparedCityObjectLogged = 0;
         FirstImportedCityObjectLogged = 0;

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteCommonMaterialSetupPreparer.cs
@@ -43,7 +43,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
             ResoniteCommonMaterialPlans.CreateCatalogPlans(commonMaterials);
         if (commonMaterialPlans.Count == 0)
         {
-            logger.WriteInformation("No common material assets are required during scene setup.");
+            logger.WriteDebug("No common material assets are required during scene setup.");
             return;
         }
 
@@ -74,7 +74,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
             }
 
             Stopwatch materialStopwatch = Stopwatch.StartNew();
-            logger.WriteInformation(
+            logger.WriteDebug(
                 "Preparing common material asset {PreparedCount}/{TotalCount}: family='{FamilySlotName}', slot='{MaterialSlotName}'.",
                 preparedCount + 1,
                 commonMaterialPlans.Count,
@@ -98,7 +98,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
                     material,
                     new CreatedMaterialAsset(existingComponent.Value, null)));
                 preparedCount++;
-                logger.WriteInformation(
+                logger.WriteDebug(
                     "Reused common material asset {PreparedCount}/{TotalCount}: family='{FamilySlotName}', slot='{MaterialSlotName}', elapsed_s={ElapsedSeconds:F2}.",
                     preparedCount,
                     commonMaterialPlans.Count,
@@ -140,7 +140,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
                 pendingMaterialSlot,
                 pendingMaterialComponent));
             preparedCount++;
-            logger.WriteInformation(
+            logger.WriteDebug(
                 "Planned common material asset {PreparedCount}/{TotalCount}: family='{FamilySlotName}', slot='{MaterialSlotName}', texture_import_elapsed_s={ElapsedSeconds:F2}.",
                 preparedCount,
                 commonMaterialPlans.Count,
@@ -167,7 +167,7 @@ internal sealed class ResoniteCommonMaterialSetupPreparer(
                     new CreatedMaterialAsset(createdMaterialComponent.Locator, null)));
             }
 
-            logger.WriteInformation(
+            logger.WriteDebug(
                 "Created {PreparedMaterialCount} common material assets in one setup component batch.",
                 preparedMaterials.Count);
         }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendFinalizer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendFinalizer.cs
@@ -50,20 +50,23 @@ internal sealed class ResoniteLiveSendFinalizer(
         }
 
         context.Logger.WriteInformation(
-            "Completing live send. Closing lane writers (attempted={AttemptedCount}, processed={ProcessedCount}, failed={FailedCount}, queued_source={QueuedSourceCount}).",
+            "Source stream ended; closing live-send queue: source_units_seen={SourceObjectUnitCount}, source_city_objects_seen={SourceCityObjectCount}, queued={QueuedSourceCount}, attempted={AttemptedCount}, sent={SentCount}, failed={FailedCount}, backlog={BacklogCount}.",
+            state.Progress.SourceObjectUnitCount,
+            state.Progress.SourceCityObjectCount,
+            state.Progress.QueuedCityObjectCount,
             state.Progress.AttemptedCityObjectCount,
             state.Progress.ProcessedCityObjectCount,
             state.Progress.FailedCityObjectCount,
-            state.Progress.QueuedCityObjectCount);
+            Math.Max(0, state.Progress.QueuedCityObjectCount - state.Progress.ProcessedCityObjectCount - state.Progress.FailedCityObjectCount));
         runtime.CompleteWriter();
 
-        context.Logger.WriteInformation(
+        context.Logger.WriteDebug(
             "Awaiting {ProcessingTaskCount} send lane task(s) to drain after queue close.",
             runtime.ProcessingTaskCount);
         await runtime.AwaitCompletionAsync(cancellationToken);
-        context.Logger.WriteInformation("All send lanes drained and completion barrier passed.");
+        context.Logger.WriteDebug("All send lanes drained and completion barrier passed.");
         context.Diagnostics.CompleteSendWindow();
-        context.Logger.WriteInformation(
+        context.Logger.WriteDebug(
             "Completed {ProcessedCount} city objects (failed={FailedCount}, attempted={AttemptedCount}, queued_source={QueuedSourceCount}).",
             state.Progress.ProcessedCityObjectCount,
             state.Progress.FailedCityObjectCount,
@@ -99,7 +102,8 @@ internal sealed class ResoniteLiveSendFinalizer(
                 ", ",
                 pendingBakeSummaries.Select(static summary =>
                     $"{summary.Name}: input={summary.InputCount}, currentOutput={summary.OutputCount}"));
-            context.Logger.WriteInformation("Starting buffered bake flush: {SummaryText}.", summaryText);
+            context.Logger.WriteInformation("Flushing buffered bake output before closing live-send queue.");
+            context.Logger.WriteDebug("Buffered bake flush input summary: {SummaryText}.", summaryText);
         }
 
         Stopwatch bakeFlushStopwatch = Stopwatch.StartNew();
@@ -109,7 +113,7 @@ internal sealed class ResoniteLiveSendFinalizer(
             context.EnqueueContext,
             cancellationToken);
         bakeFlushStopwatch.Stop();
-        context.Logger.WriteInformation(
+        context.Logger.WriteDebug(
             "Buffered bake flush produced {BakedCityObjectCount} baked city objects in {ElapsedSeconds:F3}s.",
             bakedCityObjectCount,
             bakeFlushStopwatch.Elapsed.TotalSeconds);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunExecutor.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunExecutor.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 using PlateauResoniteLink.Application.Importing;
+using PlateauResoniteLink.Diagnostics;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
@@ -111,11 +112,26 @@ internal sealed class ResoniteLiveSendRunExecutor(
             LiveSendEnqueueContext enqueueContext = phaseContextFactory.CreateEnqueueContext(context);
             await foreach (ImportedObjectUnit objectUnit in objectUnits.WithCancellation(cancellationToken))
             {
+                int sourceUnitsSeen = Interlocked.Increment(ref state.Progress.SourceObjectUnitCount);
+                int sourceCityObjectsSeen = Interlocked.Add(
+                    ref state.Progress.SourceCityObjectCount,
+                    objectUnit.CityObjects.Count);
                 await queue.QueueUnitAsync(
                     state,
                     objectUnit,
                     enqueueContext,
                     cancellationToken);
+                if (sourceUnitsSeen % 25 == 0)
+                {
+                    context.Logger.WriteInformation(
+                        "Live send ingest progress: phase=streaming, source_units_seen={SourceObjectUnitCount}, source_city_objects_seen={SourceCityObjectCount}, queued={QueuedSourceCount}, sent={SentCount}, failed={FailedCount}, backlog={BacklogCount}.",
+                        sourceUnitsSeen,
+                        sourceCityObjectsSeen,
+                        state.Progress.QueuedCityObjectCount,
+                        state.Progress.ProcessedCityObjectCount,
+                        state.Progress.FailedCityObjectCount,
+                        Math.Max(0, state.Progress.QueuedCityObjectCount - state.Progress.ProcessedCityObjectCount - state.Progress.FailedCityObjectCount));
+                }
             }
 
             SceneImportExecutionResult result = await queue.CompleteAsync(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendRunSetupPreparer.cs
@@ -41,9 +41,10 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(context);
 
-        context.Logger.WriteInformation("Reusing dataset content source provided by caller.");
-        context.Logger.WriteInformation("Setting up mutable helpers (baker).");
-        context.Logger.WriteInformation("Starting setup slot setup: dataset root, assets root, common assets root, location slot, and source-file root reference.");
+        context.Logger.WriteInformation("Starting live scene setup before city-object streaming.");
+        context.Logger.WriteDebug("Reusing dataset content source provided by caller.");
+        context.Logger.WriteDebug("Setting up mutable helpers (baker).");
+        context.Logger.WriteDebug("Starting setup slot setup: dataset root, assets root, common assets root, location slot, and source-file root reference.");
         Stopwatch setupStopwatch = Stopwatch.StartNew();
         ResoniteSceneSetupState setupState = await sceneSetupInterpreter.SetupAsync(
             GetRoutedClient(context),
@@ -72,8 +73,8 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
             request.CommonMaterials,
             context.Logger,
             cancellationToken);
-        context.Logger.WriteInformation("setup fixed dataset license metadata/component before city-object streaming starts.");
-        context.Logger.WriteInformation(
+        context.Logger.WriteDebug("setup fixed dataset license metadata/component before city-object streaming starts.");
+        context.Logger.WriteDebug(
             "Dataset metadata/license phase complete during setup. Dataset root existed={DatasetRootExisted}.",
             setupState.DatasetRootExisted);
         return preparedSetup;
@@ -85,13 +86,13 @@ internal sealed class ResoniteLiveSendRunSetupPreparer(
     {
         if (setupState.CommonMaterialAssets.Count > 0)
         {
-            context.Logger.WriteInformation(
+            context.Logger.WriteDebug(
                 "Setup batch prepared {TexturelessCommonMaterialCount} textureless common materials.",
                 setupState.CommonMaterialAssets.Count);
             return;
         }
 
-        context.Logger.WriteInformation("Setup created common material slots; no textureless common material components were needed in setup batch.");
+        context.Logger.WriteDebug("Setup created common material slots; no textureless common material components were needed in setup batch.");
     }
 
     private static IResoniteLinkClient GetRoutedClient(LiveSendRunStartContext context)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteLiveSendWorkerLauncher.cs
@@ -73,10 +73,10 @@ internal sealed class ResoniteLiveSendWorkerLauncher(
             request.ResourceBudget.Name.ToString().ToLowerInvariant(),
             request.ResourceBudget.RuntimeVramBudgetBytes);
         laneStartStopwatch.Stop();
-        context.Logger.WriteInformation(
+        context.Logger.WriteDebug(
             "Send workers ready against connection pool={ConnectionCount}.",
             connectionCount);
-        context.Logger.WriteInformation(
+        context.Logger.WriteDebug(
             "Send lane startup phase complete in {ElapsedSeconds:F2}s.",
             laneStartStopwatch.Elapsed.TotalSeconds);
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectEnqueuer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectEnqueuer.cs
@@ -140,8 +140,10 @@ internal sealed class ResoniteQueuedCityObjectEnqueuer : IResoniteQueuedCityObje
         if (Interlocked.CompareExchange(ref state.Progress.FirstQueuedCityObjectLogged, 1, 0) == 0)
         {
             context.Logger.WriteInformation(
-                "First city object queued after {ElapsedSeconds:F3}s: {DisplayName} ({PackageName}/{SlotKey}) estimated_workset_bytes={EstimatedWorksetBytes}.",
-                state.Runtime.ElapsedTotalSeconds,
+                "First city object queued after {ElapsedSeconds:F3}s.",
+                state.Runtime.ElapsedTotalSeconds);
+            context.Logger.WriteDebug(
+                "First queued city object detail: {DisplayName} ({PackageName}/{SlotKey}) estimated_workset_bytes={EstimatedWorksetBytes}.",
                 cityObject.DisplayName,
                 cityObject.PackageName,
                 cityObject.SlotKey,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectEnqueuer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectEnqueuer.cs
@@ -159,12 +159,13 @@ internal sealed class ResoniteQueuedCityObjectEnqueuer : IResoniteQueuedCityObje
             int queuedCount = Interlocked.Increment(ref state.Progress.QueuedCityObjectCount);
             if (queuedCount % 25 == 0)
             {
-                context.Logger.WriteInformation(
-                    "Live send progress: queued_source={QueuedSourceCount}, attempted={AttemptedCount}, sent={SentCount}, failed={FailedCount}.",
+                context.Logger.WriteDebug(
+                    "Live send queue progress: queued={QueuedSourceCount}, attempted={AttemptedCount}, sent={SentCount}, failed={FailedCount}, backlog={BacklogCount}.",
                     queuedCount,
                     state.Progress.AttemptedCityObjectCount,
                     state.Progress.ProcessedCityObjectCount,
-                    state.Progress.FailedCityObjectCount);
+                    state.Progress.FailedCityObjectCount,
+                    Math.Max(0, queuedCount - state.Progress.ProcessedCityObjectCount - state.Progress.FailedCityObjectCount));
             }
         }
         catch (OperationCanceledException) when (runtime.IsCancellationRequested)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparation.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectPreparation.cs
@@ -47,8 +47,10 @@ internal sealed class ResoniteQueuedCityObjectPreparation(
         if (Interlocked.CompareExchange(ref state.Progress.FirstCityObjectPreparationStartedLogged, 1, 0) == 0)
         {
             logger.WriteInformation(
-                "City object preparation started after {ElapsedSeconds:F3}s: {DisplayName} ({PackageName}/{SlotKey}) mesh='{ActualMeshCode}'.",
-                state.Runtime.ElapsedTotalSeconds,
+                "City object preparation started after {ElapsedSeconds:F3}s.",
+                state.Runtime.ElapsedTotalSeconds);
+            logger.WriteDebug(
+                "First city object preparation target: {DisplayName} ({PackageName}/{SlotKey}) mesh='{ActualMeshCode}'.",
                 cityObject.DisplayName,
                 cityObject.PackageName,
                 cityObject.SlotKey,
@@ -140,9 +142,11 @@ internal sealed class ResoniteQueuedCityObjectPreparation(
         if (Interlocked.CompareExchange(ref state.Progress.FirstPreparedCityObjectLogged, 1, 0) == 0)
         {
             logger.WriteInformation(
-                "First city object prepared in {PrepareElapsedSeconds:F3}s after scene start {ElapsedSeconds:F3}s: {DisplayName} (textures={TextureCount}, geometry={GeometryDescription}).",
+                "First city object prepared in {PrepareElapsedSeconds:F3}s after scene start {ElapsedSeconds:F3}s.",
                 stopwatch.Elapsed.TotalSeconds,
-                state.Runtime.ElapsedTotalSeconds,
+                state.Runtime.ElapsedTotalSeconds);
+            logger.WriteDebug(
+                "First prepared city object detail: {DisplayName} (textures={TextureCount}, geometry={GeometryDescription}).",
                 cityObject.DisplayName,
                 preparedTextures.Length,
                 PreparedConstructionGeometryFormatter.Describe(preparedGeometry));

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectSender.cs
@@ -76,12 +76,15 @@ internal sealed class ResoniteQueuedCityObjectSender(
                 preparedCityObject.CityObject.SlotKey);
             if (processedCount % 25 == 0)
             {
+                int queuedCount = state.Progress.QueuedCityObjectCount;
                 logger.WriteInformation(
-                    "Live send progress: attempted={AttemptedCount}, sent={SentCount}, failed={FailedCount}, queued_source={QueuedSourceCount}.",
-                    state.Progress.AttemptedCityObjectCount,
+                    "Live send progress: phase=sending, source_city_objects_seen={SourceCityObjectCount}, sent={SentCount}, failed={FailedCount}, attempted={AttemptedCount}, queued={QueuedSourceCount}, backlog={BacklogCount}.",
+                    state.Progress.SourceCityObjectCount,
                     processedCount,
                     state.Progress.FailedCityObjectCount,
-                    state.Progress.QueuedCityObjectCount);
+                    state.Progress.AttemptedCityObjectCount,
+                    queuedCount,
+                    Math.Max(0, queuedCount - processedCount - state.Progress.FailedCityObjectCount));
             }
         }
         catch (OperationCanceledException)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectWorker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteQueuedCityObjectWorker.cs
@@ -60,7 +60,9 @@ internal sealed class ResoniteQueuedCityObjectWorker(
             if (Interlocked.CompareExchange(ref state.Progress.FirstCityObjectStreamingStartedLogged, 1, 0) == 0)
             {
                 context.Logger.WriteInformation(
-                    "City-object send pipeline is active and waiting for queue on lane {LaneIndex}/{ConnectionCount}.",
+                    "City-object send pipeline is active and waiting for queued objects.");
+                context.Logger.WriteDebug(
+                    "City-object send pipeline first active lane {LaneIndex}/{ConnectionCount}.",
                     laneIndex + 1,
                     context.ConnectionCount);
             }
@@ -71,10 +73,12 @@ internal sealed class ResoniteQueuedCityObjectWorker(
                 if (Interlocked.CompareExchange(ref state.Progress.FirstCityObjectDequeuedLogged, 1, 0) == 0)
                 {
                     context.Logger.WriteInformation(
-                        "First city object dequeued on lane {LaneIndex}/{ConnectionCount} after scene-start {ElapsedSeconds:F3}s: {DisplayName} ({PackageName}/{SlotKey}).",
+                        "First city object dequeued after scene-start {ElapsedSeconds:F3}s.",
+                        state.Runtime.ElapsedTotalSeconds);
+                    context.Logger.WriteDebug(
+                        "First city object dequeued on lane {LaneIndex}/{ConnectionCount}: {DisplayName} ({PackageName}/{SlotKey}).",
                         laneIndex + 1,
                         context.ConnectionCount,
-                        state.Runtime.ElapsedTotalSeconds,
                         queuedCityObject.CityObject.DisplayName,
                         queuedCityObject.CityObject.PackageName,
                         queuedCityObject.CityObject.SlotKey);
@@ -90,7 +94,7 @@ internal sealed class ResoniteQueuedCityObjectWorker(
                 currentCityObject = null;
             }
 
-            context.Logger.WriteInformation(
+            context.Logger.WriteDebug(
                 "Send lane {LaneIndex}/{ConnectionCount} drained.",
                 laneIndex + 1,
                 context.ConnectionCount);
@@ -136,14 +140,14 @@ internal sealed class ResoniteQueuedCityObjectWorker(
         ResoniteSceneSetupInfo setupInfo = state.Context.Plan.SetupInfo;
         if (laneIndex == 0)
         {
-            context.Logger.WriteInformation(
+            context.Logger.WriteDebug(
                 "Send worker {LaneIndex}/{ConnectionCount} is ready to consume from the routed connection pool.",
                 laneIndex + 1,
                 context.ConnectionCount);
         }
         else
         {
-            context.Logger.WriteInformation(
+            context.Logger.WriteDebug(
                 "Preparing send worker {LaneIndex}/{ConnectionCount} against routed connections to {Endpoint} for dataset '{Dataset}' mesh '{MeshCode}'.",
                 laneIndex + 1,
                 context.ConnectionCount,

--- a/src/PlateauResoniteLink/Transport/ResoniteLink/LiveSendClientSession.cs
+++ b/src/PlateauResoniteLink/Transport/ResoniteLink/LiveSendClientSession.cs
@@ -57,7 +57,7 @@ internal sealed class LiveSendClientSession : ILiveSendClientSession, IDisposabl
         {
             if (loadBalancedClient is not null)
             {
-                logger.WriteInformation("Reusing existing load-balanced ResoniteLink session.");
+                logger.WriteDebug("Reusing existing load-balanced ResoniteLink session.");
                 return;
             }
 
@@ -177,7 +177,7 @@ internal sealed class LiveSendClientSession : ILiveSendClientSession, IDisposabl
     {
         Stopwatch connectionStopwatch = Stopwatch.StartNew();
         string connectionDescription = $"connection {connectionIndex + 1}/{connectionCount}";
-        logger.WriteInformation(
+        logger.WriteDebug(
             "Connecting {ConnectionDescription} ResoniteLink session to {Endpoint} for dataset '{Dataset}' mesh '{MeshCode}'.",
             connectionDescription,
             endpoint,
@@ -185,7 +185,7 @@ internal sealed class LiveSendClientSession : ILiveSendClientSession, IDisposabl
             request.MeshCode);
         await client.ConnectAsync(endpoint, cancellationToken).ConfigureAwait(false);
         connectionStopwatch.Stop();
-        logger.WriteInformation(
+        logger.WriteDebug(
             "Connected {ConnectionDescription} ResoniteLink session to {Endpoint} in {ElapsedSeconds:F2}s.",
             connectionDescription,
             endpoint,

--- a/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkSendDiagnostics.cs
+++ b/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkSendDiagnostics.cs
@@ -68,7 +68,7 @@ internal sealed class ResoniteLinkSendDiagnostics
         }
 
         sendWindowStopwatch = Stopwatch.StartNew();
-        logger.WriteInformation(
+        logger.WriteDebug(
             "Enabled live send metrics via System.Diagnostics.Metrics (connections={ConnectionCount}).",
             connectionCount);
     }

--- a/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkSendDiagnostics.cs
+++ b/src/PlateauResoniteLink/Transport/ResoniteLink/ResoniteLinkSendDiagnostics.cs
@@ -100,7 +100,7 @@ internal sealed class ResoniteLinkSendDiagnostics
                 .OrderBy(static pair => pair.Key, StringComparer.Ordinal)
                 .Select(static pair => $"{pair.Key}={pair.Value}"));
 
-        logger.WriteInformation(
+        logger.WriteDebug(
             "send_window_s={ElapsedSeconds:F3} sent={SentCount} skipped_mesh_import_failure={SkippedMeshImportFailureCount} throughput_obj_per_s={Throughput:F2} avg_prepare_s={AveragePrepareSeconds:F4} avg_send_s={AverageSendSeconds:F4} avg_rpc_per_sent={AverageRpcPerSentCityObject:F2} total_rpc={TotalRpcCalls}",
             elapsedSeconds,
             sentCount,


### PR DESCRIPTION
## Summary
- Move per-file CityGML producer logs and elapsed/statistical send-window details to Debug.
- Keep Info focused on phase-level progress: source scan aggregate progress, live-send ingest/sending counters, queue close, buffered bake flush phase, and final send summary.
- Track source units/city objects seen in `LiveSendProgressSink` from the existing streaming path, without extra CityGML scans, city object materialization, or RPCs.
- Clarify source scan completion as input completion only, explicitly noting live send may still be draining queued objects.

## Impact
The CLI no longer shows `Processing CityGML source file N/N (100%)` at Info as if the whole import were done. Default logs should now show where the pipeline really is: streaming input, sending queued objects, flushing buffered bake output, or draining/closing the live-send queue.

## Validation
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`

Final test run: 1051 passed.