### PR TITLE
[codex] Clarify repository truth surfaces

### DIFF
--- a/AGENTS.ja.md
+++ b/AGENTS.ja.md
@@ -13,33 +13,27 @@
 - Codex や同種の sandbox 制約つき WSL 環境では、検証フローの代わりに `dotnet format <sln|csproj>` の solution / project モードを使わないこと。MSBuild workspace を開く段階で `System.Net.Sockets.SocketException (13): Permission denied /tmp/<guid>` で失敗することがある。`CONTRIBUTING.md` に記した repository の検証コマンド列を使い、その中の whitespace 検証には `dotnet format whitespace . --folder --verify-no-changes` を使う。
 - push や pull request 更新の前には、`CONTRIBUTING.md` に記した検証コマンド列を必ず実行すること。`CONTRIBUTING.ja.md` はその翻訳である。
 - その検証コマンド列は直列で実行すること。同じ output tree に対して `dotnet build`、`dotnet test` などを並行実行すると、compiler / testhost の競合で `artifacts/build/windows/obj/.../*.dll` がロックされ、結果が汚染される。
-- `docs/` には、要件、アーキテクチャ意図、参照メモ、運用制約など、コードやテストだけでは表現しにくい内容だけを書く。
-- 一時的に保持したい大きな改善計画は `.tmp/plans/` 配下に置き、untracked のまま維持すること。`docs/` 配下には置かず、active documentation から現行運用の根拠としてリンクや引用をせず、採用した current outcome だけを tracked な docs / code / tests へ昇格させること。
-- 補助的な git worktree は `<repo>/.worktree/` 配下で管理し、同階層の sibling ディレクトリや `/tmp` に worktree を置かないこと。これにより一時的な worktree が既定の主ワークツリー外に散逸することを防ぐ。
-- データセット、タイル、アダプターの概念を設計するときは、`PLATEAU-SDK-for-UNITY` の用語とインポート意味論に揃える。
-- CLI のオーケストレーション、アプリケーションロジック、ドメインモデルをテスト可能でホスト非依存に保つため、Resonite 固有の I/O は抽象の背後に置く。
-- plan、state、snapshot、policy、input、output、result には、可能な限り immutable な value type を優先する。
-- 正規化、検証、ID 導出、命名、グルーピング、順序付け、予算化、plan 構築には pure transform を優先する。
-- value-based な実行契約で表現できるなら、共有 mutable object に対する ordered lifecycle API は避ける。
-- mutable state は transport、filesystem、network、cache、logging/progress、cancellation のような狭い boundary adapter に局所化する。
-- transport と target integration は immutable-by-default とし、read-once / create-only を優先し、不可避な update は専用 adapter layer に隔離する。
-- ユーザーが明示的に求めない限り、`Builder`、`Manager`、`Coordinator`、`Helper`、`Util` のような広すぎる振る舞い志向の型を新設しない。
+
+### 現在の正本の置き場所
+- コードを、現在の挙動、境界、所有、命名、既定値、依存方向の第一の正本として扱う。
+- 正しさはまず静的に守る。型、API、プロジェクト依存、所有境界、ビルド時チェックにより、不正な状態、依存、呼び出しが可能な限りコンパイル不可能になる形を優先する。
+- テストは、コードだけでは固定しきれない現在の動的挙動と、その回帰やバグの検出に限って使う。
+- テスト数を増やすより、まず動的挙動を減らすことを優先する。動的な挙動が少なければ、必要なテストも少なくなるべきである。
+- ドキュメントには、テストでは十分に表現できない現在の意図、設計理由、作業手順上の制約、参照メモ、運用文脈だけを書く。
+- 過去の判断、移行履歴、削除済み挙動、歴史的経緯は、Git 履歴、プルリクエスト、Issue、リリースに置く。古い現状説明、古いテスト、互換層を残すことで歴史を保存しない。
+- 静的な所有、命名、アーキテクチャをテストで監視しない。それらの規則はコードで表現し、コードだけでは表現しきれないものはリポジトリルートのアナライザー、スタイル設定、ビルド設定に置く。
+
+- PLATEAU の用語とインポート意味論は、`PLATEAU-SDK-for-UNITY` に揃える。
+- ResoniteLink と live target 連携は外部契約として扱う。正しさは特定の内部実装形ではなく、実際に送出された payload、読み戻し、または観測可能なターゲット状態が現在の契約を満たすことで判定する。
 - 決定的な出力、明示的なコマンド入力、再現可能なローカル/CI の挙動を優先する。
