### PR TITLE
[codex] Split DEM source-file sampling from object projection

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectProjection.cs
@@ -51,26 +51,23 @@ internal static class CityGmlParsedCityObjectProjection
             foreach (ParsedCityObject parsedCityObject in projectedInputCityObjects)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                if (predicate is not null && !predicate(parsedCityObject))
-                {
-                    continue;
-                }
-
-                foreach (ImportedCityObject cityObject in Project(
-                             parsedCityObject,
+                foreach (ImportedCityObject cityObject in ProjectObject(
+                             new CityObjectProjectionInput(sourceFile.SourceFile, parsedCityObject, sourceFile.ReferenceSystem),
+                             referenceSystem,
                              globalOriginPoint,
                              globalCartesian,
                              demTerrainTextureOverlays,
                              requestedMeshCodeBounds,
-                             terrainHeightSampler: null,
+                             selectedMeshCodes,
                              request,
                              materialResolver,
+                             new DemSourceFileTerrainGridSamplingDraft(sourceFile.SourceFile, sourceFileTerrainGridSamplingDraft),
+                             predicate,
                              logger,
-                             demTerrainGridSamplingSourceOverride: sourceFileTerrainGridSamplingDraft,
                              cancellationToken))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    yield return AttachSourceFileRoot(cityObject, sourceFile.SourceFile);
+                    yield return cityObject;
                 }
             }
 
@@ -80,25 +77,79 @@ internal static class CityGmlParsedCityObjectProjection
         foreach (ParsedCityObject parsedCityObject in projectedInputCityObjects)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (predicate is not null && !predicate(parsedCityObject))
-            {
-                continue;
-            }
-
-            foreach (ImportedCityObject cityObject in Project(
-                         parsedCityObject,
+            foreach (ImportedCityObject cityObject in ProjectObject(
+                         new CityObjectProjectionInput(sourceFile.SourceFile, parsedCityObject, sourceFile.ReferenceSystem),
+                         referenceSystem,
                          globalOriginPoint,
                          globalCartesian,
                          demTerrainTextureOverlays,
                          requestedMeshCodeBounds,
-                         terrainHeightSampler: null,
+                         selectedMeshCodes,
                          request,
                          materialResolver,
-                         logger,
+                         demTerrainGridSamplingDraft: null,
+                         predicate: predicate,
+                         logger: logger,
                          cancellationToken: cancellationToken))
             {
-                yield return AttachSourceFileRoot(cityObject, sourceFile.SourceFile);
+                yield return cityObject;
             }
+        }
+    }
+
+    internal static IEnumerable<ImportedCityObject> ProjectObject(
+        CityObjectProjectionInput input,
+        CoordinateReferenceSystem referenceSystem,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
+        IReadOnlyList<string> selectedMeshCodes,
+        PlateauImportRequest request,
+        IDefaultMaterialResolver materialResolver,
+        DemSourceFileTerrainGridSamplingDraft? demTerrainGridSamplingDraft = null,
+        Func<ParsedCityObject, bool>? predicate = null,
+        ILogger? logger = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(referenceSystem);
+        ArgumentNullException.ThrowIfNull(globalOriginPoint);
+        ArgumentNullException.ThrowIfNull(selectedMeshCodes);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(materialResolver);
+
+        LocalCityGmlObjectProjection.ValidateCompatibleReferenceSystem(
+            referenceSystem,
+            input.ReferenceSystem);
+
+        ParsedCityObject parsedCityObject = input.CityObject;
+        if (predicate is not null && !predicate(parsedCityObject))
+        {
+            yield break;
+        }
+
+        ConstructionCityObjectDraft? terrainGridSamplingDraft =
+            string.Equals(input.SourceFile.PackageName, "dem", StringComparison.OrdinalIgnoreCase)
+            && request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
+                ? demTerrainGridSamplingDraft?.Draft
+                : null;
+
+        foreach (ImportedCityObject cityObject in Project(
+                     parsedCityObject,
+                     globalOriginPoint,
+                     globalCartesian,
+                     demTerrainTextureOverlays,
+                     requestedMeshCodeBounds,
+                     terrainHeightSampler: null,
+                     request,
+                     materialResolver,
+                     logger,
+                     demTerrainGridSamplingSourceOverride: terrainGridSamplingDraft,
+                     cancellationToken))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return AttachSourceFileRoot(cityObject, input.SourceFile);
         }
     }
 
