### PR TITLE
[codex] Introduce observed source root model

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/ObservedDatasetSourceRootSelector.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ObservedDatasetSourceRootSelector.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using ResoniteLink;
+
+namespace PlateauResoniteLink.Targets.Resonite;
+
+internal static class ObservedDatasetSourceRootSelector
+{
+    internal static Slot[] Select(
+        string datasetRootSlotId,
+        IEnumerable<Slot> observedSlots,
+        IEnumerable<string> createdSlotIds)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(datasetRootSlotId);
+        ArgumentNullException.ThrowIfNull(observedSlots);
+        ArgumentNullException.ThrowIfNull(createdSlotIds);
+
+        HashSet<string> createdSlotIdSet = new(createdSlotIds, StringComparer.Ordinal);
+        return observedSlots
+            .Where(slot => string.Equals(slot.Parent?.TargetID, datasetRootSlotId, StringComparison.Ordinal))
+            .Where(slot => string.IsNullOrWhiteSpace(slot.ID) || !createdSlotIdSet.Contains(slot.ID!))
+            .Where(static slot => !string.Equals(slot.Name?.Value, "Assets", StringComparison.Ordinal))
+            .ToArray();
+    }
+}

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSlotSnapshotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSlotSnapshotIndex.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 
 using ResoniteLink;
 
@@ -57,7 +56,7 @@ internal sealed class ResoniteSlotSnapshotIndex(CreatedSlot datasetRootSlot)
 
     public IReadOnlyList<Slot> GetObservedDatasetSourceRoots()
     {
-        return observedDatasetSourceRoots ??= EnumerateObservedDatasetSourceRoots().ToArray();
+        return observedDatasetSourceRoots ??= SelectObservedDatasetSourceRoots();
     }
 
     private void IndexObservedSlotSnapshot(Slot slot)
@@ -84,12 +83,12 @@ internal sealed class ResoniteSlotSnapshotIndex(CreatedSlot datasetRootSlot)
         }
     }
 
-    private IEnumerable<Slot> EnumerateObservedDatasetSourceRoots()
+    private Slot[] SelectObservedDatasetSourceRoots()
     {
-        return observedSlotSnapshotsById.Values
-            .Where(slot => string.Equals(slot.Parent?.TargetID, datasetRootSlot.Locator.Value, StringComparison.Ordinal))
-            .Where(slot => string.IsNullOrWhiteSpace(slot.ID) || !createdSlotIds.ContainsKey(slot.ID!))
-            .Where(static slot => !string.Equals(slot.Name?.Value, "Assets", StringComparison.Ordinal));
+        return ObservedDatasetSourceRootSelector.Select(
+            datasetRootSlot.Locator.Value,
+            observedSlotSnapshotsById.Values,
+            createdSlotIds.Keys);
     }
 
     private static Field_float3 CreateFloat3(ResoniteFloat3 value)


### PR DESCRIPTION
## Summary
- Introduces an internal `ObservedDatasetSourceRoot` model for reusable source-file roots observed under the dataset root.
- Centralizes observed root candidate filtering and projection: `Assets` exclusion, current-run created slot exclusion, concrete mesh-code extraction, and required-position fail-fast.
- Updates placement resolution and scene anchor recovery to consume the observed source-root model instead of raw `Slot` snapshots.

## Scope
- Keeps public API, wire payloads, emitted slot/component structure, material planning, and live-send external contract unchanged.
- Does not convert `GetOrCreate` flows into a broader reconcile plan and does not touch setup/emission policy.

## Validation
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`