### PR TITLE
[codex] Extract import data ownership types

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -93,6 +93,7 @@ import 成功後、CLI は run で使われた CityGML source file と、terrain
 ## 参考資料
 
 - contributor 向け workflow: [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md)
+- import pipeline のデータ所有: [docs/import-pipeline-data-ownership.ja.md](docs/import-pipeline-data-ownership.ja.md)
 - Coding Agent 向け live workflow: [.agents/skills/resonite-live-send-debug/SKILL.md](.agents/skills/resonite-live-send-debug/SKILL.md)
 
 ## License And Provenance

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ After a successful import, the CLI prints a datasource summary that includes the
 ## Further Reading
 
 - Contributor workflow: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Import-pipeline data ownership: [docs/import-pipeline-data-ownership.md](docs/import-pipeline-data-ownership.md)
 - Coding-agent live workflow: [.agents/skills/resonite-live-send-debug/SKILL.md](.agents/skills/resonite-live-send-debug/SKILL.md)
 
 ## License And Provenance

--- a/docs/import-pipeline-data-ownership.ja.md
+++ b/docs/import-pipeline-data-ownership.ja.md
@@ -1,0 +1,82 @@
+# インポートパイプラインのデータ所有
+
+このメモは、インポートパイプラインにおける現在のデータ所有境界を定義します。過去の要件文書ではありません。正確な挙動の一次 truth は引き続きコードであり、この文書は今後のリファクタリングで基準にするデータ契約と pure 変換の名前を置くためのものです。
+
+以下の概念名がすべて現在の具象型として存在するわけではありません。現行実装が複数の概念を 1 つの record や static helper にまとめている場合、`現在のアンカー` 列に、その挙動を現在所有しているコードを示します。新しいコードで分割する場合は、その分割によって誤った所有や依存方向がより早く失敗する場合に限ります。
+
+## 所有ルール
+
+- source parsing は CityGML と dataset layout の事実を所有します。Resonite slot、component、RPC ID、live-send batching を知ってはいけません。
+- application importing は target-neutral な city object、surface、material、geometry、projection、DEM の契約を所有します。
+- Resonite target planning は Resonite material / component / slot plan を所有しますが、実行までは pure plan として保持します。
+- transport execution は ResoniteLink call、batch response、asset upload、readback snapshot を所有します。
+- diagnostics は canonical dump と recording を所有します。observable output の検証には使いますが、source model ではありません。
+
+## データ契約
+
+| 概念的データ型 | 概念的所有者 | 役割 | 現在のアンカー |
+| --- | --- | --- | --- |
+| `CityGmlSourceFile` / source-file unit | Source discovery と parsing | CityGML source file、package、matched mesh code、source-file root mesh context、parse stream boundary。 | `Application/Importing/LocalCityGmlParsedSourceFileModels.cs` の `SourceFileDescriptor`、`CachedSourceFileDescriptor`、`SourceFilePipeline`; `LocalCityGmlSourceFileDiscovery.cs` の discovery descriptor。 |
+| CityGML object envelope | CityGML parser | projection 前の XML element identity、display name、package、source file、raw LOD / surface entry。 | 現在は `CityGmlSourceFileCityObjectProjection` と `ParsedCityObject` 作成に畳み込まれている。 |
+| `BuildingAttributeContext` | CityGML attribute parser | 正規化済み PLATEAU building attribute。material、roof、projection policy は読むだけで、parse は所有しない。 | `Application/Importing` の `BuildingAttributeContext` と `BuildingAttributeParser`。 |
+| `ParsedCityObject` | Application importing | Resonite 依存を持たない source-CRS 上の parsed city object。 | `LocalCityGmlParsedObjectModels.cs` の `ParsedCityObject`。 |
+| `ParsedSurface` | Application importing | surface semantic、rings、texture payload、optical properties、base color を持つ source-side surface contract。 | `LocalCityGmlParsedObjectModels.cs` の `ParsedSurface` と `ParsedRing`。 |
+| City-object origin、bounds、altitude metrics | Projection support | parsed geometry から得る pure metrics。projection、clipping、overlay、height policy が使う。 | `CityObjectOriginResolver`、`CityObjectGeographicBoundsResolver`、`CityObjectAltitudeMetricsResolver`。 |
+| Projection frame | Projection layer | source CRS、global origin、local Cartesian frame、object / mesh-code frame。 | 現在は projection helper に渡される `GeodeticPoint`、`LocalCartesian`、`CoordinateReferenceSystem` と DEM frame record。 |
+| DEM source-file frame と sampling draft | DEM projection | third-mesh output projection 前の source-file-wide TIN / surface sampling boundary。 | `DemSourceFileTerrainGridSamplingDraft`、`ConstructionCityObjectDraft`。 |
+| DEM third-mesh / emission frame | DEM projection | DEM terrain object の third-mesh output identity、source-file sampling frame、output grid frame、height frame、Resonite emission placement。 | `DemTerrainObjectFrameResolver`、`CityGmlDemTerrainGridCityObjectProjection` の frame records。 |
+| DEM terrain grid geometry と metrics | DEM projection | sample count、height range、world-base height、bounds、coverage、UV scale / offset、height samples。 | `DemTerrainGridProjectionBounds`、`TerrainGridGeometry`、`TerrainGridSampleCoverage`、`CityGmlDemTerrainGridCityObjectProjection`、`CityGmlDemTerrainGridSampler`。 |
+| Terrain overlay coverage と assignment | Terrain overlay policy | contained / intersecting / none、split requirement、selected overlay、untextured fallback。 | `DemTerrainOverlayAssignment`、`TerrainOverlayMaterialSourcePartitioner`、`TerrainTextureOverlay`。 |
+| Texture provider | Material / appearance layer | dataset payload、atlas output、generated terrain texture、bundled texture、prepared texture identity。 | `TexturePayload`、`ITextureImportSource`、`GeneratedTerrainTexture`、`BundledDefaultTextureAsset`、`TerrainTextureAssetGenerator`。 |
+| Material identity | Application material layer | prepared texture URI から独立した common、dedicated、vertex-color、wireframe、projection、reuse scope、bundled family identity。 | `MaterialBinding`、`DefaultCommonMaterialMember`、`MaterialReuseScope`、`MaterialType`、`MaterialProjection`。 |
+| Renderer binding | Resonite target planning | direct material reference、main texture override、terrain property block binding などの renderer-side input。 | `ResoniteSceneEmissionPlan.cs` の `PlannedRendererMaterialBinding` と派生型。 |
+| Target material asset plan | Resonite target planning | Resonite material component plan、reuse scope、dedicated material slot 要否、texture import requirement。 | `PlannedMaterialAsset`、`PlannedDedicatedMaterialAsset`、`PlannedReusableMaterialAsset`、`ResoniteSceneMaterialPlanComposer`、`ResoniteMaterialPlanning`。 |
+| Resonite emission plan | Resonite target planning | pure な planned slots、components、mesh assets、material bindings、ordering、batch-local references。 | `ResoniteSceneEmissionPlan.cs`、`ResoniteBatchEmissionPlanner`。 |
+| Live-send queue item | Live-send runtime | live-send scheduling の runtime input unit。target class の nested detail に戻さない。 | `LiveSendQueuedCityObject`、`LiveSendQueuePlan`、`LiveSendRunPlan`。 |
+| Non-DEM bake buffer result | Non-DEM bake buffer | bake-buffer read result を found / missing / completed などの型付き結果として表す。 | `INonDemSourceFileBakeEmitter`、`NonDemSourceFileBatching`、non-DEM bake models。 |
+| Canonical scene dump | Diagnostics | execution 後の regression validation に使う observable output truth。 | `CanonicalSceneDumpSink`、`SceneSinkRecordingClientCanonicalDump`。 |
+
+## Pure 変換
+
+| Pure 変換 | 概念的所有者 | 境界ルール | 現在のアンカー |
+| --- | --- | --- | --- |
+| `XElement -> BuildingAttributeContext` | `BuildingAttributeParser` | XML code、sentinel value、metrics の parse のみ。material や target behavior を選ばない。 | `BuildingAttributeParser.Parse`。 |
+| `XElement + source-file unit -> CityGML object envelope` | CityGML object parser | identity、package、source file、LOD / surface entry で止める。projection しない。 | 現在は `CityGmlSourceFileCityObjectProjection.Parse` に畳み込まれている。 |
+| CityGML object envelope -> `ParsedCityObject` | Parsed object factory | source mesh / bounds filtering の後で source-CRS object と surfaces を作る。 | `CityGmlSourceFileCityObjectProjection`、`CityGmlParsedSurfaceReader`。 |
+| `ParsedCityObject ->` origin / bounds / altitude metrics | Projection support resolvers | 副作用や target knowledge なしで derived value を返す。 | `CityObject*Resolver` helpers。 |
+| `ParsedCityObject -> ConstructionCityObjectDraft` | Application projection preparation | tessellation 前に project-stage face role と generated-surface draft を解く。 | `ConstructionCityObjectDraft.FromParsedCityObject`、`GeneratedLod1RoofCityObjectFactory`。 |
+| `ParsedSurface[] -> ConstructionFace[]` | Surface projection policy | culling、roof generation、material role decision、tessellation の共通入力を作る。 | `ConstructionCityObjectDraft`、`CityGmlSurfaceProjectionPolicy`。 |
+| `ParsedSurface + material context -> resolved surface material` | Surface material resolver | target material planning 前に semantic、payload、default material、overlay、role を結合する。 | `ResolvedSurfaceMaterial`、`ResolvedMaterial`、`CityGmlSurfaceMaterialResolver`。 |
+| Resolved surface material -> material identity | Material identity selector | prepared texture URI に依存せず common / dedicated / vertex / wireframe identity を選ぶ。 | `MaterialBinding`、`DefaultMaterialResolver`、`CommonMaterialCatalog`。 |
+| Resolved surface material -> texture provider | Texture provider resolver | material identity を変えず、dataset、atlas、generated terrain、bundled、または texture なしを選ぶ。 | `TexturePayload`、`TerrainTextureAssetGenerator`、non-DEM bake models。 |
+| Material identity + texture provider -> renderer binding | Renderer binding composer | direct material binding、main texture override、terrain property-block input を合成する。 | `ResoniteSceneMaterialPlanComposer`。 |
+| Renderer binding + target capabilities -> target material asset plan | Resonite material planner | material component、reusable asset、dedicated slot、texture member の pure plan を作る。 | `PlannedSceneMaterialPlan`、`ResoniteMaterialPlanning`。 |
+| `ParsedSurface[] + terrain overlay policy -> terrain overlay assignment` | Terrain overlay policy | upload や RPC なしで contained / intersecting / none、split requirement、fallback を決める。 | `DemTerrainOverlayAssignment`、`TerrainOverlayMaterialSourcePartitioner`。 |
+| Terrain overlay + mesh context -> terrain overlay mesh code | Terrain overlay mesh-code resolver | actual / requested / requested-bounds fallback order を決定的に保つ。 | `TerrainOverlayMaterialSourcePartitioner`、`TerrainOverlayMeshCodeResolver`。 |
+| DEM source-file surfaces + source-file frame -> DEM sampling draft | DEM projection | per-third-mesh output 前に source-file-wide buffer boundary を明示する。 | `CityGmlParsedCityObjectProjection.CreateDemSourceFileTerrainGridSamplingDraft`。 |
+| DEM sampling draft + third mesh -> DEM terrain grid object | DEM projection | source-file frame を third-mesh output object と frame に変換する。 | `CityGmlParsedCityObjectProjection.ProjectTerrainMeshModeCityObject`。 |
+| DEM terrain object -> `TerrainGridGeometry` | DEM terrain grid projector | sample count、height range、world-base height、coverage、UV contract を作る。 | `CityGmlDemTerrainGridCityObjectProjection.TryProject`。 |
+| Imported object stream -> counting stream | Import orchestration | stream を pre-read / materialize せずに unit 数を数える。 | `CountingImportedObjectUnitStream`。 |
+| Resonite emission plan -> batch operations | Resonite batch composer | 実行前に RPC-ready operation list を作る。slot / component ID 解決は batch response 後だけにする。 | `PlannedBatchEmission`、`ResoniteBatchEmissionPlanner`、`PlannedBatchEmissionInterpreter`。 |
+| Batch response -> canonical batch entity map | Target execution | response から created slot / component locator を解く。 | `CanonicalBatchEntityMap`。 |
+| Observed slot snapshot + source-root request -> source-root placement | Setup / readback interpretation | slot creation なしで exact、ancestor、deterministic ambiguity policy を解く。 | `ResoniteSceneSlotSnapshot`、`ResoniteSceneSetupInterpreter`。 |
+| Source-root placement + city-object transform -> object slot hierarchy | Resonite placement planner | RPC 前に local position と parent scope を決める。 | `ResoniteBatchEmissionPlanner`、`ResoniteSceneCreationModels`。 |
+
+## Impure 境界
+
+| Impure 処理 | 所有者 | 境界 |
+| --- | --- | --- |
+| archive extraction と source-file IO | Dataset source resolver | parsed model は source facts と stream を受け取る。IO details を parsed city object に漏らさない。 |
+| texture download、image generation、asset upload | Texture provider executor と Resonite texture uploader | texture-provider identity を選んだ後に実行する。planning と upload を分ける。 |
+| Resonite RPC | Live-send execution と batch emitter | `ResoniteSceneEmissionPlan` / planned batch output だけを実行する。 |
+| existing slot / component readback | Setup interpreter と slot repository | observed snapshot を planning に渡す。pure planning の中に readback を隠さない。 |
+| canonical dump generation | Diagnostics sink | execution 後の observable regression truth を記録する。runtime model を dump shape に依存させない。 |
+| logging と progress | `ILogger` と progress view | domain value と pure transformation から直接 progress や logging を呼ばない。 |
+
+## リファクタリング指針
+
+- source parsing や material policy から target dependency を取り除ける場合は、小さな record や resolver の追加を優先します。
+- 既存 helper の rename は、新しい名前が ownership を明確にし、まだコードが提供していない挙動を示唆しない場合に限ります。
+- naming や ownership だけを取り締まるテストは追加しません。可能な限り type、project dependency、centralized analyzer / build policy で表現します。
+- 複数の実行経路が同じ概念を emit する場合は、経路ごとの補正ではなく等価な output contract を比較します。
+- regression では、提案した原因を反証できる emitted payload、readback、dump artifact を定義してから fix 完了と見なします。