-- 振る舞いを変更したら、自動テストを追加または更新する。
-- 回帰修正では、修正完了とみなす前に、期待する observable contract と、提案した原因を反証できる反例または観測点を定義する。
+- 挙動を変更するときは、まずその動的挙動を減らせるか、またはコードで直接表現できるかを判断する。残る動的挙動のうち、仕様固定や回帰検出が必要なものに限って自動テストを追加または更新する。
+- 回帰修正では、修正完了とみなす前に、期待する観測可能な契約と、提案した原因を反証できる反例または観測点を定義する。
 - 限定情報下では、単一仮説に固定しないこと。まずその仮説を失敗させられる観測、テスト、比較を作り、あり得る解釈の範囲で破綻しない変更だけを行う。
 - 複数の実行経路が同じ概念を出力する場合は、経路別の補正を追加するのではなく、共有契約を強制し、同等の出力同士を比較する。
-- 通常の UI や外部ターゲットの surface から出力を検査できない場合は、実際に emit される payload を検査できる boundary adapter 付近の記録、dump、readback artifact を用意し、それを完了判定に使う。
-- green test、CI、review approval だけで回帰が修正された証明として扱わない。failure mode に対応する観測 artifact が期待する契約を満たすことを確認する。
-- grep ベースの architecture test や naming test を、境界規範の正本として扱わないこと。命名規則と ownership はこのファイルで管理し、依存方向は project reference で縛り、テストでは observable behavior だけを守る。
-- 依存性注入は stack の中腹まで貫通させること。core、application、import、bootstrap、target、transport のコードは、`new`、static factory、fallback self-wiring で concrete default を隠さない。
-- legacy 変換と static projection helper は adapter edge にだけ置くこと。core concept と neutral contract は、`ToLegacy`、`FromLegacy`、target 固有 mapper utility に依存しない。
-- result model は純粋に保つこと。document/read result に bootstrap 専用・discovery 専用・connection 専用・layout 専用の state を持ち込まず、必要なら別の context / snapshot に分離する。
-- 概念名を rename するときは、directory、filename、namespace、project 名、resource、docs を同じ cut で揃え、互換 alias を残さない。
-- namespace は directory ownership と一致させる。ownership boundary を変える場合は、namespace とディレクトリ構成を同一切りで更新し、パスと namespace の対応関係を一貫性のある境界シグナルとして保つ。
-- 最終状態のアーキテクチャでは global using を残さない。dependency は各ファイルで明示し、cross-boundary usage が機械的に読める状態を保つ。
-- internal contract は target-neutral に保つ。internal model に Resonite 固有の vector semantics を持ち込まず、target 固有変換は adapter edge の converter に閉じる。
-- diagnostics を進化させるときは custom logging pipeline より `ILogger<T>` と framework 統合 observability を優先し、metrics は `System.Diagnostics.Metrics` を第一級の instrumentation として扱う。
+- 通常の UI や外部ターゲットの表示面から出力を検査できない場合は、実際に送出される payload を検査できる記録、ダンプ、読み戻し成果物を用意し、それを完了判定に使う。
+- テスト成功、CI 通過、レビュー承認だけで回帰が修正された証明として扱わない。失敗モードに対応する観測結果が期待する契約を満たすことを確認する。
+
+- 補助的な git worktree は `<repo>/.worktree/` 配下で管理し、同階層の sibling ディレクトリや `/tmp` に worktree を置かないこと。これにより一時的な worktree が既定の主ワークツリー外に散逸することを防ぐ。
 
 ## Live Send 手順
 - Coding Agent が live test を行うときは [.agents/skills/resonite-live-send-debug/SKILL.md](.agents/skills/resonite-live-send-debug/SKILL.md) に従うこと。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,32 +13,25 @@ This repository builds a .NET 10 CLI-first import pipeline that maps PLATEAU dat
 - In Codex or similarly sandboxed WSL environments, do not substitute `dotnet format <sln|csproj>` solution/project mode for the repository verification flow. It can fail while opening the MSBuild workspace with `System.Net.Sockets.SocketException (13): Permission denied /tmp/<guid>`. Use the repository verification command sequence from `CONTRIBUTING.md`, including `dotnet format whitespace . --folder --verify-no-changes`.
 - Before every push or pull request update, run the verification command sequence documented in `CONTRIBUTING.md`. `CONTRIBUTING.ja.md` is only its translation mirror.
 - Run that verification sequence serially. Do not overlap `dotnet build`, `dotnet test`, or similar commands against the same output tree, because concurrent compiler/testhost access can lock `artifacts/build/windows/obj/.../*.dll` and contaminate the result.
