### PR TITLE
[codex] Move Resonite emission decisions into plan

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteBatchEmissionPlanner.cs
@@ -46,12 +46,7 @@ internal static class ResoniteBatchEmissionPlanner
         List<PlannedBatchSlotEmission> slotEmissions = [];
         List<PlannedBatchComponentEmission> componentEmissions = [];
 
-        PlannedBatchSlotEmission presentationSlot = new(
-            PlannedSlotTargetReference.CanonicalSlot(objectSlots.LodSlot.Locator),
-            objectSlots.CityObjectSlotName,
-            objectSlots.CityObjectLocalPosition,
-            objectSlots.CityObjectRotation,
-            objectSlots.CityObjectOrderOffset);
+        PlannedBatchSlotEmission presentationSlot = PlannedBatchSlotEmission.Presentation(objectSlots);
         slotEmissions.Add(presentationSlot);
         PlannedSlotTargetReference presentationSlotTarget = PlannedSlotTargetReference.PlannedSlot(presentationSlot);
 
@@ -234,69 +229,11 @@ internal static class ResoniteBatchEmissionPlanner
                 .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal));
         componentEmissions.Add(heightTextureComponent);
 
-        PlannedFieldReference pointsField = new();
-        Field_int2 points = new()
-        {
-            Value = new int2
-            {
-                x = geometry.Width,
-                y = geometry.Height,
-            },
-        };
-        Field_float2 size = new()
-        {
-            Value = new float2
-            {
-                x = (float)geometry.Size.X,
-                y = (float)geometry.Size.Y,
-            },
-        };
-        Field_float displacement = new()
-        {
-            Value = -1.0f,
-        };
-        float firstBoundsY = (float)(geometry.MinHeight * displacement.Value);
-        float secondBoundsY = (float)(geometry.MaxHeight * displacement.Value);
-        Field_float minBoundsY = new()
-        {
-            Value = Math.Min(firstBoundsY, secondBoundsY),
-        };
-        Field_float maxBoundsY = new()
-        {
-            Value = Math.Max(firstBoundsY, secondBoundsY),
-        };
-        Field_float2? plannedUvScale = uvScale is null
-            ? null
-            : new Field_float2
-            {
-                Value = new float2
-                {
-                    x = (float)uvScale.X,
-                    y = (float)uvScale.Y,
-                },
-            };
-
-        Field_float2? plannedUvOffset = uvOffset is null
-            ? null
-            : new Field_float2
-            {
-                Value = new float2
-                {
-                    x = (float)uvOffset.X,
-                    y = (float)uvOffset.Y,
-                },
-            };
-
-        return new PlannedTerrainGridMeshBundle(
-            pointsField,
-            points,
-            size,
-            displacement,
-            minBoundsY,
-            maxBoundsY,
+        return PlannedTerrainGridMeshBundle.Create(
+            geometry,
             PlannedWorldElementReference.Planned(heightTextureComponent),
-            plannedUvScale,
-            plannedUvOffset);
+            uvScale,
+            uvOffset);
     }
 
     private static Dictionary<string, PlannedMember> CreateTerrainGridMeshMembers(
@@ -308,7 +245,7 @@ internal static class ResoniteBatchEmissionPlanner
             {
                 Value = true,
             }),
-            ["OverridenBoundingBox"] = PlannedMembers.Literal(CreateTerrainGridBoundingBox(terrainGridMesh)),
+            ["OverridenBoundingBox"] = PlannedMembers.Literal(terrainGridMesh.CreateOverriddenBoundingBox()),
             ["Points"] = PlannedMembers.AddressableField(terrainGridMesh.PointsField, terrainGridMesh.Points),
             ["Size"] = PlannedMembers.Literal(terrainGridMesh.Size),
             ["Rotation"] = PlannedMembers.Literal(TerrainGridRotation),
@@ -326,30 +263,6 @@ internal static class ResoniteBatchEmissionPlanner
         }
 
         return members;
