### PR TITLE
[codex] Introduce observed source root model

### DIFF
--- a/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneAnchorResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/Execution/ResoniteSceneAnchorResolver.cs
@@ -3,9 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using GeographicLib;
-
-using PlateauResoniteLink.Domain.Importing;
 using PlateauResoniteLink.Transport.ResoniteLink;
 
 using ResoniteLink;
@@ -47,40 +44,41 @@ internal sealed class ResoniteSceneAnchorResolver : IResoniteSceneAnchorResolver
             datasetRootSlot,
             1,
             cancellationToken);
-        Slot[] sourceFileRoots = datasetRootSnapshot.Root?.Children?
-            .Where(static child => !string.Equals(child.Name?.Value, "Assets", StringComparison.Ordinal))
-            .Where(static child => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(child.Name?.Value ?? string.Empty, out _))
-            .ToArray()
-            ?? [];
-        Slot? completionSourceFileRoot = sourceFileRoots.FirstOrDefault(
-            child => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(child.Name?.Value ?? string.Empty, out string meshCode)
-                && string.Equals(meshCode, completionMeshCode, StringComparison.Ordinal));
+        ObservedDatasetSourceRoot[] sourceFileRoots = datasetRootSnapshot.Root?.Children is null
+            ? []
+            : ObservedDatasetSourceRootSelector.SelectDirectChildren(
+                datasetRootSnapshot.Root.Children,
+                []);
+        ObservedDatasetSourceRoot? completionSourceFileRoot = sourceFileRoots.FirstOrDefault(
+            root => string.Equals(root.ConcreteMeshCode, completionMeshCode, StringComparison.Ordinal));
         if (completionSourceFileRoot is not null)
         {
+            ResoniteSlotLocator sourceRootLocator = CreateLocatorOrFallback(completionSourceFileRoot, datasetRootSlot);
             return new SceneAnchor(
-                new ResoniteSlotLocator(completionSourceFileRoot.ID ?? datasetRootSlot.Value),
+                sourceRootLocator,
                 completionMeshCode,
-                GetRequiredSourceRootPosition(completionSourceFileRoot),
-                new ResoniteSlotLocator(completionSourceFileRoot.ID ?? datasetRootSlot.Value));
+                completionSourceFileRoot.Position,
+                sourceRootLocator);
         }
 
-        (Slot Slot, string MeshCode) referenceSourceFileRoot = sourceFileRoots
-            .Select(static child => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(child.Name?.Value ?? string.Empty, out string meshCode)
-                ? (Slot: child, MeshCode: meshCode)
+        (ObservedDatasetSourceRoot Root, string MeshCode) referenceSourceFileRoot = sourceFileRoots
+            .Select(static root => root.ConcreteMeshCode is { } meshCode
+                ? (Root: root, MeshCode: meshCode)
                 : default)
-            .Where(static candidate => candidate.Slot is not null)
+            .Where(static candidate => candidate.Root is not null)
             .OrderBy(static candidate => candidate.MeshCode, StringComparer.Ordinal)
-            .ThenBy(static candidate => candidate.Slot.ID ?? string.Empty, StringComparer.Ordinal)
+            .ThenBy(static candidate => candidate.Root.SlotId, StringComparer.Ordinal)
             .FirstOrDefault();
-        if (referenceSourceFileRoot.Slot is not null)
+        if (referenceSourceFileRoot.Root is not null)
         {
+            ResoniteSlotLocator referenceRootLocator = CreateLocatorOrFallback(referenceSourceFileRoot.Root, datasetRootSlot);
             return new SceneAnchor(
-                new ResoniteSlotLocator(referenceSourceFileRoot.Slot.ID ?? datasetRootSlot.Value),
+                referenceRootLocator,
                 completionMeshCode,
-                Add(
-                    GetRequiredSourceRootPosition(referenceSourceFileRoot.Slot),
-                    ComputeMeshCodeOffset(referenceSourceFileRoot.MeshCode, completionMeshCode)),
-                new ResoniteSlotLocator(referenceSourceFileRoot.Slot.ID ?? datasetRootSlot.Value));
+                ResonitePlacementPolicy.Add(
+                    referenceSourceFileRoot.Root.Position,
+                    ResonitePlacementPolicy.ComputeMeshCodeOffset(referenceSourceFileRoot.MeshCode, completionMeshCode)),
+                referenceRootLocator);
         }
 
         return new SceneAnchor(
@@ -109,6 +107,15 @@ internal sealed class ResoniteSceneAnchorResolver : IResoniteSceneAnchorResolver
         throw new InvalidOperationException($"ResoniteLink did not surface slot '{slot.Value}' on the initial probe.");
     }
 