-- Use `docs/` only for information that code and tests cannot express well, such as requirements, architecture intent, reference notes, and workflow constraints.
-- Large improvement plans that need temporary retention must live under `.tmp/plans/` and stay untracked. Do not keep them under `docs/`, do not link or cite them from active documentation as operational truth, and promote only accepted current outcomes into tracked docs, code, or tests.
-- Keep PLATEAU terminology and import semantics aligned with `PLATEAU-SDK-for-UNITY` when shaping dataset, tile, and adapter concepts.
-- Keep Resonite-specific I/O behind abstractions so CLI orchestration, application logic, and domain models remain testable and host-agnostic.
-- Prefer immutable value types for plans, states, snapshots, policies, inputs, outputs, and results.
-- Prefer pure transforms for normalization, validation, identity derivation, naming, grouping, ordering, budgeting, and plan construction.
-- Avoid ordered lifecycle APIs over shared mutable objects when a value-based execution contract can express the same behavior.
-- Keep mutable state localized to narrow boundary adapters for transport, filesystem, network, caching, logging/progress, and cancellation.
-- Treat transport and target integration as immutable-by-default: prefer read-once/create-only flows, and isolate unavoidable update operations in dedicated adapter layers.
-- Do not introduce new broad behavior-oriented types such as `Builder`, `Manager`, `Coordinator`, `Helper`, or `Util` unless the user explicitly requests that pattern.
+
+### Repository Truth Surfaces
+- Treat code as the primary current truth for behavior, boundaries, ownership, naming, defaults, and dependency direction.
+- Make correctness static first. Prefer types, APIs, project dependencies, ownership boundaries, and build-time checks that make invalid states, dependencies, or calls fail to compile.
+- Use tests only for current dynamic behavior that code alone cannot lock down, and for catching regressions or bugs in that behavior.
+- Prefer reducing dynamic behavior over expanding test volume. When less behavior is dynamic, fewer tests should be necessary.
+- Use documentation only for current intent, architecture rationale, workflow constraints, reference notes, and operational context that tests cannot express well.
+- Keep past decisions, migration history, removed behavior, and historical rationale in git history, pull requests, issues, and releases. Do not preserve history by keeping obsolete current-state docs, tests, or compatibility surfaces.
+- Do not use tests to police static ownership, naming, or architecture. Express those rules in code, or in centralized analyzer, style, or build policy when code alone cannot express them.
+
+- Keep PLATEAU terminology and import semantics aligned with `PLATEAU-SDK-for-UNITY`.
+- Treat ResoniteLink and live target integration as external contracts. Correctness is the emitted payload, readback, or observable target state matching the current contract, not a particular internal implementation shape.
 - Prefer deterministic outputs, explicit command inputs, and reproducible local/CI behavior.
-- Add or update automated tests when behavior changes.
+- When behavior changes, first decide whether the dynamic behavior can be reduced or expressed directly in code. Add or update automated tests only for the remaining dynamic behavior that needs contract locking or regression detection.
 - For regression fixes, define the expected observable contract and the counterexamples or observation points that could disprove the proposed cause before treating the fix as complete.
 - Under limited information, do not lock onto a single hypothesis. First create observations, tests, or comparisons that can fail that hypothesis, and make only changes that stay valid across plausible interpretations.
 - When multiple execution paths emit the same concept, enforce a shared contract and compare equivalent outputs instead of adding path-specific compensation.
-- If an output cannot be inspected through the normal UI or external target surface, add a boundary-adapter recording, dump, or readback artifact that can inspect the actual emitted payload and use it in the completion criteria.
+- If an output cannot be inspected through the normal UI or external target surface, add a recording, dump, or readback artifact that can inspect the actual emitted payload and use it in the completion criteria.
 - Do not treat green tests, CI, or review approval alone as proof that a regression is fixed. Confirm that the observation artifacts relevant to the failure mode satisfy the expected contract.
