### PR TITLE
[codex] Remove facade texture from generic other materials

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CommonMaterialCatalog.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CommonMaterialCatalog.cs
@@ -55,8 +55,7 @@ public sealed class CommonMaterialCatalog<TItem>
             create(CommonMaterialDefinitions.OtherPlaster003),
             create(CommonMaterialDefinitions.OtherPlaster004),
             create(CommonMaterialDefinitions.OtherPlaster005),
-            create(CommonMaterialDefinitions.OtherPlaster006),
-            create(CommonMaterialDefinitions.OtherTextureCanFacade0022));
+            create(CommonMaterialDefinitions.OtherPlaster006));
         RoadTriplanar = new CommonRoadMaterialCatalog<TItem>(
             create(CommonMaterialDefinitions.RoadTriplanar012A),
             create(CommonMaterialDefinitions.RoadTriplanar013A),
@@ -126,7 +125,6 @@ public sealed class CommonMaterialCatalog<TItem>
             Member(CommonMaterialDefinitions.OtherPlaster004, Other.Plaster004),
             Member(CommonMaterialDefinitions.OtherPlaster005, Other.Plaster005),
             Member(CommonMaterialDefinitions.OtherPlaster006, Other.Plaster006),
-            Member(CommonMaterialDefinitions.OtherTextureCanFacade0022, Other.TextureCanFacade0022),
             Member(CommonMaterialDefinitions.RoadTriplanar012A, RoadTriplanar.Road012A),
             Member(CommonMaterialDefinitions.RoadTriplanar013A, RoadTriplanar.Road013A),
             Member(CommonMaterialDefinitions.RoadTriplanar014A, RoadTriplanar.Road014A),
@@ -351,8 +349,7 @@ public sealed record CommonOtherMaterialCatalog<TItem>(
     TItem Plaster003,
     TItem Plaster004,
     TItem Plaster005,
-    TItem Plaster006,
-    TItem TextureCanFacade0022);
+    TItem Plaster006);
 
 public sealed record CommonRoadMaterialCatalog<TItem>(
     TItem Road012A,

--- a/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinitions.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CommonMaterialDefinitions.cs
@@ -37,7 +37,6 @@ internal static class CommonMaterialDefinitions
     public static readonly CommonMaterialDefinition OtherPlaster004 = Bundled(BundledDefaultMaterialFamilies.Other, 5, "Plaster004");
     public static readonly CommonMaterialDefinition OtherPlaster005 = Bundled(BundledDefaultMaterialFamilies.Other, 6, "Plaster005");
     public static readonly CommonMaterialDefinition OtherPlaster006 = Bundled(BundledDefaultMaterialFamilies.Other, 7, "Plaster006");
-    public static readonly CommonMaterialDefinition OtherTextureCanFacade0022 = Bundled(BundledDefaultMaterialFamilies.Other, 8, "TextureCanFacade0022");
     public static readonly CommonMaterialDefinition RoadTriplanar012A = Bundled(BundledDefaultMaterialFamilies.RoadTriplanar, 0, "Road012A");
     public static readonly CommonMaterialDefinition RoadTriplanar013A = Bundled(BundledDefaultMaterialFamilies.RoadTriplanar, 1, "Road013A");
     public static readonly CommonMaterialDefinition RoadTriplanar014A = Bundled(BundledDefaultMaterialFamilies.RoadTriplanar, 2, "Road014A");

--- a/src/PlateauResoniteLink/Application/Importing/DefaultMaterialFamilyOverride.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DefaultMaterialFamilyOverride.cs
@@ -42,7 +42,7 @@ internal sealed class DefaultMaterialFamilyOverride
 
     public static readonly DefaultMaterialFamilyOverride Other = new(
         BundledDefaultMaterialFamilies.Other,
-        static (catalog, key) => StableVariantSelector.SelectBucket(key, 9) switch
+        static (catalog, key) => StableVariantSelector.SelectBucket(key, 8) switch
         {
             0 => catalog.Other.Concrete012,
             1 => catalog.Other.Ground054,
@@ -51,8 +51,7 @@ internal sealed class DefaultMaterialFamilyOverride
             4 => catalog.Other.Plaster003,
             5 => catalog.Other.Plaster004,
             6 => catalog.Other.Plaster005,
-            7 => catalog.Other.Plaster006,
-            _ => catalog.Other.TextureCanFacade0022,
+            _ => catalog.Other.Plaster006,
         });
 
     public static readonly DefaultMaterialFamilyOverride RoadTriplanar = new(

--- a/src/PlateauResoniteLink/Domain/Importing/BundledDefaultMaterialFamilies.cs
+++ b/src/PlateauResoniteLink/Domain/Importing/BundledDefaultMaterialFamilies.cs
@@ -32,7 +32,6 @@ public static class BundledDefaultMaterialFamilies
     private static readonly BundledDefaultMaterialProfile Plaster002TextureSet = new(CreateTilesPerMeterValue(2.5, 2.5));
     private static readonly BundledDefaultMaterialProfile Ground054TextureSet = new(CreateTilesPerMeterValue(3.5, 3.5));
     private static readonly BundledDefaultMaterialProfile RoadDefaultTextureSet = new(BundledDefaultMaterialTiling.DefaultTilesPerMeterValue);
-    private static readonly BundledDefaultMaterialProfile TextureCanFacadeTextureSet = new(CreateTilesPerMeterValue(6.0, 6.0));
 
     public static readonly IReadOnlyList<BundledDefaultMaterialVariant> FacadeVariants =
     [
@@ -495,12 +494,6 @@ public static class BundledDefaultMaterialFamilies
                 Height: BundledDefaultTextureAssets.Wall.Plaster006.Height,
                 Metallic: BundledDefaultTextureAssets.Wall.Plaster006.Metallic,
                 Normal: BundledDefaultTextureAssets.Wall.Plaster006.Normal)),
-        new(
-            BundledDefaultTextureAssets.TextureCanFacade.Others0022.Albedo,
-            TextureCanFacadeTextureSet,
-            TextureSources: new(
-                Metallic: BundledDefaultTextureAssets.TextureCanFacade.Others0022.Metallic,
-                Normal: BundledDefaultTextureAssets.TextureCanFacade.Others0022.Normal)),
     ];
 
     private static readonly Dictionary<string, BundledDefaultMaterialVariant> VariantsByTexturePath = CreateVariantsByTexturePath();