+    private static ResoniteSlotLocator CreateLocatorOrFallback(
+        ObservedDatasetSourceRoot sourceRoot,
+        ResoniteSlotLocator fallback)
+    {
+        return string.IsNullOrWhiteSpace(sourceRoot.SlotId)
+            ? fallback
+            : new ResoniteSlotLocator(sourceRoot.SlotId);
+    }
+
     private static ResoniteFloat3 GetSlotPositionOrDefault(Slot slot)
     {
         if (slot.Position is Field_float3 position)
@@ -117,53 +124,6 @@ internal sealed class ResoniteSceneAnchorResolver : IResoniteSceneAnchorResolver
         }
 
         return new ResoniteFloat3(0.0, 0.0, 0.0);
-    }
-
-    private static ResoniteFloat3 GetRequiredSourceRootPosition(Slot slot)
-    {
-        if (slot.Position is Field_float3 position)
-        {
-            return new ResoniteFloat3(position.Value.x, position.Value.y, position.Value.z);
-        }
-
-        throw new InvalidOperationException(
-            $"Source-file root '{slot.Name?.Value ?? slot.ID ?? "<unnamed>"}' did not expose a Position. "
-            + "Append anchor recovery requires positioned source-file roots.");
-    }
-
-    private static ResoniteFloat3 ComputeMeshCodeOffset(string referenceMeshCode, string meshCode)
-    {
-        if (!PlateauMeshCode.TryGetGeodeticCenter(referenceMeshCode, out GeodeticCoordinate referenceCenter)
-            || !PlateauMeshCode.TryGetGeodeticCenter(meshCode, out GeodeticCoordinate currentCenter))
-        {
-            return new ResoniteFloat3(0.0, 0.0, 0.0);
-        }
-
-        return ComputeOriginOffset(referenceCenter, currentCenter);
-    }
-
-    private static ResoniteFloat3 ComputeOriginOffset(
-        GeodeticCoordinate referenceCenter,
-        GeodeticCoordinate currentCenter)
-    {
-        LocalCartesian cartesian = new(
-            referenceCenter.Latitude,
-            referenceCenter.Longitude,
-            referenceCenter.Altitude,
-            Geocentric.WGS84);
-        (double x, double y, double z) eun = cartesian.Forward(
-            currentCenter.Latitude,
-            currentCenter.Longitude,
-            currentCenter.Altitude);
-        return new ResoniteFloat3(
-            X: eun.x,
-            Y: 0.0,
-            Z: eun.y);
-    }
-
-    private static ResoniteFloat3 Add(ResoniteFloat3 left, ResoniteFloat3 right)
-    {
-        return new ResoniteFloat3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
     }
 
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ObservedDatasetSourceRootSelector.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ObservedDatasetSourceRootSelector.cs
@@ -6,22 +6,85 @@ using ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
+internal sealed record ObservedDatasetSourceRoot(
+    string SlotId,
+    string SlotName,
+    ResoniteFloat3 Position,
+    string? ConcreteMeshCode);
+
 internal static class ObservedDatasetSourceRootSelector
 {
-    internal static Slot[] Select(
+    internal static ObservedDatasetSourceRoot[] Select(
         string datasetRootSlotId,
         IEnumerable<Slot> observedSlots,
-        IEnumerable<string> createdSlotIds)
+        IEnumerable<string> createdSlotIds,
+        IEnumerable<string>? expectedSourceRootSlotNames = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(datasetRootSlotId);
         ArgumentNullException.ThrowIfNull(observedSlots);
         ArgumentNullException.ThrowIfNull(createdSlotIds);
 
         HashSet<string> createdSlotIdSet = new(createdSlotIds, StringComparer.Ordinal);
+        HashSet<string> expectedSourceRootSlotNameSet = new(expectedSourceRootSlotNames ?? [], StringComparer.Ordinal);
         return observedSlots
             .Where(slot => string.Equals(slot.Parent?.TargetID, datasetRootSlotId, StringComparison.Ordinal))
-            .Where(slot => string.IsNullOrWhiteSpace(slot.ID) || !createdSlotIdSet.Contains(slot.ID!))
-            .Where(static slot => !string.Equals(slot.Name?.Value, "Assets", StringComparison.Ordinal))
+            .Where(slot => IsReusableSourceRootCandidate(slot, createdSlotIdSet, expectedSourceRootSlotNameSet))
+            .Select(CreateSourceRoot)
             .ToArray();
+    }
+
+    internal static ObservedDatasetSourceRoot[] SelectDirectChildren(
+        IEnumerable<Slot> observedDirectChildren,
+        IEnumerable<string> createdSlotIds,
+        IEnumerable<string>? expectedSourceRootSlotNames = null)
+    {
+        ArgumentNullException.ThrowIfNull(observedDirectChildren);
+        ArgumentNullException.ThrowIfNull(createdSlotIds);
+
+        HashSet<string> createdSlotIdSet = new(createdSlotIds, StringComparer.Ordinal);
+        HashSet<string> expectedSourceRootSlotNameSet = new(expectedSourceRootSlotNames ?? [], StringComparer.Ordinal);
+        return observedDirectChildren
+            .Where(slot => IsReusableSourceRootCandidate(slot, createdSlotIdSet, expectedSourceRootSlotNameSet))
+            .Select(CreateSourceRoot)
+            .ToArray();
+    }
+
+    private static bool IsReusableSourceRootCandidate(
+        Slot slot,
+        HashSet<string> createdSlotIds,
+        HashSet<string> expectedSourceRootSlotNames)
+    {
+        string? slotName = slot.Name?.Value;
+        return !string.IsNullOrWhiteSpace(slotName)
+            && !string.Equals(slotName, "Assets", StringComparison.Ordinal)
+            && (expectedSourceRootSlotNames.Contains(slotName)
+                || ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slotName, out _))
+            && (string.IsNullOrWhiteSpace(slot.ID) || !createdSlotIds.Contains(slot.ID!));
+    }
+
+    private static ObservedDatasetSourceRoot CreateSourceRoot(Slot slot)
+    {
+        string slotName = slot.Name?.Value
+            ?? throw new InvalidOperationException("Observed source-file root did not expose a Name.");
+        string? concreteMeshCode = ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slotName, out string meshCode)
+            ? meshCode
+            : null;
+        return new ObservedDatasetSourceRoot(
+            SlotId: slot.ID ?? string.Empty,
+            SlotName: slotName,
+            Position: GetRequiredSourceRootPosition(slot),
+            ConcreteMeshCode: concreteMeshCode);
+    }
+
+    private static ResoniteFloat3 GetRequiredSourceRootPosition(Slot slot)
+    {
+        if (slot.Position is Field_float3 position)
+        {
+            return new ResoniteFloat3(position.Value.x, position.Value.y, position.Value.z);
+        }
+
+        throw new InvalidOperationException(
+            $"Observed source-file root '{slot.Name?.Value ?? slot.ID ?? "<unnamed>"}' did not expose a Position. "
+            + "Append placement and anchor recovery require positioned source-file roots.");
     }
 }

