### PR TITLE
[codex] Extract Resonite material plan helpers

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteRendererMaterialBindingPlanner.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteRendererMaterialBindingPlanner.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+using PlateauResoniteLink.Domain.Importing;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal static class ResoniteRendererMaterialBindingPlanner
+{
+    internal static PlannedMainTextureOverrideRendererMaterialBinding CreateMainTextureOverrideRendererBinding(
+        PlannedMaterialAsset materialAsset,
+        LocalRendererOverrideTextureProvider mainTexture,
+        IReadOnlyDictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode,
+        ResoniteMaterialBinding sourceMaterial)
+    {
+        ArgumentNullException.ThrowIfNull(materialAsset);
+        ArgumentNullException.ThrowIfNull(mainTexture);
+        ArgumentNullException.ThrowIfNull(terrainTexturePropertyBlockComponentsByMeshCode);
+        ArgumentNullException.ThrowIfNull(sourceMaterial);
+
+        if (sourceMaterial.TerrainOverlay is null)
+        {
+            return new PlannedAlbedoMainTextureOverrideRendererMaterialBinding(materialAsset, mainTexture);
+        }
+
+        ResoniteComponentLocator? sharedMainTexturePropertyBlockComponent =
+            sourceMaterial.TerrainOverlayMaterial is not null
+            && terrainTexturePropertyBlockComponentsByMeshCode.TryGetValue(sourceMaterial.TerrainOverlayMaterial.MeshCode, out ResoniteComponentLocator propertyBlockComponent)
+                ? propertyBlockComponent
+                : null;
+        return new PlannedTerrainMainTextureOverrideRendererMaterialBinding(
+            materialAsset,
+            new SharedTerrainOverlayTextureProvider(
+                mainTexture.AssetUri,
+                SharedMainTextureComponent: null,
+                sharedMainTexturePropertyBlockComponent));
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialEmissionNormalizer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialEmissionNormalizer.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal static class ResoniteSceneMaterialEmissionNormalizer
+{
+    internal static ResoniteMaterialBinding NormalizeTerrainTextureMaterialForEmission(
+        ResoniteConstructionCityObject cityObject,
+        ResoniteMaterialBinding material)
+    {
+        ArgumentNullException.ThrowIfNull(cityObject);
+        ArgumentNullException.ThrowIfNull(material);
+
+        return (cityObject.Geometry is ResoniteTerrainGridGeometry
+                || cityObject.Geometry is ResoniteDynamicTerrainGeometry)
+            && material.TerrainOverlay is not null
+            ? material with
+            {
+                TextureScale = null,
+                TextureOffset = null,
+            }
+            : material;
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSceneMaterialPlanComposer.cs
@@ -35,7 +35,7 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
             = new Task<(PlannedMaterialAsset MaterialAsset, PlannedRendererMaterialBinding RendererBinding)>[cityObject.Materials.Count];
         for (int materialIndex = 0; materialIndex < cityObject.Materials.Count; materialIndex++)
         {
-            ResoniteMaterialBinding material = ResolveTerrainTextureMaterialForEmission(
+            ResoniteMaterialBinding material = ResoniteSceneMaterialEmissionNormalizer.NormalizeTerrainTextureMaterialForEmission(
                 cityObject,
                 cityObject.Materials[materialIndex]);
             material = ResoniteTerrainOverlayMaterialContract.ValidateMaterial(cityObject, materialIndex, material);
@@ -98,7 +98,7 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
             preparedTerrainTextureUrisByOverlay);
         PlannedRendererMaterialBinding rendererBinding = mainTextureOverride is null
             ? new PlannedDirectRendererMaterialBinding(sharedMaterialAsset)
-            : CreateMainTextureOverrideRendererBinding(
+            : ResoniteRendererMaterialBindingPlanner.CreateMainTextureOverrideRendererBinding(
                 sharedMaterialAsset,
                 mainTextureOverride,
                 terrainTexturePropertyBlockComponentsByMeshCode,
@@ -138,7 +138,7 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
             {
                 return (
                     plannedMaterial,
-                    CreateMainTextureOverrideRendererBinding(
+                    ResoniteRendererMaterialBindingPlanner.CreateMainTextureOverrideRendererBinding(
                         plannedMaterial,
                         mainTextureOverride,
                         preparedTerrainTexturePropertyBlockComponentsByMeshCode,
@@ -148,44 +148,4 @@ internal sealed class ResoniteSceneMaterialPlanComposer(IResoniteMaterialPlannin
 
         return (plannedMaterial, new PlannedDirectRendererMaterialBinding(plannedMaterial));
     }
-
-    private static ResoniteMaterialBinding ResolveTerrainTextureMaterialForEmission(
-        ResoniteConstructionCityObject cityObject,
-        ResoniteMaterialBinding material)
-    {
-        return (cityObject.Geometry is ResoniteTerrainGridGeometry
-                || cityObject.Geometry is ResoniteDynamicTerrainGeometry)
-            && material.TerrainOverlay is not null
-            ? material with
-            {
-                TextureScale = null,
-                TextureOffset = null,
-            }
-            : material;
-    }
-
-    private static PlannedMainTextureOverrideRendererMaterialBinding CreateMainTextureOverrideRendererBinding(
-        PlannedMaterialAsset materialAsset,
-        LocalRendererOverrideTextureProvider mainTexture,
-        IReadOnlyDictionary<ThirdRegionalMeshCode, ResoniteComponentLocator> terrainTexturePropertyBlockComponentsByMeshCode,
-        ResoniteMaterialBinding sourceMaterial)
-    {
-        if (sourceMaterial.TerrainOverlay is null)
-        {
-            return new PlannedAlbedoMainTextureOverrideRendererMaterialBinding(materialAsset, mainTexture);
-        }
-
-        ResoniteComponentLocator? sharedMainTexturePropertyBlockComponent =
-            sourceMaterial.TerrainOverlayMaterial is not null
-            && terrainTexturePropertyBlockComponentsByMeshCode.TryGetValue(sourceMaterial.TerrainOverlayMaterial.MeshCode, out ResoniteComponentLocator propertyBlockComponent)
-                ? propertyBlockComponent
-                : null;
-        return new PlannedTerrainMainTextureOverrideRendererMaterialBinding(
-            materialAsset,
-            new SharedTerrainOverlayTextureProvider(
-                mainTexture.AssetUri,
-                SharedMainTextureComponent: null,
-                sharedMainTexturePropertyBlockComponent));
-    }
-
 }


### PR DESCRIPTION
## Summary
- extract terrain material emission normalization from `ResoniteSceneMaterialPlanComposer`
- extract renderer main-texture override binding selection into a focused planner helper
- keep `PlannedSceneMaterialPlan`, terrain overlay validation, material planning, and batch emission output shape unchanged

## Value / Risk
This is a boundary-only refactor. It removes target-emission details from the composer while keeping the existing Resonite material binding model intact. The code growth is limited to two small internal helpers; no new public surface or behavior branch is introduced.

No new tests were added because helper-level tests would mostly freeze implementation shape. Existing material planning, batch emission, and live-send tests cover the observable behavior this refactor must preserve.

## Validation
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