--- a/docs/import-pipeline-data-ownership.md
+++ b/docs/import-pipeline-data-ownership.md
@@ -1,0 +1,82 @@
+# Import Pipeline Data Ownership
+
+This note defines the current ownership boundaries for import-pipeline data. It is not a historical requirements document. Code remains the primary truth for exact behavior; this document names the data contracts and pure transformations that should guide future refactoring.
+
+Not every conceptual name below is a concrete type today. When the current implementation still combines several concepts in one record or static helper, the `Current anchors` column points to the code that currently owns the behavior. New code should split along these boundaries only when the split makes invalid ownership or dependency direction fail earlier.
+
+## Ownership Rules
+
+- Source parsing owns CityGML and dataset-layout facts. It must not know Resonite slots, components, RPC IDs, or live-send batching.
+- Application importing owns target-neutral city-object, surface, material, geometry, projection, and DEM contracts.
+- Resonite target planning owns Resonite material/component/slot plans, but should keep them as pure plans until execution.
+- Transport execution owns ResoniteLink calls, batch responses, asset uploads, and readback snapshots.
+- Diagnostics own canonical dumps and recordings. They verify observable output, but they are not the source model.
+
+## Data Contracts
+
+| Conceptual data type | Conceptual owner | Role | Current anchors |
+| --- | --- | --- | --- |
+| `CityGmlSourceFile` / source-file unit | Source discovery and parsing | CityGML source file, package, matched mesh code, source-file root mesh context, and parse stream boundary. | `SourceFileDescriptor`, `CachedSourceFileDescriptor`, `SourceFilePipeline` in `Application/Importing/LocalCityGmlParsedSourceFileModels.cs`; discovery descriptors in `LocalCityGmlSourceFileDiscovery.cs`. |
+| CityGML object envelope | CityGML parser | XML-element identity, display name, package, source file, and raw LOD/surface entry before projection. | Currently folded into `CityGmlSourceFileCityObjectProjection` and `ParsedCityObject` creation. |
+| `BuildingAttributeContext` | CityGML attribute parser | Normalized PLATEAU building attributes. Material, roof, and projection policy read it; they do not own parsing. | `BuildingAttributeContext` and `BuildingAttributeParser` in `Application/Importing`. |
+| `ParsedCityObject` | Application importing | Parsed source-CRS city object with no Resonite dependency. | `ParsedCityObject` in `LocalCityGmlParsedObjectModels.cs`. |
+| `ParsedSurface` | Application importing | Source-side surface contract: semantic, rings, texture payload, optical properties, base color. | `ParsedSurface` and `ParsedRing` in `LocalCityGmlParsedObjectModels.cs`. |
+| City-object origin, bounds, and altitude metrics | Projection support | Pure metrics derived from parsed geometry and used by projection, clipping, overlays, and height policies. | `CityObjectOriginResolver`, `CityObjectGeographicBoundsResolver`, `CityObjectAltitudeMetricsResolver`. |
+| Projection frame | Projection layer | Source CRS, global origin, local Cartesian frame, and per-object mesh-code frame. | Currently passed as `GeodeticPoint`, `LocalCartesian`, `CoordinateReferenceSystem`, and DEM frame records in projection helpers. |
+| DEM source-file frame and sampling draft | DEM projection | Source-file-wide TIN/surface sampling boundary before third-mesh output projection. | `DemSourceFileTerrainGridSamplingDraft`, `ConstructionCityObjectDraft`. |
+| DEM third-mesh and emission frames | DEM projection | Third-mesh output identity, source-file sampling frame, output grid frame, height frame, and Resonite emission placement. | `DemTerrainObjectFrameResolver`, `CityGmlDemTerrainGridCityObjectProjection` frame records. |
+| DEM terrain grid geometry and metrics | DEM projection | Sample counts, height range, world-base height, bounds, coverage, UV scale/offset, and height samples. | `DemTerrainGridProjectionBounds`, `TerrainGridGeometry`, `TerrainGridSampleCoverage`, `CityGmlDemTerrainGridCityObjectProjection`, `CityGmlDemTerrainGridSampler`. |
+| Terrain overlay coverage and assignment | Terrain overlay policy | Contained/intersecting/none coverage, split requirement, selected overlay, or untextured fallback. | `DemTerrainOverlayAssignment`, `TerrainOverlayMaterialSourcePartitioner`, `TerrainTextureOverlay`. |
+| Texture provider | Material and appearance layer | Dataset payload, atlas output, generated terrain texture, bundled texture, or already prepared texture identity. | `TexturePayload`, `ITextureImportSource`, `GeneratedTerrainTexture`, `BundledDefaultTextureAsset`, `TerrainTextureAssetGenerator`. |
+| Material identity | Application material layer | Common, dedicated, vertex-color, wireframe, projection, reuse scope, and bundled family identity independent of prepared texture URI. | `MaterialBinding`, `DefaultCommonMaterialMember`, `MaterialReuseScope`, `MaterialType`, `MaterialProjection`. |
+| Renderer binding | Resonite target planning | Renderer-side input such as direct material reference, main texture override, and terrain property block binding. | `PlannedRendererMaterialBinding` and subclasses in `ResoniteSceneEmissionPlan.cs`. |
+| Target material asset plan | Resonite target planning | Resonite material component plan, reuse scope, dedicated material slot need, and texture import requirements. | `PlannedMaterialAsset`, `PlannedDedicatedMaterialAsset`, `PlannedReusableMaterialAsset`, `ResoniteSceneMaterialPlanComposer`, `ResoniteMaterialPlanning`. |
+| Resonite emission plan | Resonite target planning | Pure planned slots, components, mesh assets, material bindings, ordering, and batch-local references. | `ResoniteSceneEmissionPlan.cs`, `ResoniteBatchEmissionPlanner`. |
+| Live-send queue item | Live-send runtime | Runtime input unit for live-send scheduling. It should not become nested target-class detail. | `LiveSendQueuedCityObject`, `LiveSendQueuePlan`, `LiveSendRunPlan`. |
+| Non-DEM bake buffer result | Non-DEM bake buffer | Typed found/missing/completed bake-buffer read result. | `INonDemSourceFileBakeEmitter`, `NonDemSourceFileBatching`, non-DEM bake models. |
+| Canonical scene dump | Diagnostics | Observable output truth for regression validation after execution. | `CanonicalSceneDumpSink`, `SceneSinkRecordingClientCanonicalDump`. |
+
+## Pure Transformations
+
+| Pure transformation | Conceptual owner | Boundary rule | Current anchors |
+| --- | --- | --- | --- |
+| `XElement -> BuildingAttributeContext` | `BuildingAttributeParser` | Parse XML codes, sentinel values, and metrics only. Do not select material or target behavior. | `BuildingAttributeParser.Parse`. |
+| `XElement + source-file unit -> CityGML object envelope` | CityGML object parser | Stop at identity, package, source file, and LOD/surface entry. Do not project. | Currently folded into `CityGmlSourceFileCityObjectProjection.Parse`. |
+| CityGML object envelope -> `ParsedCityObject` | Parsed object factory | Create source-CRS object and surfaces after source mesh/bounds filtering. | `CityGmlSourceFileCityObjectProjection`, `CityGmlParsedSurfaceReader`. |
+| `ParsedCityObject ->` origin/bounds/altitude metrics | Projection support resolvers | Return derived values with no side effects or target knowledge. | `CityObject*Resolver` helpers. |
+| `ParsedCityObject -> ConstructionCityObjectDraft` | Application projection preparation | Resolve project-stage face roles and generated-surface drafts before tessellation. | `ConstructionCityObjectDraft.FromParsedCityObject`, `GeneratedLod1RoofCityObjectFactory`. |
+| `ParsedSurface[] -> ConstructionFace[]` | Surface projection policy | Produce shared input for culling, roof generation, material role decisions, and tessellation. | `ConstructionCityObjectDraft`, `CityGmlSurfaceProjectionPolicy`. |
+| `ParsedSurface + material context -> resolved surface material` | Surface material resolver | Combine semantic, payload, default material, overlay, and role before target material planning. | `ResolvedSurfaceMaterial`, `ResolvedMaterial`, `CityGmlSurfaceMaterialResolver`. |
+| Resolved surface material -> material identity | Material identity selector | Choose common/dedicated/vertex/wireframe identity without depending on prepared texture URI. | `MaterialBinding`, `DefaultMaterialResolver`, `CommonMaterialCatalog`. |
+| Resolved surface material -> texture provider | Texture provider resolver | Choose dataset, atlas, generated terrain, bundled, or no texture provider without changing material identity. | `TexturePayload`, `TerrainTextureAssetGenerator`, non-DEM bake models. |
+| Material identity + texture provider -> renderer binding | Renderer binding composer | Compose direct material binding, main texture override, and terrain property-block inputs. | `ResoniteSceneMaterialPlanComposer`. |
+| Renderer binding + target capabilities -> target material asset plan | Resonite material planner | Create a pure plan for material components, reusable assets, dedicated slots, and texture members. | `PlannedSceneMaterialPlan`, `ResoniteMaterialPlanning`. |
+| `ParsedSurface[] + terrain overlay policy -> terrain overlay assignment` | Terrain overlay policy | Decide contained/intersecting/none, split requirement, and fallback without upload or RPC. | `DemTerrainOverlayAssignment`, `TerrainOverlayMaterialSourcePartitioner`. |
+| Terrain overlay + mesh context -> terrain overlay mesh code | Terrain overlay mesh-code resolver | Keep actual/requested/requested-bounds fallback order deterministic. | `TerrainOverlayMaterialSourcePartitioner`, `TerrainOverlayMeshCodeResolver`. |
+| DEM source-file surfaces + source-file frame -> DEM sampling draft | DEM projection | Make the source-file-wide buffer boundary explicit before per-third-mesh output. | `CityGmlParsedCityObjectProjection.CreateDemSourceFileTerrainGridSamplingDraft`. |
+| DEM sampling draft + third mesh -> DEM terrain grid object | DEM projection | Convert source-file frame into third-mesh output object and frame. | `CityGmlParsedCityObjectProjection.ProjectTerrainMeshModeCityObject`. |
+| DEM terrain object -> `TerrainGridGeometry` | DEM terrain grid projector | Produce sample count, height range, world-base height, coverage, and UV contract. | `CityGmlDemTerrainGridCityObjectProjection.TryProject`. |
+| Imported object stream -> counting stream | Import orchestration | Count streamed units without pre-reading or materializing the stream. | `CountingImportedObjectUnitStream`. |
+| Resonite emission plan -> batch operations | Resonite batch composer | Build RPC-ready operation lists before execution; resolve slot/component IDs only after the batch response. | `PlannedBatchEmission`, `ResoniteBatchEmissionPlanner`, `PlannedBatchEmissionInterpreter`. |
+| Batch response -> canonical batch entity map | Target execution | Decode created slot/component locators from the response. | `CanonicalBatchEntityMap`. |
+| Observed slot snapshot + source-root request -> source-root placement | Setup/readback interpretation | Resolve exact, ancestor, and deterministic ambiguity policy without creating slots. | `ResoniteSceneSlotSnapshot`, `ResoniteSceneSetupInterpreter`. |
+| Source-root placement + city-object transform -> object slot hierarchy | Resonite placement planner | Decide local position and parent scope before RPC. | `ResoniteBatchEmissionPlanner`, `ResoniteSceneCreationModels`. |
+
+## Impure Boundaries
+
+| Impure processing | Owner | Boundary |
+| --- | --- | --- |
+| Archive extraction and source-file IO | Dataset source resolver | Parsed models receive source facts and streams; IO details do not leak into parsed city objects. |
+| Texture download, image generation, and asset upload | Texture provider executor and Resonite texture uploader | Execute after texture-provider identity is selected. Planning remains separate from upload. |
+| Resonite RPC | Live-send execution and batch emitter | Execute `ResoniteSceneEmissionPlan` / planned batch output only. |
+| Existing slot/component readback | Setup interpreter and slot repository | Pass observed snapshots into planning. Do not hide readback inside pure planning. |
+| Canonical dump generation | Diagnostics sink | Record observable regression truth after execution. Runtime models must not depend on dump shape. |
+| Logging and progress | `ILogger` and progress view | Domain values and pure transformations do not call progress or logging directly. |
+
+## Refactoring Guidance
+
+- Prefer adding a small record or resolver when it removes a target dependency from source parsing or material policy.
+- Prefer renaming an existing helper only when the new name clarifies ownership and does not imply behavior that the code does not yet provide.
+- Do not add tests that only police naming or ownership. Express ownership with types, project dependencies, and centralized analyzer/build policy where possible.
+- When two execution paths emit the same concept, compare equivalent output contracts instead of compensating path by path.
+- For regressions, define the observable emitted payload, readback, or dump artifact that can disprove the proposed cause before treating a fix as complete.

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlDemTerrainGridCityObjectProjection.cs
@@ -64,7 +64,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
             demTerrainTextureOverlay,
             requestedMeshCodeBounds,
             sourceFileFrame.LocalPositions,