-    }
-
-    private static Field_BoundingBox CreateTerrainGridBoundingBox(PlannedTerrainGridMeshBundle terrainGridMesh)
-    {
-        float halfWidth = Math.Abs(terrainGridMesh.Size.Value.x) / 2.0f;
-        float halfDepth = Math.Abs(terrainGridMesh.Size.Value.y) / 2.0f;
-        return new Field_BoundingBox
-        {
-            Value = new BoundingBox
-            {
-                min = new float3
-                {
-                    x = -halfWidth,
-                    y = terrainGridMesh.MinBoundsY.Value,
-                    z = -halfDepth,
-                },
-                max = new float3
-                {
-                    x = halfWidth,
-                    y = terrainGridMesh.MaxBoundsY.Value,
-                    z = halfDepth,
-                },
-            },
-        };
     }
 
     private static void AddDynamicMeshSwitchComponents(
@@ -596,53 +509,20 @@ internal static class ResoniteBatchEmissionPlanner
         PlannedBatchSlotEmission presentationSlot,
         PlannedMainTextureOverrideRendererMaterialBinding binding)
     {
-        if (binding is PlannedTerrainMainTextureOverrideRendererMaterialBinding
-            {
-                SharedMainTexturePropertyBlockComponent: { } sharedMainTexturePropertyBlockComponent,
-            })
-        {
-            return PlannedMembers.Reference(PlannedWorldElementReference.Canonical(sharedMainTexturePropertyBlockComponent));
-        }
-
-        PlannedWorldElementReference? sharedTextureTarget = binding is PlannedTerrainMainTextureOverrideRendererMaterialBinding
-        {
-            SharedMainTextureComponent: { } sharedMainTextureComponent,
-        }
-            ? PlannedWorldElementReference.Canonical(sharedMainTextureComponent)
-            : null;
-        PlannedBatchComponentEmission? textureComponent = null;
-        ResoniteSceneMaterialConventions.TextureMemberRole textureRole = binding switch
-        {
-            PlannedAlbedoMainTextureOverrideRendererMaterialBinding =>
-                ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
-            PlannedTerrainMainTextureOverrideRendererMaterialBinding =>
-                ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride,
-            _ => throw new InvalidOperationException(
-                $"Unsupported planned main texture override binding type '{binding.GetType().Name}'."),
-        };
-        if (sharedTextureTarget is null)
-        {
-            textureComponent = new PlannedBatchComponentEmission(
-                PlannedSlotTargetReference.PlannedSlot(presentationSlot),
-                "[FrooxEngine]FrooxEngine.StaticTexture2D",
-                ResoniteSceneMaterialConventions.CreateTextureMembers(
-                    binding.MainTexture.AssetUri,
-                    textureRole)
-                    .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal));
-            componentEmissions.Add(textureComponent);
-        }
-
-        PlannedWorldElementReference textureTarget = sharedTextureTarget
-            ?? PlannedWorldElementReference.Planned(textureComponent ?? throw new InvalidOperationException("Main texture property block did not create a texture component."));
-        PlannedBatchComponentEmission propertyBlock = new(
+        PlannedMainTexturePropertyBlockOverride propertyBlockOverride = PlannedMainTexturePropertyBlockOverride.Create(
             PlannedSlotTargetReference.PlannedSlot(presentationSlot),
-            "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
-            new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
-            {
-                ["Texture"] = PlannedMembers.Reference(textureTarget),
-            });
-        componentEmissions.Add(propertyBlock);
+            PlannedSlotTargetReference.PlannedSlot(presentationSlot),
+            binding);
+        if (propertyBlockOverride.TextureComponent is not null)
+        {
+            componentEmissions.Add(propertyBlockOverride.TextureComponent);
+        }
 
-        return PlannedMembers.Reference(PlannedWorldElementReference.Planned(propertyBlock));
+        if (propertyBlockOverride.PropertyBlockComponent is not null)
+        {
+            componentEmissions.Add(propertyBlockOverride.PropertyBlockComponent);
+        }
+
+        return propertyBlockOverride.PropertyBlock;
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using ResoniteLink;
 