@@ -212,7 +263,7 @@ internal static class CityGmlParsedCityObjectProjection
         }
     }
 
-    private static ConstructionCityObjectDraft? CreateDemSourceFileTerrainGridSamplingDraft(CachedSourceFileDescriptor sourceFile)
+    internal static ConstructionCityObjectDraft? CreateDemSourceFileTerrainGridSamplingDraft(CachedSourceFileDescriptor sourceFile)
     {
         ParsedCityObject[] sourceObjects = sourceFile.CityObjects;
         if (sourceObjects.Length == 0)

--- a/src/PlateauResoniteLink/Application/Importing/ICityGmlGeometryProjector.cs
+++ b/src/PlateauResoniteLink/Application/Importing/ICityGmlGeometryProjector.cs
@@ -12,6 +12,34 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal interface ICityGmlGeometryProjector
 {
+    IEnumerable<ImportedCityObject> ProjectCityObject(
+        CityObjectProjectionInput input,
+        CoordinateReferenceSystem referenceSystem,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
+        IReadOnlyList<string> selectedMeshCodes,
+        PlateauImportRequest request,
+        DemSourceFileTerrainGridSamplingDraft? demTerrainGridSamplingDraft = null,
+        Func<ParsedCityObject, bool>? predicate = null,
+        ILogger? logger = null,
+        CancellationToken cancellationToken = default)
+    {
+        return ProjectCityObjects(
+            new CachedSourceFileDescriptor(input.SourceFile, [input.CityObject], input.ReferenceSystem),
+            referenceSystem,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlays,
+            requestedMeshCodeBounds,
+            selectedMeshCodes,
+            request,
+            predicate,
+            logger,
+            cancellationToken);
+    }
+
     IEnumerable<ImportedCityObject> ProjectCityObjects(
         CachedSourceFileDescriptor sourceFile,
         CoordinateReferenceSystem referenceSystem,
@@ -23,5 +51,27 @@ internal interface ICityGmlGeometryProjector
         PlateauImportRequest request,
         Func<ParsedCityObject, bool>? predicate = null,
         ILogger? logger = null,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default)
+    {
+        foreach (ParsedCityObject cityObject in sourceFile.CityObjects)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            foreach (ImportedCityObject projectedCityObject in ProjectCityObject(
+                         new CityObjectProjectionInput(sourceFile.SourceFile, cityObject, sourceFile.ReferenceSystem),
+                         referenceSystem,
+                         globalOriginPoint,
+                         globalCartesian,
+                         demTerrainTextureOverlays,
+                         requestedMeshCodeBounds,
+                         selectedMeshCodes,
+                         request,
+                         demTerrainGridSamplingDraft: null,
+                         predicate,
+                         logger,
+                         cancellationToken))
+            {
+                yield return projectedCityObject;
+            }
+        }
+    }
 }

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlGeometryProjector.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlGeometryProjector.cs
@@ -15,6 +15,36 @@ internal sealed class LocalCityGmlGeometryProjector(
 {
     private readonly IDefaultMaterialResolver materialResolver = materialResolver;
 
+    public IEnumerable<ImportedCityObject> ProjectCityObject(
+        CityObjectProjectionInput input,
+        CoordinateReferenceSystem referenceSystem,
+        GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
+        IReadOnlyList<string> selectedMeshCodes,
+        PlateauImportRequest request,
+        DemSourceFileTerrainGridSamplingDraft? demTerrainGridSamplingDraft = null,
+        Func<ParsedCityObject, bool>? predicate = null,
+        ILogger? logger = null,
+        CancellationToken cancellationToken = default)
+    {
+        return LocalCityGmlObjectProjection.ProjectCityObject(
+            input,
+            referenceSystem,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlays,
+            requestedMeshCodeBounds,
+            selectedMeshCodes,
+            request,
+            materialResolver,
+            demTerrainGridSamplingDraft,
+            predicate,
+            logger,
+            cancellationToken);
+    }
+
     public IEnumerable<ImportedCityObject> ProjectCityObjects(
         CachedSourceFileDescriptor sourceFile,
         CoordinateReferenceSystem referenceSystem,

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlObjectProjection.cs
@@ -59,6 +59,37 @@ internal static class LocalCityGmlObjectProjection
             materialResolver);
     }
 
+    internal static IEnumerable<ImportedCityObject> ProjectCityObject(
+        global::PlateauResoniteLink.Application.Importing.CityObjectProjectionInput input,
+        global::PlateauResoniteLink.Application.Importing.CoordinateReferenceSystem referenceSystem,
+        global::PlateauResoniteLink.Application.Importing.GeodeticPoint globalOriginPoint,
+        LocalCartesian? globalCartesian,
+        IReadOnlyList<TerrainTextureOverlay> demTerrainTextureOverlays,
+        IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
+        IReadOnlyList<string> selectedMeshCodes,
+        PlateauImportRequest request,
+        IDefaultMaterialResolver materialResolver,
+        DemSourceFileTerrainGridSamplingDraft? demTerrainGridSamplingDraft = null,
+        Func<global::PlateauResoniteLink.Application.Importing.ParsedCityObject, bool>? predicate = null,
+        ILogger? logger = null,
+        CancellationToken cancellationToken = default)
+    {
+        return CityGmlParsedCityObjectProjection.ProjectObject(
+            input,
+            referenceSystem,
+            globalOriginPoint,
+            globalCartesian,
+            demTerrainTextureOverlays,
+            requestedMeshCodeBounds,
+            selectedMeshCodes,
+            request,
+            materialResolver,
+            demTerrainGridSamplingDraft,
+            predicate,
+            logger,
+            cancellationToken);
+    }
+
     internal static IEnumerable<ImportedCityObject> ProjectCityObjects(
         global::PlateauResoniteLink.Application.Importing.CachedSourceFileDescriptor sourceFile,
         global::PlateauResoniteLink.Application.Importing.CoordinateReferenceSystem referenceSystem,

--- a/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedSourceFileModels.cs
+++ b/src/PlateauResoniteLink/Application/Importing/LocalCityGmlParsedSourceFileModels.cs
@@ -27,6 +27,20 @@ internal sealed record CachedSourceFileDescriptor(
     public string PackageName => SourceFile.PackageName;
 }
 
+internal sealed record CityObjectProjectionInput(
+    SourceFileDescriptor SourceFile,
+    ParsedCityObject CityObject,
+    CoordinateReferenceSystem ReferenceSystem)
+{
+    public string RelativePath => SourceFile.RelativePath;
+
+    public string PackageName => SourceFile.PackageName;
+}
+
+internal sealed record DemSourceFileTerrainGridSamplingDraft(
+    SourceFileDescriptor SourceFile,
+    ConstructionCityObjectDraft? Draft);
+
 internal sealed class SourceFilePipeline
 {
     private readonly object parseTaskGate = new();

--- a/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
+++ b/src/PlateauResoniteLink/Application/Importing/StreamingImportedSceneSource.cs
@@ -269,18 +269,18 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
                 continue;
             }
 
-            foreach (ImportedCityObject cityObject in geometryProjector.ProjectCityObjects(
-                         new CachedSourceFileDescriptor(sourceFile.SourceFile, [parsedCityObject], parsedReferenceSystem),
-                         resolvedReferenceSystem,
-                         globalOriginPoint,
-                         globalCartesian,
-                         projectionTerrainOverlayContext.Overlays,
-                         requestedMeshCodeBounds,
-                         selectedMeshCodes,
-                         request,
+            foreach (ImportedCityObject cityObject in geometryProjector.ProjectCityObject(
+                         input: new CityObjectProjectionInput(sourceFile.SourceFile, parsedCityObject, parsedReferenceSystem),
+                         referenceSystem: resolvedReferenceSystem,
+                         globalOriginPoint: globalOriginPoint,
+                         globalCartesian: globalCartesian,
+                         demTerrainTextureOverlays: projectionTerrainOverlayContext.Overlays,
+                         requestedMeshCodeBounds: requestedMeshCodeBounds,
+                         selectedMeshCodes: selectedMeshCodes,
+                         request: request,
                          predicate: null,
-                         logger,
-                         cancellationToken))
+                         logger: logger,
+                         cancellationToken: cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 yieldedCount++;
@@ -295,25 +295,39 @@ internal sealed class StreamingImportedSceneSource : IImportedSceneSource, IImpo
                     demProjectionSource.SourceFile,
                     demProjectionSource.CityObjects,
                     selectedMeshCodes);
-            foreach (ImportedCityObject cityObject in geometryProjector.ProjectCityObjects(
-                         new CachedSourceFileDescriptor(
-                             demProjectionSource.SourceFile,
-                             aggregatedDemCityObjects,
-                             demProjectionSource.ReferenceSystem),
-                         demProjectionSource.ReferenceSystem,
-                         globalOriginPoint,
-                         globalCartesian,
-                         projectionTerrainOverlayContext.Overlays,
-                         requestedMeshCodeBounds,
-                         selectedMeshCodes,
-                         request,
-                         predicate: null,
-                         logger,
-                         cancellationToken))
+            DemSourceFileTerrainGridSamplingDraft? samplingDraft =
+                request.TerrainMeshMode is TerrainMeshMode.Grid or TerrainMeshMode.Dynamic
+                    ? new DemSourceFileTerrainGridSamplingDraft(
+                        demProjectionSource.SourceFile,
+                        CityGmlParsedCityObjectProjection.CreateDemSourceFileTerrainGridSamplingDraft(
+                            new CachedSourceFileDescriptor(
+                                demProjectionSource.SourceFile,
+                                demProjectionSource.CityObjects.ToArray(),
+                                demProjectionSource.ReferenceSystem)))
+                    : null;
+            foreach (ParsedCityObject aggregatedDemCityObject in aggregatedDemCityObjects)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                yieldedCount++;
-                yield return cityObject;
+                foreach (ImportedCityObject cityObject in geometryProjector.ProjectCityObject(
+                             input: new CityObjectProjectionInput(
+                                 demProjectionSource.SourceFile,
+                                 aggregatedDemCityObject,
+                                 demProjectionSource.ReferenceSystem),
+                             referenceSystem: demProjectionSource.ReferenceSystem,
+                             globalOriginPoint: globalOriginPoint,
+                             globalCartesian: globalCartesian,
+                             demTerrainTextureOverlays: projectionTerrainOverlayContext.Overlays,
+                             requestedMeshCodeBounds: requestedMeshCodeBounds,
+                             selectedMeshCodes: selectedMeshCodes,
+                             request: request,
+                             demTerrainGridSamplingDraft: samplingDraft,
+                             predicate: null,
+                             logger: logger,
+                             cancellationToken: cancellationToken))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    yieldedCount++;
+                    yield return cityObject;
+                }
             }
         }
 

