### PR TITLE
[codex] Contract material planning boundaries

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -61,15 +61,14 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
                 cancellationToken);
         }
 
-        List<PlannedTextureAsset> textures = await PlanBundledCompanionTexturesAsync(
+        List<TargetMaterialTextureProvider> textures = await PlanBundledCompanionTexturesAsync(
             importClient,
             material,
             albedoTextureTask,
             bundledTextureImportTasks,
             cancellationToken);
         return new PlannedDedicatedMaterialAsset(
-            material,
-            textures);
+            new TargetMaterialAssetPlan(new MaterialIdentity(material), textures));
     }
 
     public async Task<PlannedDedicatedMaterialAsset> PlanDedicatedMaterialAssetAsync(
@@ -96,19 +95,18 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             ? ImportBundledAlbedoTextureAsync(importClient, material, cancellationToken)
             : Task.FromResult<Uri?>(null);
 
-        List<PlannedTextureAsset> textures = await PlanBundledCompanionTexturesAsync(
+        List<TargetMaterialTextureProvider> textures = await PlanBundledCompanionTexturesAsync(
             importClient,
             material,
             albedoTextureTask,
             bundledTextureImportTasks: null,
             cancellationToken);
         return new PlannedDedicatedMaterialAsset(
-            material,
-            textures);
+            new TargetMaterialAssetPlan(new MaterialIdentity(material), textures));
     }
 
     public static Uri? TryGetPlannedTextureUri(
-        IEnumerable<PlannedTextureAsset> textures,
+        IEnumerable<TextureProvider> textures,
         ResoniteSceneMaterialConventions.PlannedTextureRole role)
     {
         ArgumentNullException.ThrowIfNull(textures);
@@ -116,7 +114,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         return textures.FirstOrDefault(texture => texture.Role == role)?.AssetUri;
     }
 
-    public static PlannedTextureAsset? PlanMainTextureOverride(
+    public static LocalRendererOverrideTextureProvider? PlanMainTextureOverride(
         ResoniteMaterialBinding material,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
         IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay)
@@ -137,7 +135,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             return null;
         }
 
-        return new PlannedTextureAsset(
+        return new LocalRendererOverrideTextureProvider(
             ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo,
             textureUri);
     }
@@ -321,7 +319,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         };
     }
 