-            out DemTerrainGridBounds? heightMapBounds)
+            out DemTerrainGridProjectionBounds? heightMapBounds)
             || heightMapBounds is null)
         {
             outsideSamplingBounds = true;
@@ -249,7 +249,7 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         TerrainTextureOverlay? demTerrainTextureOverlay,
         IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
         IReadOnlyList<Float3> positions,
-        out DemTerrainGridBounds? bounds)
+        out DemTerrainGridProjectionBounds? bounds)
     {
         bounds = null;
         double rawMinX = positions.Min(static position => position.X);
@@ -298,11 +298,11 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
                 return false;
             }
 
-            bounds = new DemTerrainGridBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ, clampedGeographicBounds);
+            bounds = new DemTerrainGridProjectionBounds(rawMinX, rawMaxX, rawMinZ, rawMaxZ, clampedGeographicBounds);
             return true;
         }
 
-        bounds = new DemTerrainGridBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ, clampedGeographicBounds);
+        bounds = new DemTerrainGridProjectionBounds(clippedMinX, clippedMaxX, clippedMinZ, clippedMaxZ, clampedGeographicBounds);
         return true;
     }
 
@@ -486,13 +486,6 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
 
     private static Float3 ToContractFloat3(Float3 value) => new(value.X, value.Y, value.Z);
 
