### PR TITLE
[codex] Extract Resonite material contract mapper

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteMaterialContractMapper.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using PlateauResoniteLink.Application.Importing;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal static class ResoniteMaterialContractMapper
+{
+    internal static ResoniteMaterialBinding[] ToInternal(IReadOnlyList<MaterialBinding> bindings)
+    {
+        ArgumentNullException.ThrowIfNull(bindings);
+        return bindings.Select(ToInternal).ToArray();
+    }
+
+    internal static ResoniteMaterialBinding ToInternal(MaterialBinding binding)
+    {
+        return new ResoniteMaterialBinding(
+            BaseColor: ToInternal(binding.BaseColor),
+            MaterialType: ToInternal(binding.MaterialType),
+            TexturePayload: binding.TexturePayload is null ? null : ToInternal(binding.TexturePayload),
+            TextureSourceKind: ToInternal(binding.TextureSourceKind),
+            Projection: ToInternal(binding.Projection),
+            DepthOffset: binding.DepthOffset is null ? null : ToInternal(binding.DepthOffset),
+            SubmeshIndices: binding.SubmeshIndices,
+            AssetBinding: ToInternalAssetBinding(binding),
+            TextureScale: binding.TextureScale is null ? null : ToInternal(binding.TextureScale),
+            Family: binding.Family,
+            TextureOffset: binding.TextureOffset is null ? null : ToInternal(binding.TextureOffset),
+            TerrainOverlayMaterial: binding.TerrainOverlayMaterial,
+            BundledVariantIndex: binding.BundledVariantIndex);
+    }
+
+    private static ResoniteMaterialAssetBinding ToInternalAssetBinding(MaterialBinding binding)
+    {
+        return binding switch
+        {
+            SharedCommonMaterialBinding { CommonMaterial: { } commonMaterial } =>
+                ResoniteMaterialAssetBinding.SharedCommon(commonMaterial),
+            PresentationCommonMaterialBinding { CommonMaterial: { } commonMaterial } =>
+                ResoniteMaterialAssetBinding.PresentationCommon(commonMaterial),
+            _ when binding.ReuseScope == MaterialReuseScope.Shared
+                && binding.CommonMaterial is { } commonMaterial
+                && (binding.TerrainOverlayMaterial is null || binding.CommonMaterial is not null) =>
+                ResoniteMaterialAssetBinding.SharedCommon(commonMaterial),
+            _ when binding.ReuseScope == MaterialReuseScope.Shared
+                && binding.TerrainOverlayMaterial is null =>
+                ResoniteMaterialAssetBinding.Shared,
+            _ => binding.CommonMaterial is { } commonMaterial
+                ? ResoniteMaterialAssetBinding.PresentationCommon(commonMaterial)
+                : ResoniteMaterialAssetBinding.Presentation,
+        };
+    }
+
+    private static ResoniteTexturePayload ToInternal(TexturePayload payload)
+    {
+        return payload switch
+        {
+            RawRgba32TexturePayload raw => new RawRgba32ResoniteTexturePayload(
+                raw.Width,
+                raw.Height,
+                raw.ColorProfile,
+                raw.BinaryPayload.AsSpan().ToArray(),
+                raw.Source.Description),
+            EncodedImageTexturePayload encoded => new EncodedImageResoniteTexturePayload(
+                encoded.Width,
+                encoded.Height,
+                encoded.ColorProfile,
+                encoded.Source),
+            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.GetType(), "Unsupported texture payload type."),
+        };
+    }
+
+    private static ResoniteMaterialType ToInternal(MaterialType materialType)
+    {
+        return materialType switch
+        {
+            MaterialType.Standard => ResoniteMaterialType.Standard,
+            MaterialType.Wireframe => ResoniteMaterialType.Wireframe,
+            MaterialType.VertexColor => ResoniteMaterialType.VertexColor,
+            _ => throw new ArgumentOutOfRangeException(nameof(materialType), materialType, "Unsupported material type."),
+        };
+    }
+
+    private static ResoniteTextureSourceKind ToInternal(TextureSourceKind sourceKind)
+    {
+        return sourceKind switch
+        {
+            TextureSourceKind.Dataset => ResoniteTextureSourceKind.Dataset,
+            TextureSourceKind.Bundled => ResoniteTextureSourceKind.Bundled,
+            _ => throw new ArgumentOutOfRangeException(nameof(sourceKind), sourceKind, "Unsupported texture source kind."),
+        };
+    }
+
+    private static ResoniteMaterialProjection ToInternal(MaterialProjection projection)
+    {
+        return projection switch
+        {
+            MaterialProjection.Uv => ResoniteMaterialProjection.Uv,
+            MaterialProjection.Triplanar => ResoniteMaterialProjection.Triplanar,
+            _ => throw new ArgumentOutOfRangeException(nameof(projection), projection, "Unsupported material projection."),
+        };
+    }
+
+    private static ResoniteColor ToInternal(ColorRgba value) => new(value.R, value.G, value.B, value.A);
+
+    private static ResoniteFloat2 ToInternal(Float2 value) => new(value.X, value.Y);
+
+    private static ResoniteMaterialDepthOffset ToInternal(MaterialDepthOffset value) => new(value.Factor, value.Units);
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SceneImportContractMapper.cs
@@ -10,8 +10,7 @@ internal static class SceneImportContractMapper
 {
     internal static ResoniteMaterialBinding[] ToInternal(IReadOnlyList<MaterialBinding> bindings)
     {
-        ArgumentNullException.ThrowIfNull(bindings);
-        return bindings.Select(ToInternal).ToArray();
+        return ResoniteMaterialContractMapper.ToInternal(bindings);
     }
 
     internal static ResoniteConstructionCityObject ToInternal(ImportedCityObject cityObject)
@@ -26,7 +25,7 @@ internal static class SceneImportContractMapper
                 cityObject.LodLevel,
                 ToInternal(cityObject.Transform),
                 ToInternal(triangleMesh.Mesh),
-                cityObject.Materials.Select(ToInternal).ToArray(),
+                ResoniteMaterialContractMapper.ToInternal(cityObject.Materials),
                 cityObject.CollisionEnabled,
                 cityObject.SourceFileRelativePath,
                 cityObject.SourceFileRootMeshCode,
@@ -48,7 +47,7 @@ internal static class SceneImportContractMapper
                     heightMap.HeightSamples,
                     heightMap.UvScale is null ? null : ToInternal(heightMap.UvScale),
                     heightMap.UvOffset is null ? null : ToInternal(heightMap.UvOffset)),
