### PR TITLE
[codex] Add regression verification principles

### DIFF
--- a/AGENTS.ja.md
+++ b/AGENTS.ja.md
@@ -26,6 +26,11 @@
 - ユーザーが明示的に求めない限り、`Builder`、`Manager`、`Coordinator`、`Helper`、`Util` のような広すぎる振る舞い志向の型を新設しない。
 - 決定的な出力、明示的なコマンド入力、再現可能なローカル/CI の挙動を優先する。
 - 振る舞いを変更したら、自動テストを追加または更新する。
+- 回帰修正では、修正完了とみなす前に、期待する observable contract と、提案した原因を反証できる反例または観測点を定義する。
+- 限定情報下では、単一仮説に固定しないこと。まずその仮説を失敗させられる観測、テスト、比較を作り、あり得る解釈の範囲で破綻しない変更だけを行う。
+- 複数の実行経路が同じ概念を出力する場合は、経路別の補正を追加するのではなく、共有契約を強制し、同等の出力同士を比較する。
+- 通常の UI や外部ターゲットの surface から出力を検査できない場合は、実際に emit される payload を検査できる boundary adapter 付近の記録、dump、readback artifact を用意し、それを完了判定に使う。
+- green test、CI、review approval だけで回帰が修正された証明として扱わない。failure mode に対応する観測 artifact が期待する契約を満たすことを確認する。
 - grep ベースの architecture test や naming test を、境界規範の正本として扱わないこと。命名規則と ownership はこのファイルで管理し、依存方向は project reference で縛り、テストでは observable behavior だけを守る。
 - 依存性注入は stack の中腹まで貫通させること。core、application、import、bootstrap、target、transport のコードは、`new`、static factory、fallback self-wiring で concrete default を隠さない。
 - legacy 変換と static projection helper は adapter edge にだけ置くこと。core concept と neutral contract は、`ToLegacy`、`FromLegacy`、target 固有 mapper utility に依存しない。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,11 @@ This repository builds a .NET 10 CLI-first import pipeline that maps PLATEAU dat
 - Do not introduce new broad behavior-oriented types such as `Builder`, `Manager`, `Coordinator`, `Helper`, or `Util` unless the user explicitly requests that pattern.
 - Prefer deterministic outputs, explicit command inputs, and reproducible local/CI behavior.
 - Add or update automated tests when behavior changes.
+- For regression fixes, define the expected observable contract and the counterexamples or observation points that could disprove the proposed cause before treating the fix as complete.
+- Under limited information, do not lock onto a single hypothesis. First create observations, tests, or comparisons that can fail that hypothesis, and make only changes that stay valid across plausible interpretations.
+- When multiple execution paths emit the same concept, enforce a shared contract and compare equivalent outputs instead of adding path-specific compensation.
+- If an output cannot be inspected through the normal UI or external target surface, add a boundary-adapter recording, dump, or readback artifact that can inspect the actual emitted payload and use it in the completion criteria.
+- Do not treat green tests, CI, or review approval alone as proof that a regression is fixed. Confirm that the observation artifacts relevant to the failure mode satisfy the expected contract.
 - Do not treat grep-based architecture or naming tests as the canonical boundary guard. Keep naming and ownership rules here, enforce dependency direction with project references, and cover only observable behavior with automated tests.
 - Keep dependency injection flowing through the full stack. Core, application, import, bootstrap, target, and transport code must not hide concrete defaults behind `new`, static factories, or fallback self-wiring.
 - Keep legacy conversions and static projection helpers in adapter-edge code only. Core concepts and neutral contracts must not depend on `ToLegacy`, `FromLegacy`, or target-specific mapper utilities.


### PR DESCRIPTION
## Summary
- Add generic AGENTS working rules for regression fixes.
- Require observable contracts, counterexamples, shared contracts across equivalent output paths, and boundary readback/dump artifacts when normal surfaces cannot inspect emitted payloads.
- Keep the Japanese mirror in sync with the English canonical AGENTS guidance.

## Validation
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` — 1066 passed

## Notes
- This keeps the guidance generic and avoids encoding incident-specific names, datasets, commands, or PR history.