-- Do not treat grep-based architecture or naming tests as the canonical boundary guard. Keep naming and ownership rules here, enforce dependency direction with project references, and cover only observable behavior with automated tests.
-- Keep dependency injection flowing through the full stack. Core, application, import, bootstrap, target, and transport code must not hide concrete defaults behind `new`, static factories, or fallback self-wiring.
-- Keep legacy conversions and static projection helpers in adapter-edge code only. Core concepts and neutral contracts must not depend on `ToLegacy`, `FromLegacy`, or target-specific mapper utilities.
-- Keep result models pure. Do not store bootstrap-only, discovery-only, connection-only, or layout-only state on document/read results when a separate context or snapshot can carry it.
-- When renaming concepts, update directories, filenames, namespaces, project names, resources, and docs in the same cut. Do not leave compatibility aliases behind.
-- Keep namespace declarations aligned to folder ownership boundaries. When changing ownership boundaries, update namespaces and directory layout in one cut so the source path can be read as the ownership signal.
-- Do not keep global using directives in the final-state architecture. Declare dependencies in each file so cross-boundary usage stays explicit and mechanically reviewable.
-- Keep internal contracts target-neutral. Internal models must not depend on Resonite-specific vector semantics; keep target-specific conversions inside dedicated adapter-edge converters.
-- Prefer `ILogger<T>` and framework-integrated observability over custom logging pipelines when evolving diagnostics, and use `System.Diagnostics.Metrics` for first-class metrics instrumentation.
 
 - Keep auxiliary git worktrees under `<repo>/.worktree/`, and avoid sibling directories or `/tmp` worktrees; this keeps ephemeral worktrees consistently ignored and separated from the main checkout.
 

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -9,10 +9,9 @@ PR を出す前に、次を確認してください。
 - このリポジトリで Coding Agent を使う場合は、[AGENTS.md](AGENTS.md) を読ませてください。
 - 明確な理由がない限り、runtime と SDK の前提は .NET 10 のまま保つ。
 - English Markdown を変更した場合は、対応する `.ja.md` も更新する。
-- 挙動が変わる場合は、test を追加または更新する。
-- namespace とフォルダ所有境界は一致させる。部分的な名前変更や移動で namespace とパスのズレを残さない。
+- 挙動が変わる場合は、まず正しさを静的なコードで表現する。型、API、プロジェクト依存、所有境界、ビルド時チェックにより、不正なコードがコンパイルできない形を優先する。残る動的挙動のうち、仕様固定や回帰検出が必要なものに限ってテストを追加または更新する。
 - 補助的な git worktree はリポジトリ直下の `.worktree/` 配下（例: `.../<repo>/.worktree/<name>`）で運用し、隣接ディレクトリや `/tmp` の worktree を作らないこと。
-- 概念 ownership を grep ベースの architecture test / naming test で縛らないこと。project reference による境界、review checklist、挙動仕様 test を優先する。
+- 静的な所有、命名、アーキテクチャを正本の契約にするテストは追加しないこと。コードで守ることを第一にし、コードだけでは表現しきれない機械的制約はリポジトリルートのアナライザー、スタイル設定、ビルド設定に置く。
 
 GitHub Releases を changelog の正本とします。release tag は `vX.Y.Z` 形式で作成し、各 tag で framework-dependent の CLI zip asset を公開しつつ、merge 済み pull request から release notes を自動生成します。
 
