### PR TITLE
[codex] Extract CityGML surface source mapper

### DIFF
--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedCityObjectReader.cs
@@ -79,12 +79,12 @@ internal static class CityGmlParsedCityObjectReader
         List<ParsedSurface> surfaces = [];
         foreach (XElement surfaceElement in surfaceElements)
         {
-            if (CityGmlParsedSurfaceReader.TryParse(surfaceElement, appearanceStore) is not { } surface)
+            if (CityGmlParsedSurfaceReader.TryRead(surfaceElement, appearanceStore) is not { } sourceSurface)
             {
                 continue;
             }
 
-            surfaces.Add(CityGmlParsedSurfaceReader.ApplyPackageDefaults(packageName, surface));
+            surfaces.Add(CityGmlParsedSurfaceSourceModelMapper.ToParsedSurface(packageName, sourceSurface));
         }
 
         return surfaces

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedSurfaceReader.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedSurfaceReader.cs
@@ -8,7 +8,7 @@ internal static class CityGmlParsedSurfaceReader
 {
     private static readonly XNamespace Gml = "http://www.opengis.net/gml";
 
-    internal static ParsedSurface? TryParse(XElement polygonElement, ICityGmlAppearanceStore appearanceStore)
+    internal static CityGmlParsedSurfaceSource? TryRead(XElement polygonElement, ICityGmlAppearanceStore appearanceStore)
     {
         ArgumentNullException.ThrowIfNull(polygonElement);
         ArgumentNullException.ThrowIfNull(appearanceStore);
@@ -38,20 +38,11 @@ internal static class CityGmlParsedSurfaceReader
 
         ParsedRing[] interiorRings = ParseInteriorRings(polygonElement, polygonId, appearanceStore);
 
-        return new ParsedSurface(
+        return new CityGmlParsedSurfaceSource(
             Semantic: ParseSurfaceSemantic(polygonElement),
             ExteriorRing: exteriorParsedRing,
             InteriorRings: interiorRings,
-            BaseColor: ToInternalColor(appearance.BaseColor),
-            TexturePayload: appearance.TexturePayload,
-            OpticalProperties: CreateMaterialOpticalProperties(appearance.MaterialAttributes));
-    }
-
-    internal static ParsedSurface ApplyPackageDefaults(string packageName, ParsedSurface surface)
-    {
-        ArgumentNullException.ThrowIfNull(surface);
-
-        return surface;
+            Appearance: appearance);
     }
 
     private static ParsedRing[] ParseInteriorRings(
@@ -156,22 +147,6 @@ internal static class CityGmlParsedSurfaceReader
         return ParsedSurfaceSemantic.Unknown;
     }
 
-    private static MaterialOpticalProperties? CreateMaterialOpticalProperties(CityGmlMaterialAttributes? attributes)
-    {
-        if (attributes is null)
-        {
-            return null;
-        }
-
-        return new MaterialOpticalProperties(
-            DiffuseColor: ToInternalColor(attributes.DiffuseColor),
-            EmissiveColor: attributes.EmissiveColor is null ? null : ToInternalColor(attributes.EmissiveColor),
-            SpecularColor: attributes.SpecularColor is null ? null : ToInternalColor(attributes.SpecularColor),
-            AmbientIntensity: attributes.AmbientIntensity,
-            Shininess: attributes.Shininess,
-            Transparency: attributes.Transparency);
-    }
-
     private static string? GetAttribute(XElement element, XName attributeName)
     {
         return element.Attribute(attributeName)?.Value;
@@ -183,6 +158,4 @@ internal static class CityGmlParsedSurfaceReader
             && Math.Abs(left.Longitude - right.Longitude) < 1e-8
             && Math.Abs(left.Altitude - right.Altitude) < 1e-8;
     }
-
-    private static ColorRgba ToInternalColor(ColorRgba value) => new(value.R, value.G, value.B, value.A);
 }

--- a/src/PlateauResoniteLink/Application/Importing/CityGmlParsedSurfaceSourceModelMapper.cs
+++ b/src/PlateauResoniteLink/Application/Importing/CityGmlParsedSurfaceSourceModelMapper.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace PlateauResoniteLink.Application.Importing;
+
+internal sealed record CityGmlParsedSurfaceSource(
+    ParsedSurfaceSemantic Semantic,
+    ParsedRing ExteriorRing,
+    ParsedRing[] InteriorRings,
+    CityGmlResolvedAppearance Appearance);
+
+internal static class CityGmlParsedSurfaceSourceModelMapper
+{
+    internal static ParsedSurface ToParsedSurface(
+        string packageName,
+        CityGmlParsedSurfaceSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        ParsedSurface surface = new(
+            Semantic: source.Semantic,
+            ExteriorRing: source.ExteriorRing,
+            InteriorRings: source.InteriorRings,
+            BaseColor: ToInternalColor(source.Appearance.BaseColor),
+            TexturePayload: source.Appearance.TexturePayload,
+            OpticalProperties: CreateMaterialOpticalProperties(source.Appearance.MaterialAttributes));
+
+        return ApplyPackageDefaults(packageName, surface);
+    }
+
+    private static ParsedSurface ApplyPackageDefaults(string packageName, ParsedSurface surface)
+    {
+        _ = packageName;
+        return surface;
+    }
+
+    private static MaterialOpticalProperties? CreateMaterialOpticalProperties(CityGmlMaterialAttributes? attributes)
+    {
+        if (attributes is null)
+        {
+            return null;
+        }
+
+        return new MaterialOpticalProperties(
+            DiffuseColor: ToInternalColor(attributes.DiffuseColor),
+            EmissiveColor: attributes.EmissiveColor is null ? null : ToInternalColor(attributes.EmissiveColor),
+            SpecularColor: attributes.SpecularColor is null ? null : ToInternalColor(attributes.SpecularColor),
+            AmbientIntensity: attributes.AmbientIntensity,
+            Shininess: attributes.Shininess,
+            Transparency: attributes.Transparency);
+    }
+
+    private static ColorRgba ToInternalColor(ColorRgba value) => new(value.R, value.G, value.B, value.A);
+}


### PR DESCRIPTION
## Summary
- Add a small CityGML surface source seam before Project Source IR assembly.
- Keep `ParsedSurface` and `ParsedCityObject` names and shapes unchanged.
- Move CityGML appearance/material conversion into `CityGmlParsedSurfaceSourceModelMapper` so the XML reader no longer directly constructs the final surface material shape.

## Behavior
- No intended behavior change.
- This is intentionally not a complete source-layer redesign; it only creates the first useful seam for surface appearance conversion and future package-default handling.
- No new tests were added because this should not lock the helper shape.

## Validation
- Focused entry-side tests passed: `LocalCityGmlDocumentReaderTests`, `DefaultImportedSceneSourceFactoryTests`, `LocalCityGmlObjectProjectionTests`, `CityGmlSurfaceMaterialResolverTests`, `ImportedSceneSourceDatasetTests`.
- Full repository gate passed serially:
  - `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
  - `dotnet format whitespace . --folder --verify-no-changes`
  - `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
  - `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`