--- a/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootPlacementResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ObservedSourceRootPlacementResolver.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using ResoniteLink;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal static class ObservedSourceRootPlacementResolver
@@ -14,14 +12,14 @@ internal static class ObservedSourceRootPlacementResolver
     public static ObservedSourceRootPlacement? TryResolve(
         string sourceFileSlotName,
         string rootMeshCode,
-        IReadOnlyList<Slot> directSourceRoots)
+        IReadOnlyList<ObservedDatasetSourceRoot> directSourceRoots)
     {
         ObservedSourceRootPlacement[] exactSourceRoots = directSourceRoots
-            .Where(slot => string.Equals(slot.Name?.Value, sourceFileSlotName, StringComparison.Ordinal))
-            .Select(slot => new ObservedSourceRootPlacement(
-                GetRequiredSourceRootPosition(slot),
+            .Where(root => string.Equals(root.SlotName, sourceFileSlotName, StringComparison.Ordinal))
+            .Select(root => new ObservedSourceRootPlacement(
+                root.Position,
                 ReferenceMeshCode: rootMeshCode,
-                SlotId: slot.ID ?? string.Empty))
+                SlotId: root.SlotId))
             .ToArray();
         if (exactSourceRoots.Length > 0)
         {
@@ -32,30 +30,30 @@ internal static class ObservedSourceRootPlacementResolver
         }
 
         ObservedSourceRootPlacement[] ancestorCandidates = directSourceRoots
-            .Select(static slot => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name?.Value ?? string.Empty, out string meshCode)
-                ? (Slot: slot, MeshCode: meshCode)
+            .Select(static root => root.ConcreteMeshCode is { } meshCode
+                ? (Root: root, MeshCode: meshCode)
                 : default)
-            .Where(candidate => candidate.Slot is not null
+            .Where(candidate => candidate.Root is not null
                 && rootMeshCode.StartsWith(candidate.MeshCode, StringComparison.Ordinal))
             .Select(candidate => new ObservedSourceRootPlacement(
                 ResonitePlacementPolicy.Add(
-                    GetRequiredSourceRootPosition(candidate.Slot),
+                    candidate.Root.Position,
                     ResonitePlacementPolicy.ComputeMeshCodeOffset(candidate.MeshCode, rootMeshCode)),
                 ReferenceMeshCode: candidate.MeshCode,
-                SlotId: candidate.Slot.ID ?? string.Empty))
+                SlotId: candidate.Root.SlotId))
             .OrderByDescending(static candidate => candidate.ReferenceMeshCode.Length)
             .ToArray();
         if (ancestorCandidates.Length == 0)
         {
             ObservedSourceRootPlacement[] observedMeshCodeRoots = directSourceRoots
-                .Select(static slot => ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(slot.Name?.Value ?? string.Empty, out string meshCode)
-                    ? (Slot: slot, MeshCode: meshCode)
+                .Select(static root => root.ConcreteMeshCode is { } meshCode
+                    ? (Root: root, MeshCode: meshCode)
                     : default)
-                .Where(static candidate => candidate.Slot is not null)
+                .Where(static candidate => candidate.Root is not null)
                 .Select(candidate => new ObservedSourceRootPlacement(
-                    ResolvePositionFromObservedRootOrigin(candidate.MeshCode, rootMeshCode, GetRequiredSourceRootPosition(candidate.Slot)),
+                    ResolvePositionFromObservedRootOrigin(candidate.MeshCode, rootMeshCode, candidate.Root.Position),
                     ReferenceMeshCode: candidate.MeshCode,
-                    SlotId: candidate.Slot.ID ?? string.Empty))
+                    SlotId: candidate.Root.SlotId))
                 .ToArray();
             return observedMeshCodeRoots.Length == 0
                 ? null