-    private sealed record DemTerrainGridBounds(
-        double MinX,
-        double MaxX,
-        double MinZ,
-        double MaxZ,
-        GeographicRectangle GeographicBounds);
-
     private sealed record DemTerrainThirdMeshOutputFrame(
         GeodeticPoint Origin,
         LocalCartesian Cartesian)
@@ -518,11 +511,9 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
         double ExtentX,
         double ExtentZ)
     {
-        public static bool TryCreate(DemTerrainGridBounds bounds, out DemTerrainGridOutputFrame frame)
+        public static bool TryCreate(DemTerrainGridProjectionBounds bounds, out DemTerrainGridOutputFrame frame)
         {
-            double extentX = bounds.MaxX - bounds.MinX;
-            double extentZ = bounds.MaxZ - bounds.MinZ;
-            if (extentX <= 1e-6 || extentZ <= 1e-6)
+            if (!bounds.HasUsableExtent)
             {
                 frame = default!;
                 return false;
@@ -530,10 +521,10 @@ internal static class CityGmlDemTerrainGridCityObjectProjection
 
             frame = new DemTerrainGridOutputFrame(
                 new TerrainGridSamplingBounds(bounds.MinX, bounds.MaxX, bounds.MinZ, bounds.MaxZ),
-                CenterX: (bounds.MinX + bounds.MaxX) / 2.0,
-                CenterZ: (bounds.MinZ + bounds.MaxZ) / 2.0,
-                extentX,
-                extentZ);
+                bounds.CenterX,
+                bounds.CenterZ,
+                bounds.ExtentX,
+                bounds.ExtentZ);
             return true;
         }
     }