-    private async Task<List<PlannedTextureAsset>> PlanBundledCompanionTexturesAsync(
+    private async Task<List<TargetMaterialTextureProvider>> PlanBundledCompanionTexturesAsync(
         IResoniteLinkClient importClient,
         ResoniteMaterialBinding material,
         Task<Uri?> albedoTextureTask,
@@ -388,24 +386,24 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             metallicTextureTask,
             emissionTextureTask);
 
-        List<PlannedTextureAsset> textures = [];
-        AddPlannedTextureAsset(
+        List<TargetMaterialTextureProvider> textures = [];
+        AddTargetMaterialTextureProvider(
             textures,
             ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo,
             await albedoTextureTask);
-        AddPlannedTextureAsset(
+        AddTargetMaterialTextureProvider(
             textures,
             ResoniteSceneMaterialConventions.PlannedTextureRole.Normal,
             await normalTextureTask);
-        AddPlannedTextureAsset(
+        AddTargetMaterialTextureProvider(
             textures,
             ResoniteSceneMaterialConventions.PlannedTextureRole.Height,
             await heightTextureTask);
-        AddPlannedTextureAsset(
+        AddTargetMaterialTextureProvider(
             textures,
             ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic,
             await metallicTextureTask);
-        AddPlannedTextureAsset(
+        AddTargetMaterialTextureProvider(
             textures,
             ResoniteSceneMaterialConventions.PlannedTextureRole.Emission,
             await emissionTextureTask);
@@ -476,8 +474,8 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
         return variant.TextureSources?.Albedo ?? variant.Albedo;
     }
 
-    private static void AddPlannedTextureAsset(
-        List<PlannedTextureAsset> textures,
+    private static void AddTargetMaterialTextureProvider(
+        List<TargetMaterialTextureProvider> textures,
         ResoniteSceneMaterialConventions.PlannedTextureRole role,
         Uri? assetUri)
     {
@@ -486,7 +484,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             return;
         }
 
-        textures.Add(new PlannedTextureAsset(
+        textures.Add(new TargetMaterialTextureProvider(
             role,
             assetUri));
     }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -27,9 +27,46 @@ internal sealed record PlannedDynamicTerrainGeometryAsset(
     ResoniteFloat2? UvOffset = null)
     : PlannedGeometryAsset;
 
-internal sealed record PlannedTextureAsset(
+internal sealed record MaterialIdentity(ResoniteMaterialBinding Material);
+
+internal abstract record TextureProvider(
     ResoniteSceneMaterialConventions.PlannedTextureRole Role,
     Uri AssetUri);
+
+internal sealed record TargetMaterialTextureProvider(
+    ResoniteSceneMaterialConventions.PlannedTextureRole Role,
+    Uri AssetUri)
+    : TextureProvider(Role, AssetUri);
+
+internal abstract record RendererOverrideTextureProvider(
+    ResoniteSceneMaterialConventions.PlannedTextureRole Role,
+    Uri AssetUri)
+    : TextureProvider(Role, AssetUri);
+
+internal sealed record LocalRendererOverrideTextureProvider(
+    ResoniteSceneMaterialConventions.PlannedTextureRole Role,
+    Uri AssetUri)
+    : RendererOverrideTextureProvider(Role, AssetUri);
+
+internal sealed record SharedTerrainOverlayTextureProvider(
+    Uri AssetUri,
+    ResoniteComponentLocator? SharedMainTextureComponent,
+    ResoniteComponentLocator? SharedMainTexturePropertyBlockComponent)
+    : RendererOverrideTextureProvider(
+        ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo,
+        AssetUri);
+
+internal sealed record TargetMaterialAssetPlan(
+    MaterialIdentity Identity,
+    IReadOnlyList<TargetMaterialTextureProvider> Textures);
+
+internal abstract record RendererOverride;
+
+internal sealed record AlbedoRendererOverride(LocalRendererOverrideTextureProvider MainTexture)
+    : RendererOverride;
+
+internal sealed record TerrainOverlayRendererOverride(RendererOverrideTextureProvider MainTexture)
+    : RendererOverride;
 
 internal abstract record PlannedMaterialAsset;
 
@@ -38,9 +75,21 @@ internal sealed record PlannedReusableMaterialAsset(
     : PlannedMaterialAsset;
 
 internal sealed record PlannedDedicatedMaterialAsset(
-    ResoniteMaterialBinding Material,
-    IReadOnlyList<PlannedTextureAsset> Textures)
-    : PlannedMaterialAsset;
+    TargetMaterialAssetPlan TargetMaterial)
+    : PlannedMaterialAsset
+{
+    public PlannedDedicatedMaterialAsset(
+        ResoniteMaterialBinding material,
+        IReadOnlyList<TargetMaterialTextureProvider> textures)
+        : this(
+            new TargetMaterialAssetPlan(new MaterialIdentity(material), textures))
+    {
+    }
+
+    public ResoniteMaterialBinding Material => TargetMaterial.Identity.Material;
+
+    public IReadOnlyList<TargetMaterialTextureProvider> Textures => TargetMaterial.Textures;
+}
 
 internal abstract record PlannedRendererMaterialBinding(PlannedMaterialAsset MaterialAsset);
 
@@ -49,20 +98,31 @@ internal sealed record PlannedDirectRendererMaterialBinding(PlannedMaterialAsset
 
 internal abstract record PlannedMainTextureOverrideRendererMaterialBinding(
     PlannedMaterialAsset MaterialAsset,
-    PlannedTextureAsset MainTexture)
-    : PlannedRendererMaterialBinding(MaterialAsset);
+    RendererOverride RendererOverride)
+    : PlannedRendererMaterialBinding(MaterialAsset)
+{
+    public RendererOverrideTextureProvider MainTextureProvider => RendererOverride switch
+    {
+        AlbedoRendererOverride albedo => albedo.MainTexture,
+        TerrainOverlayRendererOverride terrain => terrain.MainTexture,
+        _ => throw new InvalidOperationException(
+            $"Unsupported renderer override type '{RendererOverride.GetType().Name}'."),
+    };
+}
 
 internal sealed record PlannedAlbedoMainTextureOverrideRendererMaterialBinding(
     PlannedMaterialAsset MaterialAsset,
-    PlannedTextureAsset MainTexture)
-    : PlannedMainTextureOverrideRendererMaterialBinding(MaterialAsset, MainTexture);
+    LocalRendererOverrideTextureProvider MainTexture)
+    : PlannedMainTextureOverrideRendererMaterialBinding(
+        MaterialAsset,
+        new AlbedoRendererOverride(MainTexture));
 
 internal sealed record PlannedTerrainMainTextureOverrideRendererMaterialBinding(
     PlannedMaterialAsset MaterialAsset,
-    PlannedTextureAsset MainTexture,
-    ResoniteComponentLocator? SharedMainTextureComponent = null,
-    ResoniteComponentLocator? SharedMainTexturePropertyBlockComponent = null)
-    : PlannedMainTextureOverrideRendererMaterialBinding(MaterialAsset, MainTexture);
+    RendererOverrideTextureProvider MainTexture)
+    : PlannedMainTextureOverrideRendererMaterialBinding(
+        MaterialAsset,
+        new TerrainOverlayRendererOverride(MainTexture));
 
 internal sealed record PlannedSceneMaterialPlan(
     IReadOnlyList<PlannedMaterialAsset> MaterialAssets,
@@ -179,7 +239,7 @@ internal sealed record PlannedMainTexturePropertyBlockOverride(
         ArgumentNullException.ThrowIfNull(propertyBlockContainerTarget);
         ArgumentNullException.ThrowIfNull(binding);
 
-        if (binding is PlannedTerrainMainTextureOverrideRendererMaterialBinding
+        if (binding.MainTextureProvider is SharedTerrainOverlayTextureProvider
             {
                 SharedMainTexturePropertyBlockComponent: { } sharedMainTexturePropertyBlockComponent,
             })
@@ -190,25 +250,25 @@ internal sealed record PlannedMainTexturePropertyBlockOverride(
                 null);
         }
 
-        PlannedWorldElementReference? sharedTextureTarget = binding is PlannedTerrainMainTextureOverrideRendererMaterialBinding
+        PlannedWorldElementReference? sharedTextureTarget = binding.MainTextureProvider is SharedTerrainOverlayTextureProvider
         {
             SharedMainTextureComponent: { } sharedMainTextureComponent,
         }
             ? PlannedWorldElementReference.Canonical(sharedMainTextureComponent)
             : null;
-        ResoniteSceneMaterialConventions.TextureMemberRole textureRole = binding switch
+        ResoniteSceneMaterialConventions.TextureMemberRole textureRole = binding.MainTextureProvider switch
         {
-            PlannedAlbedoMainTextureOverrideRendererMaterialBinding =>
+            LocalRendererOverrideTextureProvider =>
                 ResoniteSceneMaterialConventions.TextureMemberRole.Albedo,
-            PlannedTerrainMainTextureOverrideRendererMaterialBinding =>
+            SharedTerrainOverlayTextureProvider =>
                 ResoniteSceneMaterialConventions.TextureMemberRole.TerrainMainTextureOverride,
             _ => throw new InvalidOperationException(
-                $"Unsupported planned main texture override binding type '{binding.GetType().Name}'."),
+                $"Unsupported planned main texture override provider type '{binding.MainTextureProvider.GetType().Name}'."),
         };
         PlannedBatchComponentEmission? textureComponent = sharedTextureTarget is null
             ? CreateTextureComponent(
                 textureContainerTarget,
-                binding.MainTexture.AssetUri,
+                binding.MainTextureProvider.AssetUri,
                 textureRole)
             : null;
         PlannedWorldElementReference textureTarget = sharedTextureTarget

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -65,7 +65,7 @@ internal abstract record RendererOverride;
 internal sealed record AlbedoRendererOverride(LocalRendererOverrideTextureProvider MainTexture)
     : RendererOverride;
 
-internal sealed record TerrainOverlayRendererOverride(RendererOverrideTextureProvider MainTexture)
+internal sealed record TerrainOverlayRendererOverride(SharedTerrainOverlayTextureProvider MainTexture)
     : RendererOverride;
 
 internal abstract record PlannedMaterialAsset;
@@ -119,7 +119,7 @@ internal sealed record PlannedAlbedoMainTextureOverrideRendererMaterialBinding(
 
 internal sealed record PlannedTerrainMainTextureOverrideRendererMaterialBinding(
     PlannedMaterialAsset MaterialAsset,
-    RendererOverrideTextureProvider MainTexture)
+    SharedTerrainOverlayTextureProvider MainTexture)
     : PlannedMainTextureOverrideRendererMaterialBinding(
         MaterialAsset,
         new TerrainOverlayRendererOverride(MainTexture));

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
@@ -92,7 +92,7 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
                 $"Setup did not resolve common material ({ResoniteMaterialComponentPolicy.DescribeForDiagnostics(sourceMaterial)}) before runtime emission.");
         }
         PlannedReusableMaterialAsset sharedMaterialAsset = new(existingMaterialAsset.MaterialComponent);
-        PlannedTextureAsset? mainTextureOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
+        LocalRendererOverrideTextureProvider? mainTextureOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
             sourceMaterial,
             preparedTextureUrisByPayload,
             preparedTerrainTextureUrisByOverlay);
@@ -130,7 +130,7 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
             cancellationToken);
         if (sourceMaterial.TerrainOverlay is not null)
         {
-            PlannedTextureAsset? mainTextureOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
+            LocalRendererOverrideTextureProvider? mainTextureOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
                 sourceMaterial,
                 preparedTextureUrisByPayload,
                 preparedTerrainTextureUrisByOverlay);
@@ -166,7 +166,7 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
 
     private static PlannedMainTextureOverrideRendererMaterialBinding CreateMainTextureOverrideRendererBinding(
         PlannedMaterialAsset materialAsset,
-        PlannedTextureAsset mainTexture,
+        LocalRendererOverrideTextureProvider mainTexture,
         IReadOnlyDictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode,
         ResoniteMaterialBinding sourceMaterial)
     {
@@ -175,14 +175,17 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
             return new PlannedAlbedoMainTextureOverrideRendererMaterialBinding(materialAsset, mainTexture);
         }
 
-        return new PlannedTerrainMainTextureOverrideRendererMaterialBinding(
-            materialAsset,
-            mainTexture,
-            null,
+        ResoniteComponentLocator? sharedMainTexturePropertyBlockComponent =
             sourceMaterial.TerrainOverlayMaterial is not null
             && terrainTexturePropertyBlockComponentsByMeshCode.TryGetValue(sourceMaterial.TerrainOverlayMaterial.MeshCode, out ResoniteComponentLocator propertyBlockComponent)
                 ? propertyBlockComponent
-                : null);
+                : null;
+        return new PlannedTerrainMainTextureOverrideRendererMaterialBinding(
+            materialAsset,
+            new SharedTerrainOverlayTextureProvider(
+                mainTexture.AssetUri,
+                SharedMainTextureComponent: null,
+                sharedMainTexturePropertyBlockComponent));
     }
 
 }

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -61,7 +61,7 @@ public sealed class ResoniteMaterialPlanningTests
             new AsyncInFlightResultCache<BundledTextureImportKey, Uri>(),
             CancellationToken.None);
 
