### PR TITLE
[codex] Scope dataset assets to terrain overlays

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteBatchEmissionPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteBatchEmissionPlanner.cs
@@ -46,13 +46,14 @@ internal static class ResoniteBatchEmissionPlanner
         List<PlannedBatchSlotEmission> slotEmissions = [];
         List<PlannedBatchComponentEmission> componentEmissions = [];
 
-        PlannedBatchSlotEmission meshAssetSlot = new(
-            PlannedSlotTargetReference.CanonicalSlot(objectSlots.AssetLodSlot.Locator),
-            geometryAsset.MeshAssetSlotName,
-            null,
-            null,
+        PlannedBatchSlotEmission presentationSlot = new(
+            PlannedSlotTargetReference.CanonicalSlot(objectSlots.LodSlot.Locator),
+            objectSlots.CityObjectSlotName,
+            objectSlots.CityObjectLocalPosition,
+            objectSlots.CityObjectRotation,
             objectSlots.CityObjectOrderOffset);
-        slotEmissions.Add(meshAssetSlot);
+        slotEmissions.Add(presentationSlot);
+        PlannedSlotTargetReference presentationSlotTarget = PlannedSlotTargetReference.PlannedSlot(presentationSlot);
 
         PlannedBatchComponentEmission? rendererGeometryComponent = null;
         PlannedTerrainGridMeshBundle? terrainGridMesh = null;
@@ -62,7 +63,7 @@ internal static class ResoniteBatchEmissionPlanner
         {
             case PlannedTriangleMeshGeometryAsset triangleMesh:
                 rendererGeometryComponent = new PlannedBatchComponentEmission(
-                    PlannedSlotTargetReference.PlannedSlot(meshAssetSlot),
+                    presentationSlotTarget,
                     "[FrooxEngine]FrooxEngine.StaticMesh",
                     new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
                     {
@@ -75,10 +76,8 @@ internal static class ResoniteBatchEmissionPlanner
                 break;
             case PlannedTerrainGridGeometryAsset heightMap:
                 terrainGridMesh = AddPlannedTerrainGridTextureAndCreateGridBundle(
-                    slotEmissions,
                     componentEmissions,
-                    objectSlots,
-                    heightMap.TerrainGridAssetSlotName,
+                    presentationSlotTarget,
                     heightMap.Geometry,
                     heightMap.HeightTextureUri,
                     heightMap.UvScale,
@@ -86,7 +85,7 @@ internal static class ResoniteBatchEmissionPlanner
                 break;
             case PlannedDynamicTerrainGeometryAsset dynamicTerrain:
                 rendererGeometryComponent = new PlannedBatchComponentEmission(
-                    PlannedSlotTargetReference.PlannedSlot(meshAssetSlot),
+                    presentationSlotTarget,
                     "[FrooxEngine]FrooxEngine.StaticMesh",
                     new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
                     {
@@ -98,10 +97,8 @@ internal static class ResoniteBatchEmissionPlanner
                 componentEmissions.Add(rendererGeometryComponent);
                 dynamicStaticMeshTarget = PlannedWorldElementReference.Planned(rendererGeometryComponent);
                 terrainGridMesh = AddPlannedTerrainGridTextureAndCreateGridBundle(
-                    slotEmissions,
                     componentEmissions,
-                    objectSlots,
-                    dynamicTerrain.TerrainGridAssetSlotName,
+                    presentationSlotTarget,
                     dynamicTerrain.GridGeometry,
                     dynamicTerrain.HeightTextureUri,
                     dynamicTerrain.UvScale,
@@ -123,9 +120,8 @@ internal static class ResoniteBatchEmissionPlanner
                     break;
                 case PlannedDedicatedMaterialAsset dedicatedMaterial:
                     PlannedWorldElementReference emittedMaterialTarget = AddPlannedDedicatedMaterialEmissions(
-                        slotEmissions,
                         componentEmissions,
-                        PlannedSlotTargetReference.PlannedSlot(meshAssetSlot),
+                        presentationSlotTarget,
                         dedicatedMaterial);
                     emittedMaterialTargets[dedicatedMaterial] = emittedMaterialTarget;
                     break;
@@ -135,18 +131,10 @@ internal static class ResoniteBatchEmissionPlanner
             }
         }
 
-        PlannedBatchSlotEmission presentationSlot = new(
-            PlannedSlotTargetReference.CanonicalSlot(objectSlots.LodSlot.Locator),
-            objectSlots.CityObjectSlotName,
-            objectSlots.CityObjectLocalPosition,
-            objectSlots.CityObjectRotation,
-            objectSlots.CityObjectOrderOffset);
-        slotEmissions.Add(presentationSlot);
-
         if (terrainGridMesh is not null)
         {
             rendererGeometryComponent = new PlannedBatchComponentEmission(
-                PlannedSlotTargetReference.PlannedSlot(presentationSlot),
+                presentationSlotTarget,
                 "[FrooxEngine]FrooxEngine.GridMesh",
                 CreateTerrainGridMeshMembers(terrainGridMesh));
             componentEmissions.Add(rendererGeometryComponent);
@@ -170,7 +158,7 @@ internal static class ResoniteBatchEmissionPlanner
 
         PlannedFieldReference rendererMeshField = new();
         componentEmissions.Add(new PlannedBatchComponentEmission(
-            PlannedSlotTargetReference.PlannedSlot(presentationSlot),
+            presentationSlotTarget,
             "[FrooxEngine]FrooxEngine.MeshRenderer",
             new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
             {
@@ -180,7 +168,6 @@ internal static class ResoniteBatchEmissionPlanner
                 ["Materials"] = CreateRendererMaterials(rendererMaterialBindings, emittedMaterialTargets),
                 ["MaterialPropertyBlocks"] = CreateRendererMaterialPropertyBlocks(
                     componentEmissions,
-                    meshAssetSlot,
                     presentationSlot,
                     rendererMaterialBindings),
             }));
@@ -195,7 +182,7 @@ internal static class ResoniteBatchEmissionPlanner
 
         PlannedFieldReference colliderMeshField = new();
         componentEmissions.Add(new PlannedBatchComponentEmission(
-            PlannedSlotTargetReference.PlannedSlot(presentationSlot),
+            presentationSlotTarget,
             "[FrooxEngine]FrooxEngine.MeshCollider",
             new Dictionary<string, PlannedMember>(StringComparer.Ordinal)
             {
@@ -233,23 +220,15 @@ internal static class ResoniteBatchEmissionPlanner
     }
 
     private static PlannedTerrainGridMeshBundle AddPlannedTerrainGridTextureAndCreateGridBundle(
-        List<PlannedBatchSlotEmission> slotEmissions,
         List<PlannedBatchComponentEmission> componentEmissions,
-        ResoniteObjectSlotHierarchy objectSlots,
-        string terrainGridAssetSlotName,
+        PlannedSlotTargetReference presentationSlotTarget,
         ResoniteTerrainGridGeometry geometry,
         Uri heightTextureUri,
         ResoniteFloat2? uvScale,
         ResoniteFloat2? uvOffset)
     {
-        PlannedBatchSlotEmission heightMapAssetSlot = new(
-            PlannedSlotTargetReference.CanonicalSlot(objectSlots.AssetLodSlot.Locator),
-            terrainGridAssetSlotName,
-            null,
-            null);
-        slotEmissions.Add(heightMapAssetSlot);
         PlannedBatchComponentEmission heightTextureComponent = new(
-            PlannedSlotTargetReference.PlannedSlot(heightMapAssetSlot),
+            presentationSlotTarget,
             "[FrooxEngine]FrooxEngine.StaticTexture2D",
             ResoniteGeometryAssetAssembler.CreateTerrainGridTextureMembers(heightTextureUri)
                 .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal));
@@ -471,26 +450,11 @@ internal static class ResoniteBatchEmissionPlanner
     }
 
     private static PlannedWorldElementReference AddPlannedDedicatedMaterialEmissions(
-        List<PlannedBatchSlotEmission> slotEmissions,
         List<PlannedBatchComponentEmission> componentEmissions,
-        PlannedSlotTargetReference meshAssetSlotTarget,
+        PlannedSlotTargetReference materialContainerTarget,
         PlannedDedicatedMaterialAsset plannedMaterial)
     {
         ResoniteMaterialBinding material = plannedMaterial.Material;
-        PlannedSlotTargetReference materialContainerTarget = meshAssetSlotTarget;
-        if (plannedMaterial.PreserveDedicatedMaterialSlot)
-        {
-            string materialSlotName = plannedMaterial.DedicatedMaterialSlotName
-                ?? throw new InvalidOperationException("Dedicated material slot preservation requires a planned material-index slot name.");
-            PlannedBatchSlotEmission materialSlot = new(
-                meshAssetSlotTarget,
-                materialSlotName,
-                null,
-                null);
-            slotEmissions.Add(materialSlot);
-            materialContainerTarget = PlannedSlotTargetReference.PlannedSlot(materialSlot);
-        }
-
         Dictionary<string, PlannedMember> materialMembers = ResoniteMaterialComponentPolicy.CreateMembers(material)
             .ToDictionary(static pair => pair.Key, static pair => PlannedMembers.Literal(pair.Value), StringComparer.Ordinal);
 
@@ -600,7 +564,6 @@ internal static class ResoniteBatchEmissionPlanner
 
     private static PlannedSyncListMember CreateRendererMaterialPropertyBlocks(
         List<PlannedBatchComponentEmission> componentEmissions,
-        PlannedBatchSlotEmission assetSlot,
         PlannedBatchSlotEmission presentationSlot,
         IReadOnlyList<PlannedRendererMaterialBinding> materialBindings)
     {
@@ -615,7 +578,6 @@ internal static class ResoniteBatchEmissionPlanner
                 propertyBlocks.Add(
                     CreateMainTexturePropertyBlockReference(
                         componentEmissions,
-                        assetSlot,
                         presentationSlot,
                         mainTextureOverrideBinding));
                 continue;
@@ -631,7 +593,6 @@ internal static class ResoniteBatchEmissionPlanner
 
     private static PlannedMember CreateMainTexturePropertyBlockReference(
         List<PlannedBatchComponentEmission> componentEmissions,
-        PlannedBatchSlotEmission assetSlot,
         PlannedBatchSlotEmission presentationSlot,
         PlannedMainTextureOverrideRendererMaterialBinding binding)
     {
@@ -662,7 +623,7 @@ internal static class ResoniteBatchEmissionPlanner
         if (sharedTextureTarget is null)
         {
             textureComponent = new PlannedBatchComponentEmission(
-                PlannedSlotTargetReference.PlannedSlot(assetSlot),
+                PlannedSlotTargetReference.PlannedSlot(presentationSlot),
                 "[FrooxEngine]FrooxEngine.StaticTexture2D",
                 ResoniteSceneMaterialConventions.CreateTextureMembers(
                     binding.MainTexture.AssetUri,

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteGeometryAssetAssembler.cs
@@ -18,7 +18,6 @@ internal static class ResoniteGeometryAssetAssembler
 {
     public static async Task<UploadedTriangleMeshAssetBatch> PrepareTriangleMeshAsync(
         IResoniteLinkClient importClient,
-        string meshAssetSlotName,
         string displayName,
         IGeometryImportSource meshSource,
         ILogger logger,
@@ -34,13 +33,11 @@ internal static class ResoniteGeometryAssetAssembler
             "Mesh '{DisplayName}' mesh import completed -> '{AssetUri}'.",
             displayName,
             assetUri);
-        return new UploadedTriangleMeshAssetBatch(meshAssetSlotName, assetUri);
+        return new UploadedTriangleMeshAssetBatch(assetUri);
     }
 
     public static async Task<UploadedTerrainGridAssetBatch> PrepareTerrainGridAsync(
         IResoniteLinkClient importClient,
-        string meshAssetSlotName,
-        string heightMapAssetSlotName,
         string displayName,
         ResoniteTerrainGridGeometry geometry,
         ITextureImportSource heightTextureSource,
@@ -59,8 +56,6 @@ internal static class ResoniteGeometryAssetAssembler
             displayName,
             textureUri);
         return new UploadedTerrainGridAssetBatch(
-            meshAssetSlotName,
-            heightMapAssetSlotName,
             geometry,
             textureUri,
             uvScale,
@@ -86,16 +81,11 @@ internal static class ResoniteGeometryAssetAssembler
     }
 }
 
-internal abstract record UploadedGeometryAssetBatch(string MeshAssetSlotName);
-
 internal sealed record UploadedTriangleMeshAssetBatch(
-    string MeshAssetSlotName,
-    Uri MeshUri) : UploadedGeometryAssetBatch(MeshAssetSlotName);
+    Uri MeshUri);
 
 internal sealed record UploadedTerrainGridAssetBatch(
-    string MeshAssetSlotName,
-    string TerrainGridAssetSlotName,
     ResoniteTerrainGridGeometry Geometry,
     Uri HeightTextureUri,
     ResoniteFloat2? UvScale,
-    ResoniteFloat2? UvOffset) : UploadedGeometryAssetBatch(MeshAssetSlotName);
+    ResoniteFloat2? UvOffset);

--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteMaterialPlanning.cs
@@ -23,10 +23,8 @@ internal interface IResoniteMaterialPlanning
     Task<PlannedDedicatedMaterialAsset> PlanDedicatedMaterialAssetAsync(
         IResoniteLinkClient importClient,
         ResoniteMaterialBinding material,
-        int materialIndex,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
         IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
-        bool preserveDedicatedMaterialSlot,
         CancellationToken cancellationToken);
 }
 
@@ -71,17 +69,14 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             cancellationToken);
         return new PlannedDedicatedMaterialAsset(
             material,
-            textures,
-            PreserveDedicatedMaterialSlot: false);
+            textures);
     }
 
     public async Task<PlannedDedicatedMaterialAsset> PlanDedicatedMaterialAssetAsync(
         IResoniteLinkClient importClient,
         ResoniteMaterialBinding material,
-        int materialIndex,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
         IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
-        bool preserveDedicatedMaterialSlot,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(importClient);
@@ -109,11 +104,7 @@ internal sealed class ResoniteMaterialPlanning : IResoniteMaterialPlanning
             cancellationToken);
         return new PlannedDedicatedMaterialAsset(
             material,
-            textures,
-            preserveDedicatedMaterialSlot,
-            DedicatedMaterialSlotName: preserveDedicatedMaterialSlot
-                ? ResoniteSceneMaterialConventions.CreateDedicatedMaterialSlotName(material, materialIndex)
-                : null);
+            textures);
     }
 
     public static Uri? TryGetPlannedTextureUri(

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteGeometryAssetPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteGeometryAssetPlanner.cs
@@ -13,8 +13,6 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal static class ResoniteGeometryAssetPlanner
 {
-    private const string TerrainGridAssetSlotSuffix = "_terrain-grid";
-
     public static async Task<PlannedGeometryAsset> PlanAsync(
         IResoniteLinkClient importClient,
         ResoniteConstructionCityObject cityObject,
@@ -31,20 +29,15 @@ internal static class ResoniteGeometryAssetPlanner
         return preparedCityObject.Geometry switch
         {
             PreparedTriangleMeshGeometry triangleMesh => CreatePlannedGeometryAsset(
-                cityObject,
                 await ResoniteGeometryAssetAssembler.PrepareTriangleMeshAsync(
                     importClient,
-                    CreateMeshAssetSlotName(cityObject),
                     cityObject.DisplayName,
                     triangleMesh.MeshSource,
                     logger,
                     cancellationToken)),
             PreparedTerrainGridGeometry heightMap => CreatePlannedGeometryAsset(
-                cityObject,
                 await ResoniteGeometryAssetAssembler.PrepareTerrainGridAsync(
                     importClient,
-                    CreateMeshAssetSlotName(cityObject),
-                    CreateTerrainGridAssetSlotName(cityObject),
                     cityObject.DisplayName,
                     heightMap.Geometry,
                     heightMap.HeightTextureSource,
@@ -53,18 +46,14 @@ internal static class ResoniteGeometryAssetPlanner
                     logger,
                     cancellationToken)),
             PreparedDynamicTerrainGeometry dynamicTerrain => CreatePlannedDynamicTerrainGeometryAsset(
-                cityObject,
                 await ResoniteGeometryAssetAssembler.PrepareTriangleMeshAsync(
                     importClient,
-                    CreateMeshAssetSlotName(cityObject),
                     cityObject.DisplayName,
                     dynamicTerrain.StaticMesh.MeshSource,
                     logger,
                     cancellationToken),
                 await ResoniteGeometryAssetAssembler.PrepareTerrainGridAsync(
                     importClient,
-                    CreateMeshAssetSlotName(cityObject),
-                    CreateTerrainGridAssetSlotName(cityObject),
                     cityObject.DisplayName,
                     dynamicTerrain.GridMesh.Geometry,
                     dynamicTerrain.GridMesh.HeightTextureSource,
@@ -78,21 +67,15 @@ internal static class ResoniteGeometryAssetPlanner
     }
 
     private static PlannedTriangleMeshGeometryAsset CreatePlannedGeometryAsset(
-        ResoniteConstructionCityObject cityObject,
         UploadedTriangleMeshAssetBatch uploadedGeometryBatch)
     {
-        return new PlannedTriangleMeshGeometryAsset(
-            uploadedGeometryBatch.MeshAssetSlotName,
-            uploadedGeometryBatch.MeshUri);
+        return new PlannedTriangleMeshGeometryAsset(uploadedGeometryBatch.MeshUri);
     }
 
     private static PlannedTerrainGridGeometryAsset CreatePlannedGeometryAsset(
-        ResoniteConstructionCityObject cityObject,
         UploadedTerrainGridAssetBatch uploadedGeometryBatch)
     {
         return new PlannedTerrainGridGeometryAsset(
-            uploadedGeometryBatch.MeshAssetSlotName,
-            uploadedGeometryBatch.TerrainGridAssetSlotName,
             uploadedGeometryBatch.Geometry,
             uploadedGeometryBatch.HeightTextureUri,
             uploadedGeometryBatch.UvScale,
@@ -100,27 +83,14 @@ internal static class ResoniteGeometryAssetPlanner
     }
 
     private static PlannedDynamicTerrainGeometryAsset CreatePlannedDynamicTerrainGeometryAsset(
-        ResoniteConstructionCityObject cityObject,
         UploadedTriangleMeshAssetBatch staticMeshBatch,
         UploadedTerrainGridAssetBatch gridMeshBatch)
     {
         return new PlannedDynamicTerrainGeometryAsset(
-            staticMeshBatch.MeshAssetSlotName,
             staticMeshBatch.MeshUri,
-            gridMeshBatch.TerrainGridAssetSlotName,
             gridMeshBatch.Geometry,
             gridMeshBatch.HeightTextureUri,
             gridMeshBatch.UvScale,
             gridMeshBatch.UvOffset);
-    }
-
-    private static string CreateMeshAssetSlotName(ResoniteConstructionCityObject cityObject)
-    {
-        return cityObject.DisplayName;
-    }
-
-    private static string CreateTerrainGridAssetSlotName(ResoniteConstructionCityObject cityObject)
-    {
-        return string.Concat(CreateMeshAssetSlotName(cityObject), TerrainGridAssetSlotSuffix);
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteObjectSlotHierarchy.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteObjectSlotHierarchy.cs
@@ -1,7 +1,6 @@
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed record ResoniteObjectSlotHierarchy(
-    CreatedSlot AssetLodSlot,
     CreatedSlot LodSlot,
     string CityObjectSlotName,
     ResoniteFloat3 CityObjectLocalPosition,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedRunSetupComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResonitePreparedRunSetupComposer.cs
@@ -19,7 +19,6 @@ internal sealed class ResonitePreparedRunSetupComposer(
         CommonMaterialAssetCache materials = CreateMaterialCache(setupState);
         ResoniteSharedSlotIndex placement = new(
             setupState.DatasetRootSlot,
-            setupState.DatasetAssetsRootSlot,
             runPlan.RequestLocalOrigin,
             runPlan.SourceFileSlotNamesByRelativePath,
             setupState.SceneAnchor,

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneEmissionPlan.cs
@@ -5,31 +5,26 @@ using ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal abstract record PlannedGeometryAsset(string MeshAssetSlotName);
+internal abstract record PlannedGeometryAsset;
 
 internal sealed record PlannedTriangleMeshGeometryAsset(
-    string MeshAssetSlotName,
     Uri MeshUri)
-    : PlannedGeometryAsset(MeshAssetSlotName);
+    : PlannedGeometryAsset;
 
 internal sealed record PlannedTerrainGridGeometryAsset(
-    string MeshAssetSlotName,
-    string TerrainGridAssetSlotName,
     ResoniteTerrainGridGeometry Geometry,
     Uri HeightTextureUri,
     ResoniteFloat2? UvScale = null,
     ResoniteFloat2? UvOffset = null)
-    : PlannedGeometryAsset(MeshAssetSlotName);
+    : PlannedGeometryAsset;
 
 internal sealed record PlannedDynamicTerrainGeometryAsset(
-    string MeshAssetSlotName,
     Uri StaticMeshUri,
-    string TerrainGridAssetSlotName,
     ResoniteTerrainGridGeometry GridGeometry,
     Uri HeightTextureUri,
     ResoniteFloat2? UvScale = null,
     ResoniteFloat2? UvOffset = null)
-    : PlannedGeometryAsset(MeshAssetSlotName);
+    : PlannedGeometryAsset;
 
 internal sealed record PlannedTextureAsset(
     ResoniteSceneMaterialConventions.PlannedTextureRole Role,
@@ -43,9 +38,7 @@ internal sealed record PlannedReusableMaterialAsset(
 
 internal sealed record PlannedDedicatedMaterialAsset(
     ResoniteMaterialBinding Material,
-    IReadOnlyList<PlannedTextureAsset> Textures,
-    bool PreserveDedicatedMaterialSlot,
-    string? DedicatedMaterialSlotName = null)
+    IReadOnlyList<PlannedTextureAsset> Textures)
     : PlannedMaterialAsset;
 
 internal abstract record PlannedRendererMaterialBinding(PlannedMaterialAsset MaterialAsset);

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialConventions.cs
@@ -45,17 +45,6 @@ internal static class ResoniteSceneMaterialConventions
         return CreateCommonMaterialSlotName(normalizedMaterial);
     }
 
-    public static string CreateDedicatedMaterialSlotName(ResoniteMaterialBinding material, int materialIndex)
-    {
-        ArgumentNullException.ThrowIfNull(material);
-        ArgumentOutOfRangeException.ThrowIfNegative(materialIndex);
-        ResoniteMaterialBinding normalizedMaterial = ResoniteDynamicMaterialUvNormalizer.NormalizeMaterialBinding(material);
-
-        return string.Create(
-            CultureInfo.InvariantCulture,
-            $"material-{materialIndex:000}-{MaterialComponentToken(normalizedMaterial)}-{ProjectionToken(normalizedMaterial.Projection)}");
-    }
-
     public static IReadOnlyList<string> CreateCommonMaterialSlotLookupNames(ResoniteMaterialBinding material)
     {
         ArgumentNullException.ThrowIfNull(material);
@@ -218,13 +207,6 @@ internal static class ResoniteSceneMaterialConventions
             || BundledDefaultMaterialFamilies.BuildingFacadeFamilies.Contains(family, StringComparer.Ordinal);
     }
 
-    private static string CreateCompactColorSuffix(ResoniteColor color)
-    {
-        return string.Create(
-            CultureInfo.InvariantCulture,
-            $"{color.R:0.###}-{color.G:0.###}-{color.B:0.###}-{color.A:0.###}");
-    }
-
     private static string CreateCommonMaterialSlotName(ResoniteMaterialBinding material)
     {
         string projectionName = ProjectionToken(material.Projection);
@@ -253,22 +235,6 @@ internal static class ResoniteSceneMaterialConventions
             ResoniteMaterialProjection.Uv => "uv",
             ResoniteMaterialProjection.Triplanar => "triplanar",
             _ => projection.ToString().ToLowerInvariant(),
-        };
-    }
-
-    private static string MaterialComponentToken(ResoniteMaterialBinding material)
-    {
-        return material.MaterialType switch
-        {
-            ResoniteMaterialType.Standard => material.Projection switch
-            {
-                ResoniteMaterialProjection.Uv => "pbs-uv",
-                ResoniteMaterialProjection.Triplanar => "pbs-triplanar",
-                _ => "material",
-            },
-            ResoniteMaterialType.VertexColor => "vertex-color",
-            ResoniteMaterialType.Wireframe => "wireframe",
-            _ => "material",
         };
     }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
@@ -56,11 +56,9 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
             materialPlanTasks[materialIndex] = PlanDedicatedRendererMaterialAsync(
                 importClient,
                 material,
-                materialIndex,
                 preparedTextureUrisByPayload,
                 preparedTerrainTextureUrisByOverlay,
                 preparedTerrainTexturePropertyBlockComponentsByMeshCode,
-                preserveDedicatedMaterialSlot: string.Equals(cityObject.PackageName, "dem", StringComparison.OrdinalIgnoreCase),
                 cancellationToken);
         }
 
@@ -111,11 +109,9 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
     private async Task<(PlannedMaterialAsset MaterialAsset, PlannedRendererMaterialBinding RendererBinding)> PlanDedicatedRendererMaterialAsync(
         IResoniteLinkClient client,
         ResoniteMaterialBinding sourceMaterial,
-        int materialIndex,
         IReadOnlyDictionary<ResoniteTexturePayload, Uri> preparedTextureUrisByPayload,
         IReadOnlyDictionary<TerrainTextureOverlay, Uri> preparedTerrainTextureUrisByOverlay,
         IReadOnlyDictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> preparedTerrainTexturePropertyBlockComponentsByMeshCode,
-        bool preserveDedicatedMaterialSlot,
         CancellationToken cancellationToken)
     {
         ResoniteMaterialBinding materialComponentSource = sourceMaterial.TerrainOverlay is null
@@ -129,10 +125,8 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
         PlannedDedicatedMaterialAsset plannedMaterial = await materialPlanning.PlanDedicatedMaterialAssetAsync(
             client,
             materialComponentSource,
-            materialIndex,
             preparedTextureUrisByPayload,
             preparedTerrainTextureUrisByOverlay,
-            preserveDedicatedMaterialSlot,
             cancellationToken);
         if (sourceMaterial.TerrainOverlay is not null)
         {

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -10,7 +10,6 @@ namespace PlateauResoniteLink.Targets.Resonite;
 
 internal sealed class ResoniteSharedSlotIndex(
     CreatedSlot datasetRootSlot,
-    CreatedSlot datasetAssetsRootSlot,
     ResoniteLocalOrigin requestLocalOrigin,
     IReadOnlyDictionary<string, string> sourceFileSlotNamesByRelativePath,
     SceneAnchor? initialSceneAnchor,
@@ -78,7 +77,6 @@ internal sealed class ResoniteSharedSlotIndex(
             ct => CreateCanonicalParentScopeAsync(client, sourceFileSlotName, rootMeshCode, cityObject.LodLevel, sourceRootPlacement.RootPosition, ct),
             cancellationToken);
         return new ResoniteObjectSlotHierarchy(
-            parentScope.AssetLodSlot,
             parentScope.LodSlot,
             cityObject.DisplayName,
             ResonitePlacementPolicy.ResolveCityObjectLocalPosition(
@@ -109,23 +107,9 @@ internal sealed class ResoniteSharedSlotIndex(
             rootPosition,
             sourceFileRootOrderOffset,
             cancellationToken);
-        CreatedSlot assetSourceFileSlot = await GetOrCreateRunScopedSourceFileRootAsync(
-            client,
-            datasetAssetsRootSlot.Locator,
-            sourceFileSlotName,
-            null,
-            sourceFileRootOrderOffset,
-            cancellationToken);
         CreatedSlot lodSlot = await GetOrCreateSharedChildSlotByIdAsync(
             client,
             sourceFileSlot.Locator,
-            lodSlotName,
-            null,
-            null,
-            cancellationToken);
-        CreatedSlot assetLodSlot = await GetOrCreateSharedChildSlotByIdAsync(
-            client,
-            assetSourceFileSlot.Locator,
             lodSlotName,
             null,
             null,
@@ -144,11 +128,7 @@ internal sealed class ResoniteSharedSlotIndex(
             };
         }
 
-        return new CanonicalParentScope(
-            sourceFileSlot,
-            assetSourceFileSlot,
-            lodSlot,
-            assetLodSlot);
+        return new CanonicalParentScope(lodSlot);
     }
 
     private async Task<CreatedSlot> GetOrCreateSharedChildSlotByIdAsync(
@@ -237,10 +217,7 @@ internal sealed class ResoniteSharedSlotIndex(
     }
 
     private sealed record CanonicalParentScope(
-        CreatedSlot SourceFileSlot,
-        CreatedSlot AssetSourceFileSlot,
-        CreatedSlot LodSlot,
-        CreatedSlot AssetLodSlot);
+        CreatedSlot LodSlot);
 
     private readonly record struct CanonicalParentSourceFile(
         string SourceFileRelativePath,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteLiveSceneImportTargetTests.cs
@@ -573,12 +573,12 @@ public sealed class ResoniteLiveSceneImportTargetTests
                 $"<color=mid.orange>🟫</color> plateau_{DatasetName}_dem_533945",
                 StringComparison.Ordinal))
             .ToArray();
-        Assert.Equal(2, demSourceFileRootSlots.Length);
+        Assert.Single(demSourceFileRootSlots);
         Assert.All(demSourceFileRootSlots, slot => Assert.Equal(533945, Assert.IsType<Field_long>(slot.OrderOffset).Value));
         Slot[] terrainObjectSlots = client.SlotsById.Values
             .Where(slot => string.Equals(slot.Name?.Value, "Terrain Grid Terrain", StringComparison.Ordinal))
             .ToArray();
-        Assert.Equal(2, terrainObjectSlots.Length);
+        Assert.Single(terrainObjectSlots);
         Assert.All(terrainObjectSlots, slot => Assert.Equal(53394525, Assert.IsType<Field_long>(slot.OrderOffset).Value));
         Assert.DoesNotContain(
             client.SlotsById.Values,

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteMaterialPlanningTests.cs
@@ -183,47 +183,6 @@ public sealed class ResoniteMaterialPlanningTests
     }
 
     [Fact]
-    public async Task PlanDedicatedMaterialAssetAsyncUsesPreserveDedicatedMaterialSlotContract()
-    {
-        using SceneSinkRecordingClient client = new();
-        ResoniteMaterialPlanning planning = new(new BundledDefaultMaterialAssetStore());
-        ResoniteMaterialBinding material = new(
-            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-            MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: null,
-            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-            Projection: ResoniteMaterialProjection.Uv,
-            DepthOffset: null,
-            SubmeshIndices: [0],
-            AssetBinding: ResoniteMaterialAssetBinding.Presentation);
-
-        PlannedDedicatedMaterialAsset preserved = await planning.PlanDedicatedMaterialAssetAsync(
-            client,
-            material,
-            materialIndex: 2,
-            new Dictionary<ResoniteTexturePayload, Uri>(),
-            new Dictionary<TerrainTextureOverlay, Uri>(),
-            preserveDedicatedMaterialSlot: true,
-            CancellationToken.None);
-        PlannedDedicatedMaterialAsset notPreserved = await planning.PlanDedicatedMaterialAssetAsync(
-            client,
-            material,
-            materialIndex: 2,
-            new Dictionary<ResoniteTexturePayload, Uri>(),
-            new Dictionary<TerrainTextureOverlay, Uri>(),
-            preserveDedicatedMaterialSlot: false,
-            CancellationToken.None);
-        string expectedDedicatedSlotName = ResoniteSceneMaterialConventions.CreateDedicatedMaterialSlotName(
-            material,
-            materialIndex: 2);
-
-        Assert.True(preserved.PreserveDedicatedMaterialSlot);
-        Assert.Equal(expectedDedicatedSlotName, preserved.DedicatedMaterialSlotName);
-        Assert.False(notPreserved.PreserveDedicatedMaterialSlot);
-        Assert.Null(notPreserved.DedicatedMaterialSlotName);
-    }
-
-    [Fact]
     public void ResolveTerrainTextureCanvasMaterialComposesExistingTransformWithCanvasOccupancy()
     {
         TerrainTextureOverlay overlay = new(
@@ -273,8 +232,7 @@ public sealed class ResoniteMaterialPlanningTests
                 new PlannedTextureAsset(
                     ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo,
                     new Uri("resdb:///texture/albedo", UriKind.Absolute)),
-            ],
-            PreserveDedicatedMaterialSlot: false);
+            ]);
 
         ResoniteMaterialPlanning.AddCommonMaterialComponents(batchBuilder, plannedMaterial, "slot");
 
@@ -299,8 +257,7 @@ public sealed class ResoniteMaterialPlanningTests
                 new PlannedTextureAsset(
                     ResoniteSceneMaterialConventions.PlannedTextureRole.Emission,
                     new Uri("resdb:///texture/emission", UriKind.Absolute)),
-            ],
-            PreserveDedicatedMaterialSlot: false);
+            ]);
 
         ResoniteMaterialPlanning.AddCommonMaterialComponents(batchBuilder, plannedMaterial, "slot");
 

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneBatchEmissionPlanningTests.cs
@@ -106,7 +106,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     public void CreatePlannedBatchEmission_CreatesTerrainGridPlanWithPlannedTextureReference()
     {
         ResoniteObjectSlotHierarchy objectSlots = new(
-            new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Terrain Grid Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(1.0, 2.0, 3.0),
@@ -114,8 +113,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchEmission batchPlan = CreateBatchPlan(
             objectSlots,
             new PlannedTerrainGridGeometryAsset(
-                "Terrain Grid Object",
-                "Terrain Grid Object_terrain-grid",
                 new ResoniteTerrainGridGeometry(
                     Width: 2,
                     Height: 3,
@@ -155,6 +152,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.Equal(0.70710677f, gridRotation.Value.w, 6);
         PlannedBatchSlotEmission presentationSlot = AssertPlanned(gridMesh.ContainerTarget);
         Assert.Equal("Terrain Grid Object", presentationSlot.SlotName);
+        Assert.Same(presentationSlot, AssertPlanned(heightTexture.ContainerTarget));
         Assert.Equal(-1.0f, Assert.IsType<Field_float>(ToMember(gridMesh.Members["DisplacementMagnitude"])).Value);
         Assert.Same(presentationSlot, AssertPlanned(meshRenderer.ContainerTarget));
         Assert.Same(presentationSlot, AssertPlanned(meshCollider.ContainerTarget));
@@ -194,10 +192,9 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     }
 
     [Fact]
-    public void CreatePlannedBatchEmission_CarriesCityObjectOrderOffsetToMeshAndPresentationSlots()
+    public void CreatePlannedBatchEmission_CarriesCityObjectOrderOffsetToPresentationSlot()
     {
         ResoniteObjectSlotHierarchy objectSlots = new(
-            new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Terrain Grid Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(1.0, 2.0, 3.0),
@@ -206,8 +203,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchEmission batchPlan = CreateBatchPlan(
             objectSlots,
             new PlannedTerrainGridGeometryAsset(
-                "Terrain Grid Object",
-                "Terrain Grid Object_terrain-grid",
                 new ResoniteTerrainGridGeometry(
                     Width: 2,
                     Height: 2,
@@ -225,12 +220,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
             Assert.Single(
                 batchPlan.SlotEmissions,
                 static slot => slot.SlotName == "Terrain Grid Object"
-                    && slot.ParentTarget is PlannedSlotTargetReference.CanonicalSlotTarget { Locator: { Value: "asset-lod-slot" } }).OrderOffset);
-        Assert.Equal(
-            53394525,
-            Assert.Single(
-                batchPlan.SlotEmissions,
-                static slot => slot.SlotName == "Terrain Grid Object"
                     && slot.ParentTarget is PlannedSlotTargetReference.CanonicalSlotTarget { Locator: { Value: "lod-slot" } }).OrderOffset);
     }
 
@@ -238,7 +227,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     public void CreatePlannedBatchEmission_CreatesDynamicTerrainPlanWithGridAsFalseFallback()
     {
         ResoniteObjectSlotHierarchy objectSlots = new(
-            new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Dynamic Terrain Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(1.0, 2.0, 3.0),
@@ -246,9 +234,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchEmission batchPlan = CreateBatchPlan(
             objectSlots,
             new PlannedDynamicTerrainGeometryAsset(
-                "Dynamic Terrain Object",
                 new Uri("resdb:///mesh/static"),
-                "Dynamic Terrain Object_terrain-grid",
                 new ResoniteTerrainGridGeometry(
                     Width: 4,
                     Height: 5,
@@ -323,7 +309,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     public void CreatePlannedBatchEmission_CarriesTerrainGridUvMembers()
     {
         ResoniteObjectSlotHierarchy objectSlots = new(
-            new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Terrain Grid Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(1.0, 2.0, 3.0),
@@ -331,8 +316,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchEmission batchPlan = CreateBatchPlan(
             objectSlots,
             new PlannedTerrainGridGeometryAsset(
-                "Terrain Grid Object",
-                "Terrain Grid Object_terrain-grid",
                 new ResoniteTerrainGridGeometry(
                     Width: 2,
                     Height: 3,
@@ -363,7 +346,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     public void CreatePlannedBatchEmission_UsesReusableTargetsAndPlansDedicatedMaterialComponents()
     {
         ResoniteObjectSlotHierarchy objectSlots = new(
-            new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Triangle Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(0.0, 0.0, 0.0),
@@ -378,14 +360,11 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 DepthOffset: null,
                 SubmeshIndices: [0],
                 ResoniteMaterialAssetBinding.Presentation),
-            [new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/albedo"))],
-            PreserveDedicatedMaterialSlot: true,
-            DedicatedMaterialSlotName: "material-000-pbs-uv-uv");
+            [new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Albedo, new Uri("resdb:///texture/albedo"))]);
         PlannedReusableMaterialAsset reusableMaterial = new(new ResoniteComponentLocator("existing-material-id"));
         PlannedBatchEmission batchPlan = CreateBatchPlan(
             objectSlots,
             new PlannedTriangleMeshGeometryAsset(
-                "Triangle Object",
                 new Uri("resdb:///mesh/triangle")),
             [
                 reusableMaterial,
@@ -414,13 +393,15 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.Equal(ToPlannedTargetId(dedicatedMaterialComponent), dedicatedMaterialReference.TargetID);
         Reference albedoReference = Assert.IsType<Reference>(ToMember(dedicatedMaterialComponent.Members["AlbedoTexture"]));
         Assert.Equal(ToPlannedTargetId(albedoTexture), albedoReference.TargetID);
+        PlannedBatchSlotEmission presentationSlot = AssertPlanned(meshRenderer.ContainerTarget);
+        Assert.Same(presentationSlot, AssertPlanned(dedicatedMaterialComponent.ContainerTarget));
+        Assert.Same(presentationSlot, AssertPlanned(albedoTexture.ContainerTarget));
     }
 
     [Fact]
-    public void CreatePlannedBatchEmission_UsesMeshAssetContainerWhenDedicatedMaterialSlotIsNotPreserved()
+    public void CreatePlannedBatchEmission_UsesPresentationSlotForDedicatedMaterialComponents()
     {
         ResoniteObjectSlotHierarchy objectSlots = new(
-            new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Triangle Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(0.0, 0.0, 0.0),
@@ -441,12 +422,10 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Height, new Uri("resdb:///texture/height")),
                 new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Metallic, new Uri("resdb:///texture/metallic")),
                 new PlannedTextureAsset(ResoniteSceneMaterialConventions.PlannedTextureRole.Emission, new Uri("resdb:///texture/emission")),
-            ],
-            PreserveDedicatedMaterialSlot: false);
+            ]);
         PlannedBatchEmission batchPlan = CreateBatchPlan(
             objectSlots,
             new PlannedTriangleMeshGeometryAsset(
-                "Triangle Object",
                 new Uri("resdb:///mesh/triangle")),
             [dedicatedMaterial],
             [new PlannedDirectRendererMaterialBinding(dedicatedMaterial)],
@@ -461,6 +440,8 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         SyncList rendererMaterials = Assert.IsType<SyncList>(ToMember(meshRenderer.Members["Materials"]));
         Reference materialReference = Assert.IsType<Reference>(Assert.Single(rendererMaterials.Elements));
         Assert.Equal(ToPlannedTargetId(materialComponent), materialReference.TargetID);
+        PlannedBatchSlotEmission presentationSlot = AssertPlanned(meshRenderer.ContainerTarget);
+        Assert.Same(presentationSlot, AssertPlanned(materialComponent.ContainerTarget));
 
         PlannedBatchComponentEmission[] materialTextures = batchPlan.ComponentEmissions
             .Where(component => string.Equals(component.ComponentType, "[FrooxEngine]FrooxEngine.StaticTexture2D", StringComparison.Ordinal))
@@ -475,6 +456,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
                 "resdb:///texture/emission",
             ],
             materialTextures.Select(static texture => Assert.IsType<Field_Uri>(ToMember(texture.Members["URL"])).Value.ToString()).ToArray());
+        Assert.All(materialTextures, texture => Assert.Same(presentationSlot, AssertPlanned(texture.ContainerTarget)));
 
         IReadOnlyDictionary<string, PlannedBatchComponentEmission> texturesByUri = materialTextures.ToDictionary(
             static texture => Assert.IsType<PlannedLiteralMember>(texture.Members["URL"]).Value is Field_Uri uri
@@ -507,7 +489,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     public void CreatePlannedBatchEmission_UsesMainTexturePropertyBlockForRendererOverride()
     {
         ResoniteObjectSlotHierarchy objectSlots = new(
-            new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Triangle Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(0.0, 0.0, 0.0),
@@ -516,7 +497,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchEmission batchPlan = CreateBatchPlan(
             objectSlots,
             new PlannedTriangleMeshGeometryAsset(
-                "Triangle Object",
                 new Uri("resdb:///mesh/triangle")),
             [reusableMaterial],
             [
@@ -543,6 +523,7 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         Assert.Equal("shared-material-id", materialReference.TargetID);
         Assert.Equal(ToPlannedTargetId(propertyBlockComponent), propertyBlockReference.TargetID);
         Assert.Equal(AssertPlanned(meshRenderer.ContainerTarget), AssertPlanned(propertyBlockComponent.ContainerTarget));
+        Assert.Equal(AssertPlanned(meshRenderer.ContainerTarget), AssertPlanned(overrideTexture.ContainerTarget));
         Assert.Equal(ToPlannedTargetId(overrideTexture), Assert.IsType<Reference>(ToMember(propertyBlockComponent.Members["Texture"])).TargetID);
         Assert.DoesNotContain("WrapModeU", overrideTexture.Members.Keys);
         Assert.DoesNotContain("WrapModeV", overrideTexture.Members.Keys);
@@ -553,7 +534,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     public void CreatePlannedBatchEmission_ClampsTerrainMainTextureOverride()
     {
         ResoniteObjectSlotHierarchy objectSlots = new(
-            new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Triangle Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(0.0, 0.0, 0.0),
@@ -562,7 +542,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchEmission batchPlan = CreateBatchPlan(
             objectSlots,
             new PlannedTriangleMeshGeometryAsset(
-                "Triangle Object",
                 new Uri("resdb:///mesh/triangle")),
             [reusableMaterial],
             [
@@ -585,7 +564,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     public void CreatePlannedBatchEmission_UsesSharedTerrainPropertyBlockWhenProvided()
     {
         ResoniteObjectSlotHierarchy objectSlots = new(
-            new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Triangle Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(0.0, 0.0, 0.0),
@@ -594,7 +572,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchEmission batchPlan = CreateBatchPlan(
             objectSlots,
             new PlannedTriangleMeshGeometryAsset(
-                "Triangle Object",
                 new Uri("resdb:///mesh/triangle")),
             [reusableMaterial],
             [
@@ -625,7 +602,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
     public void CreatePlannedBatchEmission_UsesDistinctOverrideComponentIdsForSharedMaterialOverrides()
     {
         ResoniteObjectSlotHierarchy objectSlots = new(
-            new CreatedSlot(new ResoniteSlotLocator("asset-lod-slot"), "Asset LOD"),
             new CreatedSlot(new ResoniteSlotLocator("lod-slot"), "LOD"),
             "Triangle Object",
             new PlateauResoniteLink.Targets.Resonite.ResoniteFloat3(0.0, 0.0, 0.0),
@@ -634,7 +610,6 @@ public sealed class ResoniteSceneBatchEmissionPlanningTests
         PlannedBatchEmission batchPlan = CreateBatchPlan(
             objectSlots,
             new PlannedTriangleMeshGeometryAsset(
-                "Triangle Object",
                 new Uri("resdb:///mesh/triangle")),
             [reusableMaterial],
             [

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneMaterialConventionsTests.cs
@@ -121,49 +121,6 @@ public sealed class ResoniteSceneMaterialConventionsTests
     }
 
     [Fact]
-    public void CreateDedicatedMaterialSlotName_ForDedicatedMaterial_UsesZeroBasedMaterialIndexPresentationName()
-    {
-        ResoniteMaterialBinding material = new(
-            BaseColor: new ResoniteColor(0.1, 0.2, 0.3, 1.0),
-            MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: new RawRgba32ResoniteTexturePayload(1, 1, "srgb", [255, 255, 255, 255], "textures/payload-a.png"),
-            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-            Projection: ResoniteMaterialProjection.Uv,
-            DepthOffset: new ResoniteMaterialDepthOffset(2.0, 3.0),
-            SubmeshIndices: [0],
-            AssetBinding: ResoniteMaterialAssetBinding.Presentation,
-            TextureScale: new ResoniteFloat2(0.5, 0.25),
-            TextureOffset: new ResoniteFloat2(0.125, 0.75),
-            Family: BundledDefaultMaterialFamilies.FacadeHighriseGlass,
-            BundledVariantIndex: 0);
-
-        string slotName = ResoniteSceneMaterialConventions.CreateDedicatedMaterialSlotName(material, materialIndex: 0);
-
-        Assert.Equal("material-000-pbs-uv-uv", slotName);
-        Assert.DoesNotContain("payload", slotName, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("textures", slotName, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("2x3", slotName, StringComparison.Ordinal);
-        Assert.DoesNotContain("0.5", slotName, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void CreateDedicatedMaterialSlotName_ForDedicatedMaterial_RejectsNegativeMaterialIndex()
-    {
-        ResoniteMaterialBinding material = new(
-            BaseColor: new ResoniteColor(1.0, 1.0, 1.0, 1.0),
-            MaterialType: ResoniteMaterialType.Standard,
-            TexturePayload: null,
-            TextureSourceKind: ResoniteTextureSourceKind.Dataset,
-            Projection: ResoniteMaterialProjection.Uv,
-            DepthOffset: null,
-            SubmeshIndices: [0],
-            AssetBinding: ResoniteMaterialAssetBinding.Presentation);
-
-        Assert.Throws<ArgumentOutOfRangeException>(
-            () => ResoniteSceneMaterialConventions.CreateDedicatedMaterialSlotName(material, materialIndex: -1));
-    }
-
-    [Fact]
     public void CreateMaterialSlotName_ForGenericSharedMaterial_UsesOnlyRenderingDiscriminators()
     {
         ResoniteMaterialBinding material = new(


### PR DESCRIPTION
## Summary
- Scope Dataset Root `Assets` to shared Terrain Overlay texture assets only.
- Attach regular mesh, height texture, dedicated material, override texture, renderer, and collider components directly to the city object presentation slot.
- Keep `PLATEAU Shared Assets/Common Materials` as the separate common material sharing contract.

## Validation
- Generated current canonical scene dump from `tests/Fixtures/LocalPlateauDatasetParentMeshPackages` with `--terrain-mesh grid` at `D:/Temp/codex/plateau-dump/scene.json`.
- Generated baseline dump from a clean `HEAD` worktree at `D:/Temp/codex/plateau-dump-baseline/scene.json`.
- Confirmed `imports`, `objects`, and `emittedTerrainGrids` are unchanged.
- Confirmed `PLATEAU Shared Assets/Common Materials` and `PLATEAU {dataset}/Assets/Terrain Textures/{thirdMeshCode}` subtrees are unchanged.
- Confirmed DEM grid and building moved asset components are identical after normalizing only the expected slot-path/reference relocation.
- Confirmed current Dataset Assets contains no non-terrain source-file mirrored asset slots.

## Checks
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false` (`1087/1087 passed`)