--- a/src/PlateauResoniteLink/Application/Importing/DemTerrainGridProjectionBounds.cs
+++ b/src/PlateauResoniteLink/Application/Importing/DemTerrainGridProjectionBounds.cs
@@ -1,0 +1,21 @@
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal sealed record DemTerrainGridProjectionBounds(
+    double MinX,
+    double MaxX,
+    double MinZ,
+    double MaxZ,
+    GeographicRectangle GeographicBounds)
+{
+    public double CenterX => (MinX + MaxX) / 2.0;
+
+    public double CenterZ => (MinZ + MaxZ) / 2.0;
+
+    public double ExtentX => MaxX - MinX;
+
+    public double ExtentZ => MaxZ - MinZ;
+
+    public bool HasUsableExtent => ExtentX > 1e-6 && ExtentZ > 1e-6;
+}


### PR DESCRIPTION
## Summary

- Rebased onto the latest `main` after the DEM frame/source-file sampling work landed there.
- Kept the remaining implementation change focused on extracting DEM terrain-grid projection bounds into an explicit internal data type.
- Added English/Japanese architecture docs describing import-pipeline data ownership and pure conversion boundaries, aligned with the current type names.

## Validation

- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (`1087/1087` passed)
- Real-data canonical scene dump comparison against latest `origin/main` using `tests\Fixtures\LocalPlateauDatasetParentMeshPackages`, mesh `53394525`, package `dem`, terrain `grid`: baseline and current dumps were byte-identical, SHA-256 `69C8546BCA421C30D356AB91A97C7291A9CD64B91AF78C6C0C06373E9B4B8852`.