--- a/tests/PlateauResoniteLink.Tests/Domain/BundledDefaultMaterialVariantTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Domain/BundledDefaultMaterialVariantTests.cs
@@ -197,6 +197,30 @@ public sealed class BundledDefaultMaterialVariantTests
     }
 
     [Fact]
+    public void NonBuildingMaterialFamiliesDoNotUseFacadeTextureAssets()
+    {
+        string[] nonBuildingFamilies =
+        [
+            BundledDefaultMaterialFamilies.Roof,
+            BundledDefaultMaterialFamilies.RoadUv,
+            BundledDefaultMaterialFamilies.RoadTriplanar,
+            BundledDefaultMaterialFamilies.Vegetation,
+            BundledDefaultMaterialFamilies.CityFurniture,
+            BundledDefaultMaterialFamilies.Other,
+        ];
+
+        foreach (string family in nonBuildingFamilies)
+        {
+            foreach (BundledDefaultMaterialVariant variant in BundledDefaultMaterialFamilies.GetVariantDefinitions(family))
+            {
+                Assert.All(
+                    EnumerateVariantTexturePaths(variant),
+                    texturePath => Assert.DoesNotContain("/facade/", texturePath, StringComparison.Ordinal));
+            }
+        }
+    }
+
+    [Fact]
     public void BundledDefaultMaterialAssetStoreReadsBundledResourceWithoutFileMaterialization()
     {
         string logicalPath = BundledDefaultMaterialFamilies.GetVariant(BundledDefaultMaterialFamilies.CityFurniture, 0);
@@ -288,6 +312,42 @@ public sealed class BundledDefaultMaterialVariantTests
             materialName,
             "emission.png");
         return true;
