### PR TITLE
[codex] Extract CityGML parsed object reader context

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectReader.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -10,8 +8,6 @@ namespace PlateauResoniteLink.Application.Importing;
 
 internal static class CityGmlParsedCityObjectReader
 {
-    private static readonly XNamespace Gml = "http://www.opengis.net/gml";
-
     internal static ParsedCityObject? Parse(
         XElement cityObjectElement,
         string packageName,
@@ -24,47 +20,25 @@ internal static class CityGmlParsedCityObjectReader
         IReadOnlyList<MeshCodeBounds> requestedMeshCodeBounds,
         LodFilteringStrategy lodFilteringStrategy)
     {
-        string objectTypeName = cityObjectElement.Name.LocalName;
-        string objectId = GetAttribute(cityObjectElement, Gml + "id") ?? objectTypeName;
-        string displayName = cityObjectElement.Elements(Gml + "name").FirstOrDefault()?.Value.Trim() ?? objectId;
-        if (string.IsNullOrWhiteSpace(displayName))
-        {
-            displayName = objectId;
-        }
-
-        string resolvedActualMeshCode = CityGmlMeshCodeBoundsFilter.ResolveActualMeshCode(
+        CityGmlParsedCityObjectReaderContext context = CityGmlParsedCityObjectReaderContext.Create(
+            cityObjectElement,
             packageName,
-            displayName,
-            objectId,
+            relativeSourceFile,
             actualMeshCode,
-            sharedAcrossMeshCodes);
+            sharedAcrossMeshCodes,
+            lodSelector,
+            lodFilteringStrategy);
+
         BuildingAttributeContext buildingAttributes = BuildingAttributeParser.Parse(cityObjectElement);
         int? floorsAboveGround = BuildingAttributeQueries.TryGetKnownPositiveInteger(buildingAttributes.StoreysAboveGround);
         double? measuredHeightMeters = BuildingAttributeQueries.TryGetKnownPositiveMetric(buildingAttributes.MeasuredHeightMeters);
 
-        bool isMarking = displayName.Contains("Marking", StringComparison.OrdinalIgnoreCase)
-            || objectId.Contains("Marking", StringComparison.OrdinalIgnoreCase)
-            || objectId.Contains("_road_marking", StringComparison.Ordinal);
-
-        CityGmlLodSelection lodSelection = lodSelector.SelectPreferredSurfaceElements(
-            cityObjectElement,
-            packageName,
-            isMarking,
-            lodFilteringStrategy);
-        XElement[] preferredSurfaceElements = lodSelection.SurfaceElements;
-        int? lodLevel = lodSelection.LodLevel;
-
-        if (!lodFilteringStrategy.ShouldIncludeByPattern(packageName, objectId, isMarking))
+        if (!context.ShouldInclude)
         {
             return null;
         }
 
-        if (preferredSurfaceElements.Length == 0 && lodFilteringStrategy.ShouldExcludeLod(packageName, lodLevel, isMarking))
-        {
-            return null;
-        }
-
-        ParsedSurface[] surfaces = ParseSurfaces(preferredSurfaceElements, packageName, appearanceStore);
+        ParsedSurface[] surfaces = ParseSurfaces(context.PreferredSurfaceElements, packageName, appearanceStore);
 
         if (surfaces.Length == 0)
         {
@@ -72,7 +46,7 @@ internal static class CityGmlParsedCityObjectReader
         }
 
         if (!CityGmlMeshCodeBoundsFilter.IntersectsRequestedMeshCodeBounds(
-                resolvedActualMeshCode,
+                context.ResolvedActualMeshCode,
                 sharedAcrossMeshCodes,
                 coordinateReferenceSystem,
                 requestedMeshCodeBounds,
@@ -81,17 +55,15 @@ internal static class CityGmlParsedCityObjectReader
             return null;
         }
 
-        string fileStem = Path.GetFileNameWithoutExtension(relativeSourceFile);
-        string slotKey = SanitizeIdentifier($"{packageName}_{fileStem}_{objectId}");
         return new ParsedCityObject(
-            slotKey,
-            displayName,
-            packageName,
-            resolvedActualMeshCode,
-            lodLevel,
+            context.SlotKey,
+            context.DisplayName,
+            context.PackageName,
+            context.ResolvedActualMeshCode,
+            context.LodLevel,
             surfaces,
             coordinateReferenceSystem,
-            relativeSourceFile,
+            context.RelativeSourceFile,
             SharedAcrossMeshCodes: sharedAcrossMeshCodes,
             FloorsAboveGround: floorsAboveGround,
             MeasuredHeightMeters: measuredHeightMeters,
@@ -118,16 +90,5 @@ internal static class CityGmlParsedCityObjectReader
         return surfaces
             .OrderBy(static surface => surface, ParsedSurfaceStructuralComparer.Instance)
             .ToArray();
-    }
-
-    private static string? GetAttribute(XElement element, XName attributeName)
-    {
-        return element.Attribute(attributeName)?.Value;
-    }
-
-    private static string SanitizeIdentifier(string value)
-    {
-        return string.Concat(
-            value.Select(character => char.IsLetterOrDigit(character) ? character : '_'));
     }
 }

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectReaderContext.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectReaderContext.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal sealed record CityGmlParsedCityObjectReaderContext(
+    string PackageName,
+    string RelativeSourceFile,
+    string ObjectId,
+    string DisplayName,
+    bool IsMarking,
+    string ResolvedActualMeshCode,
+    CityGmlLodSelection LodSelection,
+    bool IncludeByPattern,
+    bool ShouldExcludeByLod,
+    string SlotKey)
+{
+    private static readonly XNamespace Gml = "http://www.opengis.net/gml";
+
+    internal XElement[] PreferredSurfaceElements => LodSelection.SurfaceElements;
+
+    internal int? LodLevel => LodSelection.LodLevel;
+
+    internal bool ShouldInclude => IncludeByPattern && !ShouldExcludeByLod;
+
+    internal static CityGmlParsedCityObjectReaderContext Create(
+        XElement cityObjectElement,
+        string packageName,
+        string relativeSourceFile,
+        string actualMeshCode,
+        bool sharedAcrossMeshCodes,
+        ICityGmlLodSelector lodSelector,
+        LodFilteringStrategy lodFilteringStrategy)
+    {
+        string objectTypeName = cityObjectElement.Name.LocalName;
+        string objectId = GetAttribute(cityObjectElement, Gml + "id") ?? objectTypeName;
+        string displayName = cityObjectElement.Elements(Gml + "name").FirstOrDefault()?.Value.Trim() ?? objectId;
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = objectId;
+        }
+
+        bool isMarking = displayName.Contains("Marking", StringComparison.OrdinalIgnoreCase)
+            || objectId.Contains("Marking", StringComparison.OrdinalIgnoreCase)
+            || objectId.Contains("_road_marking", StringComparison.Ordinal);
+
+        string resolvedActualMeshCode = CityGmlMeshCodeBoundsFilter.ResolveActualMeshCode(
+            packageName,
+            displayName,
+            objectId,
+            actualMeshCode,
+            sharedAcrossMeshCodes);
+
+        CityGmlLodSelection lodSelection = lodSelector.SelectPreferredSurfaceElements(
+            cityObjectElement,
+            packageName,
+            isMarking,
+            lodFilteringStrategy);
+
+        bool includeByPattern = lodFilteringStrategy.ShouldIncludeByPattern(packageName, objectId, isMarking);
+        bool shouldExcludeByLod = lodSelection.SurfaceElements.Length == 0
+            && lodFilteringStrategy.ShouldExcludeLod(packageName, lodSelection.LodLevel, isMarking);
+
+        string fileStem = Path.GetFileNameWithoutExtension(relativeSourceFile);
+        string slotKey = SanitizeIdentifier($"{packageName}_{fileStem}_{objectId}");
+
+        return new CityGmlParsedCityObjectReaderContext(
+            packageName,
+            relativeSourceFile,
+            objectId,
+            displayName,
+            isMarking,
+            resolvedActualMeshCode,
+            lodSelection,
+            includeByPattern,
+            shouldExcludeByLod,
+            slotKey);
+    }
+
+    private static string? GetAttribute(XElement element, XName attributeName)
+    {
+        return element.Attribute(attributeName)?.Value;
+    }
+
+    private static string SanitizeIdentifier(string value)
+    {
+        return string.Concat(
+            value.Select(character => char.IsLetterOrDigit(character) ? character : '_'));
+    }
+}


### PR DESCRIPTION
## Summary
- extract the CityGML parsed-object reader context into a focused internal helper
- keep `ParsedCityObject` / `ParsedSurface` contracts and downstream projection behavior unchanged
- preserve existing parse ordering for building attributes, include filtering, surface parsing, and mesh-bounds checks

## Value / Risk
This is a boundary-only refactor. The added helper gives a named home to source identity, LOD selection, include/exclude, mesh-code resolution, and slot-key construction. That removes mixed XML/PLATEAU/source identity setup from `CityGmlParsedCityObjectReader.Parse` without introducing new runtime behavior.

No new tests were added because the value is structural and existing parser/projection/live-send tests already exercise the observable contract.

## Validation
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