@@ -49,17 +48,15 @@ dotnet test .agents/skills/resonite-live-send-debug/tools/tests/ResoniteLiveSend
 dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity minimal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "Category!=Slow"
 ```
 
-大きな repository-improvement plan を一時的に保持したい場合は、`.tmp/plans/` 配下に置き、untracked のまま維持してください。その領域を canonical documentation として扱わず、active docs から現行運用の案内としてリンクせず、採用した結論だけを tracked documentation と review 成果物へ反映してください。
-
 PR の説明には、何を変えたか、なぜ変えたか、残っている limitation や follow-up work があれば書いてください。
 
 review 時には次も確認してください。
 
-- 概念名、directory 配置、namespace 配置が ownership に一致し、互換 alias を残していない
-- project reference が意図した依存方向を保っている
-- 最終状態の source tree に global using が残っていない
-- internal contract が target-neutral を保ち、target 固有変換が adapter edge に隔離されている
-- 挙動変更が grep ベースの naming / boundary test ではなく、behavior-oriented test で守られている
-- naming rule や boundary rule を変えた場合に、agent guidance と reviewer guidance も更新されている
+- PR が、変更する現在の契約または正しさの基準を説明している
+- 静的に守れる正しさが、テスト、ドキュメント、レビュー指針だけでなく、コードまたはビルド時チェックで表現されている
+- コードだけでは表現しきれない機械的な静的規則が、テストではなくルートのアナライザー、スタイル設定、ビルド設定に置かれている
+- 変更後も残る動的挙動について、コードだけでは仕様固定や回帰検出が足りない場合に、必要な範囲のテストで守られている
+- 通常の UI やターゲット表示面から実際の送出 payload を確認できない外部出力契約について、観測、ダンプ、読み戻しの証拠がある
+- 現在の正しさの基準や作業手順上の制約を変えた場合に、エージェント向け指針とレビュー指針も更新されている
 
 ある commit が GitHub Issue を完全に解決し、merge 時に自動 close してよい場合だけ、commit message footer に `Fixes #81` や `Closes #85` を使ってください。途中段階の cut、partial migration、follow-up 用 commit では `Refs #81` を使います。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,9 @@ Before opening a PR:
 - If you use a coding agent for this repository, make sure it reads [AGENTS.md](AGENTS.md).
 - Keep runtime and SDK assumptions on .NET 10 unless the change clearly requires otherwise.
 - Update the matching `.ja.md` file when you change an English Markdown document.
-- Add or update tests when behavior changes.
-- Keep namespace declarations aligned with folder ownership boundaries and avoid partial renames that leave namespace or path mismatches.
+- When behavior changes, first express correctness in static code where feasible: types, APIs, project dependencies, ownership boundaries, and build-time checks should make invalid code fail to compile. Add or update tests only for remaining dynamic behavior that needs contract locking or regression detection.
 - Keep auxiliary git worktrees in the repository root `.worktree/` directory (for example `.../<repo>/.worktree/<name>`), and avoid leaving worktrees in sibling directories or `/tmp`.
-- Do not add grep-based architecture or naming tests to enforce concept ownership. Prefer project-reference boundaries, review checklist enforcement, and behavior-oriented tests.
+- Do not add tests that make static ownership, naming, or architecture the canonical contract. Prefer code first, then centralized analyzer, style, or build policy for mechanically checkable constraints that code alone cannot express.
 
 GitHub Releases are the canonical changelog. Create release tags as `vX.Y.Z`; each tag publishes a framework-dependent CLI zip asset and generates release notes from merged pull requests.
 