-        PlannedTextureAsset metallicAsset = Assert.Single(
+        TargetMaterialTextureProvider metallicAsset = Assert.Single(
             plannedAsset.Textures,
             texture => texture.Role == ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic);
         int metallicImportIndex = int.Parse(
@@ -229,7 +229,7 @@ public sealed class ResoniteMaterialPlanningTests
         PlannedDedicatedMaterialAsset plannedMaterial = new(
             material,
             [
-                new PlannedTextureAsset(
+                new TargetMaterialTextureProvider(
                     ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo,
                     new Uri("resdb:///texture/albedo", UriKind.Absolute)),
             ]);
@@ -251,10 +251,10 @@ public sealed class ResoniteMaterialPlanningTests
         PlannedDedicatedMaterialAsset plannedMaterial = new(
             material,
             [
-                new PlannedTextureAsset(
+                new TargetMaterialTextureProvider(
                     ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo,
                     new Uri("resdb:///texture/albedo", UriKind.Absolute)),
-                new PlannedTextureAsset(
+                new TargetMaterialTextureProvider(
                     ResoniteSceneMaterialConventions.PlannedTextureRole.Emission,
                     new Uri("resdb:///texture/emission", UriKind.Absolute)),
             ]);
@@ -332,19 +332,19 @@ public sealed class ResoniteMaterialPlanningTests
             [secondMaterial.TexturePayload!] = new Uri("resdb:///texture/second", UriKind.Absolute),
         };
 
-        PlannedTextureAsset? firstOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
+        LocalRendererOverrideTextureProvider? firstOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
             firstMaterial,
             firstPreparedUris,
             new Dictionary<TerrainTextureOverlay, Uri>());
-        PlannedTextureAsset? repeatedFirstOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
+        LocalRendererOverrideTextureProvider? repeatedFirstOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
             firstMaterial,
             firstPreparedUris,
             new Dictionary<TerrainTextureOverlay, Uri>());
-        PlannedTextureAsset? secondOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
+        LocalRendererOverrideTextureProvider? secondOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
             secondMaterial,
             secondPreparedUris,
             new Dictionary<TerrainTextureOverlay, Uri>());
-        PlannedTextureAsset? thirdOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
+        LocalRendererOverrideTextureProvider? thirdOverride = ResoniteMaterialPlanning.PlanMainTextureOverride(
             firstMaterial,
             firstPreparedUris,
             new Dictionary<TerrainTextureOverlay, Uri>());

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -360,7 +360,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 DepthOffset: null,
                 SubmeshIndices: [0],
                 ResoniteMaterialAssetBinding.Presentation),