@@ -76,7 +77,167 @@ internal sealed record PlannedTerrainGridMeshBundle(
     Field_float MaxBoundsY,
     PlannedWorldElementReference DisplacementTexture,
     Field_float2? UvScale,
-    Field_float2? UvOffset);
+    Field_float2? UvOffset)
+{
+    public static PlannedTerrainGridMeshBundle Create(
+        ResoniteTerrainGridGeometry geometry,
+        PlannedWorldElementReference displacementTexture,
+        ResoniteFloat2? uvScale,
+        ResoniteFloat2? uvOffset)
+    {
+        ArgumentNullException.ThrowIfNull(geometry);
+        ArgumentNullException.ThrowIfNull(displacementTexture);
+
+        Field_float displacement = new()
+        {
+            Value = -1.0f,
+        };
+        float firstBoundsY = (float)(geometry.MinHeight * displacement.Value);
+        float secondBoundsY = (float)(geometry.MaxHeight * displacement.Value);
+        return new PlannedTerrainGridMeshBundle(
+            new PlannedFieldReference(),
+            new Field_int2
+            {
+                Value = new int2
+                {
+                    x = geometry.Width,
+                    y = geometry.Height,
+                },
+            },
+            new Field_float2
+            {
+                Value = new float2
+                {
+                    x = (float)geometry.Size.X,
+                    y = (float)geometry.Size.Y,
+                },
+            },
+            displacement,
+            new Field_float
+            {
+                Value = Math.Min(firstBoundsY, secondBoundsY),
+            },
+            new Field_float
+            {
+                Value = Math.Max(firstBoundsY, secondBoundsY),
+            },
+            displacementTexture,
+            ToField(uvScale),
+            ToField(uvOffset));
+    }
+
+    public Field_BoundingBox CreateOverriddenBoundingBox()
+    {
+        float halfWidth = Math.Abs(Size.Value.x) / 2.0f;
+        float halfDepth = Math.Abs(Size.Value.y) / 2.0f;
+        return new Field_BoundingBox
+        {
+            Value = new BoundingBox
+            {
+                min = new float3
+                {
+                    x = -halfWidth,
+                    y = MinBoundsY.Value,
+                    z = -halfDepth,
+                },
+                max = new float3
+                {
+                    x = halfWidth,
+                    y = MaxBoundsY.Value,
+                    z = halfDepth,
+                },
+            },
+        };
+    }
+
+    private static Field_float2? ToField(ResoniteFloat2? value)
+    {
+        return value is null
+            ? null
+            : new Field_float2
+            {
+                Value = new float2
+                {
+                    x = (float)value.X,
+                    y = (float)value.Y,
+                },
+            };
+    }
+}
+
+internal sealed record PlannedMainTexturePropertyBlockOverride(
+    PlannedMember PropertyBlock,
+    PlannedBatchComponentEmission? TextureComponent,
+    PlannedBatchComponentEmission? PropertyBlockComponent)
+{
+    public static PlannedMainTexturePropertyBlockOverride Create(
+        PlannedSlotTargetReference textureContainerTarget,
+        PlannedSlotTargetReference propertyBlockContainerTarget,
+        PlannedMainTextureOverrideRendererMaterialBinding binding)
+    {
+        ArgumentNullException.ThrowIfNull(textureContainerTarget);
+        ArgumentNullException.ThrowIfNull(propertyBlockContainerTarget);
+        ArgumentNullException.ThrowIfNull(binding);
+
+        if (binding is PlannedTerrainMainTextureOverrideRendererMaterialBinding
+            {
+                SharedMainTexturePropertyBlockComponent: { } sharedMainTexturePropertyBlockComponent,
+            })
+        {
+            return new PlannedMainTexturePropertyBlockOverride(
+                PlannedMembers.Reference(PlannedWorldElementReference.Canonical(sharedMainTexturePropertyBlockComponent)),
+                null,
+                null);
+        }
+
+        PlannedWorldElementReference? sharedTextureTarget = binding is PlannedTerrainMainTextureOverrideRendererMaterialBinding
+        {
+            SharedMainTextureComponent: { } sharedMainTextureComponent,
+        }
+            ? PlannedWorldElementReference.Canonical(sharedMainTextureComponent)
+            : null;
+        ResoniteSceneMaterialConventions.TextureMemberRole textureRole = binding switch
+        {
+            PlannedAlbedoMainTextureOverrideRendererMaterialBinding =>
+                ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
+            PlannedTerrainMainTextureOverrideRendererMaterialBinding =>
+                ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride,
+            _ => throw new InvalidOperationException(
+                $"Unsupported planned main texture override binding type '{binding.GetType().Name}'."),
+        };
+        PlannedBatchComponentEmission? textureComponent = sharedTextureTarget is null
+            ? CreateTextureComponent(
+                textureContainerTarget,
+                binding.MainTexture.AssetUri,
+                textureRole)
+            : null;
+        PlannedWorldElementReference textureTarget = sharedTextureTarget
+            ?? PlannedWorldElementReference.Planned(textureComponent ?? throw new InvalidOperationException("Main texture property block did not create a texture component."));
+        PlannedBatchComponentEmission propertyBlockComponent = new(
+            propertyBlockContainerTarget,
+            "[FrooxEngine]FrooxEngine.MainTexturePropertyBlock",
+            new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
+            {
+                ["Texture"] = PlannedMembers.Reference(textureTarget),
+            });
+        return new PlannedMainTexturePropertyBlockOverride(
+            PlannedMembers.Reference(PlannedWorldElementReference.Planned(propertyBlockComponent)),
+            textureComponent,
+            propertyBlockComponent);
+    }
+
+    private static PlannedBatchComponentEmission CreateTextureComponent(
+        PlannedSlotTargetReference containerTarget,
+        Uri textureUri,
+        ResoniteSceneMaterialConventions.TextureMemberRole textureRole)
+    {
+        return new PlannedBatchComponentEmission(
+            containerTarget,
+            "[FrooxEngine]FrooxEngine.StaticTexture2D",
+            ResoniteSceneMaterialConventions.CreateTextureMembers(textureUri, textureRole)
+                .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal));
+    }
+}
 
 internal sealed class PlannedFieldReference;
 