@@ -49,17 +48,15 @@ For quick non-slow iteration between low-conflict changes, use:
 dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity minimal -m:1 --disable-build-servers -p:UseSharedCompilation=false --filter "Category!=Slow"
 ```
 
-If you need to keep a large repository-improvement plan around temporarily, keep it under `.tmp/plans/` and leave it untracked. Do not treat that area as canonical documentation, do not link it from active docs as current operating guidance, and reflect only adopted conclusions in tracked documentation and code review artifacts.
-
 In the PR description, explain what changed, why, and any remaining limitations or follow-up work.
 
 Reviewers should also check:
 
-- concept names, directory placement, and namespace placement match ownership without leaving compatibility aliases behind
-- project references still enforce the intended dependency direction
-- no global using directives remain in the final-state source tree
-- internal contracts stay target-neutral, with target-specific conversions isolated at adapter edges
-- behavior changes are covered by behavior-oriented tests rather than grep-based naming or boundary checks
-- agent guidance and reviewer guidance are updated when naming or boundary rules change
+- the PR states the current contract or correctness criterion it changes
+- static correctness is expressed in code or build-time checks where feasible, not only in tests, docs, or review guidance
+- mechanically checkable static rules that code alone cannot express are captured by root analyzer, style, or build policy rather than tests
+- remaining dynamic behavior has focused tests when code alone cannot lock the contract or catch regressions
+- external output contracts have observation, dump, or readback evidence when the normal UI or target surface cannot show the actual emitted payload
+- agent guidance and reviewer guidance are updated when current correctness criteria or workflow constraints change
 
 When a commit fully resolves a GitHub issue and is safe to auto-close on merge, use a commit message footer such as `Fixes #81` or `Closes #85`. For intermediate cuts, partial migrations, or follow-up-only commits, use `Refs #81` instead.

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 
 PlateauResoniteLink は、[PLATEAU](https://www.mlit.go.jp/plateau/) の CityGML データセットを [ResoniteLink](https://github.com/Yellow-Dog-Man/ResoniteLink) 経由で Resonite に逐次送信する .NET 10 CLI です。インポート挙動と用語は [PLATEAU SDK for Unity](https://project-plateau.github.io/PLATEAU-SDK-for-Unity/) に揃えています。changelog の正本は GitHub Releases で、各 `vX.Y.Z` release は framework-dependent な CLI asset `PlateauResoniteLink-cli-vX.Y.Z.zip` を公開します。
 
-この README は、現在の `beta` branch における、人間向け current scope の正本です。`requirements` のような別文書は復活させず、shipped と intentionally regressed はここ と tests に揃えます。
+この README は、現在の `beta` ブランチについて、人間が読むスコープ説明の正本です。別の要件文書を復活させたり、過去の要件をここに保存したりせず、現在のコードと、残る動的契約を守るテストに揃えます。
 
 ## Scope
 
@@ -18,7 +18,7 @@ Shipped:
 - DEM terrain imagery tile は既定で local cache に永続化し、再実行時に PLATEAU Ortho や fallback の GSI tile を再利用できるようにする。
 
 Intentionally regressed:
-- standalone の requirements 文書は release-truth surface としては維持しません。product scope は `README.md` と tests に置き、live-send の実行手順は `.agents/skills/resonite-live-send-debug/` 配下の Coding Agent skill に置きます。
+- 単独の要件文書は、リリース上の正本としては維持しません。現在の製品範囲はコードを第一にし、残る動的契約をテストで守り、人間向けの範囲説明をこの README で表現します。live-send の実行手順は `.agents/skills/resonite-live-send-debug/` 配下の Coding Agent 向け skill に置きます。
 
 ## Runtime And Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 PlateauResoniteLink is a .NET 10 CLI for streaming [PLATEAU](https://www.mlit.go.jp/plateau/) CityGML datasets into Resonite through [ResoniteLink](https://github.com/Yellow-Dog-Man/ResoniteLink). Import behavior and terminology stay aligned with [PLATEAU SDK for Unity](https://project-plateau.github.io/PLATEAU-SDK-for-Unity/). GitHub Releases are the canonical changelog, and each `vX.Y.Z` release publishes a framework-dependent CLI asset named `PlateauResoniteLink-cli-vX.Y.Z.zip`.
 
-This README is the canonical human-readable scope statement for the current `beta` branch. Keep shipped and intentionally regressed behavior aligned here and in tests instead of reviving a separate requirements document.
+This README is the canonical human-readable scope statement for the current `beta` branch. Keep it aligned with current code and executable tests for remaining dynamic contracts instead of reviving a separate requirements document or preserving historical requirements here.
 
 ## Scope
 
@@ -18,7 +18,7 @@ Shipped:
 - Persist terrain imagery tiles under a local cache by default so repeated DEM imports can reuse already downloaded PLATEAU Ortho or fallback GSI tiles.
 
 Intentionally regressed:
-- A standalone requirements document is not maintained as a release-truth surface. Product scope lives in `README.md` and tests, while live-send execution guidance is kept in the Coding Agent skill under `.agents/skills/resonite-live-send-debug/`.
+- A standalone requirements document is not maintained as a release-truth surface. Current product scope is expressed by code first, executable tests for remaining dynamic contracts, and this README for human-readable scope; live-send execution guidance is kept in the Coding Agent skill under `.agents/skills/resonite-live-send-debug/`.
 
 ## Runtime And Prerequisites
 


### PR DESCRIPTION
## Summary
- Clarifies repository truth surfaces: code as current truth, static code and build-time checks first, tests only for remaining dynamic behavior, docs for current context, and git history for the past.
- Removes implementation-level architecture guidance from `AGENTS.md` so it no longer freezes DI, namespace, global using, adapter-edge, target-neutral, logging, or similar refactor-specific design choices.
- Aligns `CONTRIBUTING.md` review guidance around the changed correctness contract and the surface that protects it: code/static checks, focused tests, docs, or observable evidence.
- Syncs the Japanese mirrors and keeps README scope wording aligned with code-first scope and tests for remaining dynamic contracts.

## Validation
- `git diff --check`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (1094 passed)

## Notes
- `.tmp/plans` does not exist in the current checkout.
- Existing root analyzer/style/build settings are tracked and not ignored: `.editorconfig`, `Directory.Build.props`, and related root build files.
