### PR TITLE
[codex] Return explicit non-DEM buffer take results

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemCityObjectBaker.cs
@@ -77,11 +77,13 @@ internal sealed class NonDemCityObjectBaker(
         Func<ResoniteConstructionCityObject, CancellationToken, Task> onBakedCityObject,
         CancellationToken cancellationToken)
     {
-        if (!sourceFileBuffer.TryTake(sourceFileKey, out NonDemSourceFileBakeBufferEntry bufferEntry))
+        NonDemSourceFileBakeBufferTakeResult takeResult = sourceFileBuffer.Take(sourceFileKey);
+        if (!takeResult.Found)
         {
             return;
         }
 
+        NonDemSourceFileBakeBufferEntry bufferEntry = takeResult.Entry;
         int emittedCount = 0;
         try
         {

--- a/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeBuffer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/NonDemSourceFileBakeBuffer.cs
@@ -30,21 +30,19 @@ internal sealed class NonDemSourceFileBakeBuffer
             .ToArray();
     }
 
-    public bool TryTake(
-        NonDemSourceFileBatchKey sourceFileKey,
-        out NonDemSourceFileBakeBufferEntry entry)
+    public NonDemSourceFileBakeBufferTakeResult Take(NonDemSourceFileBatchKey sourceFileKey)
     {
         if (!bufferedCityObjectsBySourceFile.Remove(sourceFileKey, out List<NonDemBufferedCityObject>? cityObjects))
         {
-            entry = default;
-            return false;
+            return NonDemSourceFileBakeBufferTakeResult.NotFound;
         }
 
-        entry = new NonDemSourceFileBakeBufferEntry(
-            sourceFileKey,
-            cityObjects,
-            nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey));
-        return true;
+        return new NonDemSourceFileBakeBufferTakeResult(
+            Found: true,
+            new NonDemSourceFileBakeBufferEntry(
+                sourceFileKey,
+                cityObjects,
+                nextBatchIndexBySourceFile.GetValueOrDefault(sourceFileKey)));
     }
 
     public void Complete(
@@ -60,3 +58,10 @@ internal readonly record struct NonDemSourceFileBakeBufferEntry(
     NonDemSourceFileBatchKey SourceFileKey,
     List<NonDemBufferedCityObject> CityObjects,
     int BatchStartIndex);
+
+internal readonly record struct NonDemSourceFileBakeBufferTakeResult(
+    bool Found,
+    NonDemSourceFileBakeBufferEntry Entry)
+{
+    public static NonDemSourceFileBakeBufferTakeResult NotFound => new(Found: false, default);
+}

--- a/tests/PlateauResoniteLink.Tests/Targets/NonDemSourceFileBakeBufferTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/NonDemSourceFileBakeBufferTests.cs
@@ -1,0 +1,96 @@
+using PlateauResoniteLink.Targets.Resonite;
+
+namespace PlateauResoniteLink.Tests.Targets;
+
+public sealed class NonDemSourceFileBakeBufferTests
+{
+    [Fact]
+    public void TakeReturnsFoundEntryForExistingSourceFile()
+    {
+        NonDemSourceFileBakeBuffer buffer = new();
+        NonDemSourceFileBatchKey sourceFileKey = CreateSourceFileKey();
+        NonDemBufferedCityObject bufferedCityObject = CreateBufferedCityObject();
+
+        buffer.Add(sourceFileKey, bufferedCityObject);
+
+        NonDemSourceFileBakeBufferTakeResult result = buffer.Take(sourceFileKey);
+
+        Assert.True(result.Found);
+        Assert.Equal(sourceFileKey, result.Entry.SourceFileKey);
+        Assert.Equal(0, result.Entry.BatchStartIndex);
+        Assert.Same(bufferedCityObject.CityObject, Assert.Single(result.Entry.CityObjects).CityObject);
+        Assert.True(buffer.IsEmpty);
+    }
+
+    [Fact]
+    public void TakeReturnsNotFoundForMissingSourceFile()
+    {
+        NonDemSourceFileBakeBuffer buffer = new();
+
+        NonDemSourceFileBakeBufferTakeResult result = buffer.Take(CreateSourceFileKey());
+
+        Assert.False(result.Found);
+    }
+
+    [Fact]
+    public void CompleteAdvancesNextBatchIndexForSourceFile()
+    {
+        NonDemSourceFileBakeBuffer buffer = new();
+        NonDemSourceFileBatchKey sourceFileKey = CreateSourceFileKey();
+
+        buffer.Add(sourceFileKey, CreateBufferedCityObject());
+        NonDemSourceFileBakeBufferTakeResult first = buffer.Take(sourceFileKey);
+        buffer.Complete(first.Entry, reservedOutputCount: 2);
+        buffer.Add(sourceFileKey, CreateBufferedCityObject());
+
+        NonDemSourceFileBakeBufferTakeResult second = buffer.Take(sourceFileKey);
+
+        Assert.True(second.Found);
+        Assert.Equal(2, second.Entry.BatchStartIndex);
+    }
+
+    private static NonDemSourceFileBatchKey CreateSourceFileKey()
+    {
+        return new(
+            ActualMeshCode: "53394525",
+            PackageName: "bldg",
+            LodLevel: 2,
+            PolicyContext: "non-dem",
+            SourceFileRelativePath: "udx/bldg/53394525_bldg_6697_op.gml");
+    }
+
+    private static NonDemBufferedCityObject CreateBufferedCityObject()
+    {
+        return new NonDemBufferedCityObject(
+            CreateCityObject(),
+            NonDemCityObjectBakePolicies.Default);
+    }
+
+    private static ResoniteConstructionCityObject CreateCityObject()
+    {
+        return new ResoniteConstructionCityObject(
+            "object",
+            "object",
+            "bldg",
+            "53394525",
+            LodLevel: 2,
+            new ResoniteTransform(new ResoniteFloat3(0.0, 0.0, 0.0)),
+            new ResoniteImportedMesh(
+                [
+                    new ResoniteMeshVertex(
+                        new ResoniteFloat3(0.0, 0.0, 0.0),
+                        new ResoniteFloat3(0.0, 1.0, 0.0),
+                        new ResoniteFloat2(0.0, 0.0)),
+                    new ResoniteMeshVertex(
+                        new ResoniteFloat3(1.0, 0.0, 0.0),
+                        new ResoniteFloat3(0.0, 1.0, 0.0),
+                        new ResoniteFloat2(1.0, 0.0)),
+                    new ResoniteMeshVertex(
+                        new ResoniteFloat3(0.0, 0.0, 1.0),
+                        new ResoniteFloat3(0.0, 1.0, 0.0),
+                        new ResoniteFloat2(0.0, 1.0)),
+                ],
+                [new ResoniteMeshSubmesh(0, [0, 1, 2])]),
+            []);
+    }
+}


### PR DESCRIPTION
## Summary
- extract the non-DEM source-file bake buffer result contract from #379 into a small standalone PR
- replace TryTake(out ...) with an explicit Take result so callers branch on a named completion state
- add focused tests for found, missing, and completed source-file buffer states

## Verification
- dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers
- dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~NonDemSourceFileBakeBufferTests|FullyQualifiedName~NonDemCityObjectBakerTests" --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
- dotnet format whitespace . --folder --verify-no-changes
- dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
- dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false

## Notes
- This intentionally does not include the broad #379 interface/test-contract trimming or DEM/archive changes.
- Next extraction candidate: DEM/import placement parity slice.