--- a/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Profiles/StreamingImportedSceneSourceStreamingTests.cs
@@ -392,8 +392,8 @@ public sealed class StreamingImportedSceneSourceStreamingTests
 
         public IReadOnlyCollection<ReferenceSystemCallRecord> CallRecords => callRecords.ToArray();
 
-        public IEnumerable<ImportedCityObject> ProjectCityObjects(
-            CachedSourceFileDescriptor sourceFile,
+        public IEnumerable<ImportedCityObject> ProjectCityObject(
+            CityObjectProjectionInput input,
             CoordinateReferenceSystem referenceSystem,
             GeodeticPoint globalOriginPoint,
             LocalCartesian? globalCartesian,
@@ -401,6 +401,7 @@ public sealed class StreamingImportedSceneSourceStreamingTests
             IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
             IReadOnlyList<string> selectedMeshCodes,
             PlateauImportRequest request,
+            DemSourceFileTerrainGridSamplingDraft? demTerrainGridSamplingDraft = null,
             Func<ParsedCityObject, bool>? predicate = null,
             ILogger? logger = null,
             CancellationToken cancellationToken = default)
@@ -414,35 +415,33 @@ public sealed class StreamingImportedSceneSourceStreamingTests
             _ = request;
             _ = logger;
             _ = cancellationToken;
-            foreach (ParsedCityObject cityObject in sourceFile.CityObjects)
+            ParsedCityObject cityObject = input.CityObject;
+            if (predicate is not null && !predicate(cityObject))
             {
-                if (predicate is not null && !predicate(cityObject))
-                {
-                    continue;
-                }
-
-                calls.Enqueue(cityObject.PackageName);
-                callRecords.Enqueue(new ReferenceSystemCallRecord(
-                    sourceFile.ReferenceSystem,
-                    cityObject.ReferenceSystem));
-                yield return new ImportedCityObject(
-                    cityObject.SlotKey,
-                    cityObject.DisplayName,
-                    cityObject.PackageName,
-                    cityObject.ActualMeshCode,
-                    cityObject.LodLevel,
-                    new Transform3D(new Float3(0.0, 0.0, 0.0)),
-                    new TriangleMeshGeometry(
-                        new ImportedMesh(
-                            [
-                                new MeshVertex(new Float3(0.0, 0.0, 0.0), new Float3(0.0, 1.0, 0.0), new Float2(0.0, 0.0)),
-                                new MeshVertex(new Float3(1.0, 0.0, 0.0), new Float3(0.0, 1.0, 0.0), new Float2(1.0, 0.0)),
-                                new MeshVertex(new Float3(0.0, 0.0, 1.0), new Float3(0.0, 1.0, 0.0), new Float2(0.0, 1.0)),
-                            ],
-                            [new MeshSubmesh(0, [0, 1, 2])])),
-                    [],
-                    SourceFileRelativePath: sourceFile.RelativePath);
+                yield break;
             }
+
+            calls.Enqueue(cityObject.PackageName);
+            callRecords.Enqueue(new ReferenceSystemCallRecord(
+                input.ReferenceSystem,
+                cityObject.ReferenceSystem));
+            yield return new ImportedCityObject(
+                cityObject.SlotKey,
+                cityObject.DisplayName,
+                cityObject.PackageName,
+                cityObject.ActualMeshCode,
+                cityObject.LodLevel,
+                new Transform3D(new Float3(0.0, 0.0, 0.0)),
+                new TriangleMeshGeometry(
+                    new ImportedMesh(
+                        [
+                            new MeshVertex(new Float3(0.0, 0.0, 0.0), new Float3(0.0, 1.0, 0.0), new Float2(0.0, 0.0)),
+                            new MeshVertex(new Float3(1.0, 0.0, 0.0), new Float3(0.0, 1.0, 0.0), new Float2(1.0, 0.0)),
+                            new MeshVertex(new Float3(0.0, 0.0, 1.0), new Float3(0.0, 1.0, 0.0), new Float2(0.0, 1.0)),
+                        ],
+                        [new MeshSubmesh(0, [0, 1, 2])])),
+                [],
+                SourceFileRelativePath: input.RelativePath);
         }
     }
 