-            [new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/albedo"))]);
+            [new TargetMaterialTextureProvider(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/albedo"))]);
         PlannedReusableMaterialAsset reusableMaterial = new(new ResoniteComponentLocator("existing-material-id"));
         PlannedBatchEmission batchPlan = CreateBatchPlan(
             objectSlots,
@@ -417,11 +417,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 SubmeshIndices: [0],
                 ResoniteMaterialAssetBinding.Presentation),
             [
-                new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/albedo")),
-                new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Normal, new Uri("resdb:///texture/normal")),
-                new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Height, new Uri("resdb:///texture/height")),
-                new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic, new Uri("resdb:///texture/metallic")),
-                new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Emission, new Uri("resdb:///texture/emission")),
+                new TargetMaterialTextureProvider(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/albedo")),
+                new TargetMaterialTextureProvider(ResoniteSceneMaterialConventions.PlannedTextureRole.Normal, new Uri("resdb:///texture/normal")),
+                new TargetMaterialTextureProvider(ResoniteSceneMaterialConventions.PlannedTextureRole.Height, new Uri("resdb:///texture/height")),
+                new TargetMaterialTextureProvider(ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic, new Uri("resdb:///texture/metallic")),
+                new TargetMaterialTextureProvider(ResoniteSceneMaterialConventions.PlannedTextureRole.Emission, new Uri("resdb:///texture/emission")),
             ]);
         PlannedBatchEmission batchPlan = CreateBatchPlan(
             objectSlots,
@@ -502,7 +502,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             [
                 new PlannedAlbedoMainTextureOverrideRendererMaterialBinding(
                     reusableMaterial,
-                    new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/override"))),
+                    new LocalRendererOverrideTextureProvider(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/override"))),
             ],
             false);
 
@@ -547,7 +547,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             [
                 new PlannedTerrainMainTextureOverrideRendererMaterialBinding(
                     reusableMaterial,
-                    new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/override"))),
+                    new SharedTerrainOverlayTextureProvider(
+                        new Uri("resdb:///texture/override"),
+                        SharedMainTextureComponent: null,
+                        SharedMainTexturePropertyBlockComponent: null)),
             ],
             false);
 
@@ -577,9 +580,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             [
                 new PlannedTerrainMainTextureOverrideRendererMaterialBinding(
                     reusableMaterial,
-                    new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/override")),
-                    SharedMainTextureComponent: new ResoniteComponentLocator("shared-terrain-texture-id"),
-                    SharedMainTexturePropertyBlockComponent: new ResoniteComponentLocator("shared-terrain-property-block-id")),
+                    new SharedTerrainOverlayTextureProvider(
+                        new Uri("resdb:///texture/override"),
+                        SharedMainTextureComponent: new ResoniteComponentLocator("shared-terrain-texture-id"),
+                        SharedMainTexturePropertyBlockComponent: new ResoniteComponentLocator("shared-terrain-property-block-id"))),
             ],
             false);
 