@@ -304,7 +465,22 @@ internal sealed record PlannedBatchSlotEmission(
     string SlotName,
     ResoniteFloat3? Position,
     ResoniteFloatQ? Rotation,
-    long? OrderOffset = null);
+    long? OrderOffset = null)
+{
+    public static PlannedBatchSlotEmission Presentation(
+        ResoniteObjectSlotHierarchy objectSlots)
+    {
+        ArgumentNullException.ThrowIfNull(objectSlots);
+
+        return new PlannedBatchSlotEmission(
+            PlannedSlotTargetReference.CanonicalSlot(objectSlots.LodSlot.Locator),
+            objectSlots.CityObjectSlotName,
+            objectSlots.CityObjectLocalPosition,
+            objectSlots.CityObjectRotation,
+            objectSlots.CityObjectOrderOffset);
+    }
+
+}
 
 internal sealed record PlannedBatchComponentEmission(
     PlannedSlotTargetReference ContainerTarget,


### PR DESCRIPTION
## Summary
- Move Resonite emission decisions for slot order, GridMesh bounds, material placement, and main-texture property-block overrides into pure plan-side helpers.
- Keep `ResoniteBatchEmissionPlanner` focused on assembling planned emissions while preserving the existing emitted DataModel payload.
- Resolve the rebase conflict onto current `main` without restoring the removed mesh-asset-slot or dedicated-material child-slot structure.

## Validation
- Canonical dump invariant check against parent commit using untracked real Matsumoto data:
  - Source: `C:\Users\esnya\Documents\PLATEAU-ResoniteLink\local\plateau-20202-matsumoto-shi-2020\source-archive.zip`
  - Dataset: `plateau-20202-matsumoto-shi-2020`
  - Mesh: `54372778`
  - Packages: `bldg`
  - Source files: `udx/bldg/54372778_bldg_6697_op.gml (1)`
  - Produced city objects: `2737`
  - Send summary in canonical dump mode: `attempted=5 sent=5 failed=0`
  - Result: byte-identical JSON
  - SHA256: `35DFFAC3F4E0700893FF9D8CD94E434123E860B76C48DF047160074CBF39C668`
  - Length: `3463076` bytes
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --configuration Release --filter FullyQualifiedName~ResoniteSceneBatchEmissionPlanningTests --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`