@@ -112,18 +110,6 @@ internal static class ObservedSourceRootPlacementResolver
             rootMeshCode,
             observedRootHeight: observedRootPosition.Y);
         return rootPosition;
-    }
-
-    private static ResoniteFloat3 GetRequiredSourceRootPosition(Slot slot)
-    {
-        if (slot.Position is not Field_float3 position)
-        {
-            throw new InvalidOperationException(
-                $"Observed source-file root '{slot.Name?.Value ?? slot.ID ?? "<unnamed>"}' did not expose a Position. "
-                + "Append placement requires positioned source-file roots.");
-        }
-
-        return new ResoniteFloat3(position.Value.x, position.Value.y, position.Value.z);
     }
 }
 

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSharedSlotIndex.cs
@@ -18,7 +18,9 @@ internal sealed class ResoniteSharedSlotIndex(
     private readonly AsyncCompletedResultCache<SharedSlotIndexKey, CreatedSlot> sharedSlotCache = new();
     private readonly AsyncCompletedResultCache<SharedSlotIndexKey, CreatedSlot> runScopedSourceFileRootCache = new();
     private readonly AsyncCompletedResultCache<CanonicalParentSourceFile, CanonicalParentScope> canonicalParentScopeCache = new();
-    private readonly ResoniteSlotSnapshotIndex slotSnapshotIndex = new(datasetRootSlot);
+    private readonly ResoniteSlotSnapshotIndex slotSnapshotIndex = new(
+        datasetRootSlot,
+        sourceFileSlotNamesByRelativePath.Values);
     public SceneAnchor? SceneAnchor { get; private set; } = initialSceneAnchor;
 
     public void IndexSetupHierarchy(ResoniteSceneSetupState setupState)

--- a/src/PlateauResoniteLink/Targets/Resonite/ResoniteSlotSnapshotIndex.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/ResoniteSlotSnapshotIndex.cs
@@ -6,12 +6,15 @@ using ResoniteLink;
 
 namespace PlateauResoniteLink.Targets.Resonite;
 
-internal sealed class ResoniteSlotSnapshotIndex(CreatedSlot datasetRootSlot)
+internal sealed class ResoniteSlotSnapshotIndex(
+    CreatedSlot datasetRootSlot,
+    IEnumerable<string>? expectedSourceRootSlotNames = null)
 {
     private readonly ConcurrentDictionary<string, byte> createdSlotIds = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<SlotIndexKey, CreatedSlot> sharedSlotIndex = new();
     private readonly ConcurrentDictionary<string, Slot> observedSlotSnapshotsById = new(StringComparer.Ordinal);
-    private Slot[]? observedDatasetSourceRoots;
+    private readonly HashSet<string> expectedSourceRootSlotNames = new(expectedSourceRootSlotNames ?? [], StringComparer.Ordinal);
+    private ObservedDatasetSourceRoot[]? observedDatasetSourceRoots;
 
     public void IndexSetupHierarchy(ResoniteSceneSetupState setupState)
     {
@@ -54,7 +57,7 @@ internal sealed class ResoniteSlotSnapshotIndex(CreatedSlot datasetRootSlot)
         createdSlotIds[createdSlot.Locator.Value] = 0;
     }
 
-    public IReadOnlyList<Slot> GetObservedDatasetSourceRoots()
+    public IReadOnlyList<ObservedDatasetSourceRoot> GetObservedDatasetSourceRoots()
     {
         return observedDatasetSourceRoots ??= SelectObservedDatasetSourceRoots();
     }
@@ -83,12 +86,13 @@ internal sealed class ResoniteSlotSnapshotIndex(CreatedSlot datasetRootSlot)
         }
     }
 