+    }
+
+    private static IEnumerable<string> EnumerateVariantTexturePaths(BundledDefaultMaterialVariant variant)
+    {
+        yield return variant.Albedo.LogicalPath;
+
+        BundledDefaultMaterialTextureSources? sources = variant.TextureSources;
+        if (sources is null)
+        {
+            yield break;
+        }
+
+        if (sources.Albedo is not null)
+        {
+            yield return sources.Albedo.LogicalPath;
+        }
+
+        if (sources.Emission is not null)
+        {
+            yield return sources.Emission.LogicalPath;
+        }
+
+        if (sources.Height is not null)
+        {
+            yield return sources.Height.LogicalPath;
+        }
+
+        if (sources.Metallic is not null)
+        {
+            yield return sources.Metallic.LogicalPath;
+        }
+
+        if (sources.Normal is not null)
+        {
+            yield return sources.Normal.LogicalPath;
+        }
     }
 
 }

--- a/tests/PlateauResoniteLink.Tests/Profiles/CommonMaterialCatalogTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/CommonMaterialCatalogTests.cs
@@ -389,9 +389,9 @@ public sealed class CommonMaterialCatalogTests
                     or BundledDefaultMaterialFamilies.CityFurniture
                     or BundledDefaultMaterialFamilies.Other
                 && material.Projection == MaterialProjection.Uv);
-        Assert.Contains(
+        Assert.DoesNotContain(
             BundledDefaultMaterialFamilies.OtherVariants,
-            variant => variant.Albedo.LogicalPath.StartsWith("default-materials/texturecan/", StringComparison.Ordinal));
+            variant => variant.Albedo.LogicalPath.Contains("/facade/", StringComparison.Ordinal));
     }
 
     private static string CreateMaterialSignature(MaterialBinding material)

--- a/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/DefaultMaterialResolverTests.cs
@@ -224,25 +224,6 @@ public sealed class DefaultMaterialResolverTests
     }
 
     [Fact]
-    public void ResolveMaterialCanReachTextureCanGenericOtherVariant()
-    {
-        ResolvedMaterial? textureCanMaterial = null;
-        for (int attempt = 0; attempt < 512 && textureCanMaterial is null; attempt++)
-        {
-            ResolvedMaterial material = resolver.ResolveMaterial(CreateFallbackRequest("brid", $"brid:tri:{attempt}"));
-            string texturePath = BundledDefaultMaterialFamilies.GetVariant(material.Family!, material.BundledVariantIndex!.Value);
-            if (texturePath.StartsWith("default-materials/texturecan/", System.StringComparison.Ordinal))
-            {
-                textureCanMaterial = material;
-            }
-        }
-
-        Assert.NotNull(textureCanMaterial);
-        Assert.Equal(BundledDefaultMaterialFamilies.Other, textureCanMaterial!.Family);
-        Assert.Equal(MaterialReuseScope.Shared, textureCanMaterial.ReuseScope);
-    }
-
-    [Fact]
     public void ResolveMaterialUsesStableBundledVariantSelection()
     {
         ResolvedMaterial first = resolver.ResolveMaterial(

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialAssetBindingTestFactory.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialAssetBindingTestFactory.cs
@@ -53,8 +53,7 @@ internal static class ResoniteMaterialAssetBindingTestFactory
                 4 => commonMaterials.Other.Plaster003,
                 5 => commonMaterials.Other.Plaster004,
                 6 => commonMaterials.Other.Plaster005,
-                7 => commonMaterials.Other.Plaster006,
-                _ => commonMaterials.Other.TextureCanFacade0022,
+                _ => commonMaterials.Other.Plaster006,
             },
             BundledDefaultMaterialFamilies.RoadTriplanar => variantIndex switch
             {


### PR DESCRIPTION
## Summary
- remove the TextureCan facade variant from the generic `Other` bundled material family
- remove the stale common-material catalog and resolver paths that made generic fallback packages able to select that facade asset
- add a guard that non-building material families do not reference `/facade/` texture assets

## Root Cause
`TextureCanFacade.Others0022` was registered as an `Other` material variant, so generic non-building fallback packages could pick a facade-oriented texture.

## Validation
- `dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --filter "FullyQualifiedName~BundledDefaultMaterialVariantTests|FullyQualifiedName~CommonMaterialCatalogTests|FullyQualifiedName~DefaultMaterialResolverTests|FullyQualifiedName~ResoniteMaterialComponentPolicyTests" --no-restore`
- `dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --no-restore`
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`