### PR DESCRIPTION
## Summary

- Split object projection input from DEM source-file-wide terrain grid sampling state.
- Route streaming projection through a per-object `CityObjectProjectionInput` while keeping source-file sampling draft only for DEM Grid/Dynamic terrain modes.
- Keep source-file projection compatibility for existing direct callers, with the streaming regression test moved onto the new object-level projector path.

## Validation

- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` （1090 tests passed）

## Baseline Dump Check

Canonical dumps were generated from both baseline `1bdeac28d35b1e8ff7e8c7e9fe0fcd16286baadf` and PR head `e08e30a0f27e9d391cc1e65106b22907b21a9c87` under `D:/Temp/codex/plateau-dump-baseline-vs-pr389/`, using `tests/Fixtures/LocalPlateauDatasetParentMeshPackages` and the same CLI arguments for `static`, `grid`, and `dynamic` terrain modes.

All baseline-vs-PR dump pairs are byte-for-byte identical:

| terrain mode | bytes | SHA-256 |
| --- | ---: | --- |
| static | 390172 | `ada07575bfbd4569db2fe44c1048ec1fb53a5d51bc393848b7647fd6e47ad96e` |
| grid | 405476 | `b87594f5baadd0618c263dd8bb10953e3034110799b4d54fec0b06a6ef3777a9` |
| dynamic | 412348 | `41a8299c719fe100db28ab75c056c38b6e1c47e886a4620ebd3a60ee33059e1e` |

This confirms the refactor is behavior-preserving across the canonical scene dump surface for the DEM/static/grid/dynamic paths covered by the fixture.