-    private Slot[] SelectObservedDatasetSourceRoots()
+    private ObservedDatasetSourceRoot[] SelectObservedDatasetSourceRoots()
     {
         return ObservedDatasetSourceRootSelector.Select(
             datasetRootSlot.Locator.Value,
             observedSlotSnapshotsById.Values,
-            createdSlotIds.Keys);
+            createdSlotIds.Keys,
+            expectedSourceRootSlotNames);
     }
 
     private static Field_float3 CreateFloat3(ResoniteFloat3 value)

--- a/src/PlateauResoniteLink/Targets/Resonite/SourceRootPlacementResolver.cs
+++ b/src/PlateauResoniteLink/Targets/Resonite/SourceRootPlacementResolver.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 
-using ResoniteLink;
-
 namespace PlateauResoniteLink.Targets.Resonite;
 
 internal static class SourceRootPlacementResolver
@@ -10,7 +8,7 @@ internal static class SourceRootPlacementResolver
         string sourceFileSlotName,
         string rootMeshCode,
         ResoniteLocalOrigin requestLocalOrigin,
-        IReadOnlyList<Slot> observedDatasetSourceRoots)
+        IReadOnlyList<ObservedDatasetSourceRoot> observedDatasetSourceRoots)
     {
         ObservedSourceRootPlacement? observedRootPlacement = ObservedSourceRootPlacementResolver.TryResolve(
             sourceFileSlotName,

--- a/tests/PlateauResoniteLink.Tests/Targets/ObservedSourceRootPlacementResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ObservedSourceRootPlacementResolverTests.cs
@@ -15,8 +15,8 @@ public sealed class ObservedSourceRootPlacementResolverTests
             "plateau_tokyo23ku_bldg_53394525",
             "53394525",
             [
-                CreateSlot("sibling-root", "plateau_tokyo23ku_bldg_53394526", new ResoniteFloat3(20.0, 1.0, 30.0)),
-                CreateSlot("exact-root", "plateau_tokyo23ku_bldg_53394525", new ResoniteFloat3(2.0, 3.0, 4.0)),
+                CreateSourceRoot("sibling-root", "plateau_tokyo23ku_bldg_53394526", new ResoniteFloat3(20.0, 1.0, 30.0)),
+                CreateSourceRoot("exact-root", "plateau_tokyo23ku_bldg_53394525", new ResoniteFloat3(2.0, 3.0, 4.0)),
             ]);
 
         Assert.Equal(new ResoniteFloat3(2.0, 3.0, 4.0), placement?.Position);
@@ -32,8 +32,8 @@ public sealed class ObservedSourceRootPlacementResolverTests
                 "plateau_tokyo23ku_bldg_53394525",
                 "53394525",
                 [
-                    CreateSlot("first-root", "plateau_tokyo23ku_bldg_53394525", new ResoniteFloat3(0.0, 0.0, 0.0)),
-                    CreateSlot("second-root", "plateau_tokyo23ku_bldg_53394525", new ResoniteFloat3(1.0, 0.0, 0.0)),
+                    CreateSourceRoot("first-root", "plateau_tokyo23ku_bldg_53394525", new ResoniteFloat3(0.0, 0.0, 0.0)),
+                    CreateSourceRoot("second-root", "plateau_tokyo23ku_bldg_53394525", new ResoniteFloat3(1.0, 0.0, 0.0)),
                 ]));
 
         Assert.Contains(
@@ -49,7 +49,7 @@ public sealed class ObservedSourceRootPlacementResolverTests
             "plateau_tokyo23ku_bldg_53394527",
             "53394527",
             [
-                CreateSlot("sibling-root", "plateau_tokyo23ku_bldg_53394525", new ResoniteFloat3(20.0, 1.0, 30.0)),
+                CreateSourceRoot("sibling-root", "plateau_tokyo23ku_bldg_53394525", new ResoniteFloat3(20.0, 1.0, 30.0)),
             ]);
         ResoniteFloat3 expected = ResonitePlacementPolicy.ResolveMeshRootPosition(
             ResonitePlacementPolicy.ResolveParentOriginFromMeshRootPosition("53394525", new ResoniteFloat3(20.0, 1.0, 30.0)),
@@ -72,8 +72,8 @@ public sealed class ObservedSourceRootPlacementResolverTests
             "plateau_tokyo23ku_bldg_53394527",
             "53394527",
             [
-                CreateSlot("first-sibling-root", "plateau_tokyo23ku_bldg_53394525", firstRootPosition),
-                CreateSlot("second-sibling-root", "plateau_tokyo23ku_bldg_53394526", secondRootPosition),
+                CreateSourceRoot("first-sibling-root", "plateau_tokyo23ku_bldg_53394525", firstRootPosition),
+                CreateSourceRoot("second-sibling-root", "plateau_tokyo23ku_bldg_53394526", secondRootPosition),
             ]);
         ResoniteFloat3 expected = ResonitePlacementPolicy.ResolveMeshRootPosition(parentOrigin, "53394527");
 