@@ -615,10 +619,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             [
                 new PlannedAlbedoMainTextureOverrideRendererMaterialBinding(
                     reusableMaterial,
-                    new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/override-a"))),
+                    new LocalRendererOverrideTextureProvider(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/override-a"))),
                 new PlannedAlbedoMainTextureOverrideRendererMaterialBinding(
                     reusableMaterial,
-                    new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/override-b"))),
+                    new LocalRendererOverrideTextureProvider(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/override-b"))),
             ],
             false);
 


### PR DESCRIPTION
## Summary

- Split material planning records into `MaterialIdentity`, `TextureProvider`, `RendererOverride`, and `TargetMaterialAssetPlan`.
- Keep target material asset textures typed as `TargetMaterialTextureProvider` while renderer overrides use separate override providers.
- Model shared terrain overlay texture/property-block wiring through `SharedTerrainOverlayTextureProvider`, so shared terrain overlay state cannot be represented as part of the mesh-specific material asset plan.

## Why

PR #380 kept mesh-specific material assets on mesh/presentation slots while preserving shared terrain overlay texture and property block behavior. This change makes that relationship explicit in the plan types instead of relying on nullable fields on a generic renderer binding.

## Real-data dump invariant check

Fresh canonical dump, not tracked:

```text
D:\Temp\codex\plateau-material-plan-contract-real-20260613\rebased-5d5133e5.matsumoto-54372778-dem-bldg-grid.json
```

Real source archive:

```text
C:\Users\esnya\Documents\PLATEAU-ResoniteLink\local\plateau-20202-matsumoto-shi-2020\source-archive.zip
```

Command used:

```text
dotnet run --project src\PlateauResoniteLink.Cli\PlateauResoniteLink.Cli.csproj --configuration Release --no-restore -- import --dataset plateau-20202-matsumoto-shi-2020 --mesh-code 54372778 --citygml-source C:\Users\esnya\Documents\PLATEAU-ResoniteLink\local\plateau-20202-matsumoto-shi-2020\source-archive.zip --packages dem,bldg --terrain-mesh grid --disable-terrain-tile-cache --exclude-gsi-terrain-tiles --canonical-scene-dump D:\Temp\codex\plateau-material-plan-contract-real-20260613\rebased-5d5133e5.matsumoto-54372778-dem-bldg-grid.json
```

Observed invariant summary from the real-data dump remained valid: terrain shared texture/property block stayed under `Assets/Terrain Textures`, renderer material property blocks referenced the shared terrain block, and terrain texture slots did not contain PBS material components. The real data also has non-terrain local `MainTexturePropertyBlock` components for AtlasBake building materials; those are separate renderer-local texture overrides, not the shared terrain overlay contract.

## Dump diff against origin/main

Same real-data command was run on updated `origin/main` in a detached comparison worktree and compared with the rebased branch dump.

```text
base:   D:\Temp\codex\plateau-material-plan-contract-real-20260613\origin-main-41d5c1f2.matsumoto-54372778-dem-bldg-grid.json
branch: D:\Temp\codex\plateau-material-plan-contract-real-20260613\rebased-5d5133e5.matsumoto-54372778-dem-bldg-grid.json
SHA256: 746C15A12A0CCC222520D86F92A43D7345ADEF1988714E2406B144F49C1B95A9
fc /b: no differences encountered
```

## Validation

```text
dotnet format whitespace . --folder --verify-no-changes
dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false
dotnet test tests\PlateauResoniteLink.Tests\PlateauResoniteLink.Tests.csproj --configuration Release --no-restore --no-build --verbosity normal --filter "FullyQualifiedName~ResoniteMaterialPlanningTests|FullyQualifiedName~ResoniteSceneBatchEmissionPlanningTests" -m:1 --disable-build-servers -p:UseSharedCompilation=false
dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false
```

Result after conflict resolution: 1086 tests passed.