-                cityObject.Materials.Select(ToInternal).ToArray(),
+                ResoniteMaterialContractMapper.ToInternal(cityObject.Materials),
                 cityObject.CollisionEnabled,
                 cityObject.SourceFileRelativePath,
                 cityObject.SourceFileRootMeshCode,
@@ -72,7 +71,7 @@ internal static class SceneImportContractMapper
                         dynamicTerrain.GridMesh.HeightSamples,
                         dynamicTerrain.GridMesh.UvScale is null ? null : ToInternal(dynamicTerrain.GridMesh.UvScale),
                         dynamicTerrain.GridMesh.UvOffset is null ? null : ToInternal(dynamicTerrain.GridMesh.UvOffset))),
-                cityObject.Materials.Select(ToInternal).ToArray(),
+                ResoniteMaterialContractMapper.ToInternal(cityObject.Materials),
                 cityObject.CollisionEnabled,
                 cityObject.SourceFileRelativePath,
                 cityObject.SourceFileRootMeshCode,
@@ -120,92 +119,6 @@ internal static class SceneImportContractMapper
 
     internal static ResoniteMaterialBinding ToInternal(MaterialBinding binding)
     {
-        return new ResoniteMaterialBinding(
-            BaseColor: ToInternal(binding.BaseColor),
-            MaterialType: ToInternal(binding.MaterialType),
-            TexturePayload: binding.TexturePayload is null ? null : ToInternal(binding.TexturePayload),
-            TextureSourceKind: ToInternal(binding.TextureSourceKind),
-            Projection: ToInternal(binding.Projection),
-            DepthOffset: binding.DepthOffset is null ? null : ToInternal(binding.DepthOffset),
-            SubmeshIndices: binding.SubmeshIndices,
-            AssetBinding: ToInternalAssetBinding(binding),
-            TextureScale: binding.TextureScale is null ? null : ToInternal(binding.TextureScale),
-            Family: binding.Family,
-            TextureOffset: binding.TextureOffset is null ? null : ToInternal(binding.TextureOffset),
-            TerrainOverlayMaterial: binding.TerrainOverlayMaterial,
-            BundledVariantIndex: binding.BundledVariantIndex);
+        return ResoniteMaterialContractMapper.ToInternal(binding);
     }