@@ -89,27 +89,19 @@ public sealed class ObservedSourceRootPlacementResolverTests
             () => ObservedSourceRootPlacementResolver.TryResolve(
                 "plateau_tokyo23ku_bldg_53394525",
                 "53394525",
-                [CreateSlotWithoutPosition("source-root", "plateau_tokyo23ku_bldg_53394525")]));
+                ObservedDatasetSourceRootSelector.SelectDirectChildren(
+                    [CreateSlotWithoutPosition("source-root", "plateau_tokyo23ku_bldg_53394525")],
+                    [])));
 
         Assert.Contains("did not expose a Position", exception.Message, StringComparison.Ordinal);
     }
 
-    private static Slot CreateSlot(string id, string name, ResoniteFloat3 position)
+    private static ObservedDatasetSourceRoot CreateSourceRoot(string id, string name, ResoniteFloat3 position)
     {
-        return new Slot
-        {
-            ID = id,
-            Name = new Field_string { Value = name },
-            Position = new Field_float3
-            {
-                Value = new float3
-                {
-                    x = (float)position.X,
-                    y = (float)position.Y,
-                    z = (float)position.Z,
-                },
-            },
-        };
+        string? concreteMeshCode = ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(name, out string meshCode)
+            ? meshCode
+            : null;
+        return new ObservedDatasetSourceRoot(id, name, position, concreteMeshCode);
     }
 
     private static Slot CreateSlotWithoutPosition(string id, string name)

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneAnchorResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSceneAnchorResolverTests.cs
@@ -97,6 +97,46 @@ public sealed class ResoniteSceneAnchorResolverTests
     }
 
     [Fact]
+    public async Task ResolveAsyncIgnoresNonSourceRootDirectChildWithoutPosition()
+    {
+        const string datasetRootSlotId = "dataset-root";
+        const string completionMeshCode = "53394525";
+        using AnchorResolverFakeClient client = new AnchorResolverFakeClient((slotId, depth, callCount) =>
+        {
+            if (string.Equals(slotId, datasetRootSlotId, StringComparison.Ordinal) && depth == 0)
+            {
+                return CreateSlot(datasetRootSlotId, "PLATEAU tokyo23ku");
+            }
+
+            if (string.Equals(slotId, datasetRootSlotId, StringComparison.Ordinal) && depth == 1)
+            {
+                return CreateSlot(
+                    datasetRootSlotId,
+                    "PLATEAU tokyo23ku",
+                    children:
+                    [
+                        CreateSlot("operator-note", "Operator Notes", datasetRootSlotId),
+                        CreateSlot("source-root", "plateau_tokyo23ku_bldg_53394525", datasetRootSlotId, new ResoniteFloat3(1.0, 0.0, 2.0)),
+                    ]);
+            }
+
+            return null;
+        });
+
+        ResoniteSceneAnchorResolver resolver = new();
+
+        SceneAnchor anchor = await resolver.ResolveAsync(
+            client,
+            new ResoniteSlotLocator(datasetRootSlotId),
+            completionMeshCode,
+            CancellationToken.None);
+
+        Assert.Equal(new ResoniteSlotLocator("source-root"), anchor.LocationSlot);
+        Assert.Equal(new ResoniteSlotLocator("source-root"), anchor.ReferenceSourceFileRoot);
+        Assert.Equal(new ResoniteFloat3(1.0, 0.0, 2.0), anchor.Position);
+    }
+
+    [Fact]
     public async Task ResolveAsyncUsesPositionedReferenceSourceFileRootForFallbackAnchorPosition()
     {
         const string datasetRootSlotId = "dataset-root";

--- a/tests/PlateauResoniteLink.Tests/Targets/ResoniteSlotSnapshotIndexTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/ResoniteSlotSnapshotIndexTests.cs
@@ -31,9 +31,15 @@ public sealed class ResoniteSlotSnapshotIndexTests
                 "dataset-root",
                 "PLATEAU tokyo23ku",
                 null,
+                children:
                 [
-                    CreateSlot("existing-root", "plateau_tokyo23ku_bldg_53394525", "dataset-root"),
+                    CreateSlot(
+                        "existing-root",
+                        "plateau_tokyo23ku_bldg_53394525",
+                        "dataset-root",
+                        new ResoniteFloat3(4.0, 5.0, 6.0)),
                     CreateSlot("assets-root", "Assets", "dataset-root"),
+                    CreateSlot("operator-note", "Operator Notes", "dataset-root"),
                 ]),
             CommonMaterialCatalog.Create().Map(static member => new ResoniteCommonMaterialAsset(
                 member,
@@ -51,14 +57,57 @@ public sealed class ResoniteSlotSnapshotIndexTests
         index.MarkCreated(createdRoot);
         index.IndexCreatedSharedSlot(datasetRoot.Locator, createdRoot, new ResoniteFloat3(1.0, 2.0, 3.0));
 
-        Slot observedRoot = Assert.Single(index.GetObservedDatasetSourceRoots());
-        Assert.Equal("existing-root", observedRoot.ID);
+        ObservedDatasetSourceRoot observedRoot = Assert.Single(index.GetObservedDatasetSourceRoots());
+        Assert.Equal("existing-root", observedRoot.SlotId);
+        Assert.Equal("plateau_tokyo23ku_bldg_53394525", observedRoot.SlotName);
+        Assert.Equal("53394525", observedRoot.ConcreteMeshCode);
+        Assert.Equal(new ResoniteFloat3(4.0, 5.0, 6.0), observedRoot.Position);
+    }
+
+    [Fact]
+    public void IndexSetupHierarchyKeepsExpectedSourceRootWithoutMeshCodeAndIgnoresOtherChildren()
+    {
+        CreatedSlot datasetRoot = new(new ResoniteSlotLocator("dataset-root"), "PLATEAU tokyo23ku");
+        CreatedSlot assetsRoot = new(new ResoniteSlotLocator("assets-root"), "Assets");
+        ResoniteSlotSnapshotIndex index = new(datasetRoot, ["sample"]);
+
+        index.IndexSetupHierarchy(new ResoniteSceneSetupState(
+            datasetRoot,
+            assetsRoot,
+            new CreatedSlot(new ResoniteSlotLocator("common-root"), "Common Materials"),
+            DatasetRootExisted: true,
+            new SceneAnchor(
+                datasetRoot.Locator,
+                "53394525",
+                new ResoniteFloat3(0.0, 0.0, 0.0),
+                ReferenceSourceFileRoot: null),
+            CreateSlot(
+                "dataset-root",
+                "PLATEAU tokyo23ku",
+                null,
+                children:
+                [
+                    CreateSlot("sample-root", "sample", "dataset-root", new ResoniteFloat3(7.0, 8.0, 9.0)),
+                    CreateSlot("operator-note", "Operator Notes", "dataset-root"),
+                ]),
+            CommonMaterialCatalog.Create().Map(static member => new ResoniteCommonMaterialAsset(
+                member,
+                SceneImportContractMapper.ToInternal(member.CreateBinding([0])),
+                default)),
+            []));
+
+        ObservedDatasetSourceRoot observedRoot = Assert.Single(index.GetObservedDatasetSourceRoots());
+        Assert.Equal("sample-root", observedRoot.SlotId);
+        Assert.Equal("sample", observedRoot.SlotName);
+        Assert.Null(observedRoot.ConcreteMeshCode);
+        Assert.Equal(new ResoniteFloat3(7.0, 8.0, 9.0), observedRoot.Position);
     }
 
     private static Slot CreateSlot(
         string id,
         string name,
         string? parentId = null,
+        ResoniteFloat3? position = null,
         Slot[]? children = null)
     {
         return new Slot
@@ -66,6 +115,15 @@ public sealed class ResoniteSlotSnapshotIndexTests
             ID = id,
             Name = new Field_string { Value = name },
             Parent = parentId is null ? null : new Reference { TargetID = parentId },
+            Position = position is null ? null : new Field_float3
+            {
+                Value = new float3
+                {
+                    x = (float)position.X,
+                    y = (float)position.Y,
+                    z = (float)position.Z,
+                },
+            },
             Children = children?.ToList(),
         };
     }