-
-    private static ResoniteMaterialAssetBinding ToInternalAssetBinding(MaterialBinding binding)
-    {
-        return binding switch
-        {
-            SharedCommonMaterialBinding { CommonMaterial: { } commonMaterial } =>
-                ResoniteMaterialAssetBinding.SharedCommon(commonMaterial),
-            PresentationCommonMaterialBinding { CommonMaterial: { } commonMaterial } =>
-                ResoniteMaterialAssetBinding.PresentationCommon(commonMaterial),
-            _ when binding.ReuseScope == MaterialReuseScope.Shared
-                && binding.CommonMaterial is { } commonMaterial
-                && (binding.TerrainOverlayMaterial is null || binding.CommonMaterial is not null) =>
-                ResoniteMaterialAssetBinding.SharedCommon(commonMaterial),
-            _ when binding.ReuseScope == MaterialReuseScope.Shared
-                && binding.TerrainOverlayMaterial is null =>
-                ResoniteMaterialAssetBinding.Shared,
-            _ => binding.CommonMaterial is { } commonMaterial
-                ? ResoniteMaterialAssetBinding.PresentationCommon(commonMaterial)
-                : ResoniteMaterialAssetBinding.Presentation,
-        };
-    }
-
-    private static ResoniteTexturePayload ToInternal(TexturePayload payload)
-    {
-        return payload switch
-        {
-            RawRgba32TexturePayload raw => new RawRgba32ResoniteTexturePayload(
-                raw.Width,
-                raw.Height,
-                raw.ColorProfile,
-                raw.BinaryPayload.AsSpan().ToArray(),
-                raw.Source.Description),
-            EncodedImageTexturePayload encoded => new EncodedImageResoniteTexturePayload(
-                encoded.Width,
-                encoded.Height,
-                encoded.ColorProfile,
-                encoded.Source),
-            _ => throw new ArgumentOutOfRangeException(nameof(payload), payload.GetType(), "Unsupported texture payload type."),
-        };
-    }
-
-    private static ResoniteMaterialType ToInternal(MaterialType materialType)
-    {
-        return materialType switch
-        {
-            MaterialType.Standard => ResoniteMaterialType.Standard,
-            MaterialType.Wireframe => ResoniteMaterialType.Wireframe,
-            MaterialType.VertexColor => ResoniteMaterialType.VertexColor,
-            _ => throw new ArgumentOutOfRangeException(nameof(materialType), materialType, "Unsupported material type."),
-        };
-    }
-
-    private static ResoniteTextureSourceKind ToInternal(TextureSourceKind sourceKind)
-    {
-        return sourceKind switch
-        {
-            TextureSourceKind.Dataset => ResoniteTextureSourceKind.Dataset,
-            TextureSourceKind.Bundled => ResoniteTextureSourceKind.Bundled,
-            _ => throw new ArgumentOutOfRangeException(nameof(sourceKind), sourceKind, "Unsupported texture source kind."),
-        };
-    }
-
-    private static ResoniteMaterialProjection ToInternal(MaterialProjection projection)
-    {
-        return projection switch
-        {
-            MaterialProjection.Uv => ResoniteMaterialProjection.Uv,
-            MaterialProjection.Triplanar => ResoniteMaterialProjection.Triplanar,
-            _ => throw new ArgumentOutOfRangeException(nameof(projection), projection, "Unsupported material projection."),
-        };
-    }
-
-    private static ResoniteMaterialDepthOffset ToInternal(MaterialDepthOffset value) => new(value.Factor, value.Units);
 }


### PR DESCRIPTION
## Summary
- Extract Resonite material contract mapping from `SceneImportContractMapper` into an internal `ResoniteMaterialContractMapper`.
- Keep `SceneImportContractMapper` focused on city object, geometry, and transform bridging.
- Preserve the existing `SceneImportContractMapper.ToInternal(MaterialBinding)` shim so existing contract tests continue to exercise the same boundary.

## Behavior
- No intended behavior change.
- `MaterialBinding -> ResoniteMaterialBinding`, common/shared material asset binding, and texture payload conversion logic were moved without changing the public/internal contract shapes.
- Terrain overlay material validation and emission policy remain outside the new mapper.
- No new tests were added because this should not lock the helper shape.

## Validation
- Focused material/import tests passed: `SceneImportContractMapperTests`, `ResoniteMaterialPlanningTests`, `ResoniteSceneBatchEmissionPlanningTests`, `ResoniteLiveSceneImportTargetTests`, `ImportedDynamicMaterialUvNormalizerTests`.
- Full repository gate passed serially:
  - `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
  - `dotnet format whitespace . --folder --verify-no-changes`
  - `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
  - `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