--- a/tests/PlateauResoniteLink.Tests/Targets/SourceRootPlacementResolverTests.cs
+++ b/tests/PlateauResoniteLink.Tests/Targets/SourceRootPlacementResolverTests.cs
@@ -16,11 +16,30 @@ public sealed class SourceRootPlacementResolverTests
             "53394525",
             new ResoniteLocalOrigin(35.0, 139.0, 0.0),
             [
-                CreateSlot(
+                CreateSourceRoot(
                     "source-root",
                     "plateau_tokyo23ku_bldg_53394525",
                     new ResoniteFloat3(4.0, 5.0, 6.0)),
             ]);
+
+        Assert.Equal(new ResoniteFloat3(4.0, 5.0, 6.0), placement.RootPosition);
+        Assert.Equal(placement.RootPosition, placement.LocalPositionReferenceRoot);
+    }
+
+    [Fact]
+    public void ResolveUsesExpectedSourceRootNameWithoutMeshCodeBeforeRequestOriginFallback()
+    {
+        SourceRootPlacement placement = SourceRootPlacementResolver.Resolve(
+            "sample",
+            "53394525",
+            new ResoniteLocalOrigin(35.0, 139.0, 0.0),
+            ObservedDatasetSourceRootSelector.SelectDirectChildren(
+                [
+                    CreateSlot("sample-root", "sample", new ResoniteFloat3(4.0, 5.0, 6.0)),
+                    CreateSlotWithoutPosition("operator-note", "Operator Notes"),
+                ],
+                [],
+                ["sample"]));
 
         Assert.Equal(new ResoniteFloat3(4.0, 5.0, 6.0), placement.RootPosition);
         Assert.Equal(placement.RootPosition, placement.LocalPositionReferenceRoot);
@@ -50,9 +69,19 @@ public sealed class SourceRootPlacementResolverTests
                 "plateau_tokyo23ku_bldg_53394525",
                 "53394525",
                 new ResoniteLocalOrigin(35.0, 139.0, 0.0),
-                [CreateSlotWithoutPosition("source-root", "plateau_tokyo23ku_bldg_53394525")]));
+                ObservedDatasetSourceRootSelector.SelectDirectChildren(
+                    [CreateSlotWithoutPosition("source-root", "plateau_tokyo23ku_bldg_53394525")],
+                    [])));
 
         Assert.Contains("did not expose a Position", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static ObservedDatasetSourceRoot CreateSourceRoot(string id, string name, ResoniteFloat3 position)
+    {
+        string? concreteMeshCode = ResoniteSourceMeshCodeAnchor.TryGetConcreteMeshCode(name, out string meshCode)
+            ? meshCode
+            : null;
+        return new ObservedDatasetSourceRoot(id, name, position, concreteMeshCode);
     }
 
     private static Slot CreateSlot(string id, string name, ResoniteFloat3 position)


### PR DESCRIPTION
## Summary
- Introduces an internal `ObservedDatasetSourceRoot` canonical model for reusable source-file roots observed under the Resonite dataset root.
- Centralizes observed root candidate filtering and projection: `Assets` exclusion, current-run created slot exclusion, concrete mesh-code extraction, and required-position fail-fast.
- Updates placement resolution and scene anchor recovery to consume the observed source-root model instead of raw `Slot` snapshots.

## Scope
- Keeps public API, wire payloads, emitted slot/component structure, material planning, and live-send external contract unchanged.
- Does not convert `GetOrCreate` flows into a broader reconcile plan and does not touch setup/emission policy.

## Validation
- `dotnet restore PlateauResoniteLink.sln --locked-mode --disable-build-servers`
- `dotnet format whitespace . --folder --verify-no-changes`
- `dotnet build PlateauResoniteLink.sln --configuration Release --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test PlateauResoniteLink.sln --configuration Release --no-restore --verbosity normal -m:1 --disable-build-servers -p:UseSharedCompilation=false`